### PR TITLE
Disable runtime exclusivity checking when using back-deployed concurrency

### DIFF
--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -6,6 +6,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: OS=wasi
+// UNSUPPORTED: use_os_stdlib
 
 // This test makes sure that:
 //

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -13,6 +13,8 @@
 // Disabled until test hang can be looked at.
 // UNSUPPORTED: OS=windows-msvc
 
+// UNSUPPORTED: use_os_stdlib
+
 // This test makes sure that we properly save/restore access when we
 // synchronously launch a task from a serial executor. The access from the task
 // should be merged into the already created access set while it runs and then

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -6,6 +6,8 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: single_threaded_runtime
 
+// UNSUPPORTED: use_os_stdlib
+
 // Tests for traps at run time when enforcing exclusive access.
 
 import StdlibUnittest


### PR DESCRIPTION
The back-deployed concurrency libraries and older Swift runtimes are
not compatible, so turn off runtime exclusivity checking when running on
older systems. Fixes rdar://84274148.
