### PR TITLE
Enter a fresh lexical scope for the enlosing brace statment of a func… 

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -590,12 +590,9 @@ public:
     auto *Parent = DebugScopeStack.size() ? DebugScopeStack.back().getPointer()
                                           : F.getDebugScope();
     auto *DS = Parent;
-    // Don't create a pointless scope for the function body's BraceStmt.
-    if (!DebugScopeStack.empty())
-      // Don't nest a scope for Loc under Parent unless it's actually different.
-      if (RegularLocation(DS->getLoc()) != RegularLocation(Loc))
-        DS = new (SGM.M)
-          SILDebugScope(RegularLocation(Loc), &getFunction(), DS);
+    // Don't nest a scope for Loc under Parent unless it's actually different.
+    if (RegularLocation(DS->getLoc()) != RegularLocation(Loc))
+      DS = new (SGM.M) SILDebugScope(RegularLocation(Loc), &getFunction(), DS);
     DebugScopeStack.emplace_back(DS, isBindingScope);
     B.setCurrentDebugScope(DS);
   }

--- a/test/DebugInfo/doubleinlines.swift
+++ b/test/DebugInfo/doubleinlines.swift
@@ -10,9 +10,10 @@ func callCondFail(arg: Builtin.Int1, msg: Builtin.RawPointer) {
     condFail(arg: arg, msg: msg)
 }
 
-// CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF"{{.*}} !dbg ![[FUNCSCOPE:.*]] {
+// CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF"{{.*}} !dbg ![[FUNC:.*]] {
 // CHECK: tail call void asm sideeffect "", "n"(i32 0) #3, !dbg ![[SCOPEONE:.*]]
 // CHECK: ![[FUNCSCOPEOTHER:.*]] = distinct !DISubprogram(name: "condFail",{{.*}}
+// CHECK: ![[FUNCSCOPE:[0-9]+]] = distinct !DILexicalBlock(scope: ![[FUNC]],
 // CHECK: ![[SCOPEONE]] = !DILocation(line: 0, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
 // CHECK: ![[SCOPETHREE]] = !DILocation(line: 6, scope: ![[SCOPEFOUR:.*]])
 // CHECK: ![[SCOPEFOUR]] = distinct !DILexicalBlock(scope: ![[FUNCSCOPE]], file: !{{.*}}, line: 10)

--- a/test/DebugInfo/guard-let-scope.swift
+++ b/test/DebugInfo/guard-let-scope.swift
@@ -3,9 +3,10 @@
 func f(c: AnyObject?) {
   let x = c
   // CHECK: sil_scope [[S1:[0-9]+]] { {{.*}} parent @{{.*}}1f
-  // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:17 parent [[S1]] }
-  // CHECK: debug_value %{{.*}} : $Optional<AnyObject>, let, name "x"{{.*}} scope [[S1]]
-  // CHECK: debug_value %{{.*}} : $AnyObject, let, name "x", {{.*}} scope [[S2]]
+  // CHECK: sil_scope [[S2:[0-9]+]] { {{.*}} parent [[S1]] }
+  // CHECK: sil_scope [[S3:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:17 parent [[S2]] }
+  // CHECK: debug_value %{{.*}} : $Optional<AnyObject>, let, name "x"{{.*}} scope [[S2]]
+  // CHECK: debug_value %{{.*}} : $AnyObject, let, name "x", {{.*}} scope [[S3]]
   guard let x = x else {
     fatalError(".")
   }

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -29,11 +29,13 @@ func yes() -> Bool { return true }
 }
 
 // SIL: sil_scope [[F:.*]] { {{.*}}parent @$s1A1CC1fyyqd__lF
-// SIL: sil_scope [[F1G:.*]] { loc "f.swift":2:5 parent [[F]] }
+// SIL: sil_scope [[F1:.*]] { {{.*}}parent [[F]] }
+// SIL: sil_scope [[F1G:.*]] { loc "f.swift":2:5 parent [[F1]] }
 // SIL: sil_scope [[F1G1:.*]] { loc "g.swift":2:3 {{.*}}inlined_at [[F1G]] }
 // SIL: sil_scope [[F1G3:.*]] { loc "g.swift":3:5 {{.*}}inlined_at [[F1G]] }
 // SIL: sil_scope [[F1G3H:.*]] { loc "h.swift":1:24
 // SIL-SAME:                     parent @{{.*}}1h{{.*}} inlined_at [[F1G3]] }
+// SIL: sil_scope [[F1G3H1:.*]] { {{.*}} parent [[F1G3H]] inlined_at [[F1G3]] }
 
 #sourceLocation(file: "C.swift", line: 1)
 public class C<R> {
@@ -46,7 +48,7 @@ public class C<R> {
   public func f<S>(_ s: S) {
     // SIL: debug_value %0 : $*S, let, name "s", argno 1, expr op_deref, {{.*}} scope [[F]]
     // SIL: function_ref {{.*}}yes{{.*}} scope [[F1G1]]
-    // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
+    // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H1]]
     // IR: dbg.value(metadata %swift.type* %S, metadata ![[MD_1_0:[0-9]+]]
     // IR: dbg.value(metadata %swift.opaque* %0, metadata ![[S:[0-9]+]]
     // IR: dbg.value(metadata %swift.opaque* %0, metadata ![[GS_T:[0-9]+]]

--- a/test/DebugInfo/inlinedAt.swift
+++ b/test/DebugInfo/inlinedAt.swift
@@ -42,9 +42,10 @@ public func f(_ i : Int) -> Int { // 301
 
 // CHECK: ![[L3:.*]] = !DILocation(line: 302, column: 10,
 // CHECK-SAME:                     scope: ![[F:.*]])
+// CHECK: ![[G1:[0-9]+]] = distinct !DILexicalBlock(scope: ![[G]],
 // CHECK: ![[H:.*]] = distinct !DISubprogram(name: "h",
 // CHECK: ![[L1]] = !DILocation(line: 101, column: 8, scope: ![[H]],
 // CHECK-SAME:                  inlinedAt: ![[L2:.*]])
-// CHECK: ![[L2]] = !DILocation(line: 203, column: 10, scope: ![[G]],
+// CHECK: ![[L2]] = !DILocation(line: 203, column: 10, scope: ![[G1]],
 // CHECK-SAME:                  inlinedAt: ![[L3]])
 

--- a/test/DebugInfo/inlinescopes.swift
+++ b/test/DebugInfo/inlinescopes.swift
@@ -24,9 +24,10 @@ func transparent(_ x: Int64) -> Int64 { return noinline(x) }
 
 @inline(__always)
 func inlined(_ x: Int64) -> Int64 {
-// CHECK-DAG: ![[CALL]] = !DILocation(line: [[@LINE+3]], column: {{.*}}, scope: ![[SCOPE:.*]], inlinedAt: ![[INLINED:.*]])
+// CHECK-DAG: ![[CALL]] = !DILocation(line: [[@LINE+4]], column: {{.*}}, scope: ![[SCOPE:.*]], inlinedAt: ![[INLINED:.*]])
 // Check if the inlined and removed function still has the correct linkage name.
-// CHECK-DAG: ![[SCOPE]] = distinct !DISubprogram(name: "inlined", linkageName: "$s4main7inlinedys5Int64VADF"
+// CHECK-DAG: ![[SCOPE]] = distinct !DILexicalBlock(scope: ![[INLINED:[0-9]+]],
+// CHECK-DAG: ![[INLINED]] = distinct !DISubprogram(name: "inlined", linkageName: "$s4main7inlinedys5Int64VADF"
   let result = transparent(x)
 // TRANSPARENT-CHECK-NOT: !DISubprogram(name: "transparent"
   return result

--- a/test/DebugInfo/mandatory-inlining-ownership.swift
+++ b/test/DebugInfo/mandatory-inlining-ownership.swift
@@ -4,9 +4,9 @@
 // RUN:   -sil-print-after=mandatory-inlining \
 // RUN:   -Xllvm -sil-print-debuginfo -o /dev/null 2>&1 | %FileCheck %s
 
-// CHECK: begin_borrow {{.*}} : $OSLog, loc {{.*}}, scope 4
-// CHECK: tuple (), loc {{.*}}, scope 4
-// CHECK: end_borrow %9 : $OSLog, loc {{.*}}, scope 4
+// CHECK: begin_borrow {{.*}} : $OSLog, loc {{.*}}, scope 5
+// CHECK: tuple (), loc {{.*}}, scope 5
+// CHECK: end_borrow %9 : $OSLog, loc {{.*}}, scope 5
 
 import os
 

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -185,8 +185,9 @@ public class Class1 {
     print("hello")
     // CHECK_INIT: call {{.*}}@"$ss5print_9separator10terminatoryypd_S2StF"{{.*}}, !dbg [[printLoc:![0-9]+]]
     // FIXME: Why doesn't ret have the correct line number?
-    // CHECK_INIT: ret i{{32|64}} 0, !dbg [[printLoc]]
-    // CHECK_INIT: [[printLoc]] = !DILocation(line: [[@LINE-4]]
+    // CHECK_INIT: ret i{{32|64}} 0, !dbg ![[RETLOC:[0-9]+]]
+    // CHECK_INIT: [[RETLOC]] = !DILocation(line: 0
+    // CHECK_INIT: [[printLoc]] = !DILocation(line: [[@LINE-5]]
     return nil
   }
 }

--- a/test/DebugInfo/shadowed-arg.swift
+++ b/test/DebugInfo/shadowed-arg.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend %s -parse-as-library -emit-ir -g -o - \
+// RUN:   -module-name main | %FileCheck %s
+// RUN: %target-swift-frontend %s -parse-as-library -emit-sil \
+// RUN:   -Xllvm -sil-print-debuginfo -o - \
+// RUN:   -module-name main | %FileCheck %s --check-prefix=SIL
+
+// The variable i and the argument i must be in different scopes or the debugger
+// doesn't know which one shadows the other.
+public func f(i: Int) {
+    let i = [i, i]
+    print(i)
+}
+
+// CHECK: ![[S1:[0-9]+]] = distinct !DISubprogram(name: "f",
+// CHECK: !DILocalVariable(name: "i", arg: 1, scope: ![[S1]],
+// CHECK: !DILocalVariable(name: "i", scope: ![[S2:[0-9]+]],
+// CHECK: ![[S2]] = distinct !DILexicalBlock(scope: ![[S1]],
+// SIL: sil_scope [[S1:[0-9]+]] { {{.*}} parent @$s4main1f1iySi_tF
+// SIL: sil_scope [[S2:[0-9]+]] { {{.*}} parent [[S1]] }
+// SIL: debug_value %0 : $Int, let, name "i", argno 1,{{.*}}, scope [[S1]]
+// SIL: debug_value {{.*}} : $Array<Int>, let, name "i", {{.*}}, scope [[S2]]

--- a/test/DebugInfo/transparent.swift
+++ b/test/DebugInfo/transparent.swift
@@ -21,8 +21,8 @@ use(z)
 // CHECK-NEXT: !dbg ![[ZERO:[0-9]+]]
 // CHECK-NEXT: }
 
+// CHECK: ![[FILE:[0-9]+]] = {{.*}}"<compiler-generated>"
 // CHECK: ![[SP]] = distinct !DISubprogram({{.*}}name: "transparent"
-// CHECK-SAME:                             file: ![[FILE:[0-9]+]]
-// CHECK: ![[FILE]] = {{.*}}"<compiler-generated>"
+// CHECK-SAME:                             file: ![[FILE]]
 // CHECK-NOT: line:
 // CHECK: ![[ZERO]] = !DILocation(line: 0,

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -4,27 +4,27 @@
 
 // CHECK: sil hidden [ossa] @$s4null19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> Int {
 // CHECK: bb0:
-// CHECK:   %0 = alloc_box ${ var Int }, var, name "x", loc {{.*}}:32:7, scope 2
-// CHECK:   %1 = project_box %0 : ${ var Int }, 0, loc {{.*}}:32:7, scope 2
-// CHECK:   %2 = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:32:11, scope 2
-// CHECK:   %3 = metatype $@thin Int.Type, loc {{.*}}:32:11, scope 2
-// CHECK:   %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 2
-// CHECK:   %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 2
-// CHECK:   store %5 to [trivial] %1 : $*Int, loc {{.*}}:32:11, scope 2
-// CHECK:   %7 = copy_value %0 : ${ var Int }, loc {{.*}}:33:11, scope 2
-// CHECK:   %8 = project_box %7 : ${ var Int }, 0, loc {{.*}}:33:11, scope 2
-// CHECK:   mark_function_escape %1 : $*Int, loc {{.*}}:33:11, scope 2
-// CHECK:   %10 = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 2
-// CHECK:   %11 = load [trivial] %8 : $*Int, loc {{.*}}:33:11, scope 2
-// CHECK:   destroy_value %7 : ${ var Int }, loc {{.*}}:33:11, scope 2
-// CHECK:   %13 = partial_apply [callee_guaranteed] %10(%11) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 2
-// CHECK:   debug_value %13 : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 2
+// CHECK:   %0 = alloc_box ${ var Int }, var, name "x", loc {{.*}}:32:7, scope 3
+// CHECK:   %1 = project_box %0 : ${ var Int }, 0, loc {{.*}}:32:7, scope 3
+// CHECK:   %2 = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:32:11, scope 3
+// CHECK:   %3 = metatype $@thin Int.Type, loc {{.*}}:32:11, scope 3
+// CHECK:   %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
+// CHECK:   %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
+// CHECK:   store %5 to [trivial] %1 : $*Int, loc {{.*}}:32:11, scope 3
+// CHECK:   %7 = copy_value %0 : ${ var Int }, loc {{.*}}:33:11, scope 3
+// CHECK:   %8 = project_box %7 : ${ var Int }, 0, loc {{.*}}:33:11, scope 3
+// CHECK:   mark_function_escape %1 : $*Int, loc {{.*}}:33:11, scope 3
+// CHECK:   %10 = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
+// CHECK:   %11 = load [trivial] %8 : $*Int, loc {{.*}}:33:11, scope 3
+// CHECK:   destroy_value %7 : ${ var Int }, loc {{.*}}:33:11, scope 3
+// CHECK:   %13 = partial_apply [callee_guaranteed] %10(%11) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
+// CHECK:   debug_value %13 : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 3
 // There used to be a begin_borrow here. We leave an emptyline here to preserve line numbers.
-// CHECK:   %15 = copy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 2
+// CHECK:   %15 = copy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
 // There used to be an end_borrow here. We leave an emptyline here to preserve line numbers.
-// CHECK:   destroy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 2
-// CHECK:   destroy_value %0 : ${ var Int }, loc {{.*}}:35:1, scope 2
-// CHECK:   return %15 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 2
+// CHECK:   destroy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 3
+// CHECK:   destroy_value %0 : ${ var Int }, loc {{.*}}:35:1, scope 3
+// CHECK:   return %15 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3
 // CHECK: }
 
 

--- a/test/SILOptimizer/castoptimizer-wrongscope.swift
+++ b/test/SILOptimizer/castoptimizer-wrongscope.swift
@@ -5,9 +5,9 @@
 // RUN:   -Xllvm -sil-print-after=diagnostic-constant-propagation \
 // RUN:   2>&1 | %FileCheck %s
 
-// CHECK: alloc_stack $R, loc {{.*}}, scope 1
-// CHECK-NEXT: init_existential_addr {{.*}} : $*R, $Float, loc {{.*}}, scope 1
-// CHECK-NEXT: copy_addr [take] %8 to [initialization] {{.*}} : $*Float, loc {{.*}}, scope 1
+// CHECK: alloc_stack $R, loc {{.*}}, scope 2
+// CHECK-NEXT: init_existential_addr {{.*}} : $*R, $Float, loc {{.*}}, scope 2
+// CHECK-NEXT: copy_addr [take] %8 to [initialization] {{.*}} : $*Float, loc {{.*}}, scope 2
 
 protocol R {}
 extension Float: R {}

--- a/test/SILOptimizer/constantprop-wrongscope.swift
+++ b/test/SILOptimizer/constantprop-wrongscope.swift
@@ -12,10 +12,10 @@
 // Make sure that the destroy_addr instruction has the same scope of the
 // instructions surrounding it.
 
-// CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 2
-// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 2
-// CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 2
-// CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 2
+// CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 3
+// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 3
+// CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 3
+// CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 3
 
 import Foundation
 func indexedSubscripting(b b: B, idx: Int, a: A) {

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -33,14 +33,14 @@ public class M {
 
 // CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:23:12, scope 4
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:23:12, scope 4
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:26:20, scope 4
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:23:12, scope 5
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:23:12, scope 5
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:26:20, scope 5
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:29:5, scope 4
-// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:29:5, scope 5
+// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
 // CHECK:   throw %{{.*}} : $Error, loc {{.*}}:23:12, scope 1

--- a/test/SILOptimizer/di-conditional-destroy-scope.swift
+++ b/test/SILOptimizer/di-conditional-destroy-scope.swift
@@ -6,9 +6,9 @@
 // REQUIRES: objc_interop
 
 
-// CHECK: [[ADR:%.*]] = ref_element_addr %{{.*}} : $RecursibleDirectoryContentsGenerator, #RecursibleDirectoryContentsGenerator.fileSystem, loc {{.*}}:39:5, scope 1
+// CHECK: [[ADR:%.*]] = ref_element_addr %{{.*}} : $RecursibleDirectoryContentsGenerator, #RecursibleDirectoryContentsGenerator.fileSystem, loc {{.*}}:39:5, scope 2
 // CHECK: [[ADR_ACCESS:%.*]] = begin_access [deinit] [static] [[ADR]]
-// CHECK: destroy_addr [[ADR_ACCESS]] : $*FileSystem, loc {{.*}}:39:5, scope 1
+// CHECK: destroy_addr [[ADR_ACCESS]] : $*FileSystem, loc {{.*}}:39:5, scope 2
 
 
 import Foundation

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -4,8 +4,8 @@
 // RUN:   -Xllvm -sil-print-debuginfo -o %t -module-name red 2>&1 | %FileCheck %s
 
 // CHECK: bb{{[0-9]+}}(%{{[0-9]+}} : @owned $Error):
-// CHECK:   dealloc_stack %{{[0-9]+}} : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:26:68, scope 1
-// CHECK:   br bb{{[0-9]+}}(%{{[0-9]+}} : $Error), loc {{.*}}:26:15, scope 1
+// CHECK:   dealloc_stack %{{[0-9]+}} : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:26:68, scope 2
+// CHECK:   br bb{{[0-9]+}}(%{{[0-9]+}} : $Error), loc {{.*}}:26:15, scope 2
 
 protocol Patatino {
   init()


### PR DESCRIPTION
…tion.

The debugger relies on function arguments and local variables to be in different
scopes in order to disambiguate between local variables that shadow function
arguments.

rdar://83769198

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
