### PR TITLE
[Concurrency] limit queue width on all non apple platforms, not just linux

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -275,7 +275,7 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 
@@ -295,7 +295,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
   const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
 
   // Create a new cooperative concurrent queue and swap it in.


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/39732 where we fixed it "for linux" but we should be fixing it for "not apple platforms" instead.

rdar://79907041

