### PR TITLE
🍒  5.5 [Concurrency] set queue width on all non-apple platforms, not just linux

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -266,7 +266,7 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__APPLE__)
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -266,7 +266,7 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 
@@ -286,7 +286,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
   const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
 
   // Create a new cooperative concurrent queue and swap it in.

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -286,7 +286,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
-#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__apple__)
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__APPLE__)
   const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
 
   // Create a new cooperative concurrent queue and swap it in.


### PR DESCRIPTION
**Description:** We recently made setting the queue width also happen on linux; but rather, it should be for "non apple platforms" -- improving the condition based on John's feedback.
**Risk:** Low
**Review by:** @DougGregor @rjmccall 
**Testing:** Ci testing
**Original PR:** https://github.com/apple/swift/pull/39764 and the previous one https://github.com/apple/swift/pull/39742
**Radar:** rdar://79907041