### PR TITLE
🍒 5.5+ [Concurrency] set queue width on non apple platforms

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -265,6 +265,10 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
+#ifndef __APPLE__
+extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
+#endif
+
 static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   size_t numericPriority = static_cast<size_t>(priority);
   if (numericPriority >= globalQueueCacheCount)
@@ -275,6 +279,25 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
+#ifndef __APPLE__
+  const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
+
+  // Create a new cooperative concurrent queue and swap it in.
+  dispatch_queue_attr_t newQueueAttr = dispatch_queue_attr_make_with_qos_class(
+      DISPATCH_QUEUE_CONCURRENT, (dispatch_qos_class_t)priority, 0);
+  dispatch_queue_t newQueue = dispatch_queue_create(
+      "Swift global concurrent queue", newQueueAttr);
+  dispatch_queue_set_width(newQueue, DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS);
+
+  if (!ptr->compare_exchange_strong(queue, newQueue,
+                                    /*success*/ std::memory_order_release,
+                                    /*failure*/ std::memory_order_acquire)) {
+    dispatch_release(newQueue);
+    return queue;
+  }
+
+  return newQueue;
+#else
   // If we don't have a queue cached for this priority, cache it now. This may
   // race with other threads doing this at the same time for this priority, but
   // that's OK, they'll all end up writing the same value.
@@ -284,6 +307,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   // Unconditionally store it back in the cache. If we raced with another
   // thread, we'll just overwrite the entry with the same value.
   ptr->store(queue, std::memory_order_relaxed);
+#endif
 
   return queue;
 }


### PR DESCRIPTION
Description: To avoid thread explosions, i.e. thread growth to the hardcoded number of 255 when tasks are blocked on Linux (and other non apple platforms), and in order to get the same behavior as Swift Concurrency has on Darwin (and back deployment), we must set the global queue width as we set it up for swift concurrency. Without this, when tasks block for even short bursts, we end up with many many threads on Linux systems. The fix sets the width, same as we do on back deployment and gets us consistent behavior across platforms, and no thread explosions.
Risk: Low, affects only non-apple platforms
Review by: @DougGregor @rjmccall @tomerd 
Testing: verified manually using example applications;
Original PR: https://github.com/apple/swift/pull/39764 and the previous one #39742
Radar: rdar://79907041