### PR TITLE
RequirementMachine: Better rule deletion heuristic

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -73,6 +73,15 @@ bool Rule::isProtocolRefinementRule() const {
           LHS[0] != LHS[1]);
 }
 
+/// Linear order on rules; compares LHS followed by RHS.
+int Rule::compare(const Rule &other, const ProtocolGraph &protos) const {
+  int compare = LHS.compare(other.LHS, protos);
+  if (compare != 0)
+    return compare;
+
+  return RHS.compare(other.RHS, protos);
+}
+
 void Rule::dump(llvm::raw_ostream &out) const {
   out << LHS << " => " << RHS;
   if (Permanent)

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -493,6 +493,11 @@ public:
   ///
   //////////////////////////////////////////////////////////////////////////////
 
+  bool
+  isCandidateForDeletion(unsigned ruleID,
+                         bool firstPass,
+                         const llvm::DenseSet<unsigned> *redundantConformances) const;
+
   Optional<unsigned>
   findRuleToDelete(bool firstPass,
                    const llvm::DenseSet<unsigned> *redundantConformances,

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -122,6 +122,8 @@ public:
     return LHS.size();
   }
 
+  int compare(const Rule &other, const ProtocolGraph &protos) const;
+
   void dump(llvm::raw_ostream &out) const;
 
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out,

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -79,6 +79,8 @@ public:
 
   void dump(llvm::raw_ostream &out) const;
 
+  int compare(Term other, const ProtocolGraph &protos) const;
+
   friend bool operator==(Term lhs, Term rhs) {
     return lhs.Ptr == rhs.Ptr;
   }

--- a/test/Generics/connected_components_concrete.swift
+++ b/test/Generics/connected_components_concrete.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-protocol-signatures=on %s 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype T
+}
+
+protocol Base {
+  associatedtype A
+  associatedtype B
+  associatedtype C
+  associatedtype D : P where B == D.T
+}
+
+// CHECK-LABEL: connected_components_concrete.(file).Derived1@
+// CHECK-LABEL: Requirement signature: <Self where Self : Base, Self.A == Int, Self.B == Int, Self.C == Int>
+protocol Derived1 : Base where A == B, A == C, A == Int {}
+
+// CHECK-LABEL: connected_components_concrete.(file).Derived2@
+// CHECK-LABEL: Requirement signature: <Self where Self : Base, Self.A == Int, Self.B == Int, Self.C == Int>
+protocol Derived2 : Base where A == D.T, A == C, B == Int {}
+
+// CHECK-LABEL: connected_components_concrete.(file).Derived3@
+// CHECK-LABEL: Requirement signature: <Self where Self : Base, Self.A == Int, Self.B == Int, Self.C == Int>
+protocol Derived3 : Base where A == B, B == C, A == Int {}
+
+// CHECK-LABEL: connected_components_concrete.(file).Derived4@
+// CHECK-LABEL: Requirement signature: <Self where Self : Base, Self.A == Int, Self.B == Int, Self.C == Int>
+protocol Derived4 : Base where A == Int, B == Int, C == Int {}
+
+// CHECK-LABEL: connected_components_concrete.(file).Derived5@
+// CHECK-LABEL: Requirement signature: <Self where Self : Base, Self.A == Int, Self.B == Int, Self.C == Int>
+protocol Derived5 : Base where A == Int, D.T == Int, C == Int {}


### PR DESCRIPTION
To match the GSB's same-type requirement minimization algorithm, prefer to mark "less canonical" rules as redundant, by defining a linear order on rules that first compares the LHS and then the RHS. This replaces the previous heuristic which simply preferred to delete lower-numbered rules.

Also, the GSB's "connected components" algorithm has special behavior with concrete type requirements that we need to simulate. I already implemented the part where if you start with:

    A == B, A == C, A == D

You get:

    A == B, B == C, C == D

However we need to handle concrete type requirements when collecting these "connected components" as well, so if you start with

    A == B, A == C, A == D, A == Int

You get:

    A == Int, B == Int, D == Int

And not:

    A == B, B == C, C == D, A == Int