### PR TITLE
[Reflection] Fix ReflectionContext::allocationMetadataPointer.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1153,7 +1153,6 @@ public:
     MetadataAllocation<Runtime> Allocation) {
     if (Allocation.Tag == GenericMetadataCacheTag) {
         struct GenericMetadataCacheEntry {
-          StoredPointer Left, Right;
           StoredPointer LockedStorage;
           uint8_t LockedStorageKind;
           uint8_t TrackingInfo;


### PR DESCRIPTION
The definition of GenericMetadataCacheEntry was wrong, causing the function to return garbage.