### PR TITLE
Update maccatalyst 13.0 target minimum to 13.1

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -600,11 +600,11 @@ toolchains::Darwin::addDeploymentTargetArgs(ArgStringList &Arguments,
         micro = 0;
       }
 
-      // Mac Catalyst was introduced with an iOS deployment target of 13.0;
+      // Mac Catalyst was introduced with an iOS deployment target of 13.1;
       // the linker doesn't want to see a deployment target before that.
       if (major < 13) {
         major = 13;
-        minor = 0;
+        minor = 1;
         micro = 0;
       }
     } else {

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -14,7 +14,7 @@
 // RUN: touch %t/lib/swift/clang/lib/darwin/libclang_rt.osx.a %t/lib/swift/clang/lib/darwin/libclang_rt.ios.a %t/lib/swift/clang/lib/darwin/libclang_rt.iossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvos.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchos.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchossim.a
 
 // RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACOS %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios13.0-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACCATALYST %s
+// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios13.1-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACCATALYST %s
 
 // RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
 // RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -17,7 +17,7 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13.1-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 

--- a/test/Driver/macabi-environment.swift
+++ b/test/Driver/macabi-environment.swift
@@ -2,9 +2,9 @@
 
 // UNSUPPORTED: windows
 
-// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.0-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS13-MACABI %s
+// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.1-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS13-MACABI %s
 // IOS13-MACABI: bin/swift
-// IOS13-MACABI: -target x86_64-apple-ios13.0-macabi
+// IOS13-MACABI: -target x86_64-apple-ios13.1-macabi
 
 // IOS13-MACABI: bin/ld
 // IOS13-MACABI-DAG: -L [[MACCATALYST_STDLIB_PATH:[^ ]+/lib/swift/maccatalyst]]
@@ -15,9 +15,9 @@
 // IOS13-MACABI-DAG: -rpath [[MACOSX_STDLIB_PATH]]
 // IOS13-MACABI-DAG: -rpath [[MACCATALYST_SDK_STDLIB_PATH]]
 // IOS13-MACABI-DAG: -rpath [[MACOSX_SDK_STDLIB_PATH]]
-// IOS13-MACABI-DAG: -platform_version mac-catalyst 13.0.0 0.0.0
+// IOS13-MACABI-DAG: -platform_version mac-catalyst 13.1.0 0.0.0
 
-// Adjust iOS versions < 13.0 to 13.0 for the linker's sake.
+// Adjust iOS versions < 13.1 to 13.1 for the linker's sake.
 
 // RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios12.0-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS12-MACABI %s
 // IOS12-MACABI: bin/swift
@@ -32,57 +32,57 @@
 // IOS12-MACABI-DAG: -rpath [[MACOSX_STDLIB_PATH]]
 // IOS12-MACABI-DAG: -rpath [[MACCATALYST_SDK_STDLIB_PATH]]
 // IOS12-MACABI-DAG: -rpath [[MACOSX_SDK_STDLIB_PATH]]
-// IOS12-MACABI-DAG: -platform_version mac-catalyst 13.0.0 0.0.0
+// IOS12-MACABI-DAG: -platform_version mac-catalyst 13.1.0 0.0.0
 
 // RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-ios12.0-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS14-MACABI %s
 // IOS14-MACABI: -platform_version mac-catalyst 14.0.0 0.0.0
 
 // Test using target-variant to build zippered outputs
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -c -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-OBJECT %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -c -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-OBJECT %s
 // ZIPPERED-VARIANT-OBJECT: bin/swift
-// ZIPPERED-VARIANT-OBJECT: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi
+// ZIPPERED-VARIANT-OBJECT: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
 
-// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -emit-library -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -module-name foo %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-LIBRARY %s
+// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -emit-library -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi -module-name foo %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-LIBRARY %s
 // ZIPPERED-VARIANT-LIBRARY: bin/swift
-// ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi
+// ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
 
 // ZIPPERED-VARIANT-LIBRARY: bin/ld
-// ZIPPERED-VARIANT-LIBRARY: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.0.0 0.0.0
+// ZIPPERED-VARIANT-LIBRARY: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.1.0 0.0.0
 
 // Make sure we pass the -target-variant when creating the pre-compiled header.
-// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -enable-bridging-pch -import-objc-header %S/Inputs/bridging-header.h %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-PCH %s
+// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi -enable-bridging-pch -import-objc-header %S/Inputs/bridging-header.h %s | %FileCheck -check-prefix=ZIPPERED-VARIANT-PCH %s
 // ZIPPERED-VARIANT-PCH: bin/swift
-// ZIPPERED-VARIANT-PCH: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi
+// ZIPPERED-VARIANT-PCH: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
 // ZIPPERED_VARIANT-PCH  -emit-pch
 // ZIPPERED-VARIANT-PCH: bin/swift
-// ZIPPERED-VARIANT-PCH: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi
+// ZIPPERED-VARIANT-PCH: -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi
 // ZIPPERED-VARIANT-PCH: bin/ld
-// ZIPPERED-VARIANT-PCH: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.0.0 0.0.0
+// ZIPPERED-VARIANT-PCH: -platform_version macos 10.14.0 0.0.0 -platform_version mac-catalyst 13.1.0 0.0.0
 
 // Test using 'reverse' target-variant to build zippered outputs when the primary
 // target is ios-macabi
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -c -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14 %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-OBJECT %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -c -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14 %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-OBJECT %s
 // REVERSE-ZIPPERED-VARIANT-OBJECT: bin/swift
-// REVERSE-ZIPPERED-VARIANT-OBJECT: -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14
+// REVERSE-ZIPPERED-VARIANT-OBJECT: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
 
-// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -emit-library -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14 -module-name foo %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-LIBRARY %s
+// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -emit-library -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14 -module-name foo %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-LIBRARY %s
 // REVERSE-ZIPPERED-VARIANT-LIBRARY: bin/swift
-// REVERSE-ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14
+// REVERSE-ZIPPERED-VARIANT-LIBRARY: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
 
 // REVERSE-ZIPPERED-VARIANT-LIBRARY: bin/ld
-// REVERSE-ZIPPERED-VARIANT-LIBRARY: -platform_version mac-catalyst 13.0.0 0.0.0 -platform_version macos 10.14.0
+// REVERSE-ZIPPERED-VARIANT-LIBRARY: -platform_version mac-catalyst 13.1.0 0.0.0 -platform_version macos 10.14.0
 
 // Make sure we pass the -target-variant when creating the pre-compiled header.
-// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14 -enable-bridging-pch -import-objc-header %S/Inputs/bridging-header.h %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-PCH %s
+// RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14 -enable-bridging-pch -import-objc-header %S/Inputs/bridging-header.h %s | %FileCheck -check-prefix=REVERSE-ZIPPERED-VARIANT-PCH %s
 // REVERSE-ZIPPERED-VARIANT-PCH: bin/swift
-// REVERSE-ZIPPERED-VARIANT-PCH: -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14
+// REVERSE-ZIPPERED-VARIANT-PCH: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
 // REVERSE-ZIPPERED_VARIANT-PCH  -emit-pch
 // REVERSE-ZIPPERED-VARIANT-PCH: bin/swift
-// REVERSE-ZIPPERED-VARIANT-PCH: -target x86_64-apple-ios13.0-macabi -target-variant x86_64-apple-macosx10.14
+// REVERSE-ZIPPERED-VARIANT-PCH: -target x86_64-apple-ios13.1-macabi -target-variant x86_64-apple-macosx10.14
 // REVERSE-ZIPPERED-VARIANT-PCH: bin/ld
-// REVERSE-ZIPPERED-VARIANT-PCH: -platform_version mac-catalyst 13.0.0 0.0.0 -platform_version macos 10.14.0 0.0.0
+// REVERSE-ZIPPERED-VARIANT-PCH: -platform_version mac-catalyst 13.1.0 0.0.0 -platform_version macos 10.14.0 0.0.0
 
 // RUN: not %swiftc_driver -sdk "" -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0 %s 2>&1 | %FileCheck --check-prefix=UNSUPPORTED-TARGET-VARIANT %s
 // RUN: not %swiftc_driver -sdk "" -target x86_64-apple-ios13.0 -target-variant x86_64-apple-macosx10.14 %s 2>&1 | %FileCheck --check-prefix=UNSUPPORTED-TARGET %s
@@ -104,21 +104,21 @@
 // Check reading the SDKSettings.json from an SDK and using it to map Catalyst
 // SDK version information.
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_ZIPPERED %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi -sdk %S/Inputs/MacOSX10.15.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_ZIPPERED %s
 // MACOS_10_15_ZIPPERED: -target-sdk-version 10.15
 // MACOS_10_15_ZIPPERED: -target-variant-sdk-version 13.1
 // MACOS_10_15_ZIPPERED: -platform_version macos 10.14.0 10.15.0
-// MACOS_10_15_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.1.0
+// MACOS_10_15_ZIPPERED: -platform_version mac-catalyst 13.1.0 13.1.0
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_ZIPPERED %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.14 -target-variant x86_64-apple-ios13.1-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_ZIPPERED %s
 // MACOS_10_15_4_ZIPPERED: -target-sdk-version 10.15.4
 // MACOS_10_15_4_ZIPPERED: -target-variant-sdk-version 13.4
 // MACOS_10_15_4_ZIPPERED: -platform_version macos 10.14.0 10.15.4
-// MACOS_10_15_4_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.4.0
+// MACOS_10_15_4_ZIPPERED: -platform_version mac-catalyst 13.1.0 13.4.0
 
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target-variant x86_64-apple-macosx10.14 -target x86_64-apple-ios13.0-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_REVERSE_ZIPPERED %s
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target-variant x86_64-apple-macosx10.14 -target x86_64-apple-ios13.1-macabi -sdk %S/Inputs/MacOSX10.15.4.versioned.sdk %s 2>&1 | %FileCheck -check-prefix MACOS_10_15_4_REVERSE_ZIPPERED %s
 // MACOS_10_15_4_REVERSE_ZIPPERED: -target-sdk-version 13.4
 // MACOS_10_15_4_REVERSE_ZIPPERED: -target-variant-sdk-version 10.15.4
-// MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version mac-catalyst 13.0.0 13.4.0
+// MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version mac-catalyst 13.1.0 13.4.0
 // MACOS_10_15_4_REVERSE_ZIPPERED: -platform_version macos 10.14.0 10.15.4
 

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -8,8 +8,8 @@
 // RUN: %swift_driver -print-target-info -target x86_64-unknown-linux -static-stdlib | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 // RUN: %swift_frontend_plain -print-target-info -target x86_64-unknown-linux -use-static-resource-dir | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 
-// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
-// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
+// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
+// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13.1-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
 // RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
@@ -79,7 +79,7 @@
 // CHECK-PRE-CONCURRENCY-ZIPPERED: }
 
 // CHECK-PRE-CONCURRENCY-ZIPPERED: "targetVariant": {
-// CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-ios13-macabi"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-ios13.1-macabi"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
 // CHECK-PRE-CONCURRENCY-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"

--- a/test/IRGen/macosx-variant-sdk-version.swift
+++ b/test/IRGen/macosx-variant-sdk-version.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.14 -target-sdk-version 10.15.4 -target-variant %target-cpu-apple-ios13.0-macabi -target-variant-sdk-version 13.4 -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.14 -target-sdk-version 10.15.4 -target-variant %target-cpu-apple-ios13.1-macabi -target-variant-sdk-version 13.4 -emit-ir | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/TBD/app-extension.swift
+++ b/test/TBD/app-extension.swift
@@ -9,7 +9,7 @@
 // EXTENSIONSAFE-NOT: not_app_extension_safe
 // NOTEXTENSIONSAFE: not_app_extension_safe
 
-// RUN: %target-swift-frontend -target-variant %target-cpu-apple-ios13.0-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd
+// RUN: %target-swift-frontend -target-variant %target-cpu-apple-ios13.1-macabi -typecheck %s -application-extension -emit-tbd -emit-tbd-path %t/target-variant.tbd
 // RUN: %FileCheck %s --check-prefix MACABI < %t/target-variant.tbd
 
 // MACABI: targets: [ {{.*}}macos{{.*}}maccatalyst{{.*}} ]

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -9,7 +9,7 @@
 // RUN: %FileCheck %s < %t/linker_directives.tbd
 // RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
 
-// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.0-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
+// RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json
 // RUN: %FileCheck -check-prefix=CHECK-ZIPPERED %s < %t/linker_directives.tbd
 // RUN: %FileCheck -check-prefix=CHECK-NO-NEW-SYMBOL %s < %t/linker_directives.tbd
 

--- a/test/cmake/modules/SwiftTestUtils.cmake
+++ b/test/cmake/modules/SwiftTestUtils.cmake
@@ -28,7 +28,7 @@ endfunction()
 function(get_swift_test_versioned_target_triple variant_triple_out_var sdk arch build_flavor)
   if(build_flavor STREQUAL "ios-like")
     # Use the macCatalyst target triple and compiler resources for the iOS-like build flavor.
-    set(variant_triple "${arch}-apple-ios13.0-macabi")
+    set(variant_triple "${arch}-apple-ios13.1-macabi")
   else()
     get_versioned_target_triple(variant_triple ${sdk} ${arch} "${SWIFT_SDK_${sdk}_DEPLOYMENT_VERSION}")
   endif()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -719,7 +719,7 @@ if 'asan' in config.available_features:
 
 if run_vendor == 'apple':
     if run_os == 'maccatalyst':
-        config.stable_abi_triple = '%s-%s-ios13.0-macabi' % (run_cpu, run_vendor)
+        config.stable_abi_triple = '%s-%s-ios13.1-macabi' % (run_cpu, run_vendor)
         config.pre_stable_abi_triple = config.stable_abi_triple
         config.next_stable_abi_triple = config.stable_abi_triple
         config.available_features.add('swift_stable_abi')

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -103,7 +103,7 @@ class DumpConfig:
             'macosx': 'x86_64-apple-macosx10.15',
             'appletvos': 'arm64-apple-tvos13.0',
             'watchos': 'armv7k-apple-watchos6.0',
-            'iosmac': 'x86_64-apple-ios13.0-macabi',
+            'iosmac': 'x86_64-apple-ios13.1-macabi',
         }
         self.tool_path = get_api_digester_path(tool_path)
         self.platform = platform


### PR DESCRIPTION
Clang enforces a minimum 13.1 deployment target. The driver, API
checker, and various tests assume 13.0 is a valid minimum. Update these
to reflect the actual 13.1 minimum.

Resolves rdar://84177900