### PR TITLE
[LoopRotate] Use ownership for backedge block.

### DIFF
--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -127,8 +127,8 @@ static SILBasicBlock *insertBackedgeBlock(SILLoop *L, DominanceInfo *DT,
   // the backedge block which correspond to any PHI nodes in the header block.
   SmallVector<SILValue, 6> BBArgs;
   for (auto *BBArg : Header->getArguments()) {
-    BBArgs.push_back(
-        BEBlock->createPhiArgument(BBArg->getType(), OwnershipKind::Owned));
+    BBArgs.push_back(BEBlock->createPhiArgument(BBArg->getType(),
+                                                BBArg->getOwnershipKind()));
   }
 
   // Arbitrarily pick one of the predecessor's branch locations.

--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -169,3 +169,29 @@ bb3:
   return %res : $()
 }
 
+// CHECK-LABEL: sil [ossa] @guaranteed_phi_argument : $@convention(thin) (@owned Klass) -> () {
+// CHECK:         {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $Klass):
+// CHECK-LABEL: } // end sil function 'guaranteed_phi_argument'
+sil [ossa] @guaranteed_phi_argument : $@convention(thin) (@owned Klass) -> () {
+entry(%instance : @owned $Klass):
+  %lifetime_1 = begin_borrow [lexical] %instance : $Klass
+  br loop_header(%lifetime_1 : $Klass)
+
+loop_header(%lifetime_2 : @guaranteed $Klass):
+  cond_br undef, loop_back_1, loop_back_2_or_exit
+
+loop_back_1:
+  br loop_header(%lifetime_2 : $Klass)
+
+loop_back_2_or_exit:
+  cond_br undef, loop_back_2, exit
+
+loop_back_2:
+  br loop_header(%lifetime_2 : $Klass)
+
+exit:
+  end_borrow %lifetime_2 : $Klass
+  destroy_value %instance : $Klass
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Previously, all phi arguments added to the backedge block were given @owned ownership.  That was not correct for arguments that needed to have @guaranteed ownership.  Here, that is corrected by using the ownership of the original argument from the header block when adding the phi argument to the backedge block.
