### PR TITLE
[stdlib] don't copy array contents on `removeAll(keepingCapacity: true)`

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1353,10 +1353,9 @@ extension Array: RangeReplaceableCollection {
     }
     else {
       let buffer = _ContiguousArrayBuffer<Element>(
-        _uninitializedCount: capacity,
-        minimumCapacity: 0
+        _uninitializedCount: 0,
+        minimumCapacity: capacity
       )
-      buffer.count = 0
       _buffer = _Buffer(_buffer: buffer, shiftedToStartIndex: startIndex)
     }
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1348,8 +1348,16 @@ extension Array: RangeReplaceableCollection {
     if !keepCapacity {
       _buffer = _Buffer()
     }
-    else {
+    else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
+    }
+    else {
+      let buffer = _ContiguousArrayBuffer<Element>(
+        _uninitializedCount: capacity,
+        minimumCapacity: 0
+      )
+      buffer.count = 0
+      _buffer = _Buffer(_buffer: buffer, shiftedToStartIndex: startIndex)
     }
   }
 

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -16,8 +16,9 @@
 /// is semantically associated with an array access, a value of this type
 /// is returned and later passed to the accessing function.
 /// For example, a typical call to `_getElement` looks like
-///   let token = _checkSubscript(index, ...)
-///   return _getElement(index, ... , matchingSubscriptCheck: token)
+///
+///     let token = _checkSubscript(index, ...)
+///     return _getElement(index, ... , matchingSubscriptCheck: token)
 @frozen
 public struct _DependenceToken {
   @inlinable

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -12,9 +12,10 @@
 /// This type is used as a result of the `_checkSubscript` call to associate the
 /// call with the array access call it guards.
 ///
-/// In order for the optimizer see that a call to `_checkSubscript` is semantically
-/// associated with an array access, a value of this type is returned and later passed
-/// to the accessing function.  For example, a typical call to `_getElement` looks like
+/// In order for the optimizer see that a call to `_checkSubscript`
+/// is semantically associated with an array access, a value of this type
+/// is returned and later passed to the accessing function.
+/// For example, a typical call to `_getElement` looks like
 ///   let token = _checkSubscript(index, ...)
 ///   return _getElement(index, ... , matchingSubscriptCheck: token)
 @frozen

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -195,11 +195,7 @@ extension ArraySlice {
   func _checkSubscript(
     _ index: Int, wasNativeTypeChecked: Bool
   ) -> _DependenceToken {
-#if _runtime(_ObjC)
     _buffer._checkValidSubscript(index)
-#else
-    _buffer._checkValidSubscript(index)
-#endif
     return _DependenceToken()
   }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1072,10 +1072,9 @@ extension ArraySlice: RangeReplaceableCollection {
     }
     else {
       let buffer = _ContiguousArrayBuffer<Element>(
-        _uninitializedCount: capacity,
-        minimumCapacity: 0
+        _uninitializedCount: 0,
+        minimumCapacity: capacity
       )
-      buffer.count = 0
       _buffer = _Buffer(_buffer: buffer, shiftedToStartIndex: startIndex)
     }
   }

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1067,8 +1067,16 @@ extension ArraySlice: RangeReplaceableCollection {
     if !keepCapacity {
       _buffer = _Buffer()
     }
-    else {
+    else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
+    }
+    else {
+      let buffer = _ContiguousArrayBuffer<Element>(
+        _uninitializedCount: capacity,
+        minimumCapacity: 0
+      )
+      buffer.count = 0
+      _buffer = _Buffer(_buffer: buffer, shiftedToStartIndex: startIndex)
     }
   }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -976,8 +976,7 @@ extension ContiguousArray: RangeReplaceableCollection {
       self.replaceSubrange(indices, with: EmptyCollection())
     }
     else {
-      _buffer = _Buffer(_uninitializedCount: capacity, minimumCapacity: 0)
-      _buffer.count = 0
+      _buffer = _Buffer(_uninitializedCount: 0, minimumCapacity: capacity)
     }
   }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -972,8 +972,12 @@ extension ContiguousArray: RangeReplaceableCollection {
     if !keepCapacity {
       _buffer = _Buffer()
     }
-    else {
+    else if _buffer.isMutableAndUniquelyReferenced() {
       self.replaceSubrange(indices, with: EmptyCollection())
+    }
+    else {
+      _buffer = _Buffer(_uninitializedCount: capacity, minimumCapacity: 0)
+      _buffer.count = 0
     }
   }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
When calling `Array.removeAll(keepingCapacity: true)`, bypass the `replaceSubrange` call unless the buffer is uniquely referenced.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13923 (rdar://71809690).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
