### PR TITLE
Fix Escape Analysis for OSSA's pattern of array.uninitialized

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -1059,8 +1059,8 @@ private:
   // returns an instantiated array struct and unsafe pointer to the elements.
   struct ArrayUninitCall {
     SILValue arrayStorageRef;
-    TupleExtractInst *arrayStruct = nullptr;
-    TupleExtractInst *arrayElementPtr = nullptr;
+    SILValue arrayStruct = nullptr;
+    SILValue arrayElementPtr = nullptr;
 
     bool isValid() const {
       return arrayStorageRef && arrayStruct && arrayElementPtr;
@@ -1072,9 +1072,9 @@ private:
   ArrayUninitCall
   canOptimizeArrayUninitializedCall(ApplyInst *ai);
 
-  /// Return true of this tuple_extract is the result of an optimizable
+  /// Return true of this tuple_extract/destructure_tuple is the result of an optimizable
   /// @_semantics("array.uninitialized") call.
-  bool canOptimizeArrayUninitializedResult(TupleExtractInst *tei);
+  bool canOptimizeArrayUninitializedResult(SILInstruction *tei);
 
   /// Handle a call to "@_semantics(array.uninitialized") precisely by mapping
   /// each call result to a separate graph node and relating them to the

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1331,7 +1331,7 @@ bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
   return %r : $()
 }
 
-// CHECK-LABEL: CG of arraysemantics_createUninitialized
+// CHECK-LABEL: CG of arraysemantics_createUninitialized1
 // CHECK-NEXT:    Arg [ref] %0 Esc: A, Succ: 
 // CHECK-NEXT:    Val [ref] %2 Esc: , Succ: (%6)
 // CHECK-NEXT:    Val [ref] %5 Esc: , Succ: %2
@@ -1339,7 +1339,7 @@ bb(%0 : $*Array<X>, %1 : $@callee_owned (@inout X) -> (@out (), @error Error)):
 // CHECK-NEXT:    Con %6.1 Esc: R, Succ: %0
 // CHECK-NEXT:    Ret [ref] return Esc: , Succ: %5
 // CHECK-NEXT:  End
-sil @arraysemantics_createUninitialized : $@convention(thin) (@owned X) -> @owned Array<X> {
+sil @arraysemantics_createUninitialized1 : $@convention(thin) (@owned X) -> @owned Array<X> {
 bb0(%0 : $X):
   %1 = function_ref @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
   %2 = apply %1() : $@convention(thin) () -> @owned AnyObject
@@ -1350,6 +1350,27 @@ bb0(%0 : $X):
   %7 = struct_extract %6 : $UnsafeMutablePointer<X>, #UnsafeMutablePointer._rawValue
   %8 = pointer_to_address %7 : $Builtin.RawPointer to $*X
   store %0 to %8 : $*X
+  return %5 : $Array<X>
+}
+
+// CHECK-LABEL: CG of arraysemantics_createUninitialized2
+// CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ: 
+// CHECK-NEXT:   Val [ref] %2 Esc: , Succ: (%6)
+// CHECK-NEXT:   Val [ref] %5 Esc: , Succ: %2
+// CHECK-NEXT:   Con [int] %6 Esc: R, Succ: (%6.1)
+// CHECK-NEXT:   Con %6.1 Esc: R, Succ: %0
+// CHECK-NEXT:   Ret [ref] return Esc: , Succ: %5
+// CHECK-NEXT: End
+sil [ossa] @arraysemantics_createUninitialized2 : $@convention(thin) (@owned X) -> @owned Array<X> {
+bb0(%0 : @owned $X):
+  %1 = function_ref @swift_bufferAllocate : $@convention(thin) () -> @owned AnyObject
+  %2 = apply %1() : $@convention(thin) () -> @owned AnyObject
+  %3 = function_ref @createUninitialized : $@convention(method) (@owned AnyObject) -> (@owned Array<X>, UnsafeMutablePointer<X>)
+  %4 = apply %3(%2) : $@convention(method) (@owned AnyObject) -> (@owned Array<X>, UnsafeMutablePointer<X>)
+  (%5, %6) = destructure_tuple %4 : $(Array<X>, UnsafeMutablePointer<X>)
+  %7 = struct_extract %6 : $UnsafeMutablePointer<X>, #UnsafeMutablePointer._rawValue
+  %8 = pointer_to_address %7 : $Builtin.RawPointer to $*X
+  store %0 to [init] %8 : $*X
   return %5 : $Array<X>
 }
 


### PR DESCRIPTION
This will improve CGNode::escapes for array.uninitialized semantic calls in OSSA.