### PR TITLE
🍒 5.5 [Codable] Improve Codable synthesis failure diagnosis for empty enums

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2921,6 +2921,9 @@ ERROR(broken_encodable_requirement,none,
       "Encodable protocol is broken: unexpected requirement", ())
 ERROR(broken_decodable_requirement,none,
       "Decodable protocol is broken: unexpected requirement", ())
+ERROR(codable_synthesis_empty_enum_not_supported,none,
+      "cannot automatically synthesize %0 conformance for empty enum %1",
+      (Type, Identifier))
 ERROR(broken_differentiable_requirement,none,
       "Differentiable protocol is broken: unexpected requirement", ())
 WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -544,7 +544,7 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
     return true;
   }
 
-  // A non-final class can't have an protocol-witnesss initializer in an
+  // A non-final class can't have a protocol-witnesses initializer in an
   // extension.
   if (auto CD = dyn_cast<ClassDecl>(Nominal)) {
     if (!CD->isSemanticallyFinal() && isa<ConstructorDecl>(synthesizing) &&
@@ -553,6 +553,16 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
           diag::cannot_synthesize_init_in_extension_of_nonfinal,
           getProtocolType(), synthesizing->getName());
       return true;
+    }
+  }
+
+  if (auto ED = dyn_cast<EnumDecl>(Nominal)) {
+    if (ED->getAllCases().empty() &&
+        (Protocol->isSpecificProtocol(KnownProtocolKind::Encodable) ||
+         Protocol->isSpecificProtocol(KnownProtocolKind::Decodable))) {
+      ED->diagnose(diag::codable_synthesis_empty_enum_not_supported,
+                   getProtocolType(), Nominal->getBaseIdentifier());
+      return false;
     }
   }
 

--- a/test/decl/protocol/special/coding/enum_codable_invalid_codingkeys.swift
+++ b/test/decl/protocol/special/coding/enum_codable_invalid_codingkeys.swift
@@ -3,7 +3,9 @@
 // Enums with a CodingKeys entity which is not a type should not derive
 // conformance.
 enum InvalidCodingKeys1 : Codable { // expected-error {{type 'InvalidCodingKeys1' does not conform to protocol 'Decodable'}}
-// expected-error@-1 {{type 'InvalidCodingKeys1' does not conform to protocol 'Encodable'}}
+  // expected-error@-1 {{type 'InvalidCodingKeys1' does not conform to protocol 'Encodable'}}
+  // expected-error@-2 {{cannot automatically synthesize 'Encodable' conformance for empty enum 'InvalidCodingKeys1'}}
+  // expected-error@-3 {{cannot automatically synthesize 'Decodable' conformance for empty enum 'InvalidCodingKeys1'}}
   static let CodingKeys = 5 // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
 }
@@ -12,6 +14,8 @@ enum InvalidCodingKeys1 : Codable { // expected-error {{type 'InvalidCodingKeys1
 // not derive conformance.
 enum InvalidCodingKeys2 : Codable { // expected-error {{type 'InvalidCodingKeys2' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'InvalidCodingKeys2' does not conform to protocol 'Encodable'}}
+  // expected-error@-2 {{cannot automatically synthesize 'Encodable' conformance for empty enum 'InvalidCodingKeys2'}}
+  // expected-error@-3 {{cannot automatically synthesize 'Decodable' conformance for empty enum 'InvalidCodingKeys2'}}
   enum CodingKeys {} // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
 }
@@ -20,6 +24,8 @@ enum InvalidCodingKeys2 : Codable { // expected-error {{type 'InvalidCodingKeys2
 // conformance.
 enum InvalidCodingKeys3 : Codable { // expected-error {{type 'InvalidCodingKeys3' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'InvalidCodingKeys3' does not conform to protocol 'Encodable'}}
+  // expected-error@-2 {{cannot automatically synthesize 'Decodable' conformance for empty enum 'InvalidCodingKeys3'}}
+  // expected-error@-3 {{cannot automatically synthesize 'Encodable' conformance for empty enum 'InvalidCodingKeys3'}}
   struct CodingKeys : CodingKey { // expected-note {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
     // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
       var stringValue: String

--- a/test/decl/protocol/special/coding/enum_codable_simple.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple.swift
@@ -42,3 +42,10 @@ let _ = SimpleEnum.CodingKeys.self // expected-error {{'CodingKeys' is inaccessi
 let _ = SimpleEnum.ACodingKeys.self // expected-error {{'ACodingKeys' is inaccessible due to 'private' protection level}}
 let _ = SimpleEnum.BCodingKeys.self // expected-error {{'BCodingKeys' is inaccessible due to 'private' protection level}}
 let _ = SimpleEnum.CCodingKeys.self // expected-error {{'CCodingKeys' is inaccessible due to 'private' protection level}}
+
+// Empty enum must be diagnosed early, rather than leave the failure to DI.
+enum EmptyCodableEnum1: Encodable {} // expected-error{{cannot automatically synthesize 'Encodable' conformance for empty enum 'EmptyCodableEnum1'}}
+enum EmptyCodableEnum2: Decodable {} // expected-error{{cannot automatically synthesize 'Decodable' conformance for empty enum 'EmptyCodableEnum2'}}
+enum EmptyCodableEnum: Codable {}
+// expected-error@-1{{cannot automatically synthesize 'Encodable' conformance for empty enum 'EmptyCodableEnum'}}
+// expected-error@-2{{cannot automatically synthesize 'Decodable' conformance for empty enum 'EmptyCodableEnum'}}


### PR DESCRIPTION
**Description:** Codable synthesis fails for empty enums -- there must be at least one case for synthesis to make sense. Currently, we don't diagnose this limitation and instead failure happens in DefiniteInitialization where it is _very_ ugly and has zero information about which type is even causing the issue: `<unknown>:0: error: 'self.init' isn't called on all paths before returning from initializer`. This change diagnoses the limitation earlier, during type-checking so it is nice and actionable: `cannot automatically synthesize 'Decodable' conformance for empty enum 'EmptyCodableEnum2'` (diagnosed on the specific line number etc of course).
**Risk:** Low
**Review by:** @drexin 
**Testing:** CI validation
**Original PR:** https://github.com/apple/swift/pull/39795
**Radar:** rdar://84339790