### PR TITLE
Use the proper install name for back-deployed concurrency on macCatalyst

### DIFF
--- a/stdlib/public/Concurrency/linker-support/magic-symbols-for-install-name.c
+++ b/stdlib/public/Concurrency/linker-support/magic-symbols-for-install-name.c
@@ -124,6 +124,12 @@
   RPATH_INSTALL_NAME_DIRECTIVE(11,  4)
   RPATH_INSTALL_NAME_DIRECTIVE(11,  5)
   RPATH_INSTALL_NAME_DIRECTIVE(11,  6)
+
+ // Link against @rpath/libswift_Concurrency.dylib for macCatalyst < 15.0.
+SWIFT_RUNTIME_EXPORT const char ld_previous_macCatalyst
+__asm("$ld$previous$@rpath/libswift_Concurrency.dylib$$6$1.0$15.0$");
+
+const char ld_previous_macCatalyst = 0;
 #else
   #error Unknown target.
 #endif

--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -7,8 +7,8 @@
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s
 // RUN: otool -L %t/linking_rpath_old | %FileCheck -check-prefix CHECK-RPATH %s
 
-// RUN: %target-build-swift -target x86_64-apple-ios15.0-macabi %s -o %t/linking_direct
-// RUN: %target-build-swift -target x86_64-apple-ios14.0-macabi %s -o %t/linking_rpath
+// RUN: %target-build-swift -disable-autolinking-runtime-compatibility-concurrency -target x86_64-apple-ios15.0-macabi %s -o %t/linking_direct
+// RUN: %target-build-swift -disable-autolinking-runtime-compatibility-concurrency -target x86_64-apple-ios14.0-macabi %s -o %t/linking_rpath
 
 // RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s

--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -7,6 +7,12 @@
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s
 // RUN: otool -L %t/linking_rpath_old | %FileCheck -check-prefix CHECK-RPATH %s
 
+// RUN: %target-build-swift -target x86_64-apple-ios15.0-macabi %s -o %t/linking_direct
+// RUN: %target-build-swift -target x86_64-apple-ios14.0-macabi %s -o %t/linking_rpath
+
+// RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
+// RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s
+
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
 


### PR DESCRIPTION
**Description:** The macOS build of the `_Concurrency` library contained the `$ld$install_name` symbols to rewrite the install name for back-deployment of macOS, but did not include the appropriate symbols for back-deployment of macCatalyst apps. Introduce an `$ld$previous` symbol to do this for macCatalyst as an additive change, fixing back-deployment for macCatalyst in a manner that does not alter macOS.
**Risk:** Low
**Testing:** PR testing, app testing in back-deployed scenarios.
**Original PR:** https://github.com/apple/swift/pull/39806
**Radar:** rdar://84393581.
