### PR TITLE
Don't emit marker protocols into runtime type metadata.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -297,8 +297,7 @@ public:
   getClangDeclForMangling(const ValueDecl *decl);
 
   void appendExistentialLayout(
-      const ExistentialLayout &layout, GenericSignature sig,
-      const ValueDecl *forDecl);
+      const ExistentialLayout &layout, const ValueDecl *forDecl);
 
 protected:
 

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -61,6 +61,9 @@ protected:
   /// concurrency library.
   bool AllowConcurrencyStandardSubstitutions = true;
 
+  /// If enabled, marker protocols can be encoded in the mangled name.
+  bool AllowMarkerProtocols = true;
+
 public:
   using SymbolicReferent = llvm::PointerUnion<const NominalTypeDecl *,
                                               const OpaqueTypeDecl *>;
@@ -292,6 +295,10 @@ public:
 
   static const clang::NamedDecl *
   getClangDeclForMangling(const ValueDecl *decl);
+
+  void appendExistentialLayout(
+      const ExistentialLayout &layout, GenericSignature sig,
+      const ValueDecl *forDecl);
 
 protected:
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5827,6 +5827,9 @@ ERROR(marker_protocol_requirement, none,
 ERROR(marker_protocol_inherit_nonmarker, none,
       "marker protocol %0 cannot inherit non-marker protocol %1",
       (DeclName, DeclName))
+ERROR(marker_protocol_inherit_class, none,
+      "marker protocol %0 cannot inherit class %1",
+      (DeclName, Type))
 ERROR(marker_protocol_cast,none,
       "marker protocol %0 cannot be used in a conditional cast", (DeclName))
 ERROR(marker_protocol_conditional_conformance,none,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1015,8 +1015,7 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
 }
 
 void ASTMangler::appendExistentialLayout(
-    const ExistentialLayout &layout, GenericSignature sig,
-    const ValueDecl *forDecl) {
+    const ExistentialLayout &layout, const ValueDecl *forDecl) {
   bool First = true;
   bool DroppedRequiresClass = false;
   bool SawRequiresClass = false;
@@ -1040,7 +1039,7 @@ void ASTMangler::appendExistentialLayout(
     appendOperator("y");
 
   if (auto superclass = layout.explicitSuperclass) {
-    appendType(superclass, sig, forDecl);
+    appendType(superclass, forDecl);
     return appendOperator("Xc");
   } else if (layout.hasExplicitAnyObject ||
              (DroppedRequiresClass && !SawRequiresClass)) {
@@ -1219,14 +1218,14 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
 
     case TypeKind::Protocol: {
       return appendExistentialLayout(
-          ExistentialLayout(cast<ProtocolType>(tybase)), sig, forDecl);
+          ExistentialLayout(cast<ProtocolType>(tybase)), forDecl);
     }
 
     case TypeKind::ProtocolComposition: {
       // We mangle ProtocolType and ProtocolCompositionType using the
       // same production:
       auto layout = type->getExistentialLayout();
-      return appendExistentialLayout(layout, sig, forDecl);
+      return appendExistentialLayout(layout, forDecl);
     }
 
     case TypeKind::UnboundGeneric:

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1014,6 +1014,41 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
   }
 }
 
+void ASTMangler::appendExistentialLayout(
+    const ExistentialLayout &layout, GenericSignature sig,
+    const ValueDecl *forDecl) {
+  bool First = true;
+  bool DroppedRequiresClass = false;
+  bool SawRequiresClass = false;
+  for (Type protoTy : layout.getProtocols()) {
+    auto proto = protoTy->castTo<ProtocolType>()->getDecl();
+    // If we aren't allowed to emit marker protocols, suppress them here.
+    if (!AllowMarkerProtocols && proto->isMarkerProtocol()) {
+      if (proto->requiresClass())
+        DroppedRequiresClass = true;
+
+      continue;
+    }
+
+    if (proto->requiresClass())
+      SawRequiresClass = true;
+
+    appendProtocolName(protoTy->castTo<ProtocolType>()->getDecl());
+    appendListSeparator(First);
+  }
+  if (First)
+    appendOperator("y");
+
+  if (auto superclass = layout.explicitSuperclass) {
+    appendType(superclass, sig, forDecl);
+    return appendOperator("Xc");
+  } else if (layout.hasExplicitAnyObject ||
+             (DroppedRequiresClass && !SawRequiresClass)) {
+    return appendOperator("Xl");
+  }
+  return appendOperator("p");
+}
+
 /// Mangle a type into the buffer.
 ///
 void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
@@ -1183,31 +1218,15 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       return appendOperator("t");
 
     case TypeKind::Protocol: {
-      bool First = true;
-      appendProtocolName(cast<ProtocolType>(tybase)->getDecl());
-      appendListSeparator(First);
-      return appendOperator("p");
+      return appendExistentialLayout(
+          ExistentialLayout(cast<ProtocolType>(tybase)), sig, forDecl);
     }
 
     case TypeKind::ProtocolComposition: {
       // We mangle ProtocolType and ProtocolCompositionType using the
       // same production:
-      bool First = true;
       auto layout = type->getExistentialLayout();
-      for (Type protoTy : layout.getProtocols()) {
-        appendProtocolName(protoTy->castTo<ProtocolType>()->getDecl());
-        appendListSeparator(First);
-      }
-      if (First)
-        appendOperator("y");
-
-      if (auto superclass = layout.explicitSuperclass) {
-        appendType(superclass, forDecl);
-        return appendOperator("Xc");
-      } else if (layout.hasExplicitAnyObject) {
-        return appendOperator("Xl");
-      }
-      return appendOperator("p");
+      return appendExistentialLayout(layout, sig, forDecl);
     }
 
     case TypeKind::UnboundGeneric:
@@ -2190,6 +2209,8 @@ void ASTMangler::appendModule(const ModuleDecl *module,
 /// Mangle the name of a protocol as a substitution candidate.
 void ASTMangler::appendProtocolName(const ProtocolDecl *protocol,
                                     bool allowStandardSubstitution) {
+  assert(AllowMarkerProtocols || !protocol->isMarkerProtocol());
+
   if (allowStandardSubstitution && tryAppendStandardSubstitution(protocol))
     return;
 
@@ -2338,6 +2359,8 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
       appendOperator("a");
       break;
     case DeclKind::Protocol:
+      assert(AllowMarkerProtocols ||
+             !cast<ProtocolDecl>(decl)->isMarkerProtocol());
       appendOperator("P");
       break;
     case DeclKind::Class:
@@ -2651,6 +2674,11 @@ void ASTMangler::appendRequirement(const Requirement &reqt) {
   case RequirementKind::Layout: {
   } break;
   case RequirementKind::Conformance: {
+    // If we don't allow marker protocols but we have one here, skip it.
+    if (!AllowMarkerProtocols &&
+        reqt.getProtocolDecl()->isMarkerProtocol())
+      return;
+
     appendProtocolName(reqt.getProtocolDecl());
   } break;
   case RequirementKind::Superclass:
@@ -3181,6 +3209,12 @@ void ASTMangler::appendAnyProtocolConformance(
                                            CanGenericSignature genericSig,
                                            CanType conformingType,
                                            ProtocolConformanceRef conformance) {
+  // If we have a conformance to a marker protocol but we aren't allowed to
+  // emit marker protocols, skip it.
+  if (!AllowMarkerProtocols &&
+      conformance.getRequirement()->isMarkerProtocol())
+    return;
+
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
     auto path = genericSig->getConformanceAccessPath(conformingType,

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -159,6 +159,8 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
       AllowConcurrencyStandardSubstitutions = false;
   }
 
+  llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(
+      AllowMarkerProtocols, false);
   return withSymbolicReferences(IGM, [&]{
     bindGenericParameters(Sig);
     appendType(Ty);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5588,6 +5588,12 @@ void AttributeChecker::visitMarkerAttr(MarkerAttr *attr) {
     }
   }
 
+  if (Type superclass = proto->getSuperclass()) {
+    proto->diagnose(
+        diag::marker_protocol_inherit_class,
+        proto->getName(), superclass);
+  }
+
   // A marker protocol cannot have any requirements.
   for (auto member : proto->getAllMembers()) {
     auto value = dyn_cast<ValueDecl>(member);

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -13,7 +13,11 @@
 extension Int: P { }
 extension Array: P where Element: P { }
 
-// CHECK: @"$s15marker_protocol1QMp" = {{(dllexport |protected )?}}constant
+// No mention of the marker protocol for runtime type instantiation.
+// CHECK-LABEL: @"$sSS_15marker_protocol1P_ptMD" =
+// CHECK-SAME: @"symbolic SS_ypt"
+
+// CHECK-LABEL: @"$s15marker_protocol1QMp" = {{(dllexport |protected )?}}constant
 // CHECK-SAME: i32 trunc{{.*}}s15marker_protocolMXM{{.*}}s15marker_protocol1QMp
 // CHECK-SAME: i32 0, i32 5, i32 0
 public protocol Q: P {
@@ -22,6 +26,31 @@ public protocol Q: P {
   func h()
   func i()
   func j()
+}
+
+protocol R { }
+
+@_marker protocol S: AnyObject { }
+
+// Note: no mention of marker protocols here.
+// CHECK-LABEL: @"$s15marker_protocol10HasMarkersVMF" =
+// CHECK-SAME: @"symbolic yp"
+// CHECK-SAME: @"symbolic ______p 15marker_protocol1QP"
+// CHECK-SAME: @"symbolic ______p 15marker_protocol1RP"
+// CHECK-SAME: @"symbolic yXl"
+struct HasMarkers {
+  var field1: P
+  var field2: P & Q
+  var field3: P & R
+  var field4: S
+}
+
+// Note: no mention of marker protocols when forming a dictionary.
+// CHECK-LABEL: define{{.*}}@"$s15marker_protocol0A12InDictionaryypyF"
+// CHECK: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSS_15marker_protocol1P_ptMD")
+public func markerInDictionary() -> Any {
+  let dict: [String: P] = ["answer" : 42]
+  return dict
 }
 
 // Note: no witness tables

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -17,6 +17,10 @@ protocol P4 { } // expected-note{{'P4' declared here}}
 
 @_marker protocol P5: P4 { } // expected-error{{marker protocol 'P5' cannot inherit non-marker protocol 'P4'}}
 
+class C { }
+@_marker protocol P5a: AnyObject { }  // okay
+@_marker protocol P5b: C { }   // expected-error{{marker protocol 'P5b' cannot inherit class 'C'}}
+
 // Legitimate uses of marker protocols.
 extension P3 {
   func f() { }


### PR DESCRIPTION
**Description:** Marker protocols like `Sendable` don't exist at runtime, but the compiler is mangling them into the strings that appear in runtime metadata, leading to miscompiles and broken mirror and tool support when there are properties and generics with type `Sendable`. Drop marker protocols when mangling a type for the purposes of runtime type metadata or reflection.
**Risk:** Low
**Reviewed by: ** Joe Groff
**Testing:** PR testing, CI, new tests
**Original PR:** https://github.com/apple/swift/pull/39782
**Radar:** rdar://82314404

