### PR TITLE
Sema: allow @_originallyDefinedIn to specify identical version numbers as @available. rdar://84425205

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1600,8 +1600,8 @@ ERROR(originally_definedin_topleve_decl,none,
 ERROR(originally_definedin_need_available,none,
       "need @available attribute for @%0", (StringRef))
 
-ERROR(originally_definedin_must_after_available_version,none,
-      "moved version from @%0 must after introduced OS version", (StringRef))
+ERROR(originally_definedin_must_not_before_available_version,none,
+      "symbols are moved to the current module before they were available in the OSs", (StringRef))
 
 // Alignment attribute
 ERROR(alignment_not_power_of_two,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3291,9 +3291,9 @@ void AttributeChecker::checkOriginalDefinedInAttrs(Decl *D,
                AttrName);
       return;
     }
-    if (IntroVer.getValue() >= Attr->MovedVersion) {
+    if (IntroVer.getValue() > Attr->MovedVersion) {
       diagnose(AtLoc,
-               diag::originally_definedin_must_after_available_version,
+               diag::originally_definedin_must_not_before_available_version,
                AttrName);
       return;
     }

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -6,11 +6,15 @@
 public func foo() {}
 
 @available(macOS 10.13, *)
-@_originallyDefinedIn(module: "original", OSX 10.12) // expected-error {{moved version from @_originallyDefinedIn must after introduced OS version}}
+@_originallyDefinedIn(module: "original", OSX 10.12) // expected-error {{symbols are moved to the current module before they were available in the OSs}}
 public class C {
   @_originallyDefinedIn(module: "original", OSX 10.13) // expected-error {{@_originallyDefinedIn is only applicable to top-level decl}}
   public func foo() {}
 }
+
+@available(macOS 10.13, *)
+@_originallyDefinedIn(module: "original", OSX 10.13)
+public class D {}
 
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", _myProject 2.0) // expected-error {{expected at least one platform version in @_originallyDefinedIn}}


### PR DESCRIPTION
rdar://84425205