### PR TITLE
[benchmark] Reenable some string benchmarks

### DIFF
--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -108,14 +108,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_ascii_unicodeScalars",
     runFunction: run_StringWalk_ascii_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_ascii_characters",
     runFunction: run_StringWalk_ascii_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -134,14 +134,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_ascii_unicodeScalars_Backwards",
     runFunction: run_StringWalk_ascii_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_ascii_characters_Backwards",
     runFunction: run_StringWalk_ascii_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -160,14 +160,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_utf16_unicodeScalars",
     runFunction: run_StringWalk_utf16_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_utf16_characters",
     runFunction: run_StringWalk_utf16_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -186,14 +186,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_utf16_unicodeScalars_Backwards",
     runFunction: run_StringWalk_utf16_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_utf16_characters_Backwards",
     runFunction: run_StringWalk_utf16_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -212,14 +212,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_tweet_unicodeScalars",
     runFunction: run_StringWalk_tweet_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_tweet_characters",
     runFunction: run_StringWalk_tweet_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -238,14 +238,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_tweet_unicodeScalars_Backwards",
     runFunction: run_StringWalk_tweet_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_tweet_characters_Backwards",
     runFunction: run_StringWalk_tweet_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -264,14 +264,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_japanese_unicodeScalars",
     runFunction: run_StringWalk_japanese_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_japanese_characters",
     runFunction: run_StringWalk_japanese_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -290,14 +290,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_japanese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_japanese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_japanese_characters_Backwards",
     runFunction: run_StringWalk_japanese_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -316,14 +316,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_chinese_unicodeScalars",
     runFunction: run_StringWalk_chinese_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_chinese_characters",
     runFunction: run_StringWalk_chinese_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -342,14 +342,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_chinese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_chinese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_chinese_characters_Backwards",
     runFunction: run_StringWalk_chinese_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -368,14 +368,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_korean_unicodeScalars",
     runFunction: run_StringWalk_korean_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_korean_characters",
     runFunction: run_StringWalk_korean_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -394,14 +394,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_korean_unicodeScalars_Backwards",
     runFunction: run_StringWalk_korean_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_korean_characters_Backwards",
     runFunction: run_StringWalk_korean_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -420,14 +420,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_russian_unicodeScalars",
     runFunction: run_StringWalk_russian_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_russian_characters",
     runFunction: run_StringWalk_russian_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -446,14 +446,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_russian_unicodeScalars_Backwards",
     runFunction: run_StringWalk_russian_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_russian_characters_Backwards",
     runFunction: run_StringWalk_russian_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -472,14 +472,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_punctuated_unicodeScalars",
     runFunction: run_StringWalk_punctuated_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_characters",
     runFunction: run_StringWalk_punctuated_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -498,14 +498,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_punctuated_unicodeScalars_Backwards",
     runFunction: run_StringWalk_punctuated_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuated_characters_Backwards",
     runFunction: run_StringWalk_punctuated_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -524,14 +524,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_unicodeScalars",
     runFunction: run_StringWalk_punctuatedJapanese_unicodeScalars,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_characters",
     runFunction: run_StringWalk_punctuatedJapanese_characters,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
@@ -550,14 +550,14 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_unicodeScalars_Backwards",
     runFunction: run_StringWalk_punctuatedJapanese_unicodeScalars_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 
   BenchmarkInfo(
     name: "StringWalk_punctuatedJapanese_characters_Backwards",
     runFunction: run_StringWalk_punctuatedJapanese_characters_Backwards,
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 

--- a/benchmark/single-source/StringWalk.swift.gyb
+++ b/benchmark/single-source/StringWalk.swift.gyb
@@ -115,7 +115,7 @@ public let benchmarks = [
   BenchmarkInfo(
     name: "StringWalk_${Name}_${Kind}${Direction}",
     runFunction: run_StringWalk_${Name}_${Kind}${Direction},
-    tags: [.api, .String, .skip],
+    tags: [.validation, .api, .String],
     legacyFactor: 40),
 
 %     end # Kinds


### PR DESCRIPTION
Reeanbles the `StringWalk` benchmarks for walking various Unicodey type strings.