### PR TITLE
[stdlib] Remove unused variable

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -433,7 +433,6 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   ExecutorRef executor = ExecutorRef::generic();
   TaskGroup *group = nullptr;
   AsyncLet *asyncLet = nullptr;
-  void *asyncLetBuffer = nullptr;
   bool hasAsyncLetResultBuffer = false;
   for (auto option = options; option; option = option->getParent()) {
     switch (option->getKind()) {
@@ -461,7 +460,6 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
       // context, so that we can emplace the eventual result there instead
       // of in a FutureFragment.
       hasAsyncLetResultBuffer = true;
-      asyncLetBuffer = aletRecord->getResultBuffer();
       assert(asyncLet && "Missing async let storage");
         
       jobFlags.task_setIsAsyncLetTask(true);


### PR DESCRIPTION
asyncLetBuffer is not used and the function being called has no side-effects, so let's remove it.
