### PR TITLE
[SR-15135] Copy over early `swift-driver` executable to the build dir instead of creating a symlink

### DIFF
--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -207,7 +207,7 @@ endfunction()
 # Once swift-frontend is built, if the standalone (early) swift-driver has been built,
 # we create a `swift-driver` symlink adjacent to the `swift` and `swiftc` executables
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
-function(swift_create_early_driver_symlinks target)
+function(swift_create_early_driver_copies target)
   # Early swift-driver is built adjacent to the compiler (swift build dir)
   set(driver_bin_dir "${CMAKE_BINARY_DIR}/../earlyswiftdriver-${SWIFT_HOST_VARIANT}-${SWIFT_HOST_VARIANT_ARCH}/release/bin")
   set(swift_bin_dir "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
@@ -217,20 +217,18 @@ function(swift_create_early_driver_symlinks target)
       return()
   endif()
 
-  message(STATUS "Creating early SwiftDriver symlinks.")
+  message(STATUS "Copying over early SwiftDriver executable.")
   message(STATUS "From: ${driver_bin_dir}/swift-driver")
   message(STATUS "To: ${swift_bin_dir}/swift-driver")
-  swift_create_post_build_symlink(swift-frontend
-    SOURCE "${driver_bin_dir}/swift-driver"
-    DESTINATION "${swift_bin_dir}/swift-driver"
-    COMMENT "Creating early SwiftDriver symlinks: swift-driver")
+  # Use configure_file instead of file(COPY...) to establish a dependency.
+  # Further Changes to `swift-driver` will cause it to be copied over.
+  configure_file(${driver_bin_dir}/swift-driver ${swift_bin_dir}/swift-driver COPYONLY)
 
   message(STATUS "From: ${driver_bin_dir}/swift-help")
   message(STATUS "To: ${swift_bin_dir}/swift-help")
-  swift_create_post_build_symlink(swift-frontend
-    SOURCE "${driver_bin_dir}/swift-help"
-    DESTINATION "${swift_bin_dir}/swift-help"
-    COMMENT "Creating early SwiftDriver symlinks: swift-help")
+  # Use configure_file instead of file(COPY...) to establish a dependency.
+  # Further Changes to `swift-driver` will cause it to be copied over.  
+  configure_file(${driver_bin_dir}/swift-help ${swift_bin_dir}/swift-help COPYONLY)
 endfunction()
 
 function(dump_swift_vars)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -52,9 +52,9 @@ target_link_libraries(swift-frontend
                         swiftDriverTool
                         libswift)
 
-# Create a `swift-driver` symlinks adjacent to the `swift-frontend` executable
+# Create a `swift-driver` executable adjacent to the `swift-frontend` executable
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
-swift_create_early_driver_symlinks(swift-frontend)
+swift_create_early_driver_copies(swift-frontend)
 
 swift_create_post_build_symlink(swift-frontend
   SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"


### PR DESCRIPTION
The SwiftDriver searches `swift-frontend` based on `Bundle.main.executablePath` (which internally uses `CFGetProcessPath`). This search dir is resolved differently on macOS and Linux so swift-frontend can't be found on Linux, forcing the driver to fallback to using the host system toolchain instead of the just-built one.