### PR TITLE
[stdlib] a minor optimization

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -161,7 +161,7 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
     }
     let destinationAddress = destination.baseAddress._unsafelyUnwrappedUnchecked
     let d = UnsafeMutableRawPointer(destinationAddress)
-    let n = Swift.min(destination.count, self.count)
+    let n = Swift.min(destination.count, s.distance(to: e))
     d.copyMemory(from: s, byteCount: n)
     return (Iterator(_position: s.advanced(by: n), _end: e), n)
   }


### PR DESCRIPTION
We have already done the hard work of unwrapping the optional pointers that represent the beginning and end of the buffer. Calling `self.count` does that all over again. Use the distance between the unwrapped pointers instead.

No SR.

This is an optimization for relatively recent code (see https://github.com/apple/swift/pull/38828).