### PR TITLE
Refactor remaining non-request usages of the GenericSignatureBuilder

### DIFF
--- a/include/swift/AST/GenericParamList.h
+++ b/include/swift/AST/GenericParamList.h
@@ -203,8 +203,6 @@ public:
   void print(ASTPrinter &Printer) const;
 };
 
-using GenericParamSource = PointerUnion<GenericContext *, GenericParamList *>;
-
 /// GenericParamList - A list of generic parameters that is part of a generic
 /// function or type, along with extra requirements placed on those generic
 /// parameters and types derived from them.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -131,10 +131,12 @@ SWIFT_REQUEST(TypeChecker, HasImplementationOnlyImportsRequest,
 SWIFT_REQUEST(TypeChecker, ModuleLibraryLevelRequest,
               LibraryLevel(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,
-              GenericSignature (ModuleDecl *, const GenericSignatureImpl *,
-                                 GenericParamSource,
-                                 SmallVector<Requirement, 2>,
-                                 SmallVector<TypeLoc, 2>, bool),
+              GenericSignature (ModuleDecl *,
+                                const GenericSignatureImpl *,
+                                GenericParamList *,
+                                WhereClauseOwner,
+                                SmallVector<Requirement, 2>,
+                                SmallVector<TypeLoc, 2>, bool),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DistributedModuleIsAvailableRequest,
               bool(ModuleDecl *), Cached, NoLocationInfo)

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -49,7 +49,6 @@
 #define SWIFT_SILOPTIMIZER_ANALYSIS_DIFFERENTIABLEACTIVITYANALYSIS_H_
 
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILValue.h"

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -34,7 +34,6 @@ namespace llvm {
 }
 
 namespace swift {
-  class GenericSignatureBuilder;
   class ArchetypeType;
   class CanType;
   class ClassDecl;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -85,7 +85,6 @@ namespace clang {
 
 namespace swift {
   class GenericSignature;
-  class GenericSignatureBuilder;
   class AssociatedConformance;
   class AssociatedType;
   class ASTContext;

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -20,9 +20,9 @@
 #include "swift/SILOptimizer/Differentiation/Common.h"
 
 #include "swift/AST/AnyFunctionRef.h"
-#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/Requirement.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/DifferentiationMangler.h"
 
@@ -53,30 +53,26 @@ CanGenericSignature buildThunkSignature(SILFunction *fn, bool inheritGenericSig,
   }
 
   auto &ctx = fn->getASTContext();
-  GenericSignatureBuilder builder(ctx);
 
   // Add the existing generic signature.
+  GenericSignature baseGenericSig;
   int depth = 0;
   if (inheritGenericSig) {
-    if (auto genericSig =
-            fn->getLoweredFunctionType()->getSubstGenericSignature()) {
-      builder.addGenericSignature(genericSig);
-      depth = genericSig.getGenericParams().back()->getDepth() + 1;
-    }
+    baseGenericSig = fn->getLoweredFunctionType()->getSubstGenericSignature();
+    if (baseGenericSig)
+      depth = baseGenericSig.getGenericParams().back()->getDepth() + 1;
   }
 
   // Add a new generic parameter to replace the opened existential.
   auto *newGenericParam = GenericTypeParamType::get(depth, 0, ctx);
-
-  builder.addGenericParameter(newGenericParam);
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
                              openedExistential->getOpenedExistentialType());
-  auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
-  builder.addRequirement(newRequirement, source, nullptr);
 
-  auto genericSig = std::move(builder).computeGenericSignature(
-      /*allowConcreteGenericParams=*/true);
+  auto genericSig = evaluateOrDefault(
+      ctx.evaluator,
+      AbstractGenericSignatureRequest{
+        baseGenericSig.getPointer(), { newGenericParam }, { newRequirement }},
+      GenericSignature());
   genericEnv = genericSig.getGenericEnvironment();
 
   newArchetype =

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -20,7 +20,6 @@
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -517,44 +517,6 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
 /// Generic types
 ///
 
-GenericSignature TypeChecker::checkGenericSignature(
-                      GenericParamSource paramSource,
-                      DeclContext *dc,
-                      GenericSignature parentSig,
-                      bool allowConcreteGenericParams,
-                      SmallVector<Requirement, 2> additionalRequirements,
-                      SmallVector<TypeLoc, 2> inferenceSources) {
-  if (auto genericParamList = paramSource.dyn_cast<GenericParamList *>())
-    assert(genericParamList && "Missing generic parameters?");
-
-  auto request = InferredGenericSignatureRequest{
-    dc->getParentModule(), parentSig.getPointer(), paramSource,
-    additionalRequirements, inferenceSources,
-    allowConcreteGenericParams};
-  auto sig = evaluateOrDefault(dc->getASTContext().evaluator,
-                               request, nullptr);
-
-  // Debugging of the generic signature builder and generic signature
-  // generation.
-  if (dc->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
-    llvm::errs() << "\n";
-    if (auto *VD = dyn_cast_or_null<ValueDecl>(dc->getAsDecl())) {
-      VD->dumpRef(llvm::errs());
-      llvm::errs() << "\n";
-    } else {
-      dc->printContext(llvm::errs());
-    }
-    llvm::errs() << "Generic signature: ";
-    sig->print(llvm::errs());
-    llvm::errs() << "\n";
-    llvm::errs() << "Canonical generic signature: ";
-    sig.getCanonicalSignature()->print(llvm::errs());
-    llvm::errs() << "\n";
-  }
-
-  return sig;
-}
-
 /// Form the interface type of an extension from the raw type and the
 /// extension's list of generic parameters.
 static Type formExtensionInterfaceType(
@@ -649,6 +611,8 @@ static unsigned getExtendedTypeGenericDepth(ExtensionDecl *ext) {
 GenericSignature
 GenericSignatureRequest::evaluate(Evaluator &evaluator,
                                   GenericContext *GC) const {
+  auto &ctx = GC->getASTContext();
+
   // The signature of a Protocol is trivial (Self: TheProtocol) so let's compute
   // it.
   if (auto PD = dyn_cast<ProtocolDecl>(GC)) {
@@ -660,7 +624,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
 
     // Debugging of the generic signature builder and generic signature
     // generation.
-    if (GC->getASTContext().TypeCheckerOpts.DebugGenericSignatures) {
+    if (ctx.TypeCheckerOpts.DebugGenericSignatures) {
       llvm::errs() << "\n";
       PD->printContext(llvm::errs());
       llvm::errs() << "Generic signature: ";
@@ -698,10 +662,10 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // If there is no generic context for the where clause to
     // rely on, diagnose that now and bail out.
     if (!GC->isGenericContext()) {
-      GC->getASTContext().Diags.diagnose(where->getWhereLoc(),
-                                         GC->getParent()->isModuleScopeContext()
-                                             ? diag::where_nongeneric_toplevel
-                                             : diag::where_nongeneric_ctx);
+      ctx.Diags.diagnose(where->getWhereLoc(),
+                         GC->getParent()->isModuleScopeContext()
+                             ? diag::where_nongeneric_toplevel
+                             : diag::where_nongeneric_ctx);
       return nullptr;
     }
   }
@@ -806,10 +770,33 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     inferenceSources.emplace_back(nullptr, extInterfaceType);
   }
 
-  return TypeChecker::checkGenericSignature(
-      GC, GC, parentSig,
-      allowConcreteGenericParams,
-      sameTypeReqs, inferenceSources);
+  auto request = InferredGenericSignatureRequest{
+      GC->getParentModule(), parentSig.getPointer(),
+      GC->getGenericParams(), WhereClauseOwner(GC),
+      sameTypeReqs, inferenceSources,
+      allowConcreteGenericParams};
+  auto sig = evaluateOrDefault(ctx.evaluator,
+                               request, nullptr);
+
+  // Debugging of the generic signature builder and generic signature
+  // generation.
+  if (ctx.TypeCheckerOpts.DebugGenericSignatures) {
+    llvm::errs() << "\n";
+    if (auto *VD = dyn_cast_or_null<ValueDecl>(GC->getAsDecl())) {
+      VD->dumpRef(llvm::errs());
+      llvm::errs() << "\n";
+    } else {
+      GC->printContext(llvm::errs());
+    }
+    llvm::errs() << "Generic signature: ";
+    sig->print(llvm::errs());
+    llvm::errs() << "\n";
+    llvm::errs() << "Canonical generic signature: ";
+    sig.getCanonicalSignature()->print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  return sig;
 }
 
 ///

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -437,10 +437,14 @@ swift::handleSILGenericParams(GenericParamList *genericParams,
     genericParams->walk(walker);
   }
 
-  return TypeChecker::checkGenericSignature(nestedList.back(), DC,
-                                         /*parentSig=*/nullptr,
-                                         /*allowConcreteGenericParams=*/true)
-    .getGenericEnvironment();
+  auto request = InferredGenericSignatureRequest{
+      DC->getParentModule(), /*parentSig=*/nullptr,
+      nestedList.back(), WhereClauseOwner(),
+      {}, {}, /*allowConcreteGenericParams=*/true};
+  auto sig = evaluateOrDefault(DC->getASTContext().evaluator,
+                               request, GenericSignature());
+
+  return sig.getGenericEnvironment();
 }
 
 void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -422,34 +422,6 @@ void checkProtocolSelfRequirements(ValueDecl *decl);
 /// declaration's type, otherwise we have no way to infer them.
 void checkReferencedGenericParams(GenericContext *dc);
 
-/// Construct a new generic environment for the given declaration context.
-///
-/// \param paramSource The source of generic info: either a generic parameter
-/// list or a generic context with a \c where clause dependent on outer
-/// generic parameters.
-///
-/// \param dc The declaration context in which to perform the validation.
-///
-/// \param outerSignature The generic signature of the outer
-/// context, if not available as part of the \c dc argument (used
-/// for SIL parsing).
-///
-/// \param allowConcreteGenericParams Whether or not to allow
-/// same-type constraints between generic parameters and concrete types.
-///
-/// \param additionalRequirements Additional requirements to add
-/// directly to the GSB.
-///
-/// \param inferenceSources Additional types to infer requirements from.
-///
-/// \returns the resulting generic signature.
-GenericSignature
-checkGenericSignature(GenericParamSource paramSource, DeclContext *dc,
-                      GenericSignature outerSignature,
-                      bool allowConcreteGenericParams,
-                      SmallVector<Requirement, 2> additionalRequirements = {},
-                      SmallVector<TypeLoc, 2> inferenceSources = {});
-
 /// Create a text string that describes the bindings of generic parameters
 /// that are relevant to the given set of types, e.g.,
 /// "[with T = Bar, U = Wibble]".

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -191,6 +191,7 @@ func invalidRequirementConformance<Scalar>(x: Scalar) -> Scalar {
   return x
 }
 
+// expected-error @+1 {{'@differentiable' attribute does not yet support layout requirements}}
 @differentiable(reverse where T: AnyObject)
 func invalidAnyObjectRequirement<T: Differentiable>(x: T) -> T {
   return x


### PR DESCRIPTION
A few places were creating GenericSignatureBuilders directly instead of using AbstractGenericSignatureRequest / InferredGenericSignatureRequest. Refactor these after generalizing InferredGenericSignatureRequest slightly to handle the new use case of `where` clauses written in attributes (`@differentiable` and `@_specialize`). This is of course a stepping stone to introducing the RequirementMachine's generic signature minimization algorithm, and removing the GenericSignatureBuilder entirely.