### PR TITLE
Adjust the referenced function type for @_unsafeSendable and @_unsafeMainActor

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6265,14 +6265,6 @@ public:
   Optional<unsigned> findPotentialCompletionHandlerParam(
       const AbstractFunctionDecl *asyncAlternative = nullptr) const;
 
-  /// Determine whether this function is implicitly known to have its
-  /// parameters of function type be @_unsafeSendable.
-  ///
-  /// This hard-codes knowledge of a number of functions that will
-  /// eventually have @_unsafeSendable and, eventually, @Sendable,
-  /// on their parameters of function type.
-  bool hasKnownUnsafeSendableFunctionParams() const;
-
   using DeclContext::operator new;
   using DeclContext::operator delete;
   using Decl::getASTContext;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3395,8 +3395,6 @@ struct ParameterListInfo {
   SmallBitVector defaultArguments;
   SmallBitVector acceptsUnlabeledTrailingClosures;
   SmallBitVector propertyWrappers;
-  SmallBitVector unsafeSendable;
-  SmallBitVector unsafeMainActor;
   SmallBitVector implicitSelfCapture;
   SmallBitVector inheritActorContext;
 
@@ -3416,16 +3414,6 @@ public:
   /// The ParamDecl at the given index if the parameter has an applied
   /// property wrapper.
   bool hasExternalPropertyWrapper(unsigned paramIdx) const;
-
-  /// Whether the given parameter is unsafe Sendable, meaning that
-  /// we will treat it as Sendable in a context that has adopted concurrency
-  /// features.
-  bool isUnsafeSendable(unsigned paramIdx) const;
-
-  /// Whether the given parameter is unsafe MainActor, meaning that
-  /// we will treat it as being part of the main actor but that it is not
-  /// part of the type system.
-  bool isUnsafeMainActor(unsigned paramIdx) const;
 
   /// Whether the given parameter is a closure that should allow capture of
   /// 'self' to be implicit, without requiring "self.".

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7733,27 +7733,6 @@ void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
   DerivativeFunctionConfigs->insert(config);
 }
 
-bool AbstractFunctionDecl::hasKnownUnsafeSendableFunctionParams() const {
-  auto nominal = getDeclContext()->getSelfNominalTypeDecl();
-  if (!nominal)
-    return false;
-
-  // DispatchQueue operations.
-  auto nominalName = nominal->getName().str();
-  if (nominalName == "DispatchQueue") {
-    auto name = getBaseName().userFacingName();
-    return llvm::StringSwitch<bool>(name)
-      .Case("sync", true)
-      .Case("async", true)
-      .Case("asyncAndWait", true)
-      .Case("asyncAfter", true)
-      .Case("concurrentPerform", true)
-      .Default(false);
-  }
-
-  return false;
-}
-
 void FuncDecl::setResultInterfaceType(Type type) {
   getASTContext().evaluator.cacheOutput(ResultTypeRequest{this},
                                         std::move(type));

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -928,36 +928,12 @@ static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
   return paramType->is<AnyFunctionType>();
 }
 
-/// Determine whether the parameter is contextually Sendable.
-static bool isParamUnsafeSendable(const ParamDecl *param) {
-  // Check for @_unsafeSendable.
-  if (param->getAttrs().hasAttribute<UnsafeSendableAttr>())
-    return true;
-
-  // Check that the parameter is of function type.
-  Type paramType = param->isVariadic() ? param->getVarargBaseTy()
-                                       : param->getInterfaceType();
-  paramType = paramType->getRValueType()->lookThroughAllOptionalTypes();
-  if (!paramType->is<FunctionType>())
-    return false;
-
-  // Check whether this function is known to have @_unsafeSendable function
-  // parameters.
-  auto func = dyn_cast<AbstractFunctionDecl>(param->getDeclContext());
-  if (!func)
-    return false;
-
-  return func->hasKnownUnsafeSendableFunctionParams();
-}
-
 ParameterListInfo::ParameterListInfo(
     ArrayRef<AnyFunctionType::Param> params,
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
   propertyWrappers.resize(params.size());
-  unsafeSendable.resize(params.size());
-  unsafeMainActor.resize(params.size());
   implicitSelfCapture.resize(params.size());
   inheritActorContext.resize(params.size());
 
@@ -1012,14 +988,6 @@ ParameterListInfo::ParameterListInfo(
       propertyWrappers.set(i);
     }
 
-    if (isParamUnsafeSendable(param)) {
-      unsafeSendable.set(i);
-    }
-
-    if (param->getAttrs().hasAttribute<UnsafeMainActorAttr>()) {
-      unsafeMainActor.set(i);
-    }
-
     if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>()) {
       implicitSelfCapture.set(i);
     }
@@ -1045,18 +1013,6 @@ bool ParameterListInfo::hasExternalPropertyWrapper(unsigned paramIdx) const {
   return paramIdx < propertyWrappers.size() ? propertyWrappers[paramIdx] : false;
 }
 
-bool ParameterListInfo::isUnsafeSendable(unsigned paramIdx) const {
-  return paramIdx < unsafeSendable.size()
-      ? unsafeSendable[paramIdx]
-      : false;
-}
-
-bool ParameterListInfo::isUnsafeMainActor(unsigned paramIdx) const {
-  return paramIdx < unsafeMainActor.size()
-      ? unsafeMainActor[paramIdx]
-      : false;
-}
-
 bool ParameterListInfo::isImplicitSelfCapture(unsigned paramIdx) const {
   return paramIdx < implicitSelfCapture.size()
       ? implicitSelfCapture[paramIdx]
@@ -1070,8 +1026,7 @@ bool ParameterListInfo::inheritsActorContext(unsigned paramIdx) const {
 }
 
 bool ParameterListInfo::anyContextualInfo() const {
-  return unsafeSendable.any() || unsafeMainActor.any() ||
-      implicitSelfCapture.any() || inheritActorContext.any();
+  return implicitSelfCapture.any() || inheritActorContext.any();
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -583,10 +583,7 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
       break;
     }
   } else if (auto *closureExpr = dyn_cast<AbstractClosureExpr>(FunctionDC)) {
-    bool wantExecutor = F.isAsync() ||
-      (wantDataRaceChecks &&
-       !(isa<ClosureExpr>(closureExpr) &&
-         cast<ClosureExpr>(closureExpr)->isUnsafeMainActor()));
+    bool wantExecutor = F.isAsync() || wantDataRaceChecks;
     auto actorIsolation = closureExpr->getActorIsolation();
     switch (actorIsolation.getKind()) {
     case ClosureActorIsolation::Independent:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5825,16 +5825,14 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     // for things like trailing closures and args to property wrapper params.
     arg.setLabel(param.getLabel());
 
-    // Determine whether the parameter is unsafe Sendable or MainActor, and
-    // record it as such.
-    bool isUnsafeSendable = paramInfo.isUnsafeSendable(paramIdx);
-    bool isMainActor = paramInfo.isUnsafeMainActor(paramIdx) ||
-        (isUnsafeSendable && apply && isMainDispatchQueue(apply->getFn()));
+    // Determine whether the closure argument should be treated as being on
+    // the main actor, having implicit self capture, or inheriting actor
+    // context.
     bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
     bool inheritsActorContext = paramInfo.inheritsActorContext(paramIdx);
     applyContextualClosureFlags(
-        argExpr, isUnsafeSendable && contextUsesConcurrencyFeatures(dc),
-        isMainActor, isImplicitSelfCapture, inheritsActorContext);
+        argExpr, false,
+        false, isImplicitSelfCapture, inheritsActorContext);
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5631,10 +5631,8 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 
 /// Apply the contextually Sendable flag to the given expression,
 static void applyContextualClosureFlags(
-      Expr *expr, bool sendable, bool forMainActor, bool implicitSelfCapture,
-      bool inheritActorContext) {
+      Expr *expr, bool implicitSelfCapture, bool inheritActorContext) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-    closure->setUnsafeConcurrent(sendable, forMainActor);
     closure->setAllowsImplicitSelfCapture(implicitSelfCapture);
     closure->setInheritsActorContext(inheritActorContext);
     return;
@@ -5642,46 +5640,14 @@ static void applyContextualClosureFlags(
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
     applyContextualClosureFlags(
-        captureList->getClosureBody(), sendable, forMainActor,
-        implicitSelfCapture, inheritActorContext);
+        captureList->getClosureBody(), implicitSelfCapture,
+        inheritActorContext);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
     applyContextualClosureFlags(
-        identity->getSubExpr(), sendable, forMainActor,
-        implicitSelfCapture, inheritActorContext);
+        identity->getSubExpr(), implicitSelfCapture, inheritActorContext);
   }
-}
-
-/// Whether this is a reference to a method on the main dispatch queue.
-static bool isMainDispatchQueue(Expr *arg) {
-  auto call = dyn_cast<DotSyntaxCallExpr>(arg);
-  if (!call)
-    return false;
-
-  auto memberRef = dyn_cast<MemberRefExpr>(
-      call->getBase()->getValueProvidingExpr());
-  if (!memberRef)
-    return false;
-
-  auto member = memberRef->getMember();
-  if (member.getDecl()->getName().getBaseName().userFacingName() != "main")
-    return false;
-
-  auto typeExpr = dyn_cast<TypeExpr>(
-      memberRef->getBase()->getValueProvidingExpr());
-  if (!typeExpr)
-    return false;
-
-  Type baseType = typeExpr->getInstanceType();
-  if (!baseType)
-    return false;
-
-  auto baseNominal = baseType->getAnyNominal();
-  if (!baseNominal)
-    return false;
-
-  return baseNominal->getName().str() == "DispatchQueue";
 }
 
 ArgumentList *ExprRewriter::coerceCallArguments(
@@ -5825,14 +5791,12 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     // for things like trailing closures and args to property wrapper params.
     arg.setLabel(param.getLabel());
 
-    // Determine whether the closure argument should be treated as being on
-    // the main actor, having implicit self capture, or inheriting actor
-    // context.
+    // Determine whether the closure argument should be treated as having
+    // implicit self capture or inheriting actor context.
     bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
     bool inheritsActorContext = paramInfo.inheritsActorContext(paramIdx);
     applyContextualClosureFlags(
-        argExpr, false,
-        false, isImplicitSelfCapture, inheritsActorContext);
+        argExpr, isImplicitSelfCapture, inheritsActorContext);
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1255,6 +1255,24 @@ static unsigned getNumRemovedArgumentLabels(ValueDecl *decl,
   llvm_unreachable("Unhandled FunctionRefKind in switch.");
 }
 
+/// Determine the number of applications
+static unsigned getNumApplications(
+    ValueDecl *decl, bool hasAppliedSelf, FunctionRefKind functionRefKind) {
+  switch (functionRefKind) {
+  case FunctionRefKind::Unapplied:
+  case FunctionRefKind::Compound:
+    return 0 + hasAppliedSelf;
+
+  case FunctionRefKind::SingleApply:
+    return 1 + hasAppliedSelf;
+
+  case FunctionRefKind::DoubleApply:
+    return 2;
+  }
+
+  llvm_unreachable("Unhandled FunctionRefKind in switch.");
+}
+
 /// Replaces property wrapper types in the parameter list of the given function type
 /// with the wrapped-value or projected-value types (depending on argument label).
 static FunctionType *
@@ -1336,8 +1354,10 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     AnyFunctionType *funcType = func->getInterfaceType()
         ->castTo<AnyFunctionType>();
-    if (!isRequirementOrWitness(locator))
-      funcType = applyGlobalActorType(funcType, func, useDC);
+    if (!isRequirementOrWitness(locator)) {
+      unsigned numApplies = getNumApplications(value, false, functionRefKind);
+      funcType = applyGlobalActorType(funcType, func, useDC, numApplies, false);
+    }
     auto openedType = openFunctionType(
         funcType, locator, replacements, func->getDeclContext());
 
@@ -1366,8 +1386,12 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
     auto numLabelsToRemove = getNumRemovedArgumentLabels(
         funcDecl, /*isCurriedInstanceReference=*/false, functionRefKind);
 
-    if (!isRequirementOrWitness(locator))
-      funcType = applyGlobalActorType(funcType, funcDecl, useDC);
+    if (!isRequirementOrWitness(locator)) {
+      unsigned numApplies = getNumApplications(
+          funcDecl, false, functionRefKind);
+      funcType = applyGlobalActorType(
+          funcType, funcDecl, useDC, numApplies, false);
+    }
 
     auto openedType = openFunctionType(funcType, locator, replacements,
                                        funcDecl->getDeclContext())
@@ -1634,6 +1658,72 @@ Type constraints::getDynamicSelfReplacementType(
       ->getMetatypeInstanceType();
 }
 
+/// Determine whether the given name is that of a DispatchQueue operation that
+/// takes a closure to be executed on the queue.
+static bool isDispatchQueueOperationName(StringRef name) {
+  return llvm::StringSwitch<bool>(name)
+    .Case("sync", true)
+    .Case("async", true)
+    .Case("asyncAndWait", true)
+    .Case("asyncAfter", true)
+    .Case("concurrentPerform", true)
+    .Default(false);
+}
+
+/// Determine whether this locator refers to a member of "DispatchQueue.main",
+/// which is a special dispatch queue that executes its work on the main actor.
+static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
+  if (!locator)
+    return false;
+
+  if (locator->getPath().size() != 1 ||
+      !locator->isLastElement<LocatorPathElt::Member>())
+    return false;
+
+  auto expr = locator->getAnchor().dyn_cast<Expr *>();
+  if (!expr)
+    return false;
+
+  auto outerUnresolvedDot = dyn_cast<UnresolvedDotExpr>(expr);
+  if (!outerUnresolvedDot)
+    return false;
+
+
+  if (!isDispatchQueueOperationName(
+          outerUnresolvedDot->getName().getBaseName().userFacingName()))
+    return false;
+
+  auto innerUnresolvedDot = dyn_cast<UnresolvedDotExpr>(
+      outerUnresolvedDot->getBase());
+  if (!innerUnresolvedDot)
+    return false;
+
+  if (innerUnresolvedDot->getName().getBaseName().userFacingName() != "main")
+    return false;
+
+  auto typeExpr = dyn_cast<TypeExpr>(innerUnresolvedDot->getBase());
+  if (!typeExpr)
+    return false;
+
+  auto typeRepr = typeExpr->getTypeRepr();
+  if (!typeRepr)
+    return false;
+
+  auto identTypeRepr = dyn_cast<IdentTypeRepr>(typeRepr);
+  if (!identTypeRepr)
+    return false;
+
+  auto components = identTypeRepr->getComponentRange();
+  if (components.empty())
+    return false;
+
+  if (components.back()->getNameRef().getBaseName().userFacingName() !=
+        "DispatchQueue")
+    return false;
+
+  return true;
+}
+
 std::pair<Type, Type>
 ConstraintSystem::getTypeOfMemberReference(
     Type baseTy, ValueDecl *value, DeclContext *useDC,
@@ -1711,8 +1801,13 @@ ConstraintSystem::getTypeOfMemberReference(
     // This is the easy case.
     funcType = value->getInterfaceType()->castTo<AnyFunctionType>();
 
-    if (!isRequirementOrWitness(locator))
-      funcType = applyGlobalActorType(funcType, value, useDC);
+    if (!isRequirementOrWitness(locator)) {
+      unsigned numApplies = getNumApplications(
+          value, hasAppliedSelf, functionRefKind);
+      funcType = applyGlobalActorType(
+          funcType, value, useDC, numApplies,
+          isMainDispatchQueueMember(locator));
+    }
   } else {
     // For a property, build a type (Self) -> PropType.
     // For a subscript, build a type (Self) -> (Indices...) -> ElementType.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -521,9 +521,6 @@ static bool isSendableClosure(
     if (forActorIsolation && explicitClosure->inheritsActorContext()) {
       return false;
     }
-
-    if (explicitClosure->isUnsafeSendable())
-      return true;
   }
 
   if (auto type = closure->getType()) {
@@ -2578,12 +2575,6 @@ namespace {
       if (auto explicitClosure = dyn_cast<ClosureExpr>(closure)) {
         if (Type globalActorType = resolveGlobalActorType(explicitClosure))
           return ClosureActorIsolation::forGlobalActor(globalActorType);
-
-        if (explicitClosure->isUnsafeMainActor()) {
-          ASTContext &ctx = closure->getASTContext();
-          if (Type mainActor = ctx.getMainActorType())
-            return ClosureActorIsolation::forGlobalActor(mainActor);
-        }
       }
 
       // Sendable closures are actor-independent unless the closure has

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -306,9 +306,22 @@ enum class SendableCheck {
 Optional<std::pair<CustomAttr *, NominalTypeDecl *>>
 checkGlobalActorAttributes(
     SourceLoc loc, DeclContext *dc, ArrayRef<CustomAttr *> attrs);
-/// Get the explicit global actor specified for a closure.
 
+/// Get the explicit global actor specified for a closure.
 Type getExplicitGlobalActor(ClosureExpr *closure);
+
+/// Adjust the given function type to account for concurrency-specific
+/// attributes whose affect on the type might differ based on context.
+/// This includes adjustments for unsafe parameter attributes like
+/// `@_unsafeSendable` and `@_unsafeMainActor` as well as a global actor
+/// on the declaration itself.
+AnyFunctionType *adjustFunctionTypeForConcurrency(
+    AnyFunctionType *fnType, ValueDecl *funcOrEnum, DeclContext *dc,
+    unsigned numApplies, bool isMainDispatchQueue);
+
+/// Determine whether the given name is that of a DispatchQueue operation that
+/// takes a closure to be executed on the queue.
+bool isDispatchQueueOperationName(StringRef name);
 
 /// Check the correctness of the given Sendable conformance.
 ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1320,13 +1320,6 @@ void checkUnknownAttrRestrictions(
 /// it to later stages.
 void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
 
-/// If the given function has a global actor that should be reflected in
-/// references to its function type from the given declaration context,
-/// update the given function type to include the global actor.
-AnyFunctionType *applyGlobalActorType(
-    AnyFunctionType *fnType, ValueDecl *funcOrEnum, DeclContext *dc,
-    unsigned numApplies, bool isMainDispatchQueue);
-
 /// If \p attr was added by an access note, wraps the error in
 /// \c diag::wrap_invalid_attr_added_by_access_note and limits it as an access
 /// note-related diagnostic should be.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1324,7 +1324,8 @@ void bindSwitchCasePatternVars(DeclContext *dc, CaseStmt *stmt);
 /// references to its function type from the given declaration context,
 /// update the given function type to include the global actor.
 AnyFunctionType *applyGlobalActorType(
-    AnyFunctionType *fnType, ValueDecl *funcOrEnum, DeclContext *dc);
+    AnyFunctionType *fnType, ValueDecl *funcOrEnum, DeclContext *dc,
+    unsigned numApplies, bool isMainDispatchQueue);
 
 /// If \p attr was added by an access note, wraps the error in
 /// \c diag::wrap_invalid_attr_added_by_access_note and limits it as an access

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -14,9 +14,17 @@ func testMe() {
   }
 }
 
-func testUnsafeSendableInAsync() async {
+func testUnsafeSendableInMainAsync() async {
   var x = 5
   DispatchQueue.main.async {
+    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+  }
+  print(x)
+}
+
+func testUnsafeSendableInAsync(queue: DispatchQueue) async {
+  var x = 5
+  queue.async {
     x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)

--- a/test/Concurrency/unsafe_param_annotations.swift
+++ b/test/Concurrency/unsafe_param_annotations.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+
+func unsafelySendableClosure(@_unsafeSendable _ closure: () -> Void) { }
+
+func unsafelyMainActorClosure(@_unsafeMainActor _ closure: () -> Void) { }
+
+func unsafelyDoEverythingClosure(@_unsafeSendable @_unsafeMainActor _ closure: () -> Void) { }
+
+struct X {
+  func unsafelyDoEverythingClosure(@_unsafeSendable @_unsafeMainActor _ closure: () -> Void) { }
+}
+
+
+func testInAsync(x: X) async {
+  let _: Int = unsafelySendableClosure // expected-error{{type '(@Sendable () -> Void) -> ()'}}
+  let _: Int = unsafelyMainActorClosure // expected-error{{type '(@MainActor () -> Void) -> ()'}}
+  let _: Int = unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '(X) -> (@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+}
+
+func testElsewhere(x: X) {
+  let _: Int = unsafelySendableClosure // expected-error{{type '(() -> Void) -> ()'}}
+  let _: Int = unsafelyMainActorClosure // expected-error{{type '(() -> Void) -> ()'}}
+  let _: Int = unsafelyDoEverythingClosure // expected-error{{type '(() -> Void) -> ()'}}
+  let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(() -> Void) -> ()'}}
+  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '(X) -> (() -> Void) -> ()'}}
+  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '(() -> Void) -> ()'}}
+}
+
+@MainActor func onMainActor() { }
+
+func testCalls(x: X) {
+  unsafelyMainActorClosure {
+    onMainActor()
+  }
+
+  unsafelyDoEverythingClosure {
+    onMainActor()
+  }
+
+  x.unsafelyDoEverythingClosure {
+    onMainActor()
+  }
+  (X.unsafelyDoEverythingClosure)(x)( {
+    onMainActor()
+    })
+}

--- a/test/SILGen/check_executor.swift
+++ b/test/SILGen/check_executor.swift
@@ -32,8 +32,8 @@ public actor MyActor {
     }
   }
 
-  // CHECK-RAW-LABEL: sil private [ossa] @$s4test7MyActorC0A10UnsafeMainyyFSiycfU_
-  // CHECK-RAW-NOT: _checkExpectedExecutor
+  // CHECK-RAW-LABEL: sil private [ossa] @$s4test7MyActorC0A10UnsafeMainyyFSiyScMYccfU_
+  // CHECK-RAW: _checkExpectedExecutor
   // CHECK-RAW: onMainActor
   // CHECK-RAW: return
   public func testUnsafeMain() {


### PR DESCRIPTION
When referencing a function that contains parameters with the hidden
`@_unsafeSendable` or `@_unsafeMainActor` attributes, adjust the
function type to make the types of those parameters `@Sendable` or
`@MainActor`, respectively, based on both the context the expression:

* `@Sendable` will be applied when we are in a context with strict
concurrency checking.
* `@MainActor` will be applied when we are in a context with strict
concurrency checking *or* the function is being directly applied so
that an argument is provided in the immediate expression.

The second part of the rule of `@MainActor` reflects the fact that
making the parameter `@MainActor` doesn't break existing code (because
there is a conversion to add a global actor to a function value), but
it does enable such code to synchronously use a `@MainActor`-qualified
API.

The main effect of this change is that, in a strict concurrency
context, the type of referencing an unapplied function involving
`@_unsafeSendable` or `@_unsafeMainActor` in a strict context will
make those parameters `@Sendable` or `@MainActor`, which ensures that
these constraints properly work with non-closure arguments. The former
solution only applied to closure literals, which left some holes in
Sendable checking.

Fixes rdar://77753021.