### PR TITLE
[ConstraintSystem] Don't increase the score for unapplied function references if the expression is an argument to `#selector`.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3464,7 +3464,8 @@ namespace {
       // Note that the subexpression of a #selector expression is
       // unevaluated.
       if (auto sel = dyn_cast<ObjCSelectorExpr>(expr)) {
-        CG.getConstraintSystem().UnevaluatedRootExprs.insert(sel->getSubExpr());
+        auto *subExpr = sel->getSubExpr()->getSemanticsProvidingExpr();
+        CG.getConstraintSystem().UnevaluatedRootExprs.insert(subExpr);
       }
 
       // Check an objc key-path expression, which fills in its semantic

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2916,7 +2916,13 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     }
 
     if (isa<AbstractFunctionDecl>(decl) || isa<TypeDecl>(decl)) {
-      if (choice.getFunctionRefKind() == FunctionRefKind::Unapplied) {
+      auto anchor = locator->getAnchor();
+      // TODO: Instead of not increasing the score for arguments to #selector,
+      // a better fix for this is to port over the #selector diagnostics from
+      // CSApply to constraint fixes, and not attempt invalid disjunction
+      // choices based on the selector kind on the valid code path.
+      if (choice.getFunctionRefKind() == FunctionRefKind::Unapplied &&
+          !UnevaluatedRootExprs.contains(getAsExpr(anchor))) {
         increaseScore(SK_UnappliedFunction);
       }
     }

--- a/test/expr/primary/selector/selector.swift
+++ b/test/expr/primary/selector/selector.swift
@@ -157,7 +157,16 @@ extension SomeProtocol {
     let _ = #selector(anotherFunction) // expected-error {{cannot use 'anotherFunction' as a selector because protocol 'SomeProtocol' is not exposed to Objective-C}} {{none}}
   }
 
-  func anotherFunction() { 
+  func anotherFunction() {
     print("Hello world!")
  }
+}
+
+@objc class OverloadedFuncAndProperty {
+  @objc static func f() {}
+  @objc var f: Int { 0 }
+}
+
+func test() -> Selector {
+  #selector(OverloadedFuncAndProperty.f)
 }


### PR DESCRIPTION
For `#selector` arguments, functions and properties are syntactically distinct with the getter/setter label, so the solver should not unconditionally prefer properties to unapplied functions. 

Note that a better fix for this is to port over the `#selector` diagnostics from CSApply to constraint fixes, and not attempt invalid disjunction choices based on the selector kind on the valid code path.

Resolves: rdar://83779014