### PR TITLE
[SILGen] Emit cleanups in unreachable-terminated blocks for lexical lifetimes.

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -238,7 +238,7 @@ SILGenFunction::emitPreconditionOptionalHasValue(SILLocation loc,
                                 SGFContext());
   }
 
-  B.createUnreachable(ArtificialUnreachableLocation());
+  emitCleanupsAndCreateUnreachable(ArtificialUnreachableLocation());
   B.clearInsertionPoint();
   B.emitBlock(contBB);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1566,6 +1566,14 @@ CleanupHandle SILGenFunction::enterAsyncLetCleanup(SILValue alet,
   return Cleanups.getTopCleanup();
 }
 
+void SILGenFunction::emitCleanupsAndCreateUnreachable(
+    SILLocation loc, SILGenBuilder *builderSpecified) {
+  SILGenBuilder *builder = builderSpecified ? builderSpecified : &B;
+  if (getASTContext().SILOpts.EnableExperimentalLexicalLifetimes)
+    Cleanups.emitCleanupsForReturn(CleanupLocation(loc), IsForUnwind);
+  builder->createUnreachable(loc);
+}
+
 /// Create a LocalVariableInitialization for the uninitialized var.
 InitializationPtr SILGenFunction::emitLocalVariableWithCleanup(
     VarDecl *vd, Optional<MarkUninitializedInst::Kind> kind, unsigned ArgNo) {

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -86,7 +86,7 @@ prepareForEpilogBlockEmission(SILGenFunction &SGF, SILLocation topLevel,
   // return, then we
   // are not allowed to fall off the end of the function and can't reach here.
   if (SGF.NeedsReturn && SGF.B.hasValidInsertionPoint())
-    SGF.B.createUnreachable(implicitReturnFromTopLevel);
+    SGF.emitCleanupsAndCreateUnreachable(implicitReturnFromTopLevel);
 
   if (epilogBB->pred_empty()) {
     // If the epilog was not branched to at all, kill the BB and

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1108,7 +1108,7 @@ void SILGenFunction::ForceTryEmission::finish() {
               },
               SGFContext());
     }
-    SGF.B.createUnreachable(Loc);
+    SGF.emitCleanupsAndCreateUnreachable(Loc);
   }
 
   // Prevent double-finishing and make the destructor a no-op.
@@ -5076,7 +5076,7 @@ RValue RValueEmitter::emitForceValue(ForceValueExpr *loc, Expr *E,
         auto boolTy = SILType::getBuiltinIntegerType(1, SGF.getASTContext());
         auto trueV = failureBuilder.createIntegerLiteral(loc, boolTy, 1);
         failureBuilder.createCondFail(loc, trueV, "force unwrapped a nil value");
-        failureBuilder.createUnreachable(loc);
+        SGF.emitCleanupsAndCreateUnreachable(loc, &failureBuilder);
       }
     }
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -814,7 +814,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
       exitCode = B.createStruct(moduleLoc, retType, exitCode);
       SILValue exitCall = B.createFunctionRef(moduleLoc, exitSILFunc);
       B.createApply(moduleLoc, exitCall, {}, {exitCode});
-      B.createUnreachable(moduleLoc);
+      emitCleanupsAndCreateUnreachable(moduleLoc);
     }
 
     if (mainFunc->hasThrows()) {
@@ -942,7 +942,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
   SILValue drainQueueFunc =
       B.createFunctionRefFor(moduleLoc, drainQueueSILFunc);
   B.createApply(moduleLoc, drainQueueFunc, {}, {});
-  B.createUnreachable(moduleLoc);
+  emitCleanupsAndCreateUnreachable(moduleLoc);
   return;
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2159,6 +2159,12 @@ public:
   // Enter a cleanup to cancel and destroy an AsyncLet as it leaves the scope.
   CleanupHandle enterAsyncLetCleanup(SILValue alet, SILValue resultBuf);
 
+  /// Create an unreachable instruction, after first emitting all outstanding
+  /// cleanups.
+  void
+  emitCleanupsAndCreateUnreachable(SILLocation loc,
+                                   SILGenBuilder *builderSpecified = nullptr);
+
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, SGFAccessKind accessKind,
                     LValueOptions options = LValueOptions());

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -995,7 +995,7 @@ chooseNecessaryColumn(const ClauseMatrix &matrix, unsigned firstRow) {
 void PatternMatchEmission::emitDispatch(ClauseMatrix &clauses, ArgArray args,
                                         const FailureHandler &outerFailure) {
   if (clauses.rows() == 0) {
-    SGF.B.createUnreachable(SILLocation(PatternMatchStmt));
+    SGF.emitCleanupsAndCreateUnreachable(PatternMatchStmt);
     return;
   }
 
@@ -2777,7 +2777,7 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
   // Emit an unreachable in place of the switch statement.
   if (subjectTy->isStructurallyUninhabited()) {
     emitIgnoredExpr(S->getSubjectExpr());
-    B.createUnreachable(S);
+    emitCleanupsAndCreateUnreachable(S);
     return;
   }
 
@@ -2897,7 +2897,7 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
     // over an @objc enum, which may contain any value of its underlying type,
     // or a switch over a non-frozen Swift enum when the user hasn't written a
     // catch-all case.
-    SWIFT_DEFER { B.createUnreachable(location); };
+    SWIFT_DEFER { emitCleanupsAndCreateUnreachable(location); };
 
     // Special case: if it's a single @objc enum, we can print the raw value.
     if (unexpectedEnumCaseInfo.isSingleObjCEnum()) {
@@ -3146,7 +3146,7 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
     // logic is emitting an unreachable block but didn't prune the failure BB.
     // Mark it as such.
     if (!ThrowDest.isValid()) {
-      B.createUnreachable(S);
+      emitCleanupsAndCreateUnreachable(S);
       return;
     }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -486,7 +486,7 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
       if (param->getType()->isStructurallyUninhabited()) {
         SILLocation unreachableLoc(param);
         unreachableLoc.markAsPrologue();
-        B.createUnreachable(unreachableLoc);
+        emitCleanupsAndCreateUnreachable(unreachableLoc);
         break;
       }
     }

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -787,7 +787,7 @@ void StmtEmitter::visitGuardStmt(GuardStmt *S) {
     // isn't valid to fall off into the normal flow.  To model this, we emit
     // an unreachable instruction and then have SIL diagnostic check this.
     if (SGF.B.hasValidInsertionPoint())
-      SGF.B.createUnreachable(S);
+      SGF.emitCleanupsAndCreateUnreachable(S);
   }
 
   // Emit the condition bindings, branching to the bodyBB if they fail.
@@ -1535,7 +1535,7 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
   // If we're suppressing error paths, just wrap it up as unreachable
   // and return.
   if (suppressErrorPath) {
-    B.createUnreachable(loc);
+    emitCleanupsAndCreateUnreachable(loc);
     return destBB;
   }
 


### PR DESCRIPTION
Previously, calls to SILBuilder::createUnreachable were created in a number of places throughout SILGen.  Cleanups were not performed before these unreachables.  That resulted in SIL that will soon be invalid.

Here, all calls are factored through a new function SILGenFunction::emitCleanupsAndCreateUnreachable.  When -enable-experimental-lexical-lifetimes is passed, cleanups are emitted before emitting the unreachable instruction.