### PR TITLE
Remove unused function from class

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -661,8 +661,6 @@ public:
     memcpy(mask, src.mask, size);
   }
 
-  void makeZero() { memset(mask, 0, size); }
-
   bool isNonZero() const { return !isZero(); }
 
   bool isZero() const {


### PR DESCRIPTION
This function is unused, so we should get rid of it