### PR TITLE
Use malloc/calloc/free instead of new/delete when the types are not objects

### DIFF
--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -104,23 +104,22 @@ public:
   static ReachingBlockMatrix allocateMatrix(unsigned numBlocks) {
     ReachingBlockMatrix m;
     m.numBitWords = numBitWordsForNumBlocks(numBlocks);
-    m.bits = new uint64_t[numBlocks * m.numBitWords];
-    memset(m.bits, 0, numBlocks * m.numBitWords * sizeof(uint64_t));
+    m.bits = static_cast<uint64_t *>(calloc(numBlocks * m.numBitWords, sizeof(uint64_t)));
     return m;
   }
   static void deallocateMatrix(ReachingBlockMatrix &m) {
-    delete[] m.bits;
+    free(m.bits);
     m.bits = nullptr;
     m.numBitWords = 0;
   }
   static ReachingBlockSet allocateSet(unsigned numBlocks) {
     ReachingBlockSet s;
     s.numBitWords = numBitWordsForNumBlocks(numBlocks);
-    s.bits = new uint64_t[s.numBitWords];
+    s.bits = static_cast<uint64_t *>(calloc(s.numBitWords, sizeof(uint64_t)));
     return s;
   }
   static void deallocateSet(ReachingBlockSet &s) {
-    delete[] s.bits;
+    free(s.bits);
     s.bits = nullptr;
     s.numBitWords = 0;
   }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2933,16 +2933,17 @@ initGenericObjCClass(ClassMetadata *self, size_t numFields,
   const unsigned NumInlineGlobalIvarOffsets = 8;
   size_t *_inlineGlobalIvarOffsets[NumInlineGlobalIvarOffsets];
   size_t **_globalIvarOffsets = nullptr;
-  auto getGlobalIvarOffsets = [&]() -> size_t** {
+  auto getGlobalIvarOffsets = [&]() -> size_t ** {
     if (!_globalIvarOffsets) {
-      if (numFields <= NumInlineGlobalIvarOffsets) {
-        _globalIvarOffsets = _inlineGlobalIvarOffsets;
+      if (numFields > NumInlineGlobalIvarOffsets) {
+        // Make sure all the entries start out null.
+        _globalIvarOffsets =
+            static_cast<size_t **>(calloc(numFields, sizeof(size_t *)));
       } else {
-        _globalIvarOffsets = new size_t*[numFields];
+        _globalIvarOffsets = _inlineGlobalIvarOffsets;
+        // Make sure all the entries start out null.
+        memset(_globalIvarOffsets, 0, sizeof(size_t *) * numFields);
       }
-
-      // Make sure all the entries start out null.
-      memset(_globalIvarOffsets, 0, sizeof(size_t*) * numFields);
     }
     return _globalIvarOffsets;
   };
@@ -3002,7 +3003,7 @@ initGenericObjCClass(ClassMetadata *self, size_t numFields,
 
     // Free the out-of-line if we allocated one.
     if (_globalIvarOffsets != _inlineGlobalIvarOffsets) {
-      delete [] _globalIvarOffsets;
+      free(_globalIvarOffsets);
     }
   }
 

--- a/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
+++ b/test/IRGen/prespecialized-metadata/Inputs/isPrespecialized.cpp
@@ -49,9 +49,9 @@ bool isStaticallySpecializedGenericMetadata(void *ptr) {
 void allocateDirtyAndFreeChunk(void) {
   uintptr_t ChunkSize = 16 * 1024;
 
-  char *allocation = new char[ChunkSize];
+  char *allocation = static_cast<char *>(malloc(ChunkSize));
 
-  memset(allocation, 255, ChunkSize);
+  memset(allocation, 0xff, ChunkSize);
 
-  delete[] allocation;
+  free(allocation);
 }


### PR DESCRIPTION
This is more efficient, especially when calling calloc instead of new + memset
