### PR TITLE
[Mem2Reg] RAUW undef lexical lifetime phis.

### DIFF
--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
@@ -1,0 +1,1195 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct SmallCodesizeStruct {
+  var cls1 : Klass
+  var cls2 : Klass
+}
+
+struct WrapperStruct {
+  var cls : Klass
+}
+
+struct LargeCodesizeStruct {
+  var s1: SmallCodesizeStruct
+  var s2: SmallCodesizeStruct
+  var s3: SmallCodesizeStruct
+  var s4: SmallCodesizeStruct
+  var s5: SmallCodesizeStruct
+}
+
+public enum NonTrivialEnum {
+  case some1(Klass)
+  case some2(NonTrivialStruct)
+}
+
+struct NonTrivialStruct {
+  var val:Klass
+}
+
+public enum FakeOptional<T> {
+  case some(T)
+  case none
+}
+
+sil [ossa] @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+sil [ossa] @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
+sil [ossa] @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
+sil [ossa] @take_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+
+///////////
+// Tests //
+///////////
+
+sil [noinline] [ossa] @blackhole : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  debug_value %0 : $*T, let, name "t", argno 1, expr op_deref
+  %2 = tuple ()
+  return %2 : $()
+}
+
+sil shared [noinline] @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @store_only_allocas :
+// CHECK-NOT: alloc_stack
+// CHECK: return
+sil [ossa] @store_only_allocas : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  %2 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = load [take] %1 : $*Klass
+  %4 = apply %2(%3) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %3 : $Klass
+  dealloc_stack %1 : $*Klass
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $Klass, [[INSTANCE_2:%[^,]+]] : @owned $Klass):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         cond_fail
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         apply
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK-LABEL: } // end sil function 'multiple_store_vals'
+sil [ossa] @multiple_store_vals : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  store %1 to [assign] %2 : $*Klass
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %2 : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %2 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals2 : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $Klass, [[INSTANCE_2:%[^,]+]] : @owned $Klass):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         cond_fail
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         apply
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK-LABEL: } // end sil function 'multiple_store_vals2'
+sil [ossa] @multiple_store_vals2 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  destroy_addr %2 : $*Klass
+  store %1 to [init] %2 : $*Klass
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %2 : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %2 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals3 : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @guaranteed $Klass, [[INSTANCE_2:%[^,]+]] : @guaranteed $Klass):
+// CHECK:         [[COPY_1:%[^,]+]] = copy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[COPY_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         cond_fail
+// CHECK:         [[COPY_2:%[^,]+]] = copy_value [[INSTANCE_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[COPY_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[COPY_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[COPY_2]]
+// CHECK:         apply
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK-LABEL: } // end sil function 'multiple_store_vals3'
+sil [ossa] @multiple_store_vals3 : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  %copy0 = copy_value %0 : $Klass
+  store %copy0 to [init] %2 : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  %copy1 = copy_value %1 : $Klass
+  store %copy1 to [assign] %2 : $*Klass
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %2 : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %2 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals4 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals4'
+sil [ossa] @multiple_store_vals4 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Klass>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Klass>, 0
+  store %1 to [assign] %2 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb2:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb3:
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals5 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals5'
+sil [ossa] @multiple_store_vals5 : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass, %2 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk : $*Klass
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Klass>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Klass>, 0
+  store %1 to [assign] %stk : $*Klass
+  store %2 to [assign] %stk : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb2:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb3:
+  destroy_addr %stk : $*Klass
+  dealloc_stack %stk : $*Klass
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals6 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals6'
+sil [ossa] @multiple_store_vals6 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  br bb1
+
+bb1:
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  store %1 to [assign] %2 : $*Klass
+  br bb2
+
+bb2:
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %2 : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %2 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals7 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals7'
+sil [ossa] @multiple_store_vals7 : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass, %2 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  br bb1
+
+bb1:
+  store %1 to [assign] %stk : $*Klass
+  store %2 to [assign] %stk : $*Klass
+  br bb2
+
+bb2:
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %stk : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %stk : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals8 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals8'
+sil [ossa] @multiple_store_vals8 : $@convention(thin) (@owned Klass, @owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass, %2 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk : $*Klass
+  %3 = integer_literal $Builtin.Int1, 0
+  cond_fail %3 : $Builtin.Int1
+  br bb1
+
+bb1:
+  store %1 to [assign] %stk : $*Klass
+  destroy_addr %stk : $*Klass
+  store %2 to [init] %stk : $*Klass
+  br bb2
+
+bb2:
+  %4 = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = load [take] %stk : $*Klass
+  %6 = apply %4(%5) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %5 : $Klass
+  dealloc_stack %stk : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @with_loads :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'with_loads'
+sil [ossa] @with_loads : $@convention(thin) (@owned Klass, @owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Klass>
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Klass>, 0
+  store %1 to [assign] %2 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb2:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Klass>
+  br bb3
+
+bb3:
+  %ret = load [take] %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  return %ret : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @basic_block_with_loads_and_stores :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'basic_block_with_loads_and_stores'
+sil [ossa] @basic_block_with_loads_and_stores : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  %3 = alloc_stack [lexical] $Klass
+  store %1 to [init] %3 : $*Klass
+  %local = alloc_ref $Klass
+  store %local to [assign] %3 : $*Klass
+  %func = function_ref @blackhole_spl : $@convention(thin) (@guaranteed Klass) -> ()
+  %arg = load [take] %3 : $*Klass
+  %applyres = apply %func(%arg) : $@convention(thin) (@guaranteed Klass) -> ()
+  destroy_value %arg : $Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %3 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @basic_block_with_loads_copy_and_take : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Klass):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE:%[^,]+]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME:%[^,]+]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED:%[^,]+]]
+// CHECK:         end_borrow [[LIFETIME:%[^,]+]]
+// CHECK:         destroy_value [[INSTANCE:%[^,]+]]
+// CHECK:         destroy_value [[COPY:%[^,]+]]
+// CHECK:         destroy_value [[LIFETIME_OWNED:%[^,]+]]
+// CHECK-LABEL: } // end sil function 'basic_block_with_loads_copy_and_take'
+sil [ossa] @basic_block_with_loads_copy_and_take : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  %copy = load [copy] %1 : $*Klass
+  %take = load [take] %1 : $*Klass
+  destroy_value %copy : $Klass
+  destroy_value %take : $Klass
+  dealloc_stack %1 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// load [copy] is not used as RunningVal
+// StackAllocationPromoter::fixBranchesAndUses will delete the loads and replace with %0
+// CHECK-LABEL: sil [ossa] @multi_basic_block_with_loads_copy_and_take_1 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multi_basic_block_with_loads_copy_and_take_1'
+sil [ossa] @multi_basic_block_with_loads_copy_and_take_1 : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  br bb1
+bb1:
+  %copy = load [copy] %1 : $*Klass
+  %take = load [take] %1 : $*Klass
+  destroy_value %copy : $Klass
+  destroy_value %take : $Klass
+  dealloc_stack %1 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// load [copy] is not used as RunningVal
+// StackAllocationPromoter::fixBranchesAndUses will delete the loads and replace with %0
+// CHECK-LABEL: sil [ossa] @multi_basic_block_with_loads_copy_and_take_2 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multi_basic_block_with_loads_copy_and_take_2'
+sil [ossa] @multi_basic_block_with_loads_copy_and_take_2 : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  br bb1
+bb1:
+  %copy = load [copy] %1 : $*Klass
+  %take = load [take] %1 : $*Klass
+  destroy_value %take : $Klass
+  dealloc_stack %1 : $*Klass
+  return %copy : $Klass
+}
+
+// load [take] is used as RunningVal in bb1
+// CHECK-LABEL: sil [ossa] @multi_basic_block_with_loads_copy_and_take_3 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multi_basic_block_with_loads_copy_and_take_3'
+sil [ossa] @multi_basic_block_with_loads_copy_and_take_3 : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  br bb1
+bb1:
+  %take = load [take] %1 : $*Klass
+  %copy = copy_value %take : $Klass
+  destroy_value %take : $Klass
+  dealloc_stack %1 : $*Klass
+  return %copy : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @multi_basic_block_with_store_assign :
+// CHECK-NOT: alloc_stack
+// CHECK: destroy_value %0 : $Klass
+// CHECK-LABEL: } // end sil function 'multi_basic_block_with_store_assign'
+sil [ossa] @multi_basic_block_with_store_assign : $@convention(thin) (@owned Klass, @owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass, %1: @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk : $*Klass
+  br bb1
+bb1:
+  store %1 to [assign] %stk : $*Klass
+  %res = load [take] %stk : $*Klass
+  dealloc_stack %stk : $*Klass
+  return %res : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @multi_basic_block_with_phiarg :
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $Klass, [[INSTANCE_2:%[^,]+]] : @owned $Klass):
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]([[INSTANCE_2]] : $Klass, [[LIFETIME_2]] : $Klass, [[LIFETIME_OWNED_2]] : $Klass)
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         br [[EXIT]]([[INSTANCE_1]] : $Klass, [[LIFETIME_1]] : $Klass, [[LIFETIME_OWNED_1]] : $Klass)
+// CHECK:       [[EXIT]]([[INSTANCE:%[^,]+]] : @owned $Klass, [[LIFETIME:%[^,]+]] : @guaranteed $Klass, [[LIFETIME_OWNED:%[^,]+]] : @owned $Klass):
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK-LABEL: } // end sil function 'multi_basic_block_with_phiarg'
+sil [ossa] @multi_basic_block_with_phiarg : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  cond_br undef, bb1, bb2
+bb1:
+  store %1 to [init] %stk : $*Klass
+  destroy_value %0 : $Klass
+  br bb3
+bb2:
+  store %0 to [init] %stk : $*Klass
+  destroy_value %1 : $Klass
+  br bb3
+bb3:
+  %val = load [take] %stk : $*Klass
+  destroy_value %val : $Klass
+  dealloc_stack %stk : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multi_asi_basic_block_with_phiarg : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $Klass, [[INSTANCE_2:%[^,]+]] : @owned $Klass):
+// CHECK:         cond_br undef, [[BASIC_BLOCK1:bb[0-9]+]], [[BASIC_BLOCK2:bb[0-9]+]]
+// CHECK:       [[BASIC_BLOCK1]]:
+// CHECK:         [[LIFETIME_2_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2_1:%[^,]+]] = copy_value [[LIFETIME_2_1]]
+// CHECK:         [[LIFETIME_1_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1_1:%[^,]+]] = copy_value [[LIFETIME_1_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]([[INSTANCE_1]] : $Klass, [[LIFETIME_1_1]] : $Klass, [[LIFETIME_OWNED_1_1]] : $Klass, [[INSTANCE_2]] : $Klass, [[LIFETIME_2_1]] : $Klass, [[LIFETIME_OWNED_2_1]] : $Klass)
+// CHECK:       [[BASIC_BLOCK2]]:
+// CHECK:         [[LIFETIME_2_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2_1_2:%[^,]+]] = copy_value [[LIFETIME_2_2]]
+// CHECK:         [[LIFETIME_1_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1_1_2:%[^,]+]] = copy_value [[LIFETIME_1_2]]
+// CHECK:         br [[EXIT]]([[INSTANCE_2]] : $Klass, [[LIFETIME_2_2]] : $Klass, [[LIFETIME_OWNED_2_1_2]] : $Klass, [[INSTANCE_1]] : $Klass, [[LIFETIME_1_2]] : $Klass, [[LIFETIME_OWNED_1_1_2]] : $Klass)
+// CHECK:       [[EXIT]]([[INSTANCE_EXIT_1:%[^,]+]] : @owned $Klass, [[LIFETIME_EXIT_1:%[^,]+]] : @guaranteed $Klass, [[LIFETIME_OWNED_EXIT_1:%[^,]+]] : @owned $Klass, [[INSTANCE_EXIT_2:%[^,]+]] : @owned $Klass, [[LIFETIME_EXIT_2:%[^,]+]] : @guaranteed $Klass, [[LIFETIME_OWNED_EXIT_2:%[^,]+]] : @owned $Klass):
+// CHECK:         end_borrow [[LIFETIME_EXIT_2]]
+// CHECK:         destroy_value [[INSTANCE_EXIT_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_EXIT_2]]
+// CHECK:         end_borrow [[LIFETIME_EXIT_1]]
+// CHECK:         destroy_value [[INSTANCE_EXIT_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_EXIT_1]]
+// CHECK-LABEL: } // end sil function 'multi_asi_basic_block_with_phiarg'
+sil [ossa] @multi_asi_basic_block_with_phiarg : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk1 = alloc_stack [lexical] $Klass
+  %stk2 = alloc_stack [lexical] $Klass
+  cond_br undef, bb1, bb2
+bb1:
+  store %1 to [init] %stk1 : $*Klass
+  store %0 to [init] %stk2 : $*Klass
+  br bb3
+bb2:
+  store %1 to [init] %stk2 : $*Klass
+  store %0 to [init] %stk1 : $*Klass
+  br bb3
+bb3:
+  %val1 = load [take] %stk1 : $*Klass
+  destroy_value %val1 : $Klass
+  %val2 = load [take] %stk2 : $*Klass
+  destroy_value %val2 : $Klass
+  dealloc_stack %stk2 : $*Klass
+  dealloc_stack %stk1 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// Test to check no dead args are passed to bb3 as phi arg
+// CHECK-LABEL: sil [ossa] @multi_basic_block_stack_deallocated_phiarg :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: bb2:
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK-LABEL: } // end sil function 'multi_basic_block_stack_deallocated_phiarg'
+sil [ossa] @multi_basic_block_stack_deallocated_phiarg : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  cond_br undef, bb1, bb2
+bb1:
+  dealloc_stack %stk : $*Klass
+  destroy_value %0 : $Klass
+  br bb3
+bb2:
+  store %0 to [init] %stk : $*Klass
+  %val = load [take] %stk : $*Klass
+  dealloc_stack %stk : $*Klass
+  destroy_value %val : $Klass
+  br bb3
+bb3:
+  %res = tuple ()
+  return %res : $()
+}
+
+// Test to check no dead args are passed to bb3 as phi arg
+// CHECK-LABEL: sil [ossa] @multi_asi_basic_block_stack_deallocated_phiarg :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: bb2:
+// CHECK: br bb3
+// CHECK: bb3:
+// CHECK-LABEL: } // end sil function 'multi_asi_basic_block_stack_deallocated_phiarg'
+sil [ossa] @multi_asi_basic_block_stack_deallocated_phiarg : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk1 = alloc_stack [lexical] $Klass
+  %stk2 = alloc_stack [lexical] $Klass
+  cond_br undef, bb1, bb2
+bb1:
+  dealloc_stack %stk2 : $*Klass
+  dealloc_stack %stk1 : $*Klass
+  destroy_value %0 : $Klass
+  destroy_value %1 : $Klass
+  br bb3
+bb2:
+  store %0 to [init] %stk1 : $*Klass
+  %val1 = load [take] %stk1 : $*Klass
+  store %1 to [init] %stk2 : $*Klass
+  %val2 = load [take] %stk2 : $*Klass
+  destroy_value %val1 : $Klass
+  destroy_value %val2 : $Klass
+  dealloc_stack %stk2 : $*Klass
+  dealloc_stack %stk1 : $*Klass
+  br bb3
+bb3:
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multi_basic_block_destroyed_last_stored_val_phiarg :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: bb3:
+// CHECK-LABEL: } // end sil function 'multi_basic_block_destroyed_last_stored_val_phiarg'
+sil [ossa] @multi_basic_block_destroyed_last_stored_val_phiarg : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %0 : $Klass
+  br bb3
+bb2:
+  store %0 to [init] %stk : $*Klass
+  %val = load [take] %stk : $*Klass
+  destroy_value %val : $Klass
+  br bb3
+bb3:
+  dealloc_stack %stk : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_debug_value : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK-NOT:   debug_value {{.*}} expr op_deref
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Klass):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         debug_value [[LIFETIME_OWNED]]
+// CHECK-LABEL: } // end sil function 'mem2reg_debug_value'
+sil [ossa] @mem2reg_debug_value : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %1 : $*Klass
+  debug_value %1 : $*Klass, expr op_deref
+  %2 = load [take] %1 : $*Klass
+  dealloc_stack %1 : $*Klass
+  return %2 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_struct_addr : {{.*}} {
+// CHECK-NOT:   alloc_stack
+// CHECK:       {{bb[0-9]+}}([[INSTANCSE:%[^,]+]] : @owned $SmallCodesizeStruct):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCSE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[LIFETIME_OWNED]]
+// CHECK:         [[ELEMENT:%[^,]+]] = struct_extract [[BORROW]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[ELEMENT]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         ([[FIELD_1:%[^,]+]], [[FIELD_2:%[^,]+]]) = destructure_struct [[LIFETIME_OWNED]]
+// CHECK:         destroy_value [[FIELD_1]]
+// CHECK:         destroy_value [[FIELD_2]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCSE]]
+// CHECK:         return [[COPY]]
+// CHECK-LABEL: } // end sil function 'mem2reg_struct_addr'
+sil [ossa] @mem2reg_struct_addr : $@convention(thin) (@owned SmallCodesizeStruct) -> @owned Klass {
+bb0(%0 : @owned $SmallCodesizeStruct):
+  %1 = alloc_stack [lexical] $SmallCodesizeStruct
+  store %0 to [init] %1 : $*SmallCodesizeStruct
+  %2 = struct_element_addr %1 : $*SmallCodesizeStruct, #SmallCodesizeStruct.cls1
+  %3 = load [copy] %2 : $*Klass
+  destroy_addr %1 : $*SmallCodesizeStruct
+  dealloc_stack %1 : $*SmallCodesizeStruct
+  return %3 : $Klass
+}
+
+// SILMem2Reg is disabled when there is a load [take] with struct_elemenet_addr/tuple_element_addr
+// CHECK-LABEL: sil [ossa] @mem2reg_struct_addr_load_take :
+// CHECK: alloc_stack
+// CHECK-LABEL: } // end sil function 'mem2reg_struct_addr_load_take'
+sil [ossa] @mem2reg_struct_addr_load_take : $@convention(thin) (@owned WrapperStruct) -> () {
+bb0(%0 : @owned $WrapperStruct):
+  %1 = alloc_stack [lexical] $WrapperStruct
+  store %0 to [init] %1 : $*WrapperStruct
+  %2 = struct_element_addr %1 : $*WrapperStruct, #WrapperStruct.cls
+  %3 = load [take] %2 : $*Klass
+  destroy_value %3 : $Klass
+  dealloc_stack %1 : $*WrapperStruct
+  %tup = tuple ()
+  return %tup : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_tuple_addr :
+// CHECK-NOT: alloc_stack
+// CHECK: [[TUP:%.*]] = tuple (%0 : $Klass, %1 : $Klass)
+// CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[TUP]]
+// CHECK:  [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK: [[BORROW:%.*]] = begin_borrow [[LIFETIME_OWNED]] : $(Klass, Klass)
+// CHECK: [[ELE:%.*]] = tuple_extract [[BORROW]]
+// CHECK: [[COPY:%.*]] = copy_value [[ELE]] : $Klass
+// CHECK: end_borrow [[BORROW]] :  $(Klass, Klass)
+// CHECK: return [[COPY]]
+// CHECK-LABEL: } // end sil function 'mem2reg_tuple_addr'
+sil [ossa] @mem2reg_tuple_addr : $@convention(thin) (@owned Klass, @owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk = alloc_stack [lexical] $(Klass, Klass)
+  %2 = tuple (%0 : $Klass, %1 : $Klass)
+  store %2 to [init] %stk : $*(Klass, Klass)
+  %4 = tuple_element_addr %stk : $*(Klass, Klass), 0
+  %5 = load [copy] %4 : $*Klass
+  destroy_addr %stk : $*(Klass, Klass)
+  dealloc_stack %stk : $*(Klass, Klass)
+  return %5 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @struct_extract_if_then_else :
+// CHECK-NOT: alloc_stack
+sil [ossa] @struct_extract_if_then_else : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64
+  store %0 to [trivial] %1 : $*Int64
+  %3 = integer_literal $Builtin.Int64, 2
+  %4 = struct_extract %0 : $Int64, #Int64._value
+  %5 = builtin "cmp_sgt_Int64"(%4 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  %6 = struct_element_addr %1 : $*Int64, #Int64._value
+  cond_br %5, bb1, bb2
+
+// CHECK: bb1:
+// CHECK: struct_extract %0
+bb1:
+  %8 = load [trivial] %6 : $*Builtin.Int64
+  %9 = integer_literal $Builtin.Int64, 1
+  %10 = integer_literal $Builtin.Int1, 0
+  %11 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %9 : $Builtin.Int64, %10 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0
+  br bb3(%12 : $Builtin.Int64)
+
+// CHECK: bb2:
+// CHECK: struct_extract %0
+bb2:
+  %14 = load [trivial] %6 : $*Builtin.Int64
+  %15 = integer_literal $Builtin.Int64, 2
+  %16 = integer_literal $Builtin.Int1, 0
+  %17 = builtin "sadd_with_overflow_Int64"(%14 : $Builtin.Int64, %15 : $Builtin.Int64, %16 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 0
+  br bb3(%18 : $Builtin.Int64)
+
+// CHECK-NOT: dealloc_stack
+bb3(%20 : $Builtin.Int64):
+  dealloc_stack %1 : $*Int64
+  %22 = struct $Int64 (%20 : $Builtin.Int64)
+  return %22 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'struct_extract_if_then_else'
+
+// Test cases where the only use is a debug_value_addr
+// CHECK-LABEL: sil [ossa] @no_real_uses :
+sil [ossa] @no_real_uses : $@convention(thin) () -> () {
+// CHECK: bb0
+bb0:
+  // CHECK-NOT: alloc_stack
+  %0 = alloc_stack [lexical] $Klass
+  %local = alloc_ref $Klass
+  store %local to [init] %0 : $*Klass
+  // CHECK-NOT: debug_value {{.*}} expr op_deref
+  debug_value %0 : $*Klass, expr op_deref
+  destroy_addr %0 : $*Klass
+  // CHECK-NOT: dealloc_stack
+  dealloc_stack %0 : $*Klass
+  %1 = tuple ()
+  return %1 : $()
+}
+// CHECK-LABEL: } // end sil function 'no_real_uses'
+
+// CHECK-LABEL: sil [ossa] @half_trivial
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $(Builtin.BridgeObject, Builtin.Int32)):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED]]
+// CHECK: destructure_tuple [[LIFETIME_OWNED]]
+// CHECK-NEXT: destroy_value
+// CHECK-NEXT: end_borrow
+// CHECK-NEXT: destroy_value
+// CHECK-NEXT: tuple
+// CHECK-LABEL: } // end sil function 'half_trivial'
+sil [ossa] @half_trivial : $@convention(thin) (@owned (Builtin.BridgeObject, Builtin.Int32)) -> () {
+bb0(%0 : @owned $(Builtin.BridgeObject, Builtin.Int32)):
+  %1 = alloc_stack [lexical] $(Builtin.BridgeObject, Builtin.Int32)
+  store %0 to [init] %1 : $*(Builtin.BridgeObject, Builtin.Int32)
+  %3 = load [copy] %1 : $*(Builtin.BridgeObject, Builtin.Int32)
+  destroy_value %3 : $(Builtin.BridgeObject, Builtin.Int32)
+  destroy_addr %1 : $*(Builtin.BridgeObject, Builtin.Int32)
+  dealloc_stack %1 : $*(Builtin.BridgeObject, Builtin.Int32)
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_debug_value :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_debug_value'
+sil [ossa] @multiple_debug_value : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  debug_value %0 : $Klass
+  %2 = alloc_stack [lexical] $Klass
+  store %0 to [init] %2 : $*Klass
+  debug_value %2 : $*Klass, expr op_deref
+  %5 = load [take] %2 : $*Klass
+  destroy_value %5 : $Klass
+  dealloc_stack %2 : $*Klass
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @multi_basic_block_bug1 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multi_basic_block_bug1'
+sil [ossa] @multi_basic_block_bug1 : $@convention(thin) (@owned Klass, @owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk1 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  %new1 = load [take] %stk1 : $*Klass
+  destroy_value %1 : $Klass
+  dealloc_stack %stk1 : $*Klass
+  br bbret(%new1 : $Klass)
+
+bb2:
+  store %1 to [assign] %stk1 : $*Klass
+  %new2 = load [take] %stk1 : $*Klass
+  dealloc_stack %stk1 : $*Klass
+  br bbret(%new2 : $Klass)
+
+bbret(%new : @owned $Klass):
+  return %new : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @multi_basic_block_bug2 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multi_basic_block_bug2'
+sil [ossa] @multi_basic_block_bug2 : $@convention(thin) (@owned Klass, @owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %stk1 = alloc_stack [lexical] $Klass
+  store %0 to [init] %stk1 : $*Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  %new1 = load [take] %stk1 : $*Klass
+  destroy_value %1 : $Klass
+  br bbret(%new1 : $Klass)
+
+bb2:
+  store %1 to [assign] %stk1 : $*Klass
+  %new2 = load [take] %stk1 : $*Klass
+  br bbret(%new2 : $Klass)
+
+bbret(%new : @owned $Klass):
+  dealloc_stack %stk1 : $*Klass
+  return %new : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @test_dynamiclifetime1 :
+// CHECK: alloc_stack [dynamic_lifetime]
+// CHECK-LABEL: } // end sil function 'test_dynamiclifetime1'
+sil [ossa] @test_dynamiclifetime1 : $@convention(thin) () -> () {
+bb0:
+  %2 = alloc_stack [lexical] $Builtin.Int1
+  %3 = alloc_stack [lexical] [dynamic_lifetime] $NonTrivialStruct
+  %4 = integer_literal $Builtin.Int1, 0
+  store %4 to [trivial] %2 : $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  %func = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %val = apply %func() : $@convention(thin) () -> @owned NonTrivialStruct
+  %27 = integer_literal $Builtin.Int1, -1
+  store %27 to [trivial] %2 : $*Builtin.Int1
+  store %val to [init] %3 : $*NonTrivialStruct
+  br bb3
+
+bb3:
+  %32 = load [trivial] %2 : $*Builtin.Int1
+  cond_br %32, bb4, bb5
+
+bb4:
+  %34 = load [take] %3 : $*NonTrivialStruct
+  destroy_value %34 : $NonTrivialStruct
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*NonTrivialStruct
+  dealloc_stack %2 : $*Builtin.Int1
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_dynamiclifetime2 :
+// CHECK: alloc_stack [dynamic_lifetime]
+// CHECK-LABEL: } // end sil function 'test_dynamiclifetime2'
+sil [ossa] @test_dynamiclifetime2 : $@convention(thin) () -> () {
+bb0:
+  %2 = alloc_stack [lexical] $Builtin.Int1
+  %3 = alloc_stack [lexical] [dynamic_lifetime] $NonTrivialStruct
+  %4 = integer_literal $Builtin.Int1, 0
+  store %4 to [trivial] %2 : $*Builtin.Int1
+  %func1 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %val1 = apply %func1() : $@convention(thin) () -> @owned NonTrivialStruct
+  store %val1 to [init] %3 : $*NonTrivialStruct
+  %ld1 = load [take] %3 : $*NonTrivialStruct
+  %func2 = function_ref @take_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  apply %func2(%ld1) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  %val = apply %func1() : $@convention(thin) () -> @owned NonTrivialStruct
+  %27 = integer_literal $Builtin.Int1, -1
+  store %27 to [trivial] %2 : $*Builtin.Int1
+  store %val to [init] %3 : $*NonTrivialStruct
+  br bb3
+
+bb3:
+  %32 = load [trivial] %2 : $*Builtin.Int1
+  cond_br %32, bb4, bb5
+
+bb4:
+  %ld2 = load [take] %3 : $*NonTrivialStruct
+  destroy_value %ld2 : $NonTrivialStruct
+  br bb6
+
+bb5:
+  br bb6
+
+bb6:
+  dealloc_stack %3 : $*NonTrivialStruct
+  dealloc_stack %2 : $*Builtin.Int1
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_deadphi1 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_deadphi1'
+sil [ossa] @test_deadphi1 : $@convention(thin)  () -> () {
+bb0:
+  br bb1
+
+bb1:
+  cond_br undef, bb1a, bb6
+
+bb1a:
+  br bb2
+
+bb2:
+  %stk = alloc_stack [lexical] $NonTrivialStruct
+  cond_br undef, bb3, bb4
+
+bb3:
+  %func = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %val = apply %func() : $@convention(thin) () -> @owned NonTrivialStruct
+  store %val to [init] %stk : $*NonTrivialStruct
+  %lval1 = load [copy] %stk : $*NonTrivialStruct
+  destroy_value %lval1 : $NonTrivialStruct
+  %lval2 = load [take] %stk : $*NonTrivialStruct
+  destroy_value %lval2 : $NonTrivialStruct
+  dealloc_stack %stk : $*NonTrivialStruct
+  cond_br undef, bb3a, bb3b
+
+bb3a:
+  br bb1
+
+bb3b:
+  br bb5
+
+bb4:
+  dealloc_stack %stk : $*NonTrivialStruct
+  unreachable
+
+bb5:
+  br bb2
+
+bb6:
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_deadphi2 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_deadphi2'
+sil [ossa] @test_deadphi2 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $NonTrivialStruct
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %3 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %4 = apply %3() : $@convention(thin) () -> @owned NonTrivialStruct
+  store %4 to [init] %0 : $*NonTrivialStruct
+  cond_br undef, bb4, bb5
+
+bb3:
+  dealloc_stack %0 : $*NonTrivialStruct
+  br bb7
+
+bb4:
+  %lval1 = load [take] %0 : $*NonTrivialStruct
+  destroy_value %lval1 : $NonTrivialStruct
+  dealloc_stack %0 : $*NonTrivialStruct
+  br bb7
+
+bb5:
+  %lval2 = load [take] %0 : $*NonTrivialStruct
+  destroy_value %lval2 : $NonTrivialStruct
+  dealloc_stack %0 : $*NonTrivialStruct
+  br bb7
+
+bb6:
+  %17 = tuple ()
+  return %17 : $()
+
+bb7:
+  br bb6
+}
+
+// CHECK-LABEL: sil [ossa] @test_deadphi3 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_deadphi3'
+sil [ossa] @test_deadphi3 : $@convention(thin) (@owned NonTrivialEnum) -> () {
+bb0(%0 : @owned $NonTrivialEnum):
+  %1 = alloc_stack [lexical] $NonTrivialStruct
+  switch_enum %0 : $NonTrivialEnum, case #NonTrivialEnum.some1!enumelt: bb1, case #NonTrivialEnum.some2!enumelt: bb5
+
+bb1(%3 : @owned $Klass):
+  destroy_value %3 : $Klass
+  %5 = function_ref @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
+  %6 = apply %5() : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
+  switch_enum %6 : $FakeOptional<NonTrivialStruct>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb2
+
+bb2:
+  br bb3
+
+bb3:
+  unreachable
+
+bb4(%10 : @owned $NonTrivialStruct):
+  store %10 to [init] %1 : $*NonTrivialStruct
+  br bb9
+
+bb5(%13 : @owned $NonTrivialStruct):
+  destroy_value %13 : $NonTrivialStruct
+  %15 = function_ref @get_optionalnontrivialstruct : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
+  %16 = apply %15() : $@convention(thin) () -> @owned FakeOptional<NonTrivialStruct>
+  switch_enum %16 : $FakeOptional<NonTrivialStruct>, case #FakeOptional.some!enumelt: bb8, case #FakeOptional.none!enumelt: bb6
+
+bb6:
+  br bb7
+
+bb7:
+  unreachable
+
+bb8(%20 : @owned $NonTrivialStruct):
+  store %20 to [init] %1 : $*NonTrivialStruct
+  br bb9
+
+bb9:
+  %23 = function_ref @get_nontrivialenum : $@convention(thin) () -> @owned NonTrivialEnum
+  %24 = apply %23() : $@convention(thin) () -> @owned NonTrivialEnum
+  switch_enum %24 : $NonTrivialEnum, case #NonTrivialEnum.some1!enumelt: bb10, case #NonTrivialEnum.some2!enumelt: bb11
+
+bb10(%26 : @owned $Klass):
+  %27 = load [copy] %1 : $*NonTrivialStruct
+  destroy_value %27 : $NonTrivialStruct
+  destroy_value %26 : $Klass
+  br bb12
+
+bb11(%31 : @owned $NonTrivialStruct):
+  %32 = load [copy] %1 : $*NonTrivialStruct
+  destroy_value %32 : $NonTrivialStruct
+  destroy_value %31 : $NonTrivialStruct
+  br bb12
+
+bb12:
+  %36 = load [take] %1 : $*NonTrivialStruct
+  destroy_value %36 : $NonTrivialStruct
+  dealloc_stack %1 : $*NonTrivialStruct
+  %39 = tuple ()
+  return %39 : $()
+}
+
+enum KlassOptional {
+  case some(Klass)
+  case none
+}
+
+sil @return_optional_or_error : $@convention(thin) () -> (@owned KlassOptional, @error Error)
+
+// CHECK-LABEL: sil [ossa] @test_deadphi4 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_deadphi4'
+sil [ossa] @test_deadphi4 : $@convention(thin) (@owned KlassOptional) -> () {
+bb0(%0 : @owned $KlassOptional):
+  %stk = alloc_stack [lexical] $KlassOptional
+  switch_enum %0 : $KlassOptional, case #KlassOptional.some!enumelt: bb2, case #KlassOptional.none!enumelt: bb1
+
+bb1:
+  dealloc_stack %stk : $*KlassOptional
+  br bb7
+
+bb2(%some : @owned $Klass):
+  destroy_value %some : $Klass
+  %19 = function_ref @return_optional_or_error : $@convention(thin) () -> (@owned KlassOptional, @error Error)
+  try_apply %19() : $@convention(thin) () -> (@owned KlassOptional, @error Error), normal bb3, error bb8
+
+bb3(%callresult : @owned $KlassOptional):
+  store %callresult to [init] %stk : $*KlassOptional
+  %29 = load [take] %stk : $*KlassOptional
+  switch_enum %29 : $KlassOptional, case #KlassOptional.some!enumelt: bb5, case #KlassOptional.none!enumelt: bb4
+
+bb4:
+  dealloc_stack %stk : $*KlassOptional
+  br bb7
+
+bb5(%33 : @owned $Klass):
+  destroy_value %33 : $Klass
+  dealloc_stack %stk : $*KlassOptional
+  br bb6
+
+bb6:
+  %39 = tuple ()
+  return %39 : $()
+
+bb7:
+  br bb6
+
+bb8(%err : @owned $Error):
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @test_deadphi5 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test_deadphi5'
+sil [ossa] @test_deadphi5 : $@convention(thin) () -> () {
+bb0:
+  %stk = alloc_stack [lexical] $NonTrivialStruct
+  cond_br undef, bb2, bb1
+
+bb1:
+  %func1 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %val1 = apply %func1() : $@convention(thin) () -> @owned NonTrivialStruct
+  store %val1 to [init] %stk : $*NonTrivialStruct
+  br bb5
+
+bb2:
+  %func2 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %val2 = apply %func2() : $@convention(thin) () -> @owned NonTrivialStruct
+  store %val2 to [init] %stk : $*NonTrivialStruct
+  cond_br undef, bb3, bb4
+
+bb3:
+  br bb5
+
+bb4:
+  %lval1 = load [take] %stk : $*NonTrivialStruct
+  destroy_value %lval1 : $NonTrivialStruct
+  dealloc_stack %stk : $*NonTrivialStruct
+  br bb9
+
+bb5:
+  cond_br undef, bb6, bb7
+
+bb6:
+  %lval2 = load [take] %stk : $*NonTrivialStruct
+  destroy_value %lval2 : $NonTrivialStruct
+  br bb8
+
+bb7:
+  %lval3 = load [take] %stk : $*NonTrivialStruct
+  destroy_value %lval3 : $NonTrivialStruct
+  br bb8
+
+bb8:
+  dealloc_stack %stk : $*NonTrivialStruct
+  br bb9
+
+bb9:
+  %res = tuple ()
+  return %res : $()
+}
+

--- a/test/SILOptimizer/mem2reg_simple_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_simple_lifetime.sil
@@ -1,0 +1,451 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// func foo(v : Int) -> Int {
+//   var x : Int = 0
+//   if v == 3 { x = 3 } else {
+//     if (v == 2) { x = 2 }
+//   }
+//   var i : Int = 0
+//   while (i < 10) { i = i+1 }
+//   return x
+// }
+
+// CHECK: sil [ossa] @place_phi :
+// CHECK-NOT: alloc_stack
+sil [ossa] @place_phi : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "v"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  %7 = integer_literal $Builtin.Int64, 3
+  %9 = struct_extract %0 : $Int64, #Int64._value
+  %10 = builtin "cmp_eq_Int64"(%9 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %10, bb1, bb2
+
+bb1:
+  %12 = struct $Int64 (%7 : $Builtin.Int64)
+  store %12 to [trivial] %3 : $*Int64
+  br bb6
+
+bb2:
+  %15 = integer_literal $Builtin.Int64, 2
+  %16 = builtin "cmp_eq_Int64"(%9 : $Builtin.Int64, %15 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %16, bb3, bb4
+
+bb3:
+  %18 = struct $Int64 (%15 : $Builtin.Int64)
+  store %18 to [trivial] %3 : $*Int64
+  br bb5
+
+bb4:
+  br bb5
+
+bb5:
+  br bb6
+
+// CHECK: bb6([[PHI:%[0-9]+]] : $Int64):
+// CHECK-NOT: alloc_stack
+bb6:
+  %22 = alloc_stack [lexical] $Int64, var, name "i"
+  store %5 to [trivial] %22 : $*Int64
+  br bb7
+
+// CHECK: bb7([[PHI2:%[0-9]+]] : $Int64):
+bb7:
+  // CHECK: struct_extract [[PHI2]]
+  %25 = struct_element_addr %22 : $*Int64, #Int64._value
+  %26 = load [trivial] %25 : $*Builtin.Int64
+  %27 = integer_literal $Builtin.Int64, 10
+  %29 = builtin "cmp_slt_Int64"(%26 : $Builtin.Int64, %27 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %29, bb8, bb9
+
+bb8:
+  // CHECK: struct_extract [[PHI2]]
+  %31 = struct_element_addr %22 : $*Int64, #Int64._value
+  %32 = load [trivial] %31 : $*Builtin.Int64
+  %33 = integer_literal $Builtin.Int64, 1
+  %35 = builtin "sadd_with_overflow_Int64"(%32 : $Builtin.Int64, %33 : $Builtin.Int64, %29 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %36 = tuple_extract %35 : $(Builtin.Int64, Builtin.Int1), 0
+  %37 = tuple_extract %35 : $(Builtin.Int64, Builtin.Int1), 1
+  %38 = struct $Int64 (%36 : $Builtin.Int64)
+  cond_fail %37 : $Builtin.Int1
+  store %38 to [trivial] %22 : $*Int64
+  br bb7
+
+bb9:
+  %42 = load [trivial] %3 : $*Int64
+  dealloc_stack %22 : $*Int64
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %42 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'place_phi'
+
+// func loop(c : Int) -> Int {
+//   var x : Int = 0
+//   while (x < c) { x = x + 1 }
+//   return x
+// }
+
+// CHECK: sil [ossa] @func_loop :
+// CHECK-NOT: alloc_stack
+sil [ossa] @func_loop: $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  br bb1
+
+// CHECK: bb1([[VAR:%[0-9]+]] : $Int64):
+bb1:
+  %8 = load [trivial] %3 : $*Int64
+  %10 = struct_extract %8 : $Int64, #Int64._value
+  %11 = struct_extract %0 : $Int64, #Int64._value
+  %12 = builtin "cmp_slt_Int64"(%10 : $Builtin.Int64, %11 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %12, bb2, bb3
+
+bb2:
+  %14 = load [trivial] %3 : $*Int64
+  %15 = integer_literal $Builtin.Int64, 1
+  %16 = integer_literal $Builtin.Int1, -1
+  %18 = struct_extract %14 : $Int64, #Int64._value
+  %19 = builtin "sadd_with_overflow_Int64"(%18 : $Builtin.Int64, %15 : $Builtin.Int64, %16 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %20 = tuple_extract %19 : $(Builtin.Int64, Builtin.Int1), 0
+  %21 = tuple_extract %19 : $(Builtin.Int64, Builtin.Int1), 1
+  %22 = struct $Int64 (%20 : $Builtin.Int64)
+  cond_fail %21 : $Builtin.Int1
+  store %22 to [trivial] %3 : $*Int64
+  br bb1
+
+bb3:
+  %26 = load [trivial] %3 : $*Int64
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+// CHECK-NOT: dealloc_stack
+  return %26 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'func_loop'
+
+// func nest(c : Int) -> Int {
+// var x : Int = 0
+//   if (c > 1) { if (c > 2) { if (c > 3) { if (c > 4) {
+//   if (c > 5) { if (c > 6) { if (c > 7) { if (c > 8) {
+//   if (c > 9) { if (c > 10) { if (c > 11) { if (c > 12) {
+//   if (c > 13) { if (c > 14) { if (c > 15) { if (c > 16) {
+//   if (c > 17) { x = 7 }}}}}}}}}}}}}}}}} return x
+// }
+
+// This test should kill exponential algorithms.
+// CHECK: sil [ossa] @high_nest :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK-LABEL: } // end sil function 'high_nest'
+sil [ossa] @high_nest : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  %7 = integer_literal $Builtin.Int64, 1
+  %9 = struct_extract %0 : $Int64, #Int64._value
+  %10 = builtin "cmp_sgt_Int64"(%9 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %10, bb1, bb34
+
+bb1:
+  %12 = integer_literal $Builtin.Int64, 2
+  %14 = struct_extract %0 : $Int64, #Int64._value
+  %15 = builtin "cmp_sgt_Int64"(%14 : $Builtin.Int64, %12 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %15, bb2, bb33
+
+bb2:
+  %17 = integer_literal $Builtin.Int64, 3
+  %19 = struct_extract %0 : $Int64, #Int64._value
+  %20 = builtin "cmp_sgt_Int64"(%19 : $Builtin.Int64, %17 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %20, bb3, bb32
+
+bb3:
+  %22 = integer_literal $Builtin.Int64, 4
+  %24 = struct_extract %0 : $Int64, #Int64._value
+  %25 = builtin "cmp_sgt_Int64"(%24 : $Builtin.Int64, %22 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %25, bb4, bb31
+
+bb4:
+  %27 = integer_literal $Builtin.Int64, 5
+  %29 = struct_extract %0 : $Int64, #Int64._value
+  %30 = builtin "cmp_sgt_Int64"(%29 : $Builtin.Int64, %27 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %30, bb5, bb30
+
+bb5:
+  %32 = integer_literal $Builtin.Int64, 6
+  %34 = struct_extract %0 : $Int64, #Int64._value
+  %35 = builtin "cmp_sgt_Int64"(%34 : $Builtin.Int64, %32 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %35, bb6, bb29
+
+bb6:
+  %37 = integer_literal $Builtin.Int64, 7
+  %39 = struct_extract %0 : $Int64, #Int64._value
+  %40 = builtin "cmp_sgt_Int64"(%39 : $Builtin.Int64, %37 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %40, bb7, bb28
+
+bb7:
+  %42 = integer_literal $Builtin.Int64, 8
+  %44 = struct_extract %0 : $Int64, #Int64._value
+  %45 = builtin "cmp_sgt_Int64"(%44 : $Builtin.Int64, %42 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %45, bb8, bb27
+
+bb8:
+  %47 = integer_literal $Builtin.Int64, 9
+  %49 = struct_extract %0 : $Int64, #Int64._value
+  %50 = builtin "cmp_sgt_Int64"(%49 : $Builtin.Int64, %47 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %50, bb9, bb26
+
+bb9:
+  %52 = integer_literal $Builtin.Int64, 10
+  %54 = struct_extract %0 : $Int64, #Int64._value
+  %55 = builtin "cmp_sgt_Int64"(%54 : $Builtin.Int64, %52 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %55, bb10, bb25
+
+bb10:
+  %57 = integer_literal $Builtin.Int64, 11
+  %59 = struct_extract %0 : $Int64, #Int64._value
+  %60 = builtin "cmp_sgt_Int64"(%59 : $Builtin.Int64, %57 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %60, bb11, bb24
+
+bb11:
+  %62 = integer_literal $Builtin.Int64, 12
+  %64 = struct_extract %0 : $Int64, #Int64._value
+  %65 = builtin "cmp_sgt_Int64"(%64 : $Builtin.Int64, %62 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %65, bb12, bb23
+
+bb12:
+  %67 = integer_literal $Builtin.Int64, 13
+  %69 = struct_extract %0 : $Int64, #Int64._value
+  %70 = builtin "cmp_sgt_Int64"(%69 : $Builtin.Int64, %67 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %70, bb13, bb22
+
+
+bb13:
+  %72 = integer_literal $Builtin.Int64, 14
+  %74 = struct_extract %0 : $Int64, #Int64._value
+  %75 = builtin "cmp_sgt_Int64"(%74 : $Builtin.Int64, %72 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %75, bb14, bb21
+
+bb14:
+  %77 = integer_literal $Builtin.Int64, 15
+  %79 = struct_extract %0 : $Int64, #Int64._value
+  %80 = builtin "cmp_sgt_Int64"(%79 : $Builtin.Int64, %77 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %80, bb15, bb20
+
+bb15:
+  %82 = integer_literal $Builtin.Int64, 16
+  %84 = struct_extract %0 : $Int64, #Int64._value
+  %85 = builtin "cmp_sgt_Int64"(%84 : $Builtin.Int64, %82 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %85, bb16, bb19
+
+bb16:
+  %87 = integer_literal $Builtin.Int64, 17
+  %89 = struct_extract %0 : $Int64, #Int64._value
+  %90 = builtin "cmp_sgt_Int64"(%89 : $Builtin.Int64, %87 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %90, bb17, bb18
+
+bb17:
+  %92 = integer_literal $Builtin.Int64, 7
+  %93 = struct $Int64 (%92 : $Builtin.Int64)
+  store %93 to [trivial] %3 : $*Int64
+  br bb35
+
+bb18:
+  br bb35
+bb35:
+  br bb36
+
+bb19:
+  br bb36
+bb36:
+  br bb37
+
+bb20:
+  br bb37
+bb37:
+  br bb38
+
+bb21:
+  br bb38
+bb38:
+  br bb39
+
+bb22:
+  br bb39
+bb39:
+  br bb40
+
+bb23:
+  br bb40
+bb40:
+  br bb41
+
+bb24:
+  br bb41
+bb41:
+  br bb42
+
+bb25:
+  br bb42
+bb42:
+  br bb43
+
+bb26:
+  br bb43
+bb43:
+  br bb44
+
+bb27:
+  br bb44
+bb44:
+  br bb45
+
+bb28:
+  br bb45
+bb45:
+  br bb46
+
+bb29:
+  br bb46
+bb46:
+  br bb47
+
+bb30:
+  br bb47
+bb47:
+  br bb48
+
+bb31:
+  br bb48
+bb48:
+  br bb49
+
+bb32:
+  br bb49
+bb49:
+  br bb50
+
+bb33:
+  br bb50
+bb50:
+  br bb51
+
+bb34:
+  br bb51
+
+bb51:
+  %112 = load [trivial] %3 : $*Int64
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %112 : $Int64
+}
+
+// CHECK-LABEL: sil [ossa] @simple_if :
+// CHECK-NOT: alloc_stack
+sil [ossa] @simple_if : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 0
+// CHECK: [[INIT:%[0-9]+]] = struct $Int64
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  %8 = struct_extract %0 : $Int64, #Int64._value
+  %9 = builtin "cmp_sgt_Int64"(%4 : $Builtin.Int64, %8 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %9, bb1, bb2
+
+bb1:
+  %11 = integer_literal $Builtin.Int64, 2
+// CHECK: [[INIT2:%[0-9]+]] = struct $Int64
+  %12 = struct $Int64 (%11 : $Builtin.Int64)
+  store %12 to [trivial] %3 : $*Int64
+// CHECK: br bb3([[INIT2]] : $Int64)
+  br bb3
+
+bb2:
+// CHECK: br bb3([[INIT]] : $Int64)
+  br bb3
+
+bb3:
+  %15 = load [trivial] %3 : $*Int64
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %15 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'simple_if'
+
+enum X {
+  case One
+  case Two
+  case Three
+}
+
+// CHECK-LABEL: sil [ossa] @test_switch :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+sil [ossa] @test_switch: $@convention(thin) (Int64, X) -> Int64 {
+bb0(%0 : $Int64, %1 : $X):
+  %2 = alloc_stack [lexical] $Int64, var, name "xi"
+  %3 = alloc_stack [lexical] $X, var, name "c"
+  store %0 to [trivial] %2 : $*Int64
+  store %1 to [trivial] %3 : $*X
+  %6 = alloc_stack [lexical] $Int64, var, name "x"
+  store %0 to [trivial] %6 : $*Int64
+  %8 = tuple ()
+  switch_enum %1 : $X, case #X.One!enumelt: bb1, case #X.Two!enumelt: bb3, case #X.Three!enumelt: bb5
+
+bb1:
+  br bb2
+
+bb2:
+  %11 = integer_literal $Builtin.Int64, 3
+  %12 = struct $Int64 (%11 : $Builtin.Int64)
+  store %12 to [trivial] %6 : $*Int64
+  br bb7
+
+bb3:
+  br bb4
+
+bb4:
+  %16 = integer_literal $Builtin.Int64, 2
+  %17 = struct $Int64 (%16 : $Builtin.Int64)
+  store %17 to [trivial] %6 : $*Int64
+  br bb7
+
+bb5:
+  br bb6
+
+bb6:
+  %21 = integer_literal $Builtin.Int64, 1
+  %22 = struct $Int64 (%21 : $Builtin.Int64)
+  store %22 to [trivial] %6 : $*Int64
+  br bb7
+
+bb7:
+  %25 = load [trivial] %6 : $*Int64
+  dealloc_stack %6 : $*Int64
+  dealloc_stack %3 : $*X
+  dealloc_stack %2 : $*Int64
+  return %25 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'test_switch'
+
+

--- a/test/SILOptimizer/mem2reg_unreachable_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_unreachable_lifetime.sil
@@ -1,0 +1,68 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg
+
+// Make sure we are not crashing on blocks that are not dominated by the entry block.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil [ossa] @_TF4main3fooFT1xSi1ySi_Si : 
+// CHECK-NEXT: alloc_stack
+// CHECK-LABEL: } // end sil function '_TF4main3fooFT1xSi1ySi_Si'
+sil [ossa] @_TF4main3fooFT1xSi1ySi_Si : $@convention(thin) (Int32, Int32) -> Int32 {
+bb0(%0 : $Int32, %1 : $Int32):
+  debug_value %0 : $Int32, let, name "x"
+  debug_value %1 : $Int32, let, name "y"
+  %4 = alloc_stack [lexical] $Int32, var, name "g"
+  %6 = struct_extract %1 : $Int32, #Int32._value
+  %7 = struct_extract %0 : $Int32, #Int32._value
+  %8 = builtin "cmp_sgt_Word"(%6 : $Builtin.Int32, %7 : $Builtin.Int32) : $Builtin.Int1
+  %9 = struct $Bool (%8 : $Builtin.Int1)
+  %10 = struct_extract %9 : $Bool, #Bool._value
+  br bb2
+
+// bb1 is unreachable
+// CHECK-LABEL: bb1:
+// CHECK-NEXT: br bb3
+bb1:
+  %12 = integer_literal $Builtin.Int32, 5
+  %13 = struct $Int32 (%12 : $Builtin.Int32)
+  store %13 to [trivial] %4 : $*Int32
+  br bb3
+
+bb2:
+  %16 = integer_literal $Builtin.Int32, 4
+  %17 = struct $Int32 (%16 : $Builtin.Int32)
+  store %17 to [trivial] %4 : $*Int32
+  br bb3
+
+bb3:
+  %20 = load [trivial] %4 : $*Int32
+  dealloc_stack %4 : $*Int32
+  return %20 : $Int32
+}
+
+struct S {}
+
+// CHECK-LABEL: sil hidden [ossa] @handle_unreachable :
+// CHECK-NOT: alloc_stack
+// CHECK: debug_value undef : $S, let, name "newvalue", argno 1
+// CHECK-LABEL: } // end sil function 'handle_unreachable'
+sil hidden [ossa] @handle_unreachable : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack [lexical] $S, var, name "x"
+  %1 = struct $S ()
+  store %1 to [trivial] %0 : $*S
+  unreachable
+
+bb1:
+  debug_value %0 : $*S, let, name "newvalue", argno 1, expr op_deref
+  br bb2
+
+bb2:
+  %3 = load [trivial] %0 : $*S
+  dealloc_stack %0 : $*S
+  %4 = tuple ()
+  return %4 : $()
+}


### PR DESCRIPTION
Previously, if it was determined that a proactive phi was unnecessary, it was removed, along with the phis for the lifetime and the original value of which the proactive phi was a copy.  The uses of only one of the three phis (namely, the proactive phi) was RAUW undef.  In the case where the only usage of the phi was to branch back to the block that took the phi as an argument, that was a problem.  Here, that is fixed by giving all three phis the same treatment.  To avoid duplicating code, that treatment is pulled out into a new lambda.

This was exposed by adding lifetime versions of some OSSA versions of mem2reg tests that had been missed previously.
