### PR TITLE
Properly serialize 'isolated' bit on function parameter declarations.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3080,12 +3080,14 @@ public:
     bool isIUO;
     bool isVariadic;
     bool isAutoClosure;
+    bool isIsolated;
     uint8_t rawDefaultArg;
 
     decls_block::ParamLayout::readRecord(scratch, argNameID, paramNameID,
                                          contextID, rawSpecifier,
                                          interfaceTypeID, isIUO, isVariadic,
-                                         isAutoClosure, rawDefaultArg);
+                                         isAutoClosure, isIsolated,
+                                         rawDefaultArg);
 
     auto argName = MF.getIdentifier(argNameID);
     auto paramName = MF.getIdentifier(paramNameID);
@@ -3119,6 +3121,7 @@ public:
     param->setImplicitlyUnwrappedOptional(isIUO);
     param->setVariadic(isVariadic);
     param->setAutoClosure(isAutoClosure);
+    param->setIsolated(isIsolated);
 
     // Decode the default argument kind.
     // FIXME: Default argument expression, if available.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 621; // builtin protocol conformances
+const uint16_t SWIFTMODULE_VERSION_MINOR = 622; // 'isolated' in param decls
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1322,6 +1322,7 @@ namespace decls_block {
     BCFixed<1>,              // isIUO?
     BCFixed<1>,              // isVariadic?
     BCFixed<1>,              // isAutoClosure?
+    BCFixed<1>,              // isIsolated?
     DefaultArgumentField,    // default argument kind
     BCBlob                   // default argument text
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3614,6 +3614,7 @@ public:
         param->isImplicitlyUnwrappedOptional(),
         param->isVariadic(),
         param->isAutoClosure(),
+        param->isIsolated(),
         getRawStableDefaultArgumentKind(argKind),
         defaultArgumentText);
 

--- a/test/Serialization/Inputs/def_isolated.swift
+++ b/test/Serialization/Inputs/def_isolated.swift
@@ -1,0 +1,7 @@
+public actor A {
+}
+
+public struct S {
+  public func f(a: isolated A) {
+  }
+}

--- a/test/Serialization/isolated-params.swift
+++ b/test/Serialization/isolated-params.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+// RUN: %target-swift-frontend -emit-module -o %t-scratch/def_isolated~partial.swiftmodule -primary-file %S/Inputs/def_isolated.swift -module-name def_isolated  -disable-availability-checking
+// RUN: %target-swift-frontend -merge-modules -emit-module -parse-as-library -enable-testing %t-scratch/def_isolated~partial.swiftmodule -module-name def_isolated -o %t/def_isolated.swiftmodule  -disable-availability-checking
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -disable-availability-checking
+
+// REQUIRES: concurrency
+
+import def_isolated
+
+func test(a: A, a2: isolated A, s: S) async {
+  await s.f(a: a)
+  s.f(a: a) // expected-error{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-1{{calls to instance method 'f(a:)' from outside of its actor context are implicitly asynchronous}}
+
+  s.f(a: a2)
+}


### PR DESCRIPTION
**Description:** The new `isolated` parameters feature of Swift Concurrency had a silly module serialization bug that made APIs with `isolated` parameters unusable across module boundaries. Serialize the one necessary bit to address the problem.
**Risk:** Low
**Reviewed by: ** Becca Royal-Gordon
**Testing:** PR testing, CI, new tests
**Original PR:** https://github.com/apple/swift/pull/39835
**Radar:** rdar://83380879.
