### PR TITLE
Re-enable ClangImporter/overlay.swift test

### DIFF
--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -3,8 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar83592270
-
 // Do not import Foundation! This tests indirect visibility.
 #if REVERSED
 import Redeclaration


### PR DESCRIPTION
This test was broken with llvm commit https://github.com/apple/llvm-project/commit/9454716dcd6a444f7365034613f2e7cfa5806050.
That was reverted in https://github.com/apple/llvm-project/pull/3369, so now the test passes.