### PR TITLE
Update CHECK to make sure prologue_end's are only on non-zero line number locs and also accounts for multiple digits for column number and file number

### DIFF
--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -7,7 +7,7 @@ func markUsed<T>(_ t: T) {}
 // proceeds to the first line.
 // CHECK: .loc    {{[0-9]}} 0 {{[0-9]}}
 // CHECK-NOT: Lfunc_end0:
-// CHECK: .loc    {{[0-9]}} {{[0-9][0-9]*}} {{[0-9]}} prologue_end
+// CHECK: .loc    {{[0-9]+}} {{[1-9][0-9]*}} {{[0-9]+}} prologue_end
 var a = 1
 var b = 2
 markUsed(a+b)


### PR DESCRIPTION
There was a bug when building watchOSarm64_32 where the CHECK line was only checking for single digit column numbers and file numbers but the column number was a double digit value.

Also, the line number regex needs to be checking for non-zero line numbers, as we cannot have a prologue_end on a non-zero line number after commit: https://github.com/apple/llvm-project/commit/1813652b0398345c4b4407d5fd5ffb749830fdd4