### PR TITLE
[Sema] Don't check availability in assigned properties initializers for -check-api-availaiblity-only mode

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -136,6 +136,9 @@ ERROR(error_mode_cannot_emit_module_semantic_info,none,
 ERROR(cannot_emit_ir_skipping_function_bodies,none,
       "the -experimental-skip-*-function-bodies* flags do not support "
       "emitting IR", ())
+ERROR(cannot_emit_ir_checking_api_availability_only,none,
+      "the flag -check-api-availability-only does not support "
+      "emitting IR", ())
 
 WARNING(emit_reference_dependencies_without_primary_file,none,
         "ignoring -emit-reference-dependencies (requires -primary-file)", ())

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5890,7 +5890,8 @@ bool hasExplicitResult(ClosureExpr *closure);
 /// Emit diagnostics for syntactic restrictions within a given solution
 /// application target.
 void performSyntacticDiagnosticsForTarget(
-    const SolutionApplicationTarget &target, bool isExprStmt);
+    const SolutionApplicationTarget &target,
+    bool isExprStmt,bool disableExprAvailabiltyChecking = false);
 
 /// Given a member of a protocol, check whether `Self` type of that
 /// protocol is contextually bound to some concrete type via same-type

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -229,13 +229,19 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (checkUnusedSupplementaryOutputPaths())
     return true;
 
-  if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction) &&
-      (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||
-       Args.hasArg(OPT_experimental_skip_all_function_bodies) ||
-       Args.hasArg(
-         OPT_experimental_skip_non_inlinable_function_bodies_without_types))) {
-    Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_skipping_function_bodies);
-    return true;
+  if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction)) {
+    if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||
+        Args.hasArg(OPT_experimental_skip_all_function_bodies) ||
+        Args.hasArg(
+         OPT_experimental_skip_non_inlinable_function_bodies_without_types)) {
+      Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_skipping_function_bodies);
+      return true;
+    }
+
+    if (Args.hasArg(OPT_check_api_availability_only)) {
+      Diags.diagnose(SourceLoc(), diag::cannot_emit_ir_checking_api_availability_only);
+      return true;
+    }
   }
 
   if (const Arg *A = Args.getLastArg(OPT_module_abi_name))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4732,7 +4732,8 @@ void swift::checkPatternBindingDeclAsyncUsage(PatternBindingDecl *decl) {
 /// Emit diagnostics for syntactic restrictions on a given expression.
 void swift::performSyntacticExprDiagnostics(const Expr *E,
                                             const DeclContext *DC,
-                                            bool isExprStmt) {
+                                            bool isExprStmt,
+                                            bool disableExprAvailabiltyChecking) {
   auto &ctx = DC->getASTContext();
   TypeChecker::diagnoseSelfAssignment(E);
   diagSyntacticUseRestrictions(E, DC, isExprStmt);
@@ -4744,7 +4745,7 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
   diagnoseComparisonWithNaN(E, DC);
   if (!ctx.isSwiftVersionAtLeast(5))
     diagnoseDeprecatedWritableKeyPath(E, DC);
-  if (!ctx.LangOpts.DisableAvailabilityChecking)
+  if (!ctx.LangOpts.DisableAvailabilityChecking && !disableExprAvailabiltyChecking)
     diagnoseExprAvailability(E, const_cast<DeclContext*>(DC));
   if (ctx.LangOpts.EnableObjCInterop)
     diagDeprecatedObjCSelectors(DC, E);

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -34,8 +34,9 @@ namespace swift {
   class ValueDecl;
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
-void performSyntacticExprDiagnostics(const Expr *E, const DeclContext *DC,
-                                     bool isExprStmt);
+void performSyntacticExprDiagnostics(
+    const Expr *E, const DeclContext *DC,
+    bool isExprStmt, bool disableExprAvailabiltyChecking = false);
 
 /// Emit diagnostics for a given statement.
 void performStmtDiagnostics(const Stmt *S, DeclContext *DC);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1640,19 +1640,6 @@ public:
   // "name: TheType" form, we can get better results by diagnosing the TypeRepr.
   UNINTERESTING(Var)
 
-  static bool shouldCheck(Decl *D) {
-    if (D && D->getASTContext().LangOpts.CheckAPIAvailabilityOnly) {
-      // Skip whole decl if not API-public.
-      if (auto valueDecl = dyn_cast<const ValueDecl>(D)) {
-        AccessScope scope =
-          valueDecl->getFormalAccessScope(/*useDC*/nullptr,
-                                          /*treatUsableFromInlineAsPublic*/true);
-        if (!scope.isPublic())
-          return false;
-      }
-    }
-    return true;
-  }
 
   /// \see visitPatternBindingDecl
   void checkNamedPattern(const NamedPattern *NP,
@@ -1699,7 +1686,7 @@ public:
   }
 
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
-    if (!shouldCheck(PBD->getAnchoringVarDecl(0)))
+    if (!shouldCheckAvailability(PBD->getAnchoringVarDecl(0)))
       return;
 
     llvm::DenseSet<const VarDecl *> seenVars;
@@ -1969,8 +1956,22 @@ void swift::checkAccessControl(Decl *D) {
   if (where.isImplicit())
     return;
 
-  if (!DeclAvailabilityChecker::shouldCheck(D))
+  if (!shouldCheckAvailability(D))
     return;
 
   DeclAvailabilityChecker(where).visit(D);
+}
+
+bool swift::shouldCheckAvailability(const Decl *D) {
+  if (D && D->getASTContext().LangOpts.CheckAPIAvailabilityOnly) {
+    // Skip whole decl if not API-public.
+    if (auto valueDecl = dyn_cast<const ValueDecl>(D)) {
+      AccessScope scope =
+        valueDecl->getFormalAccessScope(/*useDC*/nullptr,
+                                        /*treatUsableFromInlineAsPublic*/true);
+      if (!scope.isPublic())
+        return false;
+    }
+  }
+  return true;
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -265,6 +265,10 @@ bool diagnoseExplicitUnavailability(
 /// Check if \p decl has a introduction version required by -require-explicit-availability
 void checkExplicitAvailability(Decl *decl);
 
+/// Check if \p D needs to be checked for correct availability depending on the
+/// flag -check-api-availability-only.
+bool shouldCheckAvailability(const Decl *D);
+
 } // namespace swift
 
 #endif // SWIFT_SEMA_TYPE_CHECK_AVAILABILITY_H

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -134,6 +134,9 @@ enum class TypeCheckExprFlags {
   /// unchecked. This is used by source tooling functionalities such as code
   /// completion.
   LeaveClosureBodyUnchecked = 0x04,
+
+  /// Don't type check expressions for correct availability.
+  DisableExprAvailabilityChecking = 0x08,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;

--- a/test/Sema/api-availability-only-ok.swift
+++ b/test/Sema/api-availability-only-ok.swift
@@ -12,6 +12,9 @@
 public protocol NewProto {}
 
 @available(macOS 11.0, *)
+public struct NewStruct {}
+
+@available(macOS 11.0, *)
 public func newFunc() {}
 
 @available(macOS 11.0, *)
@@ -57,6 +60,10 @@ public struct Struct {
   internal var internalVar: NewProto
   private var privateVar: NewProto
   fileprivate var fileprivateVar: NewProto
+
+  internal var internalAssigned = NewStruct()
+  private var privateAssigned = NewStruct()
+  fileprivate var fileprivateAssigned = NewStruct()
 
   @available(macOS 11.0, *)
   public typealias PubTA = NewProto

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -3,6 +3,9 @@
 
 // RUN: %target-typecheck-verify-swift -module-name MyModule -target %target-cpu-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
 
+// RUN: not %target-build-swift -emit-executable %s -g -o %t -emit-module -Xfrontend -check-api-availability-only 2>&1 | %FileCheck %s
+// CHECK: the flag -check-api-availability-only does not support emitting IR
+
 // REQUIRES: OS=macosx
 
 @available(macOS 11.0, *)

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -9,6 +9,11 @@
 public protocol NewProto {}
 
 @available(macOS 11.0, *)
+public struct NewStruct {
+    public init() {}
+}
+
+@available(macOS 11.0, *)
 public func newFunc() {}
 
 // expected-note @+1 {{add @available attribute to enclosing}}
@@ -23,7 +28,7 @@ public func apiFunc(s : NewProto) { // expected-error {{'NewProto' is only avail
   newFunc()
 }
 
-// expected-note @+1 3 {{add @available attribute to enclosing}}
+// expected-note @+1 6 {{add @available attribute to enclosing}}
 @inlinable func inlinable(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
 
   // expected-note @+1 {{add 'if #available' version check}}
@@ -31,6 +36,17 @@ public func apiFunc(s : NewProto) { // expected-error {{'NewProto' is only avail
 
   // expected-note @+1 {{add 'if #available' version check}}
   newFunc() // expected-error {{'newFunc()' is only available in macOS 11.0 or newer}}
+
+  // expected-note @+1 {{add 'if #available' version check}}
+  let _ = NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
+
+  // expected-note @+2 {{add 'if #available' version check}}
+  // expected-warning @+1 {{initialization of immutable value 'a' was never used}}
+  let a = NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
+
+  // expected-note @+2 {{add 'if #available' version check}}
+  // expected-warning @+1 {{result of 'NewStruct' initializer is unused}}
+  NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
 }
 
 // expected-note @+1 {{add @available attribute to enclosing}}
@@ -54,12 +70,17 @@ fileprivate func fileprivateFunc(s : NewProto) {
   newFunc()
 }
 
-// expected-note @+1 7 {{add @available attribute to enclosing struct}}
+// expected-note @+1 8 {{add @available attribute to enclosing struct}}
 public struct Struct {
   public var publicVar: NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
   internal var internalVar: NewProto
   private var privateVar: NewProto
   fileprivate var fileprivateVar: NewProto
+
+  public var publicAssigned = NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
+  internal var internalAssigned = NewStruct()
+  private var privateAssigned = NewStruct()
+  fileprivate var fileprivateAssigned = NewStruct()
 
   // expected-note @+1 {{add @available attribute to enclosing}}
   public typealias PubTA = NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}


### PR DESCRIPTION
For a non-public property where the type is defined by an assignment, like `internal var internalAssigned = NewStruct()`, type-checking the type's availability is done via checking the initializer expression.

In -check-api-availaiblity-only mode, pass down a flag to not check availability in expressions for initializer expressions of such non-public properties.

To make sure this doesn't have unintended side-effects on generated code, forbid IR generation when the flag `-check-api-availaiblity-only` is used.

rdar://84389825

---

Followup to #39640.