### PR TITLE
Emit debug info for `catch let errorvar` variables. 

### DIFF
--- a/test/DebugInfo/catch_let.swift
+++ b/test/DebugInfo/catch_let.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+enum MyError : Error {
+  case Yikes
+}
+
+func throwing() throws -> () {
+  throw MyError.Yikes
+}
+
+func use<T>(_ t: T) {}
+
+public func foo() {
+  do {
+    try throwing()
+  }
+  catch let error {
+    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[ERROR:[0-9]+]],
+    // CHECK: ![[ERROR]] = !DILocalVariable(name: "error"
+    use(error)
+  }
+}
+foo();


### PR DESCRIPTION
This implementation adds the debug info emission to
SILGenFunction::emitTemporaryAllocation() which may not be the optimal place to
do this. It may be better to change SILGen to unconditionally emit an
alloc_stack instead of relying on a temporary alloca to be requested.

rdar://75499821
