### PR TITLE
Infer 'isolated' closure parameters from context.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1200,6 +1200,9 @@ public:
   llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
       caseLabelItems;
 
+  /// The set of parameters that have been inferred to be 'isolated'.
+  llvm::SmallVector<ParamDecl *, 2> isolatedParams;
+
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
       resultBuilderTransformed;
@@ -2360,6 +2363,9 @@ private:
   llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
       caseLabelItems;
 
+  /// The set of parameters that have been inferred to be 'isolated'.
+  llvm::SmallVector<ParamDecl *, 2> isolatedParams;
+
   /// Maps closure parameters to type variables.
   llvm::DenseMap<const ParamDecl *, TypeVariableType *>
     OpenedParameterTypes;
@@ -2923,6 +2929,9 @@ public:
 
     /// The length of \c caseLabelItems.
     unsigned numCaseLabelItems;
+
+    /// The length of \c isolatedParams.
+    unsigned numIsolatedParams;
 
     /// The length of \c ImplicitValueConversions.
     unsigned numImplicitValueConversions;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2364,7 +2364,7 @@ private:
       caseLabelItems;
 
   /// The set of parameters that have been inferred to be 'isolated'.
-  llvm::SmallVector<ParamDecl *, 2> isolatedParams;
+  llvm::SmallSetVector<ParamDecl *, 2> isolatedParams;
 
   /// Maps closure parameters to type variables.
   llvm::DenseMap<const ParamDecl *, TypeVariableType *>

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1370,6 +1370,12 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
     auto *params = closure->getParameters();
     TypeChecker::coerceParameterListToType(params, closureFnType);
 
+    // Find any isolated parameters in this closure and mark them as isolated.
+    for (auto param : solution.isolatedParams) {
+      if (param->getDeclContext() == closure)
+        param->setIsolated(true);
+    }
+
     // Coerce the result type, if it was written explicitly.
     if (closure->hasExplicitResultType()) {
       closure->setExplicitResultType(closureFnType->getResult());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8999,7 +8999,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
         // Note when a parameter is inferred to be isolated.
         if (contextualParam->isIsolated() && !flags.isIsolated() && paramDecl)
-          isolatedParams.push_back(paramDecl);
+          isolatedParams.insert(paramDecl);
 
         param =
             param.withFlags(flags.withInOut(contextualParam->isInOut())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1854,7 +1854,8 @@ static bool isSingleTupleParam(ASTContext &ctx,
     return false;
 
   const auto &param = params.front();
-  if (param.isVariadic() || param.isInOut() || param.hasLabel())
+  if (param.isVariadic() || param.isInOut() || param.hasLabel() ||
+      param.isIsolated())
     return false;
 
   auto paramType = param.getPlainType();
@@ -8988,15 +8989,22 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     auto param = inferredClosureType->getParams()[i];
     auto *paramDecl = paramList->get(i);
 
-    // In case of anonymous or name-only parameters, let's infer inout/variadic
-    // flags from context, that helps to propagate type information into the
-    // internal type of the parameter and reduces inference solver has to make.
+    // In case of anonymous or name-only parameters, let's infer
+    // inout/variadic/isolated flags from context, that helps to propagate
+    // type information into the internal type of the parameter and reduces
+    // inference solver has to make.
     if (!paramDecl->getTypeRepr()) {
       if (auto contextualParam = getContextualParamAt(i)) {
         auto flags = param.getParameterFlags();
+
+        // Note when a parameter is inferred to be isolated.
+        if (contextualParam->isIsolated() && !flags.isIsolated() && paramDecl)
+          isolatedParams.push_back(paramDecl);
+
         param =
             param.withFlags(flags.withInOut(contextualParam->isInOut())
-                                 .withVariadic(contextualParam->isVariadic()));
+                                 .withVariadic(contextualParam->isVariadic())
+                                 .withIsolated(contextualParam->isIsolated()));
       }
     }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -186,7 +186,8 @@ Solution ConstraintSystem::finalize() {
 
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;
-  solution.isolatedParams = isolatedParams;
+  solution.isolatedParams.clear();
+  solution.isolatedParams.append(isolatedParams.begin(), isolatedParams.end());
 
   for (const auto &transformed : resultBuilderTransformed) {
     solution.resultBuilderTransformed.insert(transformed);
@@ -294,7 +295,7 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   }
 
   for (auto param : solution.isolatedParams) {
-    isolatedParams.push_back(param);
+    isolatedParams.insert(param);
   }
 
   for (const auto &transformed : solution.resultBuilderTransformed) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -186,7 +186,6 @@ Solution ConstraintSystem::finalize() {
 
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;
-  solution.isolatedParams.clear();
   solution.isolatedParams.append(isolatedParams.begin(), isolatedParams.end());
 
   for (const auto &transformed : resultBuilderTransformed) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -186,6 +186,7 @@ Solution ConstraintSystem::finalize() {
 
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;
+  solution.isolatedParams = isolatedParams;
 
   for (const auto &transformed : resultBuilderTransformed) {
     solution.resultBuilderTransformed.insert(transformed);
@@ -290,6 +291,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   for (const auto &info : solution.caseLabelItems) {
     if (!getCaseLabelItemInfo(info.first))
       setCaseLabelItemInfo(info.first, info.second);
+  }
+
+  for (auto param : solution.isolatedParams) {
+    isolatedParams.push_back(param);
   }
 
   for (const auto &transformed : solution.resultBuilderTransformed) {
@@ -521,6 +526,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numContextualTypes = cs.contextualTypes.size();
   numSolutionApplicationTargets = cs.solutionApplicationTargets.size();
   numCaseLabelItems = cs.caseLabelItems.size();
+  numIsolatedParams = cs.isolatedParams.size();
   numImplicitValueConversions = cs.ImplicitValueConversions.size();
   numArgumentLists = cs.ArgumentLists.size();
 
@@ -628,6 +634,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any case label item infos.
   truncate(cs.caseLabelItems, numCaseLabelItems);
+
+  // Remove any isolated parameters.
+  truncate(cs.isolatedParams, numIsolatedParams);
 
   // Remove any implicit value conversions.
   truncate(cs.ImplicitValueConversions, numImplicitValueConversions);

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -111,3 +111,23 @@ func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
   // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
 }
+
+// Inference of "isolated" on closure parameters.
+@available(SwiftStdlib 5.5, *)
+func testIsolatedClosureInference(a: A) {
+  let _: (isolated A) -> Void = {
+    $0.f()
+  }
+
+  let _: (isolated A) -> Void = {
+    $0.f()
+  }
+
+  let _: (isolated A) -> Void = { a2 in
+    a2.f()
+  }
+
+  let _: (isolated A) -> Void = { (a2: isolated A) in
+    a2.f()
+  }
+}


### PR DESCRIPTION
When a closure is provided with a contextual type that has isolated
parameters, infer that the corresponding closure parameter is "isolated".

Fixes rdar://83732479.
