### PR TITLE
[CursorInfo] Always add module name to response

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -1,0 +1,120 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/frameworks/LibA.framework/Modules/LibA.swiftmodule %t/mods %t/mods
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -module-name LibB -emit-module -emit-module-path %t/mods/LibB.swiftmodule -emit-module-source-info-path %t/mods/LibB.swiftsourceinfo %t/libB.swift
+// RUN: %target-swift-frontend -module-name LibC -emit-module -emit-module-path %t/mods/LibC.swiftmodule %t/libC.swift
+// RUN: %target-swift-frontend -module-name LibA -emit-module -emit-module-path %t/frameworks/LibA.framework/Modules/LibA.swiftmodule/%target-swiftmodule-name -import-underlying-module -disable-implicit-concurrency-module-import -F %t/frameworks -I %t/mods %t/libA.swift
+// RUN: %swift-ide-test -print-module -print-interface -source-filename dummy -module-to-print LibA -F %t/frameworks -target %target-triple &> %t/generated.swift
+
+// Check that we always include module name, regardless of whether we have
+// source information or not. If we have source information, we should also
+// output it.
+
+//--- use.swift
+
+import LibA
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):8 -print-raw-response %t/use.swift -- -F %t/frameworks -target %target-triple %t/use.swift | %FileCheck %s --check-prefix=CHECKSWIFT
+let _: ASwiftType
+// CHECKSWIFT: key.name: "ASwiftType"
+// CHECKSWIFT: key.modulename: "LibA"
+// CHECKSWIFT: key.decl_lang: source.lang.swift
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):8 -print-raw-response %t/use.swift -- -F %t/frameworks -target %target-triple %t/use.swift | %FileCheck %s --check-prefix=CHECKOBJC
+let _: AObjcType
+// CHECKOBJC: key.name: "AObjcType"
+// CHECKOBJC: key.modulename: "LibA"
+// CHECKOBJC: key.decl_lang: source.lang.objc
+
+//--- libA.swift
+
+import LibB
+import LibC
+import LibD
+
+public class ASwiftType {
+  public func aTypes(swift: ASwiftType, objc: AObjcType, sub: ASubType) {}
+  public func others(b: BType, c: CType, d: DType) {}
+}
+
+// LibA is a mixed framework with no source info and a submodule
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
+// CHECKA: key.name: "ASwiftType"
+// CHECKA: key.modulename: "LibA"
+// CHECKA: key.decl_lang: source.lang.swift
+
+//--- frameworks/LibA.framework/module.map
+framework module LibA {
+  header "LibA.h"
+  export *
+
+  module Sub {
+    header "LibASub.h"
+  }
+}
+
+//--- frameworks/LibA.framework/Headers/LibA.h
+@interface AObjcType
+@end
+
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
+// CHECKAOBJ: key.name: "AObjcType"
+// CHECKAOBJ: key.line: [[@LINE-5]]
+// CHECKAOBJ: key.column: 12
+// CHECKAOBJ: key.filepath: {{.*}}LibA.h
+// CHECKAOBJ: key.modulename: "LibA"
+// CHECKAOBJ: key.decl_lang: source.lang.objc
+
+//--- frameworks/LibA.framework/Headers/LibASub.h
+@interface ASubType
+@end
+
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
+// CHECKASUB: key.name: "ASubType"
+// CHECKASUB: key.line: [[@LINE-5]]
+// CHECKASUB: key.column: 12
+// CHECKASUB: key.filepath: {{.*}}LibASub.h
+// CHECKASUB: key.modulename: "LibA.Sub"
+// CHECKASUB: key.decl_lang: source.lang.objc
+
+//--- libB.swift
+public class BType {}
+
+// LibB has source info
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
+// CHECKB: key.name: "BType"
+// CHECKB: key.line: [[@LINE-5]]
+// CHECKB: key.column: 14
+// CHECKB: key.filepath: {{.*}}libB.swift
+// CHECKB: key.modulename: "LibB"
+// CHECKB: key.decl_lang: source.lang.swift
+
+//--- libC.swift
+public class CType {}
+
+// LibC has no source info
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
+// CHECKC: key.name: "CType"
+// CHECKC: key.modulename: "LibC"
+// CHECKC: key.decl_lang: source.lang.swift
+
+//--- mods/LibD.h
+@interface DType
+@end
+
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
+// CHECKD: key.name: "DType"
+// CHECKD: key.line: [[@LINE-5]]
+// CHECKD: key.column: 12
+// CHECKD: key.filepath: {{.*}}LibD.h
+// CHECKD: key.modulename: "LibD"
+// CHECKD: key.decl_lang: source.lang.objc
+
+//--- mods/module.map
+module LibD {
+  header "LibD.h"
+  export *
+}

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -261,6 +261,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK3-NEXT: source.lang.swift
 // CHECK3-NEXT: Int{{$}}
 // CHECK3-NEXT: $sSiD
+// CHECK3-NEXT: cursor_info{{$}}
 // CHECK3-NEXT: <Declaration>let x: <Type usr="s:Si">Int</Type></Declaration>
 // CHECK3-NEXT: <decl.var.parameter><syntaxtype.keyword>let</syntaxtype.keyword> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>
 
@@ -302,6 +303,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK7-NEXT: source.lang.swift
 // CHECK7-NEXT: S1.Type
 // CHECK7-NEXT: $s
+// CHECK7-NEXT: cursor_info{{$}}
 // CHECK7-NEXT: <Declaration>struct S1</Declaration>
 // CHECK7-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>
 // CHECK7-NEXT: <Class file="{{[^"]+}}cursor_info.swift" line="13" column="8"><Name>S1</Name><USR>s:11cursor_info2S1V</USR><Declaration>struct S1</Declaration><CommentParts><Abstract><Para>Aaa.  S1.  Bbb.</Para></Abstract></CommentParts></Class>
@@ -314,6 +316,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK8-NEXT: (CC.Type) -> (Int) -> CC
 // CHECK8-NEXT: $s1x11cursor_info2CCCSi_tcD
 // CHECK8-NEXT: <Container>$s11cursor_info2CCCD</Container>
+// CHECK8-NEXT: cursor_info{{$}}
 // CHECK8-NEXT: <Declaration>init(x: <Type usr="s:Si">Int</Type>)</Declaration>
 // CHECK8-NEXT: <decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>
 
@@ -419,6 +422,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK29-NEXT: source.lang.swift
 // CHECK29-NEXT: (C3) -> ()
 // CHECK29-NEXT: $syycD
+// CHECK29-NEXT: cursor_info{{$}}
 // CHECK29-NEXT: <Declaration>deinit</Declaration>
 // CHECK29-NEXT: <decl.function.destructor><syntaxtype.keyword>deinit</syntaxtype.keyword></decl.function.destructor>
 
@@ -429,6 +433,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK30-NEXT: source.lang.swift
 // CHECK30-NEXT: (C3.Type) -> (Int) -> C3?
 // CHECK30-NEXT: $s1x11cursor_info2C3CSgSi_tcD
+// CHECK30-NEXT: cursor_info{{$}}
 // CHECK30-NEXT: <Declaration>init!(x: <Type usr="s:Si">Int</Type>)</Declaration>
 // CHECK30-NEXT: <decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>
 
@@ -439,6 +444,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK31-NEXT: source.lang.swift
 // CHECK31-NEXT: (C3.Type) -> (Int) -> C3?
 // CHECK31-NEXT: $s1y11cursor_info2C3CSgSi_tcD
+// CHECK31-NEXT: cursor_info{{$}}
 // CHECK31-NEXT: <Declaration>init?(y: <Type usr="s:Si">Int</Type>)</Declaration>
 // CHECK31-NEXT: <decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>?(<decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>
 
@@ -449,6 +455,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK32-NEXT: source.lang.swift
 // CHECK32-NEXT: (C3.Type) -> (Int) throws -> C3
 // CHECK32-NEXT: $s1z11cursor_info2C3CSi_tKcD
+// CHECK32-NEXT: cursor_info{{$}}
 // CHECK32-NEXT: <Declaration>init(z: <Type usr="s:Si">Int</Type>) throws</Declaration>
 // CHECK32-NEXT: <decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>z</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>throws</syntaxtype.keyword></decl.function.constructor>
 
@@ -757,6 +764,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK87-NEXT: source.lang.swift
 // CHECK87-NEXT: HasLocalizationKey.Type
 // CHECK87-NEXT: $s
+// CHECK87-NEXT: cursor_info{{$}}
 // CHECK87-NEXT: <Declaration>struct HasLocalizationKey</Declaration>
 // CHECK87-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>HasLocalizationKey</decl.name></decl.struct>
 // CHECK87-NEXT: <Class file="{{[^"]+}}cursor_info.swift" line="213" column="8"><Name>HasLocalizationKey</Name><USR>s:11cursor_info18HasLocalizationKeyV</USR><Declaration>struct HasLocalizationKey</Declaration><CommentParts><Abstract><Para>Brief.</Para></Abstract></CommentParts></Class>
@@ -769,6 +777,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK88-NEXT: source.lang.swift
 // CHECK88-NEXT: () -> ()
 // CHECK88-NEXT: $s
+// CHECK88-NEXT: cursor_info{{$}}
 // CHECK88-NEXT: <Declaration>func hasLocalizationKey2()</Declaration>
 // CHECK88-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hasLocalizationKey2</decl.name>()</decl.function.free>
 // CHECK88-NEXT: <Function file="{{[^"]+}}cursor_info.swift" line="216" column="6"><Name>hasLocalizationKey2()</Name><USR>s:11cursor_info19hasLocalizationKey2yyF</USR><Declaration>func hasLocalizationKey2()</Declaration><CommentParts></CommentParts></Function>

--- a/test/SourceKit/CursorInfo/cursor_opaque_result.swift
+++ b/test/SourceKit/CursorInfo/cursor_opaque_result.swift
@@ -23,6 +23,7 @@ func test(value: MyStruct) {
 // OPAQUE-NEXT: (MyStruct) -> () -> some Comparable
 // OPAQUE-NEXT: $sQrycD
 // OPAQUE-NEXT: <Container>$s8MyModule0A6StructVD</Container>
+// OPAQUE-NEXT: MyModule{{$}}
 // OPAQUE-NEXT: <Declaration>public func foo() -&gt; some <Type usr="s:SL">Comparable</Type></Declaration>
 // OPAQUE-NEXT: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>some</syntaxtype.keyword> <ref.protocol usr="s:SL">Comparable</ref.protocol></decl.function.returntype></decl.function.method.instance>
 
@@ -33,5 +34,6 @@ func test(value: MyStruct) {
 // ASSOC-NEXT: <Self where Self : P> (Self) -> () -> Self.Assoc
 // ASSOC-NEXT: $s5AssocQzycD
 // ASSOC-NEXT: <Container>$s8MyModule0A6StructVD</Container>
+// ASSOC-NEXT: MyModule{{$}}
 // ASSOC-NEXT: <Declaration>func bar() -&gt; <Type usr="s:8MyModule0A6StructV5Assoca">Assoc</Type></Declaration>
 // ASSOC-NEXT: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>() -&gt; <decl.function.returntype><ref.typealias usr="s:8MyModule0A6StructV5Assoca">Assoc</ref.typealias></decl.function.returntype></decl.function.method.instance>

--- a/test/SourceKit/CursorInfo/cursor_some_type.swift
+++ b/test/SourceKit/CursorInfo/cursor_some_type.swift
@@ -26,6 +26,7 @@ func test(value: S) {
 // DECLSITE-NEXT: source.lang.swift
 // DECLSITE-NEXT: <T> (S) -> (T) -> some Base & Proto
 // DECLSITE-NEXT: $s1xQrx_tcluD
+// DECLSITE-NEXT: Test{{$}}
 // DECLSITE-NEXT: <Declaration>public func foo&lt;T&gt;(x: <Type usr=[[T_USR:.*]]>T</Type>) -&gt; some <Type usr=[[Base_USR:.*]]>Base</Type> &amp; <Type usr=[[Proto_USR:.*]]>Proto</Type></Declaration>
 // DECLSITE-NEXT: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>&lt;<decl.generic_type_param usr=[[T_USR]]><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=[[T_USR]]>T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><syntaxtype.keyword>some</syntaxtype.keyword> <ref.class usr=[[Base_USR]]>Base</ref.class> &amp; <ref.protocol usr=[[Proto_USR]]>Proto</ref.protocol></decl.function.returntype></decl.function.method.instance>
 
@@ -36,6 +37,7 @@ func test(value: S) {
 // PROTO_AFTER_SOME-NEXT: source.lang.swift
 // PROTO_AFTER_SOME-NEXT: Proto.Protocol
 // PROTO_AFTER_SOME-NEXT: $s4Test5Proto_pmD
+// PROTO_AFTER_SOME-NEXT: Test{{$}}
 // PROTO_AFTER_SOME-NEXT: <Declaration>public protocol Proto</Declaration>
 // PROTO_AFTER_SOME-NEXT: <decl.protocol><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Proto</decl.name></decl.protocol>
 
@@ -47,5 +49,6 @@ func test(value: S) {
 // USESITE-NEXT: <T> (S) -> (T) -> some Base & Proto
 // USESITE-NEXT: $s1xQrx_tcluD
 // USESITE-NEXT: <Container>$s4Test1SVD</Container>
+// USESITE-NEXT: Test{{$}}
 // USESITE-NEXT: <Declaration>public func foo&lt;T&gt;(x: <Type usr="s:4Test1SV3foo1xQrx_tlFQO1Txmfp">T</Type>) -&gt; some <Type usr=[[Base_USR:.*]]>Base</Type> &amp; <Type usr=[[Proto_USR:.*]]>Proto</Type></Declaration>
 // USESITE-NEXT: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>&lt;<decl.generic_type_param usr="s:4Test1SV3foo1xQrx_tlFQO1Txmfp"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr="s:4Test1SV3foo1xQrx_tlFQO1Txmfp">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><syntaxtype.keyword>some</syntaxtype.keyword> <ref.class usr=[[Base_USR]]>Base</ref.class> &amp; <ref.protocol usr=[[Proto_USR]]>Proto</ref.protocol></decl.function.returntype></decl.function.method.instance>

--- a/test/SourceKit/CursorInfo/cursor_usr.swift
+++ b/test/SourceKit/CursorInfo/cursor_usr.swift
@@ -22,6 +22,7 @@ func foo(x: FooStruct1) -> S1 {}
 // CHECK_SANITY1-NEXT: source.lang.swift
 // CHECK_SANITY1-NEXT: S1.Type
 // CHECK_SANITY1-NEXT: $s10cursor_usr2S1VmD
+// CHECK_SANITY1-NEXT: cursor_usr{{$}}
 // CHECK_SANITY1-NEXT: <Declaration>struct S1</Declaration>
 // CHECK_SANITY1-NEXT: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>
 
@@ -39,4 +40,3 @@ func foo(x: FooStruct1) -> S1 {}
 // CHECK1: source.lang.swift.decl.struct (5:8-5:10)
 // CHECK1: s1
 // CHECK1: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>
-

--- a/test/SourceKit/CursorInfo/rdar_34348776.swift
+++ b/test/SourceKit/CursorInfo/rdar_34348776.swift
@@ -2,13 +2,14 @@ public struct MyStruct<T> {}
 public typealias Alias<T> = MyStruct<T>
 public typealias Aliased = Alias
 
-// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s -module-name AliasTest | %FileCheck %s
 
 // CHECK: source.lang.swift.decl.typealias (3:18-3:25)
 // CHECK-NEXT: Aliased
-// CHECK-NEXT: s:13rdar_343487767Aliaseda
+// CHECK-NEXT: s:9AliasTest7Aliaseda
 // CHECK-NEXT: source.lang.swift
 // CHECK-NEXT: Alias.Type
-// CHECK-NEXT: $s13rdar_343487765AliasamD
-// CHECK-NEXT: <Declaration>public typealias Aliased = <Type usr="s:13rdar_343487765Aliasa">Alias</Type></Declaration>
-// CHECK-NEXT: <decl.typealias><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Aliased</decl.name> = <ref.typealias usr="s:13rdar_343487765Aliasa">Alias</ref.typealias></decl.typealias>
+// CHECK-NEXT: $s9AliasTest0A0amD
+// CHECK-NEXT: AliasTest{{$}}
+// CHECK-NEXT: <Declaration>public typealias Aliased = <Type usr="s:9AliasTest0A0a">Alias</Type></Declaration>
+// CHECK-NEXT: <decl.typealias><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Aliased</decl.name> = <ref.typealias usr="s:9AliasTest0A0a">Alias</ref.typealias></decl.typealias>

--- a/test/SourceKit/CursorInfo/result_builder.swift
+++ b/test/SourceKit/CursorInfo/result_builder.swift
@@ -51,6 +51,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // ATTR_NAME-NEXT: source.lang.swift
 // ATTR_NAME-NEXT: TaggedBuilder<Tag>.Type
 // ATTR_NAME-NEXT: $s11BuilderTest06TaggedA0VyxGmD
+// ATTR_NAME-NEXT: BuilderTest{{$}}
 // ATTR_NAME-NEXT: <Declaration>@resultBuilder struct TaggedBuilder&lt;Tag&gt;</Declaration>
 // ATTR_NAME-NEXT: <decl.struct><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@resultBuilder</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>TaggedBuilder</decl.name>&lt;<decl.generic_type_param usr="s:11BuilderTest06TaggedA0V3Tagxmfp"><decl.generic_type_param.name>Tag</decl.generic_type_param.name></decl.generic_type_param>&gt;</decl.struct>
 
@@ -62,6 +63,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // ATTR_GENERICARG-NEXT: source.lang.swift
 // ATTR_GENERICARG-NEXT: Color.Type
 // ATTR_GENERICARG-NEXT: $s11BuilderTest5ColorOmD
+// ATTR_GENERICARG-NEXT: BuilderTest{{$}}
 // ATTR_GENERICARG-NEXT: <Declaration>enum Color</Declaration>
 // ATTR_GENERICARG-NEXT: <decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>Color</decl.name></decl.enum>
 
@@ -73,6 +75,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // CALL_BUILDERFUNC-NEXT: source.lang.swift
 // CALL_BUILDERFUNC-NEXT: <Result> (body: (Color) -> Result) -> ()
 // CALL_BUILDERFUNC-NEXT: $s4bodyyx11BuilderTest5ColorOXE_tcluD
+// CALL_BUILDERFUNC-NEXT: BuilderTest{{$}}
 // CALL_BUILDERFUNC-NEXT: <Declaration>func acceptColorTagged&lt;Result&gt;(@<Type usr="s:11BuilderTest06TaggedA0V">TaggedBuilder</Type>&lt;<Type usr="s:11BuilderTest5ColorO">Color</Type>&gt; body: (<Type usr="s:11BuilderTest5ColorO">Color</Type>) -&gt; <Type usr="s:11BuilderTest17acceptColorTagged4bodyyxAA0D0OXE_tlF6ResultL_xmfp">Result</Type>)</Declaration>
 // CALL_BUILDERFUNC-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>acceptColorTagged</decl.name>&lt;<decl.generic_type_param usr="s:11BuilderTest17acceptColorTagged4bodyyxAA0D0OXE_tlF6ResultL_xmfp"><decl.generic_type_param.name>Result</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@<ref.struct usr="s:11BuilderTest06TaggedA0V">TaggedBuilder</ref.struct>&lt;<ref.enum usr="s:11BuilderTest5ColorO">Color</ref.enum>&gt;</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <decl.var.parameter.argument_label>body</decl.var.parameter.argument_label>: <decl.var.parameter.type>(<decl.var.parameter><decl.var.parameter.type><ref.enum usr="s:11BuilderTest5ColorO">Color</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.generic_type_param usr="s:11BuilderTest17acceptColorTagged4bodyyxAA0D0OXE_tlF6ResultL_xmfp">Result</ref.generic_type_param></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>
 
@@ -84,6 +87,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // CLOSUREPARAM_DECL-NEXT: source.lang.swift
 // CLOSUREPARAM_DECL-NEXT: Color
 // CLOSUREPARAM_DECL-NEXT: $s11BuilderTest5ColorOD
+// CLOSUREPARAM_DECL-NEXT: BuilderTest{{$}}
 // CLOSUREPARAM_DECL-NEXT: <Declaration>let color: <Type usr="s:11BuilderTest5ColorO">Color</Type></Declaration>
 // CLOSUREPARAM_DECL-NEXT: <decl.var.parameter><syntaxtype.keyword>let</syntaxtype.keyword> <decl.var.parameter.name>color</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr="s:11BuilderTest5ColorO">Color</ref.enum></decl.var.parameter.type></decl.var.parameter>
 
@@ -95,6 +99,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // CLOSUREPARAM_USER-NEXT: source.lang.swift
 // CLOSUREPARAM_USER-NEXT: Color
 // CLOSUREPARAM_USER-NEXT: $s11BuilderTest5ColorOD
+// CLOSUREPARAM_USER-NEXT: BuilderTest{{$}}
 // CLOSUREPARAM_USER-NEXT: <Declaration>let color: <Type usr="s:11BuilderTest5ColorO">Color</Type></Declaration>
 // CLOSUREPARAM_USER-NEXT: <decl.var.parameter><syntaxtype.keyword>let</syntaxtype.keyword> <decl.var.parameter.name>color</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr="s:11BuilderTest5ColorO">Color</ref.enum></decl.var.parameter.type></decl.var.parameter>
 
@@ -106,6 +111,7 @@ func testAcceptColorTagged(i: Int, s: String) {
 // CAPTURED_VALUE-NEXT: source.lang.swift
 // CAPTURED_VALUE-NEXT: Int
 // CAPTURED_VALUE-NEXT: $sSiD
+// CAPTURED_VALUE-NEXT: BuilderTest{{$}}
 // CAPTURED_VALUE-NEXT: <Declaration>let i: <Type usr="s:Si">Int</Type></Declaration>
 // CAPTURED_VALUE-NEXT: <decl.var.parameter><syntaxtype.keyword>let</syntaxtype.keyword> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -753,26 +753,23 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
   return SM.getLocOffsetInBuffer(Loc, SM.findBufferContainingLoc(Loc));
 }
 
-static StringRef
-getModuleName(const ValueDecl *VD, llvm::BumpPtrAllocator &Allocator,
-              ModuleDecl *IgnoreModule = nullptr) {
+static StringRef getModuleName(const ValueDecl *VD,
+                               llvm::BumpPtrAllocator &Allocator) {
   ASTContext &Ctx = VD->getASTContext();
   ClangImporter *Importer =
       static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
-  auto ClangNode = VD->getClangNode();
-  if (ClangNode) {
-    auto ClangMod = Importer->getClangOwningModule(ClangNode);
-    if (ClangMod)
+  if (auto ClangNode = VD->getClangNode()) {
+    if (const auto *ClangMod = Importer->getClangOwningModule(ClangNode))
       return copyString(Allocator, ClangMod->getFullModuleName());
-  } else if (VD->getModuleContext() != IgnoreModule) {
-    ModuleDecl *MD = VD->getModuleContext();
-    // If the decl is from a cross-import overlay module, report the
-    // overlay's declaring module as the owning module.
-    if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
-      MD = Declaring;
-    return MD->getNameStr();
+    return "";
   }
-  return "";
+
+  ModuleDecl *MD = VD->getModuleContext();
+  // If the decl is from a cross-import overlay module, report the
+  // overlay's declaring module as the owning module.
+  if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
+    MD = Declaring;
+  return MD->getNameStr();
 }
 
 struct DeclInfo {
@@ -1044,9 +1041,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
                                          llvm::makeArrayRef(ReferencedDecls));
   }
 
-  Symbol.ModuleName = copyString(Allocator,
-                                 getModuleName(DInfo.VD, Allocator,
-                                               /*ModuleToIgnore=*/MainModule));
+  Symbol.ModuleName = getModuleName(DInfo.VD, Allocator);
   if (auto IFaceGenRef =
           Lang.getIFaceGenContexts().find(Symbol.ModuleName, Invoc))
     Symbol.ModuleInterfaceName = IFaceGenRef->getDocumentName();


### PR DESCRIPTION
To simplify clients, have the cursorinfo result be consistent whether
requesting a symbol within the current module or not, ie. do not skip
adding the module name.

Resolves rdar://77003299
