### PR TITLE
[CS] Add special case to preserve compatibility for rdar://84279742

### DIFF
--- a/test/Constraints/ranking.swift
+++ b/test/Constraints/ranking.swift
@@ -343,6 +343,55 @@ struct S4 {
   }
 }
 
+// rdar://84279742 – Make sure we prefer the unlabeled init here.
+struct S5 {
+  init(x: Int...) {}
+  init(_ x: Int...) {}
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7ranking2S5V15testInitRankingyyF
+  func testInitRanking() {
+    // CHECK: function_ref @$s7ranking2S5VyACSid_tcfC : $@convention(method) (@owned Array<Int>, @thin S5.Type) -> S5
+    _ = S5()
+  }
+}
+
+// We should also prefer the unlabeled case here.
+struct S6 {
+  init(_: Int = 0, x: Int...) {}
+  init(_: Int = 0, _: Int...) {}
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7ranking2S6V15testInitRankingyyF
+  func testInitRanking() {
+    // CHECK: function_ref @$s7ranking2S6VyACSi_SidtcfC : $@convention(method) (Int, @owned Array<Int>, @thin S6.Type) -> S6
+    _ = S6()
+  }
+}
+
+// However subtyping rules take precedence over labeling rules, so we should
+// prefer the labeled init here.
+struct S7 {
+  init(x: Int...) {}
+  init(_: Int?...) {}
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7ranking2S7V15testInitRankingyyF
+  func testInitRanking() {
+    // CHECK: function_ref @$s7ranking2S7V1xACSid_tcfC : $@convention(method) (@owned Array<Int>, @thin S7.Type) -> S7
+    _ = S7()
+  }
+}
+
+// Subtyping rules also let us prefer the Int... init here.
+struct S8 {
+  init(_: Int?...) {}
+  init(_: Int...) {}
+
+  // CHECK-LABEL: sil hidden [ossa] @$s7ranking2S8V15testInitRankingyyF
+  func testInitRanking() {
+    // CHECK: function_ref @$s7ranking2S8VyACSid_tcfC : $@convention(method) (@owned Array<Int>, @thin S8.Type) -> S8
+    _ = S8()
+  }
+}
+
 //--------------------------------------------------------------------
 // Pointer conversions
 //--------------------------------------------------------------------

--- a/test/Constraints/ranking_ambiguities.swift
+++ b/test/Constraints/ranking_ambiguities.swift
@@ -25,3 +25,36 @@ struct S1 {
     _ = S1.init() // expected-error {{ambiguous use of 'init'}}
   }
 }
+
+// Ambiguous because we don't prefer one label over the other.
+struct S2 {
+  init(x: Int...) {} // expected-note {{found this candidate}}
+  init(y: Int...) {} // expected-note {{found this candidate}}
+
+  func testInitRanking() {
+    _ = S2() // expected-error {{ambiguous use of 'init'}}
+  }
+}
+
+// Ambiguous because we don't apply the prefer-unlabeled rule if the types
+// aren't compatible.
+struct S3 {
+  init(x: Int...) {} // expected-note {{found this candidate}}
+  init(_: String...) {} // expected-note {{found this candidate}}
+
+  func testInitRanking() {
+    _ = S3() // expected-error {{ambiguous use of 'init'}}
+  }
+}
+
+// Ambiguous because this ends up being a comparison between a paren and tuple
+// parameter list, and we don't have a special case for it. Ideally we would
+// align this behavior with the variadic behavior.
+struct S4 {
+  init(x: Int = 0) {} // expected-note {{found this candidate}}
+  init(_: Int = 0) {} // expected-note {{found this candidate}}
+
+  func testInitRanking() {
+    _ = S4() // expected-error {{ambiguous use of 'init'}}
+  }
+}


### PR DESCRIPTION
When ranking constructor parameter lists, we compose them as tuples or parens, and check if they are subtypes or unlabeled versions of each other. Previously this was done with the parameter flags intact, but recently in #39543 I changed the logic to explicitly strip parameter flags in preparation for no longer storing the flags on these types.

This caused a slight behavior change, as it turns out we have a special case in `TupleType::get` that allows an unlabeled single parameter to be composed as a tuple type if its variadic bit is set. With the parameter flags now stripped, we produce a paren type. This means that when comparing the parameter lists e.g `(x: Int...)` and `(Int...)`, instead of comparing two tuple types, we end up comparing a tuple with a paren and fail.

To preserve the old behavior, implement a special case for when we have an unlabeled and labeled variadic comparison for a single parameter. In this case, add the parameter types directly to the type diff, and track which one had the label. The ranking logic can then use this to prefer the unlabeled variant. This is only needed in the single parameter case, as other cases will compare as tuples the same as before. In cases where variadics aren't used, we may end up trying to compare parens with tuples, but that's consistent with what we previously did.

SR-15362
rdar://84279742
