### PR TITLE
Remove unused SWIFT_DEBUG_RUNTIME macro.

### DIFF
--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -20,10 +20,6 @@
 #include <condition_variable>
 #include <thread>
 
-#ifndef SWIFT_DEBUG_RUNTIME
-#define SWIFT_DEBUG_RUNTIME 0
-#endif
-
 namespace swift {
 
 #if !SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR


### PR DESCRIPTION
The use of the macro was removed back in 2018 under f304c321f3b.

@swift-ci Please smoke test