### PR TITLE
Update `test/Concurrency/Backdeploy/linking.swift` to require macCatalyst supported environment

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -15,6 +15,7 @@
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
+// REQUIRES: maccatalyst_support
 
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib


### PR DESCRIPTION
Resolves rdar://84441879
