### PR TITLE
[5.5] Update `test/Concurrency/Backdeploy/linking.swift` to require macCatalyst supported environment

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -15,6 +15,7 @@
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
+// REQUIRES: maccatalyst_support
 
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/39856
---------------------------------------------------------
Resolves rdar://84441879
