### PR TITLE
Fixing random issues on the next branch

### DIFF
--- a/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
+++ b/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
@@ -42,29 +42,29 @@ public:
 
   llvm::support::endianness getEndian() const override { return Endian; }
 
-  llvm::Error readBytes(uint32_t Offset, uint32_t Size,
+  llvm::Error readBytes(uint64_t Offset, uint64_t Size,
                         ArrayRef<uint8_t> &Buffer) override;
 
-  llvm::Error readLongestContiguousChunk(uint32_t Offset,
+  llvm::Error readLongestContiguousChunk(uint64_t Offset,
                                          ArrayRef<uint8_t> &Buffer) override;
 
   MutableArrayRef<uint8_t> data() { return Data; }
 
-  uint32_t getLength() override { return Data.size(); }
+  uint64_t getLength() override { return Data.size(); }
 
-  llvm::Error writeBytes(uint32_t Offset, ArrayRef<uint8_t> Buffer) override;
+  llvm::Error writeBytes(uint64_t Offset, ArrayRef<uint8_t> Buffer) override;
 
   /// This is an optimized version of \c writeBytes specifically for integers.
   /// Integers are written in little-endian byte order.
   template<typename T>
-  llvm::Error writeInteger(uint32_t Offset, T Value) {
+  llvm::Error writeInteger(uint64_t Offset, T Value) {
     static_assert(std::is_integral<T>::value, "Integer required.");
     if (auto Error = checkOffsetForWrite(Offset, sizeof(T))) {
       return Error;
     }
 
     // Resize the internal buffer if needed.
-    uint32_t RequiredSize = Offset + sizeof(T);
+    uint64_t RequiredSize = Offset + sizeof(T);
     if (RequiredSize > Data.size()) {
       Data.resize(RequiredSize);
     }

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2220,25 +2220,21 @@ private:
       return false;
     };
 
-    bool isTypeContext = false;
     switch (auto contextKind = descriptor->getKind()) {
     case ContextDescriptorKind::Class:
       if (!getContextName())
         return nullptr;
       nodeKind = Demangle::Node::Kind::Class;
-      isTypeContext = true;
       break;
     case ContextDescriptorKind::Struct:
       if (!getContextName())
         return nullptr;
       nodeKind = Demangle::Node::Kind::Structure;
-      isTypeContext = true;
       break;
     case ContextDescriptorKind::Enum:
       if (!getContextName())
         return nullptr;
       nodeKind = Demangle::Node::Kind::Enum;
-      isTypeContext = true;
       break;
     case ContextDescriptorKind::Protocol: {
       if (!getContextName())

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2175,18 +2175,17 @@ getSwiftFunctionTypeForIntrinsic(llvm::Intrinsic::ID ID,
       return false;
     ArgElts.push_back(ArgTy);
   }
-  
+
   // Translate LLVM function attributes to Swift function attributes.
   IntrinsicInfo II;
   II.ID = ID;
   auto attrs = II.getOrCreateAttributes(Context);
-  if (attrs.hasAttribute(llvm::AttributeList::FunctionIndex,
-                         llvm::Attribute::NoReturn)) {
+  if (attrs.hasFnAttr(llvm::Attribute::NoReturn)) {
     ResultTy = Context.getNeverType();
     if (!ResultTy)
       return false;
   }
-  
+
   return true;
 }
 

--- a/lib/Basic/ExponentialGrowthAppendingBinaryByteStream.cpp
+++ b/lib/Basic/ExponentialGrowthAppendingBinaryByteStream.cpp
@@ -16,7 +16,7 @@ using namespace llvm;
 using namespace swift;
 
 Error ExponentialGrowthAppendingBinaryByteStream::readBytes(
-    uint32_t Offset, uint32_t Size, ArrayRef<uint8_t> &Buffer) {
+    uint64_t Offset, uint64_t Size, ArrayRef<uint8_t> &Buffer) {
   if (auto Error = checkOffsetForRead(Offset, Size)) {
     return Error;
   }
@@ -26,7 +26,7 @@ Error ExponentialGrowthAppendingBinaryByteStream::readBytes(
 }
 
 Error ExponentialGrowthAppendingBinaryByteStream::readLongestContiguousChunk(
-    uint32_t Offset, ArrayRef<uint8_t> &Buffer) {
+    uint64_t Offset, ArrayRef<uint8_t> &Buffer) {
   if (auto Error = checkOffsetForRead(Offset, 0)) {
     return Error;
   }
@@ -40,7 +40,7 @@ void ExponentialGrowthAppendingBinaryByteStream::reserve(size_t Size) {
 }
 
 Error ExponentialGrowthAppendingBinaryByteStream::writeBytes(
-    uint32_t Offset, ArrayRef<uint8_t> Buffer) {
+    uint64_t Offset, ArrayRef<uint8_t> Buffer) {
   if (Buffer.empty())
     return Error::success();
 
@@ -49,7 +49,7 @@ Error ExponentialGrowthAppendingBinaryByteStream::writeBytes(
   }
   
   // Resize the internal buffer if needed.
-  uint32_t RequiredSize = Offset + Buffer.size();
+  uint64_t RequiredSize = Offset + Buffer.size();
   if (RequiredSize > Data.size()) {
     Data.resize(RequiredSize);
   }

--- a/lib/ClangImporter/CFTypeInfo.h
+++ b/lib/ClangImporter/CFTypeInfo.h
@@ -14,9 +14,10 @@
 //
 //===----------------------------------------------------------------------===//
 #ifndef SWIFT_IMPORTER_CFTYPEINFO_H
-#define SWIFT_IMPORTER_CFTYPEINFO_H 
+#define SWIFT_IMPORTER_CFTYPEINFO_H
 
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace clang {
   class RecordDecl;

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -253,8 +253,7 @@ private:
     auto *ObjectPtrTy = getObjectPtrTy();
     auto &M = getModule();
     auto AttrList = AttributeList::get(M.getContext(), 1, Attribute::NoCapture);
-    AttrList = AttrList.addAttribute(
-        M.getContext(), AttributeList::FunctionIndex, Attribute::NoUnwind);
+    AttrList = AttrList.addFnAttribute(M.getContext(), Attribute::NoUnwind);
     CheckUnowned = cast<llvm::Function>(
         M.getOrInsertFunction("swift_checkUnowned", AttrList,
                               Type::getVoidTy(M.getContext()), ObjectPtrTy)

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1287,8 +1287,8 @@ bool SwiftMergeFunctions::replaceDirectCallers(Function *Old, Function *New,
     unsigned ParamIdx = 0;
     
     // Add the existing parameters.
-    for (Value *OldArg : CI->arg_operands()) {
-      NewArgAttrs.push_back(NewPAL.getParamAttributes(ParamIdx));
+    for (Value *OldArg : CI->args()) {
+      NewArgAttrs.push_back(NewPAL.getParamAttrs(ParamIdx));
       NewArgs.push_back(OldArg);
       OldParamTypes.push_back(OldArg->getType());
       ++ParamIdx;
@@ -1315,7 +1315,7 @@ bool SwiftMergeFunctions::replaceDirectCallers(Function *Old, Function *New,
     // Don't transfer attributes from the function to the callee. Function
     // attributes typically aren't relevant to the calling convention or ABI.
     NewCI->setAttributes(AttributeList::get(Context, /*FnAttrs=*/AttributeSet(),
-                                            NewPAL.getRetAttributes(),
+                                            NewPAL.getRetAttrs(),
                                             NewArgAttrs));
     CI->replaceAllUsesWith(NewCI);
     CI->eraseFromParent();


### PR DESCRIPTION
This fixes a bunch of random failures caused by changes to upstream llvm.
This won't get you building, but will get past some of the issues.
I'm still trying to figure out how to fix the issue of the ambiguous `llvm::report_fatal_error` since it's getting hung up on `llvm::StringRef` vs `llvm::Twine&`.