### PR TITLE
[CSStep] Conjunction: Reset current/best score only on failure

### DIFF
--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -909,10 +909,8 @@ public:
 
     // Restore best score only if conjunction fails because
     // successful outcome should keep a score set by `restoreOuterState`.
-    if (HadFailure) {
-      CS.solverState->BestScore = BestScore;
-      CS.CurrentScore = CurrentScore;
-    }
+    if (HadFailure)
+      restoreOriginalScores();
   }
 
   StepResult resume(bool prevFailed) override;
@@ -957,6 +955,12 @@ protected:
   }
 
 private:
+  /// Restore best and current scores as they were before conjunction.
+  void restoreOriginalScores() const {
+    CS.solverState->BestScore = BestScore;
+    CS.CurrentScore = CurrentScore;
+  }
+
   // Restore constraint system state before conjunction.
   //
   // Note that this doesn't include conjunction constraint

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -907,9 +907,12 @@ public:
     // Restore conjunction constraint.
     restore(AfterConjunction, Conjunction);
 
-    // Restore best score.
-    CS.solverState->BestScore = BestScore;
-    CS.CurrentScore = CurrentScore;
+    // Restore best score only if conjunction fails because
+    // successful outcome should keep a score set by `restoreOuterState`.
+    if (HadFailure) {
+      CS.solverState->BestScore = BestScore;
+      CS.CurrentScore = CurrentScore;
+    }
   }
 
   StepResult resume(bool prevFailed) override;


### PR DESCRIPTION
Successful conjunction should preseve a score set by a follow-up
solve with outer context. Failure should reset the score back to
original one pre-conjunction.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
