### PR TITLE
Speedup test by not using StdlibUnittest

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
+++ b/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -parse-as-library -Xfrontend -disable-availability-checking) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -12,7 +12,6 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
 distributed actor LocalWorker {
   init(transport: ActorTransport) {
     defer { transport.actorReady(self) } // FIXME(distributed): rdar://81783599 this should be injected automatically
@@ -27,7 +26,6 @@ distributed actor LocalWorker {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
 extension LocalWorker {
   @_dynamicReplacement(for: _remote_function())
   // TODO(distributed): @_remoteDynamicReplacement(for: function()) - could be a nicer spelling, hiding that we use dynamic under the covers
@@ -44,8 +42,6 @@ extension LocalWorker {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-
-@available(SwiftStdlib 5.5, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -53,7 +49,6 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -83,7 +78,6 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
 func test_local() async throws {
   let transport = FakeTransport()
 
@@ -95,7 +89,6 @@ func test_local() async throws {
   // CHECK: call: local:
 }
 
-@available(SwiftStdlib 5.5, *)
 func test_remote() async throws {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
@@ -110,7 +103,6 @@ func test_remote() async throws {
   // CHECK: call: _cluster_remote_echo(name:):Charlie
 }
 
-@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     try! await test_local()

--- a/test/Distributed/Runtime/distributed_actor_identity.swift
+++ b/test/Distributed/Runtime/distributed_actor_identity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -8,10 +8,8 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-import StdlibUnittest
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
 struct ActorAddress: ActorIdentity, CustomStringConvertible {
   let id: String
   var description: Swift.String {
@@ -19,41 +17,38 @@ struct ActorAddress: ActorIdentity, CustomStringConvertible {
   }
 }
 
+
+func equality() {
+  let a = ActorAddress(id: "a")
+  let b = ActorAddress(id: "b")
+
+  let anyA = AnyActorIdentity(a)
+  let anyB = AnyActorIdentity(b)
+
+  print("\(a == a)") // CHECK: true
+  print("\(anyA == anyA)") // CHECK: true
+
+  print("\(a != b)") // CHECK: true
+  print("\(anyA != anyB)") // CHECK: true
+}
+
+func hash() {
+  let a = ActorAddress(id: "a")
+  let b = ActorAddress(id: "b")
+
+  let anyA = AnyActorIdentity(a)
+  let anyB = AnyActorIdentity(b)
+
+  print("\(a.hashValue == a.hashValue)") // CHECK: true
+  print("\(anyA.hashValue == anyA.hashValue)") // CHECK: true
+
+  print("\(a.hashValue != b.hashValue)") // CHECK: true
+  print("\(anyA.hashValue != anyB.hashValue)") // CHECK: true
+}
+
 @main struct Main {
-  static func main() async {
-    if #available(SwiftStdlib 5.5, *) {
-
-      let ActorIdentityTests = TestSuite("ActorIdentity")
-
-      ActorIdentityTests.test("equality") {
-        let a = ActorAddress(id: "a")
-        let b = ActorAddress(id: "b")
-
-        let anyA = AnyActorIdentity(a)
-        let anyB = AnyActorIdentity(b)
-
-        expectEqual(a, a)
-        expectEqual(anyA, anyA)
-
-        expectNotEqual(a, b)
-        expectNotEqual(anyA, anyB)
-      }
-
-      ActorIdentityTests.test("hash") {
-        let a = ActorAddress(id: "a")
-        let b = ActorAddress(id: "b")
-
-        let anyA = AnyActorIdentity(a)
-        let anyB = AnyActorIdentity(b)
-
-        expectEqual(a.hashValue, a.hashValue)
-        expectEqual(anyA.hashValue, anyA.hashValue)
-
-        expectNotEqual(a.hashValue, b.hashValue)
-        expectNotEqual(anyA.hashValue, anyB.hashValue)
-      }
-    }
-
-    await runAllTestsAsync()
+  static func main() {
+    equality()
+    hash()
   }
 }


### PR DESCRIPTION
Very weird but it seems using this lib makes the testsuite add another 30 seconds to start.

Resolves rdar://84524314