### PR TITLE
[Test] Complicate a "fast" type checker test to make it slow.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
@@ -1,8 +1,0 @@
-// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
-// REQUIRES: tools-release,no_asan
-// UNSUPPORTED: swift_test_mode_optimize_none && OS=linux-gnu
-
-func rdar26564101(a: [Double], m: Double) -> Double {
-  return Double(Array(0...a.count - 1).reduce(0) { $0 + $1 - m })
-  // expected-error@-1 {{cannot convert value of type}}
-}

--- a/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar26564101.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink
+// REQUIRES: tools-release,no_asan
+// UNSUPPORTED: swift_test_mode_optimize_none && OS=linux-gnu
+
+func rdar26564101(a: [Double], m: Double) -> Double {
+  // expected-error@+1 {{unable to type-check this expression in reasonable time}}
+  return Double(Array(0...a.count - 1).reduce(0) {
+    $0 + $1 - m + $0 + $1 + $0
+  })
+}


### PR DESCRIPTION
This test only happened to be under the constraint system thresholds, but the performance was not fast. This test was also flaky in CI, and fragile when making changes to operator overload resolution. Add a few operands to the `+` chain, and disable shrink to push the solver past the performance thresholds.

Resolves: rdar://84523782