### PR TITLE
[Driver][SymbolGraph] add new flag -symbol-graph-minimum-access-level

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1269,6 +1269,11 @@ def emit_symbol_graph_dir : Separate<["-"], "emit-symbol-graph-dir">,
   HelpText<"Emit a symbol graph to directory <dir>">,
   MetaVarName<"<dir>">;
 
+def symbol_graph_minimum_access_level: Separate<["-"], "symbol-graph-minimum-access-level">,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
+  HelpText<"Include symbols with this access level or more when emitting a symbol graph">,
+  MetaVarName<"<level>">;
+
 def pretty_print: Flag<["-"], "pretty-print">,
   Flags<[SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Pretty-print the output JSON">;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -32,10 +32,7 @@ namespace swift {
     const char *OutputPath = nullptr;
     const char *DocOutputPath = nullptr;
     const char *SourceInfoOutputPath = nullptr;
-    std::string SymbolGraphOutputDir;
     std::string ABIDescriptorPath;
-    bool SkipSymbolGraphInheritedDocs = true;
-    bool IncludeSPISymbolsInSymbolGraph = false;
     llvm::VersionTuple UserModuleVersion;
     std::string SDKName;
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -86,6 +86,10 @@ namespace swift {
     class SourceFileDepGraph;
   }
 
+  namespace symbolgraphgen {
+    struct SymbolGraphOptions;
+  }
+
   /// @{
 
   /// \returns true if the declaration should be verified.  This can return
@@ -187,6 +191,7 @@ namespace swift {
   /// Serializes a module or single source file to the given output file.
   void
   serialize(ModuleOrSourceFile DC, const SerializationOptions &options,
+            const symbolgraphgen::SymbolGraphOptions &symbolGraphOptions,
             const SILModule *M = nullptr,
             const fine_grained_dependencies::SourceFileDepGraph *DG = nullptr);
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -590,6 +590,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
   }
   context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
+  context.Args.AddLastArg(Arguments, options::OPT_symbol_graph_minimum_access_level);
 
   return II;
 }
@@ -1081,6 +1082,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
   context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
+  context.Args.AddLastArg(Arguments, options::OPT_symbol_graph_minimum_access_level);
 
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1104,8 +1104,20 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
   Opts.SkipInheritedDocs = Args.hasArg(OPT_skip_inherited_docs);
   Opts.IncludeSPISymbols = Args.hasArg(OPT_include_spi_symbols);
 
+  if (auto *A = Args.getLastArg(OPT_symbol_graph_minimum_access_level)) {
+    Opts.MinimumAccessLevel =
+        llvm::StringSwitch<AccessLevel>(A->getValue())
+            .Case("open", AccessLevel::Open)
+            .Case("public", AccessLevel::Public)
+            .Case("internal", AccessLevel::Internal)
+            .Case("fileprivate", AccessLevel::FilePrivate)
+            .Case("private", AccessLevel::Private)
+            .Default(AccessLevel::Public);
+  } else {
+    Opts.MinimumAccessLevel = AccessLevel::Public;
+  }
+
   // default values for generating symbol graphs during a build
-  Opts.MinimumAccessLevel = AccessLevel::Public;
   Opts.PrettyPrint = false;
   Opts.EmitSynthesizedMembers = true;
   Opts.PrintMessages = false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -153,19 +153,6 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
       getIRGenOptions().PublicLinkLibraries;
   serializationOpts.SDKName = getLangOptions().SDKName;
   serializationOpts.ABIDescriptorPath = outs.ABIDescriptorOutputPath.c_str();
-
-  if (opts.EmitSymbolGraph) {
-    if (!opts.SymbolGraphOutputDir.empty()) {
-      serializationOpts.SymbolGraphOutputDir = opts.SymbolGraphOutputDir;
-    } else {
-      serializationOpts.SymbolGraphOutputDir = serializationOpts.OutputPath;
-    }
-    SmallString<256> OutputDir(serializationOpts.SymbolGraphOutputDir);
-    llvm::sys::fs::make_absolute(OutputDir);
-    serializationOpts.SymbolGraphOutputDir = OutputDir.str().str();
-  }
-  serializationOpts.SkipSymbolGraphInheritedDocs = opts.SkipInheritedDocs;
-  serializationOpts.IncludeSPISymbolsInSymbolGraph = opts.IncludeSPISymbolsInSymbolGraph;
   
   if (!getIRGenOptions().ForceLoadSymbolName.empty())
     serializationOpts.AutolinkForceLoad = true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -65,6 +65,7 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
 #include "swift/Syntax/SyntaxNodes.h"
 #include "swift/TBDGen/TBDGen.h"
@@ -1301,7 +1302,9 @@ static bool serializeSIB(SILModule *SM, const PrimarySpecificPaths &PSPs,
   serializationOpts.SerializeAllSIL = true;
   serializationOpts.IsSIB = true;
 
-  serialize(MSF, serializationOpts, SM);
+  symbolgraphgen::SymbolGraphOptions symbolGraphOptions;
+
+  serialize(MSF, serializationOpts, symbolGraphOptions, SM);
   return Context.hadError();
 }
 
@@ -1554,11 +1557,11 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
       fine_grained_dependencies::withReferenceDependencies(
           Mod, *Instance.getDependencyTracker(), Mod->getModuleFilename(),
           alsoEmitDotFile, [&](SourceFileDepGraph &&g) {
-            serialize(MSF, serializationOpts, SM.get(), &g);
+            serialize(MSF, serializationOpts, Invocation.getSymbolGraphOptions(), SM.get(), &g);
             return false;
           });
     } else {
-      serialize(MSF, serializationOpts, SM.get());
+      serialize(MSF, serializationOpts, Invocation.getSymbolGraphOptions(), SM.get());
     }
   };
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5746,6 +5746,7 @@ void swift::serializeToBuffers(
 
 void swift::serialize(ModuleOrSourceFile DC,
                       const SerializationOptions &options,
+                      const symbolgraphgen::SymbolGraphOptions &symbolGraphOptions,
                       const SILModule *M,
                       const fine_grained_dependencies::SourceFileDepGraph *DG) {
   assert(!withNullAsEmptyStringRef(options.OutputPath).empty());
@@ -5790,22 +5791,12 @@ void swift::serialize(ModuleOrSourceFile DC,
     });
   }
 
-  if (!options.SymbolGraphOutputDir.empty()) {
+  if (!symbolGraphOptions.OutputDir.empty()) {
     if (DC.is<ModuleDecl *>()) {
       auto *M = DC.get<ModuleDecl*>();
       FrontendStatsTracer tracer(getContext(DC).Stats,
                                  "Serialization, symbolgraph");
-      symbolgraphgen::SymbolGraphOptions SGOpts {
-        options.SymbolGraphOutputDir,
-        M->getASTContext().LangOpts.Target,
-        /* PrettyPrint */false,
-        AccessLevel::Public,
-        /*EmitSynthesizedMembers*/true,
-        /*PrintMessages*/false,
-        /*EmitInheritedDocs*/options.SkipSymbolGraphInheritedDocs,
-        /*IncludeSPISymbols*/options.IncludeSPISymbolsInSymbolGraph,
-      };
-      symbolgraphgen::emitSymbolGraphForModule(M, SGOpts);
+      symbolgraphgen::emitSymbolGraphForModule(M, symbolGraphOptions);
     }
   }
   emitABIDescriptor(DC, options);

--- a/test/SymbolGraph/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/EmitWhileBuilding.swift
@@ -1,12 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PUB
 
 // also try without the trailing slash on `-emit-symbol-graph-dir` and make sure it works
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PUB
 
 // also try while forcing the use of supplementary file maps to make sure the symbol graph path gets
 // added to the file map for the inner frontend call
@@ -14,6 +16,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t -driver-filelist-threshold=0 -O -whole-module-optimization
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PUB
 
 // also try with an up-to-date incremental build to make sure that adding the symbol graph flags
 // can get them to be generated
@@ -23,8 +26,21 @@
 // RUN: cd %t && %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental
 // RUN: cd %t && %target-build-swift %t/EmitWhileBuilding.swift -module-name EmitWhileBuilding -c -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-dependencies -incremental -output-file-map=%S/Inputs/EmitWhileBuilding.output.json -working-directory %t -v -driver-show-incremental -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PUB
+
+// now run with -symbol-graph-minimum-access-level to change the available symbols
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -symbol-graph-minimum-access-level private
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix PRIV
 
 /// Does a foo.
 public func foo() {}
 
+/// Does a bar.
+func bar() {}
+
 // CHECK: "precise":"s:17EmitWhileBuilding3fooyyF"
+// PUB-NOT: "precise":"s:17EmitWhileBuilding3baryyF"
+// PRIV: "precise":"s:17EmitWhileBuilding3baryyF"

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -36,6 +36,7 @@
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "swift/Subsystems.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -356,7 +357,9 @@ int main(int argc, char **argv) {
     serializationOpts.SerializeAllSIL = true;
     serializationOpts.IsSIB = true;
 
-    serialize(CI.getMainModule(), serializationOpts, SILMod.get());
+    symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
+
+    serialize(CI.getMainModule(), serializationOpts, symbolGraphOpts, SILMod.get());
   } else {
     const StringRef OutputFile =
         OutputFilename.size() ? StringRef(OutputFilename) : "-";

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -31,6 +31,7 @@
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/SerializedSILLoader.h"
 #include "swift/Serialization/SerializationOptions.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/IRGenSILPasses.h"
 #include "llvm/ADT/Statistic.h"
@@ -633,7 +634,9 @@ int main(int argc, char **argv) {
     serializationOpts.SerializeAllSIL = EmitSIB;
     serializationOpts.IsSIB = EmitSIB;
 
-    serialize(CI.getMainModule(), serializationOpts, SILMod.get());
+    symbolgraphgen::SymbolGraphOptions symbolGraphOptions;
+
+    serialize(CI.getMainModule(), serializationOpts, symbolGraphOptions, SILMod.get());
   } else {
     const StringRef OutputFile = OutputFilename.size() ?
                                    StringRef(OutputFilename) : "-";


### PR DESCRIPTION
Resolves rdar://79099869

When generating a symbol graph, it's sometimes useful to include information for non-public symbols. However, symbol graphs generating during a compile were always forced to a "minimum access level" of "public". The only option was to run `swift-symbolgraph-extract` after the fact and use its `-minimum-access-level` flag. This PR adds a new flag to the driver, `-symbol-graph-minimum-access-level`, that allows users to specify access levels other than "public" when generating symbol graphs during a compile.

I also took the opportunity to strip out the symbol-graph-specific fields from `SerializationOptions`, in favor of pulling the `SymbolGraphOptions` directly from the `CompilerInvocation` that parses them from the args. (I added those args back in #38070, but didn't connect them all the way down to where they were used in the `serialize()` function. Here, i finished the job.)