### PR TITLE
[libswift] Undefine IBAction/IBOutlet ObjC macros when building lib swift

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -730,7 +730,8 @@ function(add_libswift name)
 
   set(libswift_compile_options
       "-Xfrontend" "-validate-tbd-against-ir=none"
-      "-Xfrontend" "-enable-cxx-interop")
+      "-Xfrontend" "-enable-cxx-interop"
+      "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
 
   if(CMAKE_BUILD_TYPE STREQUAL Debug)
     list(APPEND libswift_compile_options "-g")


### PR DESCRIPTION
When we compile libswift with c++-interop enabled, it actually ends up compiling the project as objc++ on Darwin platforms because objc interop is necessarily enabled by default. This causes problems in the libswift bridging header because we try to expand the ObjC IBAction/IBOutlet/IBInspectable macros in inappropriate places. 

This change fixes the problem by undefining these macros via `-U` flags passed when building libswift. 
