### PR TITLE
RequirementMachine: Simplified rules are not always redundant

### DIFF
--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -913,15 +913,10 @@ void RewriteSystem::verifyMinimizedRules() const {
     if (rule.isRedundant())
       continue;
 
-    // Simplified rules should be redundant.
-    if (rule.isSimplified()) {
-      llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
-    }
-
     // Rules with unresolved name symbols (other than permanent rules for
     // associated type introduction) should be redundant.
+    //
+    // FIXME: What about invalid code?
     if (rule.getLHS().containsUnresolvedSymbols() ||
         rule.getRHS().containsUnresolvedSymbols()) {
       llvm::errs() << "Unresolved rule is not redundant: " << rule << "\n\n";

--- a/test/Generics/symmetric_group_4.swift
+++ b/test/Generics/symmetric_group_4.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+// This is a funny presentation of the symmetric group on 4 elements
+// from Joe Groff.
+
+// CHECK-LABEL: symmetric_group_4.(file).O1@
+// CHECK-LABEL: Requirement signature: <Self where Self == Self.C.C.C.C, Self.C : O1, Self.R : O1, Self.C.C.C.C == Self.C.C.R.C.C.R, Self.C.C.R.C.C.R == Self.R.C.R.C.R.C>
+protocol O1 {
+  associatedtype R : O1
+  associatedtype C : O1
+    where C.C.C.C == Self,
+          C.C.R.C.C.R == Self,
+          R.C.R.C.R.C == Self
+}
+
+// CHECK-LABEL: symmetric_group_4.(file).O2@
+// CHECK-LABEL: Requirement signature: <Self where Self == Self.C.C.C.C, Self.C : O2, Self.R : O2, Self.C.C.C.C == Self.C.C.R.C.C.R, Self.C.C.R.C.C.R == Self.R.C.R.C.R.C>
+protocol O2 {
+  associatedtype R : O2
+  associatedtype C : O2
+    where Self == C.C.C.C,
+          C.C.C.C == C.C.R.C.C.R,
+          C.C.R.C.C.R == R.C.R.C.R.C
+}
+
+// The GSB incorrectly minimized this one, dropping all of the same-type requirements.
+
+// CHECK-LABEL: symmetric_group_4.(file).O3@
+// CHECK-LABEL: Requirement signature: <Self where Self == Self.C.C.C.C, Self.C : O3, Self.R : O3, Self.C.C.C.C == Self.C.C.R.C.C.R, Self.C.C.R.C.C.R == Self.R.C.R.C.R.C>
+protocol O3 {
+  associatedtype R : O3
+  associatedtype C : O3
+    where C.C.C.C == C.C.R.C.C.R,
+          C.C.R.C.C.R == R.C.R.C.R.C,
+          R.C.R.C.R.C == Self
+}


### PR DESCRIPTION
A simplified rewrite system is one where no rule's left hand side
can be reduced by any other rule.

I thought that if a rule's left hand side can be reduced by some
other rule, the rule will necessary be redundant according to
homotopy reduction. However, it appears that these two notions
are independent.

Thanks to @jckarter for the counterexample.