### PR TITLE
Ensure that we hop off the main actor after MainActor.run.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -642,7 +642,7 @@ SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
     actorType->getTypeOfMember(SGM.SwiftModule, sharedInstanceDecl);
 
   auto metaRepr =
-    nominal->isResilient(SGM.SwiftModule, ResilienceExpansion::Maximal)
+    nominal->isResilient(SGM.SwiftModule, F.getResilienceExpansion())
     ? MetatypeRepresentation::Thick
     : MetatypeRepresentation::Thin;
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -54,11 +54,7 @@ extension MainActor {
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
   ) async rethrows -> T {
-    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) rethrows -> T {
-      return try body()
-    }
-
-    return try await runOnMain(body: body)
+    return try await body()
   }
 
   /// Execute the given body closure on the main actor.

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -45,12 +45,29 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
-  @_silgen_name("$sScM3run10resultType4bodyxxm_xyYbKScMYcXEtYaKlFZ")
+  ///
+  /// Historical ABI entry point, superceded by the Sendable version that is
+  /// also inlined to back-deploy a semantic fix where this operation would
+  /// not hop back at the end.
+  @usableFromInline
+  static func run<T>(
+    resultType: T.Type = T.self,
+    body: @MainActor @Sendable () throws -> T
+  ) async rethrows -> T {
+    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) rethrows -> T {
+      return try body()
+    }
+
+    return try await runOnMain(body: body)
+  }
+
+  /// Execute the given body closure on the main actor.
+  @_alwaysEmitIntoClient
   public static func run<T: Sendable>(
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
   ) async rethrows -> T {
-    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) async rethrows -> T {
+    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) rethrows -> T {
       return try body()
     }
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -67,10 +67,6 @@ extension MainActor {
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
   ) async rethrows -> T {
-    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) rethrows -> T {
-      return try body()
-    }
-
-    return try await runOnMain(body: body)
+    return try await body()
   }
 }

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -81,6 +81,10 @@ actor A {
 // CHECK-NOT: ERROR
 // CHECK: finished with return counter = 4
 
+// CHECK: detached task not on main queue
+// CHECK: on main queue again
+// CHECK: detached task hopped back
+
 @main struct RunIt {
   static func main() async {
     print("starting")
@@ -91,5 +95,25 @@ actor A {
     }
     let result = await someFunc()
     print("finished with return counter = \(result)")
+
+    // Check actor hopping with MainActor.run.
+    let task = Task.detached {
+      if checkIfMainQueue(expectedAnswer: false) {
+        print("detached task not on main queue")
+      } else {
+        print("ERROR: detached task is on the main queue?")
+      }
+
+      _ = await MainActor.run {
+        checkAnotherFn(1)
+      }
+
+      if checkIfMainQueue(expectedAnswer: false) {
+        print("detached task hopped back")
+      } else {
+        print("ERROR: detached task is on the main queue?")
+      }
+    }
+    _ = await task.value
   }
 }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -50,4 +50,5 @@
 // UNSUPPORTED: swift_evolve
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
+Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -50,5 +50,4 @@
 // UNSUPPORTED: swift_evolve
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
-
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
Asynchronous functions isolated to global actors hop to the global at
the beginning of the function but do not hop back on return. For
`MainActor.run`, this means that we would not "hop back" off the main
actor after executing the closure, which lead to too much code running
on the main thread. Dropping the "async" ensures that we hop back.
While we my also want the general "hop back" semantics for
asynchronous actor-isolated functions, for now this addresses the
problem with `MainActor.run`.

Fixes rdar://82138050.
