### PR TITLE
Ensure that we hop off the main actor after MainActor.run.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -611,7 +611,7 @@ SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
     actorType->getTypeOfMember(SGM.SwiftModule, sharedInstanceDecl);
 
   auto metaRepr =
-    nominal->isResilient(SGM.SwiftModule, ResilienceExpansion::Maximal)
+    nominal->isResilient(SGM.SwiftModule, F.getResilienceExpansion())
     ? MetatypeRepresentation::Thick
     : MetatypeRepresentation::Thin;
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -59,6 +59,7 @@ extension MainActor {
   }
 
   /// Execute the given body closure on the main actor.
+  @_silgen_name("$sScM12runAndReturn10resultType4bodyxxm_xyYbKScMYcXEtYaKlFZ")
   @_alwaysEmitIntoClient
   public static func run<T>(
     resultType: T.Type = T.self,

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -45,14 +45,25 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
+  ///
+  /// Historical ABI entry point, superceded by the Sendable version that is
+  /// also inlined to back-deploy a semantic fix where this operation would
+  /// not hop back at the end.
+  @_silgen_name("$sScM3run10resultType4bodyxxm_xyYbKScMYcXEtYaKlFZ")
+  @usableFromInline
+  static func _historicalRunForABI<T>(
+    resultType: T.Type = T.self,
+    body: @MainActor @Sendable () throws -> T
+  ) async rethrows -> T {
+    return try await body()
+  }
+
+  /// Execute the given body closure on the main actor.
+  @_alwaysEmitIntoClient
   public static func run<T>(
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
   ) async rethrows -> T {
-    @MainActor func runOnMain(body: @MainActor @Sendable () throws -> T) async rethrows -> T {
-      return try body()
-    }
-
-    return try await runOnMain(body: body)
+    return try await body()
   }
 }

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -80,6 +80,10 @@ actor A {
 // CHECK-NOT: ERROR
 // CHECK: finished with return counter = 4
 
+// CHECK: detached task not on main queue
+// CHECK: on main queue again
+// CHECK: detached task hopped back
+
 @main struct RunIt {
   static func main() async {
     print("starting")
@@ -90,5 +94,25 @@ actor A {
     }
     let result = await someFunc()
     print("finished with return counter = \(result)")
+
+    // Check actor hopping with MainActor.run.
+    let task = Task.detached {
+      if checkIfMainQueue(expectedAnswer: false) {
+        print("detached task not on main queue")
+      } else {
+        print("ERROR: detached task is on the main queue?")
+      }
+
+      _ = await MainActor.run {
+        checkAnotherFn(1)
+      }
+
+      if checkIfMainQueue(expectedAnswer: false) {
+        print("detached task hopped back")
+      } else {
+        print("ERROR: detached task is on the main queue?")
+      }
+    }
+    _ = await task.value
   }
 }


### PR DESCRIPTION
**Description:** The Swift Concurrency operation `MainActor.run`, which runs code on the main actor, was failing to "hop back" to the original executing context after executing its closure on the main actor, which meant that tasks meant to be offloaded onto other threads were, in fact, still running on the main actor, tying up the main thread. Make sure we always "hop back" at the end.
**Risk:** Low
**Reviewed by:** Kavon Farvardin, Joe Groff
**Testing:** PR testing, new executable test, testing with sample app provided by 3rd party developer
**Original PR:** https://github.com/apple/swift/pull/39872
**Radar:** rdar://82138050.
