### PR TITLE
[test] Enable some language features in validation-test lit config

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.5, *)
 public protocol AsyncIteratorProtocol {
     associatedtype Element
     associatedtype Failure: Error
@@ -10,6 +11,7 @@ public protocol AsyncIteratorProtocol {
     mutating func cancel()
 }
 
+@available(SwiftStdlib 5.5, *)
 public protocol AsyncSequence {
     associatedtype Element
     associatedtype Failure: Error
@@ -18,6 +20,7 @@ public protocol AsyncSequence {
     func makeAsyncIterator() -> AsyncIterator
 }
 
+@available(SwiftStdlib 5.5, *)
 struct Just<Element>: AsyncSequence {
     typealias Failure = Never
 

--- a/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-library-evolution -enable-experimental-concurrency
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.5, *)
 public class X {
   public func f() async { }
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar71491604.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71491604.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-library-evolution -enable-experimental-concurrency
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.5, *)
 public protocol P {
   func f() async
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
@@ -1,8 +1,10 @@
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -enable-experimental-concurrency
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.5, *)
 func getIntAndString() async -> (Int, String) { (5, "1") }
 
+@available(SwiftStdlib 5.5, *)
 func testDecompose() async -> Int {
   async let (i, s) = await getIntAndString()
   return await i

--- a/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
@@ -1,11 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-experimental-concurrency
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.5, *)
 protocol P {
   func f<T>() async throws -> T?
 }
+@available(SwiftStdlib 5.5, *)
 extension P {
   func f<T>() async throws -> T? { nil }
 }
+@available(SwiftStdlib 5.5, *)
 class X: P {}
 

--- a/validation-test/compiler_crashers_2_fixed/sr15248.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15248.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -emit-ir %s
 // REQUIRES: concurrency
+
 private struct TransformResult<T> {
     var index: Int
     var transformedElement: T
@@ -11,7 +12,7 @@ private struct TransformResult<T> {
 }
 
 public extension Collection {
-    @available(macOS 12.0.0, *)
+    @available(SwiftStdlib 5.5, *)
     private func f<T>(_ transform: @escaping (Element) async throws -> T) async throws -> [T] {
         return try await withThrowingTaskGroup(of: TransformResult<T>.self) { group in
           return []

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -116,6 +116,15 @@ else:
     # even if SWIFT_USE_LINKER isn't set, we cannot use BFD for Android
     config.android_linker_name = "gold"
 
+if "@SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING@" == "TRUE":
+    config.available_features.add('differentiable_programming')
+if "@SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY@" == "TRUE":
+    config.available_features.add('concurrency')
+if "@SWIFT_BACK_DEPLOY_CONCURRENCY@" == "TRUE":
+    config.available_features.add('back_deploy_concurrency')
+if "@SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED@" == "TRUE":
+    config.available_features.add('distributed')
+
 # Let the main config do the real work.
 config.test_exec_root = os.path.dirname(os.path.realpath(__file__))
 lit_config.load_config(config, "@SWIFT_SOURCE_DIR@/validation-test/lit.cfg")


### PR DESCRIPTION
The logic in `test/lit.site.cfg.in` and `validation-test/lit.site.cfg.in` is largely duplicated.
This adds some of the missing features in order to try to fix backdeployconcurrency testing.
This should be more fundamentally fixed to keep the different test configs in sync.