### PR TITLE
[SILOptimizer] Keep lexical lifetime markers.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -29,6 +29,11 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   if (!ctx.shouldPerform(ARCTransformKind::RedundantBorrowScopeElimPeephole))
     return false;
 
+  // Lexical borrow scopes must remain in order to ensure that value lifetimes
+  // are not observably shortened.
+  if (bbi->isLexical())
+    return false;
+
   auto kind = bbi->getOperand().getOwnershipKind();
   SmallVector<EndBorrowInst *, 16> endBorrows;
   for (auto *op : bbi->getUses()) {

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -450,6 +450,11 @@ static SILBasicBlock::iterator
 eliminateSimpleBorrows(BeginBorrowInst *bbi, CanonicalizeInstruction &pass) {
   auto next = std::next(bbi->getIterator());
 
+  // Never eliminate lexical borrow scopes.  They must be kept to ensure that
+  // value lifetimes aren't observably shortened.
+  if (bbi->isLexical())
+    return next;
+
   // We know that our borrow is completely within the lifetime of its base value
   // if the borrow is never reborrowed. We check for reborrows and do not
   // optimize such cases. Otherwise, we can eliminate our borrow and instead use

--- a/validation-test/SILOptimizer/lexical-lifetimes.swift
+++ b/validation-test/SILOptimizer/lexical-lifetimes.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift -Xfrontend -enable-experimental-lexical-lifetimes -O -Xfrontend -enable-copy-propagation | %FileCheck %s
+
+// =============================================================================
+// = Declarations                                                           {{ =
+// =============================================================================
+
+class C {
+  init(_ d: D) {
+    self.d = d
+  }
+  weak var d: D?
+  func foo(_ string: String) {
+    d?.cWillFoo(self, string)
+  }
+}
+class D {
+  func cWillFoo(_ c: C, _ string: String) {
+    print(#function, string)
+  }
+}
+
+// =============================================================================
+// = Declarations                                                           }} =
+// =============================================================================
+
+// =============================================================================
+// = Tests                                                                  {{ =
+// =============================================================================
+
+func test_localLetKeepsObjectAliveBeyondCallToClassWithWeakReference() {
+  let d = D()
+  let c = C(d)
+  // CHECK: cWillFoo{{.*}} test_localLetKeepsObjectAliveBeyondCallToClassWithWeakReference
+  c.foo(#function)
+}
+
+func test_localVarKeepsObjectAliveBeyondCallToClassWithWeakReference() {
+  var d = D()
+  let c = C(d)
+  // CHECK: cWillFoo{{.*}} test_localVarKeepsObjectAliveBeyondCallToClassWithWeakReference
+  c.foo(#function)
+}
+
+// =============================================================================
+// = Tests                                                                  }} =
+// =============================================================================
+
+func run() {
+  test_localLetKeepsObjectAliveBeyondCallToClassWithWeakReference()
+  test_localVarKeepsObjectAliveBeyondCallToClassWithWeakReference()
+}
+
+run()
+


### PR DESCRIPTION
Previously, TempRValueElimination would peephole simple alloc_stacks, even when they were lexical; here, they are left for Mem2Reg to properly handle.

Previously, SemanticARCOpts would eliminate lexical begin_borrows, incorrectly allowing the lifetime of the value borrowed by them to be observably shortened.  Here, those borrow scopes are not eliminated if they are lexical.

Added an executable test that verifies that a local variable strongly referencing a delegate object keeps that delegate alive through the call to an object that weakly references the delegate and calls out to it.
