### PR TITLE
[cxx-interop] Bump data length to use uint32_t.

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1239,11 +1239,11 @@ namespace {
       // # of entries
       uint32_t dataLength =
         sizeof(uint16_t) + sizeof(uint64_t) * data.size();
-      assert(dataLength == static_cast<uint16_t>(dataLength));
+      assert(dataLength == static_cast<uint32_t>(dataLength));
 
       endian::Writer writer(out, little);
       writer.write<uint16_t>(keyLength);
-      writer.write<uint16_t>(dataLength);
+      writer.write<uint32_t>(dataLength);
       return { keyLength, dataLength };
     }
 
@@ -1513,7 +1513,7 @@ namespace {
     static std::pair<unsigned, unsigned>
     ReadKeyDataLength(const uint8_t *&data) {
       unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-      unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+      unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
       return { keyLength, dataLength };
     }
 

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -276,7 +276,7 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 16; // Lazy Member Loading Index
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 17; // Lazy Member Loading Index
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.


### PR DESCRIPTION
We're seeing some C++ projects that cause an integer overflow when this is only 16 bits.
