### PR TITLE
[cxx-interop] [nfc] `llvm::Optional<AnyFunctionRef>` -> `std::unique_ptr<AnyFunctionRef>`.

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -263,7 +263,7 @@ struct SILDeclRef {
   /// Retrieves the ASTContext from the underlying AST node being stored.
   ASTContext &getASTContext() const;
 
-  llvm::Optional<AnyFunctionRef> getAnyFunctionRef() const;
+  std::unique_ptr<AnyFunctionRef> getAnyFunctionRef() const;
   
   SILLocation getAsRegularLocation() const;
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -175,16 +175,16 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
   pointer = prespecializedSig.getPointer();
 }
 
-Optional<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
+std::unique_ptr<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
   switch (getLocKind()) {
   case LocKind::Decl:
     if (auto *afd = getAbstractFunctionDecl())
-      return AnyFunctionRef(afd);
-    return None;
+      return std::make_unique<AnyFunctionRef>(afd);
+    return nullptr;
   case LocKind::Closure:
-    return AnyFunctionRef(getAbstractClosureExpr());
+    return std::make_unique<AnyFunctionRef>(getAbstractClosureExpr());
   case LocKind::File:
-    return None;
+    return nullptr;
   }
   llvm_unreachable("Unhandled case in switch");
 }


### PR DESCRIPTION
`AnyFunctionRef` is a forward declared class in `SILDeclRef.h` this is requred for dependency /layering reasons. However, we cannot get the alignement, etc. of a forward declared class, so we can't use it with `llvm::Optional`. It must only be a pointer.

(This is needed to be able to import `SILDeclRef.h` with C++ interop.)

This also helps us follows the general rule that C++ headers should be self-contained.