### PR TITLE
[cxx-interop] Disable round trip checking for C++ debug types.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -884,7 +884,9 @@ private:
     Mangle::ASTMangler Mangler;
     std::string Result = Mangler.mangleTypeForDebugger(Ty, Sig);
 
-    if (!Opts.DisableRoundTripDebugTypes) {
+    // TODO(SR-15377): We currently cannot round trip some C++ types.
+    if (!Opts.DisableRoundTripDebugTypes &&
+        !Ty->getASTContext().LangOpts.EnableCXXInterop) {
       // Make sure we can reconstruct mangled types for the debugger.
 #ifndef NDEBUG
       auto &Ctx = Ty->getASTContext();


### PR DESCRIPTION
This doesn't work for some C++ types, so, as a stop gap solution, I'm disabling it when C++ interop is enabled.

https://bugs.swift.org/browse/SR-15377 to re-enable it in the future.