### PR TITLE
Allow -explicit-swift-module-map-file without full explicit module build

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -556,7 +556,7 @@ bool CompilerInstance::setUpModuleLoaders() {
   // If implicit modules are disabled, we need to install an explicit module
   // loader.
   bool ExplicitModuleBuild = Invocation.getFrontendOptions().DisableImplicitModules;
-  if (ExplicitModuleBuild) {
+  if (ExplicitModuleBuild || !Invocation.getSearchPathOptions().ExplicitSwiftModuleMap.empty()) {
     auto ESML = ExplicitSwiftModuleLoader::create(
         *Context,
         getDependencyTracker(), MLM,
@@ -564,7 +564,9 @@ bool CompilerInstance::setUpModuleLoaders() {
         IgnoreSourceInfoFile);
     this->DefaultSerializedLoader = ESML.get();
     Context->addModuleLoader(std::move(ESML));
-  } else {
+  }
+
+  if (!ExplicitModuleBuild) {
     if (MLM != ModuleLoadingMode::OnlySerialized) {
       // We only need ModuleInterfaceLoader for implicit modules.
       auto PIML = ModuleInterfaceLoader::create(

--- a/test/ScanDependencies/can_import_with_map_and_implicit.swift
+++ b/test/ScanDependencies/can_import_with_map_and_implicit.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: mkdir -p %t/barinputs
+// RUN: echo "public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/Foo.swiftmodule -emit-module-doc-path %t/inputs/Foo.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/Foo.swiftsourceinfo -module-cache-path %t.module-cache %t/foo.swift -module-name Foo
+// RUN: echo "public func bar() {}" >> %t/bar.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/barinputs/Bar.swiftmodule -emit-module-doc-path %t/barinputs/Bar.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/barinputs/Bar.swiftsourceinfo -module-cache-path %t.module-cache %t/bar.swift -module-name Bar
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Foo\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/Foo.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/Foo.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/Foo.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: not %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules
+// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -I %t/barinputs
+import Foo
+import Bar


### PR DESCRIPTION
This enables the use of `-explicit-swift-module-map-file` for some
modules in the build, while still loading implicit modules as before.
This is useful to improve the performance of builds with many modules to
avoid searching many different directories pass with `-I`. Previously
VFS overlays could be used for this use case as well, but it seems
valuable to unify on the same infrastructure used for explicit module
builds.