### PR TITLE
[Windows/Distributed] Disable failing test

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,6 +8,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// FIXME(distributed): we need to revisit what's going on on windows with distributed actors rdar://84574311
+// XFAIL: OS=windows-msvc
+
 import _Distributed
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -9,7 +9,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): we need to revisit what's going on on windows with distributed actors rdar://84574311
-// XFAIL: OS=windows-msvc
+// UNSUPPORTED: OS=windows-msvc
 
 import _Distributed
 


### PR DESCRIPTION
The test seems to be failing https://ci-external.swift.org/job/swift-PR-windows/18048/console since the new initializers work in https://github.com/apple/swift/pull/39762