### PR TITLE
[Distributed] be more explicit about DA being Sendable

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -35,7 +35,7 @@ public protocol AnyActor: Sendable, AnyObject {}
 /// distributed actor.
 @available(SwiftStdlib 5.5, *)
 public protocol DistributedActor:
-    AnyActor, Identifiable, Hashable, Codable {
+    AnyActor, Sendable, Identifiable, Hashable, Codable {
     /// Resolves the passed in `identity` against the `transport`, returning
     /// either a local or remote actor reference.
     ///

--- a/test/Distributed/distributed_actor_concurrency_warnings.swift
+++ b/test/Distributed/distributed_actor_concurrency_warnings.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -warn-concurrency -enable-experimental-distributed -disable-availability-checking
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+
+actor Charlie {
+    // should not cause sendable warnings, Worker is Sendable as implied by DA
+    func two<Worker>() -> Set<Worker> where Worker: DistributedActor {
+        []
+    }
+}


### PR DESCRIPTION
I don't seem to be able to reproduce the warning now but might as well just be more explicit about the sendability...

I was getting warnings about a returned `Set<Worker>` not conforming to Sendable, like the test shows.

Refs rdar://84577606