### PR TITLE
Mark distributed_actor_default_init/deinit tests as requiring macOS

### DIFF
--- a/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
@@ -2,6 +2,8 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
+// REQUIRES: OS=macosx
+
 import _Distributed
 
 class SomeClass {}

--- a/test/Distributed/SIL/distributed_actor_default_init_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil.swift
@@ -2,6 +2,8 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
+// REQUIRES: OS=macosx
+
 import _Distributed
 
 class SomeClass {}


### PR DESCRIPTION
They currently block PR testing.