### PR TITLE
[docs] Update for OpenBSD 7.1.

### DIFF
--- a/docs/OpenBSD.md
+++ b/docs/OpenBSD.md
@@ -1,13 +1,13 @@
 # Getting started with Swift on OpenBSD
 
-Swift builds and runs on OpenBSD (tested on 6.8), with some special considerations.
+Swift builds and runs on OpenBSD, with some special considerations. This document was last tested on OpenBSD 7.1, but may also work on later versions.
 
 ## Preparing
 
 The following packages are required to build Swift. You can install these via `pkg_add`:
 
 ```shell
-$ doas pkg_add bash cmake e2fsprogs git icu4c ninja py-six python3
+$ doas pkg_add bash cmake e2fsprogs git icu4c ninja py3-six python3
 ```
 
 Because LLVM is built as part of building Swift and does not include some of the patches to handle the OpenBSD library naming convention, you will need to create some symlinks:
@@ -23,10 +23,10 @@ $ doas ln -s /usr/lib/libpthread.so.26.1 /usr/lib/libpthread.so
 
 *Note: you may need to update the version numbers if necessary.*
 
-Also link `~/bin/python` to the `python2.7` binary:
+Also link `~/bin/python` to the `python3` binary:
 
 ```shell
-$ doas ln -s /usr/local/bin/python2.7 ~/bin/python
+$ ln -s /usr/local/bin/python3 ~/bin/python
 ```
 
 Since the build requires significant amounts of memory at certain points, you may need to ensure that the user you are using to build Swift has the appropriate limits set. Using the `staff` group in `login.conf` and ensuring the shell limits are raised is recommended.
@@ -50,13 +50,15 @@ Download the sources with the [Getting Started](/docs/HowToGuides/GettingStarted
       "aliases": [ "main", "swift/main" ],
       "repos": {
         "cmark": "main",
-        "llvm-project": "swift/main",
+        "llvm-project": "stable/20211026",
         "swift": "main"
       }
     }
   }
 }
 ```
+
+*Note: you may need to check `utils/update_checkout/update-checkout-config.json` for the correct LLVM stable branch to build against.*
 
 ## Building
 
@@ -66,23 +68,26 @@ These options are:
 * `--skip-build-clang-tools-extra` and `--skip-build-compiler-rt`: to ensure LLVM builds cleanly,
 * `--extra-cmake-options=`
   * `-DCMAKE_DISABLE_FIND_PACKAGE_Backtrace=TRUE,-DCMAKE_DISABLE_FIND_PACKAGE_LibXml2=TRUE,-DLLVM_VERSION_SUFFIX=''`: to ensure LLVM builds cleanly,
-  * `-DSWIFT_BUILD_SOURCEKIT=OFF,-DSWIFT_BUILD_SYNTAXPARSERLIB=OFF,-DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=OFF`: to ensure Swift does not attempt to build libdispatch, which is not yet supported on OpenBSD,
+  * `-DSWIFT_ENABLE_DISPATCH=FALSE,-DSWIFT_BUILD_SOURCEKIT=OFF,-DSWIFT_BUILD_SYNTAXPARSERLIB=OFF,-DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=OFF,-DSWIFT_IMPLICIT_CONCURRENCY_IMPORT=OFF,-DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=OFF`: to ensure Swift does not attempt to build libdispatch, which is not yet supported on OpenBSD,
   * `-DSWIFT_USE_LINKER=lld`: to specify that `lld` should be used over `gold`,
   * `-DCMAKE_INSTALL_DIR=/usr/local"`: to set the correct platform install directory.
 
 In full, the minimal set of flags to supply to `build-script` looks like:
 ```shell
 $ ./utils/build-script \
+    --release \
     --skip-build-clang-tools-extra \
     --skip-build-compiler-rt \
     --extra-cmake-options="\
         -DCMAKE_DISABLE_FIND_PACKAGE_Backtrace=TRUE,\
         -DCMAKE_DISABLE_FIND_PACKAGE_LibXml2=TRUE,\
         -DLLVM_VERSION_SUFFIX='',\
+        -DSWIFT_ENABLE_DISPATCH=OFF,\
         -DSWIFT_BUILD_SOURCEKIT=OFF,\
         -DSWIFT_BUILD_SYNTAXPARSERLIB=OFF,\
         -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=OFF,\
         -DSWIFT_IMPLICIT_CONCURRENCY_IMPORT=OFF,\
+        -DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=OFF,\
         -DSWIFT_USE_LINKER=lld,\
         -DCMAKE_INSTALL_DIR=/usr/local"
 ```


### PR DESCRIPTION
Make the following documentation changes:

* update last tested version number and emphasize that the process
  may work for later platform versions,

* update required packages to emphasize py3 instead of py2.7,

* update the suggested checkout config file to the stable branch used
  in the "upstream" checkout config file, and

* mention some extra flags are now required to properly switch off
  Dispatch (since without pr apple/swift-corelibs-libdispatch#559
  Dispatch won't compile).