### PR TITLE
SwiftScan: avoid swapping compilers

### DIFF
--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -1,6 +1,3 @@
-include(SwiftWindowsSupport)
-swift_swap_compiler_if_needed("libSwiftScan")
-
 # Use an 'internal' name, this is primarily intended for SwiftDriver to import.
 set(SWIFT_SCAN_LIB_NAME "_InternalSwiftScan")
 


### PR DESCRIPTION
This library can and should be buildable with a standard compiler.
Disable the forced switch of the compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
