### PR TITLE
GenericEnvironment: Replace 'substDependentTypesWithErrorTypes' with an assertion

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -317,9 +317,6 @@ public:
              LookupConformanceFn conformances,
              SubstOptions options=None) const;
 
-  /// Replace references to substitutable types with error types.
-  Type substDependentTypesWithErrorTypes() const;
-  
   bool isPrivateStdlibType(bool treatNonBuiltinProtocolsAsPublic = true) const;
 
   SWIFT_DEBUG_DUMP;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -87,9 +87,12 @@ Optional<Type> GenericEnvironment::getMappingIfPresent(
 Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
                                             Type type) {
   assert(!type->hasArchetype() && "already have a contextual type");
+  assert((env || !type->hasTypeParameter()) &&
+         "no generic environment provided for type with type parameters");
 
-  if (!env)
-    return type.substDependentTypesWithErrorTypes();
+  if (!env) {
+    return type;
+  }
 
   return env->mapTypeIntoContext(type);
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4151,13 +4151,6 @@ Type Type::subst(TypeSubstitutionFn substitutions,
   return substType(*this, substitutions, conformances, options);
 }
 
-Type Type::substDependentTypesWithErrorTypes() const {
-  return substType(*this,
-                   [](SubstitutableType *t) -> Type { return Type(); },
-                   MakeAbstractConformanceForGenericType(),
-                   SubstFlags::AllowLoweredTypes);
-}
-
 const DependentMemberType *TypeBase::findUnresolvedDependentMemberType() {
   if (!hasTypeParameter()) return nullptr;
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1011,7 +1011,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         // Hashable because DerivedConformance::canDeriveHashable returns true
         // even if the conformance can't be derived. See the note there for
         // details.
-        auto *dc = ConformanceDecl->getDeclContext();
+        auto *dc = cast<DeclContext>(ConformanceDecl);
         tryDiagnoseFailedHashableDerivation(dc, Nominal);
         return nullptr;
       }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1199,7 +1199,23 @@ AssociatedTypeDecl *AssociatedTypeInference::completeSolution(
         // If the substitution produced an error, we're done.
         if (type->hasError())
           return witness.getAssocType();
+
+        // FIXME: If we still have a type parameter and it isn't a generic
+        // parameter of the conforming nominal, it's either a cycle or a
+        // solution that is beyond the current algorithm, i.e.
+        //
+        // protocol P {
+        //   associatedtype A = B
+        //   associatedtype B = C
+        //   associatedtype C = Int
+        // }
+        // struct Conformer: P {}
+        if (type->hasTypeParameter() &&
+            !adoptee->getAnyNominal()->isGeneric()) {
+          return witness.getAssocType();
+        }
       }
+
       type = dc->mapTypeIntoContext(type);
     }
 

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -173,6 +173,12 @@ func genericNotHashable() {
   GenericNotHashable<String>.A("a").hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
 }
 
+enum GenericNotHashable2<T: Equatable, U: Hashable>: Hashable {
+// expected-error@-1 {{type 'GenericNotHashable2' does not conform to protocol 'Hashable'}}
+  case A(U, T) // expected-note {{associated value type 'T' does not conform to protocol 'Hashable', preventing synthesized conformance of 'GenericNotHashable2<T, U>' to 'Hashable'}}
+  case B
+}
+
 // An enum with no cases should also derive conformance.
 enum NoCases: Hashable {}
 


### PR DESCRIPTION
Following Slava's [suggestion](https://github.com/apple/swift/pull/39652#discussion_r730040270).

