### PR TITLE
[Distributed] Skip availability checks, checking if distributed is available is enough

### DIFF
--- a/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
@@ -1,14 +1,11 @@
-// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -enable-experimental-distributed | %FileCheck %s --enable-var-scope --dump-input=fail
+// RUN: %target-swift-frontend -module-name default_deinit -primary-file %s -emit-sil -enable-experimental-distributed -disable-availability-checking | %FileCheck %s --enable-var-scope --dump-input=fail
 // REQUIRES: concurrency
 // REQUIRES: distributed
-
-// REQUIRES: OS=macosx
 
 import _Distributed
 
 class SomeClass {}
 
-@available(macOS 12, *)
 distributed actor MyDistActor {
   let localOnlyField: SomeClass
 

--- a/test/Distributed/SIL/distributed_actor_default_init_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil.swift
@@ -1,14 +1,11 @@
-// RUN: %target-swift-frontend -module-name test -primary-file %s -emit-sil -enable-experimental-distributed | %FileCheck %s --enable-var-scope --dump-input=fail --implicit-check-not=actorReady --implicit-check-not=resignIdentity --implicit-check-not=hop_to_executor
+// RUN: %target-swift-frontend -module-name test -primary-file %s -emit-sil -enable-experimental-distributed -disable-availability-checking | %FileCheck %s --enable-var-scope --dump-input=fail --implicit-check-not=actorReady --implicit-check-not=resignIdentity --implicit-check-not=hop_to_executor
 // REQUIRES: concurrency
 // REQUIRES: distributed
-
-// REQUIRES: OS=macosx
 
 import _Distributed
 
 class SomeClass {}
 
-@available(macOS 12, *)
 distributed actor MyDistActor {
   var localOnlyField: SomeClass
 


### PR DESCRIPTION
Attempt to fix the availability issue discovered by @aschwaighofer in https://github.com/apple/swift/pull/39892

See https://github.com/apple/swift/pull/39762#issuecomment-950188852 for discussion.

I guess they passed smoke test since that is only macOS...?