### PR TITLE
[Stdlib] Enable -Wformat-nonliteral and make it an error.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -38,6 +38,14 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
   list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-xc++")
 endif()
 
+# We should avoid non-literals in format strings, or appropriately mark
+# functions.
+check_cxx_compiler_flag("-Wformat-nonliteral -Werror=format-nonliteral" CXX_SUPPORTS_FORMAT_NONLITERAL_WARNING)
+if (CXX_SUPPORTS_FORMAT_NONLITERAL_WARNING)
+  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-Wformat-nonliteral"
+    "-Werror=format-nonliteral")
+endif()
+
 # C++ code in the runtime and standard library should generally avoid
 # introducing static constructors or destructors.
 check_cxx_compiler_flag("-Wglobal-constructors -Werror=global-constructors" CXX_SUPPORTS_GLOBAL_CONSTRUCTORS_WARNING)


### PR DESCRIPTION
Turn on `-Wformat-nonliteral` so that any format string that is passed through a variable is turned into an error.  There are a variety of reasonable ways of fixing these where they occur, and it's safer to have this switched on.

This should only be merged after #39900.

rdar://84571859