### PR TITLE
Fix `_customContainsEquatableElement` implementation for `Stride*` types

### DIFF
--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -379,8 +379,10 @@ extension StrideTo: Sequence {
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
-    if element < _start || _end <= element {
-      return false
+    if _stride < 0 {
+      if element <= _end || _start < element { return false }
+    } else {
+      if element < _start || _end <= element { return false }
     }
     return nil
   }
@@ -592,8 +594,10 @@ extension StrideThrough: Sequence {
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
-    if element < _start || _end < element {
-      return false
+    if _stride < 0 {
+      if element < _end || _start < element { return false }
+    } else {
+      if element < _start || _end < element { return false }
     }
     return nil
   }

--- a/test/stdlib/Strideable.swift
+++ b/test/stdlib/Strideable.swift
@@ -255,5 +255,25 @@ StrideTestSuite.test("StrideToIterator/past end/backward") {
   strideIteratorTest(stride(from: 3, to: 0, by: -1), nonNilResults: 3)
 }
 
+StrideTestSuite.test("Contains") {
+  expectTrue(stride(from: 1, through: 5, by: 1).contains(3))
+  expectTrue(stride(from: 1, to: 5, by: 1).contains(3))
+  expectTrue(stride(from: 1, through: 5, by: 1).contains(5))
+  expectFalse(stride(from: 1, to: 5, by: 1).contains(5))
+  expectFalse(stride(from: 1, through: 5, by: -1).contains(3))
+  expectFalse(stride(from: 1, to: 5, by: -1).contains(3))
+  expectFalse(stride(from: 1, through: 5, by: -1).contains(1))
+  expectFalse(stride(from: 1, to: 5, by: -1).contains(1))
+
+  expectTrue(stride(from: 5, through: 1, by: -1).contains(3))
+  expectTrue(stride(from: 5, to: 1, by: -1).contains(3))
+  expectTrue(stride(from: 5, through: 1, by: -1).contains(1))
+  expectFalse(stride(from: 5, to: 1, by: -1).contains(1))
+  expectFalse(stride(from: 5, through: 1, by: 1).contains(3))
+  expectFalse(stride(from: 5, to: 1, by: 1).contains(3))
+  expectFalse(stride(from: 5, through: 1, by: 1).contains(5))
+  expectFalse(stride(from: 5, to: 1, by: 1).contains(5))
+}
+
 runAllTests()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Recently [reported](https://forums.swift.org/t/is-there-a-bug-in-stride-fromby-or-is-it-me/53043) on the Swift forums, `Stride*` types fail to account for the scenario of striding "backwards" in its implementations of `_customContainsEquatableElement` when determining if an element is contained within the given interval.

This PR fixes that issue. Specifically, we modify the implementation to branch on the sign of `_stride`. Recall that we deliberately allow striding in the "opposite" direction of that specified by `from` and `to`/`through`, which results in an empty sequence—in that case, this PR results in `_customContainsEquatableElement` correctly returning `false` regardless of `element` without special cases.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15384.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
