### PR TITLE
Revert "ABI checker: use dedicated mangled name field to diagnose mangled name changes"

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -360,13 +360,12 @@ class SDKNodeDecl: public SDKNode {
   Optional<uint8_t> FixedBinaryOrder;
   PlatformIntroVersion introVersions;
   StringRef ObjCName;
-  mutable Optional<StringRef> demangledName;
+
 protected:
   SDKNodeDecl(SDKNodeInitInfo Info, SDKNodeKind Kind);
   virtual ~SDKNodeDecl() = default;
 public:
   StringRef getUsr() const { return Usr; }
-  StringRef getDemangledName() const;
   StringRef getLocation() const { return Location; }
   StringRef getModuleName() const {return ModuleName;}
   StringRef getHeaderName() const;

--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -63,11 +63,8 @@ bool printExtensionUSR(const ExtensionDecl *ED, raw_ostream &OS);
 /// \returns true if it failed, false on success.
 bool printDeclUSR(const Decl *D, raw_ostream &OS);
 
-/// Get mangled name from a USR.
-std::string getMangledNameFromUSR(StringRef usr);
-
-/// Demangle a mangled name to a human readable name.
-std::string demangleMangledName(StringRef mangled);
+/// Demangle a mangle-name-based USR to a human readable name.
+std::string demangleUSR(StringRef mangled);
 
 } // namespace ide
 } // namespace swift

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -256,23 +256,16 @@ swift::USRGenerationRequest::evaluate(Evaluator &evaluator,
   return NewMangler.mangleDeclAsUSR(D, getUSRSpacePrefix());
 }
 
-std::string ide::getMangledNameFromUSR(StringRef usr) {
-  if (usr.startswith(getUSRSpacePrefix())) {
-    usr = usr.substr(getUSRSpacePrefix().size());
+std::string ide::demangleUSR(StringRef mangled) {
+  if (mangled.startswith(getUSRSpacePrefix())) {
+    mangled = mangled.substr(getUSRSpacePrefix().size());
   }
   SmallString<128> buffer;
   buffer += "$s";
-  buffer += usr;
-  return buffer.str().str();
-}
-
-std::string ide::demangleMangledName(StringRef mangled) {
+  buffer += mangled;
+  mangled = buffer.str();
   Demangler Dem;
-  std::string result = nodeToString(Dem.demangleSymbol(mangled));
-  if (result.empty()) {
-    return mangled.str();
-  }
-  return result;
+  return nodeToString(Dem.demangleSymbol(mangled));
 }
 
 std::string

--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -232,6 +232,3 @@ open class AddingNewDesignatedInit {
     print(foo)
   }
 }
-
-@_silgen_name("sil_name_before")
-public func silGenNameGiven() {}

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -252,6 +252,3 @@ public extension Float {
 }
 
 infix operator <==> : AssignmentPrecedence
-
-@_silgen_name("sil_name_after")
-public func silGenNameGiven() {}

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -10,7 +10,6 @@ cake: Func S1.foo5(x:y:) has mangled name changing from 'cake.S1.foo5(x: Swift.I
 cake: Func Somestruct2.foo1(_:) has mangled name changing from 'static cake.Somestruct2.foo1(cake.C3) -> ()' to 'static cake.NSSomestruct2.foo1(cake.C1) -> ()'
 cake: Func ownershipChange(_:_:) has mangled name changing from 'cake.ownershipChange(inout Swift.Int, __shared Swift.Int) -> ()' to 'cake.ownershipChange(Swift.Int, __owned Swift.Int) -> ()'
 cake: Func returnFunctionTypeOwnershipChange() has mangled name changing from 'cake.returnFunctionTypeOwnershipChange() -> (cake.C1) -> ()' to 'cake.returnFunctionTypeOwnershipChange() -> (__owned cake.C1) -> ()'
-cake: Func silGenNameGiven() has mangled name changing from 'sil_name_before' to 'sil_name_after'
 cake: Protocol P3 has generic signature change from <Self : cake.P1, Self : cake.P2> to <Self : cake.P1, Self : cake.P4>
 cake: Struct Somestruct2 has mangled name changing from 'cake.Somestruct2' to 'cake.NSSomestruct2'
 


### PR DESCRIPTION

This reverts commit b937d0da8631551c1fedbd55aa24e51f25a76e25.
