### PR TITLE
[cxx-interop] Fix lazy loading for result types.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2176,8 +2176,12 @@ static void addNamespaceMembers(Decl *decl,
   for (auto redecl : namespaceDecl->redecls()) {
     for (auto member : redecl->decls()) {
       if (auto classTemplate = dyn_cast<clang::ClassTemplateDecl>(member)) {
-        // Hack in the class template specializations that live here.
-        for (auto spec : classTemplate->specializations()) {
+        // Add all specializtaions to a worklist so we don't accidently mutate
+        // the list of decls we're iterating over.
+        llvm::SmallPtrSet<const clang::ClassTemplateSpecializationDecl *, 16> specWorklist;
+        for (auto spec : classTemplate->specializations())
+          specWorklist.insert(spec);
+        for (auto spec : specWorklist) {
           if (auto import =
                   ctx.getClangModuleLoader()->importDeclDirectly(spec))
             if (addedMembers.insert(import).second)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1837,7 +1837,8 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
           dyn_cast<clang::TemplateTypeParmType>(clangDecl->getReturnType())) {
     importedType = {findGenericTypeInGenericDecls(templateType, genericParams),
                     false};
-  } else if (!isa<clang::RecordType>(clangDecl->getReturnType()) ||
+  } else if (!(isa<clang::RecordType>(clangDecl->getReturnType()) ||
+               isa<clang::TemplateSpecializationType>(clangDecl->getReturnType())) ||
              // TODO: we currently don't lazily load operator return types, but
              // this should be trivial to add.
              clangDecl->isOverloadedOperator()) {


### PR DESCRIPTION
When applying attributes, don't check the result type of the Swift function, so that we can get the benefits of lazy loading.