### PR TITLE
Add to-do for `Stride*` implementation of `_customContainsEquatableElement`

### DIFF
--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -384,6 +384,8 @@ extension StrideTo: Sequence {
     } else {
       if element < _start || _end <= element { return false }
     }
+    // TODO: Additional implementation work will avoid always falling back to the
+    // predicate version of `contains` when the sequence *does* contain `element`.
     return nil
   }
 }
@@ -599,6 +601,8 @@ extension StrideThrough: Sequence {
     } else {
       if element < _start || _end < element { return false }
     }
+    // TODO: Additional implementation work will avoid always falling back to the
+    // predicate version of `contains` when the sequence *does* contain `element`.
     return nil
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
A follow-up to #39903 (see discussion in that PR), to remind ourselves that `_customContainsEquatableElement` has been implemented for `Stride*` types in a way that always falls back to the predicate version of `contains` when the element being tested lies between `_start` and `_end`.

Future work may identify other scenarios that benefit (performance-wise) from being quickly ruled in or out within this function rather than falling back.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
