### PR TITLE
[cxx-interop][nfc] Remove internal header dependency on swift shims.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -20,8 +20,8 @@
 #define SWIFT_DEMANGLING_DEMANGLE_H
 
 #include "swift/Demangling/NamespaceMacros.h"
-#include "swift/Runtime/Config.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <memory>
@@ -514,7 +514,7 @@ enum class OperatorKind {
 };
 
 /// A mangling error, which consists of an error code and a Node pointer
-struct SWIFT_NODISCARD ManglingError {
+struct LLVM_NODISCARD ManglingError {
   enum Code {
     Success = 0,
     AssertionFailed,
@@ -556,7 +556,7 @@ struct SWIFT_NODISCARD ManglingError {
 
 /// Used as a return type for mangling functions that may fail
 template <typename T>
-class SWIFT_NODISCARD ManglingErrorOr {
+class LLVM_NODISCARD ManglingErrorOr {
 private:
   ManglingError err_;
   T             value_;

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/Compiler.h"
 #include "swift/Demangling/Demangler.h"
 #include "DemanglerAssert.h"
 #include "swift/Demangling/ManglingMacros.h"
@@ -90,7 +91,7 @@ static bool isRequirement(Node::Kind kind) {
 // Public utility functions    //
 //////////////////////////////////
 
-SWIFT_NORETURN void swift::Demangle::failAssert(const char *file, unsigned line,
+LLVM_NODISCARD void swift::Demangle::failAssert(const char *file, unsigned line,
                                                 NodePointer node,
                                                 const char *expr) {
   fprintf(stderr, "%s:%u: assertion failed for Node %p: %s", file, line, node,

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_DEMANGLING_ASSERT_H
 #define SWIFT_DEMANGLING_ASSERT_H
 
+#include "llvm/Support/Compiler.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/NamespaceMacros.h"
 
@@ -50,7 +51,7 @@ namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE
 
-SWIFT_NORETURN void failAssert(const char *file, unsigned line,
+LLVM_NODISCARD void failAssert(const char *file, unsigned line,
                                NodePointer node, const char *expr);
 
 SWIFT_END_INLINE_NAMESPACE


### PR DESCRIPTION
The internal compiler headers should not include swift shim headers. Removing this dependency allows libSwift to import Swift compiler headers (otherwise, we get name conflicts, because we import SwiftShims headers twice: from the source includes and build includes).