### PR TITLE
Disable IRGen tests to unblock CI

### DIFF
--- a/test/IRGen/virtual-function-elimination-exec.swift
+++ b/test/IRGen/virtual-function-elimination-exec.swift
@@ -14,6 +14,9 @@
 // FIXME(mracek): More work needed to get this to work on non-Apple platforms.
 // REQUIRES: VENDOR=apple
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 class MyClass {
   func foo() { print("MyClass.foo") }
   func bar() { print("MyClass.bar") }

--- a/test/IRGen/witness-method-elimination-exec.swift
+++ b/test/IRGen/witness-method-elimination-exec.swift
@@ -14,6 +14,9 @@
 // FIXME(mracek): More work needed to get this to work on non-Apple platforms.
 // REQUIRES: VENDOR=apple
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 protocol TheProtocol {
   func func1_live()
   func func2_dead()

--- a/test/IRGen/witness-method-elimination-two-modules.swift
+++ b/test/IRGen/witness-method-elimination-two-modules.swift
@@ -35,6 +35,9 @@
 // FIXME(mracek): More work needed to get this to work on non-Apple platforms.
 // REQUIRES: VENDOR=apple
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 #if LIBRARY
 
 public protocol MyProtocol {


### PR DESCRIPTION
Seeing failures in:
```
19:37:18 Failed Tests (3):
19:37:18   Swift(macosx-x86_64) :: IRGen/virtual-function-elimination-exec.swift
19:37:18   Swift(macosx-x86_64) :: IRGen/witness-method-elimination-exec.swift
19:37:18   Swift(macosx-x86_64) :: IRGen/witness-method-elimination-two-modules.swift
```

Tracking in rdar://84643923
