### PR TITLE
[Concurrency] Re-fix ABI regression in task groups due to Sendable requirements.

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -62,7 +62,7 @@ import Swift
 ///   - the group will await any not yet complete tasks,
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
 @available(SwiftStdlib 5.5, *)
-@_silgen_name("_$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
+@_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -142,7 +142,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// - if the body throws:
 ///   - all tasks remaining in the group will be automatically cancelled.
 @available(SwiftStdlib 5.5, *)
-@_silgen_name("_$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
+@_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,


### PR DESCRIPTION
There was an attempted fix in bed3c4b3134ecfeb3e21486c65210d750cc81165 but it had extra underscores at the start of the @_silgen_name identifiers.

rdar://83617067