### PR TITLE
[WIP] Improve ClangImporter Diagnostics

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1160,6 +1160,9 @@ public:
   InheritedProtocolConformance *
   getInheritedConformance(Type type, ProtocolConformance *inherited);
 
+  /// Check if \p decl is included in LazyContexts.
+  bool isLazyContext(const DeclContext *decl);
+
   /// Get the lazy data for the given declaration.
   ///
   /// \param lazyLoader If non-null, the lazy loader to use when creating the

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -182,6 +182,9 @@ public:
   /// Imports a clang decl directly, rather than looking up its name.
   virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
 
+  /// Emits any import diagnostics associated with the provided decl.
+  virtual void diagnoseDeclDirectly(const clang::NamedDecl *decl) = 0;
+
   /// Instantiate and import class template using given arguments.
   ///
   /// This method will find the clang::ClassTemplateSpecialization decl if

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -100,5 +100,30 @@ WARNING(import_multiple_mainactor_attr,none,
 
 ERROR(module_map_not_found, none, "module map file '%0' not found", (StringRef))
 
+NOTE(macro_not_imported_unsupported_operator, none, "operator not supported in macro arithmetic", ())
+NOTE(macro_not_imported_unsupported_named_operator, none, "operator '%0' not supported in macro arithmetic", (StringRef))
+NOTE(macro_not_imported_invalid_string_literal, none, "invalid string literal", ())
+NOTE(macro_not_imported_invalid_numeric_literal, none, "invalid numeric literal", ())
+NOTE(macro_not_imported_unsupported_literal, none, "only numeric and string macro literals supported", ())
+NOTE(macro_not_imported_nested_cast, none, "non-null nested casts not supported", ())
+
+ERROR(macro_not_imported_function_like, none, "macro '%0' not imported: function like macros not supported", (StringRef))
+ERROR(macro_not_imported_unsupported_structure, none, "macro '%0' not imported: structure not supported", (StringRef))
+ERROR(macro_not_imported, none, "macro '%0' not imported", (StringRef))
+
+NOTE(return_type_not_imported, none, "return type not imported", ())
+NOTE(parameter_type_not_imported, none, "parameter %0 not imported", (const clang::NamedDecl*))
+NOTE(incomplete_interface, none, "interface %0 is incomplete", (const clang::NamedDecl*))
+NOTE(incomplete_protocol, none, "protocol %0 is incomplete", (const clang::NamedDecl*))
+NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))
+
+WARNING(record_field_not_imported, none, "field %0 not imported", (const clang::NamedDecl*))
+WARNING(invoked_func_not_imported, none, "function %0 not imported", (const clang::NamedDecl*))
+WARNING(record_method_not_imported, none, "method %0 not imported", (const clang::NamedDecl*))
+WARNING(objc_property_not_imported, none, "property %0 not imported", (const clang::NamedDecl*))
+
+NOTE(forward_declared_interface_label, none, "interface %0 forward declared here", (const clang::NamedDecl*))
+NOTE(forward_declared_protocol_label, none, "protocol %0 forward declared here", (const clang::NamedDecl*))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -85,6 +85,9 @@ public:
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) = 0;
 
+  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
+                                          DeclName name) = 0;
+
   /// Populates the given vector with all conformances for \p D.
   ///
   /// The implementation should \em not call setConformances on \p D.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -320,6 +320,12 @@ namespace swift {
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;
 
+    /// Enable experimental ClangImporter diagnostics.
+    bool EnableExperimentalClangImporterDiagnostics = false;
+
+    /// Enable experimental eager Clang module diagnostics.
+    bool EnableExperimentalEagerClangModuleDiagnostics = false;
+
     /// Enable inference of Sendable conformances for public types.
     bool EnableInferPublicSendable = false;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -40,6 +40,7 @@ namespace clang {
   class EnumDecl;
   class MacroInfo;
   class Module;
+  class ModuleMacro;
   class NamedDecl;
   class Sema;
   class TargetInfo;
@@ -108,6 +109,11 @@ public:
   /// vtable anchor.
   virtual void anchor();
 };
+
+typedef llvm::PointerUnion<const clang::Decl *, const clang::MacroInfo *,
+                           const clang::ModuleMacro *, const clang::Type *,
+                           const clang::Token *>
+    ImportDiagnosticTarget;
 
 /// Class that imports Clang modules into Swift, mapping directly
 /// from Clang ASTs over to Swift ASTs.
@@ -509,6 +515,9 @@ public:
 
   /// Imports a clang decl directly, rather than looking up it's name.
   Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
+
+  /// Emits any pending diagnostics associated with the provided decl.
+  void diagnoseDeclDirectly(const clang::NamedDecl *decl) override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -287,6 +287,14 @@ def enable_experimental_flow_sensitive_concurrent_captures :
   Flag<["-"], "enable-experimental-flow-sensitive-concurrent-captures">,
   HelpText<"Enable flow-sensitive concurrent captures">;
 
+def enable_experimental_clang_importer_diagnostics :
+  Flag<["-"], "enable-experimental-clang-importer-diagnostics">,
+  HelpText<"Enable experimental diagnostics when importing C, C++, and Objective-C libraries">;
+
+def enable_experimental_eager_clang_module_diagnostics :
+  Flag<["-"], "enable-experimental-eager-clang-module-diagnostics">,
+  HelpText<"Enable experimental eager diagnostics reporting on the importability of all referenced C, C++, and Objective-C libraries">;
+
 def enable_resilience : Flag<["-"], "enable-resilience">,
      HelpText<"Deprecated, use -enable-library-evolution instead">;
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2462,6 +2462,10 @@ ASTContext::getInheritedConformance(Type type, ProtocolConformance *inherited) {
   return result;
 }
 
+bool ASTContext::isLazyContext(const DeclContext *dc) {
+  return getImpl().LazyContexts.count(dc) != 0;
+}
+
 LazyContextData *ASTContext::getOrCreateLazyContextData(
                                                 const DeclContext *dc,
                                                 LazyMemberLoader *lazyLoader) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -16,11 +16,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticSuppression.h"
+#include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrintOptions.h"
@@ -30,6 +30,8 @@
 #include "swift/Config.h"
 #include "swift/Localization/LocalizationFormat.h"
 #include "swift/Parse/Lexer.h" // bad dependency
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
@@ -566,6 +568,11 @@ static bool isMainActor(Type type) {
   return false;
 }
 
+void swift::printClangDeclName(const clang::NamedDecl *ND,
+                               llvm::raw_ostream &os) {
+  ND->getNameForDiagnostic(os, ND->getASTContext().getPrintingPolicy(), false);
+}
+
 /// Format a single diagnostic argument and write it to the given
 /// stream.
 static void formatDiagnosticArgument(StringRef Modifier,
@@ -832,6 +839,13 @@ static void formatDiagnosticArgument(StringRef Modifier,
                                            diagArg->FormatArgs);
     break;
   }
+
+  case DiagnosticArgumentKind::ClangDecl:
+    assert(Modifier.empty() && "Improper modifier for ClangDecl argument");
+    Out << FormatOpts.OpeningQuotationMark;
+    printClangDeclName(Arg.getAsClangDecl(), Out);
+    Out << FormatOpts.ClosingQuotationMark;
+    break;
   }
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1494,12 +1494,22 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
       populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
     }
 
-    Table.markLazilyComplete(name.getBaseName());
+    Table.markLazilyComplete(baseName);
   }
 
   // Look for a declaration with this name.
   auto known = Table.find(name);
   if (known == Table.end()) {
+    // Diagnose the missing member if:
+    // - The flag enabling ClangImporter diagnostics is passed.
+    // - The containing decl is a ClangDecl.
+    // - The containing decl (and DeclContext) is lazy.
+    if (ctx.LangOpts.EnableExperimentalClangImporterDiagnostics &&
+        ctx.isLazyContext(decl) && decl->getDecl()->getClangDecl()) {
+      auto ci =
+          ctx.getOrCreateLazyIterableContextData(decl, /*lazyLoader=*/nullptr);
+      ci->loader->diagnoseMissingNamedMember(decl, name);
+    }
     return TinyPtrVector<ValueDecl *>();
   }
 

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -16,7 +16,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImporterImpl.h"
-#include "llvm/ADT/SmallString.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Stmt.h"
+#include "swift/AST/Types.h"
+#include "swift/Basic/PrettyStackTrace.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
 #include "clang/Lex/MacroInfo.h"
@@ -24,12 +30,7 @@
 #include "clang/Sema/DelayedDiagnostic.h"
 #include "clang/Sema/Sema.h"
 #include "clang/StaticAnalyzer/Core/PathSensitive/APSIntType.h"
-#include "swift/AST/ASTContext.h"
-#include "swift/AST/Expr.h"
-#include "swift/AST/Stmt.h"
-#include "swift/AST/Types.h"
-#include "swift/Basic/PrettyStackTrace.h"
-#include "swift/ClangImporter/ClangModule.h"
+#include "llvm/ADT/SmallString.h"
 
 using namespace swift;
 using namespace importer;
@@ -47,6 +48,17 @@ parseNumericLiteral(ClangImporter::Implementation &impl,
 // FIXME: Duplicated from ImportDecl.cpp.
 static bool isInSystemModule(DeclContext *D) {
   return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
+}
+
+static Optional<StringRef> getTokenSpelling(ClangImporter::Implementation &impl,
+                                            const clang::Token &tok) {
+  bool tokenInvalid = false;
+  llvm::SmallString<32> spellingBuffer;
+  StringRef tokenSpelling = impl.getClangPreprocessor().getSpelling(
+      tok, spellingBuffer, &tokenInvalid);
+  if (tokenInvalid)
+    return None;
+  return tokenSpelling;
 }
 
 static ValueDecl *
@@ -79,13 +91,10 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
     // FIXME: remove this when the following radar is implemented:
     // <rdar://problem/16445608> Swift should set up a DiagnosticConsumer for
     // Clang
-    llvm::SmallString<32> SpellingBuffer;
-    bool Invalid = false;
-    StringRef TokSpelling =
-        Impl.getClangPreprocessor().getSpelling(tok, SpellingBuffer, &Invalid);
-    if (Invalid)
+    Optional<StringRef> TokSpelling = getTokenSpelling(Impl, tok);
+    if (!TokSpelling)
       return nullptr;
-    if (TokSpelling.contains('_'))
+    if (TokSpelling->contains('_'))
       return nullptr;
   }
 
@@ -198,17 +207,42 @@ static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,
                                 ClangNode ClangN,
                                 clang::QualType castType) {
   switch (tok.getKind()) {
-  case clang::tok::numeric_constant:
-    return importNumericLiteral(Impl, DC, MI, name, /*signTok*/nullptr, tok,
-                                ClangN, castType);
-
+  case clang::tok::numeric_constant: {
+    ValueDecl *importedNumericLiteral = importNumericLiteral(
+        Impl, DC, MI, name, /*signTok*/ nullptr, tok, ClangN, castType);
+    if (!importedNumericLiteral) {
+      Impl.addImportDiagnostic(
+          &tok, Diagnostic(diag::macro_not_imported_invalid_numeric_literal),
+          tok.getLocation());
+      Impl.addImportDiagnostic(MI,
+                               Diagnostic(diag::macro_not_imported, name.str()),
+                               MI->getDefinitionLoc());
+    }
+    return importedNumericLiteral;
+  }
   case clang::tok::string_literal:
-  case clang::tok::utf8_string_literal:
-    return importStringLiteral(Impl, DC, MI, name, tok,
-                               MappedStringLiteralKind::CString, ClangN);
+  case clang::tok::utf8_string_literal: {
+    ValueDecl *importedStringLiteral = importStringLiteral(
+        Impl, DC, MI, name, tok, MappedStringLiteralKind::CString, ClangN);
+    if (!importedStringLiteral) {
+      Impl.addImportDiagnostic(
+          &tok, Diagnostic(diag::macro_not_imported_invalid_string_literal),
+          tok.getLocation());
+      Impl.addImportDiagnostic(MI,
+                               Diagnostic(diag::macro_not_imported, name.str()),
+                               MI->getDefinitionLoc());
+    }
+    return importedStringLiteral;
+  }
 
   // TODO: char literals.
   default:
+    Impl.addImportDiagnostic(
+        &tok, Diagnostic(diag::macro_not_imported_unsupported_literal),
+        tok.getLocation());
+    Impl.addImportDiagnostic(MI,
+                             Diagnostic(diag::macro_not_imported, name.str()),
+                             MI->getDefinitionLoc());
     return nullptr;
   }
 }
@@ -333,6 +367,13 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
          "Add the name of the macro to visitedMacros before calling this "
          "function.");
 
+  if (macro->isFunctionLike()) {
+    impl.addImportDiagnostic(
+        macro, Diagnostic(diag::macro_not_imported_function_like, name.str()),
+        macro->getDefinitionLoc());
+    return nullptr;
+  }
+
   auto numTokens = macro->getNumTokens();
   auto tokenI = macro->tokens_begin(), tokenE = macro->tokens_end();
 
@@ -354,6 +395,7 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       tokenI[2].is(clang::tok::r_paren)) {
     if (!castType.isNull()) {
       // this is a nested cast
+      // TODO(SR-15429): Diagnose nested cast
       return nullptr;
     }
 
@@ -376,9 +418,11 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       if (parsedType && diagPool.empty()) {
         castType = parsedType.get();
       } else {
+        // TODO(SR-15429): Add diagnosis
         return nullptr;
       }
       if (!castType->isBuiltinType() && !castTypeIsId) {
+        // TODO(SR-15429): Add diagnosis
         return nullptr;
       }
     } else {
@@ -387,6 +431,7 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       if (builtinType) {
         castType = builtinType.getValue();
       } else {
+        // TODO(SR-15429): Add diagnosis
         return nullptr;
       }
     }
@@ -443,6 +488,9 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
       // FIXME: If the identifier refers to a declaration, alias it?
     }
+
+    // TODO(SR-15429): Seems rare to have a single token that is neither a
+    // literal nor an identifier, but add diagnosis
     return nullptr;
   }
   case 2: {
@@ -455,14 +503,38 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     clang::Token const &first = tokenI[0];
     clang::Token const &second = tokenI[1];
 
-    if (isSignToken(first) && second.is(clang::tok::numeric_constant))
-      return importNumericLiteral(impl, DC, macro, name, &first, second, ClangN,
-                                  castType);
+    if (isSignToken(first) && second.is(clang::tok::numeric_constant)) {
+      ValueDecl *importedNumericLiteral = importNumericLiteral(
+          impl, DC, macro, name, &first, second, ClangN, castType);
+      if (!importedNumericLiteral) {
+        impl.addImportDiagnostic(
+            macro, Diagnostic(diag::macro_not_imported, name.str()),
+            macro->getDefinitionLoc());
+        impl.addImportDiagnostic(
+            &second,
+            Diagnostic(diag::macro_not_imported_invalid_numeric_literal),
+            second.getLocation());
+      }
+      return importedNumericLiteral;
+    }
 
     // We also allow @"string".
-    if (first.is(clang::tok::at) && isStringToken(second))
-      return importStringLiteral(impl, DC, macro, name, second,
-                                 MappedStringLiteralKind::NSString, ClangN);
+    if (first.is(clang::tok::at) && isStringToken(second)) {
+      ValueDecl *importedStringLiteral =
+          importStringLiteral(impl, DC, macro, name, second,
+                              MappedStringLiteralKind::NSString, ClangN);
+      if (!importedStringLiteral) {
+        impl.addImportDiagnostic(
+            macro, Diagnostic(diag::macro_not_imported, name.str()),
+            macro->getDefinitionLoc());
+        impl.addImportDiagnostic(
+            &second,
+            Diagnostic(diag::macro_not_imported_invalid_string_literal),
+            second.getLocation());
+      }
+      return importedStringLiteral;
+    }
+
     break;
   }
   case 3: {
@@ -478,6 +550,11 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       firstValue     = firstInt->first;
       firstSwiftType = firstInt->second;
     } else {
+      impl.addImportDiagnostic(
+          macro,
+          Diagnostic(diag::macro_not_imported_unsupported_structure,
+                     name.str()),
+          macro->getDefinitionLoc());
       return nullptr;
     }
 
@@ -488,6 +565,11 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
       secondValue     = secondInt->first;
       secondSwiftType = secondInt->second;
     } else {
+      impl.addImportDiagnostic(
+          macro,
+          Diagnostic(diag::macro_not_imported_unsupported_structure,
+                     name.str()),
+          macro->getDefinitionLoc());
       return nullptr;
     }
 
@@ -601,6 +683,22 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
     // Unhandled operators.
     } else {
+      if (Optional<StringRef> operatorSpelling =
+              getTokenSpelling(impl, tokenI[1])) {
+        impl.addImportDiagnostic(
+            &tokenI[1],
+            Diagnostic(diag::macro_not_imported_unsupported_named_operator,
+                       *operatorSpelling),
+            tokenI[1].getLocation());
+      } else {
+        impl.addImportDiagnostic(
+            &tokenI[1],
+            Diagnostic(diag::macro_not_imported_unsupported_operator),
+            tokenI[1].getLocation());
+      }
+      impl.addImportDiagnostic(macro,
+                               Diagnostic(diag::macro_not_imported, name.str()),
+                               macro->getDefinitionLoc());
       return nullptr;
     }
 
@@ -641,6 +739,10 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     break;
   }
 
+  impl.addImportDiagnostic(
+      macro,
+      Diagnostic(diag::macro_not_imported_unsupported_structure, name.str()),
+      macro->getDefinitionLoc());
   return nullptr;
 }
 
@@ -660,7 +762,8 @@ ValueDecl *ClangImporter::Implementation::importMacro(Identifier name,
   } else {
     // Check whether this macro has already been imported.
     for (const auto &entry : known->second) {
-      if (entry.first == macro) return entry.second;
+      if (entry.first == macro)
+        return entry.second;
     }
 
     // Otherwise, check whether this macro is identical to a macro that has

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2225,10 +2225,6 @@ static bool shouldIgnoreMacro(StringRef name, const clang::MacroInfo *macro,
   if (macro->tokens_empty())
     return true;
 
-  // Currently we only convert non-function-like macros.
-  if (macro->isFunctionLike())
-    return true;
-
   // Consult the list of macros to suppress.
   auto suppressMacro = llvm::StringSwitch<bool>(name)
 #define SUPPRESS_MACRO(NAME) .Case(#NAME, true)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -379,27 +379,37 @@ namespace {
       llvm_unreachable("Invalid BuiltinType.");
     }
 
-    ImportResult VisitExtIntType(const clang::ExtIntType *) {
+    ImportResult VisitExtIntType(const clang::ExtIntType *type) {
+      Impl.addImportDiagnostic(type, Diagnostic(diag::unsupported_builtin_type,
+                                                type->getTypeClassName()));
       // ExtInt is not supported in Swift.
       return Type();
     }
 
-    ImportResult VisitPipeType(const clang::PipeType *) {
+    ImportResult VisitPipeType(const clang::PipeType *type) {
+      Impl.addImportDiagnostic(type, Diagnostic(diag::unsupported_builtin_type,
+                                                type->getTypeClassName()));
       // OpenCL types are not supported in Swift.
       return Type();
     }
 
     ImportResult VisitMatrixType(const clang::MatrixType *ty) {
+      Impl.addImportDiagnostic(ty, Diagnostic(diag::unsupported_builtin_type,
+                                              ty->getTypeClassName()));
       // Matrix types are not supported in Swift.
       return Type();
     }
 
     ImportResult VisitComplexType(const clang::ComplexType *type) {
+      Impl.addImportDiagnostic(type, Diagnostic(diag::unsupported_builtin_type,
+                                                type->getTypeClassName()));
       // FIXME: Implement once Complex is in the library.
       return Type();
     }
 
     ImportResult VisitAtomicType(const clang::AtomicType *type) {
+      Impl.addImportDiagnostic(type, Diagnostic(diag::unsupported_builtin_type,
+                                                type->getTypeClassName()));
       // FIXME: handle pointers and fields of atomic type
       return Type();
     }
@@ -983,11 +993,24 @@ namespace {
     VisitObjCObjectPointerType(const clang::ObjCObjectPointerType *type) {
       Type importedType = Impl.SwiftContext.getAnyObjectType();
 
+      if (!type->qual_empty()) {
+        for (auto cp = type->qual_begin(), end = type->qual_end(); cp != end;
+             ++cp) {
+          if (!(*cp)->hasDefinition())
+            Impl.addImportDiagnostic(
+                type, Diagnostic(diag::incomplete_protocol, *cp));
+        }
+      }
+
       // If this object pointer refers to an Objective-C class (possibly
       // qualified),
       if (auto objcClass = type->getInterfaceDecl()) {
         auto imported = castIgnoringCompatibilityAlias<ClassDecl>(
             Impl.importDecl(objcClass, Impl.CurrentVersion));
+        if (!imported && !objcClass->hasDefinition())
+          Impl.addImportDiagnostic(
+              type, Diagnostic(diag::incomplete_interface, objcClass));
+
         if (!imported)
           return nullptr;
 
@@ -1839,8 +1862,11 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
              clangDecl->isOverloadedOperator()) {
     importedType =
         importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt);
-    if (!importedType)
+    if (!importedType) {
+      addImportDiagnostic(clangDecl, Diagnostic(diag::return_type_not_imported),
+                          clangDecl->getSourceRange().getBegin());
       return {Type(), false};
+    }
   }
 
   Type swiftResultTy = importedType.getType();
@@ -1938,8 +1964,12 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
       }
       auto importedType = importType(paramTy, importKind, allowNSUIntegerAsInt,
                                      Bridgeability::Full, OptionalityOfParam);
-      if (!importedType)
+      if (!importedType) {
+        addImportDiagnostic(
+            param, Diagnostic(diag::parameter_type_not_imported, param),
+            param->getSourceRange().getBegin());
         return nullptr;
+      }
 
       isParamTypeImplicitlyUnwrapped = importedType.isImplicitlyUnwrapped();
       swiftParamTy = importedType.getType();
@@ -2389,8 +2419,11 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     }
   }
 
-  if (!swiftResultTy)
+  if (!swiftResultTy) {
+    addImportDiagnostic(clangDecl, Diagnostic(diag::return_type_not_imported),
+                        clangDecl->getSourceRange().getBegin());
     return {Type(), false};
+  }
 
   swiftResultTy = mapGenericArgs(origDC, dc, swiftResultTy);
 
@@ -2497,8 +2530,12 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
       paramIsIUO = importedParamType.isImplicitlyUnwrapped();
       swiftParamTy = importedParamType.getType();
     }
-    if (!swiftParamTy)
+    if (!swiftParamTy) {
+      addImportDiagnostic(param,
+                          Diagnostic(diag::parameter_type_not_imported, param),
+                          param->getSourceRange().getBegin());
       return {Type(), false};
+    }
 
     swiftParamTy = mapGenericArgs(origDC, dc, swiftParamTy);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -22,29 +22,34 @@
 #include "ImportEnumInfo.h"
 #include "ImportName.h"
 #include "SwiftLookupTable.h"
-#include "swift/ClangImporter/ClangImporter.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
-#include "swift/AST/ForeignErrorConvention.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/ClangImporter/ClangImporter.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclVisitor.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Serialization/ModuleFileExtension.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Path.h"
+#include <functional>
 #include <set>
+#include <unordered_set>
+#include <vector>
 
 namespace llvm {
 
@@ -179,6 +184,21 @@ enum class ImportTypeKind {
   ///
   /// This provides special treatment for 'NSUInteger'.
   Enum
+};
+
+struct ImportDiagnostic {
+  ImportDiagnosticTarget target;
+  Diagnostic diag;
+  clang::SourceLocation loc;
+
+  ImportDiagnostic(ImportDiagnosticTarget target, const Diagnostic &diag,
+                   clang::SourceLocation loc)
+      : target(target), diag(diag), loc(loc) {}
+
+  bool operator==(const ImportDiagnostic &other) const {
+    return target == other.target && loc == other.loc &&
+           diag.getID() == other.diag.getID();
+  }
 };
 
 /// Controls whether \p decl, when imported, should name the fully-bridged
@@ -330,6 +350,19 @@ struct HeaderLoc {
     : clangLoc(clangLoc), fallbackLoc(fallbackLoc), sourceMgr(sourceMgr) {}
 };
 
+struct ImportDiagnosticTargetHasher {
+  std::size_t operator()(const ImportDiagnosticTarget &target) const {
+    return std::hash<void *>()(target.getOpaqueValue());
+  }
+};
+
+struct ImportDiagnosticHasher {
+  std::size_t operator()(const ImportDiagnostic &diag) const {
+    return llvm::hash_combine(diag.target.getOpaqueValue(), diag.diag.getID(),
+                              diag.loc.getHashValue());
+  }
+};
+
 /// Implementation of the Clang importer.
 class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation 
   : public LazyMemberLoader,
@@ -343,8 +376,38 @@ public:
                  DWARFImporterDelegate *dwarfImporterDelegate);
   ~Implementation();
 
+  class DiagnosticWalker : public clang::RecursiveASTVisitor<DiagnosticWalker> {
+  public:
+    DiagnosticWalker(ClangImporter::Implementation &Impl);
+    bool TraverseDecl(clang::Decl *D);
+    bool TraverseParmVarDecl(clang::ParmVarDecl *D);
+    bool VisitDecl(clang::Decl *D);
+    bool VisitMacro(const clang::MacroInfo *MI);
+    bool VisitObjCObjectPointerType(clang::ObjCObjectPointerType *T);
+    bool VisitType(clang::Type *T);
+
+  private:
+    Implementation &Impl;
+    clang::SourceLocation TypeReferenceSourceLocation;
+  };
+
   /// Swift AST context.
   ASTContext &SwiftContext;
+
+  // Associates a vector of import diagnostics with a ClangNode
+  std::unordered_map<ImportDiagnosticTarget, std::vector<ImportDiagnostic>,
+                     ImportDiagnosticTargetHasher>
+      ImportDiagnostics;
+
+  // Tracks the set of import diagnostics already produced for deduplication
+  // purposes.
+  std::unordered_set<ImportDiagnostic, ImportDiagnosticHasher>
+      CollectedDiagnostics;
+
+  // ClangNodes for which all import diagnostics have been both collected and
+  // emitted.
+  std::unordered_set<ImportDiagnosticTarget, ImportDiagnosticTargetHasher>
+      DiagnosedValues;
 
   const bool ImportForwardDeclarations;
   const bool DisableSwiftBridgeAttr;
@@ -363,6 +426,8 @@ public:
     "<bridging-header-import>";
 
 private:
+  DiagnosticWalker Walker;
+
   /// The Swift lookup table for the bridging header.
   std::unique_ptr<SwiftLookupTable> BridgingHeaderLookupTable;
 
@@ -816,6 +881,10 @@ public:
     SwiftContext.Diags.diagnose(swiftLoc, std::forward<Args>(args)...);
   }
 
+  void addImportDiagnostic(
+      ImportDiagnosticTarget target, Diagnostic &&diag,
+      const clang::SourceLocation &loc = clang::SourceLocation());
+
   /// Import the given Clang identifier into Swift.
   ///
   /// \param identifier The Clang identifier to map into Swift.
@@ -898,7 +967,7 @@ public:
                    bool UseCanonicalDecl = true) {
     return importDeclAndCacheImpl(ClangDecl, version,
                                   /*SuperfluousTypedefsAreTransparent=*/true,
-                                  /*UseCanonicalDecl*/UseCanonicalDecl);
+                                  /*UseCanonicalDecl*/ UseCanonicalDecl);
   }
 
   /// Import the given Clang declaration into Swift.  Use this function
@@ -1386,6 +1455,9 @@ public:
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;
 
+  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
+                                          DeclName name) override;
+
 private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
@@ -1501,7 +1573,7 @@ public:
 
   /// Look for namespace-scope values with the given name in the given
   /// Swift lookup table.
-  void lookupValue(SwiftLookupTable &table, DeclName name,
+  bool lookupValue(SwiftLookupTable &table, DeclName name,
                    VisibleDeclConsumer &consumer);
 
   /// Look for namespace-scope values with the given name using the
@@ -1528,6 +1600,21 @@ public:
   void lookupAllObjCMembers(SwiftLookupTable &table,
                             VisibleDeclConsumer &consumer);
 
+  /// Emit any import diagnostics associated with the given name.
+  void diagnoseValue(SwiftLookupTable &table, DeclName name);
+
+  /// Emit any import diagnostics associated with the given Clang node.
+  void diagnoseTargetDirectly(ImportDiagnosticTarget target);
+
+private:
+  ImportDiagnosticTarget importDiagnosticTargetFromLookupTableEntry(
+      SwiftLookupTable::SingleEntry entry);
+
+  bool emitDiagnosticsForTarget(
+      ImportDiagnosticTarget target,
+      clang::SourceLocation fallbackLoc = clang::SourceLocation());
+
+public:
   /// Determine the effective Clang context for the given Swift nominal type.
   EffectiveClangContext
   getEffectiveClangContext(const NominalTypeDecl *nominal);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -461,6 +461,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalFlowSensitiveConcurrentCaptures |=
     Args.hasArg(OPT_enable_experimental_flow_sensitive_concurrent_captures);
 
+  Opts.EnableExperimentalClangImporterDiagnostics |=
+      Args.hasArg(OPT_enable_experimental_clang_importer_diagnostics);
+
+  Opts.EnableExperimentalEagerClangModuleDiagnostics |=
+      Args.hasArg(OPT_enable_experimental_eager_clang_module_diagnostics);
+
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6379,6 +6379,13 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   }
 }
 
+void ModuleFile::diagnoseMissingNamedMember(const IterableDeclContext *IDC,
+                                            DeclName name) {
+  // TODO: Implement diagnostics for failed member lookups from module files.
+  llvm_unreachable(
+      "Missing member diangosis is not implemented for module files.");
+}
+
 static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
     // Missing module errors are most likely caused by an
     // implementation-only import hiding types and decls.

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -693,6 +693,9 @@ public:
   virtual void loadAllMembers(Decl *D,
                               uint64_t contextData) override;
 
+  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
+                                          DeclName name) override;
+
   virtual TinyPtrVector<ValueDecl *>
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;

--- a/test/ClangImporter/Inputs/experimental_clang_importer_diagnostics_bridging_header.h
+++ b/test/ClangImporter/Inputs/experimental_clang_importer_diagnostics_bridging_header.h
@@ -1,0 +1,15 @@
+// A briding header defining a small sample of unimportable declarations.
+@class ForwardDeclaredInterface;
+
+ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+
+#define FUNC_LIKE_MACRO() 0
+
+struct PartialImport {
+  int a;
+  int b;
+  int _Complex c;
+  int _Complex d;
+};
+
+_Complex int unsupported_return_type();

--- a/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
+++ b/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
@@ -1,0 +1,52 @@
+// RUN: not %target-swift-frontend -enable-experimental-clang-importer-diagnostics -enable-objc-interop -import-objc-header %S/Inputs/experimental_clang_importer_diagnostics_bridging_header.h -typecheck %s 2>&1 | %FileCheck %s
+
+let s: PartialImport
+s.c = 5
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: s.c = 5
+// CHECK-NEXT: ~ ^
+
+_ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = FUNC_LIKE_MACRO()
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+// CHECK-NEXT: _ = FUNC_LIKE_MACRO()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~
+
+unsupported_return_type()
+// CHECK: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'unsupported_return_type' in scope
+// CHECK-NEXT: unsupported_return_type()
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_cfuncs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cfuncs.swift
@@ -1,0 +1,40 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+import cfuncs
+
+unsupported_parameter_type(1,2)
+// CHECK:      cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_parameter_type' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: parameter 'param2' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+// CHECK-NEXT: experimental_diagnostics_cfuncs.swift:5:1: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK-NEXT: unsupported_parameter_type(1,2)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+
+unsupported_return_type()
+// CHECK: cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: experimental_diagnostics_cfuncs.swift:19:1: error: cannot find 'unsupported_return_type' in scope
+// CHECK-NEXT: unsupported_return_type()
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~
+
+unsupported_parameter_type(1,2)
+// CHECK: experimental_diagnostics_cfuncs.swift:33:1: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK-NEXT: unsupported_parameter_type(1,2)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+unsupported_return_type()
+// CHECK: experimental_diagnostics_cfuncs.swift:37:1: error: cannot find 'unsupported_return_type' in scope
+// CHECK-NEXT: unsupported_return_type()
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_cmacros.swift
@@ -1,0 +1,148 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+import macros
+
+_ = INVALID_INTEGER_LITERAL_2
+// CHECK:      macros.h:{{[0-9]+}}:{{[0-9]+}}: error: invalid digit 'a' in decimal constant
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}                                    ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}                                  ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_INTEGER_LITERAL_2' in scope
+// CHECK-NEXT: _ = INVALID_INTEGER_LITERAL_2
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+_ = FUNC_LIKE_MACRO()
+_ = FUNC_LIKE_MACRO()
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+// CHECK-NEXT: _ = FUNC_LIKE_MACRO()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+// CHECK-NEXT: _ = FUNC_LIKE_MACRO()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+
+
+
+_ = INVALID_ARITHMETIC_1
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_1' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_1
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_2
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_2' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_2
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_3
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_3' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_3
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_4
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_4' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_4
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_5
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_5' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_5
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_6
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_6' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_6
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+_ = INVALID_ARITHMETIC_7
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
+// CHECK-NEXT: {{^}}                               ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_7' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_7
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+
+
+
+_ = CHAR_LITERAL
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'CHAR_LITERAL' not imported
+// CHECK-NEXT:      #define CHAR_LITERAL 'a'
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
+// CHECK-NEXT:      #define CHAR_LITERAL 'a'
+// CHECK-NEXT: {{^}}                     ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CHAR_LITERAL' in scope
+// CHECK-NEXT: _ = CHAR_LITERAL
+// CHECK-NEXT:     ^~~~~~~~~~~~
+
+
+
+UNSUPPORTED_1
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_1' in scope
+// CHECK-NEXT: UNSUPPORTED_1
+// CHECK-NEXT: ^~~~~~~~~~~~~
+
+UNSUPPORTED_2
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_2' in scope
+// CHECK-NEXT: UNSUPPORTED_2
+// CHECK-NEXT: ^~~~~~~~~~~~~
+
+UNSUPPORTED_3
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_3' in scope
+// CHECK-NEXT: UNSUPPORTED_3
+// CHECK-NEXT: ^~~~~~~~~~~~~
+
+UNSUPPORTED_4
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_4' in scope
+// CHECK-NEXT: UNSUPPORTED_4
+// CHECK-NEXT: ^~~~~~~~~~~~~
+
+UNSUPPORTED_5
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_5' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_5' in scope
+// CHECK-NEXT: UNSUPPORTED_5
+// CHECK-NEXT: ^~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_cstructs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cstructs.swift
@@ -1,0 +1,34 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+import ctypes
+
+let s: PartialImport
+s.c = 5
+// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: s.c = 5
+// CHECK-NEXT: ~ ^
+
+partialImport.c = 5
+// CHECK: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:15: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: partialImport.c = 5
+// CHECK-NEXT: ~~~~~~~~~~~~~ ^
+
+var newPartialImport = PartialImport()
+newPartialImport.a = 5
+newPartialImport.b = 5
+newPartialImport.d = 5
+// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'd' not imported
+// CHECK-NEXT:   int _Complex d;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex d;
+// CHECK-NEXT:   ^
+// CHECK: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:18: error: value of type 'PartialImport' has no member 'd'
+// CHECK-NEXT: newPartialImport.d = 5
+// CHECK-NEXT: ~~~~~~~~~~~~~~~~ ^

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
@@ -1,0 +1,170 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+// REQUIRES: objc_interop
+
+import IncompleteTypes
+
+let bar = Bar()
+_ = bar.methodReturningForwardDeclaredInterface()
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredInterface' not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredInterface'
+// CHECK-NEXT: _ = bar.methodReturningForwardDeclaredInterface()
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = bar.methodTakingAForwardDeclaredInterfaceAsAParameter(nil, andAnother: nil)
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredInterfaceAsAParameter'
+// CHECK-NEXT: _ = bar.methodTakingAForwardDeclaredInterfaceAsAParameter(nil, andAnother: nil)
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+bar.propertyUsingAForwardDeclaredInterface = nil
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredInterface' not imported
+// CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredInterface'
+// CHECK-NEXT: bar.propertyUsingAForwardDeclaredInterface = nil
+// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' in scope
+// CHECK-NEXT: CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = bar.methodReturningForwardDeclaredProtocol()
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredProtocol' not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredProtocol'
+// CHECK-NEXT: _ = bar.methodReturningForwardDeclaredProtocol()
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredProtocolAsAParameter'
+// CHECK-NEXT: _ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+bar.propertyUsingAForwardDeclaredProtocol = nil
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredProtocol' not imported
+// CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredProtocol'
+// CHECK-NEXT: bar.propertyUsingAForwardDeclaredProtocol = nil
+// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_ = CFunctionReturningAForwardDeclaredProtocol()
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredProtocol' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredProtocol()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' in scope
+// CHECK-NEXT: CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
@@ -1,0 +1,74 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+// REQUIRES: objc_interop
+
+import IncompleteTypes
+
+let foo = Foo()
+_ = foo.methodReturningCompleteInterface()
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodReturningCompleteInterface' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteInterface'
+
+_ = foo.methodTakingACompleteInterfaceAsAParameter(nil, andAnother: nil)
+// CHECK-NOT:     IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodTakingACompleteInterfaceAsAParameter:andAnother:' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteInterfaceAsAParameter'
+
+foo.propertyUsingACompleteInterface = nil
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: property 'propertyUsingACompleteInterface' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'propertyUsingACompleteInterface'
+
+_ = CFunctionReturningACompleteInterface()
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionReturningACompleteInterface' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteInterface' in scope
+
+CFunctionTakingACompleteInterfaceAsAParameter(nil)
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionTakingACompleteInterfaceAsAParameter' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteInterfaceAsAParameter' in scope
+
+_ = foo.methodReturningCompleteProtocol()
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodReturningCompleteProtocol' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteProtocol'
+
+_ = foo.methodTakingACompleteProtocolAsAParameter(nil)
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodTakingACompleteProtocolAsAParameter:' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteProtocolAsAParameter'
+
+foo.propertyUsingACompleteProtocol = nil
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: property 'propertyUsingACompleteProtocol' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'propertyUsingACompleteProtocol'
+
+_ = CFunctionReturningACompleteProtocol()
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionReturningACompleteProtocol' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteProtocol' in scope
+
+CFunctionTakingACompleteProtocolAsAParameter(nil)
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionTakingACompleteProtocolAsAParameter' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteProtocolAsAParameter' in scope

--- a/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
@@ -1,0 +1,32 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+import macros
+
+_ = INVALID_INTEGER_LITERAL_2
+
+// Test that experimental diagnostics for the function like macro in the same header is suppressed.
+// CHECK: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NOT: #define FUNC_LIKE_MACRO() 0
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_1' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_2' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_3' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_4' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_5' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_6' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: operator '%' not supported in macro arithmetic
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'CHAR_LITERAL' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: only numeric and string macro literals supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_5' not imported: structure not supported

--- a/test/ClangImporter/experimental_eager_diagnostics.swift
+++ b/test/ClangImporter/experimental_eager_diagnostics.swift
@@ -1,0 +1,247 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-eager-clang-module-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+// REQUIRES: objc_interop
+
+import cfuncs
+import ctypes
+import IncompleteTypes
+import macros
+
+// C Functions
+
+// CHECK:      cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_parameter_type' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: parameter 'param2' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+
+// CHECK: cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+
+// C structs
+
+// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+
+// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'd' not imported
+// CHECK-NEXT:   int _Complex d;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex d;
+// CHECK-NEXT:   ^
+
+// Incomplete types
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredProtocol' not imported
+// CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredInterface' not imported
+// CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredProtocol' not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredInterface' not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+// CHECK-NEXT:                                                          ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+
+// Macros
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'CHAR_LITERAL' not imported
+// CHECK-NEXT:      #define CHAR_LITERAL 'a'
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
+// CHECK-NEXT:      #define CHAR_LITERAL 'a'
+// CHECK-NEXT: {{^}}                     ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
+// CHECK-NEXT: {{^}}                               ^
+
+// CHECK:      macros.h:{{[0-9]+}}:{{[0-9]+}}: error: invalid digit 'a' in decimal constant
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}                                    ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}        ^
+// CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
+// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
+// CHECK-NEXT: {{^}}                                  ^
+
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
+// CHECK-NEXT: {{^}}        ^
+
+// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_5' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
+// CHECK-NEXT: {{^}}        ^

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -39,6 +39,8 @@
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SNSomeProtocol:
 // CHECK-NEXT:     TU: SNSomeProtocol
+// CHECK-NEXT:   SWIFT_NAME:
+// CHECK-NEXT:     TU: Macro
 // CHECK-NEXT:   SomeClass:
 // CHECK-NEXT:     TU: SNSomeClass
 // CHECK-NEXT:   SomeProtocol:

--- a/test/Inputs/clang-importer-sdk/usr/include/IncompleteTypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/IncompleteTypes.h
@@ -1,0 +1,40 @@
+#include <Foundation.h>
+
+@class ForwardDeclaredInterface;
+@protocol ForwardDeclaredProtocol;
+
+@interface Bar : NSObject
+@property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
+@property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
+- (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+- (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+- (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
+- (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+@end
+
+ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
+void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
+
+NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
+void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
+
+@interface CompleteInterface
+@end
+@protocol CompleteProtocol
+@end
+
+@interface Foo : NSObject
+@property id<CompleteProtocol> propertyUsingACompleteProtocol;
+@property CompleteInterface *propertyUsingACompleteInterface;
+- (NSObject<CompleteProtocol> *)methodReturningCompleteProtocol;
+- (CompleteInterface *)methodReturningCompleteInterface;
+- (int)methodTakingACompleteProtocolAsAParameter:(id<CompleteProtocol>)param1;
+- (int)methodTakingACompleteInterfaceAsAParameter:(CompleteInterface *)param1
+                                       andAnother:(CompleteInterface *)param2;
+@end
+
+CompleteInterface *CFunctionReturningACompleteInterface();
+void CFunctionTakingACompleteInterfaceAsAParameter(CompleteInterface *param1);
+
+NSObject<CompleteProtocol> *CFunctionReturningACompleteProtocol();
+void CFunctionTakingACompleteProtocolAsAParameter(id<CompleteProtocol> param1);

--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -58,3 +58,5 @@ struct not_importable;
 
 void opaque_pointer_param(struct not_importable *);
 
+int unsupported_parameter_type(int param1, _Complex int param2);
+_Complex int unsupported_return_type();

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -324,4 +324,13 @@ typedef double real_t __attribute__((availability(swift,unavailable,message="use
 
 extern real_t realSin(real_t value);
 
+struct PartialImport {
+  int a;
+  int b;
+  int _Complex c;
+  int _Complex d;
+};
+
+struct PartialImport partialImport = {1, 2, 3, 4};
+
 #endif

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -163,3 +163,30 @@ typedef unsigned unavailable_t __attribute__((unavailable));
 typedef unsigned deprecated_t __attribute__((deprecated));
 #define OKAY_TYPED_ONE ((okay_t)1)
 typedef unsigned okay_t;
+
+#define FUNC_LIKE_MACRO() 0
+#define FUNC_LIKE_MACRO_2(PARAM) PARAM
+
+// Unsupported binary arithmetic
+#define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+#define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
+#define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
+#define INVALID_ARITHMETIC_4                                                   \
+  INVALID_INTEGER_LITERAL_1 - INVALID_INTEGER_LITERAL_1
+#define INVALID_ARITHMETIC_5 1 + VERSION_STRING
+#define INVALID_ARITHMETIC_6 1 + 'c'
+#define INVALID_ARITHMETIC_7 3 % 2
+
+// Unsupported literals
+#define CHAR_LITERAL 'a'
+
+// Unsupported macro structures
+#define UNSUPPORTED_1 FUNC_LIKE_MACRO()
+#define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
+#define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
+#define UNSUPPORTED_4                                                          \
+  extern bool globalFlag;                                                      \
+  if (globalFlag) {                                                            \
+    /* do something */                                                         \
+  }
+#define UNSUPPORTED_5 1 + 1 + 1

--- a/test/Inputs/clang-importer-sdk/usr/include/module.map
+++ b/test/Inputs/clang-importer-sdk/usr/include/module.map
@@ -146,3 +146,8 @@ module EffectfulProperties {
   header "EffectfulProperties.h"
   export *
 }
+
+module IncompleteTypes {
+  header "IncompleteTypes.h"
+  export *
+}


### PR DESCRIPTION
In this diff, I took some of our discussion and made a small example using C functions. There are many ways to expand upon this strategy, this is just a baseline. High level summary:

- Avoid wrapping return values in structs to bubble up diagnostics
   - Instead load notes into a queue
   - As you move up the tree, you can add more detail to the notes once you have the required context (ie. SourceLoc)
   - Finally, at some point you produce an error and attach the accumulated notes
   - Obviously, there is some "inaccuracy" with this queue, but we could add some more control (ex: note error target ids, note priority for sorting)
   - We have to a little bit careful that we assert notes are consumed and consumed properly, but I it is manageable
   
- Use the fatal errors to suppress further diagnostics
   - This makes it easy to not worry about repeated lookups etc
   - The downside obviously is you only get a single error at a time
   - There are compromises, we can experiment with adding diagnostics to the ignore list and "recovering" from a fatal diagnostics is also just a single method call in situations where we think it appropriate to keep displaying errors
   
 Overall, I think this strategy or one derived from it gives us a little less control, but I think its easier to work with and avoids some of the big problems we've been having with stubs