### PR TITLE
Disable flaky `distributed_actor_init_local.swift` test

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -11,6 +11,9 @@
 // FIXME(distributed): we need to revisit what's going on on windows with distributed actors rdar://83859906
 // UNSUPPORTED: OS=windows-msvc
 
+// Flaky CI test
+// REQUIRES: radar84649015
+
 import _Distributed
 
 enum MyError: Error {


### PR DESCRIPTION
Example failure:
https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon//1575/console
