### PR TITLE
Fix incorrect precondition test (gt instead of gte) in TemporaryAllocation.swift

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -38,7 +38,7 @@ internal func _byteCountForTemporaryAllocation<T>(
   // emitting equivalent compile-time diagnostics because the call to
   // Builtin.stackAlloc() becomes unreachable.
   if _isComputed(capacity) {
-    _precondition(capacity > 0, "Allocation capacity must be greater than or equal to zero")
+    _precondition(capacity >= 0, "Allocation capacity must be greater than or equal to zero")
   }
   let stride = MemoryLayout<T>.stride
   let (byteCount, overflow) = capacity.multipliedReportingOverflow(by: stride)


### PR DESCRIPTION
…ation.swift

<!-- What's in this pull request? -->
Typo in one of the preconditions in `withUnsafeTemporaryAllocation()` that wasn't caught when testing. Existing test should be sufficient when run in Debug mode.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://84672024.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
