### PR TITLE
[Driver] Move the flag -check-api-availability-only to the driver

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -469,10 +469,6 @@ def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;
 
-def check_api_availability_only : Flag<["-"],
-  "check-api-availability-only">,
-  HelpText<"Only check the availability of the APIs, ignore function bodies">;
-
 def enable_conformance_availability_errors : Flag<["-"],
   "enable-conformance-availability-errors">,
   HelpText<"Diagnose conformance availability violations as errors">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -422,6 +422,10 @@ def define_availability : Separate<["-"], "define-availability">,
   HelpText<"Define an availability macro in the format 'macroName : iOS 13.0, macOS 10.15'">,
   MetaVarName<"<macro>">;
 
+def check_api_availability_only : Flag<["-"], "check-api-availability-only">,
+  Flags<[HelpHidden, FrontendOption, NoInteractiveOption]>,
+  HelpText<"Only check the availability of the APIs, ignore function bodies">;
+
 def library_level : Separate<["-"], "library-level">,
   MetaVarName<"<level>">,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -242,6 +242,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_sendable);
+  inputArgs.AddLastArg(arguments, options::OPT_check_api_availability_only);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/test/Sema/api-availability-only-ok.swift
+++ b/test/Sema/api-availability-only-ok.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %swiftc_driver -emit-module %s -target %target-cpu-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -Xfrontend -check-api-availability-only -verify-emitted-module-interface
+// RUN: %swiftc_driver -emit-module %s -target %target-cpu-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -check-api-availability-only -verify-emitted-module-interface
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/main.swiftinterface
 
 // REQUIRES: OS=macosx

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-typecheck-verify-swift -module-name MyModule -target %target-cpu-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
 
+/// The flag -check-api-availability-only should reject builds going up to IR and further.
 // RUN: not %target-build-swift -emit-executable %s -g -o %t -emit-module -Xfrontend -check-api-availability-only 2>&1 | %FileCheck %s
 // CHECK: the flag -check-api-availability-only does not support emitting IR
 


### PR DESCRIPTION
Make -check-api-availability-only a driver flag. In the new Swift driver only this flag is passed down only to compile jobs but not swiftinterface verification. In the C++ driver let's just pass it down to all frontend jobs as a compatibility thing.

Swift driver PR: https://github.com/apple/swift-driver/pull/889