### PR TITLE
Module Aliasing: do not allow module real names to appear in source files

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -477,26 +477,24 @@ public:
   /// specified string.
   Identifier getIdentifier(StringRef Str) const;
 
-  /// Convert a given alias map to a map of Identifiers between module aliases and their actual names.
-  /// For example, if '-module-alias Foo=X -module-alias Bar=Y' input is passed in, the aliases Foo and Bar are
-  /// the names of the imported or referenced modules in source files in the main module, and X and Y
-  /// are the real (physical) module names on disk.
+  /// Convert a given module alias map (with `-module-alias` option) to a map of entries that are
+  /// keyed both module aliases and real names along with a boolean indicating whether the entry
+  /// is an alias or a real name.
+  /// An entry with a module alias as key will have value: (real module name, true), and
+  /// an entry with a module real name as key will have value: (module alias, false).
   void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
 
   /// Retrieve the actual module name if a module alias is used via '-module-alias Foo=X', where Foo is
   /// a module alias and X is the real (physical) name. Returns \p key if no aliasing is used.
   Identifier getRealModuleName(Identifier key) const;
 
-  /// Checks if the given \p key is a module alias or a module real name.
-  /// If \p key is a module alias, it returns a pair of its corresponding real name and 'true',
-  /// if \p key is a module real name, it returns a pair of its corresponding alias, and 'false', and
-  /// if \p key is a non-aliased module name, it returns a pair of that given name and 'true'.
-  ///
-  /// This can be used to check if the module real name appears in source files, in which case error diags
-  /// should be emitted (only aliases should allowed).
-  ///
-  /// \param key A module name (alias, real name, or non-aliased name)
-  /// \returns A pair of the module real name and 'true' if the \p key is an alias
+  /// Retrieve the value mapped to the given key.
+  /// \param key A module alias or real name (or non-aliased name) to look up
+  /// \returns A pair of a module alias or real name given \p key, and a boolean indicating if the
+  ///          \p key is an alias
+  /// If \p key is a module alias, it returns: (corresponding real name, true)
+  /// if \p key is a module real name, it returns: (corresponding alias, false), and
+  /// if \p key is a non-aliased module name, it returns (key, true).
   std::pair<Identifier, bool> getRealModuleNameOrAlias(Identifier key) const;
 
   /// Decide how to interpret two precedence groups.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -491,13 +491,21 @@ public:
 
   /// Look up the module alias map by the given \p key.
   ///
-  /// \param key A module alias or real name to look up the map by.
-  /// \param reverseLookup Default to false, but if true, it will treat the \p key as a real name and
-  ///        look up the alias, which can be used to guard against real names appearing in source files.
-  /// \returns The real name or alias mapped to the key.
-  ///          If \p reverseLookup is true but the \p key is an alias, it will return an empty Identifier.
-  ///          If no aliasing is used, \p key will be returned.
-  Identifier getRealModuleName(Identifier key, bool reverseLookup = false) const;
+  /// \param key A module alias or real name to look up the map by
+  /// \param alwaysReturnRealName Indicates whether it should always retrieve the real module name
+  ///        given \p key. Defaults to true. This takes a higher precedence than
+  ///        \p lookupAliasFromReal.
+  /// \param lookupAliasFromReal Indicates whether to look up an alias by treating \p key
+  ///        as a real name. Defaults to false.
+  /// \return The real name or alias mapped to the key.
+  ///         If \p alwaysReturnRealName is true, return the real module name if \p key is an alias
+  ///         or the key itself since that's the real name.
+  ///         If \p lookupAliasFromReal is true, and \p alwaysReturnRealName is false, return
+  ///         only if \p key is a real name, else an empty Identifier.
+  ///         If no aliasing is used, return \p key.
+  Identifier getRealModuleName(Identifier key,
+                               bool alwaysReturnRealName = true,
+                               bool lookupAliasFromReal = false) const;
 
   /// Decide how to interpret two precedence groups.
   Associativity associateInfixOperators(PrecedenceGroupDecl *left,

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -351,7 +351,7 @@ private:
   mutable llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
   
   /// Mapping between aliases and real (physical) names of imported or referenced modules.
-  mutable llvm::DenseMap<Identifier, Identifier> ModuleAliasMap;
+  mutable llvm::DenseMap<Identifier, std::pair<Identifier, bool>> ModuleAliasMap;
 
   /// Retrieve the allocator for the given arena.
   llvm::BumpPtrAllocator &
@@ -486,6 +486,18 @@ public:
   /// Retrieve the actual module name if a module alias is used via '-module-alias Foo=X', where Foo is
   /// a module alias and X is the real (physical) name. Returns \p key if no aliasing is used.
   Identifier getRealModuleName(Identifier key) const;
+
+  /// Checks if the given \p key is a module alias or a module real name.
+  /// If \p key is a module alias, it returns a pair of its corresponding real name and 'true',
+  /// if \p key is a module real name, it returns a pair of its corresponding alias, and 'false', and
+  /// if \p key is a non-aliased module name, it returns a pair of that given name and 'true'.
+  ///
+  /// This can be used to check if the module real name appears in source files, in which case error diags
+  /// should be emitted (only aliases should allowed).
+  ///
+  /// \param key A module name (alias, real name, or non-aliased name)
+  /// \returns A pair of the module real name and 'true' if the \p key is an alias
+  std::pair<Identifier, bool> getRealModuleNameOrAlias(Identifier key) const;
 
   /// Decide how to interpret two precedence groups.
   Associativity associateInfixOperators(PrecedenceGroupDecl *left,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -303,7 +303,8 @@ ERROR(getset_cannot_be_implied,none,
 ERROR(decl_expected_module_name,none,
       "expected module name in import declaration", ())
 ERROR(expected_module_alias,none,
-      "module real name should not appear in source files; only the module alias is allowed", ())
+      "cannot refer to module as %0 because it has been aliased; use %1 "
+      "instead", (Identifier, Identifier))
 
 // Extension
 ERROR(expected_lbrace_extension,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -302,6 +302,8 @@ ERROR(getset_cannot_be_implied,none,
 // Import
 ERROR(decl_expected_module_name,none,
       "expected module name in import declaration", ())
+ERROR(expected_module_alias,none,
+      "module real name should not appear in source files; only the module alias is allowed", ())
 
 // Extension
 ERROR(expected_lbrace_extension,PointsToFirstBadToken,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1653,19 +1653,25 @@ void ASTContext::setModuleAliases(const llvm::StringMap<StringRef> &aliasMap) {
   }
 }
 
-Identifier ASTContext::getRealModuleName(Identifier key, bool reverseLookup) const {
+Identifier ASTContext::getRealModuleName(Identifier key, bool alwaysReturnRealName, bool lookupAliasFromReal) const {
   auto found = ModuleAliasMap.find(key);
   if (found == ModuleAliasMap.end())
     return key;
 
   // Found an entry
   auto realOrAlias = found->second;
-  // If reverseLookup, i.e. look up an alias by real name, but the found
-  // entry is keyed by an alias, return an empty Identifier
-  if (reverseLookup && realOrAlias.second)
-    return Identifier();
 
-  // Return a real name or an alias (if reverseLookup) mapped to the given key
+  // If alwaysReturnRealName, return the real name if the key is an
+  // alias or the key itself since that's the real name
+  if (alwaysReturnRealName) {
+     return realOrAlias.second ? realOrAlias.first : key;
+  }
+
+  // If lookupAliasFromReal, and the found entry should be keyed by a real
+  // name, return the entry value, otherwise, return an empty Identifier.
+  if (lookupAliasFromReal == realOrAlias.second)
+      return Identifier();
+
   return realOrAlias.first;
 }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -439,7 +439,6 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   // passed, the alias 'Foo' should appear in source files, not 'Bar'.
   // If no module aliasing is used, this will simply return the given
   // name and 'true' indicating the check passed.
-  // Is this *not* the real name of an aliased module?
   if (!Ctx.getRealModuleName(givenName).empty()) {
     desiredModule = Ctx.getLoadedModule(givenName);
   }

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -431,7 +431,19 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
 #endif
     return;
   }
-  ModuleDecl *desiredModule = Ctx.getLoadedModule(Name.getBaseIdentifier());
+
+  ModuleDecl *desiredModule = nullptr;
+  auto givenName = Name.getBaseIdentifier();
+  // Check if the given name appearing in the source file is a module
+  // real name or alias; for example, if `-module-alias Foo=Bar` was
+  // passed, the alias 'Foo' should appear in source files, not 'Bar'.
+  // If no module aliasing is used, this will simply return the given
+  // name and 'true' indicating the check passed.
+  auto checkResult = Ctx.getRealModuleNameOrAlias(givenName);
+  if (checkResult.second) { // Check passed
+    desiredModule = Ctx.getLoadedModule(givenName);
+  }
+
   if (!desiredModule && Name.getFullName() == Ctx.TheBuiltinModule->getName())
     desiredModule = Ctx.TheBuiltinModule;
   if (desiredModule) {

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -437,9 +437,11 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   // Check if the given name appearing in the source file is a module
   // real name or alias; for example, if `-module-alias Foo=Bar` was
   // passed, the alias 'Foo' should appear in source files, not 'Bar'.
-  // If no module aliasing is used, this will simply return the given
-  // name and 'true' indicating the check passed.
-  if (!Ctx.getRealModuleName(givenName).empty()) {
+  // If the real name 'Bar' was used, looking up getRealModuleName will
+  // return an empty Identifier.
+  if (!Ctx.getRealModuleName(givenName, /*alwaysReturnRealName=*/false).empty()) {
+    // Only load the module if the lookup value is not empty, i.e. given
+    // name is a module alias, not a real module name.
     desiredModule = Ctx.getLoadedModule(givenName);
   }
 

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -439,8 +439,8 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   // passed, the alias 'Foo' should appear in source files, not 'Bar'.
   // If no module aliasing is used, this will simply return the given
   // name and 'true' indicating the check passed.
-  auto checkResult = Ctx.getRealModuleNameOrAlias(givenName);
-  if (checkResult.second) { // Check passed
+  // Is this *not* the real name of an aliased module?
+  if (!Ctx.getRealModuleName(givenName).empty()) {
     desiredModule = Ctx.getLoadedModule(givenName);
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4826,7 +4826,7 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   if (Context.getRealModuleName(parsedModuleID).empty()) {
     // If reached here, it means the parsed module name is a real module name
     // which appeared in the source file; only a module alias should be allowed
-    auto aliasName = Context.getRealModuleName(parsedModuleID, /*lookupAliasFromReal=*/true);
+    auto aliasName = Context.getRealModuleName(parsedModuleID, /*reverseLookup=*/true);
     diagnose(importPath.front().Loc, diag::expected_module_alias,
                      parsedModuleID, aliasName)
       .fixItReplace(importPath.front().Loc, aliasName.str());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4823,10 +4823,10 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   // and check that the module alias appeared in source files instead of
   // its corresponding real name
   auto parsedModuleID = importPath.get().front().Item;
-  if (Context.getRealModuleName(parsedModuleID).empty()) {
+  if (Context.getRealModuleName(parsedModuleID, /*alwaysReturnRealName=*/false).empty()) {
     // If reached here, it means the parsed module name is a real module name
     // which appeared in the source file; only a module alias should be allowed
-    auto aliasName = Context.getRealModuleName(parsedModuleID, /*reverseLookup=*/true);
+    auto aliasName = Context.getRealModuleName(parsedModuleID, /*alwaysReturnRealName=*/false, /*lookupAliasFromReal=*/true);
     diagnose(importPath.front().Loc, diag::expected_module_alias,
                      parsedModuleID, aliasName)
       .fixItReplace(importPath.front().Loc, aliasName.str());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4825,8 +4825,8 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   auto parsedModuleID = importPath.get().front().Item;
   auto checkResult = Context.getRealModuleNameOrAlias(parsedModuleID);
   if (!checkResult.second) {
-    // This means the parsed module name is the real name that appeared in
-    // the source file; only the module alias should be allowed
+    // If reached here, it means the parsed module name is a real module name
+    // which appeared in the source file; only a module alias should be allowed
     diagnose(importPath.front().Loc, diag::expected_module_alias)
       .fixItReplace(importPath.front().Loc, checkResult.first.str());
     return nullptr;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4823,12 +4823,13 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   // and check that the module alias appeared in source files instead of
   // its corresponding real name
   auto parsedModuleID = importPath.get().front().Item;
-  auto checkResult = Context.getRealModuleNameOrAlias(parsedModuleID);
-  if (!checkResult.second) {
+  if (Context.getRealModuleName(parsedModuleID).empty()) {
     // If reached here, it means the parsed module name is a real module name
     // which appeared in the source file; only a module alias should be allowed
-    diagnose(importPath.front().Loc, diag::expected_module_alias)
-      .fixItReplace(importPath.front().Loc, checkResult.first.str());
+    auto aliasName = Context.getRealModuleName(parsedModuleID, /*lookupAliasFromReal=*/true);
+    diagnose(importPath.front().Loc, diag::expected_module_alias,
+                     parsedModuleID, aliasName)
+      .fixItReplace(importPath.front().Loc, aliasName.str());
     return nullptr;
   }
 

--- a/test/Frontend/module-alias-diags.swift
+++ b/test/Frontend/module-alias-diags.swift
@@ -26,7 +26,7 @@
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibC %t/FileLibImportRealName.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibC.swiftmodule 2> %t/result-LibC.output
 // RUN: %FileCheck %s -input-file %t/result-LibC.output -check-prefix CHECK-NOT-IMPORT
-// CHECK-NOT-IMPORT: error: module real name should not appear in source files; only the module alias is allowed
+// CHECK-NOT-IMPORT: error: cannot refer to module as 'AppleLogging' because it has been aliased; use 'XLogging' instead
 
 /// 4-1. Fail: referencing the real module name that's aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging

--- a/test/Frontend/module-alias-diags.swift
+++ b/test/Frontend/module-alias-diags.swift
@@ -1,0 +1,121 @@
+/// Test diagnostics with module aliasing.
+///
+/// Module 'Lib' imports module 'XLogging', and 'XLogging' is aliased 'AppleLogging'.
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+/// Create AppleLogging.swiftmodule by aliasing XLogging
+// RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
+// RUN: test -f %t/AppleLogging.swiftmodule
+
+/// 1. Pass: load and reference a module with module aliasing
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: %target-swift-frontend -module-name LibA %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibA.swiftmodule -Rmodule-loading 2> %t/result-LibA.output
+// RUN: test -f %t/LibA.swiftmodule
+// RUN: %FileCheck %s -input-file %t/result-LibA.output -check-prefix CHECK-LOAD
+// CHECK-LOAD: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+
+/// 2. Fail: trying to access a non-member of a module (with module aliasing) should fail with the module alias in the diags
+/// Try building module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibB %t/FileLibNoSuchMember.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibB.swiftmodule 2> %t/result-LibB.output
+// RUN: %FileCheck %s -input-file %t/result-LibB.output -check-prefix CHECK-NO-MEMBER
+// CHECK-NO-MEMBER: error: module 'XLogging' has no member named 'setupErr'
+
+/// 3. Fail: importing the real module name that's being aliased should fail
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibC %t/FileLibImportRealName.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibC.swiftmodule 2> %t/result-LibC.output
+// RUN: %FileCheck %s -input-file %t/result-LibC.output -check-prefix CHECK-NOT-IMPORT
+// CHECK-NOT-IMPORT: error: module real name should not appear in source files; only the module alias is allowed
+
+/// 4-1. Fail: referencing the real module name that's aliased should fail
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibD %t/FileLibRefRealName1.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibD.swiftmodule 2> %t/result-LibD.output
+// RUN: %FileCheck %s -input-file %t/result-LibD.output -check-prefix CHECK-NOT-REF1
+// CHECK-NOT-REF1: error: cannot find 'AppleLogging' in scope
+
+/// 4-2. Fail: referencing the real module name that's aliased should fail
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibE %t/FileLibRefRealName2.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibE.swiftmodule 2> %t/result-LibE.output
+// RUN: %FileCheck %s -input-file %t/result-LibE.output -check-prefix CHECK-NOT-REF2
+// CHECK-NOT-REF2: error: cannot find type 'AppleLogging' in scope
+
+/// 4-3. Fail: referencing the real module name that's aliased should fail
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibF %t/FileLibRefRealName3.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibF.swiftmodule 2> %t/result-LibF.output
+// RUN: %FileCheck %s -input-file %t/result-LibF.output -check-prefix CHECK-NOT-REF3
+// CHECK-NOT-REF3: error: cannot find type 'AppleLogging' in scope
+
+/// 4-4. Fail: referencing the real module name that's aliased should fail
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibG %t/FileLibRefRealName4.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibG.swiftmodule 2> %t/result-LibG.output
+// RUN: %FileCheck %s -input-file %t/result-LibG.output -check-prefix CHECK-NOT-REF4
+// CHECK-NOT-REF4: error: cannot find type 'AppleLogging' in scope
+
+
+// BEGIN FileLogging.swift
+public protocol Loggable {
+  var verbosity: Int { get }
+}
+
+public struct Logger {
+  public init() {}
+}
+
+public func setup() -> XLogging.Logger? {
+  return Logger()
+}
+
+// BEGIN FileLib.swift
+import XLogging
+
+public func start() {
+  _ = XLogging.setup()
+}
+
+// BEGIN FileLibNoSuchMember.swift
+import XLogging
+
+public func start() {
+  _ = XLogging.setupErr()
+}
+
+// BEGIN FileLibImportRealName.swift
+import XLogging
+import AppleLogging
+
+public func start() {
+  _ = XLogging.setup()
+}
+
+// BEGIN FileLibRefRealName1.swift
+import XLogging
+
+public func start() {
+  _ = AppleLogging.setup()
+}
+
+// BEGIN FileLibRefRealName2.swift
+import XLogging
+
+public struct MyStruct: AppleLogging.Loggable {
+  public var verbosity: Int {
+    return 3
+  }
+}
+
+// BEGIN FileLibRefRealName3.swift
+import XLogging
+
+public struct MyStruct<T> where T: AppleLogging.Loggable {
+  func log<T>(_ arg: T) {
+  }
+}
+
+// BEGIN FileLibRefRealName4.swift
+import XLogging
+
+public struct MyStruct {
+  func log<T: AppleLogging.Loggable>(_ arg: T) {
+  }
+}


### PR DESCRIPTION
When module aliasing is used, module real names should not appear in source files (only aliases should be allowed).
Resolves rdar://83592084