### PR TITLE
[Mem2Reg] Handled unreachables for single-block allocations.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1651,12 +1651,42 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
 
   if (runningVals && runningVals->isStorageValid &&
       shouldAddLexicalLifetime(asi)) {
-    assert(isa<UnreachableInst>(parentBlock->getTerminator()) &&
-           "valid storage after reaching end of single-block allocation not "
-           "terminated by unreachable?!");
-    endLexicalLifetimeBeforeInst(
-        asi, /*beforeInstruction=*/parentBlock->getTerminator(), ctx,
-        runningVals->value);
+    // There is still valid storage after visiting all instructions in this
+    // block which are the only instructions involving this alloc_stack.
+    // This can only happen if all paths from this block end in unreachable.
+    //
+    // We need to end the lexical lifetime at the last possible location, either
+    // just before an unreachable instruction or just before a branch to a block
+    // that is not dominated by parentBlock.
+
+    // Walk forward from parentBlock until finding blocks which either
+    // (1) terminate in unreachable
+    // (2) have successors which are not dominated by parentBlock
+    GraphNodeWorklist<SILBasicBlock *, 2> worklist;
+    worklist.initialize(parentBlock);
+    while (auto *block = worklist.pop()) {
+      auto *terminator = block->getTerminator();
+      if (isa<UnreachableInst>(terminator)) {
+        endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/terminator, ctx,
+                                     runningVals->value);
+        continue;
+      }
+      bool endedLifetime = false;
+      for (auto *successor : block->getSuccessorBlocks()) {
+        if (!domInfo->dominates(parentBlock, successor)) {
+          endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/terminator,
+                                       ctx, runningVals->value);
+          endedLifetime = true;
+          break;
+        }
+      }
+      if (endedLifetime) {
+        continue;
+      }
+      for (auto *successor : block->getSuccessorBlocks()) {
+        worklist.insert(successor);
+      }
+    }
   }
 }
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1733,6 +1733,10 @@ bool MemoryToRegisters::run() {
     f.verifyCriticalEdges();
 
   for (auto &block : f) {
+    // Don't waste time optimizing unreachable blocks.
+    if (!domInfo->isReachableFromEntry(&block)) {
+      continue;
+    }
     for (SILInstruction *inst : deleter.updatingReverseRange(&block)) {
       auto *asi = dyn_cast<AllocStackInst>(inst);
       if (!asi)

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -523,6 +523,8 @@ enum E {
 case one(C)
 }
 
+sil [ossa] @getC : $@convention(thin) () -> @owned C
+
 sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 sil [ossa] @callee_error_owned : $@convention(thin) (@owned C) -> @error Error
@@ -1542,6 +1544,185 @@ entry(%instance : @owned $C):
   store %instance to [init] %addr : $*C
   %instance_loaded = load [take] %addr : $*C
   store %instance_loaded to [init] %addr : $*C
+  unreachable
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_5 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_5'
+sil [ossa] @unreachable_5 : $@convention(thin) (@owned C) -> () {
+entry(%instance_1 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr :$*C
+  br exit
+exit:
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @unreachable_6 : $@convention(thin) (@owned C) -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'unreachable_6'
+sil [ossa] @unreachable_6 : $@convention(thin) (@owned C) -> () {
+entry(%instance_1 : @owned $C):
+  br exit
+unr:
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr :$*C
+  br die
+die:
+  unreachable
+exit:
+  %res = tuple ()
+  return %res : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_7 : $@convention(thin) (@owned C) -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'unreachable_7'
+sil [ossa] @unreachable_7 : $@convention(thin) (@owned C) -> () {
+entry(%instance_1 : @owned $C):
+  cond_br undef, exit, die_later
+unr:
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr :$*C
+  br die_later_2
+die_later_2:
+  br die
+die_later:
+  br die
+die:
+  unreachable
+exit:
+  %res = tuple ()
+  return %res : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_8 : $@convention(thin) (@owned C) -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'unreachable_8'
+sil [ossa] @unreachable_8 : $@convention(thin) (@owned C) -> () {
+entry(%instance_1 : @owned $C):
+  cond_br undef, exit, die_later
+unr:
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  cond_br undef, die_later_2_a, die_later_2_b
+die_later_2_a:
+  br die_later_2
+die_later_2_b:
+  br die_later_2
+die_later_2:
+  br die
+die_later:
+  br die
+die:
+  unreachable
+exit:
+  %res = tuple ()
+  return %res : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_loop_1 : $@convention(thin) () -> () {
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         [[GET_C:%[^,]+]] = function_ref @getC : $@convention(thin) () -> @owned C
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_C]]() : $@convention(thin) () -> @owned C
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         br [[LOOP_HEADER:bb[0-9]+]]
+// CHECK:       [[LOOP_HEADER]]:
+// CHECK:         br [[LOOP_BODY:bb[0-9]+]]
+// CHECK:       [[LOOP_BODY]]:
+// CHECK:         br [[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       [[LOOP_EXIT]]:
+// CHECK:         cond_br undef, [[LOOP_BACKEDGE:bb[0-9]+]], [[DIE:bb[0-9]+]]
+// CHECK:       [[LOOP_BACKEDGE]]:
+// CHECK:         br [[LOOP_HEADER]]
+// CHECK:       [[DIE]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_loop_1'
+sil [ossa] @unreachable_loop_1 : $@convention(thin) () -> () {
+entry:
+  %delegate_var = alloc_stack [lexical] $C
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %delegate = apply %getC() : $@convention(thin) () -> @owned C
+  store %delegate to [init] %delegate_var : $*C
+  br loop_header
+loop_header:
+  br loop_body
+loop_body:
+  br loop_exit
+loop_exit:
+  cond_br undef, loop_backedge, die
+loop_backedge:
+  br loop_header
+die:
+  unreachable
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_loop_2 : $@convention(thin) () -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'unreachable_loop_2'
+sil [ossa] @unreachable_loop_2 : $@convention(thin) () -> () {
+entry:
+  br loop_header
+unr:
+  %delegate_var = alloc_stack [lexical] $C
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %delegate = apply %getC() : $@convention(thin) () -> @owned C
+  store %delegate to [init] %delegate_var : $*C
+  br loop_header
+loop_header:
+  br loop_body
+loop_body:
+  br loop_exit
+loop_exit:
+  cond_br undef, loop_backedge, die
+loop_backedge:
+  br loop_header
+die:
+  unreachable
+}
+
+
+// CHECK-LABEL: sil [ossa] @unreachable_loop_3 : $@convention(thin) () -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'unreachable_loop_3'
+sil [ossa] @unreachable_loop_3 : $@convention(thin) () -> () {
+entry:
+  br die_entry
+die_entry:
+  br die
+unr:
+  %delegate_var = alloc_stack [lexical] $C
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %delegate = apply %getC() : $@convention(thin) () -> @owned C
+  store %delegate to [init] %delegate_var : $*C
+  br loop_header
+loop_header:
+  br loop_body
+loop_body:
+  br loop_exit
+loop_exit:
+  cond_br undef, loop_backedge, die_loop
+loop_backedge:
+  br loop_header
+die_loop:
+  br die
+die:
   unreachable
 }
 


### PR DESCRIPTION
Previously, it was asserted that any single-block allocation which had valid memory after all instructions in the block were visited terminated in unreachable.  That assertion was false--while all paths through that block must end in unreachable, the block itself need not be terminated with an unreachable inst.  Here, that is corrected by walking forward from the block until blocks terminated by unreachables or blocks to which there are paths that do not go through the block containing the alloc_stack are reached.  In the first case, the lifetime is ended just before the unreachable inst.  In the second, the lifetime is ended just before the branch to such a successor block.
