### PR TITLE
[moveOnly] Teach loadable by address to just delete move_value that it sees when it is rewriting code.

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1709,6 +1709,8 @@ private:
                          SmallVectorImpl<SILInstruction *> &Delete);
   bool fixStoreToBlockStorageInstr(SILInstruction &I,
                          SmallVectorImpl<SILInstruction *> &Delete);
+  bool deleteMoveValue(SILInstruction &I,
+                       SmallVectorImpl<SILInstruction *> &Delete);
 
   bool recreateDifferentiabilityWitnessFunction(
       SILInstruction &I, SmallVectorImpl<SILInstruction *> &Delete);
@@ -1723,6 +1725,7 @@ private:
       uncheckedTakeEnumDataAddrOfFunc;
   llvm::SetVector<StoreInst *> storeToBlockStorageInstrs;
   llvm::SetVector<SILInstruction *> modApplies;
+  llvm::SetVector<MoveValueInst *> movesToRAUW;
   llvm::MapVector<SILInstruction *, SILValue> allApplyRetToAllocMap;
   LargeSILTypeMapper MapperCache;
 };
@@ -2699,6 +2702,17 @@ bool LoadableByAddress::recreateUncheckedTakeEnumDataAddrInst(
   return true;
 }
 
+bool LoadableByAddress::deleteMoveValue(
+    SILInstruction &inputInst,
+    SmallVectorImpl<SILInstruction *> &instsToDelete) {
+  auto *mvi = dyn_cast<MoveValueInst>(&inputInst);
+  if (!mvi || !movesToRAUW.count(mvi))
+    return false;
+  mvi->replaceAllUsesWith(mvi->getOperand());
+  instsToDelete.push_back(mvi);
+  return true;
+}
+
 bool LoadableByAddress::fixStoreToBlockStorageInstr(
     SILInstruction &I, SmallVectorImpl<SILInstruction *> &Delete) {
   auto *instr = dyn_cast<StoreInst>(&I);
@@ -3030,6 +3044,8 @@ void LoadableByAddress::run() {
                    isa<DifferentiableFunctionExtractInst>(&I) ||
                    isa<LinearFunctionExtractInst>(&I)) {
           conversionInstrs.insert(cast<SingleValueInstruction>(&I));
+        } else if (auto *mvi = dyn_cast<MoveValueInst>(&I)) {
+          movesToRAUW.insert(mvi);
         }
       }
     }
@@ -3059,6 +3075,8 @@ void LoadableByAddress::run() {
     SmallVector<SILInstruction *, 32> Delete;
     for (SILBasicBlock &BB : CurrF) {
       for (SILInstruction &I : BB) {
+        if (deleteMoveValue(I, Delete))
+          continue;
         if (recreateTupleInstr(I, Delete))
           continue;
         else if (recreateConvInstr(I, Delete))

--- a/test/SILOptimizer/big_types_tests.sil
+++ b/test/SILOptimizer/big_types_tests.sil
@@ -1,9 +1,10 @@
-// RUN: %target-swift-frontend -I %S/Inputs/abi %s -emit-ir -sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt -I %S/Inputs/abi %s -loadable-address -sil-verify-all | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 
 sil_stage lowered
+
 import Builtin
 import Swift
 
@@ -20,10 +21,9 @@ public struct BigStruct {
   var i9 : Builtin.NativeObject
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(%T15big_types_tests9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
-// CHECK-NEXT: entry
-// CHECK-NEXT: call %T15big_types_tests9BigStructV* @"$s15big_types_tests9BigStructVWOs"(%T15big_types_tests9BigStructV* %0)
-// CHECK-NEXT: ret void
+// CHECK-LABEL: sil @testDestroyValue : $@convention(thin) (@in_constant BigStruct) -> () {
+// CHECK: release_value_addr %0
+// CHECK: } // end sil function 'testDestroyValue'
 sil @testDestroyValue : $@convention(thin) (@owned BigStruct) -> ()  {
 entry(%x : $BigStruct):
   release_value %x : $BigStruct
@@ -45,6 +45,9 @@ entry(%x : $BigStruct, %i : $Builtin.Int1):
 }
 
 // Make sure that we can handle this example and not choke.
+// CHECK-LABEL: sil @test_move_value : $@convention(thin) (@in_constant BigStruct, Builtin.Int1) -> () {
+// CHECK-NOT: move_value
+// CHECK: } // end sil function 'test_move_value'
 sil @test_move_value : $@convention(thin) (@owned BigStruct, Builtin.Int1) -> () {
 entry(%x : $BigStruct, %i : $Builtin.Int1):
   %x1 = move_value %x : $BigStruct


### PR DESCRIPTION
For now I am preserving move_value to the end of the pipeline. This just
prevents LoadableByAddress from needing a move_value_addr. We can add that if we
need to though. For now we just RAUW the move_value as we convert the function
argument from its object to its addr form.

TLDR: This just simplifies loadable by address.

rdar://83957088