### PR TITLE
Fix embedded plist of back-deployed concurrency library

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1201,7 +1201,9 @@ function(_add_swift_target_library_single target name)
   set(PLIST_INFO_PLIST "Info.plist" CACHE STRING "Plist name")
   if("${SWIFTLIB_SINGLE_SDK}" IN_LIST SWIFT_APPLE_PLATFORMS AND SWIFTLIB_SINGLE_IS_STDLIB)
     set(PLIST_INFO_NAME ${name})
-    set(PLIST_INFO_UTI "com.apple.dt.runtime.${name}")
+
+    # Underscores aren't permitted in the bundle identifier.
+    string(REPLACE "_" "" PLIST_INFO_UTI "com.apple.dt.runtime.${name}")
     set(PLIST_INFO_VERSION "${SWIFT_VERSION}")
     if (SWIFT_COMPILER_VERSION)
       set(PLIST_INFO_BUILD_VERSION

--- a/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
+++ b/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
@@ -84,6 +84,13 @@ class BackDeployConcurrency(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_HOST_VARIANT_ARCH:STRING', arch)
         self.cmake_options.define('BUILD_STANDALONE:BOOL', True)
 
+        # Propagate version information
+        if self.args.swift_user_visible_version is not None:
+            self.cmake_options.define('SWIFT_VERSION', str(self.args.swift_user_visible_version))
+        if self.args.swift_compiler_version is not None:
+            self.cmake_options.define('SWIFT_COMPILER_VERSION', str(self.args.swift_compiler_version))
+
+
         # Only install the "stdlib" component, which contains the concurrency
         # module.
         self.cmake_options.define('SWIFT_INSTALL_COMPONENTS:STRING', 'back-deployment')

--- a/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
+++ b/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
@@ -86,10 +86,11 @@ class BackDeployConcurrency(cmake_product.CMakeProduct):
 
         # Propagate version information
         if self.args.swift_user_visible_version is not None:
-            self.cmake_options.define('SWIFT_VERSION', str(self.args.swift_user_visible_version))
+            self.cmake_options.define('SWIFT_VERSION',
+                                      str(self.args.swift_user_visible_version))
         if self.args.swift_compiler_version is not None:
-            self.cmake_options.define('SWIFT_COMPILER_VERSION', str(self.args.swift_compiler_version))
-
+            self.cmake_options.define('SWIFT_COMPILER_VERSION',
+                                      str(self.args.swift_compiler_version))
 
         # Only install the "stdlib" component, which contains the concurrency
         # module.


### PR DESCRIPTION
Fix two issues with the embedded plist for the back-deployed concurrency library:

* Remove underscores from `CFBundleIdentifier` of libraries, because they're not permitted in the reverse-DNS name there.
* Propagate Swift version information to the back-deployed binaries, because it's better than leaving it empty.

Fixes rdar://84645973.