### PR TITLE
Disable the definition and use of swift_async_extendedFramePointerFlags on watchOS

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1822,15 +1822,16 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
     }
+  } else if (Triple.isWatchOS() && !Triple.isSimulatorEnvironment()) {
+    // watchOS does not support auto async frame pointers due to bitcode, so
+    // silently override "auto" to "never" when back-deploying. This approach
+    // sacrifies async backtraces when back-deploying but prevents crashes in
+    // older tools that cannot handle the async frame bit in the frame pointer.
+    unsigned major, minor, micro;
+    Triple.getWatchOSVersion(major, minor, micro);
+    if (major < 8)
+      Opts.SwiftAsyncFramePointer = SwiftAsyncFramePointerKind::Never;
   }
-
-  // watchOS does not support auto async frame pointers due to bitcode, so
-  // silently override "auto" to "always". This approach sacrifies async
-  // backtraces in older watchOS versions to gain better backtraces in newer
-  // versions.
-  if (Triple.isWatchOS() &&
-      Opts.SwiftAsyncFramePointer == SwiftAsyncFramePointerKind::Auto)
-    Opts.SwiftAsyncFramePointer = SwiftAsyncFramePointerKind::Always;
 
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1824,6 +1824,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     }
   }
 
+  // watchOS does not support auto async frame pointers due to bitcode, so
+  // silently override "auto" to "always". This approach sacrifies async
+  // backtraces in older watchOS versions to gain better backtraces in newer
+  // versions.
+  if (Triple.isWatchOS() &&
+      Opts.SwiftAsyncFramePointer == SwiftAsyncFramePointerKind::Auto)
+    Opts.SwiftAsyncFramePointer = SwiftAsyncFramePointerKind::Always;
+
   return false;
 }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -38,8 +38,12 @@
 #include <Availability.h>
 #include <TargetConditionals.h>
 #if TARGET_OS_WATCH
-// Bitcode compilation for the watch precludes defining the following asm
-// symbols, so we don't use them.
+// Bitcode compilation for the watch device precludes defining the following asm
+// symbols, so we don't use them... but simulators are okay.
+#if TARGET_OS_SIMULATOR
+asm("\n .globl _swift_async_extendedFramePointerFlags" \
+    "\n _swift_async_extendedFramePointerFlags = 0x0");
+#endif
 #else
 asm("\n .globl _swift_async_extendedFramePointerFlags" \
     "\n _swift_async_extendedFramePointerFlags = 0x0");

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -35,8 +35,15 @@
 #endif
 
 #if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
+#include <Availability.h>
+#include <TargetConditionals.h>
+#if TARGET_OS_WATCH
+// Bitcode compilation for the watch precludes defining the following asm
+// symbols, so we don't use them.
+#else
 asm("\n .globl _swift_async_extendedFramePointerFlags" \
     "\n _swift_async_extendedFramePointerFlags = 0x0");
+#endif
 #else
 #ifdef __APPLE__
 #if __POINTER_WIDTH__ == 64

--- a/test/IRGen/swift_async_extended_frame_info_watchos.swift
+++ b/test/IRGen/swift_async_extended_frame_info_watchos.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos8 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=auto %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=never %s -S | %FileCheck  -check-prefix=NEVER %s
+
+// REQUIRES: OS=watchos
+
+public func someAsyncFunction() async {
+}
+
+// ALWAYS-NOT: swift_async_extendedFramePointerFlags
+// NEVER-NOT: swift_async_extendedFramePointerFlags

--- a/test/IRGen/swift_async_extended_frame_info_watchos.swift
+++ b/test/IRGen/swift_async_extended_frame_info_watchos.swift
@@ -1,12 +1,20 @@
-// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7 %s -S | %FileCheck  -check-prefix=NEVER %s
 // RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos8 %s -S | %FileCheck  -check-prefix=ALWAYS %s
-// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=auto %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=always %s -S | %FileCheck  -check-prefix=ALWAYS %s
 // RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=never %s -S | %FileCheck  -check-prefix=NEVER %s
+// RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=auto %s -S | %FileCheck  -check-prefix=AUTO %s
 
 // REQUIRES: OS=watchos
+// REQUIRES: CPU=armv7k || CPU=arm64_32
 
 public func someAsyncFunction() async {
 }
 
+// AUTO: swift_async_extendedFramePointerFlags
+
 // ALWAYS-NOT: swift_async_extendedFramePointerFlags
+// ALWAYS: 0x1000000000000000
+// ALWAYS-NOT: swift_async_extendedFramePointerFlags
+
 // NEVER-NOT: swift_async_extendedFramePointerFlags
+// NEVER-NOT: 0x1000000000000000


### PR DESCRIPTION
The asm definition of `swift_async_extendedFramePointerFlags` prevents the use of bitcode with the back-deployment libraries on watchOS, so remove the definition and use of this symbol from watchOS binaries entirely. This affects whether the async bit is set in frame pointers. Setting the async bit in the frame pointer can cause older APIs (such as backtrace APIs in the OS) to crash when they encounter such frame pointers, but we cannot dynamically set it without `swift_async_extendedFramePointerFlags`. So, we never set the bit when back-deploying for watchOS device, to avoid said crashes.

The trade-off here is that a back-deployed watchOS app will never have the async frame pointer bit set, so async backtraces will be unavailable even when running such an app on watchOS 8 or newer. Moving the deployment target forward to watchOS 8, or running under the simulator for watchOS 8, will restore async back traces.

One can override this behavior with the option`-swift-async-frame-pointer=always`, which statically sets the async bit in the frame pointer. This restores async back traces on watchOS 8, but can lead to the aforementioned crashes on older versions. This approach may be suitable for debugging but is unlikely to be a good idea when deploying.

Fixes rdar://84687579.
