### PR TITLE
[Diagnostics] Add a fix-it to insert 'some' when associated type inference failed because existential types can't conform to protocols.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2263,6 +2263,11 @@ NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a nominal type and so can't conform to %2",
      (Identifier, Type, Type))
+NOTE(suggest_opaque_type_witness,none,
+     "cannot infer %0 = %1 because %1 as a type cannot "
+     "conform to protocols; did you mean to use an opaque "
+     "result type?",
+     (Identifier, Type, Type))
 NOTE(associated_type_witness_inherit_impossible,none,
      "candidate can not infer %0 = %1 because %1 "
      "is not a class type and so can't inherit from %2",

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1768,6 +1768,9 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
             } else if (auto *func = dyn_cast<FuncDecl>(failed.Witness)) {
               resultType = func->getResultInterfaceType();
               typeRange = func->getResultTypeSourceRange();
+            } else if (auto *subscript = dyn_cast<SubscriptDecl>(failed.Witness)) {
+              resultType = subscript->getElementInterfaceType();
+              typeRange = subscript->getElementTypeSourceRange();
             }
 
             // If the type witness was inferred from an existential

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -119,6 +119,15 @@ struct S4: P13 { // expected-error {{type 'S4' does not conform to protocol 'P13
   // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{12-12=some }}
 }
 
+protocol P14 {
+  associatedtype A : P11 // expected-note {{unable to infer associated type 'A' for protocol 'P14'}}
+  subscript(i: Int) -> A { get }
+}
+struct S5: P14 { // expected-error {{type 'S5' does not conform to protocol 'P14'}}
+  subscript(i: Int) -> P11 { return i }
+  // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{24-24=some }}
+}
+
 // SR-12759
 struct CountSteps1<T> : Collection {
   init(count: Int) { self.count = count }

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -107,7 +107,16 @@ protocol P12 {
 extension Int : P11 {}
 struct S3 : P12 { // expected-error {{type 'S3' does not conform to protocol 'P12'}}
     func bar() -> P11 { return 0 }
-    // expected-note@-1 {{candidate can not infer 'A' = 'P11' because 'P11' is not a nominal type and so can't conform to 'P11'}}
+    // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{19-19=some }}
+}
+
+protocol P13 {
+  associatedtype A : P11 // expected-note {{unable to infer associated type 'A' for protocol 'P13'}}
+  var bar: A { get }
+}
+struct S4: P13 { // expected-error {{type 'S4' does not conform to protocol 'P13'}}
+  var bar: P11 { return 0 }
+  // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{12-12=some }}
 }
 
 // SR-12759


### PR DESCRIPTION
Protocol conformances for existential types are not supported today. If a programmers tries to fulfill an associated type with conformance requirements using an existential type, they'll get an unactionable error message:

```swift
protocol P1 {}
protocol P2 {
  associatedtype A: P1 // note: unable to infer associated type 'A' for protocol 'P2'
  var a: A { get }
}

struct S1: P1 {}
struct S2: P2 { // error: Type 'S2' does not conform to protocol 'P2'
  var a: P1 { S1() } // note: Candidate can not infer 'A' = 'P1' because 'P1' is not a nominal type and so can't conform to 'P1'
}
```

When the associated type was inferred from an existential result type, the compiler can suggest that the programmer use an opaque type instead by inserting `some`, which is usually a better solution for hiding a concrete return type behind a protocol:

```
note: cannot infer 'A' = 'P1' because 'P1' as a type cannot conform to protocols; did you mean to use an opaque result type?
  var a: P1 { S1() }
         ^~
         some 
```