### PR TITLE
Disable IRGen tests to unblock CI

### DIFF
--- a/test/IRGen/virtual-function-elimination-exec.swift
+++ b/test/IRGen/virtual-function-elimination-exec.swift
@@ -19,6 +19,9 @@
 // loaded too late").
 // REQUIRES: no_asan
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 class MyClass {
   func foo() { print("MyClass.foo") }
   func bar() { print("MyClass.bar") }

--- a/test/IRGen/witness-method-elimination-exec.swift
+++ b/test/IRGen/witness-method-elimination-exec.swift
@@ -19,6 +19,9 @@
 // loaded too late").
 // REQUIRES: no_asan
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 protocol TheProtocol {
   func func1_live()
   func func2_dead()

--- a/test/IRGen/witness-method-elimination-two-modules.swift
+++ b/test/IRGen/witness-method-elimination-two-modules.swift
@@ -40,6 +40,9 @@
 // loaded too late").
 // REQUIRES: no_asan
 
+// Disable to unblock CI
+// REQUIRES: rdar84643923
+
 #if LIBRARY
 
 public protocol MyProtocol {


### PR DESCRIPTION
Seeing failures in:
```
19:37:18 Failed Tests (3):
19:37:18   Swift(macosx-x86_64) :: IRGen/virtual-function-elimination-exec.swift
19:37:18   Swift(macosx-x86_64) :: IRGen/witness-method-elimination-exec.swift
19:37:18   Swift(macosx-x86_64) :: IRGen/witness-method-elimination-two-modules.swift
```
e.g. https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator//4847/console
Tracking in rdar://84643923
