### PR TITLE
[DepScanner] Do not remove the resource directory path

### DIFF
--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -126,7 +126,11 @@ import SubE
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
-// CHECK-NOT: "BUILD_DIR/bin/clang"
+// CHECK-NOT:  "BUILD_DIR/bin/clang"
+// CHECK:      "-Xcc"
+// CHECK-NEXT: "-resource-dir"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "BUILD_DIR/lib/swift/clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",


### PR DESCRIPTION
The clang importer sets the clang resource directory to
`RuntimeResourcePath`/clang (usually "lib/swift/clang", a symbolic link
into "lib/clang/<version>"). This was inadvertently being removed in a
check to remove the clang *executable* path.

Modify that check to only the first argument so the resource directory
is properly passed through.