### PR TITLE
[5.5] ConstantFolding: remove a wrong peephole optimization for signed "< 0" and ">= 0" comparisons

### DIFF
--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -476,48 +476,6 @@ static SILValue constantFoldCompare(BuiltinInst *BI, BuiltinValueKind ID) {
       return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
     }
   }
-
-  // Fold x < 0 into false, if x is known to be a result of an unsigned
-  // operation with overflow checks enabled.
-  BuiltinInst *BIOp;
-  if (match(BI, m_BuiltinInst(BuiltinValueKind::ICMP_SLT,
-                              m_TupleExtractOperation(m_BuiltinInst(BIOp), 0),
-                              m_Zero()))) {
-    // Check if Other is a result of an unsigned operation with overflow.
-    switch (BIOp->getBuiltinInfo().ID) {
-    default:
-      break;
-    case BuiltinValueKind::UAddOver:
-    case BuiltinValueKind::USubOver:
-    case BuiltinValueKind::UMulOver:
-      // Was it an operation with an overflow check?
-      if (match(BIOp->getOperand(2), m_One())) {
-        SILBuilderWithScope B(BI);
-        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt());
-      }
-    }
-  }
-
-  // Fold x >= 0 into true, if x is known to be a result of an unsigned
-  // operation with overflow checks enabled.
-  if (match(BI, m_BuiltinInst(BuiltinValueKind::ICMP_SGE,
-                              m_TupleExtractOperation(m_BuiltinInst(BIOp), 0),
-                              m_Zero()))) {
-    // Check if Other is a result of an unsigned operation with overflow.
-    switch (BIOp->getBuiltinInfo().ID) {
-    default:
-      break;
-    case BuiltinValueKind::UAddOver:
-    case BuiltinValueKind::USubOver:
-    case BuiltinValueKind::UMulOver:
-      // Was it an operation with an overflow check?
-      if (match(BIOp->getOperand(2), m_One())) {
-        SILBuilderWithScope B(BI);
-        return B.createIntegerLiteral(BI->getLoc(), BI->getType(), APInt(1, 1));
-      }
-    }
-  }
-
   return nullptr;
 }
 

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -470,10 +470,7 @@ bb0:
 // CHECK-NEXT: return %4 : $Builtin.Int64
 }
 
-// Fold x < 0 into false, if x is known to be a result of an unsigned
-// operation with overflow checks enabled.
-// At the same time x >= 0 is always true under the same conditions.
-sil @fold_unsigned_op_with_overflow_lt_zero : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
+sil @dont_fold_unsigned_op_with_overflow_lt_zero : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
 bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
  %zero  = integer_literal $Builtin.Int64, 0
  %2 = integer_literal $Builtin.Int1, -1
@@ -503,17 +500,10 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
 
  return %uadd_with_overflow_result : $Builtin.Int64
 
-// CHECK-LABEL: sil @fold_unsigned_op_with_overflow_lt_zero
+// CHECK-LABEL: sil @dont_fold_unsigned_op_with_overflow_lt_zero
 // CHECK: builtin "uadd_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0 
-// CHECK: integer_literal $Builtin.Int1, -1 
-// CHECK: builtin "usub_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0 
-// CHECK: integer_literal $Builtin.Int1, -1 
-// CHECK: builtin "umul_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0 
-// CHECK: integer_literal $Builtin.Int1, -1 
-// CHECK-NEXT: return {{.*}}$Builtin.Int64
+// CHECK-NOT: integer_literal
+// CHECK: } // end sil function 'dont_fold_unsigned_op_with_overflow_lt_zero'
 }
 
 

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -539,22 +539,11 @@ bb0:
 // CHECK-NEXT: return %4 : $Builtin.Int64
 }
 
-// Fold x < 0 into false, if x is known to be a result of an unsigned
-// operation with overflow checks enabled.
-// At the same time x >= 0 is always true under the same conditions.
-//
-// CHECK-LABEL: sil [ossa] @fold_unsigned_op_with_overflow_lt_zero :
+// CHECK-LABEL: sil [ossa] @dont_fold_unsigned_op_with_overflow_lt_zero :
 // CHECK: builtin "uadd_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK: builtin "usub_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK: builtin "umul_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: return {{.*}}$Builtin.Int64
-sil [ossa] @fold_unsigned_op_with_overflow_lt_zero : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
+// CHECK-NOT: integer_literal
+// CHECK: } // end sil function 'dont_fold_unsigned_op_with_overflow_lt_zero'
+sil [ossa] @dont_fold_unsigned_op_with_overflow_lt_zero : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
 bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
  %zero  = integer_literal $Builtin.Int64, 0
  %2 = integer_literal $Builtin.Int1, -1
@@ -585,18 +574,11 @@ bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
  return %uadd_with_overflow_result : $Builtin.Int64
 }
 
-// CHECK-LABEL: sil [ossa] @fold_unsigned_op_with_overflow_lt_zero_destructure :
+// CHECK-LABEL: sil [ossa] @dont_fold_unsigned_op_with_overflow_lt_zero_destructure :
 // CHECK: builtin "uadd_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK: builtin "usub_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK: builtin "umul_with_overflow_Int64"
-// CHECK: integer_literal $Builtin.Int1, 0
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK-NEXT: return {{.*}}$Builtin.Int64
-sil [ossa] @fold_unsigned_op_with_overflow_lt_zero_destructure : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
+// CHECK-NOT: integer_literal
+// CHECK: } // end sil function 'dont_fold_unsigned_op_with_overflow_lt_zero_destructure'
+sil [ossa] @dont_fold_unsigned_op_with_overflow_lt_zero_destructure : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 {
 bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
  %zero  = integer_literal $Builtin.Int64, 0
  %2 = integer_literal $Builtin.Int1, -1

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -116,6 +116,12 @@ RangeTraps.test("throughNaN")
   _ = ...Double.nan
 }
 
+RangeTraps.test("UIntOverflow")
+  .code {
+  expectCrashLater()
+  _blackHole((0 ..< UInt.max).count)
+}
+
 if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
   // Debug check was introduced in https://github.com/apple/swift/pull/34961
   RangeTraps.test("UncheckedHalfOpen")


### PR DESCRIPTION
The wrong optimization was: fold x < 0 into false, if x is known to be a result of an unsigned operation with overflow checks enabled.
It was done under the wrong assumption that the result of an overflow-checked unsigned operation fits into a signed integer and is positive.
This is wrong, because the result of an unsigned operation can be larger than Int.max and therefore, when used in a signed integer operation, be re-interpreted as a negative signed value.

Fixes a miscompile which resulted in a missing abort on arithmetic overflow.

This is a cherry-pick of https://github.com/apple/swift/pull/39938

rdar://73596890
