### PR TITLE
correct swift by default is a very dynamic language

### DIFF
--- a/docs/OptimizationTips.rst
+++ b/docs/OptimizationTips.rst
@@ -68,7 +68,7 @@ Module Optimization' by the abbreviation 'WMO'.
 Reducing Dynamic Dispatch
 =========================
 
-Swift by default is a very dynamic language like Objective-C. Unlike Objective-C,
+Swift by default is not a very dynamic language like Objective-C. Unlike Objective-C,
 Swift gives the programmer the ability to improve runtime performance when
 necessary by removing or reducing this dynamism. This section goes through
 several examples of language constructs that can be used to perform such an


### PR DESCRIPTION
<!-- What's in this pull request? -->
correct line 71 in OptimizationTips.rst that mention `swift by default is a very dynamic language` which is missing `Not`
