### PR TITLE
Add new libpthread dependencies to check_freestanding_dependencies.py for withUnsafeTemporaryAllocation()

### DIFF
--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -61,6 +61,7 @@ common_expected_dependencies = [
 vendor_apple_specific_dependencies = [
     "___stack_chk_fail", "___stack_chk_guard",
     "_getsectiondata", "__dyld_register_func_for_add_image",
+    "_pthread_get_stackaddr_np", "_pthread_get_stacksize_np", "_pthread_self",
 ]
 ################################################################################
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change updates check_freestanding_dependencies.py to include vendor-specific symbols that are used by the `withUnsafeTemporaryAllocation()` implementation.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://84739108.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
