### PR TITLE
Update SwiftWindowsSupport.cmake

### DIFF
--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -81,7 +81,7 @@ endfunction()
 # NOTE(compnerd) we use a macro here as this modifies global variables
 macro(swift_swap_compiler_if_needed target)
   if(NOT CMAKE_C_COMPILER_ID MATCHES Clang)
-    if(CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME)
+    if(CMAKE_SYSTEM_NAME STREQUAL CMAKE_HOST_SYSTEM_NAME AND CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
       if(SWIFT_BUILT_STANDALONE)
         get_target_property(CLANG_LOCATION clang LOCATION)
         get_filename_component(CLANG_LOCATION ${CLANG_LOCATION} DIRECTORY)


### PR DESCRIPTION
Do not attempt to use a cross-compiled compiler for a foreign target.  This is not guaranteed to work (e.g. building for ARM on x64).  This at least surfaces the error properly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
