### PR TITLE
Amend _swift_stdlib_getCurrentStackBounds() to do nothing when SWIFT_STDLIB_SINGLE_THREADED_RUNTIME is defined.

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -506,7 +506,12 @@ __swift_bool swift_stdlib_isStackAllocationSafe(__swift_size_t byteCount,
 
 __swift_bool _swift_stdlib_getCurrentStackBounds(__swift_uintptr_t *outBegin,
                                                  __swift_uintptr_t *outEnd) {
-#if defined(__APPLE__)
+#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+  // This platform does not support threads, so the API we'd call to get stack
+  // bounds (i.e. libpthread) is not going to be usable.
+  return false;
+  
+#elif defined(__APPLE__)
   pthread_t thread = pthread_self();
   // On Apple platforms, the stack grows down, so that the end of the stack
   // comes before the beginning on the number line, and an address on the stack


### PR DESCRIPTION
…STDLIB_SINGLE_THREADED_RUNTIME is defined.

<!-- What's in this pull request? -->
This change amends the new `_swift_stdlib_getCurrentStackBounds()` runtime call so that it returns immediately when `SWIFT_STDLIB_SINGLE_THREADED_RUNTIME` is defined. When that macro is defined, the expectation is that the current platform doesn't have libpthread or other thread mechanisms, so it has no way to query stack bounds.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://84739108.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
