### PR TITLE
[moveOnly] Move @_noImplicitCopy behind the flag -enable-experimental-move-only

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6036,6 +6036,10 @@ ERROR(wrap_invalid_attr_added_by_access_note, none,
 
 // Move Only diagnostics
 
+ERROR(experimental_moveonly_feature_can_only_be_used_when_enabled,
+      none, "Can not use feature when experimental move only is disabled! Pass"
+      " the frontend flag -enable-experimental-move-only to swift to enable "
+      "the usage of this language feature", ())
 ERROR(noimplicitcopy_attr_valid_only_on_local_let,
       none, "'@_noImplicitCopy' attribute can only be applied to local lets", ())
 ERROR(noimplicitcopy_attr_invalid_in_generic_context,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ImportCache.h"
@@ -270,6 +271,15 @@ public:
 } // end anonymous namespace
 
 void AttributeChecker::visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr) {
+  // Only allow for this attribute to be used when experimental move only is
+  // enabled.
+  if (!D->getASTContext().LangOpts.EnableExperimentalMoveOnly) {
+    auto error =
+        diag::experimental_moveonly_feature_can_only_be_used_when_enabled;
+    diagnoseAndRemoveAttr(attr, error);
+    return;
+  }
+
   auto *dc = D->getDeclContext();
   auto *vd = dyn_cast<VarDecl>(D);
   if (!vd) {

--- a/test/Sema/noimplicitcopy_attr.swift
+++ b/test/Sema/noimplicitcopy_attr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -parse-stdlib -disable-availability-checking -verify-syntax-tree
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only -parse-stdlib -disable-availability-checking -verify-syntax-tree
 
 import Swift
 

--- a/test/Sema/noimplicitcopy_attr_check_behind_flag.swift
+++ b/test/Sema/noimplicitcopy_attr_check_behind_flag.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib -disable-availability-checking -verify-syntax-tree
+
+class Klass {}
+
+func useKlass(_ k: Klass) {}
+
+// Make sure that we properly error when someone uses no implicit copy without
+// setting -enable-experimental-move-only.
+func letDecls(_ x: Klass) -> () {
+    @_noImplicitCopy let y: Klass = x // expected-error {{Can not use feature when experimental move only is disabled! Pass the frontend flag -enable-experimental-move-only to swift to enable the usage of this language feature}}
+    useKlass(y)
+}


### PR DESCRIPTION
I included a helpful diagnostic that explains to the user that they need to pass
-enable-experimental-move-only to use this language feature.
