### PR TITLE
[moveOnly] Add a new experimental move only checker that checks noImplicitCopy variables.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -690,5 +690,16 @@ NOTE(capturepromotion_variable_defined_here,none,
 ERROR(move_operator_used_on_generic_or_existential_value, none,
       "move() used on a generic or existential value", ())
 
+// noimplicitcopy on generic or existential binding
+ERROR(noimplicitcopy_used_on_generic_or_existential, none,
+      "@_noImplicitCopy can not be used on a generic or existential typed "
+      "binding or a nominal type containing such typed things", ())
+
+// move only checker diagnostics
+ERROR(sil_moveonlychecker_value_consumed_more_than_once, none,
+      "'%0' consumed more than once", (StringRef))
+NOTE(sil_moveonlychecker_consuming_use_here, none,
+     "consuming use", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -174,6 +174,18 @@ inline SILInstruction *getSingleNonDebugUser(SILValue V) {
   return I->getUser();
 }
 
+/// If \p value has a single debug user, return the operand associated with that
+/// use. Otherwise, returns nullptr.
+inline Operand *getSingleDebugUse(SILValue value) {
+  auto range = getDebugUses(value);
+  auto ii = range.begin(), ie = range.end();
+  if (ii == ie)
+    return nullptr;
+  if (std::next(ii) != ie)
+    return nullptr;
+  return *ii;
+}
+
 /// Erases the instruction \p I from it's parent block and deletes it, including
 /// all debug instructions which use \p I.
 /// Precondition: The instruction may only have debug instructions as uses.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -416,6 +416,8 @@ PASS(BugReducerTester, "bug-reducer-tester",
      "sil-bug-reducer Tool Testing by Asserting on a Sentinel Function")
 PASS(AssemblyVisionRemarkGenerator, "assembly-vision-remark-generator",
      "Emit assembly vision remarks that provide source level guidance of where runtime calls ended up")
+PASS(MoveOnlyChecker, "sil-move-only-checker",
+     "Pass that enforces move only invariants on raw SIL")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(swiftSILOptimizer PRIVATE
   IRGenPrepare.cpp
   LowerHopToActor.cpp
   MandatoryInlining.cpp
+  MoveOnlyChecker.cpp
   NestedSemanticFunctionCheck.cpp
   OptimizeHopToExecutor.cpp
   PredictableMemOpt.cpp

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -1,0 +1,191 @@
+//===--- MoveOnlyChecker.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-move-only-checker"
+
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/Basic/Defer.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/ClosureScope.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                            Diagnostic Utilities
+//===----------------------------------------------------------------------===//
+
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+//===----------------------------------------------------------------------===//
+//                                 Main Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct MoveOnlyChecker {
+  SILFunction *fn;
+
+  MoveOnlyChecker(SILFunction *fn) : fn(fn) {}
+  bool check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
+             DominanceInfo *domTree);
+};
+
+} // namespace
+
+bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
+                            DominanceInfo *domTree) {
+  SmallSetVector<MoveValueInst *, 32> moveIntroducersToProcess;
+
+  for (auto &block : *fn) {
+    for (auto &ii : block) {
+      auto *mvi = dyn_cast<MoveValueInst>(&ii);
+      // For now only handle move_only.
+      if (!mvi)
+        continue;
+      auto *cvi = dyn_cast<CopyValueInst>(mvi->getOperand());
+      if (!cvi)
+        continue;
+      auto *bbi = dyn_cast<BeginBorrowInst>(cvi->getOperand());
+      if (!bbi || !bbi->isLexical())
+        continue;
+      moveIntroducersToProcess.insert(mvi);
+    }
+  }
+
+  auto callbacks =
+      InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
+        if (auto *mvi = dyn_cast<MoveValueInst>(instToDelete))
+          moveIntroducersToProcess.remove(mvi);
+        instToDelete->eraseFromParent();
+      });
+  InstructionDeleter deleter(std::move(callbacks));
+  bool changed = false;
+
+  SmallVector<Operand *, 32> consumingUsesNeedingCopy;
+  auto foundConsumingUseNeedingCopy = [&](Operand *use) {
+    consumingUsesNeedingCopy.push_back(use);
+  };
+  SmallVector<Operand *, 32> consumingUsesNotNeedingCopy;
+  auto foundConsumingUseNotNeedingCopy = [&](Operand *use) {
+    consumingUsesNotNeedingCopy.push_back(use);
+  };
+
+  CanonicalizeOSSALifetime canonicalizer(
+      false /*pruneDebugMode*/, false /*poisonRefsMode*/, accessBlockAnalysis,
+      domTree, deleter, foundConsumingUseNeedingCopy,
+      foundConsumingUseNotNeedingCopy);
+  auto &astContext = fn->getASTContext();
+  auto movesToProcess = llvm::makeArrayRef(moveIntroducersToProcess.begin(),
+                                           moveIntroducersToProcess.end());
+  while (!movesToProcess.empty()) {
+    SWIFT_DEFER {
+      consumingUsesNeedingCopy.clear();
+      consumingUsesNotNeedingCopy.clear();
+    };
+
+    SILValue movedValue = movesToProcess.front();
+    movesToProcess = movesToProcess.drop_front(1);
+    LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *movedValue);
+    changed |= canonicalizer.canonicalizeValueLifetime(movedValue);
+
+    if (consumingUsesNeedingCopy.empty())
+      continue;
+
+    StringRef varName = "unknown";
+    if (auto *use = getSingleDebugUse(movedValue)) {
+      DebugVarCarryingInst debugVar(use->getUser());
+      if (auto varInfo = debugVar.getVarInfo()) {
+        varName = varInfo->Name;
+      } else {
+        if (auto *decl = debugVar.getDecl()) {
+          varName = decl->getBaseName().userFacingName();
+        }
+      }
+    }
+
+    diagnose(astContext,
+             movedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_value_consumed_more_than_once, varName);
+
+    while (consumingUsesNeedingCopy.size()) {
+      auto *consumingUse = consumingUsesNeedingCopy.pop_back_val();
+      diagnose(astContext, consumingUse->getUser()->getLoc().getSourceLoc(),
+               diag::sil_moveonlychecker_consuming_use_here);
+    }
+
+    while (consumingUsesNotNeedingCopy.size()) {
+      auto *consumingUse = consumingUsesNotNeedingCopy.pop_back_val();
+      diagnose(astContext, consumingUse->getUser()->getLoc().getSourceLoc(),
+               diag::sil_moveonlychecker_consuming_use_here);
+    }
+  }
+
+  // Now go back through all of the move_value and change their copy_value to be
+  // on the operand of the lexical begin_borrow that introduced it.
+  while (!moveIntroducersToProcess.empty()) {
+    auto *mvi = moveIntroducersToProcess.pop_back_val();
+    auto *cvi = cast<CopyValueInst>(mvi->getOperand());
+    auto *bbi = cast<BeginBorrowInst>(cvi->getOperand());
+    cvi->setOperand(bbi->getOperand());
+    changed = true;
+  }
+
+  return changed;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MoveOnlyCheckerPass : public SILFunctionTransform {
+  void run() override {
+    auto *fn = getFunction();
+
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
+    assert(fn->getModule().getStage() == SILStage::Raw &&
+           "Should only run on Raw SIL");
+
+    auto *accessBlockAnalysis = getAnalysis<NonLocalAccessBlockAnalysis>();
+    auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
+    DominanceInfo *domTree = dominanceAnalysis->get(fn);
+
+    if (MoveOnlyChecker(getFunction()).check(accessBlockAnalysis, domTree)) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // anonymous namespace
+
+SILTransform *swift::createMoveOnlyChecker() {
+  return new MoveOnlyCheckerPass();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -164,6 +164,9 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // dead allocations.
   P.addPredictableDeadAllocationElimination();
 
+  // Now perform move only checking.
+  P.addMoveOnlyChecker();
+
   P.addOptimizeHopToExecutor();
 
   P.addDiagnoseUnreachable();

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -86,6 +86,12 @@ STATISTIC(NumUnknownUsers, "number of functions with unknown users");
 //                           MARK: General utilities
 //===----------------------------------------------------------------------===//
 
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
 /// The lifetime extends beyond given consuming use. Copy the value.
 ///
 /// This can set the operand value, but cannot invalidate the use iterator.
@@ -626,19 +632,32 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
 
     // If this use was not marked as a final destroy *or* this is not the first
     // consumed operand we visited, then it needs a copy.
-    if (!consumes.claimConsume(user))
+    if (!consumes.claimConsume(user)) {
+      maybeNotifyMoveOnlyCopy(use);
       return false;
+    }
 
     // Final consumes that need poison, also need a copy.
-    if (consumes.needsPoison(user))
+    if (consumes.needsPoison(user)) {
+      maybeNotifyMoveOnlyCopy(use);
       return false;
+    }
 
     // If another destroy is reachable on this path, then this consume needs
     // poison even though findOrInsertDestroyInBlock didn't know that.
     if (remnantLiveOutBlocks.count(user->getParent())) {
       consumes.recordNeedsPoison(user);
+      maybeNotifyMoveOnlyCopy(use);
       return false;
     }
+
+    // Ok, this is a final user that isn't a destroy_value. Notify our caller if
+    // we were asked to.
+    //
+    // If we need this for diagnostics, we will only use it if we found actual
+    // uses that required copies.
+    maybeNotifyFinalConsumingUse(use);
+
     return true;
   };
 
@@ -776,6 +795,7 @@ bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
   initDef(def);
   // Step 1: compute liveness
   if (!computeCanonicalLiveness()) {
+    LLVM_DEBUG(llvm::errs() << "Failed to compute canonical liveness?!\n");
     clearLiveness();
     return false;
   }

--- a/test/SILOptimizer/move_only_checker.swift
+++ b/test/SILOptimizer/move_only_checker.swift
@@ -1,0 +1,359 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
+
+import Swift
+
+public class Klass {
+    var k: Klass? = nil
+}
+
+var boolValue: Bool { return true }
+
+public func classUseMoveOnlyWithoutEscaping(_ x: Klass) {
+}
+public func classConsume(_ x: __owned Klass) {
+}
+
+public func classSimpleChainTest(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    let y2 = x2
+    let k2 = y2
+    classUseMoveOnlyWithoutEscaping(k2)
+}
+
+public func classSimpleNonConsumingUseTest(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    classUseMoveOnlyWithoutEscaping(x2)
+}
+
+public func classMultipleNonConsumingUseTest(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    classUseMoveOnlyWithoutEscaping(x2)
+    classUseMoveOnlyWithoutEscaping(x2)
+    print(x2)
+}
+
+public func classUseAfterConsume(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    classUseMoveOnlyWithoutEscaping(x2)
+    classConsume(x2) // expected-note {{consuming use}}
+    print(x2) // expected-note {{consuming use}}
+}
+
+public func classDoubleConsume(_ x: Klass) {
+    @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
+    classConsume(x2) // expected-note {{consuming use}}
+    classConsume(x2) // expected-note {{consuming use}}
+}
+
+public func classLoopConsume(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+        classConsume(x2) // expected-note {{consuming use}}
+    }
+}
+
+public func classDiamond(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    if boolValue {
+        classConsume(x2)
+    } else {
+        classConsume(x2)
+    }
+}
+
+public func classDiamondInLoop(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+      if boolValue {
+          classConsume(x2) // expected-note {{consuming use}}
+      } else {
+          classConsume(x2) // expected-note {{consuming use}}
+      }
+    }
+}
+
+public func classAssignToVar1(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    var x3 = x2 // expected-note {{consuming use}}
+    x3 = x2 // expected-note {{consuming use}}
+    x3 = x
+    print(x3)
+}
+
+public func classAssignToVar2(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    var x3 = x2 // expected-note {{consuming use}}
+    x3 = x2 // expected-note {{consuming use}}
+    classUseMoveOnlyWithoutEscaping(x3)
+}
+
+public func classAssignToVar3(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    var x3 = x2
+    x3 = x
+    print(x3)
+}
+
+public func classAssignToVar4(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x3 = x2 // expected-note {{consuming use}}
+    print(x2) // expected-note {{consuming use}}
+    print(x3)
+}
+
+public func classAssignToVar5(_ x: Klass) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    var x3 = x2 // expected-note {{consuming use}}
+    // TODO: Need to mark this as the lifetime extending use. We fail
+    // appropriately though.
+    classUseMoveOnlyWithoutEscaping(x2)
+    x3 = x
+    print(x3)
+}
+
+public func classAccessField(_ x: Klass) {
+    @_noImplicitCopy let x2 = x
+    print(x2.k!)
+    for _ in 0..<1024 {
+        print(x2.k!)
+    }
+}
+
+//////////////////////
+// Aggregate Struct //
+//////////////////////
+
+public struct AggStruct {
+    var lhs: Klass
+    var center: Builtin.Int32
+    var rhs: Klass
+}
+
+public func aggStructUseMoveOnlyWithoutEscaping(_ x: AggStruct) {
+}
+public func aggStructConsume(_ x: __owned AggStruct) {
+}
+
+public func aggStructSimpleChainTest(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x
+    let y2 = x2
+    let k2 = y2
+    aggStructUseMoveOnlyWithoutEscaping(k2)
+}
+
+public func aggStructSimpleNonConsumingUseTest(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x
+    aggStructUseMoveOnlyWithoutEscaping(x2)
+}
+
+public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x
+    aggStructUseMoveOnlyWithoutEscaping(x2)
+    aggStructUseMoveOnlyWithoutEscaping(x2)
+    print(x2)
+}
+
+public func aggStructUseAfterConsume(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    aggStructUseMoveOnlyWithoutEscaping(x2)
+    aggStructConsume(x2) // expected-note {{consuming use}}
+    print(x2) // expected-note {{consuming use}}
+}
+
+public func aggStructDoubleConsume(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
+    aggStructConsume(x2) // expected-note {{consuming use}}
+    aggStructConsume(x2) // expected-note {{consuming use}}
+}
+
+public func aggStructLoopConsume(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+        aggStructConsume(x2) // expected-note {{consuming use}}
+    }
+}
+
+public func aggStructDiamond(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x
+    if boolValue {
+        aggStructConsume(x2)
+    } else {
+        aggStructConsume(x2)
+    }
+}
+
+public func aggStructDiamondInLoop(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+      if boolValue {
+          aggStructConsume(x2) // expected-note {{consuming use}}
+      } else {
+          aggStructConsume(x2) // expected-note {{consuming use}}
+      }
+    }
+}
+
+public func aggStructAccessField(_ x: AggStruct) {
+    @_noImplicitCopy let x2 = x
+    print(x2.lhs)
+    for _ in 0..<1024 {
+        print(x2.lhs)
+    }
+}
+
+//////////////////////////////
+// Aggregate Generic Struct //
+//////////////////////////////
+
+public struct AggGenericStruct<T> {
+    var lhs: Klass
+    var rhs: Builtin.RawPointer
+}
+
+public func aggGenericStructUseMoveOnlyWithoutEscaping(_ x: AggGenericStruct<Klass>) {
+}
+public func aggGenericStructConsume(_ x: __owned AggGenericStruct<Klass>) {
+}
+
+public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x
+    let y2 = x2
+    let k2 = y2
+    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+}
+
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+}
+
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    print(x2)
+}
+
+public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    print(x2) // expected-note {{consuming use}}
+}
+
+public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+}
+
+public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+        aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    }
+}
+
+public func aggGenericStructDiamond(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x
+    if boolValue {
+        aggGenericStructConsume(x2)
+    } else {
+        aggGenericStructConsume(x2)
+    }
+}
+
+public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+      if boolValue {
+          aggGenericStructConsume(x2) // expected-note {{consuming use}}
+      } else {
+          aggGenericStructConsume(x2) // expected-note {{consuming use}}
+      }
+    }
+}
+
+public func aggGenericStructAccessField(_ x: AggGenericStruct<Klass>) {
+    @_noImplicitCopy let x2 = x
+    print(x2.lhs)
+    for _ in 0..<1024 {
+        print(x2.lhs)
+    }
+}
+
+////////////////////////////////////////////////////////////
+// Aggregate Generic Struct + Generic But Body is Trivial //
+////////////////////////////////////////////////////////////
+
+public func aggGenericStructUseMoveOnlyWithoutEscaping<T>(_ x: AggGenericStruct<T>) {
+}
+public func aggGenericStructConsume<T>(_ x: __owned AggGenericStruct<T>) {
+}
+
+public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x
+    let y2 = x2
+    let k2 = y2
+    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+}
+
+public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+}
+
+public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    print(x2)
+}
+
+public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    print(x2) // expected-note {{consuming use}}
+}
+
+public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x  // expected-error {{'x2' consumed more than once}}
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    aggGenericStructConsume(x2) // expected-note {{consuming use}}
+}
+
+public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+        aggGenericStructConsume(x2) // expected-note {{consuming use}}
+    }
+}
+
+public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x
+    if boolValue {
+        aggGenericStructConsume(x2)
+    } else {
+        aggGenericStructConsume(x2)
+    }
+}
+
+public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    for _ in 0..<1024 {
+      if boolValue {
+          aggGenericStructConsume(x2) // expected-note {{consuming use}}
+      } else {
+          aggGenericStructConsume(x2) // expected-note {{consuming use}}
+      }
+    }
+}
+
+public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) {
+    @_noImplicitCopy let x2 = x
+    print(x2.lhs)
+    for _ in 0..<1024 {
+        print(x2.lhs)
+    }
+}

--- a/test/SILOptimizer/move_only_checker_addressonly_fail.swift
+++ b/test/SILOptimizer/move_only_checker_addressonly_fail.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
+
+func useValue<T>(_ x: T) {}
+func consumeValue<T>(_ x: __owned T) {}
+
+struct GenericAggregate<T> {
+    var value: T
+}
+
+func test1<T>(_ x: T) {
+    @_noImplicitCopy let x2 = x // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+    consumeValue(x2)
+    consumeValue(x2)
+}


### PR DESCRIPTION
NOTE: This is only available when the flag -enable-experimental-move-only. There
are no effects when the flag is disabled.

The way that this works is that it takes advantage of the following changes to
SILGen emission:

* When SILGen initializes a let with NoImplicitCopyAttribute, SILGen now emits
a begin_borrow [lexical] + copy + move_only. This is a pattern that we can check
and know that we are processing a move only value. When performing move
checking, we check move_only as a move only value and that it isn't consumed
multiple times.

* The first point works well for emitting all diagnostics except for
initializing an additional let var. To work around that I changed let
initialization to always bind to an owned value to a move of that owned
value. There is no semantic difference since that value is going to be consumed
by the binding operation anyways so we effectively just move the cleanup from
the original value we wanted to bind to the move. We still then actually borrow
the new let value with a begin_borrow [lexical] for the new let value. This
ensures that an initialization of a let value appears to be a consuming use to
the move only value checker while ensuring that the value has a proper
begin_borrow [lexical].

Some notes on functionality:

1. This attribute can only be applied to local 'let'.

2. "print" due to how we call it today with a vararg array is treated as a
   consuming use (unfortunately).

3. I have not added the builtin copy operator yet, but I recently added a _move
   skeleton attribute so one can end the lifetimes of these values early.

4. This supports all types that are not address only types (similar to
   _move). To support full on address only types we need opaque values.

rdar://83957088

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
