### PR TITLE
[5.5] [SILGen] Handled foreign funcs with async, error, and more args.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3270,26 +3270,33 @@ private:
   }
   
   void maybeEmitForeignArgument() {
-    if (Foreign.async
-        && Foreign.async->completionHandlerParamIndex() == Args.size()) {
-      SILParameterInfo param = claimNextParameters(1).front();
-      (void)param;
+    bool keepGoing = true;
+    while (keepGoing) {
+      keepGoing = false;
+      if (Foreign.async &&
+          Foreign.async->completionHandlerParamIndex() == Args.size()) {
+        SILParameterInfo param = claimNextParameters(1).front();
+        (void)param;
 
-      // Leave a placeholder in the position. We'll fill this in with a block
-      // capturing the current continuation right before we invoke the
-      // function.
-      // (We can't do this immediately, because evaluating other arguments
-      // may require suspending the async task, which is not allowed while its
-      // continuation is active.)
-      Args.push_back(ManagedValue::forInContext());
-    } else if (Foreign.error
-               && Foreign.error->getErrorParameterIndex() == Args.size()) {
-      SILParameterInfo param = claimNextParameters(1).front();
-      assert(param.getConvention() == ParameterConvention::Direct_Unowned);
-      (void) param;
+        // Leave a placeholder in the position. We'll fill this in with a block
+        // capturing the current continuation right before we invoke the
+        // function.
+        // (We can't do this immediately, because evaluating other arguments
+        // may require suspending the async task, which is not allowed while its
+        // continuation is active.)
+        Args.push_back(ManagedValue::forInContext());
+        keepGoing = true;
+      }
+      if (Foreign.error &&
+          Foreign.error->getErrorParameterIndex() == Args.size()) {
+        SILParameterInfo param = claimNextParameters(1).front();
+        assert(param.getConvention() == ParameterConvention::Direct_Unowned);
+        (void)param;
 
-      // Leave a placeholder in the position.
-      Args.push_back(ManagedValue::forInContext());
+        // Leave a placeholder in the position.
+        Args.push_back(ManagedValue::forInContext());
+        keepGoing = true;
+      }
     }
   }
 
@@ -3515,7 +3522,9 @@ struct ParamLowering {
       }
     }
 
-    if (foreign.error || foreign.async)
+    if (foreign.error)
+      ++count;
+    if (foreign.async)
       ++count;
 
     if (foreign.self.isImportAsMember()) {
@@ -4172,18 +4181,12 @@ ApplyOptions CallEmission::emitArgumentsForNormalApply(
 
     args.push_back({});
 
-    if (!foreign.async || (foreign.async && foreign.error)) {
-      // Claim the foreign error argument(s) with the method formal params.
-      auto siteForeignError = CalleeTypeInfo::ForeignInfo{foreign.error, {}, {}};
-      std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
-                                args.back(), delayedArgs, siteForeignError);
-    }
-    if (foreign.async) {
-      // Claim the foreign async argument(s) with the method formal params.
-      auto siteForeignAsync = CalleeTypeInfo::ForeignInfo{{}, foreign.async, {}};
-      std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
-                                args.back(), delayedArgs, siteForeignAsync);
-    }
+    // Claim the foreign error and/or async arguments when claiming the formal
+    // params.
+    auto siteForeignError = CalleeTypeInfo::ForeignInfo{foreign.error, foreign.async, {}};
+    // Claim the method formal params.
+    std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
+                              args.back(), delayedArgs, siteForeignError);
   }
 
   uncurriedLoc = callSite->Loc;

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_3.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_3.h
@@ -1,0 +1,28 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(int status, NSInteger bytesTransferred);
+
+@interface PFXObject : NSObject
+- (BOOL)enqueueFailingRequestWithData:(nullable NSMutableData *)data
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+- (BOOL)enqueuePassingRequestWithData:(nullable NSMutableData *)data
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+- (BOOL)enqueueFailingRequestWithData:(nullable NSMutableData *)data
+                    completionTimeout:(NSTimeInterval)completionTimeout
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+- (BOOL)enqueuePassingRequestWithData:(nullable NSMutableData *)data
+                    completionTimeout:(NSTimeInterval)completionTimeout
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_3.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_3.m
@@ -1,0 +1,45 @@
+#include "rdar80704984_3.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+
+- (BOOL)enqueueFailingRequestWithData:(nullable NSMutableData *)data
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  *error = [[NSError alloc] initWithDomain:@"d" code:1 userInfo:nil];
+  return NO;
+}
+- (BOOL)enqueuePassingRequestWithData:(nullable NSMutableData *)data
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler(0, 2);
+  });
+  return YES;
+}
+
+- (BOOL)enqueueFailingRequestWithData:(nullable NSMutableData *)data
+                    completionTimeout:(NSTimeInterval)completionTimeout
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  *error = [[NSError alloc] initWithDomain:@"d" code:2 userInfo:nil];
+  return NO;
+}
+- (BOOL)enqueuePassingRequestWithData:(nullable NSMutableData *)data
+                    completionTimeout:(NSTimeInterval)completionTimeout
+                                error:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler(0, 3);
+  });
+  return YES;
+}
+
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704984_3.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704984_3.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704984_3.m -I %S/Inputs -c -o %t/rdar80704984_3.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704984_3.h -Xlinker %t/rdar80704984_3.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// rdar://82123254
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+func run1(on object: PFXObject) async throws {
+  do {
+    _ = try await object.enqueueFailingRequest(with: nil)
+  }
+  catch let error {
+    // CHECK: Domain=d Code=1 
+    print(error)
+  }
+}
+
+func run2(on object: PFXObject) async throws {
+    // CHECK: (0, 2)
+    print(try await object.enqueuePassingRequest(with: nil))
+  
+}
+
+func run3(on object: PFXObject) async throws {
+  do {
+    _ = try await object.enqueueFailingRequest(with: nil, completionTimeout: 57.0)
+  }
+  catch let error {
+    // CHECK: Domain=d Code=2 
+    print(error)
+  }
+}
+
+func run4(on object: PFXObject) async throws {
+    // CHECK: (0, 3)
+    print(try await object.enqueuePassingRequest(with: nil, completionTimeout: 57.0))
+  
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run1(on: object)
+    try await run2(on: object)
+    try await run3(on: object)
+    try await run4(on: object)
+  }
+}


### PR DESCRIPTION
5.5 Summary: Fix compiler crashes during emission of calls-as-async to ObjC functions that take error out parameters and other parameters.

---

Explanation: When an ObjC method is called-as-async from Swift, SILGen generates code to handle ObjC's conventions around error handling.  A called-as-async ObjC method can communicate an error eithej via its completion handler or via with an error out-parameter as in
```
- (BOOL)minimalWithError:(NSError* _Nullable*)error
         completionHandler:(void (^ _Nonnull)(void))completionHandler;
```

Earlier, an earlier patch added the machinery to deal with ObjC functions that had a top-level error and also were called as async; in various places it was assumed that methods could either be called-as-async, or alternatively have an error out parameter but not both.  That patch addressed most of the places where that assumption was employed, but it missed a couple.  Because those spots were missed, it also added a few lines of code to specially match up the completion handler argument.  That patch worked with the case above, but did not work with more complicated cases like
```
- (BOOL)biggerWithError:(NSError* _Nullable*)error
                   data:(NSMutableData *)data
      completionHandler:(void (^ _Nonnull)(void))completionHandler;
```
Here, the missing spots where that assumption was employed are corrected, and those few lines of code are removed.

Issue: rdar://80704984
Original PR: https://github.com/apple/swift/pull/39957
Testing: New regression tests, Swift CI
Reviewed by: Joe Groff
Risk: Low.
Scope: Limited to calls to ObjC methods called as async that have both error and async parameters.