### PR TITLE
[stdlib] Introduce availability macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,18 @@ if(SWIFT_ENABLE_DISPATCH AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   endif()
 endif()
 
+set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS
+  "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2"
+  "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
+  "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4"
+  "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"
+  "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5"
+  "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0"
+  "SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"
+  "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" # Unknown future release
+  CACHE STRING
+  "Availability macros for stdlib versions")
+
 #
 # Include CMake modules
 #

--- a/docs/StandardLibraryProgrammersManual.md
+++ b/docs/StandardLibraryProgrammersManual.md
@@ -298,7 +298,7 @@ Just like access control modifiers, we prefer to put `@available` attributes on 
 
 ```swift
 // 😢👎
-@available(macOS 10.6, iOS 10, watchOS 3, tvOS 12, *)
+@available(SwiftStdlib 5.2, *)
 extension String {
   public func blanch() { ... }
   public func roast() { ... }
@@ -306,26 +306,55 @@ extension String {
 
 // 🥲👍
 extension String {
-  @available(macOS 10.6, iOS 10, watchOS 3, tvOS 12, *)
+  @available(SwiftStdlib 5.2, *)
   public func blanch() { ... }
 
-  @available(macOS 10.6, iOS 10, watchOS 3, tvOS 12, *)
+  @available(SwiftStdlib 5.2, *)
   public func roast() { ... }
 }
 ```
 
 This coding style is enforced by the ABI checker -- it will complain if an extension member declaration that needs an availability doesn't have it directly attached.
 
-Features under development that haven't been released yet must be marked with the placeholder version number `9999`. This special version is always considered available in custom builds of the Swift toolchain (including development snapshots), but not in any ABI-stable production release.
+This repository defines a set of availability macros (of the form `SwiftStdlib x.y`) that map Swift Stdlib releases to the OS versions that shipped them, for all ABI stable platforms. The following two definitions are equivalent, but the second one is less error-prone, so we prefer that:
 
 ```swift
+extension String {
+  // 😵‍💫👎
+  @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+  public func fiddle() { ... }
+
+  // 😎👍
+  @available(SwiftStdlib 5.2, *)
+  public func fiddle() { ... }
+}
+```
+
+(Mistakes in the OS version number list are very easy to miss during review, but can have major ABI consequences.)
+
+This is especially important for newly introduced APIs, where the corresponding OS releases may not even be known yet. 
+
+Features under development that haven't shipped yet must be marked as available in the placeholder OS version `9999`. This special version is always considered available in custom builds of the Swift toolchain (including development snapshots), but not in any ABI-stable production release. 
+
+Never explicitly spell out such placeholder availability -- instead, use the `SwiftStdlib` macro corresponding to the Swift version we're currently working on:
+
+```swift
+// 😵‍💫👎
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public struct FutureFeature {
+  ...
+}
+
+// 😎👍
+@available(SwiftStdlib 6.3, *) // Or whatever
 public struct FutureFeature {
   ...
 }
 ```
 
-On these platforms, the Swift Standard Library ships as an integrated part of the operating system; as such, it is the platform owners' responsibility to update these placeholder version numbers to actual versions as part of their release process.
+This way, platform owners can easily update declarations to the correct set of version numbers by simply changing the definition of the macro, rather than having to update each individual declaration.
+
+If we haven't defined a version number for the "next" Swift release yet, please use the special placeholder version `SwiftStdlib 9999`, which always expands to 9999 versions. Declarations that use this version will need to be manually updated once we decide on the corresponding Swift version number.
 
 ## Internals
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -927,7 +927,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
   if (!getMainExecutorFuncDecl) {
     // If it doesn't exist due to an SDK-compiler mismatch, we can conjure one
     // up instead of crashing:
-    // @available(SwiftStdlib 5.5, *)
+    // @available(SwiftStdlib 5.1, *)
     // @_silgen_name("swift_task_getMainExecutor")
     // internal func _getMainExecutor() -> Builtin.Executor
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1722,6 +1722,11 @@ function(add_swift_target_library name)
         "Either SHARED, STATIC, or OBJECT_LIBRARY must be specified")
   endif()
 
+  # Define availability macros.
+  foreach(def ${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS})
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend" "-define-availability" "-Xfrontend" "${def}") 
+  endforeach()
+  
   # In the standard library and overlays, warn about implicit overrides
   # as a reminder to consider when inherited protocols need different
   # behavior for their requirements.

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -56,7 +56,7 @@ add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   SWIFT_MODULE_DEPENDS_WINDOWS CRT WinSDK
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
+    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}"
   LINK_LIBRARIES ${swift_stdlib_unittest_link_libraries})

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -55,8 +55,6 @@ add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_MODULE_DEPENDS_WINDOWS CRT WinSDK
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-    -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}"
   LINK_LIBRARIES ${swift_stdlib_unittest_link_libraries})

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -880,7 +880,7 @@ func _childProcess() {
 }
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @inline(never)
 func _childProcessAsync() async {
   _installTrapInterceptor()
@@ -1375,7 +1375,7 @@ class _ParentProcess {
   }
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   internal func runOneTestAsync(
     fullTestName: String,
     testSuite: TestSuite,
@@ -1542,7 +1542,7 @@ class _ParentProcess {
   }
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   func runAsync() async {
     if let filter = _filter {
       print("StdlibUnittest: using filter: \(filter)")
@@ -1727,7 +1727,7 @@ public func runAllTests() {
 }
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func runAllTestsAsync() async {
   if PersistentState.runNoTestsWasCalled {
     print("runAllTests() called after runNoTests(). Aborting.")
@@ -1915,7 +1915,7 @@ public final class TestSuite {
   }
 
 #if SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   func _runTestAsync(name testName: String, parameter: Int?) async {
     PersistentState.ranSomething = true
     for r in _allResettables {

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -17,7 +17,7 @@ import Swift
 ///
 /// The `Actor` protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol Actor: AnyObject, Sendable {
 
   /// Retrieve the executor for this actor as an optimized, unowned
@@ -37,17 +37,17 @@ public protocol Actor: AnyObject, Sendable {
 
 /// Called to initialize the default actor instance in an actor.
 /// The implementation will call this within the actor's initializer.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_defaultActor_initialize")
 public func _defaultActorInitialize(_ actor: AnyObject)
 
 /// Called to destroy the default actor instance in an actor.
 /// The implementation will call this within the actor's deinit.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_defaultActor_destroy")
 public func _defaultActorDestroy(_ actor: AnyObject)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_enqueueMainExecutor")
 @usableFromInline
 internal func _enqueueOnMain(_ job: UnownedJob)

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that maps the given closure over the
   /// asynchronous sequence’s elements, omitting results that don't return a
@@ -55,7 +55,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that maps a given closure over the asynchronous
 /// sequence’s elements, omitting results that don't return a value.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -73,7 +73,7 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncCompactMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Omits a specified number of elements from the base asynchronous sequence,
   /// then passes through all remaining elements.
@@ -48,7 +48,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence which omits a specified number of elements from the
 /// base asynchronous sequence, then passes through all remaining elements.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -63,7 +63,7 @@ public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropFirstSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///
@@ -116,7 +116,7 @@ extension AsyncDropFirstSequence: AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropFirstSequence {
   /// Omits a specified number of elements from the base asynchronous sequence,
   /// then passes through all remaining elements.

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Omits elements from the base asynchronous sequence until a given closure
   /// returns false, after which it passes through all remaining elements.
@@ -52,7 +52,7 @@ extension AsyncSequence {
 /// An asynchronous sequence which omits elements from the base sequence until a
 /// given closure returns false, after which it passes through all remaining
 /// elements.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -70,7 +70,7 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropWhileSequence: AsyncSequence {
   
   /// The type of element produced by this asynchronous sequence.

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that contains, in order, the elements of
   /// the base sequence that satisfy the given predicate.
@@ -43,7 +43,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that contains, in order, the elements of
 /// the base sequence that satisfy a given predicate.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -61,7 +61,7 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncFilterSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that concatenates the results of calling
   /// the given transformation with each element of this sequence.
@@ -49,7 +49,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that concatenates the results of calling a given
 /// transformation with each element of this sequence.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -67,7 +67,7 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncFlatMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -84,7 +84,7 @@ import Swift
 /// If the iterator needs to clean up on cancellation, it can do so after
 /// checking for cancellation as described above, or in `deinit` if it's
 /// a reference type.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @rethrows
 public protocol AsyncIteratorProtocol {
   associatedtype Element

--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -16,7 +16,7 @@ import Swift
 // ==== Async Let -------------------------------------------------------------
 // Only has internal / builtin functions as it is not really accessible directly
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_start")
 public func _asyncLetStart<T>(
   asyncLet: Builtin.RawPointer,
@@ -25,34 +25,34 @@ public func _asyncLetStart<T>(
 )
 
 /// DEPRECATED. use _asyncLet_get instead
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_wait")
 public func _asyncLetGet<T>(asyncLet: Builtin.RawPointer) async -> T
 
 /// DEPRECATED. use _asyncLet_get_throwing instead
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_wait_throwing")
 public func _asyncLetGetThrowing<T>(asyncLet: Builtin.RawPointer) async throws -> T
 
 /// DEPRECATED. use _asyncLet_finish instead
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_end")
 public func _asyncLetEnd(
   asyncLet: Builtin.RawPointer // TODO: should this take __owned?
 )
 
 /// Wait if necessary and then project the result value of an async let
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_get")
 public func _asyncLet_get(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async -> Builtin.RawPointer
 
 /// Wait if necessary and then project the result value of an async let that throws
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_get_throwing")
 public func _asyncLet_get_throwing(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async throws -> Builtin.RawPointer
 
 /// Wait if necessary and then tear down the async let task
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_finish")
 public func _asyncLet_finish(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async
 

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that maps the given closure over the
   /// asynchronous sequence’s elements.
@@ -53,7 +53,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that maps the given closure over the asynchronous
 /// sequence’s elements.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -71,7 +71,7 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence, up to the specified maximum length,
   /// containing the initial elements of the base asynchronous sequence.
@@ -48,7 +48,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence, up to a specified maximum length,
 /// containing the initial elements of a base asynchronous sequence.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncPrefixSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -63,7 +63,7 @@ public struct AsyncPrefixSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence, containing the initial, consecutive
   /// elements of the base sequence that satisfy the given predicate.
@@ -48,7 +48,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence, containing the initial, consecutive
 /// elements of the base sequence that satisfy a given predicate.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -66,7 +66,7 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixWhileSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -71,7 +71,7 @@ import Swift
 ///     }
 ///     // Prints: Odd Even Odd Even Odd Even Odd Even Odd Even
 ///
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @rethrows
 public protocol AsyncSequence {
   /// The type of asynchronous iterator that produces elements of this
@@ -87,7 +87,7 @@ public protocol AsyncSequence {
   __consuming func makeAsyncIterator() -> AsyncIterator
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns the result of combining the elements of the asynchronous sequence
   /// using the given closure.
@@ -173,7 +173,7 @@ extension AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @inlinable
 @inline(__always)
 func _contains<Source: AsyncSequence>(
@@ -188,7 +188,7 @@ func _contains<Source: AsyncSequence>(
   return false
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns a Boolean value that indicates whether the asynchronous sequence
   /// contains an element that satisfies the given predicate.
@@ -249,7 +249,7 @@ extension AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence where Element: Equatable {
   /// Returns a Boolean value that indicates whether the asynchronous sequence
   /// contains the given element.
@@ -277,7 +277,7 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @inlinable
 @inline(__always)
 func _first<Source: AsyncSequence>(
@@ -292,7 +292,7 @@ func _first<Source: AsyncSequence>(
   return nil
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate.
@@ -322,7 +322,7 @@ extension AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns the minimum element in the asynchronous sequence, using the given
   /// predicate as the comparison between elements.
@@ -435,7 +435,7 @@ extension AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence where Element: Comparable {
   /// Returns the minimum element in an asynchronous sequence of comparable
   /// elements.

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -46,7 +46,7 @@ import Swift
 ///       print(digit)
 ///     }
 ///
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncStream<Element> {
   public struct Continuation: Sendable {
     /// Indication of the type of termination informed to
@@ -189,7 +189,7 @@ public struct AsyncStream<Element> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncStream: AsyncSequence {
   /// The asynchronous iterator for iterating a AsyncStream.
   ///
@@ -220,7 +220,7 @@ extension AsyncStream: AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncStream.Continuation {
   /// Resume the task awaiting the next iteration point by having it return
   /// normally from its suspension point or buffer the value if no awaiting

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -51,7 +51,7 @@ func _lock(_ ptr: UnsafeRawPointer)
 func _unlock(_ ptr: UnsafeRawPointer)
 #endif
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncStream {
   internal final class _Storage: UnsafeSendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
@@ -283,7 +283,7 @@ extension AsyncStream {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream {
   internal final class _Storage: UnsafeSendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that maps an error-throwing closure over
   /// the base sequence’s elements, omitting results that don't return a value.
@@ -67,7 +67,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that maps an error-throwing closure over the base
 /// sequence’s elements, omitting results that don't return a value.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -85,7 +85,7 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingCompactMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Omits elements from the base sequence until a given error-throwing closure
   /// returns false, after which it passes through all remaining elements.
@@ -65,7 +65,7 @@ extension AsyncSequence {
 /// An asynchronous sequence which omits elements from the base sequence until a
 /// given error-throwing closure returns false, after which it passes through
 /// all remaining elements.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -83,7 +83,7 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingDropWhileSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that contains, in order, the elements of
   /// the base sequence that satisfy the given error-throwing predicate.
@@ -55,7 +55,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that contains, in order, the elements of
 /// the base sequence that satisfy the given error-throwing predicate.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -73,7 +73,7 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFilterSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that concatenates the results of calling
   /// the given error-throwing transformation with each element of this
@@ -63,7 +63,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that concatenates the results of calling a given
 /// error-throwing transformation with each element of this sequence.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -81,7 +81,7 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFlatMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that maps the given error-throwing
   /// closure over the asynchronous sequence’s elements.
@@ -66,7 +66,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that maps the given error-throwing closure over the
 /// asynchronous sequence’s elements.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -84,7 +84,7 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingMapSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence, containing the initial, consecutive
   /// elements of the base sequence that satisfy the given error-throwing
@@ -61,7 +61,7 @@ extension AsyncSequence {
 /// An asynchronous sequence, containing the initial, consecutive
 /// elements of the base sequence that satisfy the given error-throwing
 /// predicate.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -79,7 +79,7 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
   /// The type of element produced by this asynchronous sequence.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingStream<Element, Failure: Error> {
   public struct Continuation: Sendable {
     /// Indication of the type of termination informed to
@@ -143,7 +143,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: AsyncSequence {
   /// The asynchronous iterator for iterating a AsyncThrowingStream.
   ///
@@ -165,7 +165,7 @@ extension AsyncThrowingStream: AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream.Continuation {
   /// Resume the task awaiting the next iteration point by having it return
   /// normally from its suspension point or buffer the value if no awaiting

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -128,7 +128,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     -parse-stdlib
     -Xfrontend -enable-experimental-concurrency
     -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
+    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}
   INSTALL_IN_COMPONENT ${swift_concurrency_install_component}

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -127,8 +127,6 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-concurrency
-    -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}
   INSTALL_IN_COMPONENT ${swift_concurrency_install_component}

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -12,13 +12,13 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_continuation_logFailedCheck")
 internal func logFailedCheck(_ message: UnsafeRawPointer)
 
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 internal final class CheckedContinuationCanary {
   // The instance state is stored in tail-allocated raw memory, so that
   // we can atomically check the continuation state.
@@ -109,7 +109,7 @@ internal final class CheckedContinuationCanary {
 /// of `withCheckedContinuation` or `withCheckedThrowingContinuation` should be
 /// enough to obtain the extra checking without further source modification in
 /// most circumstances.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
   private let canary: CheckedContinuationCanary
   
@@ -175,7 +175,7 @@ public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension CheckedContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -241,7 +241,7 @@ extension CheckedContinuation {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func withCheckedContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Never>) -> Void
@@ -251,7 +251,7 @@ public func withCheckedContinuation<T>(
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func withCheckedThrowingContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Error>) -> Void

--- a/stdlib/public/Concurrency/Deque.swift
+++ b/stdlib/public/Concurrency/Deque.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct _Deque<Element> {
   internal struct _UnsafeHandle {
     let _header: UnsafeMutablePointer<_Storage._Header>

--- a/stdlib/public/Concurrency/Errors.swift
+++ b/stdlib/public/Concurrency/Errors.swift
@@ -13,7 +13,7 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_deletedAsyncMethodError")
 public func swift_deletedAsyncMethodError() async {
     fatalError("Fatal error: Call of deleted method")

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -13,13 +13,13 @@
 import Swift
 
 /// A service which can execute jobs.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol Executor: AnyObject, Sendable {
   func enqueue(_ job: UnownedJob)
 }
 
 /// A service which can execute jobs.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol SerialExecutor: Executor {
   // This requirement is repeated here as a non-override so that we
   // get a redundant witness-table entry for it.  This allows us to
@@ -44,7 +44,7 @@ public protocol SerialExecutor: Executor {
 /// also keep the actor's associated executor alive; if they are
 /// different objects, the executor must be referenced strongly by the
 /// actor.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct UnownedSerialExecutor {
   #if compiler(>=5.5) && $BuiltinExecutor
@@ -70,14 +70,14 @@ public struct UnownedSerialExecutor {
 }
 
 // Used by the concurrency runtime
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("_swift_task_enqueueOnExecutor")
 internal func _enqueueOnExecutor<E>(job: UnownedJob, executor: E)
 where E: SerialExecutor {
   executor.enqueue(job)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_transparent
 public // COMPILER_INTRINSIC
 func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
@@ -98,7 +98,7 @@ func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
 // or else SILGen will emit a retain/release in unoptimized builds,
 // which won't work because DispatchQueues aren't actually
 // Swift-retainable.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_enqueueOnDispatchQueue")
 internal func _enqueueOnDispatchQueue(_ job: UnownedJob,
                                       queue: DispatchQueueShim)
@@ -110,7 +110,7 @@ internal func _enqueueOnDispatchQueue(_ job: UnownedJob,
 /// Expected to work for any primitive dispatch queue; note that this
 /// means a dispatch_queue_t, which is not the same as DispatchQueue
 /// on platforms where that is an instance of a wrapper class.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 internal final class DispatchQueueShim: UnsafeSendable, SerialExecutor {
   func enqueue(_ job: UnownedJob) {
     _enqueueOnDispatchQueue(job, queue: self)

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -22,7 +22,7 @@ import Swift
 /// such a declaration from another actor (or from nonisolated code),
 /// synchronization is performed through the \c shared actor instance to ensure
 /// mutually-exclusive access to the declaration.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol GlobalActor {
   /// The type of the shared actor instance that will be used to provide
   /// mutually-exclusive access to declarations annotated with the given global
@@ -43,7 +43,7 @@ public protocol GlobalActor {
   static var sharedUnownedExecutor: UnownedSerialExecutor { get }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension GlobalActor {
   public static var sharedUnownedExecutor: UnownedSerialExecutor {
     shared.unownedExecutor

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -14,7 +14,7 @@ import Swift
 
 /// A singleton actor whose executor is equivalent to the main
 /// dispatch queue.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor public final actor MainActor: GlobalActor {
   public static let shared = MainActor()
 
@@ -42,7 +42,7 @@ import Swift
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
   ///

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -13,14 +13,14 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_job_run")
 @usableFromInline
 internal func _swiftJobRun(_ job: UnownedJob,
                            _ executor: UnownedSerialExecutor) -> ()
 
 /// A job is a unit of scheduleable work.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct UnownedJob: Sendable {
   private var context: Builtin.Job
@@ -32,7 +32,7 @@ public struct UnownedJob: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct UnsafeContinuation<T, E: Error>: Sendable {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
@@ -106,7 +106,7 @@ public struct UnsafeContinuation<T, E: Error>: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension UnsafeContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -175,7 +175,7 @@ extension UnsafeContinuation {
 #if _runtime(_ObjC)
 
 // Intrinsics used by SILGen to resume or fail continuations.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeContinuation<T>(
   _ continuation: UnsafeContinuation<T, Never>,
@@ -184,7 +184,7 @@ internal func _resumeUnsafeContinuation<T>(
   continuation.resume(returning: value)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuation<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -193,7 +193,7 @@ internal func _resumeUnsafeThrowingContinuation<T>(
   continuation.resume(returning: value)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuationWithError<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -207,7 +207,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 public func withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -220,7 +220,7 @@ public func withUnsafeContinuation<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
@@ -231,7 +231,7 @@ public func withUnsafeThrowingContinuation<T>(
 }
 
 /// A hack to mark an SDK that supports swift_continuation_await.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 public func _abiEnableAwaitContinuation() {
   fatalError("never use this function")

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -16,7 +16,7 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "Task.Priority has been removed; use TaskPriority")
   public typealias Priority = TaskPriority
@@ -37,7 +37,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskPriority {
   @available(*, deprecated, message: "unspecified priority will be removed; use nil")
   @_alwaysEmitIntoClient
@@ -52,7 +52,7 @@ extension TaskPriority {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 public func withTaskCancellationHandler<T>(
   handler: @Sendable () -> Void,
@@ -61,7 +61,7 @@ public func withTaskCancellationHandler<T>(
   try await withTaskCancellationHandler(operation: operation, onCancel: handler)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
   @_alwaysEmitIntoClient
@@ -73,7 +73,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Error {
   @discardableResult
   @_alwaysEmitIntoClient
@@ -87,7 +87,7 @@ extension Task where Failure == Error {
 }
 
 @discardableResult
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`detach` was replaced by `Task.detached` and will be removed shortly.")
 @_alwaysEmitIntoClient
 public func detach<T>(
@@ -98,7 +98,7 @@ public func detach<T>(
 }
 
 @discardableResult
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`detach` was replaced by `Task.detached` and will be removed shortly.")
 @_alwaysEmitIntoClient
 public func detach<T>(
@@ -109,7 +109,7 @@ public func detach<T>(
 }
 
 @discardableResult
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`asyncDetached` was replaced by `Task.detached` and will be removed shortly.")
 @_alwaysEmitIntoClient
 public func asyncDetached<T>(
@@ -120,7 +120,7 @@ public func asyncDetached<T>(
 }
 
 @discardableResult
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`asyncDetached` was replaced by `Task.detached` and will be removed shortly.")
 @_alwaysEmitIntoClient
 public func asyncDetached<T>(
@@ -130,7 +130,7 @@ public func asyncDetached<T>(
   return Task.detached(priority: priority, operation: operation)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`async` was replaced by `Task.init` and will be removed shortly.")
 @discardableResult
 @_alwaysEmitIntoClient
@@ -141,7 +141,7 @@ public func async<T>(
   .init(priority: priority, operation: operation)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "`async` was replaced by `Task.init` and will be removed shortly.")
 @discardableResult
 @_alwaysEmitIntoClient
@@ -152,7 +152,7 @@ public func async<T>(
   .init(priority: priority, operation: operation)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
   public typealias Group<TaskResult: Sendable> = ThrowingTaskGroup<TaskResult, Error>
@@ -170,7 +170,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task {
   @available(*, deprecated, message: "get() has been replaced by .value")
   @_alwaysEmitIntoClient
@@ -185,7 +185,7 @@ extension Task {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
   @available(*, deprecated, message: "get() has been replaced by .value")
   @_alwaysEmitIntoClient
@@ -194,7 +194,7 @@ extension Task where Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
@@ -244,7 +244,7 @@ extension TaskGroup {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension ThrowingTaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
@@ -294,10 +294,10 @@ extension ThrowingTaskGroup {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "please use UnsafeContination<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @available(*, deprecated, renamed: "UnownedJob")
 public typealias PartialAsyncTask = UnownedJob

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -35,7 +35,7 @@ import Swift
 /// These partial periods towards the task's completion are
 /// individually schedulable as jobs.  Jobs are generally not interacted
 /// with by end-users directly, unless implementing a scheduler.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct Task<Success: Sendable, Failure: Error>: Sendable {
   @usableFromInline
@@ -47,7 +47,7 @@ public struct Task<Success: Sendable, Failure: Error>: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task {
   /// Wait for the task to complete, returning (or throwing) its result.
   ///
@@ -121,7 +121,7 @@ extension Task {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
   /// Wait for the task to complete, returning its result.
   ///
@@ -143,14 +143,14 @@ extension Task where Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -192,7 +192,7 @@ extension Task: Equatable {
 /// TODO: Define the details of task priority; It is likely to be a concept
 ///       similar to Darwin Dispatch's QoS; bearing in mind that priority is not as
 ///       much of a thing on other platforms (i.e. server side Linux systems).
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct TaskPriority: RawRepresentable, Sendable {
   public typealias RawValue = UInt8
   public var rawValue: UInt8
@@ -218,7 +218,7 @@ public struct TaskPriority: RawRepresentable, Sendable {
   public static let `default`: TaskPriority = .init(rawValue: 0x15)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskPriority: Equatable {
   public static func == (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
     lhs.rawValue == rhs.rawValue
@@ -229,7 +229,7 @@ extension TaskPriority: Equatable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskPriority: Comparable {
   public static func < (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
     lhs.rawValue < rhs.rawValue
@@ -248,10 +248,10 @@ extension TaskPriority: Comparable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskPriority: Codable { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
 
   /// Returns the `current` task's priority.
@@ -274,7 +274,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskPriority {
   /// Downgrade user-interactive to user-initiated.
   var _downgradeUserInteractive: TaskPriority {
@@ -287,7 +287,7 @@ extension TaskPriority {
 /// Flags for schedulable jobs.
 ///
 /// This is a port of the C++ FlagSet.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct JobFlags {
   /// Kinds of schedulable jobs.
   enum Kind: Int32 {
@@ -394,7 +394,7 @@ struct JobFlags {
 // ==== Task Creation Flags --------------------------------------------------
 
 /// Form task creation flags for use with the createAsyncTask builtins.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 func taskCreateFlags(
   priority: TaskPriority?, isChildTask: Bool, copyTaskLocals: Bool,
@@ -422,7 +422,7 @@ func taskCreateFlags(
 }
 
 // ==== Task Creation ----------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
   /// Run given `operation` as asynchronously in its own top-level task.
   ///
@@ -463,7 +463,7 @@ extension Task where Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Error {
   /// Run given `operation` as asynchronously in its own top-level task.
   ///
@@ -502,7 +502,7 @@ extension Task where Failure == Error {
 }
 
 // ==== Detached Tasks ---------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
   /// Run given throwing `operation` as part of a new top-level task.
   ///
@@ -557,7 +557,7 @@ extension Task where Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Failure == Error {
   /// Run given throwing `operation` as part of a new top-level task.
   ///
@@ -617,7 +617,7 @@ extension Task where Failure == Error {
 
 // ==== Voluntary Suspension -----------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
 
   /// Explicitly suspend the current task, potentially giving up execution actor
@@ -659,7 +659,7 @@ extension Task where Success == Never, Failure == Never {
 /// It is possible to obtain a `Task` fom the `UnsafeCurrentTask` which is safe
 /// to access from other tasks or even store for future reference e.g. equality
 /// checks.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) rethrows -> T {
   guard let _task = _getCurrentAsyncTask() else {
     return try body(nil)
@@ -686,7 +686,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 /// represented by this handle itself. Doing so may result in undefined behavior,
 /// and most certainly will break invariants in other places of the program
 /// actively running on this task.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
 
@@ -717,14 +717,14 @@ public struct UnsafeCurrentTask {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -733,33 +733,33 @@ extension UnsafeCurrentTask: Equatable {
 }
 
 // ==== Internal ---------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getCurrent")
 func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getJobFlags")
 func getJobFlags(_ task: Builtin.NativeObject) -> JobFlags
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_enqueueGlobal")
 @usableFromInline
 func _enqueueJobGlobal(_ task: Builtin.Job)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_enqueueGlobalWithDelay")
 @usableFromInline
 func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
 internal func _asyncMainDrainQueue() -> Never
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getMainExecutor")
 internal func _getMainExecutor() -> Builtin.Executor
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func _runAsyncMain(@_unsafeSendable _ asyncFun: @escaping () async throws -> ()) {
   Task.detached {
     do {
@@ -782,33 +782,33 @@ public func _runAsyncMain(@_unsafeSendable _ asyncFun: @escaping () async throws
 // FIXME: both of these ought to take their arguments _owned so that
 //        we can do a move out of the future in the common case where it's
 //        unreferenced
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_future_wait")
 public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_future_wait_throwing")
 public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_cancel")
 func _taskCancel(_ task: Builtin.NativeObject)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_isCancelled")
 @usableFromInline
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_createNullaryContinuationJob")
 func _taskCreateNullaryContinuationJob(priority: Int, continuation: Builtin.RawUnsafeContinuation) -> Builtin.Job
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_isCurrentExecutor")
 func _taskIsCurrentExecutor(_ executor: Builtin.Executor) -> Bool
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_reportUnexpectedExecutor")
 func _reportUnexpectedExecutor(_ _filenameStart: Builtin.RawPointer,
@@ -817,7 +817,7 @@ func _reportUnexpectedExecutor(_ _filenameStart: Builtin.RawPointer,
                                _ _line: Builtin.Word,
                                _ _executor: Builtin.Executor)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_getCurrentThreadPriority")
 func _getCurrentThreadPriority() -> Int
 
@@ -825,7 +825,7 @@ func _getCurrentThreadPriority() -> Int
 
 /// Intrinsic used by SILGen to launch a task for bridging a Swift async method
 /// which was called through its ObjC-exported completion-handler-based API.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -27,7 +27,7 @@ import Swift
 /// Does not check for cancellation, and always executes the passed `operation`.
 ///
 /// This function returns instantly and will never suspend.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void
@@ -40,7 +40,7 @@ public func withTaskCancellationHandler<T>(
   return try await operation()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task {
   /// Returns `true` if the task is cancelled, and should stop executing.
   ///
@@ -50,7 +50,7 @@ extension Task {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   /// Returns `true` if the task is cancelled, and should stop executing.
   ///
@@ -65,7 +65,7 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   /// Check if the task is cancelled and throw an `CancellationError` if it was.
   ///
@@ -92,17 +92,17 @@ extension Task where Success == Never, Failure == Never {
 ///
 /// This error is also thrown automatically by `Task.checkCancellation()`,
 /// if the current task has been cancelled.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct CancellationError: Error {
   // no extra information, cancellation is intended to be light-weight
   public init() {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_addCancellationHandler")
 func _taskAddCancellationHandler(handler: () -> Void) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_removeCancellationHandler")
 func _taskRemoveCancellationHandler(
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -61,7 +61,7 @@ import Swift
 /// - if the body returns normally:
 ///   - the group will await any not yet complete tasks,
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
@@ -141,7 +141,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
 /// - if the body throws:
 ///   - all tasks remaining in the group will be automatically cancelled.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
@@ -179,7 +179,7 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 /// A task group serves as storage for dynamically spawned tasks.
 ///
 /// It is created by the `withTaskGroup` function.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct TaskGroup<ChildTaskResult: Sendable> {
 
@@ -406,7 +406,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 /// child tasks.
 ///
 /// It is created by the `withTaskGroup` function.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @frozen
 public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 
@@ -641,7 +641,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 
 /// ==== TaskGroup: AsyncSequence ----------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TaskGroup: AsyncSequence {
   public typealias AsyncIterator = Iterator
   public typealias Element = ChildTaskResult
@@ -660,7 +660,7 @@ extension TaskGroup: AsyncSequence {
   /// after any task completes by throwing an error.
   ///
   /// - SeeAlso: `TaskGroup.next()`
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ChildTaskResult
 
@@ -694,7 +694,7 @@ extension TaskGroup: AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension ThrowingTaskGroup: AsyncSequence {
   public typealias AsyncIterator = Iterator
   public typealias Element = ChildTaskResult
@@ -714,7 +714,7 @@ extension ThrowingTaskGroup: AsyncSequence {
   /// throwing an error, no further task results are returned.
   ///
   /// - SeeAlso: `ThrowingTaskGroup.next()`
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ChildTaskResult
 
@@ -753,11 +753,11 @@ extension ThrowingTaskGroup: AsyncSequence {
 
 /// ==== -----------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_destroy")
 func _taskGroupDestroy(group: __owned Builtin.RawPointer)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_addPending")
 @usableFromInline
 func _taskGroupAddPendingTask(
@@ -765,25 +765,25 @@ func _taskGroupAddPendingTask(
   unconditionally: Bool
 ) -> Bool
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
 /// Checks ONLY if the group was specifically cancelled.
 /// The task itself being cancelled must be checked separately.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_wait_next_throwing")
 func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_hasTaskGroupStatusRecord")
 func _taskHasTaskGroupStatusRecord() -> Bool
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum PollStatus: Int {
   case empty   = 0
   case waiting = 1
@@ -791,7 +791,7 @@ enum PollStatus: Int {
   case error   = 3
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_isEmpty")
 func _taskGroupIsEmpty(
   _ group: Builtin.RawPointer

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -94,7 +94,7 @@ import Swift
 /// This type must be a `class` so it has a stable identity, that is used as key
 /// value for lookups in the task local storage.
 @propertyWrapper
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible {
   let defaultValue: Value
 
@@ -211,24 +211,24 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
   value: __owned Value
 ) // where Key: TaskLocal
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_localValueGet")
 func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_localsCopyTo")
 func _taskLocalsCopy(
   to target: Builtin.NativeObject
@@ -236,7 +236,7 @@ func _taskLocalsCopy(
 
 // ==== Checks -----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @usableFromInline
 func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) {
   if _taskHasTaskGroupStatusRecord() {
@@ -247,7 +247,7 @@ func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) 
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroup")
 func _reportIllegalTaskLocalBindingWithinWithTaskGroup(

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -12,7 +12,7 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, renamed: "Task.sleep(nanoseconds:)")
   public static func sleep(_ duration: UInt64) async {

--- a/stdlib/public/Distributed/ActorTransport.swift
+++ b/stdlib/public/Distributed/ActorTransport.swift
@@ -13,7 +13,7 @@
 import Swift
 import _Concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol ActorTransport: Sendable {
 
   // ==== ---------------------------------------------------------------------

--- a/stdlib/public/Distributed/ActorTransport.swift
+++ b/stdlib/public/Distributed/ActorTransport.swift
@@ -13,7 +13,7 @@
 import Swift
 import _Concurrency
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public protocol ActorTransport: Sendable {
 
   // ==== ---------------------------------------------------------------------

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -34,8 +34,6 @@ add_swift_target_library(swift_Distributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-distributed
-    -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _Concurrency

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -34,10 +34,6 @@ add_swift_target_library(swift_Distributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-distributed
-    -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
-    -Xfrontend -define-availability
-    -Xfrontend "SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _Concurrency

--- a/stdlib/public/Distributed/CMakeLists.txt
+++ b/stdlib/public/Distributed/CMakeLists.txt
@@ -34,6 +34,10 @@ add_swift_target_library(swift_Distributed ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-distributed
+    -Xfrontend -define-availability
+    -Xfrontend "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
+    -Xfrontend -define-availability
+    -Xfrontend "SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _Concurrency

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -20,7 +20,7 @@ import _Concurrency
 ///
 /// FIXME(distributed): We'd need Actor to also conform to this, but don't want to add that conformance in _Concurrency yet.
 @_marker
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol AnyActor: Sendable, AnyObject {}
 
 // ==== Distributed Actor -----------------------------------------------------
@@ -33,7 +33,7 @@ public protocol AnyActor: Sendable, AnyObject {}
 ///
 /// The 'DistributedActor' protocol provides the core functionality of any
 /// distributed actor.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol DistributedActor:
     AnyActor, Sendable, Identifiable, Hashable, Codable {
     /// Resolves the passed in `identity` against the `transport`, returning
@@ -79,7 +79,7 @@ public protocol DistributedActor:
 
 // ==== Hashable conformance ---------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension DistributedActor {
   nonisolated public func hash(into hasher: inout Hasher) {
     self.id.hash(into: &hasher)
@@ -93,11 +93,11 @@ extension DistributedActor {
 // ==== Codable conformance ----------------------------------------------------
 
 extension CodingUserInfoKey {
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   public static let actorTransportKey = CodingUserInfoKey(rawValue: "$dist_act_transport")!
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension DistributedActor {
   nonisolated public init(from decoder: Decoder) throws {
     guard let transport = decoder.userInfo[.actorTransportKey] as? ActorTransport else {
@@ -118,7 +118,7 @@ extension DistributedActor {
 
 // ==== Local actor special handling -------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension DistributedActor {
 
   /// Executes the passed 'body' only when the distributed actor is local instance.
@@ -143,10 +143,10 @@ extension DistributedActor {
 /******************************************************************************/
 
 /// Uniquely identifies a distributed actor, and enables sending messages and identifying remote actors.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol ActorIdentity: Sendable, Hashable, Codable {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable, CustomStringConvertible {
   public let underlying: Any
   @usableFromInline let _hashInto: (inout Hasher) -> ()
@@ -208,11 +208,11 @@ public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable, CustomString
 /******************************************************************************/
 
 /// Error protocol to which errors thrown by any `ActorTransport` should conform.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol ActorTransportError: Error {
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct DistributedActorCodingError: ActorTransportError {
   public let message: String
 

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -20,7 +20,7 @@ import _Concurrency
 ///
 /// FIXME(distributed): We'd need Actor to also conform to this, but don't want to add that conformance in _Concurrency yet.
 @_marker
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public protocol AnyActor: Sendable, AnyObject {}
 
 // ==== Distributed Actor -----------------------------------------------------
@@ -33,7 +33,7 @@ public protocol AnyActor: Sendable, AnyObject {}
 ///
 /// The 'DistributedActor' protocol provides the core functionality of any
 /// distributed actor.
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public protocol DistributedActor:
     AnyActor, Sendable, Identifiable, Hashable, Codable {
     /// Resolves the passed in `identity` against the `transport`, returning
@@ -79,7 +79,7 @@ public protocol DistributedActor:
 
 // ==== Hashable conformance ---------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension DistributedActor {
   nonisolated public func hash(into hasher: inout Hasher) {
     self.id.hash(into: &hasher)
@@ -93,11 +93,11 @@ extension DistributedActor {
 // ==== Codable conformance ----------------------------------------------------
 
 extension CodingUserInfoKey {
-  @available(SwiftStdlib 5.1, *)
+  @available(SwiftStdlib 5.6, *)
   public static let actorTransportKey = CodingUserInfoKey(rawValue: "$dist_act_transport")!
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension DistributedActor {
   nonisolated public init(from decoder: Decoder) throws {
     guard let transport = decoder.userInfo[.actorTransportKey] as? ActorTransport else {
@@ -118,7 +118,7 @@ extension DistributedActor {
 
 // ==== Local actor special handling -------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension DistributedActor {
 
   /// Executes the passed 'body' only when the distributed actor is local instance.
@@ -143,10 +143,10 @@ extension DistributedActor {
 /******************************************************************************/
 
 /// Uniquely identifies a distributed actor, and enables sending messages and identifying remote actors.
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public protocol ActorIdentity: Sendable, Hashable, Codable {}
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable, CustomStringConvertible {
   public let underlying: Any
   @usableFromInline let _hashInto: (inout Hasher) -> ()
@@ -208,11 +208,11 @@ public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable, CustomString
 /******************************************************************************/
 
 /// Error protocol to which errors thrown by any `ActorTransport` should conform.
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public protocol ActorTransportError: Error {
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public struct DistributedActorCodingError: ActorTransportError {
   public let message: String
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,6 +385,10 @@ foreach(SDK ${SWIFT_SDKS})
           list(APPEND LIT_ARGS "--param" "distributed")
         endif()
 
+        # Define availability macros, escaping semicolons to get around CMake
+        string(REPLACE ";" "\\$<SEMICOLON>" availability_defs "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS}")
+        list(APPEND LIT_ARGS "--param" "availability_macros=${availability_defs}")
+
         foreach(test_subset ${TEST_SUBSETS})
           set(directories)
           set(dependencies ${test_dependencies})

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -8,7 +8,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -42,7 +42,7 @@ nonisolated var randomPriority: TaskPriority? {
   return priorities.randomElement()!
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -52,7 +52,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -79,7 +79,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Concurrency/Runtime/actor_detach.swift
+++ b/test/Concurrency/Runtime/actor_detach.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Manager {
     static var shared = Manager()
 
@@ -25,7 +25,7 @@ actor Manager {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() {
     detach {
         let x = await Manager.shared.manage()
@@ -37,7 +37,7 @@ func test() {
     }
 }
 
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
  test()
  sleep(30)
 } else {

--- a/test/Concurrency/Runtime/actor_init.swift
+++ b/test/Concurrency/Runtime/actor_init.swift
@@ -7,7 +7,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Number {
     var val: Int
     var task: Task<Void, Never>?
@@ -52,7 +52,7 @@ actor Number {
     }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
     static func main() async {
 

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -20,7 +20,7 @@ import StdlibUnittest
 
 var asyncTests = TestSuite("Async")
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActor {
   func synchronous() { }
 
@@ -32,7 +32,7 @@ actor MyActor {
   }
 }
 
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
   let actor = MyActor()
 
   asyncTests.test("Detach") {

--- a/test/Concurrency/Runtime/async_initializer.swift
+++ b/test/Concurrency/Runtime/async_initializer.swift
@@ -8,7 +8,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor NameGenerator {
   private var counter = 0
   private var prefix : String
@@ -19,13 +19,13 @@ actor NameGenerator {
    }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol Person {
   init() async
   var name : String { get set }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class EarthPerson : Person {
   private static let oracle = NameGenerator("Earthling")
 
@@ -40,7 +40,7 @@ class EarthPerson : Person {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class NorthAmericaPerson : EarthPerson {
   private static let oracle = NameGenerator("NorthAmerican")
   required init() async {
@@ -53,7 +53,7 @@ class NorthAmericaPerson : EarthPerson {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class PrecariousClass {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -87,7 +87,7 @@ enum Something : Error {
   case bogus
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct PrecariousStruct {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -122,7 +122,7 @@ struct PrecariousStruct {
 // CHECK-NEXT: struct threw
 // CHECK: done
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct RunIt {
   static func main() async {
     let people : [Person] = [

--- a/test/Concurrency/Runtime/async_let_fibonacci.swift
+++ b/test/Concurrency/Runtime/async_let_fibonacci.swift
@@ -19,7 +19,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -39,7 +39,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -48,7 +48,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Concurrency/Runtime/async_let_throws.swift
+++ b/test/Concurrency/Runtime/async_let_throws.swift
@@ -14,7 +14,7 @@ func boom() throws -> Int {
   throw Boom()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() async {
   async let result = boom()
 
@@ -25,7 +25,7 @@ func test() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -14,27 +14,27 @@ import StdlibUnittest
 // Utility functions for closure based operators to force them into throwing
 // and async and throwing async contexts.
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func throwing<T>(_ value: T) throws -> T {
   return value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asynchronous<T>(_ value: T) async -> T {
   return value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asynchronousThrowing<T>(_ value: T) async throws -> T {
   return value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct Failure: Error, Equatable {
   var value = 1
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func failable<T, E: Error>(
   _ results: [Result<T, E>]
 ) -> AsyncThrowingMapSequence<AsyncLazySequence<[Result<T, E>]>, T> {
@@ -42,7 +42,7 @@ func failable<T, E: Error>(
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Sequence {
   @inlinable
   public var async: AsyncLazySequence<Self> {
@@ -52,7 +52,7 @@ extension Sequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   public typealias Element = S.Element
   public typealias AsyncIterator = Iterator
@@ -85,7 +85,7 @@ public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
   @inlinable
   public func collect() async rethrows -> [Element] {
@@ -98,7 +98,7 @@ extension AsyncSequence {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension AsyncSequence where Element: Equatable {
   func `throw`(_ error: Error, on element: Element) -> AsyncThrowingMapSequence<Self, Element> {
     return map { (value: Element) throws -> Element in
@@ -110,7 +110,7 @@ extension AsyncSequence where Element: Equatable {
 
 @main struct Main {
   static func main() async {
-    if #available(SwiftStdlib 5.5, *) {
+    if #available(SwiftStdlib 5.1, *) {
 
     var AsyncLazySequenceTests = TestSuite("AsyncLazySequence")
 

--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -9,7 +9,7 @@
 
 // REQUIRES: rdar_77671328
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func printWaitPrint(_ int: Int) async -> Int {
   print("start, cancelled:\(Task.isCancelled), id:\(int)")
   while !Task.isCancelled {
@@ -19,7 +19,7 @@ func printWaitPrint(_ int: Int) async -> Int {
   return int
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() async {
   let h = detach {
     await printWaitPrint(0)
@@ -70,7 +70,7 @@ func test() async {
   print("exit")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_task_cancellation_early.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_early.swift
@@ -13,7 +13,7 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detach_cancel_child_early() async {
   print(#function) // CHECK: test_detach_cancel_child_early
   let h: Task<Bool, Error> = Task.detached {
@@ -35,7 +35,7 @@ func test_detach_cancel_child_early() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_child_early()

--- a/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
@@ -12,7 +12,7 @@ import Dispatch
 
 let seconds: UInt64 = 1_000_000_000
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detach_cancel_while_child_running() async {
   let task: Task<Bool, Error> = Task.detached {
     async let childCancelled: Bool = { () -> Bool in
@@ -36,7 +36,7 @@ func test_detach_cancel_while_child_running() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancel_while_withTaskCancellationHandler_inflight() async {
   let task: Task<Bool, Error> = Task.detached {
     await withTaskCancellationHandler {
@@ -63,7 +63,7 @@ func test_cancel_while_withTaskCancellationHandler_inflight() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancel_while_withTaskCancellationHandler_onlyOnce() async {
   let task: Task<Bool, Error> = Task.detached {
     await withTaskCancellationHandler {
@@ -91,7 +91,7 @@ func test_cancel_while_withTaskCancellationHandler_onlyOnce() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_while_child_running()

--- a/test/Concurrency/Runtime/async_task_detach.swift
+++ b/test/Concurrency/Runtime/async_task_detach.swift
@@ -21,7 +21,7 @@ class X {
 
 struct Boom: Error {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detach() async {
   let x = X()
   let h = detach {
@@ -33,7 +33,7 @@ func test_detach() async {
   // CHECK: X: deinit
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detach_throw() async {
   let x = X()
   let h = detach {
@@ -51,7 +51,7 @@ func test_detach_throw() async {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -7,7 +7,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     let task = Task.detached {

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -17,7 +17,7 @@ final class StringLike: Sendable, CustomStringConvertible {
   var description: String { value }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
 
   @TaskLocal
@@ -33,7 +33,7 @@ enum TL {
   static var clazz: ClassTaskLocal?
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 final class ClassTaskLocal: Sendable {
   init() {
     print("clazz init \(ObjectIdentifier(self))")
@@ -44,7 +44,7 @@ final class ClassTaskLocal: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocalAsync<V>(
     _ key: TaskLocal<V>,
@@ -54,7 +54,7 @@ func printTaskLocalAsync<V>(
   printTaskLocal(key, expected, file: file, line: line)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -72,7 +72,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func simple() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   TL.$number.withValue(1) {
@@ -80,7 +80,7 @@ func simple() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func simple_deinit() async {
   TL.$clazz.withValue(ClassTaskLocal()) {
     // CHECK: clazz init [[C:.*]]
@@ -93,7 +93,7 @@ func simple_deinit() async {
 struct Boom: Error {
   let value: String
 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func simple_throw() async {
   do {
     try TL.$clazz.withValue(ClassTaskLocal()) {
@@ -105,7 +105,7 @@ func simple_throw() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func nested() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   TL.$string.withValue("hello") {
@@ -122,7 +122,7 @@ func nested() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   TL.$string.withValue("one") {
@@ -139,7 +139,7 @@ func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   TL.$string.withValue("one") {
@@ -156,7 +156,7 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func nested_3_onlyTopContributesAsync() async {
   await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -173,7 +173,7 @@ func nested_3_onlyTopContributesAsync() async {
   await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func nested_3_onlyTopContributesMixed() async {
   await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -190,7 +190,7 @@ func nested_3_onlyTopContributesMixed() async {
   await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func withLocal_body_mustNotEscape() async {
   var something = "Nice"
   TL.$string.withValue("xxx") {
@@ -199,7 +199,7 @@ func withLocal_body_mustNotEscape() async {
   _ = something // silence not used warning
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await simple()

--- a/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
@@ -9,7 +9,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
@@ -17,7 +17,7 @@ enum TL {
   static var other: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -35,7 +35,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func copyTo_async() async {
   await TL.$number.withValue(1111) {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
@@ -59,7 +59,7 @@ func copyTo_async() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func copyTo_async_noWait() async {
   print(#function)
   TL.$number.withValue(1111) {
@@ -81,7 +81,7 @@ func copyTo_async_noWait() async {
   await Task.sleep(2 * second)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class CustomClass {
   @TaskLocal
   static var current: CustomClass?
@@ -95,7 +95,7 @@ class CustomClass {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_unstructured_retains() async {
   let instance = CustomClass()
   CustomClass.$current.withValue(instance) {
@@ -120,20 +120,20 @@ func test_unstructured_retains() async {
   await Task.sleep(2 * 1_000_000_000)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_unstructured_noValues() async {
   await Task {
     // no values to copy
   }.value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func downloadImage(from url: String) async throws -> String {
   await Task.sleep(10_000)
   return ""
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_unstructured_noValues_childTasks() async {
   @Sendable func work() async throws {
     let handle = Task {
@@ -153,7 +153,7 @@ func test_unstructured_noValues_childTasks() async {
 
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await copyTo_async()

--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -9,13 +9,13 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -33,7 +33,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func groups() async {
   // no value
   _ = await withTaskGroup(of: Int.self) { group in
@@ -79,7 +79,7 @@ func groups() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func taskInsideGroup() async {
   Task {
     print("outside") // CHECK: outside
@@ -108,7 +108,7 @@ func taskInsideGroup() async {
 //  await t.value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await groups()

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
@@ -11,7 +11,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number: Int = 2
@@ -19,7 +19,7 @@ enum TL {
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func bindAroundGroupSpawn() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
@@ -36,7 +36,7 @@ func bindAroundGroupSpawn() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await bindAroundGroupSpawn()

--- a/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
@@ -8,13 +8,13 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   async let x1: () = TL.$number.withValue(2) {
@@ -54,7 +54,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -77,7 +77,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
+++ b/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
@@ -8,13 +8,13 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func synchronous_bind() {
 
   func synchronous() {
@@ -50,7 +50,7 @@ func synchronous_bind() {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() {
     synchronous_bind()

--- a/test/Concurrency/Runtime/async_task_locals_wrapper.swift
+++ b/test/Concurrency/Runtime/async_task_locals_wrapper.swift
@@ -8,13 +8,13 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func async_let_nested() async {
   print("TL: \(TL.$number)")
   
@@ -56,7 +56,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -79,7 +79,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -17,7 +17,7 @@ extension TaskPriority: CustomStringConvertible {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     print("main priority: \(Task.currentPriority)") // CHECK: main priority: TaskPriority(rawValue: [[#MAIN_PRIORITY:]])
@@ -26,7 +26,7 @@ extension TaskPriority: CustomStringConvertible {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detach() async {
   let a1 = Task.currentPriority
   print("a1: \(a1)") // CHECK: a1: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
@@ -43,7 +43,7 @@ func test_detach() async {
   print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_multiple_lo_indirectly_escalated() async {
   @Sendable
   func loopUntil(priority: TaskPriority) async {

--- a/test/Concurrency/Runtime/async_task_sleep.swift
+++ b/test/Concurrency/Runtime/async_task_sleep.swift
@@ -11,7 +11,7 @@ import _Concurrency
 // FIXME: should not depend on Dispatch
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static let pause = 500_000_000 // 500ms
   

--- a/test/Concurrency/Runtime/async_task_sleep_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_sleep_cancel.swift
@@ -11,7 +11,7 @@ import _Concurrency
 // FIXME: should not depend on Dispatch
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static let pause = 500_000_000 // 500ms
 

--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -8,12 +8,12 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol Go: Actor {
   func go(times: Int) async -> Int
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Go {
   func go(times: Int) async -> Int {
     for i in 0...times {
@@ -24,12 +24,12 @@ extension Go {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor One: Go {}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Two: Go {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func yielding() async {
   let one = One()
   let two = Two()
@@ -43,7 +43,7 @@ func yielding() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await yielding()

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -11,7 +11,7 @@ func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_next() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -44,7 +44,7 @@ func test_taskGroup_next() async {
   print("result with group.next(): \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_for_in() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -75,7 +75,7 @@ func test_taskGroup_for_in() async {
   print("result with for-in: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_asyncIterator() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -113,7 +113,7 @@ func test_taskGroup_asyncIterator() async {
   print("result with async iterator: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_contains() async {
   let sum = await withTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...4 {
@@ -145,7 +145,7 @@ func test_taskGroup_contains() async {
   print("result with async iterator: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_next()

--- a/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 /// Tests that only the specific group we cancelAll on is cancelled,
 /// and not accidentally all tasks in all groups within the given parent task.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_cancelAll_onlySpecificGroup() async {
   async let g1: Int = withTaskGroup(of: Int.self) { group in
 
@@ -79,7 +79,7 @@ func test_taskGroup_cancelAll_onlySpecificGroup() async {
 
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancelAll_onlySpecificGroup()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_cancel_from_inside_child() async {
   let one = try! await withTaskGroup(of: Int.self, returning: Int.self) { group in
     await group.next()
@@ -45,7 +45,7 @@ func test_taskGroup_cancel_from_inside_child() async {
 
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_from_inside_child()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_cancel_parent_affects_group() async {
 
   let x = detach {
@@ -47,7 +47,7 @@ func test_taskGroup_cancel_parent_affects_group() async {
 
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_parent_affects_group()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -28,7 +28,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_cancel_then_completions() async {
   // CHECK: test_taskGroup_cancel_then_completions
   print("before \(#function)")
@@ -73,7 +73,7 @@ func test_taskGroup_cancel_then_completions() async {
   print("result: \(result)") // CHECK: result: 3
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_completions()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_cancel_then_add() async {
   // CHECK: test_taskGroup_cancel_then_add
   print("\(#function)")
@@ -55,7 +55,7 @@ func test_taskGroup_cancel_then_add() async {
 
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_add()

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -9,7 +9,7 @@
 
 // UNSUPPORTED: linux
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_is_asyncSequence() async {
   print(#function)
 
@@ -33,7 +33,7 @@ func test_taskGroup_is_asyncSequence() async {
   print("result: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_throwingTaskGroup_is_asyncSequence() async throws {
   print(#function)
 
@@ -57,7 +57,7 @@ func test_throwingTaskGroup_is_asyncSequence() async throws {
   print("result: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_is_asyncSequence()

--- a/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_isEmpty() async {
   print("before all")
   let result = await withTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -44,7 +44,7 @@ func test_taskGroup_isEmpty() async {
   print("result: \(result)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_isEmpty()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
@@ -47,7 +47,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
   assert(result == 0)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext_butInvokeCancelAll()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_skipCallingNext() async {
   let numbers = [1, 1]
 
@@ -43,7 +43,7 @@ func test_skipCallingNext() async {
   assert(result == 0)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext()

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_sum_nextOnCompleted() async {
   let numbers = [1, 2, 3, 4, 5]
   let expected = 15 // FIXME: numbers.reduce(0, +) this hangs?
@@ -60,7 +60,7 @@ func test_sum_nextOnCompleted() async {
   print("result: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompleted()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -10,15 +10,15 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func one() async -> Int { 1 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_throws() async {
   let got: Int = try await withThrowingTaskGroup(of: Int.self) { group in
     group.addTask { try await boom()  }
@@ -66,7 +66,7 @@ func test_taskGroup_throws() async {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -10,12 +10,12 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func echo(_ i: Int) async -> Int { i }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_throws_rethrows() async {
   do {
     let got = try await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -45,7 +45,7 @@ func test_taskGroup_throws_rethrows() async {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws_rethrows()

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -14,12 +14,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -72,7 +72,7 @@ func testSimple(
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -22,7 +22,7 @@ class Canary {
   }
 }
 
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
   let task = detach {
     let canary = Canary()
     _ = await Task.withCancellationHandler {

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -14,7 +14,7 @@ struct TestError: Error {}
   static func main() async {
     var tests = TestSuite("CheckedContinuation")
 
-    if #available(SwiftStdlib 5.5, *) {
+    if #available(SwiftStdlib 5.1, *) {
       tests.test("trap on double resume non-throwing continuation") {
         expectCrashLater()
 

--- a/test/Concurrency/Runtime/custom_executors.swift
+++ b/test/Concurrency/Runtime/custom_executors.swift
@@ -21,7 +21,7 @@ actor Custom {
   var count = 0
   let simple = Simple()
 
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("custom unownedExecutor")
     return simple.unownedExecutor
@@ -35,7 +35,7 @@ actor Custom {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     print("begin")

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -20,7 +20,7 @@ enum BallKind {
   case KirksandLignature
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class Specs {
   // obtains the number of dimples
   subscript(_ bk : BallKind) -> Int {
@@ -37,7 +37,7 @@ class Specs {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Database {
   var currentData : Specs {
     get async {
@@ -52,21 +52,21 @@ actor Database {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol SphericalObject {
   var name : String { get async throws }
   var dimples : Int { get async throws }
   var description : String { get async throws }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class Ball : SphericalObject {
   var name : String { get async throws { throw GeneralError.Todo } }
   var dimples : Int { get async throws { throw GeneralError.Todo } }
   var description : String { get async throws { throw GeneralError.Todo } }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class GolfBall : Ball {
   private static let db : Database = Database()
 
@@ -110,17 +110,17 @@ class GolfBall : Ball {
 // CHECK: obtaining specs...
 // CHECK: this golf ball has 0 dimples
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func printAsBall(_ b : Ball) async {
   print(try! await b.description)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func printAsAsSphericalObject(_ b : SphericalObject) async {
   print(try! await b.description)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct RunIt {
   static func main() async {
     let balls : [(Bool, Ball)] = [

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -46,7 +46,7 @@ public func debugLog(_ s: String) {
 #endif
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main
 struct Runner {
     @MainActor

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -50,7 +50,7 @@ public func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) -> U) -> U {
     return f(&x)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor @inline(never)
 func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
     debugLog("==> Enter 'withExclusiveAccessAsync'")
@@ -58,7 +58,7 @@ func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) asyn
     return await f(&x)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public final class MySerialExecutor : SerialExecutor {
     public init() {
         debugLog("==> MySerialExecutor: Creating MySerialExecutor!")
@@ -93,7 +93,7 @@ public final class MySerialExecutor : SerialExecutor {
 
 /// A singleton actor whose executor is equivalent to the main
 /// dispatch queue.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor public final actor MyMainActor: Executor {
     public static let shared = MyMainActor()
     public let executor = MySerialExecutor()
@@ -120,7 +120,7 @@ public final class MySerialExecutor : SerialExecutor {
 /// An actor that we use to test that after eliminating the synchronous
 /// accesses, we properly deserialize the task access set causing a crash in
 /// unownedExecutor.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor public final actor MyMainActorWithAccessInUnownedExecAccessor: Executor {
     public static let shared = MyMainActorWithAccessInUnownedExecAccessor()
     public let executor = MySerialExecutor()
@@ -145,7 +145,7 @@ public final class MySerialExecutor : SerialExecutor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Custom {
   var count = 0
 
@@ -155,7 +155,7 @@ actor Custom {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor
 struct CustomActor {
     static var shared: Custom {
@@ -169,7 +169,7 @@ public var global2: Int = 6
 public var global3: Int = 7
 public var global4: Int = 8
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main
 struct Runner {
     @MainActor static func main() async {

--- a/test/Concurrency/Runtime/executor_deinit2.swift
+++ b/test/Concurrency/Runtime/executor_deinit2.swift
@@ -11,7 +11,7 @@
 // this needs to match with the check count below.
 let NUM_TASKS : Int = 100
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 final class Capture : Sendable {
     func doSomething() { }
     deinit {
@@ -20,7 +20,7 @@ final class Capture : Sendable {
     }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main
 struct App {
     static func main() async {

--- a/test/Concurrency/Runtime/executor_deinit3.swift
+++ b/test/Concurrency/Runtime/executor_deinit3.swift
@@ -16,7 +16,7 @@
     import Glibc
 #endif
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class Runner {
     func run() async {
         while !Task.isCancelled {
@@ -25,7 +25,7 @@ class Runner {
     }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Container {
     var generation = 0
     var runners = [Int : Task<Void, Never>]()
@@ -67,7 +67,7 @@ actor Container {
 // FIXME: this doesn't work until we have https://github.com/apple/swift/pull/36298
 // COM: deinit Container with {{[0-9]+}} runners
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct RunIt {
     static func startTest() async {
         let c = Container()
@@ -76,7 +76,7 @@ actor Container {
         await c.cancelAll()
     }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 static func main() async {
         print("starting")
         await RunIt.startTest()

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -21,7 +21,7 @@ func fib(_ n: Int) -> Int {
     return first
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -46,7 +46,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runFibonacci(_ n: Int) async {
   var result = await asyncFib(n)
 
@@ -55,7 +55,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(15)

--- a/test/Concurrency/Runtime/task_creation.swift
+++ b/test/Concurrency/Runtime/task_creation.swift
@@ -12,7 +12,7 @@ enum SomeError: Error {
   case bad
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     let condition = false

--- a/test/Concurrency/actor_definite_init.swift
+++ b/test/Concurrency/actor_definite_init.swift
@@ -11,7 +11,7 @@ enum BogusError: Error {
     case blah
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Convenient {
     var x: Int
     var y: Convenient?
@@ -84,13 +84,13 @@ actor Convenient {
 
 func randomInt() -> Int { return 4 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func callMethod(_ a: MyActor) {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func passInout<T>(_ a: inout T) {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActor {
     var x: Int
     var y: Int
@@ -309,7 +309,7 @@ actor MyActor {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor X {
     var counter: Int
 
@@ -333,10 +333,10 @@ struct CardboardBox<T> {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 var globalVar: EscapeArtist?
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor EscapeArtist {
     var x: Int
 

--- a/test/Concurrency/actor_definite_init_swift6.swift
+++ b/test/Concurrency/actor_definite_init_swift6.swift
@@ -7,7 +7,7 @@ enum BogusError: Error {
     case blah
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Convenient {
     var x: Int
     var y: Convenient?
@@ -80,13 +80,13 @@ actor Convenient {
 
 func randomInt() -> Int { return 4 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func callMethod(_ a: MyActor) {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func passInout<T>(_ a: inout T) {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActor {
     var x: Int
     var y: Int
@@ -305,7 +305,7 @@ actor MyActor {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor X {
     var counter: Int
 
@@ -329,10 +329,10 @@ struct CardboardBox<T> {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 var globalVar: EscapeArtist? // expected-note 2 {{var declared here}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor EscapeArtist {
     var x: Int
 

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -22,7 +22,7 @@ struct Point {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor TestActor {
   // expected-note@+1{{mutation of this property is only permitted within the actor}}
   var position = Point(x: 0, y: 0)
@@ -37,15 +37,15 @@ actor TestActor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum Container {
   static let modifyAsyncValue = modifyAsynchronously
 }
 
 // external function call
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TestActor {
 
   // Can't pass actor-isolated primitive into a function
@@ -82,7 +82,7 @@ extension TestActor {
 }
 
 // internal method call
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TestActor {
   func modifyByValue(_ other: inout Int) async {
     other += value1
@@ -95,7 +95,7 @@ extension TestActor {
 }
 
 // external class method call
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class NonAsyncClass {
   func modifyOtherAsync(_ other : inout Int) async {
     // ...
@@ -107,7 +107,7 @@ class NonAsyncClass {
 }
 
 // Calling external class/struct async function
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TestActor {
   // Can't pass state into async method of another class
 
@@ -136,12 +136,12 @@ extension TestActor {
 }
 
 // Check implicit async testing
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor DifferentActor {
   func modify(_ state: inout Int) {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension TestActor {
   func modify(_ state: inout Int) {}
 
@@ -160,7 +160,7 @@ extension TestActor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActor {
   var points: [Point] = []
   var int: Int = 0
@@ -194,7 +194,7 @@ actor MyActor {
 
 // Verify global actor protection
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor
 struct MyGlobalActor {
   static let shared = TestActor()
@@ -207,34 +207,34 @@ struct MyGlobalActor {
 
 // expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
 // expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
 let _ = Task.detached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 }
 
 // attempt to pass global state owned by the global actor to another async function
 // expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor func sneaky() async { await modifyAsynchronously(&number) }
 
 // It's okay to pass actor state inout to synchronous functions!
 
 func globalSyncFunction(_ foo: inout Int) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorSyncFunction(_ foo: inout Int) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
 
 // Gently unwrap things that are fine
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct Cat {
   mutating func meow() async { }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct Dog {
   var cat: Cat?
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -8,29 +8,29 @@ import OtherActors
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func globalFunc() { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptClosure<T>(_: () -> T) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptConcurrentClosure<T>(_: @Sendable () -> T) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptEscapingClosure<T>(_: @escaping () -> T) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @discardableResult func acceptAsyncClosure<T>(_: () async -> T) -> T { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptInout<T>(_: inout T) {}
 
 
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutation of this property is only permitted within the actor}}
 
@@ -51,7 +51,7 @@ class Point { // expected-note{{class 'Point' does not conform to the 'Sendable'
   var y : Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActor: MySuperActor { // expected-error{{actor types do not support inheritance}}
   let immutable: Int = 17
   // expected-note@+2 2{{property declared here}}
@@ -81,14 +81,14 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Camera {
   func accessProp(act : MyActor) async -> String {
     return await act.name
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
@@ -109,7 +109,7 @@ func checkAsyncPropertyAccess() async {
   _ = act.point  // expected-warning{{cannot use property 'point' with a non-sendable type 'Point' across actors}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension MyActor {
   nonisolated var actorIndependentVar: Int {
     get { 5 }
@@ -321,35 +321,35 @@ extension MyActor {
 // ----------------------------------------------------------------------
 // Global actor isolation restrictions
 // ----------------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor SomeActor { }
 
 @globalActor
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SomeOtherGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeGlobalActor func onions() {} // expected-note{{calls to global function 'onions()' from outside of its actor context are implicitly asynchronous}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor func beets() { onions() } // expected-error{{call to global actor 'SomeGlobalActor'-isolated global function 'onions()' in a synchronous main actor-isolated context}}
 // expected-note@-1{{calls to global function 'beets()' from outside of its actor context are implicitly asynchronous}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Crystal {
   // expected-note@+2 {{property declared here}}
   // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
@@ -378,21 +378,21 @@ actor Crystal {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note {{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeOtherGlobalActor func asyncOtherGlobalActorFunc() async {
   await syncGlobalActorFunc()
   await asyncGlobalActorFunc()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
     syncGlobalActorFunc()
@@ -406,7 +406,7 @@ func testGlobalActorClosures() {
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {
     // Access to other functions in this actor are okay.
@@ -470,7 +470,7 @@ extension MyActor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct GenericStruct<T> {
   @GenericGlobalActor<T> func f() { } // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
@@ -485,7 +485,7 @@ struct GenericStruct<T> {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension GenericStruct where T == String {
   @GenericGlobalActor<T>
   func h2() {
@@ -504,7 +504,7 @@ func badNumberUser() {
   print("The protected number is: \(number)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncBadNumberUser() async {
   print("The protected number is: \(await number)")
 }
@@ -512,7 +512,7 @@ func asyncBadNumberUser() async {
 // ----------------------------------------------------------------------
 // Non-actor code isolation restrictions
 // ----------------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testGlobalRestrictions(actor: MyActor) async {
   let _ = MyActor()
 
@@ -572,7 +572,7 @@ func testGlobalRestrictions(actor: MyActor) async {
 
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func f() {
   acceptConcurrentClosure {
     _ = mutableGlobal // expected-warning{{reference to var 'mutableGlobal' is not concurrency-safe because it involves shared mutable state}}
@@ -586,7 +586,7 @@ func f() {
 // ----------------------------------------------------------------------
 // Local function isolation restrictions
 // ----------------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func checkLocalFunctions() async {
   var i = 0
   var j = 0
@@ -635,7 +635,7 @@ func checkLocalFunctions() async {
 // Lazy properties with initializers referencing 'self'
 // ----------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor LazyActor {
     var v: Int = 0
     // expected-note@-1 6 {{property declared here}}
@@ -673,7 +673,7 @@ actor LazyActor {
 }
 
 // Infer global actors from context only for instance members.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class SomeClassInActor {
   enum ID: String { case best }
@@ -681,7 +681,7 @@ class SomeClassInActor {
   func inActor() { } // expected-note{{calls to instance method 'inActor()' from outside of its actor context are implicitly asynchronous}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension SomeClassInActor.ID {
   func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
     object.inActor() // expected-error{{call to main actor-isolated instance method 'inActor()' in a synchronous nonisolated context}}
@@ -691,7 +691,7 @@ extension SomeClassInActor.ID {
 // ----------------------------------------------------------------------
 // Initializers (through typechecking only)
 // ----------------------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
@@ -757,7 +757,7 @@ actor SomeActorWithInits {
   nonisolated func nonisolated() {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class SomeClassWithInits {
   var mutableState: Int = 17
@@ -797,7 +797,7 @@ class SomeClassWithInits {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
   _ = SomeClassWithInits.shared // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
@@ -823,11 +823,11 @@ func testCrossModuleLets(actor: OtherModuleActor) async {
 // Actor protocols.
 // ----------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A: Actor { // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class C: Actor, UnsafeSendable {
   // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}}
   // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
@@ -836,47 +836,47 @@ class C: Actor, UnsafeSendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol P: Actor {
   func f()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension P {
   func g() { f() }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor MyActorP: P {
   func f() { }
 
   func h() { g() }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol SP {
   static func s()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor ASP: SP {
   static func s() { }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol SPD {
   static func sd()
 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension SPD {
   static func sd() { }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor ASPD: SPD {
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testCrossActorProtocol<T: P>(t: T) async {
   await t.f()
   await t.g()
@@ -896,7 +896,7 @@ func testCrossActorProtocol<T: P>(t: T) async {
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension MyActor {
   func testSendableAndInheriting() {
     acceptAsyncSendableClosure {
@@ -918,14 +918,14 @@ extension MyActor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor // expected-note {{'GloballyIsolatedProto' is isolated to global actor 'MainActor' here}}
 protocol GloballyIsolatedProto {
 }
 
 // rdar://75849035 - trying to conform an actor to a global-actor isolated protocol should result in an error
 func test_conforming_actor_to_global_actor_protocol() {
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   actor MyValue : GloballyIsolatedProto {}
   // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
 }

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -6,12 +6,12 @@ enum PictureData {
   case failedToLoadImagePlaceholder
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancellation_checkCancellation() async throws {
   try Task.checkCancellation()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   guard !Task.isCancelled else {
     return PictureData.failedToLoadImagePlaceholder
@@ -20,12 +20,12 @@ func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   return PictureData.value("...")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SomeFile: Sendable {
   func close() {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> PictureData {
   let handle: Task<PictureData, Error> = .init {
     let file = SomeFile()
@@ -40,7 +40,7 @@ func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> Pic
   handle.cancel()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_cancellation_loop() async -> Int {
   struct SampleTask { func process() async {} }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -2,36 +2,36 @@
 // REQUIRES: concurrency
 
 // expected-note@+2{{add 'async' to function 'missingAsync' to make it asynchronous}}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func missingAsync<T : AsyncSequence>(_ seq: T) throws { 
   for try await _ in seq { } // expected-error{{'async' in a function that does not support concurrency}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func missingThrows<T : AsyncSequence>(_ seq: T) async {
   for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func executeAsync(_ work: () async -> Void) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func execute(_ work: () -> Void) { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { // expected-error{{invalid conversion from throwing function of type '() async throws -> Void' to non-throwing function type '() async -> Void'}}
     for try await _ in seq { }
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
     for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
   execute { // expected-error{{cannot pass function of type '() async -> Void' to parameter expecting synchronous function type}}
     do { 
@@ -40,7 +40,7 @@ func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   var it = seq.makeAsyncIterator()
   // expected-note@+2{{call is to 'rethrows' function, but a conformance has a throwing witness}}
@@ -48,7 +48,7 @@ func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   let _ = await it.next()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   typealias Element = Int
   typealias AsyncIterator = Self
@@ -59,7 +59,7 @@ struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   func makeAsyncIterator() -> Self { return self }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
   var it = seq.makeAsyncIterator()
   // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
@@ -67,7 +67,7 @@ func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
 }
 
 // rdar://75274975
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   do {
     for try await item in source {
@@ -76,7 +76,7 @@ func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   } catch {} // no-warning
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func forAwaitWithConcreteType(_ seq: ThrowingAsyncSequence) throws { // expected-note {{add 'async' to function 'forAwaitWithConcreteType' to make it asynchronous}}
   for try await elt in seq { // expected-error {{'async' in a function that does not support concurrency}}
     _ = elt

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -4,11 +4,11 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncFunc() async -> Int { 42 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncThrowsFunc() async throws -> Int { 42 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
@@ -19,7 +19,7 @@ func asyncThrowsOnCancel() async throws -> Int {
   throw CancellationError()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_add() async throws -> Int {
   try await withThrowingTaskGroup(of: Int.self) { group in
     group.addTask {
@@ -42,12 +42,12 @@ func test_taskGroup_add() async throws -> Int {
 // MARK: Example group Usages
 
 struct Boom: Error {}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func work() async -> Int { 42 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func first_allMustSucceed() async throws {
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
@@ -66,7 +66,7 @@ func first_allMustSucceed() async throws {
   // Expected: re-thrown Boom
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func first_ignoreFailures() async throws {
   @Sendable func work() async -> Int { 42 }
   @Sendable func boom() async throws -> Int { throw Boom() }
@@ -100,7 +100,7 @@ func first_ignoreFailures() async throws {
 // ==== ------------------------------------------------------------------------
 // MARK: Advanced Custom Task Group Usage
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_taskGroup_quorum_thenCancel() async {
   // imitates a typical "gather quorum" routine that is typical in distributed systems programming
   enum Vote {
@@ -156,7 +156,7 @@ func test_taskGroup_quorum_thenCancel() async {
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -167,7 +167,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendable {
 
   /// Just another example of how one might use task groups.

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func someAsyncFunc() async -> String { "" }
 
 struct MyError: Error {}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func someThrowingAsyncFunc() async throws -> String { throw MyError() }
 
 // ==== Unsafe Continuations ---------------------------------------------------
@@ -27,7 +27,7 @@ func buyVegetables(
 ) {}
 
 // returns 1 or more vegetables or throws an error
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
   try await withUnsafeThrowingContinuation { continuation in
     var veggies: [Vegetable] = []
@@ -43,7 +43,7 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
@@ -64,7 +64,7 @@ func test_unsafeContinuations() async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_unsafeThrowingContinuations() async throws {
   let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
@@ -89,7 +89,7 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detached() async throws {
   let handle = Task.detached {
     await someAsyncFunc() // able to call async functions
@@ -99,7 +99,7 @@ func test_detached() async throws {
   _ = result
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_detached_throwing() async -> String {
   let handle: Task<String, Error> = Task.detached {
     try await someThrowingAsyncFunc() // able to call async functions

--- a/test/Concurrency/builtin_silgen.swift
+++ b/test/Concurrency/builtin_silgen.swift
@@ -15,7 +15,7 @@ func suspend() async {}
 // CHECK:   hop_to_executor [mandatory] [[ACTOR]] : $MainActor
 // CHECK:   strong_release [[ACTOR]] : $MainActor
 // CHECK:   apply %{{.*}}() : $@convention(thin) @async () -> ()
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runDetached() {
   Task.detached {
     Builtin.hopToActor(MainActor.shared)

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -6,10 +6,10 @@
 
 import ShadowsConcur
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func f(_ t : UnsafeCurrentTask) -> Bool {
   return t.someProperty == "123"
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func g(_: _Concurrency.UnsafeCurrentTask) {}

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -85,7 +85,7 @@ struct HasFunctions {
   var cfp: @convention(c) () -> Void
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor
 actor MyGlobalActor {
   static let shared = MyGlobalActor()

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,17 +1,17 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A {
   func f() { }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
   func g() { }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testA<T: Actor>(
   a: isolated A,
   b: isolated T,
@@ -22,20 +22,20 @@ func testA<T: Actor>(
   b.g()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 typealias Fn = (isolated A) -> Void
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func globalFunc(_ a: A) { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func globalFuncIsolated(_: isolated A) { // expected-note{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
   let _: Int = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type 'Int'}}
   let _: (A) -> Void = globalFuncIsolated // expected-error{{cannot convert value of type '(isolated A) -> ()' to specified type '(A) -> Void'}}
   let _: Fn = globalFunc // okay
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testIsolatedParamCalls(a: isolated A, b: A) {
   globalFunc(a)
   globalFunc(b)
@@ -44,7 +44,7 @@ func testIsolatedParamCalls(a: isolated A, b: A) {
   globalFuncIsolated(b) // expected-error{{call to actor-isolated global function 'globalFuncIsolated' in a synchronous nonisolated context}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
   globalFunc(a)
   globalFunc(b)
@@ -69,7 +69,7 @@ func check() {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol P {
   func f(isolated: MyActor) async
   func g(isolated x: MyActor) async
@@ -80,7 +80,7 @@ protocol P {
   func l(isolated _: Int) -> Int
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct S: P {
   func f(isolated: MyActor) async { await isolated.hello() }
   func g(isolated x: MyActor) async { await x.hello() }
@@ -105,7 +105,7 @@ func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration 
 
 func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
   tuplify(testTuplingIsolated)
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
@@ -113,7 +113,7 @@ func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
 }
 
 // Inference of "isolated" on closure parameters.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testIsolatedClosureInference(a: A) {
   let _: (isolated A) -> Void = {
     $0.f()

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct TL {
   @TaskLocal
   static var number: Int = 0
@@ -22,7 +22,7 @@ var global: Int = 0
 
 class NotSendable {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test () async {
   TL.number = 10 // expected-error{{cannot assign to property: 'number' is a get-only property}}
   TL.$number = 10 // expected-error{{cannot assign value of type 'Int' to type 'TaskLocal<Int>'}}

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -31,14 +31,14 @@ protocol MP { }
 
 class M : MP {
 
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   func throwWithIndirectResult<T>(_ a: P<T>) async throws -> T {
     throw E.err
   }
 }
 
 extension MP {
-  @available(SwiftStdlib 5.5, *)
+  @available(SwiftStdlib 5.1, *)
   func l<A, B, C, D, E2, F> (_ a : P<A>, _ b: P<B>, _ c: P<C>, _ d : P<D>, _ e: P<E2>, _ f: P<F>) async throws -> (A, B, C, D, E2, F) {
     throw E.err
   }
@@ -48,7 +48,7 @@ extension MP {
   static func main() async {
     var tests = TestSuite("Async Throw")
 
-    if #available(SwiftStdlib 5.5, *) {
+    if #available(SwiftStdlib 5.1, *) {
       tests.test("throwing of naturally direct but indirect reabstration") {
         let task2 = detach {
           let m = M()

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -203,7 +203,7 @@ func adopt(voucher: voucher_t?) {
 
 let tests = TestSuite("Voucher Propagation")
 
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
   tests.test("simple voucher propagation") {
     withVouchers { v1, v2, v3 in
       let a = Accumulator(label: "a: ")

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -2,7 +2,7 @@
 // RUN:    -module-name M  -disable-availability-checking | %FileCheck %s --dump-input always
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Collection where Element: Sendable {
   public func f() async throws {
     return try await withThrowingTaskGroup(of: Element.self) { group in

--- a/test/Demangle/rdar-82252704.swift
+++ b/test/Demangle/rdar-82252704.swift
@@ -4,7 +4,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c %s -o %t/test.o
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func MyFunction() async throws {
     class MyClass {}
 }

--- a/test/Distributed/Runtime/distributed_actor_decode.swift
+++ b/test/Distributed/Runtime/distributed_actor_decode.swift
@@ -9,7 +9,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA: CustomStringConvertible {
   nonisolated var description: String {
     "DA(\(self.id))"
@@ -18,7 +18,7 @@ distributed actor DA: CustomStringConvertible {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -39,7 +39,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     print("FakeTransport.decodeIdentity from:\(decoder)")
@@ -71,7 +71,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Test Coding ------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 class TestEncoder: Encoder {
   var codingPath: [CodingKey]
   var userInfo: [CodingUserInfoKey: Any]
@@ -135,7 +135,7 @@ class TestEncoder: Encoder {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 class TestDecoder: Decoder {
   let encoder: TestEncoder
   let data: String
@@ -190,7 +190,7 @@ class TestDecoder: Decoder {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test() {
   let transport = FakeTransport()
 
@@ -210,7 +210,7 @@ func test() {
   print("decoded da2: \(da2)")
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     test()

--- a/test/Distributed/Runtime/distributed_actor_decode.swift
+++ b/test/Distributed/Runtime/distributed_actor_decode.swift
@@ -9,7 +9,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA: CustomStringConvertible {
   nonisolated var description: String {
     "DA(\(self.id))"
@@ -18,7 +18,7 @@ distributed actor DA: CustomStringConvertible {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -39,7 +39,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     print("FakeTransport.decodeIdentity from:\(decoder)")
@@ -71,7 +71,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Test Coding ------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class TestEncoder: Encoder {
   var codingPath: [CodingKey]
   var userInfo: [CodingUserInfoKey: Any]
@@ -135,7 +135,7 @@ class TestEncoder: Encoder {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class TestDecoder: Decoder {
   let encoder: TestEncoder
   let data: String
@@ -190,7 +190,7 @@ class TestDecoder: Decoder {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() {
   let transport = FakeTransport()
 
@@ -210,7 +210,7 @@ func test() {
   print("decoded da2: \(da2)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     test()

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -12,22 +12,22 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA {
   init(transport: ActorTransport) {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA_userDefined {
   init(transport: ActorTransport) {}
 
   deinit {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA_userDefined2 {
   init(transport: ActorTransport) {}
 
@@ -37,7 +37,7 @@ distributed actor DA_userDefined2 {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA_state {
   var name = "Hello"
   var age = 42
@@ -52,7 +52,7 @@ distributed actor DA_state {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -60,7 +60,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 final class FakeTransport: @unchecked Sendable, ActorTransport {
 
   var n = 0
@@ -95,7 +95,7 @@ final class FakeTransport: @unchecked Sendable, ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() {
   let transport = FakeTransport()
 
@@ -147,7 +147,7 @@ func test() {
   // CHECK-NEXT: Deinitializing
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     test()

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -12,22 +12,22 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 actor A {}
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA {
   init(transport: ActorTransport) {}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA_userDefined {
   init(transport: ActorTransport) {}
 
   deinit {}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA_userDefined2 {
   init(transport: ActorTransport) {}
 
@@ -37,7 +37,7 @@ distributed actor DA_userDefined2 {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA_state {
   var name = "Hello"
   var age = 42
@@ -52,7 +52,7 @@ distributed actor DA_state {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -60,7 +60,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 final class FakeTransport: @unchecked Sendable, ActorTransport {
 
   var n = 0
@@ -95,7 +95,7 @@ final class FakeTransport: @unchecked Sendable, ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test() {
   let transport = FakeTransport()
 
@@ -147,7 +147,7 @@ func test() {
   // CHECK-NEXT: Deinitializing
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     test()

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -20,22 +20,22 @@ enum MyError: Error {
   case test
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor PickATransport1 {
   init(kappa transport: ActorTransport, other: Int) {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor PickATransport2 {
   init(other: Int, theTransport: ActorTransport) async {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor LocalWorker {
   init(transport: ActorTransport) {}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor Bug_CallsReadyTwice {
   var x: Int
   init(transport: ActorTransport, wantBug: Bool) async {
@@ -46,7 +46,7 @@ distributed actor Bug_CallsReadyTwice {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor Throwy {
   init(transport: ActorTransport, doThrow: Bool) throws {
     if doThrow {
@@ -55,7 +55,7 @@ distributed actor Throwy {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor ThrowBeforeFullyInit {
   var x: Int
   init(transport: ActorTransport, doThrow: Bool) throws {
@@ -68,7 +68,7 @@ distributed actor ThrowBeforeFullyInit {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address: String) {
@@ -79,7 +79,7 @@ struct ActorAddress: ActorIdentity {
 // global to track available IDs
 var nextID: Int = 1
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -109,7 +109,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test() async {
   let transport = FakeTransport()
 
@@ -156,7 +156,7 @@ func test() async {
   // CHECK-DAG: resign id:AnyActorIdentity(ActorAddress(address: "[[ID7]]"))
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -20,22 +20,22 @@ enum MyError: Error {
   case test
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor PickATransport1 {
   init(kappa transport: ActorTransport, other: Int) {}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor PickATransport2 {
   init(other: Int, theTransport: ActorTransport) async {}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor LocalWorker {
   init(transport: ActorTransport) {}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor Bug_CallsReadyTwice {
   var x: Int
   init(transport: ActorTransport, wantBug: Bool) async {
@@ -46,7 +46,7 @@ distributed actor Bug_CallsReadyTwice {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor Throwy {
   init(transport: ActorTransport, doThrow: Bool) throws {
     if doThrow {
@@ -55,7 +55,7 @@ distributed actor Throwy {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor ThrowBeforeFullyInit {
   var x: Int
   init(transport: ActorTransport, doThrow: Bool) throws {
@@ -68,7 +68,7 @@ distributed actor ThrowBeforeFullyInit {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address: String) {
@@ -79,7 +79,7 @@ struct ActorAddress: ActorIdentity {
 // global to track available IDs
 var nextID: Int = 1
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -109,7 +109,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test() async {
   let transport = FakeTransport()
 
@@ -156,7 +156,7 @@ func test() async {
   // CHECK-DAG: resign id:AnyActorIdentity(ActorAddress(address: "[[ID7]]"))
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -13,14 +13,14 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeSpecificDistributedActor {
   distributed func hello() async throws -> String {
     "local impl"
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension SomeSpecificDistributedActor {
 
   @_dynamicReplacement(for: _remote_hello())
@@ -31,17 +31,17 @@ extension SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeActorID: ActorIdentity {
   let id: UInt64
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 enum FakeTransportError: ActorTransportError {
   case unsupportedActorIdentity(AnyActorIdentity)
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -49,7 +49,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -88,7 +88,7 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_remote() async {
   let address = ActorAddress(parse: "sact://127.0.0.1/example#1234")
   let transport = FakeTransport()
@@ -113,7 +113,7 @@ func test_remote() async {
   print("done") // CHECK: done
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -13,14 +13,14 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeSpecificDistributedActor {
   distributed func hello() async throws -> String {
     "local impl"
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension SomeSpecificDistributedActor {
 
   @_dynamicReplacement(for: _remote_hello())
@@ -31,17 +31,17 @@ extension SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeActorID: ActorIdentity {
   let id: UInt64
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum FakeTransportError: ActorTransportError {
   case unsupportedActorIdentity(AnyActorIdentity)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -49,7 +49,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -88,7 +88,7 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_remote() async {
   let address = ActorAddress(parse: "sact://127.0.0.1/example#1234")
   let transport = FakeTransport()
@@ -113,7 +113,7 @@ func test_remote() async {
   print("done") // CHECK: done
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -14,7 +14,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeSpecificDistributedActor {
 
   distributed func hello() async throws {
@@ -37,7 +37,7 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -45,7 +45,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented \(#function)")
@@ -71,7 +71,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_initializers() {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
@@ -80,7 +80,7 @@ func test_initializers() {
   _ = try! SomeSpecificDistributedActor.resolve(.init(address), using: transport)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_address() {
   let transport = FakeTransport()
 
@@ -88,7 +88,7 @@ func test_address() {
   _ = actor.id
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_run(transport: FakeTransport) async {
   let actor = SomeSpecificDistributedActor(transport: transport)
 
@@ -97,7 +97,7 @@ func test_run(transport: FakeTransport) async {
   print("after") // CHECK: after
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_echo(transport: FakeTransport) async {
   let actor = SomeSpecificDistributedActor(transport: transport)
 
@@ -105,7 +105,7 @@ func test_echo(transport: FakeTransport) async {
   print("echo: \(echo)") // CHECK: echo: 42
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_run(transport: FakeTransport())

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -14,7 +14,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeSpecificDistributedActor {
 
   distributed func hello() async throws {
@@ -37,7 +37,7 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -45,7 +45,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented \(#function)")
@@ -71,7 +71,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_initializers() {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
@@ -80,7 +80,7 @@ func test_initializers() {
   _ = try! SomeSpecificDistributedActor.resolve(.init(address), using: transport)
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_address() {
   let transport = FakeTransport()
 
@@ -88,7 +88,7 @@ func test_address() {
   _ = actor.id
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_run(transport: FakeTransport) async {
   let actor = SomeSpecificDistributedActor(transport: transport)
 
@@ -97,7 +97,7 @@ func test_run(transport: FakeTransport) async {
   print("after") // CHECK: after
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_echo(transport: FakeTransport) async {
   let actor = SomeSpecificDistributedActor(transport: transport)
 
@@ -105,7 +105,7 @@ func test_echo(transport: FakeTransport) async {
   print("echo: \(echo)") // CHECK: echo: 42
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     await test_run(transport: FakeTransport())

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -10,7 +10,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeSpecificDistributedActor {
   let name: String
   let surname: String
@@ -33,17 +33,17 @@ distributed actor SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeActorID: ActorIdentity {
   let id: UInt64
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 enum FakeTransportError: ActorTransportError {
   case unsupportedActorIdentity(AnyActorIdentity)
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -51,7 +51,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -81,7 +81,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_remote() async {
   let address = ActorAddress(parse: "sact://127.0.0.1/example#1234")
   let transport = FakeTransport()
@@ -96,7 +96,7 @@ func test_remote() async {
   print("done") // CHECK: done
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -10,7 +10,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeSpecificDistributedActor {
   let name: String
   let surname: String
@@ -33,17 +33,17 @@ distributed actor SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeActorID: ActorIdentity {
   let id: UInt64
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum FakeTransportError: ActorTransportError {
   case unsupportedActorIdentity(AnyActorIdentity)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -51,7 +51,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -81,7 +81,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_remote() async {
   let address = ActorAddress(parse: "sact://127.0.0.1/example#1234")
   let transport = FakeTransport()
@@ -96,7 +96,7 @@ func test_remote() async {
   print("done") // CHECK: done
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -21,7 +21,7 @@ struct Boom: Error {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeSpecificDistributedActor {
   let state: String = "hi there"
 
@@ -77,7 +77,7 @@ distributed actor SomeSpecificDistributedActor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension SomeSpecificDistributedActor {
   @_dynamicReplacement(for:_remote_helloAsyncThrows())
   nonisolated func _remote_impl_helloAsyncThrows() async throws -> String {
@@ -138,12 +138,12 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -168,7 +168,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_remote_invoke(address: ActorAddress, transport: ActorTransport) async {
   func check(actor: SomeSpecificDistributedActor) async {
     let personality = __isRemoteActor(actor) ? "remote" : "local"
@@ -241,7 +241,7 @@ func test_remote_invoke(address: ActorAddress, transport: ActorTransport) async 
   print(remote)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     let address = ActorAddress(address: "")

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -21,7 +21,7 @@ struct Boom: Error {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeSpecificDistributedActor {
   let state: String = "hi there"
 
@@ -77,7 +77,7 @@ distributed actor SomeSpecificDistributedActor {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension SomeSpecificDistributedActor {
   @_dynamicReplacement(for:_remote_helloAsyncThrows())
   nonisolated func _remote_impl_helloAsyncThrows() async throws -> String {
@@ -138,12 +138,12 @@ func __isLocalActor(_ actor: AnyObject) -> Bool {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -168,7 +168,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_remote_invoke(address: ActorAddress, transport: ActorTransport) async {
   func check(actor: SomeSpecificDistributedActor) async {
     let personality = __isRemoteActor(actor) ? "remote" : "local"
@@ -241,7 +241,7 @@ func test_remote_invoke(address: ActorAddress, transport: ActorTransport) async 
   print(remote)
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     let address = ActorAddress(address: "")

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -22,7 +22,7 @@ distributed actor Capybara {
 
 
 // ==== Fake Transport ---------------------------------------------------------
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address: String) {
@@ -30,7 +30,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -75,7 +75,7 @@ func test() async throws {
   print("valueWhenRemote: \(valueWhenRemote ?? "nil")")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     try! await test()

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -22,7 +22,7 @@ distributed actor Capybara {
 
 
 // ==== Fake Transport ---------------------------------------------------------
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address: String) {
@@ -30,7 +30,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -75,7 +75,7 @@ func test() async throws {
   print("valueWhenRemote: \(valueWhenRemote ?? "nil")")
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     try! await test()

--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -14,7 +14,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeSpecificDistributedActor {
   distributed func hello() async throws -> String {
     "local impl"
@@ -23,7 +23,7 @@ distributed actor SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -31,7 +31,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -60,7 +60,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_remote() async {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
@@ -71,7 +71,7 @@ func test_remote() async {
   // CHECK: SOURCE_DIR/test/Distributed/Runtime/distributed_no_transport_boom.swift:{{[0-9]+}}: Fatal error: Invoked remote placeholder function '_remote_hello' on remote distributed actor of type 'main.SomeSpecificDistributedActor'. Configure an appropriate 'ActorTransport' for this actor to resolve this error (e.g. by depending on some specific transport library).
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -14,7 +14,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeSpecificDistributedActor {
   distributed func hello() async throws -> String {
     "local impl"
@@ -23,7 +23,7 @@ distributed actor SomeSpecificDistributedActor {
 
 // ==== Fake Transport ---------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {
@@ -31,7 +31,7 @@ struct ActorAddress: ActorIdentity {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct FakeTransport: ActorTransport {
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
     fatalError("not implemented:\(#function)")
@@ -60,7 +60,7 @@ struct FakeTransport: ActorTransport {
 
 // ==== Execute ----------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_remote() async {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
@@ -71,7 +71,7 @@ func test_remote() async {
   // CHECK: SOURCE_DIR/test/Distributed/Runtime/distributed_no_transport_boom.swift:{{[0-9]+}}: Fatal error: Invoked remote placeholder function '_remote_hello' on remote distributed actor of type 'main.SomeSpecificDistributedActor'. Configure an appropriate 'ActorTransport' for this actor to resolve this error (e.g. by depending on some specific transport library).
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_remote()

--- a/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
+++ b/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
@@ -4,21 +4,21 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension Actor {
     func f() -> String { "Life is Study!" }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func g<A: Actor>(a: A) async { // expected-note{{where 'A' = 'MA'}}
     print(await a.f())
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor MA {
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func h(ma: MA) async {
     // this would have been a bug, a non distributed function might have been called here,
     // so we must not allow for it, because if the actor was remote calling a non-distributed func

--- a/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
+++ b/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
@@ -4,21 +4,21 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Actor {
     func f() -> String { "Life is Study!" }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func g<A: Actor>(a: A) async { // expected-note{{where 'A' = 'MA'}}
     print(await a.f())
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor MA {
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func h(ma: MA) async {
     // this would have been a bug, a non distributed function might have been called here,
     // so we must not allow for it, because if the actor was remote calling a non-distributed func

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -4,7 +4,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor D {
 
   func hello() {} // expected-note{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -17,7 +17,7 @@ distributed actor D {
   distributed func distHelloAsyncThrows() async throws { } // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_not_distributed_funcs(distributed: D) async {
   distributed.hello() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
   distributed.helloAsync() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -30,7 +30,7 @@ func test_not_distributed_funcs(distributed: D) async {
   // expected-error@-3{{call can throw, but it is not marked with 'try' and the error is not handled}} // TODO: no need to diagnose this, it is impossible to call anyway
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_outside(distributed: D) async throws {
   distributed.distHello() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -4,7 +4,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor D {
 
   func hello() {} // expected-note{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -17,7 +17,7 @@ distributed actor D {
   distributed func distHelloAsyncThrows() async throws { } // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_not_distributed_funcs(distributed: D) async {
   distributed.hello() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
   distributed.helloAsync() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -30,7 +30,7 @@ func test_not_distributed_funcs(distributed: D) async {
   // expected-error@-3{{call can throw, but it is not marked with 'try' and the error is not handled}} // TODO: no need to diagnose this, it is impossible to call anyway
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test_outside(distributed: D) async throws {
   distributed.distHello() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -9,32 +9,32 @@ actor SomeActor { }
 // ==== ------------------------------------------------------------------------
 // MARK: Declaring distributed actors
 // GOOD:
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeDistributedActor_0 { }
 
 // BAD:
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed class SomeDistributedActor_1 { } // expected-error{{'distributed' can only be applied to 'actor' definitions, and distributed actor-isolated async functions}}
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed struct SomeDistributedActor_2 { } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed enum SomeDistributedActor_3 { } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
 
 // ==== ------------------------------------------------------------------------
 // MARK: Declaring distributed functions
 // NOTE: not distributed actor, so cannot have any distributed functions
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 struct SomeNotActorStruct_2 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 class SomeNotActorClass_3 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 actor SomeNotDistributedActor_4 {
   distributed func notInDistActorAsyncThrowing() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
@@ -43,34 +43,34 @@ protocol DP {
   distributed func hello()  // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 protocol DPOK: DistributedActor {
   distributed func hello()  // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 protocol DPOK2: DPOK {
   distributed func again()  // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 enum SomeNotActorEnum_5 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeDistributedActor_6 {
   distributed func yay() async throws -> Int { 42 } // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SomeDistributedActor_7 {
   distributed func dont_1() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_1' remote counterpart '_remote_dont_1' cannot not be implemented manually.}}
   distributed func dont_2() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_2' remote counterpart '_remote_dont_2' cannot not be implemented manually.}}
   distributed func dont_3() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_3' remote counterpart '_remote_dont_3' cannot not be implemented manually.}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 extension SomeDistributedActor_7 {
 
   // TODO: we should diagnose a bit more precisely here
@@ -93,7 +93,7 @@ extension SomeDistributedActor_7 {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor BadValuesDistributedActor_7 {
   distributed var varItNope: Int { 13 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
   distributed let letItNope: Int = 13 // expected-error{{'distributed' modifier cannot be applied to this declaration}}

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -9,32 +9,32 @@ actor SomeActor { }
 // ==== ------------------------------------------------------------------------
 // MARK: Declaring distributed actors
 // GOOD:
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeDistributedActor_0 { }
 
 // BAD:
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed class SomeDistributedActor_1 { } // expected-error{{'distributed' can only be applied to 'actor' definitions, and distributed actor-isolated async functions}}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed struct SomeDistributedActor_2 { } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed enum SomeDistributedActor_3 { } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
 
 // ==== ------------------------------------------------------------------------
 // MARK: Declaring distributed functions
 // NOTE: not distributed actor, so cannot have any distributed functions
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct SomeNotActorStruct_2 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class SomeNotActorClass_3 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor SomeNotDistributedActor_4 {
   distributed func notInDistActorAsyncThrowing() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
@@ -43,34 +43,34 @@ protocol DP {
   distributed func hello()  // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol DPOK: DistributedActor {
   distributed func hello()  // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol DPOK2: DPOK {
   distributed func again()  // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 enum SomeNotActorEnum_5 {
   distributed func nopeAsyncThrows() async throws -> Int { 42 } // expected-error{{'distributed' function can only be declared within 'distributed actor'}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeDistributedActor_6 {
   distributed func yay() async throws -> Int { 42 } // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SomeDistributedActor_7 {
   distributed func dont_1() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_1' remote counterpart '_remote_dont_1' cannot not be implemented manually.}}
   distributed func dont_2() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_2' remote counterpart '_remote_dont_2' cannot not be implemented manually.}}
   distributed func dont_3() async throws -> Int { 42 } // expected-error{{Distributed function's 'dont_3' remote counterpart '_remote_dont_3' cannot not be implemented manually.}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension SomeDistributedActor_7 {
 
   // TODO: we should diagnose a bit more precisely here
@@ -93,7 +93,7 @@ extension SomeDistributedActor_7 {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor BadValuesDistributedActor_7 {
   distributed var varItNope: Int { 13 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
   distributed let letItNope: Int = 13 // expected-error{{'distributed' modifier cannot be applied to this declaration}}

--- a/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
+++ b/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
@@ -4,11 +4,11 @@
 
 actor SomeActor {}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA {}
 // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor class DAC {}
 // expected-error@-1{{distributed' can only be applied to 'actor' definitions, and distributed actor-isolated async functions}}
 // expected-error@-2{{keyword 'class' cannot be used as an identifier here}}
@@ -23,7 +23,7 @@ actor A {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA2 {
   // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
   func normal() async {}

--- a/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
+++ b/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
@@ -4,11 +4,11 @@
 
 actor SomeActor {}
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA {}
 // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor class DAC {}
 // expected-error@-1{{distributed' can only be applied to 'actor' definitions, and distributed actor-isolated async functions}}
 // expected-error@-2{{keyword 'class' cannot be used as an identifier here}}
@@ -23,7 +23,7 @@ actor A {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA2 {
   // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
   func normal() async {}

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -4,7 +4,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor DA {
 
   let local: Int = 42

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -4,7 +4,7 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor DA {
 
   let local: Int = 42

--- a/test/Distributed/distributed_actor_resolve.swift
+++ b/test/Distributed/distributed_actor_resolve.swift
@@ -4,15 +4,15 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor Capybara { }
 
-//@available(SwiftStdlib 5.5, *)
+//@available(SwiftStdlib 5.1, *)
 //protocol Wheeker: DistributedActor { }
-//@available(SwiftStdlib 5.5, *)
+//@available(SwiftStdlib 5.1, *)
 //distributed actor GuineaPing: Wheeker { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test(identity: AnyActorIdentity, transport: ActorTransport) async throws {
   let _: Capybara = try Capybara.resolve(identity, using: transport)
 

--- a/test/Distributed/distributed_actor_resolve.swift
+++ b/test/Distributed/distributed_actor_resolve.swift
@@ -4,15 +4,15 @@
 
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor Capybara { }
 
-//@available(SwiftStdlib 5.1, *)
+//@available(SwiftStdlib 5.6, *)
 //protocol Wheeker: DistributedActor { }
-//@available(SwiftStdlib 5.1, *)
+//@available(SwiftStdlib 5.6, *)
 //distributed actor GuineaPing: Wheeker { }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func test(identity: AnyActorIdentity, transport: ActorTransport) async throws {
   let _: Capybara = try Capybara.resolve(identity, using: transport)
 

--- a/test/Distributed/distributed_missing_import.swift
+++ b/test/Distributed/distributed_missing_import.swift
@@ -4,7 +4,7 @@
 
 actor SomeActor { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor MissingImportDistributedActor_0 { }
 // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
 

--- a/test/Distributed/distributed_missing_import.swift
+++ b/test/Distributed/distributed_missing_import.swift
@@ -4,7 +4,7 @@
 
 actor SomeActor { }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor MissingImportDistributedActor_0 { }
 // expected-error@-1{{'_Distributed' module not imported, required for 'distributed actor'}}
 

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -7,7 +7,7 @@ import _Distributed
 // ==== -----------------------------------------------------------------------
 // MARK: Good cases
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol DistProtocol: DistributedActor {
   // FIXME(distributed): avoid issuing these warnings, these originate from the call on the DistProtocol where we marked this func as dist isolated,
   func local() -> String
@@ -24,7 +24,7 @@ protocol DistProtocol: DistributedActor {
   distributed func distAsyncThrows() async throws -> String
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor SpecificDist: DistProtocol {
 
   nonisolated func local() -> String { "hi" }
@@ -47,7 +47,7 @@ distributed actor SpecificDist: DistProtocol {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func outside_good(dp: SpecificDist) async throws {
   _ = dp.local()
 
@@ -58,7 +58,7 @@ func outside_good(dp: SpecificDist) async throws {
   _ = try await dp.distAsyncThrows() // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func outside_good_generic<DP: DistProtocol>(dp: DP) async throws {
   _ = dp.local() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
   _ = await dp.local() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -76,7 +76,7 @@ func outside_good_generic<DP: DistProtocol>(dp: DP) async throws {
   _ = try await dp.distAsyncThrows() // ok
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
   _ = try await dp.dist() // implicit async throws
   _ = try await dp.dist(string: "") // implicit async throws
@@ -88,13 +88,13 @@ func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
 // ==== -----------------------------------------------------------------------
 // MARK: Error cases
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol ErrorCases: DistributedActor {
   distributed func unexpectedAsyncThrows() -> String
   // expected-note@-1{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 distributed actor BadGreeter: ErrorCases {
   // expected-error@-1{{type 'BadGreeter' does not conform to protocol 'ErrorCases'}}
 

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -7,7 +7,7 @@ import _Distributed
 // ==== -----------------------------------------------------------------------
 // MARK: Good cases
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 protocol DistProtocol: DistributedActor {
   // FIXME(distributed): avoid issuing these warnings, these originate from the call on the DistProtocol where we marked this func as dist isolated,
   func local() -> String
@@ -24,7 +24,7 @@ protocol DistProtocol: DistributedActor {
   distributed func distAsyncThrows() async throws -> String
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor SpecificDist: DistProtocol {
 
   nonisolated func local() -> String { "hi" }
@@ -47,7 +47,7 @@ distributed actor SpecificDist: DistProtocol {
   }
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func outside_good(dp: SpecificDist) async throws {
   _ = dp.local()
 
@@ -58,7 +58,7 @@ func outside_good(dp: SpecificDist) async throws {
   _ = try await dp.distAsyncThrows() // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func outside_good_generic<DP: DistProtocol>(dp: DP) async throws {
   _ = dp.local() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
   _ = await dp.local() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
@@ -76,7 +76,7 @@ func outside_good_generic<DP: DistProtocol>(dp: DP) async throws {
   _ = try await dp.distAsyncThrows() // ok
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
   _ = try await dp.dist() // implicit async throws
   _ = try await dp.dist(string: "") // implicit async throws
@@ -88,13 +88,13 @@ func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
 // ==== -----------------------------------------------------------------------
 // MARK: Error cases
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 protocol ErrorCases: DistributedActor {
   distributed func unexpectedAsyncThrows() -> String
   // expected-note@-1{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
 }
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 distributed actor BadGreeter: ErrorCases {
   // expected-error@-1{{type 'BadGreeter' does not conform to protocol 'ErrorCases'}}
 

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -7,7 +7,7 @@ import _Distributed
 // Type descriptor.
 // CHECK-LABEL: @"$s17distributed_actor7MyActorC0B9Transport12_Distributed0dE0_pvpWvd"
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public distributed actor MyActor {
     // nothing
 }

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -7,7 +7,7 @@ import _Distributed
 // Type descriptor.
 // CHECK-LABEL: @"$s17distributed_actor7MyActorC0B9Transport12_Distributed0dE0_pvpWvd"
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public distributed actor MyActor {
     // nothing
 }

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,4 +1,4 @@
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor public final class MeowActor {
   public static let shared = _Impl()
   

--- a/test/ModuleInterface/Inputs/OldActor.swiftinterface
+++ b/test/ModuleInterface/Inputs/OldActor.swiftinterface
@@ -4,7 +4,7 @@ import Swift
 import _Concurrency
 
 #if compiler(>=5.3) && $Actors
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor Monk {
   public init()
   deinit

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -12,14 +12,14 @@
 
 // CHECK: public actor SomeActor
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor SomeActor {
   nonisolated func maine() { }
 }
 
 // CHECK: @globalActor public struct SomeGlobalActor
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @globalActor
 public struct SomeGlobalActor {
   public static let shared = SomeActor()
@@ -28,7 +28,7 @@ public struct SomeGlobalActor {
 // CHECK: @{{(Test.)?}}SomeGlobalActor public protocol P1
 // CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor func method()
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeGlobalActor
 public protocol P1 {
   func method()
@@ -37,58 +37,58 @@ public protocol P1 {
 // CHECK: class C1
 // CHECK-NEXT: @{{(Test.)?}}SomeGlobalActor public func method()
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C1: P1 {
   public func method() { }
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @SomeGlobalActor
 public class C2 { }
 
 // CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C3: C2 { }
 
 // CHECK: public class C4 : Swift.UnsafeSendable
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C4: UnsafeSendable { }
 
 // CHECK: public class C5 : @unchecked Swift.Sendable
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C5: @unchecked Sendable { }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C6 { }
 
 // CHECK: extension {{(Test.)?}}C6 : @unchecked Swift.Sendable
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension C6: @unchecked Sendable { }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C7 { }
 
 // CHECK: extension {{(Test.)?}}C7 : Swift.UnsafeSendable
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension C7: UnsafeSendable { }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol P2 {
   @SomeGlobalActor func method()
 }
 
 
 // CHECK: class {{(Test.)?}}C8 : {{(Test.)?}}P2 {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class C8 : P2 {
   // CHECK: @{{(Test.)?}}SomeGlobalActor public func method()
   public func method() {}

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -15,6 +15,6 @@ import Foundation
 // CHECK-LABEL: @objc @_inheritsConvenienceInitializers
 // CHECK: public actor SomeActor : ObjectiveC.NSObject {
 // CHECK: @objc override public init()
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor SomeActor: NSObject {
 }

--- a/test/ModuleInterface/actor_old_compat.swift
+++ b/test/ModuleInterface/actor_old_compat.swift
@@ -10,7 +10,7 @@
 
 import OldActor
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension Monk {
   public func test() async {
     method()

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -12,46 +12,46 @@
 // CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor PlainActorClass {
   nonisolated public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor ExplicitActorClass : Actor {
   nonisolated public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor EmptyActor {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor EmptyActor {}
 
 // CHECK: public actor EmptyActorClass {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor EmptyActorClass {}
 
 // CHECK: public protocol Cat : _Concurrency.Actor {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol Cat : Actor {
   func mew()
 }
 
 // CHECK: public actor HouseCat : Library.Cat {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor HouseCat : Cat {
   nonisolated public func mew() {}
   nonisolated public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public protocol ToothyMouth {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol ToothyMouth {
   func chew()
 }
 
 // CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor Lion : ToothyMouth, Actor {
   nonisolated public func chew() {}
   nonisolated public func enqueue(_ job: UnownedJob) { }

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -28,7 +28,7 @@ public func onMyProjectV2_5() {}
 // CHECK: @available(macOS 10.12, *)
 // CHECK-NEXT: public func onMyProjectV2_5
 
-@_specialize(exported: true, availability: SwiftStdlib 5.5, *; where T == Int)
+@_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func testSemanticsAvailability<T>(_ t: T) {}
 // CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift.Int)
 // CHECK-NEXT: public func testSemanticsAvailability

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -3,7 +3,7 @@
 
 import MeowActor
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MeowActor func doMeow() {}
 
 // RUN: %target-swift-frontend  -disable-availability-checking -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
@@ -14,7 +14,7 @@ import MeowActor
 // RUN: %target-swift-frontend  -disable-availability-checking -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
 // CHECK-FRAGILE: metatype $@thin MeowActor.Type
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func someFunc() async {
   await doMeow()
 }

--- a/test/Reflection/Inputs/ConcurrencyTypes.swift
+++ b/test/Reflection/Inputs/ConcurrencyTypes.swift
@@ -1,8 +1,8 @@
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor SomeActor {
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public struct UsesConcurrency {
   public var mainActorFunction: @MainActor () -> Void
   public var actorIsolatedFunction: (isolated SomeActor) -> Void

--- a/test/Runtime/concurrentTypeByName.swift
+++ b/test/Runtime/concurrentTypeByName.swift
@@ -1044,7 +1044,7 @@ class Super<T>: P {
 class Sub: Super<Int> {}
 
 ConcurrentTypeByNameTests.test("concurrent _typeByName") {
-  if #available(SwiftStdlib 5.5, *) {
+  if #available(SwiftStdlib 5.1, *) {
     func printTypeByName() {
       print(_typeByName("4main14GenericWrapperCyAA3SubCG")! as Any)
     }

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -60,7 +60,7 @@ func globalActorMetatypeFn<T>(_: T.Type) -> Any.Type {
   return Fn.self
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func f1_actor(_: (isolated Actor) -> Void) { }
 
 DemangleToMetadataTests.test("function types") {
@@ -119,7 +119,7 @@ DemangleToMetadataTests.test("function types") {
   expectEqual(MainActorFn.self, globalActorMetatypeFn(Float.self))
 
   // isolated parameters
-  if #available(SwiftStdlib 5.5, *) {
+  if #available(SwiftStdlib 5.1, *) {
     expectEqual(type(of: f1_actor), _typeByName("yyScA_pYiXEc")!)
     typealias IsolatedFn = ((isolated Actor) -> Void) -> Void
     expectEqual(IsolatedFn.self, type(of: f1_actor))
@@ -515,7 +515,7 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
   }
 }
 
-if #available(SwiftStdlib 5.5, *) {
+if #available(SwiftStdlib 5.1, *) {
   DemangleToMetadataTests.test("Concurrency standard substitutions") {
     expectEqual(TaskGroup<Int>.self, _typeByName("ScGySiG")!)
   }

--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -187,12 +187,12 @@ func callActorMethodFromGeneric(a: SomeActor) async {
   await a.someMethod()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func makeActorInTask() async {
   Task.detached { await SomeActor() }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func callActorMethodInTask(a: SomeActor) async {
   Task.detached { await a.someMethod() }
 }

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -635,7 +635,7 @@ struct Blah {
     // CHECK:       end_access [[VAL_ACCESS]] : $*Optional<Int>
     // CHECK:       hop_to_executor {{%[0-9]+}} : $Optional<Builtin.Executor>
     // CHECK: } // end sil function '$s4test4BlahVAAyyFyyYaYbcfU_'
-    @available(SwiftStdlib 5.5, *)
+    @available(SwiftStdlib 5.1, *)
     func test() {
         Task.detached {
             if await coordinator.someValue == nil {

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -1,12 +1,12 @@
 // RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 | %FileCheck %s
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public actor A {
   // CHECK: sil{{.*}} [ossa] @$s4test1AC6methodyyF
   public func method() { }
 }
 
 // CHECK: sil{{.*}} [ossa] @$s4test13takesIsolatedyyAA1ACYiF
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public func takesIsolated(_: isolated A) { }

--- a/test/SILOptimizer/definite_init_actor.swift
+++ b/test/SILOptimizer/definite_init_actor.swift
@@ -210,7 +210,7 @@ actor MultiVarActor {
     }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor TaskMaster {
     var task: Task<Void, Never>?
 

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: linux
 // UNSUPPORTED: windows
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -37,7 +37,7 @@ actor Counter {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -47,7 +47,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -74,7 +74,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -23,7 +23,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -43,7 +43,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -52,7 +52,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -11,7 +11,7 @@
 
 var scratchBuffer: UnsafeMutableBufferPointer<Int> = .allocate(capacity: 1000)
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func completeFastOrSlow(n: Int) async -> Int {
   if n % 2 == 0 {
     await Task.sleep(2_000_000_000)
@@ -21,7 +21,7 @@ func completeFastOrSlow(n: Int) async -> Int {
   return n
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func test_sum_nextOnCompletedOrPending() async {
   scratchBuffer.initialize(repeating: 0)
 
@@ -57,7 +57,7 @@ func test_sum_nextOnCompletedOrPending() async {
   assert(sum == expected, "Expected: \(expected), got: \(sum)")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompletedOrPending()

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -18,12 +18,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -76,7 +76,7 @@ func testSimple(
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -17,7 +17,7 @@
 
 var globalCounterValue = 0
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Counter {
   func next() -> Int {
     let current = globalCounterValue
@@ -26,7 +26,7 @@ actor Counter {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for _ in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -36,7 +36,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -62,7 +62,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -27,7 +27,7 @@ func fib(_ n: Int) -> Int {
 
 var racyCounter = 0
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func asyncFib(_ n: Int) async -> Int {
   racyCounter += 1
   if n == 0 || n == 1 {
@@ -48,7 +48,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -57,7 +57,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Serialization/Inputs/def_distributed.swift
+++ b/test/Serialization/Inputs/def_distributed.swift
@@ -1,6 +1,6 @@
 import _Distributed
 
-@available(SwiftStdlib 5.1, *)
+@available(SwiftStdlib 5.6, *)
 public distributed actor DA {
   public distributed func doSomethingDistributed(param: String) async -> Int {
     return 0

--- a/test/Serialization/Inputs/def_distributed.swift
+++ b/test/Serialization/Inputs/def_distributed.swift
@@ -1,6 +1,6 @@
 import _Distributed
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public distributed actor DA {
   public distributed func doSomethingDistributed(param: String) async -> Int {
     return 0

--- a/test/Syntax/round_trip_concurrency.swift
+++ b/test/Syntax/round_trip_concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -24,7 +24,7 @@ actor Counter {
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -34,7 +34,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -61,7 +61,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module -define-availability 'SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' | %FileCheck %s
+// RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' | %FileCheck %s
 
 struct S<T> {}
 
@@ -341,5 +341,5 @@ public func testAvailability3<T>(_ t: T) {}
 
 // CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Int)
 // CHECK: public func testAvailability4<T>(_ t: T)
-@_specialize(exported: true, availability: SwiftStdlib 5.5, *; where T == Int)
+@_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func testAvailability4<T>(_ t: T) {}

--- a/test/decl/protocol/conforms/actor_derived.swift
+++ b/test/decl/protocol/conforms/actor_derived.swift
@@ -1,27 +1,27 @@
 // RUN: %target-typecheck-verify-swift
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A1: Hashable {
   nonisolated func hash(into hasher: inout Hasher) { }
   static func ==(lhs: A1, rhs: A1) -> Bool { true }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A2: Hashable {
   nonisolated var hashValue: Int { 0 } // expected-warning{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'A2' to 'Hashable' by implementing 'hash(into:)' instead}}
   static func ==(lhs: A2, rhs: A2) -> Bool { true }
 }
 
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class C1: Hashable {
   nonisolated func hash(into hasher: inout Hasher) { }
   nonisolated static func ==(lhs: C1, rhs: C1) -> Bool { true }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class C2: Hashable {
   nonisolated var hashValue: Int { 0 } // expected-warning{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'C2' to 'Hashable' by implementing 'hash(into:)' instead}}

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -3,30 +3,30 @@
 
 // Synthesis of conformances for actors.
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A1 {
   var x: Int = 17
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A2: Actor {
   var x: Int = 17
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A3<T>: Actor {
   var x: Int = 17
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A4: A1 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A5: A2 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
   // expected-error@-2{{actor types do not support inheritance}}
@@ -34,14 +34,14 @@ actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protoc
 
 // Explicitly satisfying the requirement.
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 actor A7 {
   // Okay: satisfy the requirement explicitly
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
   // expected-error@-2{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
@@ -50,7 +50,7 @@ class C1: Actor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
   // expected-error@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
@@ -60,7 +60,7 @@ class C2: Actor {
   }
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
@@ -69,10 +69,10 @@ class C3: Actor {
 }
 
 // Make sure the conformances actually happen.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptActor<T: Actor>(_: T.Type) { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testConformance() {
   acceptActor(A1.self)
   acceptActor(A2.self)

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -47,12 +47,12 @@ distributed actor D5: P1 {
 // ==== Tests ------------------------------------------------------------------
 
 // Make sure the conformances have been added implicitly.
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptDistributedActor<Act: DistributedActor>(_: Act.Type) { }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func acceptAnyActor<Act: AnyActor>(_: Act.Type) { }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testConformance() {
   acceptDistributedActor(D1.self)
   acceptAnyActor(D1.self)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -432,7 +432,7 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # Define availability macros for known stdlib releases.
-for macro in lit_config.params.get('availability_macros').split(";"):
+for macro in lit_config.params.get('availability_macros', '').split(";"):
     config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
     config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -431,10 +431,10 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
-# Define a macro for the next release OS version.
-swift_stdlib_macro = '\'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0\''
-config.swift_frontend_test_options += ' -define-availability ' + swift_stdlib_macro
-config.swift_driver_test_options += ' -Xfrontend -define-availability -Xfrontend ' + swift_stdlib_macro
+# Define availability macros for known stdlib releases.
+for macro in lit_config.params.get('availability_macros').split(";"):
+    config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
+    config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
 
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
 if differentiable_programming is not None:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -432,7 +432,7 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # Define a macro for the next release OS version.
-swift_stdlib_macro = '\'SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0\''
+swift_stdlib_macro = '\'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0\''
 config.swift_frontend_test_options += ' -define-availability ' + swift_stdlib_macro
 config.swift_driver_test_options += ' -Xfrontend -define-availability -Xfrontend ' + swift_stdlib_macro
 

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -6,11 +6,11 @@ import _Concurrency
 
 // Make sure the type shows up (including under its old name, for
 // short-term source compatibility)
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension PartialAsyncTask {
   // expected-warning@-1 {{'PartialAsyncTask' is deprecated: renamed to 'UnownedJob'}}
   // expected-note@-2 {{use 'UnownedJob' instead}}
 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension UnownedJob {
 }

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -6,7 +6,7 @@ enum MyError : Error {
   case bad
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func shouldThrow() async {
   // expected-error@+1 {{errors thrown from here are not handled}}
   let _: Int = try await withUnsafeThrowingContinuation { continuation in

--- a/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70144083.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol AsyncIteratorProtocol {
     associatedtype Element
     associatedtype Failure: Error
@@ -11,7 +11,7 @@ public protocol AsyncIteratorProtocol {
     mutating func cancel()
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol AsyncSequence {
     associatedtype Element
     associatedtype Failure: Error
@@ -20,7 +20,7 @@ public protocol AsyncSequence {
     func makeAsyncIterator() -> AsyncIterator
 }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 struct Just<Element>: AsyncSequence {
     typealias Failure = Never
 

--- a/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71260862.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-library-evolution -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public class X {
   public func f() async { }
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar71491604.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71491604.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-library-evolution -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 public protocol P {
   func f() async
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71816041.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func getIntAndString() async -> (Int, String) { (5, "1") }
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 func testDecompose() async -> Int {
   async let (i, s) = await getIntAndString()
   return await i

--- a/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar72397303.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 protocol P {
   func f<T>() async throws -> T?
 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 extension P {
   func f<T>() async throws -> T? { nil }
 }
-@available(SwiftStdlib 5.5, *)
+@available(SwiftStdlib 5.1, *)
 class X: P {}
 

--- a/validation-test/compiler_crashers_2_fixed/sr15248.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15248.swift
@@ -12,7 +12,7 @@ private struct TransformResult<T> {
 }
 
 public extension Collection {
-    @available(SwiftStdlib 5.5, *)
+    @available(SwiftStdlib 5.1, *)
     private func f<T>(_ transform: @escaping (Element) async throws -> T) async throws -> [T] {
         return try await withThrowingTaskGroup(of: TransformResult<T>.self) { group in
           return []


### PR DESCRIPTION
Define the following availability macros throughout all Swift libraries and tests in this repository:

```
SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0
SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4
SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
```

These correspond to previous Swift Stdlib releases, in addition to the "5.6" release that we're currently working on, and the a placeholder "9999" release that we can use in place of an unknown future Swift release.

As part of this, we need to replace the pre-existing `SwiftStdlib 5.5` macro defined in the `_Concurrency` module with the correct `SwiftStdlib 5.1`, so that its expansion matches our release history. (The concurrency runtime now deploys back to macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, which corresponds to the 5.1 release of the stdlib. Before this PR, this was reflected in the expansion of `SwiftStdlib 5.5`, but not its name.)

The new module `_Distributed` also defines `SwiftStdlib 5.5`, but its declarations need to have availability corresponding to the future Swift 5.6 release -- so this PR replaces it with `SwiftStdlib 5.6`.

To keep this PR (relatively) small, it does not include changes necessary to adopt these macros in existing stdlib code. (Beyond cleaning up the `_Concurrency` vs `_Distributed` situation.)