### PR TITLE
Disable moveonly_builtin.swift test

### DIFF
--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-silgen -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL %s
 
+// REQUIRES: rdar84780237
+
 import Swift
 
 class Klass {}


### PR DESCRIPTION
The test is failing on the "OSS - Swift (Tools Opt+Assert, Stdlib
DebInfo+Assert, Test Simulator) - macOS (main) bot."

https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulator/1496

rdar://84780237