### PR TITLE
AST: GenericEnvironment::getOrCreateArchetypeFromInterfaceType() needs to handle case where parent of concrete anchor is concrete

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -119,11 +119,7 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
 
   auto requirements = genericSig->getLocalRequirements(depType);
 
-  // FIXME: With the RequirementMachine, we will always have an anchor.
-  if (requirements.concreteType && !requirements.anchor) {
-    if (requirements.concreteType->is<ErrorType>())
-      return requirements.concreteType;
-
+  if (requirements.concreteType) {
     return mapTypeIntoContext(requirements.concreteType,
                               conformanceLookupFn);
   }
@@ -140,9 +136,7 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   if (auto depMemTy = requirements.anchor->getAs<DependentMemberType>()) {
     parentArchetype =
       getOrCreateArchetypeFromInterfaceType(depMemTy->getBase())
-        ->getAs<ArchetypeType>();
-    if (!parentArchetype)
-      return ErrorType::get(depMemTy);
+        ->castTo<ArchetypeType>();
 
     auto name = depMemTy->getName();
     if (auto type = parentArchetype->getNestedTypeIfKnown(name))
@@ -156,39 +150,27 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     addMapping(genericParam, ErrorType::get(ctx));
   }
 
-  Type result;
-
-  // If this equivalence class is mapped to a concrete type, produce that
-  // type.
-  if (requirements.concreteType) {
-    result = mapTypeIntoContext(requirements.concreteType,
-                                conformanceLookupFn);
-  } else {
-    // Substitute into the superclass.
-    Type superclass = requirements.superclass;
-    if (superclass && superclass->hasTypeParameter()) {
-      superclass = mapTypeIntoContext(superclass,
-                                      conformanceLookupFn);
-      if (superclass->is<ErrorType>())
-        superclass = Type();
-    }
-
-    if (parentArchetype) {
-      auto *depMemTy = requirements.anchor->castTo<DependentMemberType>();
-      result = NestedArchetypeType::getNew(ctx, parentArchetype, depMemTy,
-                                           requirements.protos, superclass,
-                                           requirements.layout);
-    } else {
-      result = PrimaryArchetypeType::getNew(ctx, this, genericParam,
-                                            requirements.protos, superclass,
-                                            requirements.layout);
-    }
+  // Substitute into the superclass.
+  Type superclass = requirements.superclass;
+  if (superclass && superclass->hasTypeParameter()) {
+    superclass = mapTypeIntoContext(superclass,
+                                    conformanceLookupFn);
+    if (superclass->is<ErrorType>())
+      superclass = Type();
   }
 
-  // Cache the new archetype for future lookups.
-  if (auto depMemTy = requirements.anchor->getAs<DependentMemberType>()) {
+  Type result;
+
+  if (parentArchetype) {
+    auto *depMemTy = requirements.anchor->castTo<DependentMemberType>();
+    result = NestedArchetypeType::getNew(ctx, parentArchetype, depMemTy,
+                                         requirements.protos, superclass,
+                                         requirements.layout);
     parentArchetype->registerNestedType(depMemTy->getName(), result);
   } else {
+    result = PrimaryArchetypeType::getNew(ctx, this, genericParam,
+                                          requirements.protos, superclass,
+                                          requirements.layout);
     addMapping(genericParam, result);
   }
 

--- a/test/Generics/rdar84734584.swift
+++ b/test/Generics/rdar84734584.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {
+  associatedtype T1
+}
+
+protocol P2 {
+  associatedtype T2 : P1
+}
+
+struct S1 : P1 {
+  typealias T1 = S2
+}
+
+struct S2 {}
+
+func foo<X1: P2, X2: P1>(_: X1, _: X2)
+    where X2.T1 == S2 { }
+
+func bar<X1: P2, X2: P1>(x: X1, u: X2, uu: X2.T1)
+    where X1.T2 == S1, X2.T1: P1, X2.T1.T1 == S2 {
+  // this call should type-check successfully
+  foo(x, uu)
+
+  // so should this
+  let _: S2.Type = X2.T1.T1.self
+  let _: S2.Type = X1.T2.T1.self
+}


### PR DESCRIPTION
This still doesn't handle the case where a non-concrete anchor has a
concrete parent; that requires switching the archetype representation
to be "flat".

Fixes <rdar://problem/84734584>.