### PR TITLE
Under VFE/WME, disable mangled accessors and disable LLVM MergeFunctions

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1958,14 +1958,32 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_llvm_vfe)) {
     Opts.VirtualFunctionElimination = true;
+
+    // FIXME(mracek): There are still some situations where we use mangled name
+    // without symbolic references, which means the dependency is not statically
+    // visible to the compiler/linker. Temporarily disable mangled accessors
+    // until we fix that.
+    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_enable_llvm_wme)) {
     Opts.WitnessMethodElimination = true;
+
+    // FIXME(mracek): There are still some situations where we use mangled name
+    // without symbolic references, which means the dependency is not statically
+    // visible to the compiler/linker. Temporarily disable mangled accessors
+    // until we fix that.
+    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_conditional_runtime_records)) {
     Opts.ConditionalRuntimeRecords = true;
+
+    // FIXME(mracek): There are still some situations where we use mangled name
+    // without symbolic references, which means the dependency is not statically
+    // visible to the compiler/linker. Temporarily disable mangled accessors
+    // until we fix that.
+    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_internalize_at_link)) {

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -231,6 +231,12 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
         llvm::createAlwaysInlinerLegacyPass(/*insertlifetime*/false);
   }
 
+  // LLVM MergeFunctions doesn't understand the string in the metadata on calls
+  // in @llvm.type.checked.load intrinsics is important, and mis-compiles
+  // (mis-merge) unrelated functions.
+  if (Opts.VirtualFunctionElimination || Opts.WitnessMethodElimination)
+    PMBuilder.MergeFunctions = false;
+
   bool RunSwiftSpecificLLVMOptzns =
       !Opts.DisableSwiftSpecificLLVMOptzns && !Opts.DisableLLVMOptzns;
 


### PR DESCRIPTION
Two fixes for problems under VFE/WME/CRR (Virtual Function Elimination, Witness Method Elimination, Conditional Runtime Records):

1) Using type metadata accessors that use mangled name to reference types is problematic, because that hides a dependency/reference to the type from the compiler, as it's only a string-based runtime lookup. Let's disable mangled name accessors under WME/VFE/CRR.

2) When using VFE/WME, calls that go via vtables/wtables are using the `@llvm.type.checked.load` intrinsic to make a load from the vtable/wtable and pass a string metadata as the type identifier. However, MergeFunctions doesn't account for the type identifier when deciding whether functions are equal -- this very likely warrants a bugfix in LLVM, but until it's ready, let's disable LLVM's MergeFunctions pass when VFE/WME is on. 