### PR TITLE
[build] correct libdispatch test flag

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -103,7 +103,7 @@ foreach(sdk ${DISPATCH_SDKS})
                           -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}
                           -DBUILD_SHARED_LIBS=YES
                           -DENABLE_SWIFT=NO
-                          -DENABLE_TESTING=NO
+                          -DBUILD_TESTING=NO
                         INSTALL_COMMAND
                           # NOTE(compnerd) provide a custom install command to
                           # ensure that we strip out the DESTDIR environment
@@ -195,7 +195,7 @@ foreach(sdk ${DISPATCH_SDKS})
                             -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}
                             -DBUILD_SHARED_LIBS=NO
                             -DENABLE_SWIFT=NO
-                            -DENABLE_TESTING=NO
+                            -DBUILD_TESTING=NO
                           INSTALL_COMMAND
                             # NOTE(compnerd) provide a custom install command to
                             # ensure that we strip out the DESTDIR environment


### PR DESCRIPTION
The option `ENABLE_TESTING` was replaced by `BUILD_TESTING` in https://github.com/apple/swift-corelibs-libdispatch/pull/518.