### PR TITLE
On targets smaller than 64 bits, emit a compile-time error if withUnsafeTemporaryAllocation(of:capacity:) byte count overflows

### DIFF
--- a/test/IRGen/temporary_allocation/size_too_large.swift
+++ b/test/IRGen/temporary_allocation/size_too_large.swift
@@ -3,7 +3,7 @@
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
 
-withUnsafeTemporaryAllocation(byteCount: 1, alignment: -1) { buffer in
+withUnsafeTemporaryAllocation(of: Int.self, capacity: .max) { buffer in
     blackHole(buffer.baseAddress)
 }
-// CHECK: error: alignment value must be greater than zero
+// CHECK: error: allocation byte count too large


### PR DESCRIPTION
<!-- What's in this pull request? -->
On 64-bit targets, if `withUnsafeTemporaryAllocation(of:capacity:)` is called with parameters that produce a byte count too large to fit in `Int`, a compile-time error is emitted. This change enables the same error for targets with smaller bit widths for `Int` (i.e. 32-bit.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
