### PR TITLE
Remove "iff" from doc comments.

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -97,7 +97,8 @@ extension _ArrayBuffer {
     return _isNativeTypeChecked
   }
 
-  /// Returns `true` iff this buffer's storage is uniquely-referenced.
+  /// Returns `true` if this buffer's storage is uniquely referenced;
+  /// otherwise, returns `false`.
   ///
   /// This function should only be used for internal sanity checks.
   /// To guard a buffer mutation, use `beginCOWMutation`.
@@ -109,8 +110,9 @@ extension _ArrayBuffer {
     return _storage.isUniquelyReferencedNative()
    }
   
-  /// Returns `true` and puts the buffer in a mutable state iff the buffer's
-  /// storage is uniquely-referenced.
+  /// Returns `true` and puts the buffer in a mutable state if the buffer's
+  /// storage is uniquely-referenced; otherwise performs no action and
+  /// returns `false`.
   ///
   /// - Precondition: The buffer must be immutable.
   ///

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -49,8 +49,8 @@ where Indices == Range<Int> {
     minimumCapacity: Int
   ) -> _ContiguousArrayBuffer<Element>?
 
-  /// Returns `true` iff this buffer is backed by a uniquely-referenced mutable
-  /// _ContiguousArrayBuffer.
+  /// Returns `true` if this buffer is backed by a uniquely-referenced mutable
+  /// _ContiguousArrayBuffer; otherwise, returns `false`.
   ///
   /// - Note: This function must remain mutating; otherwise the buffer
   ///   may acquire spurious extra references, which will cause

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -182,8 +182,8 @@ internal func _conditionallyUnreachable() -> Never {
 @_silgen_name("_swift_isClassOrObjCExistentialType")
 internal func _swift_isClassOrObjCExistentialType<T>(_ x: T.Type) -> Bool
 
-/// Returns `true` iff `T` is a class type or an `@objc` existential such as
-/// `AnyObject`.
+/// Returns `true` if `T` is a class type or an `@objc` existential such as
+/// `AnyObject`; otherwise, returns `false`.
 @inlinable
 @inline(__always)
 internal func _isClassOrObjCExistential<T>(_ x: T.Type) -> Bool {
@@ -303,8 +303,8 @@ func _uncheckedUnsafeAssume(_ condition: Bool) {
 
 //===--- Runtime shim wrappers --------------------------------------------===//
 
-/// Returns `true` iff the class indicated by `theClass` uses native
-/// Swift reference-counting.
+/// Returns `true` if the class indicated by `theClass` uses native
+/// Swift reference-counting; otherwise, returns `false`.
 #if _runtime(_ObjC)
 // Declare it here instead of RuntimeShims.h, because we need to specify
 // the type of argument to be AnyClass. This is currently not possible

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -668,7 +668,8 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     }
   }
 
-  /// Returns `true` iff this buffer's storage is uniquely-referenced.
+  /// Returns `true` if this buffer's storage is uniquely-referenced;
+  /// otherwise, returns `false`.
   ///
   /// This function should only be used for internal sanity checks.
   /// To guard a buffer mutation, use `beginCOWMutation`.
@@ -677,8 +678,9 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     return _isUnique(&_storage)
   }
 
-  /// Returns `true` and puts the buffer in a mutable state iff the buffer's
-  /// storage is uniquely-referenced.
+  /// Returns `true` and puts the buffer in a mutable state if the buffer's
+  /// storage is uniquely-referenced; otherwise, performs no action and returns
+  /// `false`.
   ///
   /// - Precondition: The buffer must be immutable.
   ///
@@ -817,7 +819,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
     return UnsafeRawPointer(firstElementAddress)
   }
   
-  /// Returns `true` iff we have storage for elements of the given
+  /// Returns `true` if we have storage for elements of the given
   /// `proposedElementType`.  If not, we'll be treated as immutable.
   @inlinable
   func canStoreElements(ofDynamicType proposedElementType: Any.Type) -> Bool {

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -55,9 +55,9 @@ extension Dictionary {
   /// initialized and the elements in the range `c..<capacity` are
   /// uninitialized.
   ///
-  /// The resulting dictionary has a `count` less than or equal to `c`. The
-  /// actual count is less iff some of the initialized keys were duplicates.
-  /// (This cannot happen if `allowingDuplicates` is false.)
+  /// The resulting dictionary has a `count` less than or equal to `c`.
+  /// If some of the initialized keys were duplicates, the actual count is less.
+  /// This cannot happen for any other reasons or if `allowingDuplicates` is false.
   ///
   /// The buffers passed to the closure are only valid for the duration of the
   /// call.  After the closure returns, this initializer moves all initialized

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -30,8 +30,8 @@ cFuncSuffix2 = {16: 'f16', 32: 'f', 64: 'd', 80: 'ld'}
 
 }%
 
-/// Returns `true` iff isspace(u) would return nonzero when the current
-/// locale is the C locale.
+/// Returns `true` if isspace(u) would return nonzero when the current
+/// locale is the C locale; otherwise, returns false.
 @inlinable // FIXME(sil-serialize-all)
 internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
   return "\t\n\u{b}\u{c}\r ".utf16.contains(u)

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -245,7 +245,9 @@ extension _NativeDictionary { // ensureUnique
   }
 
   /// Ensure storage of self is uniquely held and can hold at least `capacity`
-  /// elements. Returns true iff contents were rehashed.
+  /// elements.
+  ///
+  /// -Returns: `true` if contents were rehashed; otherwise, `false`.
   @inlinable
   @_semantics("optimize.sil.specialize.generic.size.never")
   internal mutating func ensureUnique(isUnique: Bool, capacity: Int) -> Bool {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -224,7 +224,9 @@ extension _NativeSet { // ensureUnique
   }
 
   /// Ensure storage of self is uniquely held and can hold at least `capacity`
-  /// elements. Returns true iff contents were rehashed.
+  /// elements.
+  ///
+  /// -Returns: `true` if contents were rehashed; otherwise, `false`.
   @inlinable
   @inline(__always)
   internal mutating func ensureUnique(isUnique: Bool, capacity: Int) -> Bool {

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -302,7 +302,8 @@ internal struct _SliceBuffer<Element>
     return count
   }
 
-  /// Returns `true` iff this buffer's storage is uniquely-referenced.
+  /// Returns `true` if this buffer's storage is uniquely-referenced;
+  /// otherwise, returns `false`.
   ///
   /// This function should only be used for internal sanity checks and for
   /// backward compatibility.
@@ -312,8 +313,9 @@ internal struct _SliceBuffer<Element>
     return isKnownUniquelyReferenced(&owner)
   }
 
-  /// Returns `true` and puts the buffer in a mutable state iff the buffer's
-  /// storage is uniquely-referenced.
+  /// Returns `true` and puts the buffer in a mutable state if the buffer's
+  /// storage is uniquely-referenced; otherwise, performs no action and returns
+  /// `false`.
   ///
   /// - Precondition: The buffer must be immutable.
   ///

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -780,8 +780,8 @@ extension String {
   internal func _uppercaseASCII(_ x: UInt8) -> UInt8 {
     /// A "table" for which ASCII characters need to be upper cased.
     /// To determine which bit corresponds to which ASCII character, subtract 1
-    /// from the ASCII value of that character and divide by 2. The bit is set iff
-    /// that character is a lower case character.
+    /// from the ASCII value of that character and divide by 2. The bit is set if
+    /// that character is a lower case character; otherwise, it's not set.
     let _lowercaseTable: UInt64 =
       0b0001_1111_1111_1111_0000_0000_0000_0000 &<< 32
 
@@ -804,8 +804,8 @@ extension String {
   internal func _lowercaseASCII(_ x: UInt8) -> UInt8 {
     /// A "table" for which ASCII characters need to be lower cased.
     /// To determine which bit corresponds to which ASCII character, subtract 1
-    /// from the ASCII value of that character and divide by 2. The bit is set iff
-    /// that character is a upper case character.
+    /// from the ASCII value of that character and divide by 2. The bit is set if
+    /// that character is a upper case character; otherwise, it's not set.
     let _uppercaseTable: UInt64 =
       0b0000_0000_0000_0000_0001_1111_1111_1111 &<< 32
 

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -21,15 +21,15 @@
 #if _runtime(_ObjC)
 import SwiftShims
 
-/// Returns `true` iff the given `index` is valid as a position, i.e. `0
-/// ≤ index ≤ count`.
+/// Returns `true` if the given `index` is valid as a position (`0
+/// ≤ index ≤ count`); otherwise, returns `false`.
 @usableFromInline @_transparent
 internal func _isValidArrayIndex(_ index: Int, count: Int) -> Bool {
   return (index >= 0) && (index <= count)
 }
 
-/// Returns `true` iff the given `index` is valid for subscripting, i.e.
-/// `0 ≤ index < count`.
+/// Returns `true` if the given `index` is valid for subscripting 
+/// (`0 ≤ index < count`); otherwise, returns `false`.
 @usableFromInline @_transparent
 internal func _isValidArraySubscript(_ index: Int, count: Int) -> Bool {
   return (index >= 0) && (index < count)


### PR DESCRIPTION
This abbreviation for "if and only if" is confusing to those not coming
from a background in formal mathematics, and is frequently reported as a
type by developers reading the documentation.

This commit also changes doc comments in internal and private members,
which don't become part of the public documentation, because omitting
"iff" everywhere makes it much easier to check for any later changes
that reintroduce it.

Fixes <rdar://31371832>