### PR TITLE
[Serialization] Reword error message on memory corruption or format failures

### DIFF
--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -344,9 +344,12 @@ public:
     fatal(expected.takeError());
   }
 
+  /// Report an unexpected format error that could happen only from a memory-level
+  /// inconsistency. Please prefer passing an error to `fatal(llvm::Error error)` when possible.
   [[noreturn]] void fatal() const {
     fatal(llvm::make_error<llvm::StringError>(
-        "(see \"While...\" info below)", llvm::inconvertibleErrorCode()));
+        "Memory corruption or serialization format inconsistency.",
+        llvm::inconvertibleErrorCode()));
   }
 
   /// Outputs information useful for diagnostics to \p out


### PR DESCRIPTION
The old message `(see "While..." info below)` is misleading ever since we moved the serialization failure information to the stacktrace as the context appears before this error. Plus this message was only used for low-level errors when the data read is unexpected, so in the case of a corrupted swiftmodule file or when there's a collision between two different serialization formats. Let's make it more clear and direct.

We could test this change by truncating a swiftmodule file at the exact right position to trigger this error, but it could require maintenance at each serialization format update.