### PR TITLE
[Result Builders] Correct type witness substitution when computing inferred result builder attributes from protocol requirements.

### DIFF
--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -297,9 +297,11 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
         if (witness != lookupDecl)
           continue;
 
-        // Substitute into the result builder type.
-        auto subs =
-            conformance->getSubstitutions(lookupDecl->getModuleContext());
+        // Substitute Self and associated type witnesses into the
+        // result builder type.
+        auto subs = SubstitutionMap::getProtocolSubstitutions(
+            protocol, dc->getSelfTypeInContext(),
+            ProtocolConformanceRef(conformance));
         Type subResultBuilderType = resultBuilderType.subst(subs);
 
         matches.push_back(

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -298,11 +298,16 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
           continue;
 
         // Substitute Self and associated type witnesses into the
-        // result builder type.
+        // result builder type. Then, map all type parameters from
+        // the conforming type into context. We don't want type
+        // parameters to appear in the result builder type, because
+        // the result builder type will only be used inside the body
+        // of this decl; it's not part of the interface type.
         auto subs = SubstitutionMap::getProtocolSubstitutions(
-            protocol, dc->getSelfTypeInContext(),
+            protocol, dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
-        Type subResultBuilderType = resultBuilderType.subst(subs);
+        Type subResultBuilderType = dc->mapTypeIntoContext(
+            resultBuilderType.subst(subs));
 
         matches.push_back(
             Match::forConformance(

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+
+protocol P {
+  associatedtype A
+
+  @Builder<A>
+  var x1: [S] { get }
+    
+  @Builder<Self>
+  var x2: [S] { get }
+}
+
+@resultBuilder
+enum Builder<T> {
+  static func buildBlock(_ args: S...) -> [S] { args }
+}
+
+struct S {}
+
+// CHECK: struct_decl{{.*}}TestGenericBuilderInference
+struct TestGenericBuilderInference: P {
+  typealias A = Int
+
+  // CHECK: var_decl{{.*}}x1
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> Int))
+  var x1: [S] { S() }
+
+  // CHECK: var_decl{{.*}}x2
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> TestGenericBuilderInference))
+  var x2: [S] { S() }
+}

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -17,8 +17,8 @@ enum Builder<T> {
 
 struct S {}
 
-// CHECK: struct_decl{{.*}}TestGenericBuilderInference
-struct TestGenericBuilderInference: P {
+// CHECK: struct_decl{{.*}}ProtocolSubstitution
+struct ProtocolSubstitution: P {
   typealias A = Int
 
   // CHECK: var_decl{{.*}}x1
@@ -26,6 +26,32 @@ struct TestGenericBuilderInference: P {
   var x1: [S] { S() }
 
   // CHECK: var_decl{{.*}}x2
-  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> TestGenericBuilderInference))
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ProtocolSubstitution))
+  var x2: [S] { S() }
+}
+
+// CHECK: struct_decl{{.*}}ArchetypeSubstitution
+struct ArchetypeSubstitution<A>: P {
+  // CHECK: var_decl{{.*}}x1
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> A))
+  var x1: [S] { S() }
+
+  // CHECK: var_decl{{.*}}x2
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ArchetypeSubstitution<A>))
+  var x2: [S] { S() }
+}
+
+// CHECK: struct_decl{{.*}}ConcreteTypeSubstitution
+struct ConcreteTypeSubstitution<Value> {}
+
+extension ConcreteTypeSubstitution: P where Value == Int {
+  typealias A = Value
+
+  // CHECK: var_decl{{.*}}x1
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> Int))
+  var x1: [S] { S() }
+
+  // CHECK: var_decl{{.*}}x2
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> ConcreteTypeSubstitution<Int>))
   var x2: [S] { S() }
 }


### PR DESCRIPTION
Fix a few bugs when inferring a result builder attribute on a value witness from the protocol requirement:
* Map protocol type parameters to their type witnesses to properly support `Self` and associated types inside result builder attributes.
* Map type parameters from the conforming type into context. Result builders applied to function/property/subscript bodies are not part of the interface type; the builder type will only be used for calls to `buildBlock` and friends in the body.

Resolves: rdar://84818325