### PR TITLE
[moveOnly] Allow the @_noImplicitCopy decl attribute to be applied to parameters

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -676,7 +676,7 @@ SIMPLE_DECL_ATTR(_noImplicitCopy, NoImplicitCopy,
   UserInaccessible |
   ABIStableToAdd | ABIBreakingToRemove |
   APIStableToAdd | APIBreakingToRemove |
-  OnVar,
+  OnParam | OnVar,
   122)
 
 SIMPLE_DECL_ATTR(_noLocks, NoLocks,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5371,6 +5371,10 @@ public:
     Bits.ParamDecl.defaultArgumentKind = static_cast<unsigned>(K);
   }
 
+  bool isNoImplicitCopy() const {
+    return getAttrs().hasAttribute<NoImplicitCopyAttr>();
+  }
+
   /// Whether this parameter has a default argument expression available.
   ///
   /// Note that this will return false for deserialized declarations, which only

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6040,8 +6040,8 @@ ERROR(experimental_moveonly_feature_can_only_be_used_when_enabled,
       none, "Can not use feature when experimental move only is disabled! Pass"
       " the frontend flag -enable-experimental-move-only to swift to enable "
       "the usage of this language feature", ())
-ERROR(noimplicitcopy_attr_valid_only_on_local_let,
-      none, "'@_noImplicitCopy' attribute can only be applied to local lets", ())
+ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
+      none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
 ERROR(noimplicitcopy_attr_invalid_in_generic_context,
       none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -927,6 +928,9 @@ namespace {
 
       if (P->getAttrs().hasAttribute<NonEphemeralAttr>())
         OS << " nonEphemeral";
+
+      if (P->getAttrs().hasAttribute<NoImplicitCopyAttr>())
+        OS << " noImplicitCopy";
 
       if (P->getDefaultArgumentKind() != DefaultArgumentKind::None) {
         printField("default_arg",

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1573,13 +1573,17 @@ class DestructureInputs {
   SmallVectorImpl<SILParameterInfo> &Inputs;
   SubstFunctionTypeCollector &Subst;
   unsigned NextOrigParamIndex = 0;
+  Optional<SmallBitVector> NoImplicitCopyIndices;
+
 public:
   DestructureInputs(TypeExpansionContext expansion, TypeConverter &TC,
                     const Conventions &conventions, const ForeignInfo &foreign,
                     SmallVectorImpl<SILParameterInfo> &inputs,
-                    SubstFunctionTypeCollector &subst)
+                    SubstFunctionTypeCollector &subst,
+                    Optional<SmallBitVector> noImplicitCopyIndices)
       : expansion(expansion), TC(TC), Convs(conventions), Foreign(foreign),
-        Inputs(inputs), Subst(subst) {}
+        Inputs(inputs), Subst(subst),
+        NoImplicitCopyIndices(noImplicitCopyIndices) {}
 
   void destructure(AbstractionPattern origType,
                    CanAnyFunctionType::CanParamArrayRef params,
@@ -1617,6 +1621,9 @@ private:
     // Add any foreign parameters that are positioned here.
     maybeAddForeignParameters();
 
+    bool hasNoImplicitCopy =
+        NoImplicitCopyIndices.hasValue() && NoImplicitCopyIndices->any();
+
     // Process all the non-self parameters.
     for (unsigned i = 0; i != numNonSelfParams; ++i) {
       auto ty = params[i].getParameterType();
@@ -1624,7 +1631,8 @@ private:
       auto flags = params[i].getParameterFlags();
 
       visit(flags.getValueOwnership(), /*forSelf=*/false, eltPattern, ty,
-            flags.isNoDerivative());
+            flags.isNoDerivative(),
+            hasNoImplicitCopy && (*NoImplicitCopyIndices)[i]);
     }
 
     // Process the self parameter.  Note that we implicitly drop self
@@ -1635,8 +1643,8 @@ private:
       auto eltPattern = origType.getFunctionParamType(numNonSelfParams);
       auto flags = selfParam.getParameterFlags();
 
-      visit(flags.getValueOwnership(), /*forSelf=*/true,
-            eltPattern, ty);
+      visit(flags.getValueOwnership(), /*forSelf=*/true, eltPattern, ty, false,
+            false);
     }
 
     TopLevelOrigType = AbstractionPattern::getInvalid();
@@ -1645,7 +1653,7 @@ private:
 
   void visit(ValueOwnership ownership, bool forSelf,
              AbstractionPattern origType, CanType substType,
-             bool isNonDifferentiable = false) {
+             bool isNonDifferentiable, bool isNoImplicitCopy) {
     assert(!isa<InOutType>(substType));
 
     // Tuples get handled specially, in some cases:
@@ -1662,9 +1670,8 @@ private:
           auto ownership = elt.getParameterFlags().getValueOwnership();
           assert(ownership == ValueOwnership::Default);
           assert(!elt.isVararg());
-          visit(ownership, forSelf,
-                origType.getTupleElementType(i),
-                CanType(elt.getRawType()));
+          visit(ownership, forSelf, origType.getTupleElementType(i),
+                CanType(elt.getRawType()), false, false);
         }
         return;
       case ValueOwnership::InOut:
@@ -1692,6 +1699,9 @@ private:
     } else if (substTL.isTrivial()) {
       convention = ParameterConvention::Direct_Unowned;
     } else {
+      // If we are no implicit copy, our ownership is always Owned.
+      if (isNoImplicitCopy)
+        ownership = ValueOwnership::Owned;
       convention = Convs.getDirect(ownership, forSelf, origParamIndex, origType,
                                    substTLConv);
       assert(!isIndirectFormalParameter(convention));
@@ -1757,9 +1767,8 @@ private:
     if (ForeignSelf) {
       // This is a "self", but it's not a Swift self, we handle it differently.
       visit(ForeignSelf->SubstSelfParam.getValueOwnership(),
-            /*forSelf=*/false,
-            ForeignSelf->OrigSelfParam,
-            ForeignSelf->SubstSelfParam.getParameterType());
+            /*forSelf=*/false, ForeignSelf->OrigSelfParam,
+            ForeignSelf->SubstSelfParam.getParameterType(), false, false);
     }
     return true;
   }
@@ -2107,7 +2116,8 @@ static CanSILFunctionType getSILFunctionType(
     SILExtInfoBuilder extInfoBuilder, const Conventions &conventions,
     const ForeignInfo &foreignInfo, Optional<SILDeclRef> origConstant,
     Optional<SILDeclRef> constant, Optional<SubstitutionMap> reqtSubs,
-    ProtocolConformanceRef witnessMethodConformance) {
+    ProtocolConformanceRef witnessMethodConformance,
+    Optional<SmallBitVector> noImplicitCopyIndices) {
   // Find the generic parameters.
   CanGenericSignature genericSig =
     substFnInterfaceType.getOptGenericSignature();
@@ -2197,7 +2207,8 @@ static CanSILFunctionType getSILFunctionType(
   SmallVector<SILParameterInfo, 8> inputs;
   {
     DestructureInputs destructurer(expansionContext, TC, conventions,
-                                   foreignInfo, inputs, subst);
+                                   foreignInfo, inputs, subst,
+                                   noImplicitCopyIndices);
     destructurer.destructure(origType, substFnInterfaceType.getParams(),
                              extInfoBuilder);
   }
@@ -2498,14 +2509,15 @@ static CanSILFunctionType getNativeSILFunctionType(
     AbstractionPattern origType, CanAnyFunctionType substInterfaceType,
     SILExtInfoBuilder extInfoBuilder, Optional<SILDeclRef> origConstant,
     Optional<SILDeclRef> constant, Optional<SubstitutionMap> reqtSubs,
-    ProtocolConformanceRef witnessMethodConformance) {
+    ProtocolConformanceRef witnessMethodConformance,
+    Optional<SmallBitVector> noImplicitCopyIndices) {
   assert(bool(origConstant) == bool(constant));
   auto getSILFunctionTypeForConventions =
       [&](const Conventions &convs) -> CanSILFunctionType {
     return getSILFunctionType(TC, context, origType, substInterfaceType,
                               extInfoBuilder, convs, ForeignInfo(),
                               origConstant, constant, reqtSubs,
-                              witnessMethodConformance);
+                              witnessMethodConformance, noImplicitCopyIndices);
   };
   switch (extInfoBuilder.getRepresentation()) {
   case SILFunctionType::Representation::Block:
@@ -2568,7 +2580,7 @@ CanSILFunctionType swift::getNativeSILFunctionType(
 
   return ::getNativeSILFunctionType(
       TC, context, origType, substType, silExtInfo.intoBuilder(), origConstant,
-      substConstant, reqtSubs, witnessMethodConformance);
+      substConstant, reqtSubs, witnessMethodConformance, None);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2947,7 +2959,7 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
     return getSILFunctionType(
         TC, TypeExpansionContext::minimal(), origPattern, substInterfaceType,
         extInfoBuilder, ObjCMethodConventions(method), foreignInfo, constant,
-        constant, None, ProtocolConformanceRef());
+        constant, None, ProtocolConformanceRef(), None);
   }
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
@@ -2963,7 +2975,7 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
                               substInterfaceType, extInfoBuilder, conventions,
                               foreignInfo, constant, constant, None,
-                              ProtocolConformanceRef());
+                              ProtocolConformanceRef(), None);
   }
 
   if (auto func = dyn_cast<clang::FunctionDecl>(clangDecl)) {
@@ -2976,7 +2988,7 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
                               substInterfaceType, extInfoBuilder,
                               CFunctionConventions(func), foreignInfo, constant,
-                              constant, None, ProtocolConformanceRef());
+                              constant, None, ProtocolConformanceRef(), None);
   }
 
   llvm_unreachable("call to unknown kind of C function");
@@ -3004,7 +3016,7 @@ static CanSILFunctionType getSILFunctionTypeForAbstractCFunction(
       return getSILFunctionType(
           TC, TypeExpansionContext::minimal(), origType, substType,
           extInfoBuilder, CFunctionTypeConventions(fnType), ForeignInfo(),
-          constant, constant, None, ProtocolConformanceRef());
+          constant, constant, None, ProtocolConformanceRef(), None);
     }
   }
 
@@ -3012,7 +3024,7 @@ static CanSILFunctionType getSILFunctionTypeForAbstractCFunction(
   return getSILFunctionType(TC, TypeExpansionContext::minimal(), origType,
                             substType, extInfoBuilder,
                             DefaultBlockConventions(), ForeignInfo(), constant,
-                            constant, None, ProtocolConformanceRef());
+                            constant, None, ProtocolConformanceRef(), None);
 }
 
 /// Try to find a clang method declaration for the given function.
@@ -3180,7 +3192,7 @@ static CanSILFunctionType getSILFunctionTypeForObjCSelectorFamily(
       TC, TypeExpansionContext::minimal(), AbstractionPattern(origType),
       substInterfaceType, extInfoBuilder, ObjCSelectorFamilyConventions(family),
       foreignInfo, constant, constant,
-      /*requirement subs*/ None, ProtocolConformanceRef());
+      /*requirement subs*/ None, ProtocolConformanceRef(), None);
 }
 
 static bool isImporterGeneratedAccessor(const clang::Decl *clangDecl,
@@ -3250,10 +3262,23 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
       }
     }();
 
+    Optional<SmallBitVector> noImplicitCopyIndices;
+    if (constant.hasDecl()) {
+      auto decl = constant.getDecl();
+      if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
+        noImplicitCopyIndices.emplace(funcDecl->getParameters()->size());
+        for (auto p : llvm::enumerate(*funcDecl->getParameters())) {
+          if (p.value()->isNoImplicitCopy()) {
+            noImplicitCopyIndices->set(p.index());
+          }
+        }
+      }
+    }
+
     return ::getNativeSILFunctionType(
-        TC, context, origType,
-        origLoweredInterfaceType, extInfoBuilder, constant, constant, None,
-        witnessMethodConformance);
+        TC, context, origType, origLoweredInterfaceType, extInfoBuilder,
+        constant, constant, None, witnessMethodConformance,
+        noImplicitCopyIndices);
   }
 
   ForeignInfo foreignInfo;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -155,6 +155,7 @@ struct SILValuePrinterInfo {
   ID ValueID;
   SILType Type;
   Optional<ValueOwnershipKind> OwnershipKind;
+  bool IsNoImplicitCopy = false;
 
   SILValuePrinterInfo(ID ValueID) : ValueID(ValueID), Type(), OwnershipKind() {}
   SILValuePrinterInfo(ID ValueID, SILType Type)
@@ -162,6 +163,13 @@ struct SILValuePrinterInfo {
   SILValuePrinterInfo(ID ValueID, SILType Type,
                       ValueOwnershipKind OwnershipKind)
       : ValueID(ValueID), Type(Type), OwnershipKind(OwnershipKind) {}
+  SILValuePrinterInfo(ID ValueID, SILType Type,
+                      ValueOwnershipKind OwnershipKind, bool IsNoImplicitCopy)
+      : ValueID(ValueID), Type(Type), OwnershipKind(OwnershipKind),
+        IsNoImplicitCopy(IsNoImplicitCopy) {}
+  SILValuePrinterInfo(ID ValueID, SILType Type, bool IsNoImplicitCopy)
+      : ValueID(ValueID), Type(Type), OwnershipKind(),
+        IsNoImplicitCopy(IsNoImplicitCopy) {}
 };
 
 /// Return the fully qualified dotted path for DeclContext.
@@ -623,6 +631,8 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
     if (!i.Type)
       return *this;
     *this << " : ";
+    if (i.IsNoImplicitCopy)
+      *this << "@noImplicitCopy ";
     if (i.OwnershipKind && *i.OwnershipKind != OwnershipKind::None) {
       *this << "@" << i.OwnershipKind.getValue() << " ";
     }
@@ -655,8 +665,15 @@ public:
   SILValuePrinterInfo getIDAndType(SILValue V) {
     return {Ctx.getID(V), V ? V->getType() : SILType()};
   }
+  SILValuePrinterInfo getIDAndType(SILFunctionArgument *arg) {
+    return {Ctx.getID(arg), arg->getType(), arg->isNoImplicitCopy()};
+  }
   SILValuePrinterInfo getIDAndTypeAndOwnership(SILValue V) {
     return {Ctx.getID(V), V ? V->getType() : SILType(), V.getOwnershipKind()};
+  }
+  SILValuePrinterInfo getIDAndTypeAndOwnership(SILFunctionArgument *arg) {
+    return {Ctx.getID(arg), arg->getType(), arg->getOwnershipKind(),
+            arg->isNoImplicitCopy()};
   }
 
   //===--------------------------------------------------------------------===//
@@ -728,20 +745,40 @@ public:
     if (BB->args_empty())
       return;
     *this << '(';
-    ArrayRef<SILArgument *> Args = BB->getArguments();
-
     // If SIL ownership is enabled and the given function has not had ownership
     // stripped out, print out ownership of SILArguments.
     if (BB->getParent()->hasOwnership()) {
-      *this << getIDAndTypeAndOwnership(Args[0]);
-      for (SILArgument *Arg : Args.drop_front()) {
-        *this << ", " << getIDAndTypeAndOwnership(Arg);
+      if (BB->isEntry()) {
+        auto Args = BB->getSILFunctionArguments();
+        *this << getIDAndTypeAndOwnership(Args[0]);
+        for (unsigned i : range(1, Args.size())) {
+          SILFunctionArgument *Arg = Args[i];
+          *this << ", " << getIDAndTypeAndOwnership(Arg);
+        }
+        *this << ')';
+      } else {
+        ArrayRef<SILArgument *> Args = BB->getArguments();
+        *this << getIDAndTypeAndOwnership(Args[0]);
+        for (SILArgument *Arg : Args.drop_front()) {
+          *this << ", " << getIDAndTypeAndOwnership(Arg);
+        }
+        *this << ')';
+      }
+      return;
+    }
+
+    if (BB->isEntry()) {
+      auto Args = BB->getSILFunctionArguments();
+      *this << getIDAndType(Args[0]);
+      for (unsigned i : range(1, Args.size())) {
+        SILFunctionArgument *Arg = Args[i];
+        *this << ", " << getIDAndType(Arg);
       }
       *this << ')';
       return;
     }
 
-    // Otherwise, fall back to the old behavior
+    ArrayRef<SILArgument *> Args = BB->getArguments();
     *this << getIDAndType(Args[0]);
     for (SILArgument *Arg : Args.drop_front()) {
       *this << ", " << getIDAndType(Arg);

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -294,6 +294,22 @@ namespace {
       TypeLoc = P.Tok.getLoc();
       return parseASTType(result, genericEnv, genericParams);
     }
+
+    bool parseIsNoImplicitCopy() {
+      // We parse here @ <identifier>.
+      if (P.Tok.getKind() != tok::at_sign)
+        return false;
+
+      // Make sure our text is no implicit copy.
+      if (P.peekToken().getText() != "noImplicitCopy")
+        return false;
+
+      // Ok, we can do this.
+      P.consumeToken(tok::at_sign);
+      P.consumeToken(tok::identifier);
+      return true;
+    }
+
     bool parseSILOwnership(ValueOwnershipKind &OwnershipKind) {
       // We parse here @ <identifier>.
       if (!P.consumeIf(tok::at_sign)) {
@@ -6108,6 +6124,8 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
             P.parseToken(tok::colon, diag::expected_sil_colon_value_ref))
           return true;
 
+        bool foundNoImplicitCopy = parseIsNoImplicitCopy();
+
         // If SILOwnership is enabled and we are not assuming that we are
         // parsing unqualified SIL, look for printed value ownership kinds.
         if (F->hasOwnership() &&
@@ -6119,7 +6137,10 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
 
         SILArgument *Arg;
         if (IsEntry) {
-          Arg = BB->createFunctionArgument(Ty);
+          auto *fArg = BB->createFunctionArgument(Ty);
+          fArg->setNoImplicitCopy(foundNoImplicitCopy);
+          Arg = fArg;
+
           // Today, we construct the ownership kind straight from the function
           // type. Make sure they are in sync, otherwise bail. We want this to
           // be an exact check rather than a compatibility check since we do not

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -432,12 +432,14 @@ ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v,
 
 static ManagedValue createInputFunctionArgument(SILGenBuilder &B, SILType type,
                                                 SILLocation loc,
-                                                ValueDecl *decl = nullptr) {
+                                                ValueDecl *decl = nullptr,
+                                                bool isNoImplicitCopy = false) {
   auto &SGF = B.getSILGenFunction();
   SILFunction &F = B.getFunction();
   assert((F.isBare() || decl) &&
          "Function arguments of non-bare functions must have a decl");
   auto *arg = F.begin()->createFunctionArgument(type, decl);
+  arg->setNoImplicitCopy(isNoImplicitCopy);
   switch (arg->getArgumentConvention()) {
   case SILArgumentConvention::Indirect_In_Guaranteed:
   case SILArgumentConvention::Direct_Guaranteed:
@@ -469,8 +471,10 @@ static ManagedValue createInputFunctionArgument(SILGenBuilder &B, SILType type,
 }
 
 ManagedValue SILGenBuilder::createInputFunctionArgument(SILType type,
-                                                        ValueDecl *decl) {
-  return ::createInputFunctionArgument(*this, type, SILLocation(decl), decl);
+                                                        ValueDecl *decl,
+                                                        bool isNoImplicitCopy) {
+  return ::createInputFunctionArgument(*this, type, SILLocation(decl), decl,
+                                       isNoImplicitCopy);
 }
 
 ManagedValue

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -223,7 +223,8 @@ public:
 
   /// Create a SILArgument for an input parameter. Asserts if used to create a
   /// function argument for an out parameter.
-  ManagedValue createInputFunctionArgument(SILType type, ValueDecl *decl);
+  ManagedValue createInputFunctionArgument(SILType type, ValueDecl *decl,
+                                           bool isNoImplicitCopy = false);
 
   /// Create a SILArgument for an input parameter. Uses \p loc to create any
   /// copies necessary. Asserts if used to create a function argument for an out

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -10,20 +10,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SILGenFunction.h"
+#include "ArgumentSource.h"
 #include "ExecutorBreadcrumb.h"
 #include "Initialization.h"
 #include "ManagedValue.h"
+#include "SILGenFunction.h"
 #include "Scope.h"
-#include "ArgumentSource.h"
-#include "swift/SIL/SILArgument.h"
 #include "swift/AST/CanTypeVisitor.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/SIL/SILArgument.h"
 
 using namespace swift;
 using namespace Lowering;
+
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
 
 SILValue SILGenFunction::emitSelfDecl(VarDecl *selfDecl) {
   // Emit the implicit 'self' argument.
@@ -49,11 +56,13 @@ public:
   SILLocation loc;
   CanSILFunctionType fnTy;
   ArrayRef<SILParameterInfo> &parameters;
+  bool isNoImplicitCopy;
 
   EmitBBArguments(SILGenFunction &sgf, SILBasicBlock *parent, SILLocation l,
                   CanSILFunctionType fnTy,
-                  ArrayRef<SILParameterInfo> &parameters)
-    : SGF(sgf), parent(parent), loc(l), fnTy(fnTy), parameters(parameters) {}
+                  ArrayRef<SILParameterInfo> &parameters, bool isNoImplicitCopy)
+      : SGF(sgf), parent(parent), loc(l), fnTy(fnTy), parameters(parameters),
+        isNoImplicitCopy(isNoImplicitCopy) {}
 
   ManagedValue visitType(CanType t, AbstractionPattern orig) {
     return visitType(t, orig, /*isInOut=*/false);
@@ -79,7 +88,7 @@ public:
     auto paramType =
         SGF.F.mapTypeIntoContext(SGF.getSILType(parameterInfo, fnTy));
     ManagedValue mv = SGF.B.createInputFunctionArgument(
-        paramType, loc.getAsASTNode<ValueDecl>());
+        paramType, loc.getAsASTNode<ValueDecl>(), isNoImplicitCopy);
 
     // This is a hack to deal with the fact that Self.Type comes in as a static
     // metatype, but we have to downcast it to a dynamic Self metatype to get
@@ -98,12 +107,21 @@ public:
 
     // This can happen if the value is resilient in the calling convention
     // but not resilient locally.
-    if (argType.isLoadable(SGF.F) && argType.isAddress()) {
-      if (mv.isPlusOne(SGF))
-        mv = SGF.B.createLoadTake(loc, mv);
-      else
-        mv = SGF.B.createLoadBorrow(loc, mv);
-      argType = argType.getObjectType();
+    if (argType.isLoadable(SGF.F)) {
+      if (argType.isAddress()) {
+        if (mv.isPlusOne(SGF))
+          mv = SGF.B.createLoadTake(loc, mv);
+        else
+          mv = SGF.B.createLoadBorrow(loc, mv);
+        argType = argType.getObjectType();
+      }
+    } else {
+      if (isNoImplicitCopy) {
+        // We do not support no implicit copy address only types. Emit an error.
+        auto diag = diag::noimplicitcopy_used_on_generic_or_existential;
+        diagnose(SGF.getASTContext(), mv.getValue().getLoc().getSourceLoc(),
+                 diag);
+      }
     }
 
     if (argType.getASTType() != paramType.getASTType()) {
@@ -217,14 +235,14 @@ struct ArgumentInitHelper {
 
   unsigned getNumArgs() const { return ArgNo; }
 
-  ManagedValue makeArgument(Type ty, bool isInOut, SILBasicBlock *parent,
-                            SILLocation l) {
+  ManagedValue makeArgument(Type ty, bool isInOut, bool isNoImplicitCopy,
+                            SILBasicBlock *parent, SILLocation l) {
     assert(ty && "no type?!");
 
     // Create an RValue by emitting destructured arguments into a basic block.
     CanType canTy = ty->getCanonicalType();
-    EmitBBArguments argEmitter(SGF, parent, l,
-                               f.getLoweredFunctionType(), parameters);
+    EmitBBArguments argEmitter(SGF, parent, l, f.getLoweredFunctionType(),
+                               parameters, isNoImplicitCopy);
 
     // Note: inouts of tuples are not exploded, so we bypass visit().
     AbstractionPattern origTy = OrigFnType
@@ -241,7 +259,8 @@ struct ArgumentInitHelper {
     SILLocation loc(pd);
     loc.markAsPrologue();
 
-    ManagedValue argrv = makeArgument(ty, pd->isInOut(), parent, loc);
+    ManagedValue argrv =
+        makeArgument(ty, pd->isInOut(), pd->isNoImplicitCopy(), parent, loc);
 
     if (pd->isInOut()) {
       assert(argrv.getType().isAddress() && "expected inout to be address");
@@ -297,7 +316,8 @@ struct ArgumentInitHelper {
     Scope discardScope(SGF.Cleanups, CleanupLocation(PD));
 
     // Manage the parameter.
-    auto argrv = makeArgument(type, PD->isInOut(), &*f.begin(), paramLoc);
+    auto argrv = makeArgument(type, PD->isInOut(), PD->isNoImplicitCopy(),
+                              &*f.begin(), paramLoc);
 
     // Emit debug information for the argument.
     SILLocation loc(PD);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -915,7 +915,10 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
     auto ValueCategory = SILValueCategory(Args[I + 1] & 0xF);
     SILType SILArgTy = getSILType(ArgTy, ValueCategory, Fn);
     if (IsEntry) {
-      Arg = CurrentBB->createFunctionArgument(SILArgTy);
+      auto *fArg = CurrentBB->createFunctionArgument(SILArgTy);
+      bool isNoImplicitCopy = (Args[I + 1] >> 16) & 0x1;
+      fArg->setNoImplicitCopy(isNoImplicitCopy);
+      Arg = fArg;
     } else {
       auto OwnershipKind = ValueOwnershipKind((Args[I + 1] >> 8) & 0xF);
       Arg = CurrentBB->createPhiArgument(SILArgTy, OwnershipKind);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 638; // PerformanceConstraints
+const uint16_t SWIFTMODULE_VERSION_MINOR = 639; // @_noImplicitCopy param
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -585,9 +585,14 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
                                    SA->getOwnershipKind())::innerty>::type,
                                uint8_t>::value,
                   "Expected an underlying uint8_t type");
+    // This is 31 bits in size.
     unsigned packedMetadata = 0;
-    packedMetadata |= unsigned(SA->getType().getCategory());
-    packedMetadata |= unsigned(SA->getOwnershipKind()) << 8;
+    packedMetadata |= unsigned(SA->getType().getCategory());  // 8 bits
+    packedMetadata |= unsigned(SA->getOwnershipKind()) << 8;  // 8 bits
+    packedMetadata |= unsigned(SA->isNoImplicitCopy()) << 16; // 1 bit
+    // Used: 17 bits. Free: 15.
+    //
+    // TODO: We should be able to shrink the packed metadata of the first two.
     Args.push_back(packedMetadata);
 
     Args.push_back(vId);

--- a/test/SIL/Parser/no_implicit_copy.sil
+++ b/test/SIL/Parser/no_implicit_copy.sil
@@ -1,0 +1,14 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-experimental-move-only -enable-sil-verify-all=true %s | %target-sil-opt -enable-objc-interop -enable-experimental-move-only -enable-sil-verify-all=true | %FileCheck %s
+
+sil_stage canonical
+
+class Klass {}
+
+// CHECK: bb0(%0 : @noImplicitCopy @owned $Klass):
+
+sil [ossa] @noImplicitCopyTest : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @noImplicitCopy @owned $Klass):
+  destroy_value %0 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/Serialization/no_implicit_copy.sil
+++ b/test/SIL/Serialization/no_implicit_copy.sil
@@ -1,0 +1,19 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name noImplicitCopy
+// RUN: %target-sil-opt %t/tmp.sib -module-name noImplicitCopy | %FileCheck %s
+
+sil_stage canonical
+
+class Klass {}
+
+// CHECK-LABEL: sil [serialized] [ossa] @noImplicitCopyTest : $@convention(thin) (@owned Klass) -> () {
+// CHECK: bb0(%0 : @noImplicitCopy @owned $Klass):
+// CHECK: } // end sil function 'noImplicitCopyTest'
+sil [serialized] [ossa] @noImplicitCopyTest : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @noImplicitCopy @owned $Klass):
+  destroy_value %0 : $Klass
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILGen/noimplicitcopy_attr.swift
+++ b/test/SILGen/noimplicitcopy_attr.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-move-only -parse-stdlib -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -enable-experimental-move-only -parse-stdlib -disable-availability-checking %s | %FileCheck -check-prefix=CHECK-SIL %s
+// RUN: %target-swift-emit-sil -O -enable-experimental-move-only -Xllvm -sil-disable-pass=FunctionSignatureOpts -parse-stdlib -disable-availability-checking %s | %FileCheck -check-prefix=CHECK-SIL %s
+
+public class Klass {}
+
+// CHECK: bb0(%0 : @noImplicitCopy @owned $Klass):
+// CHECK-SIL: bb0(%0 : @noImplicitCopy $Klass):
+
+public func arguments(@_noImplicitCopy _ x: Klass) -> Klass {
+    let y = x
+    let z = x
+    return x
+}

--- a/test/SILGen/noimplicitcopy_attr.swift
+++ b/test/SILGen/noimplicitcopy_attr.swift
@@ -8,7 +8,5 @@ public class Klass {}
 // CHECK-SIL: bb0(%0 : @noImplicitCopy $Klass):
 
 public func arguments(@_noImplicitCopy _ x: Klass) -> Klass {
-    let y = x
-    let z = x
     return x
 }

--- a/test/SILGen/noimplicitcopy_attr_arg_generic_users_banned.swift
+++ b/test/SILGen/noimplicitcopy_attr_arg_generic_users_banned.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-sil -enable-experimental-move-only -parse-stdlib -disable-availability-checking -verify-syntax-tree -verify %s
+
+import Swift
+
+class Klass {}
+
+
+struct MyStruct {
+    // Error if @_noImplicitCopy on struct fields. We do not have move only types and
+    // these are part of MyStruct.
+    //
+    // TODO: Make error specific for move only on struct/enum.
+    func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+    }
+}
+
+struct MyGenericStruct<T> {
+    func foo(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+    }
+}
+
+func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+}
+
+class MyClass {
+    func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+    }
+}
+
+class MyGenericClass<T> {
+    func foo(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
+    }
+}

--- a/test/SILOptimizer/move_only_checker.swift
+++ b/test/SILOptimizer/move_only_checker.swift
@@ -357,3 +357,17 @@ public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) {
         print(x2.lhs)
     }
 }
+
+/////////////////////////////////
+// No Implicit Copy Attributes //
+/////////////////////////////////
+
+public func klassNoImplicitCopyArgument(@_noImplicitCopy _ x: Klass) -> Klass {
+    return x
+}
+
+public func klassNoImplicitCopyArgumentError(@_noImplicitCopy _ x: Klass) -> Klass { // expected-error {{'x' consumed more than once}}
+    let y = x // expected-note {{consuming use}}
+    print(y)
+    return x // expected-note {{consuming use}}
+}

--- a/test/Sema/noimplicitcopy_attr.swift
+++ b/test/Sema/noimplicitcopy_attr.swift
@@ -4,7 +4,7 @@ import Swift
 
 class Klass {}
 
-func argumentsAndReturns(@_noImplicitCopy _ x: Klass) -> Klass { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+func argumentsAndReturns(@_noImplicitCopy _ x: Klass) -> Klass {
     return x
 }
 func letDecls(_ x: Klass) -> () {
@@ -40,12 +40,12 @@ struct MyStruct {
         return getKlass()
     }
 
-    func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+    func foo<T>(@_noImplicitCopy _ t: T) {
     }
 }
 
 struct MyGenericStruct<T> {
-    func foo(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+    func foo(@_noImplicitCopy _ t: T) {
     }
 }
 
@@ -53,7 +53,7 @@ protocol P {
     @_noImplicitCopy var x: Builtin.NativeObject { get } // expected-error {{'@_noImplicitCopy' attribute can only be applied to local lets}}
 }
 
-func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+func foo<T>(@_noImplicitCopy _ t: T) {
 }
 
 // Do not error on class fields. The noImplicitCopy field is separate from the
@@ -67,7 +67,7 @@ class MyClass {
         return getKlass()
     }
 
-    func foo<T>(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+    func foo<T>(@_noImplicitCopy _ t: T) {
     }
 }
 
@@ -83,7 +83,7 @@ class MyGenericClass<T> {
         return nil
     }
 
-    func foo(@_noImplicitCopy _ t: T) { // expected-error {{@_noImplicitCopy may only be used on 'var' declarations}}
+    func foo(@_noImplicitCopy _ t: T) {
     }
 }
 


### PR DESCRIPTION
Everything in this PR can only be used if one passes in the flag -enable-experimental-move-only.

Marking a parameter with this attribute looks as follows:

```
func myFunc(@_noImplicitCopy _ x: Klass) {
...
}
```

operationally this has the following effects:

1. x is a move only value and goes through move only checking.
2. x is passed at +1 by default.

This lets one now create whole call trees by passing @_noImplicitCopy lets as @_noImplicitCopy arguments.

rdar://83957088