### PR TITLE
[stdlib] Adopt availability macros

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1632,6 +1632,9 @@ Parser::parseAvailabilityMacro(SmallVectorImpl<AvailabilitySpec *> &Specs) {
   if (NameMatch == Map.end())
     return makeParserSuccess(); // No match, it could be a standard platform.
 
+  SyntaxParsingContext VersionRestrictionContext(
+      SyntaxContext, SyntaxKind::AvailabilityVersionRestriction);
+
   consumeToken();
 
   llvm::VersionTuple Version;

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -982,7 +982,7 @@ self.test("\(testNamePrefix).partition/DispatchesThroughDirectStorageAccessors")
     withUnsafeMutableBufferPointerIsSupported ? 1 : 0,
     actualWUMBPIFNonNil + actualWCMSIAIFNonNil)
 
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     // `partition(by:)` is expected to dispatch to the public API in releases
     // that contain https://github.com/apple/swift/pull/36003.
     expectEqual(0, actualWUMBPIF)

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -66,7 +66,7 @@ public func getUInt64(_ x: UInt64) -> UInt64 { return _opaqueIdentity(x) }
 public func getUInt(_ x: UInt) -> UInt { return _opaqueIdentity(x) }
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 @inline(never)
 public func getFloat16(_ x: Float16) -> Float16 { return _opaqueIdentity(x) }
 #endif

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -270,7 +270,7 @@ public func _isStdlibDebugConfiguration() -> Bool {
 
 // Return true if the Swift runtime available is at least 5.1
 public func _hasSwift_5_1() -> Bool {
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(SwiftStdlib 5.1, *) {
     return true
   }
   return false

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -262,7 +262,7 @@ extension AnyHashable: CustomReflectable {
 }
 #endif
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 extension AnyHashable: _HasCustomAnyHashableRepresentation {
 }
 

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -311,7 +311,8 @@ internal func _internalInvariant_5_1(
   // FIXME: The below won't run the assert on 5.1 stdlib if testing on older
   // OSes, which means that testing may not test the assertion. We need a real
   // solution to this.
-  guard #available(SwiftStdlib 5.1, *) else { return }
+  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) //SwiftStdlib 5.1
+  else { return }
   _internalInvariant(condition(), message, file: file, line: line)
 #endif
 }

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -311,7 +311,7 @@ internal func _internalInvariant_5_1(
   // FIXME: The below won't run the assert on 5.1 stdlib if testing on older
   // OSes, which means that testing may not test the assertion. We need a real
   // solution to this.
-  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else { return }
+  guard #available(SwiftStdlib 5.1, *) else { return }
   _internalInvariant(condition(), message, file: file, line: line)
 #endif
 }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -88,7 +88,7 @@ public protocol _ObjectiveCBridgeable {
 // Note: This function is not intended to be called from Swift.  The
 // availability information here is perfunctory; this function isn't considered
 // part of the Stdlib's Swift ABI.
-@available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+@available(SwiftStdlib 5.2, *)
 @_cdecl("_SwiftCreateBridgedArray")
 @usableFromInline
 internal func _SwiftCreateBridgedArray_DoNotCall(
@@ -103,7 +103,7 @@ internal func _SwiftCreateBridgedArray_DoNotCall(
 // Note: This function is not intended to be called from Swift.  The
 // availability information here is perfunctory; this function isn't considered
 // part of the Stdlib's Swift ABI.
-@available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+@available(SwiftStdlib 5.2, *)
 @_cdecl("_SwiftCreateBridgedMutableArray")
 @usableFromInline
 internal func _SwiftCreateBridgedMutableArray_DoNotCall(

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -58,7 +58,7 @@ public typealias CLongLong = Int64
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 /// The C '_Float16' type.
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 public typealias CFloat16 = Float16
 #endif
 

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -4732,7 +4732,7 @@ extension RawRepresentable where RawValue == Float, Self: Decodable {
 }
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 extension Float16: Codable {
   /// Creates a new instance by decoding from the given decoder.
   ///

--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -12,7 +12,7 @@
 
 /// A collection of insertions and removals that describe the difference 
 /// between two ordered collection states.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public struct CollectionDifference<ChangeElement> {
   /// A single change to a collection.
   @frozen
@@ -233,7 +233,7 @@ public struct CollectionDifference<ChangeElement> {
 ///   }
 /// }
 /// ```
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Collection {
   public typealias Element = Change
 
@@ -281,7 +281,7 @@ extension CollectionDifference: Collection {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Index: Equatable {
   @inlinable
   public static func == (
@@ -292,7 +292,7 @@ extension CollectionDifference.Index: Equatable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Index: Comparable {
   @inlinable
   public static func < (
@@ -303,7 +303,7 @@ extension CollectionDifference.Index: Comparable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Index: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
@@ -311,19 +311,19 @@ extension CollectionDifference.Index: Hashable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Change: Equatable where ChangeElement: Equatable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Equatable where ChangeElement: Equatable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Change: Hashable where ChangeElement: Hashable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Hashable where ChangeElement: Hashable {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference where ChangeElement: Hashable {
   /// Returns a new collection difference with associations between individual
   /// elements that have been removed and inserted only once.
@@ -380,7 +380,7 @@ extension CollectionDifference where ChangeElement: Hashable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Change: Codable where ChangeElement: Codable {
   private enum _CodingKeys: String, CodingKey {
     case offset
@@ -417,12 +417,12 @@ extension CollectionDifference.Change: Codable where ChangeElement: Codable {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Codable where ChangeElement: Codable {}
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference: Sendable where ChangeElement: Sendable { }
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Change: Sendable where ChangeElement: Sendable { }
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference.Index: Sendable where ChangeElement: Sendable { }

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -12,7 +12,7 @@
 
 // MARK: Diff application to RangeReplaceableCollection
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension CollectionDifference {
   fileprivate func _fastEnumeratedApply(
     _ consume: (Change) throws -> Void
@@ -67,7 +67,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Complexity: O(*n* + *c*), where *n* is `self.count` and *c* is the
   ///   number of changes contained by the parameter.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func applying(_ difference: CollectionDifference<Element>) -> Self? {
 
     func append(
@@ -142,7 +142,7 @@ extension BidirectionalCollection {
   /// - Complexity: Worst case performance is O(*n* * *m*), where *n* is the
   ///   count of this collection and *m* is `other.count`. You can expect
   ///   faster execution when the collections share many common elements.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func difference<C: BidirectionalCollection>(
     from other: C,
     by areEquivalent: (C.Element, Element) -> Bool
@@ -169,7 +169,7 @@ extension BidirectionalCollection where Element: Equatable {
   ///   count of this collection and *m* is `other.count`. You can expect
   ///   faster execution when the collections share many common elements, or
   ///   if `Element` conforms to `Hashable`.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func difference<C: BidirectionalCollection>(
     from other: C
   ) -> CollectionDifference<Element> where C.Element == Self.Element {
@@ -224,7 +224,7 @@ private struct _V {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 private func _myers<C,D>(
   from old: C, to new: D,
   using cmp: (C.Element, D.Element) -> Bool

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1895,7 +1895,7 @@ extension BinaryFloatingPoint {
     switch (Source.exponentBitCount, Source.significandBitCount) {
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     case (5, 10):
-      guard #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+      guard #available(SwiftStdlib 5.3, *) else {
         // Convert signaling NaN to quiet NaN by multiplying by 1.
         self = Self._convert(from: value).value * 1
         break

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1895,7 +1895,8 @@ extension BinaryFloatingPoint {
     switch (Source.exponentBitCount, Source.significandBitCount) {
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
     case (5, 10):
-      guard #available(SwiftStdlib 5.3, *) else {
+      guard #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) //SwiftStdlib 5.3
+      else {
         // Convert signaling NaN to quiet NaN by multiplying by 1.
         self = Self._convert(from: value).value * 1
         break

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -47,7 +47,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 % end
 
 %if bits == 16:
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 %end
 extension ${Self}: LosslessStringConvertible {
   /// Creates a new instance from the given string.
@@ -165,7 +165,7 @@ extension ${Self}: LosslessStringConvertible {
   %if bits == 16:
     self.init(Substring(text))
   %else:
-    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+    if #available(SwiftStdlib 5.3, *) {
       self.init(Substring(text))
     } else {
       self = 0.0
@@ -195,7 +195,7 @@ extension ${Self}: LosslessStringConvertible {
   // In particular, we still have to export
   // _swift_stdlib_strtoXYZ_clocale()
   // as ABI to support old compiled code that still requires it.
-  @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(SwiftStdlib 5.3, *)
   public init?(_ text: Substring) {
     self = 0.0
     let success = withUnsafeMutablePointer(to: &self) { p -> Bool in

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -165,7 +165,7 @@ extension ${Self}: LosslessStringConvertible {
   %if bits == 16:
     self.init(Substring(text))
   %else:
-    if #available(SwiftStdlib 5.3, *) {
+    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) { //SwiftStdlib 5.3
       self.init(Substring(text))
     } else {
       self = 0.0

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -40,7 +40,7 @@ RawSignificand = 'UInt' + str(SignificandSize)
 
 def Availability(bits):
     if bits == 16:
-        return '@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)'
+        return '@available(SwiftStdlib 5.3, *)'
     return ''
 
 if Self == 'Float16':
@@ -1366,7 +1366,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 ${SelfDocComment}
 @frozen
 %  if bits == 16:
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(SwiftStdlib 5.3, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 %  else:
@@ -1385,7 +1385,7 @@ public struct ${Self} {
 // from the implicit conformance emitted into the generated .swiftinterface
 // file. See https://github.com/apple/swift/pull/36669 for details.
 // FIXME: rdar://76092800
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(SwiftStdlib 5.3, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 extension ${Self}: Sendable { }

--- a/stdlib/public/core/Identifiable.swift
+++ b/stdlib/public/core/Identifiable.swift
@@ -38,7 +38,7 @@
 /// `ObjectIdentifier`), which is only guaranteed to remain unique for the
 /// lifetime of an object. If an object has a stronger notion of identity, it
 /// may be appropriate to provide a custom implementation.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public protocol Identifiable {
 
   /// A type representing the stable identity of the entity associated with
@@ -49,7 +49,7 @@ public protocol Identifiable {
   var id: ID { get }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension Identifiable where Self: AnyObject {
   public var id: ObjectIdentifier {
     return ObjectIdentifier(self)

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1155,7 +1155,7 @@ public struct ${Self}
   ///   `source` must be representable in this type after rounding toward
   ///   zero.
 %     if FloatType == 'Float16':
-  @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(SwiftStdlib 5.3, *)
 %     end
   @_transparent
   public init(_ source: ${FloatType}) {
@@ -1193,7 +1193,7 @@ public struct ${Self}
   ///
   /// - Parameter source: A floating-point value to convert to an integer.
 %     if FloatType == 'Float16':
-  @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(SwiftStdlib 5.3, *)
 %     end
   @_transparent
   public init?(exactly source: ${FloatType}) {

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -64,13 +64,13 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
 
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 @_silgen_name("swift_getMangledTypeName")
 public func _getMangledTypeName(_ type: Any.Type)
   -> (UnsafePointer<UInt8>, Int)
 
 /// Returns the mangled name for a given type.
-@available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 public // SPI
 func _mangledTypeName(_ type: Any.Type) -> String? {
   let (stringPtr, count) = _getMangledTypeName(type)

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -34,9 +34,9 @@ extension Never: Error {}
 
 extension Never: Equatable, Comparable, Hashable {}
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 extension Never: Identifiable {
-  @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+  @available(SwiftStdlib 5.5, *)
   public var id: Never {
     switch self {}
   }

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -188,7 +188,7 @@ extension Mirror {
 }
 
 /// Options for calling `_forEachField(of:options:body:)`.
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 @_spi(Reflection)
 public struct _EachFieldOptions: OptionSet {
   public var rawValue: UInt32
@@ -211,7 +211,7 @@ public struct _EachFieldOptions: OptionSet {
 }
 
 /// The metadata "kind" for a type.
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 @_spi(Reflection)
 public enum _MetadataKind: UInt {
   // With "flags":
@@ -259,7 +259,7 @@ public enum _MetadataKind: UInt {
 ///     and the `_MetadataKind` of the field's type.
 /// - Returns: `true` if every invocation of `body` returns `true`; otherwise,
 ///   `false`.
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 @discardableResult
 @_spi(Reflection)
 public func _forEachField(
@@ -302,7 +302,7 @@ public func _forEachField(
 ///     and the `_MetadataKind` of the field's type.
 /// - Returns: `true` if every invocation of `body` returns `true`; otherwise,
 ///   `false`.
-@available(macOS 11.3, iOS 14.5, tvOS 14.5, watchOS 7.4, *)
+@available(SwiftStdlib 5.4, *)
 @discardableResult
 @_spi(Reflection)
 public func _forEachFieldWithKeyPath<Root>(

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -304,7 +304,7 @@ internal func _float16ToStringImpl(
   _ debug: Bool
 ) -> Int
 
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 internal func _float16ToString(
   _ value: Float16,
   debug: Bool

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -308,7 +308,7 @@ extension SIMD${n} where Scalar == ${Scalar} {
 %  MaskExt = "Builtin.sext_" + VecPre + "Int1_" + VecPre + "Int" + str(bits)
 %  if bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 %  end
 extension SIMD${n} where Scalar == ${Scalar} {
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -264,7 +264,7 @@ extension ${Self}: SIMDScalar {
 %for (Self, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
 % if bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 % end
 extension ${Self} : SIMDScalar {
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -516,7 +516,7 @@ extension String {
   ///     memory with room for `capacity` UTF-8 code units, initializes
   ///     that memory, and returns the number of initialized elements.
   @inline(__always)
-  @available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(SwiftStdlib 5.3, *)
   public init(
     unsafeUninitializedCapacity capacity: Int,
     initializingUTF8With initializer: (

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -630,7 +630,7 @@ extension String {
 // Note: This function is not intended to be called from Swift.  The
 // availability information here is perfunctory; this function isn't considered
 // part of the Stdlib's Swift ABI.
-@available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+@available(SwiftStdlib 5.2, *)
 @_cdecl("_SwiftCreateBridgedString")
 @usableFromInline
 internal func _SwiftCreateBridgedString_DoNotCall(
@@ -672,7 +672,7 @@ public func _getDescription<T>(_ x: T) -> AnyObject {
 
 @_silgen_name("swift_stdlib_NSStringFromUTF8")
 @usableFromInline //this makes the symbol available to the runtime :(
-@available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+@available(SwiftStdlib 5.2, *)
 internal func _NSStringFromUTF8(_ s: UnsafePointer<UInt8>, _ len: Int)
   -> AnyObject {
   return String(

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -103,7 +103,7 @@ extension String.Index {
   ///     `sourcePosition` must be a valid index of at least one of the views
   ///     of `target`.
   ///   - target: The string referenced by the resulting index.
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public init?<S: StringProtocol>(
     _ sourcePosition: String.Index, within target: S
   ) {

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -18,7 +18,7 @@ internal let _cocoaASCIIEncoding:UInt = 1 /* NSASCIIStringEncoding */
 internal let _cocoaUTF8Encoding:UInt = 4 /* NSUTF8StringEncoding */
 
 extension String {
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.6, *)
   @_spi(Foundation)
   public init?(_nativeStorage: AnyObject) {
     let knownOther = _KnownCocoaString(_nativeStorage)

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -89,7 +89,7 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 
   // Finally, take a slow path through the standard library to see if the
   // current environment can accept a larger stack allocation.
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+  guard #available(SwiftStdlib 5.6, *) else {
     return false
   }
   return swift_stdlib_isStackAllocationSafe(byteCount, alignment)

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -89,7 +89,8 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 
   // Finally, take a slow path through the standard library to see if the
   // current environment can accept a larger stack allocation.
-  guard #available(SwiftStdlib 5.6, *) else {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) //SwiftStdlib 5.6
+  else {
     return false
   }
   return swift_stdlib_isStackAllocationSafe(byteCount, alignment)

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -436,7 +436,7 @@ extension Unicode.Scalar.UTF16View: RandomAccessCollection {
 }
 
 extension Unicode.Scalar {
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   @frozen
   public struct UTF8View: Sendable {
     @usableFromInline
@@ -448,12 +448,12 @@ extension Unicode.Scalar {
     }
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   @inlinable
   public var utf8: UTF8View { return UTF8View(value: self) }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 extension Unicode.Scalar.UTF8View: RandomAccessCollection {
   public typealias Indices = Range<Int>
 

--- a/test/Casting/CastTraps.swift.gyb
+++ b/test/Casting/CastTraps.swift.gyb
@@ -105,7 +105,7 @@ CastTrapsTestSuite.test("${t1}__${t2}")
 % end
 
 protocol P2 {}
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected null")
   .crashOutputMatches("Found unexpected null pointer value while trying to cast value of type '")
   .crashOutputMatches("Foo'")
@@ -125,7 +125,7 @@ CastTrapsTestSuite.test("Unexpected null")
 
 
 #if _runtime(_ObjC)
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
 CastTrapsTestSuite.test("Unexpected Obj-C null")
   .crashOutputMatches("Found unexpected null pointer value while trying to cast value of type '")
   .crashOutputMatches("NSObject'")

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -102,7 +102,7 @@ CastsTests.test("Optional<T>.none can be casted to Optional<U>.none in generic c
 #if _runtime(_ObjC)
 protocol P2 {}
 CastsTests.test("Cast from ObjC existential to Protocol (SR-3871)") {
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     struct S: P2 {}
 
     class ObjCWrapper {
@@ -167,7 +167,7 @@ CastsTests.test("Dynamic casts of CF types to protocol existentials (SR-2289)")
     reason: "This test behaves unpredictably in optimized mode."))
 .code {
   expectTrue(isP(10 as Int))
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectTrue(isP(CFBitVector.makeImmutable(from: [10, 20])))
     expectTrue(isP(CFMutableBitVector.makeMutable(from: [10, 20])))
   }
@@ -195,7 +195,7 @@ CastsTests.test("Casting struct -> Obj-C -> Protocol fails (SR-3871, SR-5590, SR
 
 
 protocol P4552 {}
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
 CastsTests.test("Casting Any(Optional(T)) -> Protocol fails (SR-4552)") {
   struct S: P4552 {
     let tracker = LifetimeTracked(13)
@@ -257,7 +257,7 @@ CastsTests.test("Store Swift metatype in ObjC property and cast back to Any.Type
   let sValue2 = a.sVar as? Any.Type
   let objcValue2 = a.objcVar as? Any.Type
   expectTrue(sValue2 == b)
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectTrue(sValue2 == objcValue2)
     expectTrue(objcValue2 == b)
   }
@@ -303,7 +303,7 @@ CastsTests.test("Casts from @objc Type") {
   let user = User(name: "Kermit")
   let exporter: Exporter = UserExporter()
 
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectTrue(exporter.type is User.Type)
   }
   expectNotNil(exporter.export(item: user))
@@ -319,7 +319,7 @@ CastsTests.test("Conditional NSNumber -> Bool casts") {
 #endif
 
 // rdar://45217461 ([dynamic casting] [SR-8964]: Type check operator (is) fails for Any! variable holding an Error (struct) value)
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
 CastsTests.test("Casts from Any(struct) to Error (SR-8964)") {
   struct MyError: Error { }
 
@@ -393,7 +393,7 @@ CastsTests.test("Swift Protocol Metatypes don't self-conform") {
   let a = SwiftProtocol.self
   // `is P.Protocol` tests whether the argument is a subtype of P.
   // In particular, the protocol identifier `P.self` is such a subtype.
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectNotNil(runtimeCast(a, to: SwiftProtocol.Protocol.self)) // Fixed by rdar://58991956
   }
   expectNotNil(a as? SwiftProtocol.Protocol)
@@ -446,7 +446,7 @@ CastsTests.test("Self-conformance for Error.self")
 @objc protocol ObjCProtocol {}
 CastsTests.test("ObjC Protocol Metatypes self-conform") {
   let a = ObjCProtocol.self
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectNotNil(runtimeCast(a, to: ObjCProtocol.Protocol.self))
   }
   expectNotNil(a as? ObjCProtocol.Protocol)
@@ -472,7 +472,7 @@ CastsTests.test("String/NSString extension compat") {
 #endif
 
 protocol P1999 {}
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
 CastsTests.test("Cast Any(Optional(class)) to Protocol type (SR-1999)") {
   class Foo: P1999 { }
 

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -26,7 +26,7 @@ var tests = TestSuite("AsyncStream")
 
 @main struct Main {
   static func main() async {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       final class Expectation: UnsafeSendable {
         var fulfilled = false
       }

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -2,38 +2,38 @@
 
 // REQUIRES: concurrency
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func doAsynchronously() async { }
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func doSynchronously() { }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func testConversions() async {
   let _: () -> Void = doAsynchronously // expected-error{{invalid conversion from 'async' function of type '() async -> ()' to synchronous function type '() -> Void'}}
   let _: () async -> Void = doSynchronously // okay
 }
 
 // Overloading
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 @available(swift, deprecated: 4.0, message: "synchronous is no fun")
 func overloadedSame(_: Int = 0) -> String { "synchronous" }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func overloadedSame() async -> String { "asynchronous" }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func overloaded() -> String { "synchronous" }
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func overloaded() async -> Double { 3.14159 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 @available(swift, deprecated: 4.0, message: "synchronous is no fun")
 func overloadedOptDifference() -> String { "synchronous" }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func overloadedOptDifference() async -> String? { nil }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func testOverloadedSync() {
   _ = overloadedSame() // expected-warning{{synchronous is no fun}}
 
@@ -63,7 +63,7 @@ func testOverloadedSync() {
   let _: Int = fn4 // expected-error{{value of type '() async -> ()'}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func testOverloadedAsync() async {
   _ = await overloadedSame() // no warning
 
@@ -98,12 +98,12 @@ func testOverloadedAsync() async {
   let _: Int = fn4 // expected-error{{value of type '() async -> ()'}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func takesAsyncClosure(_ closure: () async -> String) -> Int { 0 }
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func takesAsyncClosure(_ closure: () -> String) -> String { "" }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func testPassAsyncClosure() {
   let a = takesAsyncClosure { await overloadedSame() }
   let _: Double = a // expected-error{{convert value of type 'Int'}}
@@ -112,7 +112,7 @@ func testPassAsyncClosure() {
   let _: Double = b // expected-error{{convert value of type 'String'}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 struct FunctionTypes {
   var syncNonThrowing: () -> Void
   var syncThrowing: () throws -> Void
@@ -135,27 +135,27 @@ struct FunctionTypes {
 }
 
 // Overloading when there is conversion from sync to async.
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func bar(_ f: (Int) -> Int) -> Int {
   return f(2)
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func bar(_ f: (Int) async -> Int) async -> Int {
   return await f(2)
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func incrementSync(_ x: Int) -> Int {
   return x + 1
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func incrementAsync(_ x: Int) async -> Int {
   return x + 1
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func testAsyncWithConversions() async {
   _ = bar(incrementSync)
   _ = bar { -$0 }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1219,14 +1219,14 @@ func voidFuncWithEffects1() throws {
   // expected-note@-2 {{did you mean to add a return type?}}{{35-35= -> <#Return Type#>}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func voidFuncWithEffects2() async throws {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
   // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 // expected-error@+1 {{'async' must precede 'throws'}}
 func voidFuncWithEffects3() throws async {
   return 1
@@ -1234,7 +1234,7 @@ func voidFuncWithEffects3() throws async {
   // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func voidFuncWithEffects4() async {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
@@ -1247,7 +1247,7 @@ func voidFuncWithEffects5(_ closure: () throws -> Void) rethrows {
   // expected-note@-2 {{did you mean to add a return type?}}{{65-65= -> <#Return Type#>}}
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func voidGenericFuncWithEffects<T>(arg: T) async where T: CustomStringConvertible {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}

--- a/test/IRGen/opaque_result_type_access_path.swift
+++ b/test/IRGen/opaque_result_type_access_path.swift
@@ -31,18 +31,18 @@ extension X : P where T : P {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 func bar() -> some P {
   return 27
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 func foo() -> some P {
   return X(bar())
 }
 
 // CHECK: 27
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(SwiftStdlib 5.1, *) {
 print(foo().get())
 } else {
   print(27)

--- a/test/Interpreter/SDK/check_class_for_archiving.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving.swift
@@ -64,13 +64,13 @@ suite.test("NSKeyedUnarchiver") {
 }
 
 // Disable negative tests on older OSes because of rdar://problem/50504765
-if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+if #available(SwiftStdlib 5.5, *) {
   suite.test("PrivateClass") {
     expectNotEqual(0, NSKeyedUnarchiver._swift_checkClassAndWarnForKeyedArchiving(PrivateClass.self, operation: op))
   }
 }
 
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
   // Generic classes and nested classes were considered to have unstable names
   // in earlier releases.
   suite.test("GenericClass") {

--- a/test/Interpreter/SDK/check_class_for_archiving_log.swift
+++ b/test/Interpreter/SDK/check_class_for_archiving_log.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 // A tricky way to make the FileCheck tests conditional on the OS version.
-if #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) {
+if #available(SwiftStdlib 5.5, *) {
   print("-check-prefix=CHECK")
 } else {
   // Disable the checks for older OSes because of rdar://problem/50504765

--- a/test/Interpreter/SDK/protocol_lookup_foreign.swift
+++ b/test/Interpreter/SDK/protocol_lookup_foreign.swift
@@ -42,7 +42,7 @@ ProtocolLookupForeign.test("NSPoint") {
 }
 
 ProtocolLookupForeign.test("CFSet") {
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     expectEqual("CFSet", fooify(CFSetCreate(kCFAllocatorDefault, nil, 0, nil)!))
   }
 }

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -17,11 +17,11 @@ defer { runAllTests() }
 
 var Tests = TestSuite("Actor.AssocObject")
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 final actor Actor {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("final class crash when set assoc object")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -31,11 +31,11 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 actor Actor2 {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("non-final class crash when set assoc object")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -45,13 +45,13 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("base generic class crash when set assoc object")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -69,10 +69,10 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 actor ActorNSObjectSubKlass : NSObject {}
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("no crash when inherit from nsobject")
   .code {
     let x = ActorNSObjectSubKlass()
@@ -80,13 +80,13 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 actor ActorNSObjectSubKlassGeneric<T> : NSObject {
   var state: T
   init(state: T) { self.state = state }
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("no crash when generic inherit from nsobject")
   .code {
     let x = ActorNSObjectSubKlassGeneric(state: 5)

--- a/test/Interpreter/class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/class_forbid_objc_assoc_objects.swift
@@ -11,11 +11,11 @@ defer { runAllTests() }
 
 var Tests = TestSuite("AssocObject")
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 final class AllowedToHaveAssocObject {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("no crash when set assoc object, assign") {
     let x = AllowedToHaveAssocObject()
     objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_ASSIGN)
@@ -42,12 +42,12 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 final class UnableToHaveAssocObjects {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object, assign")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -89,7 +89,7 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 final class UnableToHaveAssocObjectsGeneric<T> {
   var state: T
@@ -97,7 +97,7 @@ final class UnableToHaveAssocObjectsGeneric<T> {
   init(state: T) { self.state = state }
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object (generic)")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -110,16 +110,16 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 // In this case, we mark the child. This is unsound since we will get different
 // answers since the type checker isn't enforcing this.
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 class UnsoundAbleToHaveAssocObjectsParentClass {
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 final class UnsoundUnableToHaveAssocObjectsSubClass : UnsoundAbleToHaveAssocObjectsParentClass {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("no crash when set assoc object set only on child subclass, but assoc to parent")
   .code {
     let x = UnsoundAbleToHaveAssocObjectsParentClass()
@@ -137,16 +137,16 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 
 // In this case, we mark the parent. It seems like the bit is propagated... I am
 // not sure.
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 class UnsoundAbleToHaveAssocObjectsParentClass2 {
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 final class UnsoundUnableToHaveAssocObjectsSubClass2 : UnsoundAbleToHaveAssocObjectsParentClass2 {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object set only on parent class")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -156,11 +156,11 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 class UnsoundUnableToHaveAssocObjectsSubClass3 : UnsoundAbleToHaveAssocObjectsParentClass2 {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object set only on parent class, child not final")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -174,18 +174,18 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 
 // In this case, we mark the child. This is unsound since we will get different
 // answers since the type checker isn't enforcing this.
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 class GenericAbleToHaveAssocObjectsParentClass<T> {
   public var state: T
   init(state: T) { self.state = state }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 final class GenericUnableToHaveAssocObjectsSubClass<T> : GenericAbleToHaveAssocObjectsParentClass<T> {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("no crash when set assoc object set only on child subclass, but assoc to parent")
   .code {
     let x = GenericAbleToHaveAssocObjectsParentClass(state: 5)
@@ -203,18 +203,18 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 
 // In this case, we mark the parent. It seems like the bit is propagated... I am
 // not sure.
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 @_semantics("objc.forbidAssociatedObjects")
 class GenericAbleToHaveAssocObjectsParentClass2<T> {
   public var state: T
   init(state: T) { self.state = state }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 final class GenericUnableToHaveAssocObjectsSubClass2<T> : GenericAbleToHaveAssocObjectsParentClass2<T> {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object set only on parent class")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {
@@ -224,11 +224,11 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   }
 }
 
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+@available(SwiftStdlib 5.0, *)
 class GenericUnableToHaveAssocObjectsSubClass3<T> : GenericAbleToHaveAssocObjectsParentClass2<T> {
 }
 
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+if #available(SwiftStdlib 5.0, *) {
   Tests.test("crash when set assoc object set only on parent class, child not final")
   .crashOutputMatches("objc_setAssociatedObject called on instance")
   .code {

--- a/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_B.swift
+++ b/test/Interpreter/dynamic_replacement_multifile/Inputs/dynamic_replacement_multi_file_B.swift
@@ -7,12 +7,12 @@ func replaceable2_r() -> Int {
   return 3
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 dynamic func bar3(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 @_dynamicReplacement(for: bar3(_:))
 func bar3_r(_ x: Int) -> some P {
   return Pair()

--- a/test/Interpreter/dynamic_replacement_multifile/main.swift
+++ b/test/Interpreter/dynamic_replacement_multifile/main.swift
@@ -34,12 +34,12 @@ struct Pair {
 
 extension Pair : P {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 dynamic func bar(_ x: Int) -> some P {
   return x
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 @_dynamicReplacement(for: bar(_:))
 func bar_r(_ x: Int) -> some P {
   return Pair()
@@ -48,7 +48,7 @@ func bar_r(_ x: Int) -> some P {
 var DynamicallyReplaceable = TestSuite("DynamicallyReplaceable")
 
 DynamicallyReplaceable.test("DynamicallyReplaceable") {
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(SwiftStdlib 5.1, *) {
     expectEqual(1, replaceable())
     expectEqual(2, replaceable1())
     expectEqual(3, replaceable2())

--- a/test/Interpreter/generic_casts.swift
+++ b/test/Interpreter/generic_casts.swift
@@ -165,7 +165,7 @@ func nongenericAnyIsPAndPCSubType(type: Any.Type) -> Bool {
 func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   // If we're testing against a runtime that doesn't have the fix this tests,
   // just pretend we got it right.
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     // Remember: If `T` is bound to `P`, then `T.Type` is `P.Protocol`
     return type is T.Type
   } else {
@@ -191,7 +191,7 @@ func nongenericAnyAsConditionalPAndPCSubType(type: Any.Type) -> Bool {
 func genericAnyAsConditional<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   // If we're testing against a runtime that doesn't have the fix this tests,
   // just pretend we got it right.
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     return (type as? T.Type) != nil
   } else {
     return expected
@@ -217,7 +217,7 @@ func nongenericAnyAsUnconditionalPAndPCSubType(type: Any.Type) -> Bool {
   return true
 }
 func genericAnyAsUnconditional<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     blackhole(type as! T.Type)
   }
   return true

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -26,7 +26,7 @@ func nongenericAnyIsPObjCProtocol(type: Any.Type) -> Bool {
 func genericAnyIs<T>(type: Any.Type, to: T.Type, expected: Bool) -> Bool {
   // If we're testing against a runtime that doesn't have the fix this tests,
   // just pretend we got it right.
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     return type is T.Type
   } else {
     return expected

--- a/test/ModuleInterface/Inputs/opaque-result-types-client.swift
+++ b/test/ModuleInterface/Inputs/opaque-result-types-client.swift
@@ -13,7 +13,7 @@ func getAssocSubscriptType<T: AssocTypeInference>(_ x: T) -> T.AssocSubscript {
 struct MyFoo: Foo {}
 struct YourFoo: Foo {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 func someTypeIsTheSame() {
   var a = foo(0)
   a = foo(0)

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -4,12 +4,12 @@
 // REQUIRES: concurrency
 
 #if LIBRARY
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 public func fn() async {
   fatalError()
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 public func reasyncFn(_: () async -> ()) reasync {
   fatalError()
 }
@@ -19,7 +19,7 @@ public func reasyncFn(_: () async -> ()) reasync {
 #else
 import Library
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func callFn() async {
   await fn()
 }

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -7,19 +7,19 @@ public protocol Foo {}
 extension Int: Foo {}
 
 // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public func foo(_: Int) -> some Foo {
   return 1738
 }
 
 // CHECK-LABEL: @inlinable public func foo(_: Swift.String) -> some OpaqueResultTypes.Foo {
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 @inlinable public func foo(_: String) -> some Foo {
   return 679
 }
 
 // CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T : OpaqueResultTypes.Foo
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
 }
@@ -35,53 +35,53 @@ public protocol AssocTypeInference {
   subscript() -> AssocSubscript { get }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public struct Bar<T>: AssocTypeInference {
   public init() {}
 
   // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Bas: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -91,37 +91,37 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Bass<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo(_ x: U) -> some OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -131,11 +131,11 @@ public struct Bar<T>: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T, U>
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public var prop: some Foo {
     return 123
   }
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public subscript() -> some Foo {
     return 123
   }
@@ -145,87 +145,87 @@ public struct Bar<T>: AssocTypeInference {
   // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<T>
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(SwiftStdlib 5.1, *)
 public struct Zim: AssocTypeInference {
   public init() {}
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo(_: Int) -> some Foo {
     return 20721
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo(_: String) -> some Foo {
     return 219
   }
 
   // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Zang: AssocTypeInference {
     public init() {}
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
     // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public subscript() -> some Foo {
       return 123
     }
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public struct Zung<U: Foo>: AssocTypeInference {
     public init() {}
 
     // CHECK-LABEL: public func foo(_: Swift.Int) -> some OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: Int) -> some Foo {
       return 20721
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_: String) -> some Foo {
       return 219
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo(_ x: U) -> some Foo {
       return x
     }
 
     // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public var prop: some Foo {
       return 123
     }
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @available(SwiftStdlib 5.1, *)
     public subscript() -> some Foo {
       return 123
     }
@@ -235,11 +235,11 @@ public struct Zim: AssocTypeInference {
     // CHECK-LABEL: public typealias AssocSubscript = @_opaqueReturnTypeOf("{{.*}}", 0) {{.*}}<U>
   }
 
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public var prop: some Foo {
     return 123
   }
-  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  @available(SwiftStdlib 5.1, *)
   public subscript() -> some Foo {
     return 123
   }

--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -100,10 +100,8 @@ private struct Parent<Unused> {
 }
 
 AssociatedTypeDemangleTests.test("nested private generic types in associated type witnesses") {
-  // Fixed in custom runtimes.
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, * ) {}
   // Fixed in Swift 5.1+ runtimes.
-  else if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {}
+  if #available(SwiftStdlib 5.1, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
     // FIXME: rdar://problem/51959305

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -482,7 +482,7 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
   // V !: P3 in InnerTEqualsConformsToP1
 }
 
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
   DemangleToMetadataTests.test("Round-trip with _mangledTypeName and _typeByName") {
     func roundTrip<T>(_ type: T.Type) {
       let mangledName: String? = _mangledTypeName(type)

--- a/test/SourceKit/Sema/oslog.swift
+++ b/test/SourceKit/Sema/oslog.swift
@@ -15,7 +15,7 @@ public struct Foo {
   public init() { self.prop = "boop" }
 }
 
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 extension OSLogInterpolation {
   @_optimize(none)
   @_transparent
@@ -30,7 +30,7 @@ extension OSLogInterpolation {
 import os
 import Lib
 
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
   let logger = Logger()
   logger.log("Log a foo: \(Foo())")
 }

--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -488,7 +488,7 @@ tests.test("verbatimBridged/Base/withUnsafeBufferPointer") {
   // https://bugs.swift.org/browse/SR-14663
   // This tests a bad precondition that was fixed in
   // https://github.com/apple/swift/pull/37960
-  guard #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) else { return }
+  guard #available(SwiftStdlib 5.5, *) else { return }
   let a = NSArray(array: [Base(0), Base(1), Base(2), Base(3)])
   let b = a as! [Base]
   let success: Bool = b.withUnsafeBufferPointer { buffer in
@@ -507,7 +507,7 @@ tests.test("verbatimBridged/AnyObject/withUnsafeBufferPointer") {
   // https://bugs.swift.org/browse/SR-14663
   // This tests a bad precondition that was fixed in
   // https://github.com/apple/swift/pull/37960
-  guard #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) else { return }
+  guard #available(SwiftStdlib 5.5, *) else { return }
   let a = NSArray(array: [Base(0), Base(1), Base(2), Base(3)])
   let b = a as [AnyObject]
   let success: Bool = b.withUnsafeBufferPointer { buffer in

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -417,7 +417,7 @@ UnicodeScalarTests.test("LosslessStringConvertible") {
   checkLosslessStringConvertible((0...127).map { UnicodeScalar(Int($0))! })
 }
 
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(SwiftStdlib 5.1, *) {
   UnicodeScalarTests.test("Views") {
     let scalars = baseScalars + continuingScalars
     for scalar in scalars {

--- a/test/stdlib/Diffing.swift
+++ b/test/stdlib/Diffing.swift
@@ -8,7 +8,7 @@ let suite = TestSuite("Diffing")
 
 // This availability test has to be this awkward because of
 // rdar://problem/48450376 - Availability checks don't apply to top-level code
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(SwiftStdlib 5.1, *) {
 
   suite.test("Diffing empty collections") {
     let a = [Int]()
@@ -630,7 +630,7 @@ if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
   }
 }
 
-if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
+if #available(SwiftStdlib 5.2, *) {
 
   suite.test("Fast applicator error condition") {
     let bear = "bear"
@@ -695,7 +695,7 @@ if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
   }
 }
 
-if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+if #available(SwiftStdlib 5.1, *) {
 
   suite.test("Fast applicator fuzzer") {
     func makeArray() -> [Int] {

--- a/test/stdlib/EmptyCollectionSingletonRealization.swift
+++ b/test/stdlib/EmptyCollectionSingletonRealization.swift
@@ -25,7 +25,7 @@ import Foundation
 @objc protocol P {}
 
 
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
   do {
     let d: [NSObject: NSObject] = [:]
     let c: AnyClass? = object_getClass(d)

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -217,7 +217,7 @@ func throwJazzHands() throws {
 }
 
 ErrorTests.test("willThrow") {
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     // Error isn't allowed in a @convention(c) function when ObjC interop is
     // not available, so pass it through an OpaquePointer.
     typealias WillThrow = @convention(c) (OpaquePointer) -> Void

--- a/test/stdlib/ErrorBridged.swift
+++ b/test/stdlib/ErrorBridged.swift
@@ -771,7 +771,7 @@ ErrorBridgingTests.test("@objc error domains for nested types") {
 ErrorBridgingTests.test("error-to-NSObject casts") {
   let error = MyCustomizedError(code: 12345)
 
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     // Unconditional cast
     let nsErrorAsObject1 = unconditionalCast(error, to: NSObject.self)
     let nsError1 = unconditionalCast(nsErrorAsObject1, to: NSError.self)
@@ -801,7 +801,7 @@ ErrorBridgingTests.test("NSError-to-Error casts") {
     expectTrue(something is Error)
   }
 
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     // TODO: Wrap some leak checking around this
     // Until then, this is a helpful debug tool
 		should_not_leak_nserror()
@@ -814,7 +814,7 @@ ErrorBridgingTests.test("CFError-to-Error casts") {
     expectTrue(something is Error)
   }
 
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     // TODO: Wrap some leak checking around this
     // Until then, this is a helpful debug tool
 		should_not_leak_cferror()
@@ -827,7 +827,7 @@ enum MyError: Error {
 
 ErrorBridgingTests.test("SR-9207 crash in failed cast to NSError") {
 
-  if #available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *) {
+  if #available(SwiftStdlib 5.2, *) {
     let error = MyError.someThing
     let foundationError = error as NSError
 
@@ -850,7 +850,7 @@ ErrorBridgingTests.test("Swift Error bridged to NSError description") {
     expectEqual("Something", bridgedError.description)
   }
 
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     checkDescription()
   }
 }
@@ -881,7 +881,7 @@ ErrorBridgingTests.test("Swift Error description memory management") {
     }
   }
 
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     checkDescription()
   }
 }

--- a/test/stdlib/ForEachField.swift
+++ b/test/stdlib/ForEachField.swift
@@ -137,7 +137,7 @@ class NSObjectSubclass: NSObject {
 class EmptyNSObject: NSObject {}
 #endif
 
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 func checkFields<T>(
   of type: T.Type,
   options: _EachFieldOptions = [],
@@ -163,7 +163,7 @@ func checkFields<T>(
   expectEqual(fields.count, count)
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(SwiftStdlib 5.5, *)
 func checkFieldsWithKeyPath<T>(
   of type: T.Type,
   options: _EachFieldOptions = [],
@@ -194,7 +194,7 @@ extension TestStruct: ExistentialProtocol {}
 extension GenericStruct: ExistentialProtocol {}
 extension GenericSubclass: ExistentialProtocol {}
 
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 extension ExistentialProtocol {
   static func doCheckFields(
     options: _EachFieldOptions = [],
@@ -204,7 +204,7 @@ extension ExistentialProtocol {
   }
 }
 
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 func checkFieldsAsExistential(
   of type: ExistentialProtocol.Type,
   options: _EachFieldOptions = [],
@@ -213,7 +213,7 @@ func checkFieldsAsExistential(
   type.doCheckFields(options: options, fields: fields)
 }
 
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 func _withTypeEncodingCallback(encoding: inout String, name: UnsafePointer<CChar>, offset: Int, type: Any.Type, kind: _MetadataKind) -> Bool {
   if type == Bool.self {
     encoding += "B"
@@ -247,7 +247,7 @@ func _withTypeEncodingCallback(encoding: inout String, name: UnsafePointer<CChar
   return true
 }
 
-@available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+@available(SwiftStdlib 5.2, *)
 func getTypeEncoding<T>(_ type: T.Type) -> String? {
   var encoding = ""
   _ = _forEachField(of: type) { name, offset, type, kind in
@@ -260,7 +260,7 @@ func getTypeEncoding<T>(_ type: T.Type) -> String? {
 
 var tests = TestSuite("ForEachField")
 
-if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
+if #available(SwiftStdlib 5.2, *) {
 
   tests.test("TestTuple") {
     checkFields(
@@ -299,7 +299,7 @@ if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
     })
   }
 
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     tests.test("StructKeyPath") {
       checkFieldsWithKeyPath(
         of: TestStruct.self,

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -119,7 +119,7 @@ ${Suite}.test("${ArrayType}/appendNonUnique")
 %   if ArrayType != 'ArraySlice':
 ${Suite}.test("${ArrayType}/removeNonUnique")
   .code {
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     var x = ${ArrayType}<Int>(repeating: 27, count: 200)
     x.reserveCapacity(10002)
     for _ in 1...100 {

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -623,7 +623,7 @@ mirrors.test("Weak and Unowned Obj-C refs in class (SR-5289)") {
     }
   }
 
-	if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+	if #available(SwiftStdlib 5.3, *) {
 		let objc = WeakUnownedObjCClass()
 		let classWithReferences = SwiftClassWithWeakAndUnowned(objc)
 		let m = Mirror(reflecting: classWithReferences)
@@ -657,7 +657,7 @@ mirrors.test("Weak and Unowned Obj-C refs in struct") {
     }
   }
 
-	if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+	if #available(SwiftStdlib 5.3, *) {
 		let objc = WeakUnownedObjCClass()
 		let structWithReferences = SwiftStructWithWeakAndUnowned(objc)
 		let m = Mirror(reflecting: structWithReferences)
@@ -693,7 +693,7 @@ mirrors.test("Weak and Unowned Swift refs in class") {
     }
   }
 
-	if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+	if #available(SwiftStdlib 5.3, *) {
 		let swift = WeakUnownedSwiftClass()
 		let classWithReferences = SwiftClassWithWeakAndUnowned(swift)
 		let m = Mirror(reflecting: classWithReferences)
@@ -727,7 +727,7 @@ mirrors.test("Weak and Unowned Swift refs in struct") {
     }
   }
 
-	if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+	if #available(SwiftStdlib 5.3, *) {
 		let swift = WeakUnownedSwiftClass()
 		let structWithReferences = SwiftStructWithWeakAndUnowned(swift)
 		let m = Mirror(reflecting: structWithReferences)

--- a/test/stdlib/OptionSetTest.swift
+++ b/test/stdlib/OptionSetTest.swift
@@ -94,7 +94,7 @@ tests.test("set algebra") {
 
   p = P.boxOrBag
   let removed = p.remove(P.satchelOrBag)
-  if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
     // https://github.com/apple/swift/pull/28378
     expectEqual(P.bag, removed)
   }

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -347,7 +347,7 @@ let PrintTests = TestSuite("FloatingPointPrinting")
 % for FloatType in ['Float16', 'Float', 'Double', 'Float80']:
 % if FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 % elif FloatType == 'Float80':
 #if !os(Windows) && (arch(i386) || arch(x86_64))
 % end
@@ -384,7 +384,7 @@ fileprivate func expectDescription(_ expected: String, _ object: ${FloatType},
 //   that is closest (as an infinitely-precise real number) to the original
 //   binary float (interpreted as an infinitely-precise real number).
 % if FloatType == 'Float16':
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.3, *)
 % end
 fileprivate func expectAccurateDescription(_ object: ${FloatType},
   _ message: @autoclosure () -> String = "",
@@ -585,7 +585,7 @@ PrintTests.test("Printable_CDouble") {
 }
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 PrintTests.test("Printable_Float16") {
   func asFloat16(_ f: Float16) -> Float16 { return f }
 

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -123,7 +123,7 @@ RangeTraps.test("UIntOverflow")
   _blackHole((0 ..< UInt.max).count)
 }
 
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
   // Debug check was introduced in https://github.com/apple/swift/pull/34961
   RangeTraps.test("UncheckedHalfOpen")
   .xfail(.custom(

--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -49,7 +49,7 @@ var ${Scalar}x${n}_TestSuite = TestSuite("${Scalar}x${n}")
 %  end
 ${Scalar}x${n}_TestSuite.test("comparisons") {
 %  if bits == 16:
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(SwiftStdlib 5.3, *) {
 %  end
   let a = ${Vector}.random(in: -1 ..< 1)
   let ap1 = a + ${Vector}(repeating: 1)

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -46,7 +46,7 @@ StringCreateTests.test("String(decoding:as:)") {
     "", String(decoding: UnsafeBufferPointer(_empty: ()), as: UTF32.self))
 }
 
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
   StringCreateTests.test("String(unsafeUninitializedCapacity:initializingUTF8With:)") {
     for simpleString in SimpleString.allCases {
       let expected = simpleString.rawValue
@@ -92,7 +92,7 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
   }
 }
 
-if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
   StringCreateTests.test("Small string unsafeUninitializedCapacity") {
     let str1 = "42"
     let str2 = String(42)

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -200,7 +200,7 @@ StringIndexTests.test("Scalar Align UTF-8 indices") {
 #if _runtime(_ObjC)
 import Foundation
 StringIndexTests.test("String.Index(_:within) / Range<String.Index>(_:in:)") {
-  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+  guard #available(SwiftStdlib 5.1, *) else {
     return
   }
 
@@ -311,7 +311,7 @@ StringIndexTests.test("Exhaustive Index Interchange") {
     file: String = #file,
     line: UInt = #line
   ) {
-    guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+    guard #available(SwiftStdlib 5.1, *) else {
       return
     }
 

--- a/test/stdlib/TestScanner.swift
+++ b/test/stdlib/TestScanner.swift
@@ -49,7 +49,7 @@ extension CharacterSet {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 class TestScanner : TestScannerSuper {
   func testScanFloatingPoint() {
     // Leading whitespace:
@@ -491,7 +491,7 @@ class TestScanner : TestScannerSuper {
 }
 
 #if !FOUNDATION_XCTEST
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   let testSuite = TestSuite("TestScanner")
   let handler = TestScanner()
   testSuite.test("testScanFloatingPoint") { handler.testScanFloatingPoint() }

--- a/test/stdlib/URLSession.swift
+++ b/test/stdlib/URLSession.swift
@@ -5,7 +5,7 @@
 import StdlibUnittest
 import Foundation
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 private func testWebSocketTask() {
   let task = URLSession.shared.webSocketTask(with: URL(string:"wss://test.example")!)
 
@@ -26,7 +26,7 @@ private func testWebSocketTask() {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 private func testURLError(_ error: Error) {
   if let error = error as? URLError {
     if error.networkUnavailableReason == .constrained {
@@ -39,13 +39,13 @@ private func testURLError(_ error: Error) {
   }
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 private func testURLCache() {
   _ = URLCache(memoryCapacity: 0, diskCapacity: 0)
   _ = URLCache(memoryCapacity: 0, diskCapacity: 0, directory: URL(fileURLWithPath: "/tmp"))
 }
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(SwiftStdlib 5.1, *)
 private func testTaskMetrics(_ metrics: URLSessionTaskMetrics) {
   if let transaction = metrics.transactionMetrics.last {
     if transaction.remotePort == 443 {

--- a/test/stdlib/Unicode.swift
+++ b/test/stdlib/Unicode.swift
@@ -63,7 +63,7 @@ typealias UTF16 = Unicode.UTF16
 typealias UTF32 = Unicode.UTF32
 
 UnicodeAPIs.test("UTF-8 and UTF-16 queries") {
-  guard #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+  guard #available(SwiftStdlib 5.1, *) else {
     return
   }
   let str = "abéÏ01😓🎃👨‍👨‍👧‍👦アイウエオ"

--- a/test/stdlib/objc-array-slice.swift
+++ b/test/stdlib/objc-array-slice.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+if #available(SwiftStdlib 5.5, *) {
   // This tests behavior that was fixed in
   // https://github.com/apple/swift/pull/36355
 

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -255,7 +255,7 @@ SubstringTests.test("UTF8View") {
 
     // The specialization for Substring.withContiguousStorageIfAvailable was
     // added in https://github.com/apple/swift/pull/29146.
-    guard #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+    guard #available(SwiftStdlib 5.3, *) else {
       return
     }
     checkHasContiguousStorage(t)

--- a/validation-test/Casting/Inputs/BoxingCasts.swift.gyb
+++ b/validation-test/Casting/Inputs/BoxingCasts.swift.gyb
@@ -198,7 +198,7 @@ contents = [
 %       nextTestNumber()
 BoxingCasts.test("${testFunctionName()}(): Casting ${box.name}(${content.name}) to ${target}") {
   // TODO: Selectively enable/disable cases that work with earlier stdlib
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     ${testFunctionName()}()
   }
 }
@@ -224,7 +224,7 @@ func ${testFunctionName()}() {
 %         nextTestNumber()
 BoxingCasts.test("${testFunctionName()}(): Casting ${box.name}(${innerBox.name}(${content.name})) to ${target}") {
   // TODO: Selectively enable/disable cases that work with earlier stdlib
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     ${testFunctionName()}()
   }
 }

--- a/validation-test/Reflection/existentials_objc.swift
+++ b/validation-test/Reflection/existentials_objc.swift
@@ -19,7 +19,7 @@ import SwiftReflectionTest
 
 class MyClass<T> {}
 
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // Imported class wrapped in AnyObject
 
   // CHECK: Type reference:

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt.swift
@@ -333,7 +333,7 @@ FixedPointConversion_Debug32_ToInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt16.swift
@@ -398,7 +398,7 @@ FixedPointConversion_Debug32_ToInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt32.swift
@@ -333,7 +333,7 @@ FixedPointConversion_Debug32_ToInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt64.swift
@@ -272,7 +272,7 @@ FixedPointConversion_Debug32_ToInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt8.swift
@@ -440,7 +440,7 @@ FixedPointConversion_Debug32_ToInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt.swift
@@ -361,7 +361,7 @@ FixedPointConversion_Debug32_ToUInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToUInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt16.swift
@@ -407,7 +407,7 @@ FixedPointConversion_Debug32_ToUInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToUInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt32.swift
@@ -361,7 +361,7 @@ FixedPointConversion_Debug32_ToUInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToUInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt64.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Debug32_ToUInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToUInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt8.swift
@@ -430,7 +430,7 @@ FixedPointConversion_Debug32_ToUInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug32_ToUInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
@@ -291,7 +291,7 @@ FixedPointConversion_Debug64_ToInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
@@ -398,7 +398,7 @@ FixedPointConversion_Debug64_ToInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
@@ -356,7 +356,7 @@ FixedPointConversion_Debug64_ToInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
@@ -291,7 +291,7 @@ FixedPointConversion_Debug64_ToInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
@@ -440,7 +440,7 @@ FixedPointConversion_Debug64_ToInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Debug64_ToUInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToUInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
@@ -407,7 +407,7 @@ FixedPointConversion_Debug64_ToUInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToUInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
@@ -384,7 +384,7 @@ FixedPointConversion_Debug64_ToUInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToUInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Debug64_ToUInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToUInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
@@ -430,7 +430,7 @@ FixedPointConversion_Debug64_ToUInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Debug64_ToUInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt.swift
@@ -333,7 +333,7 @@ FixedPointConversion_Release32_ToInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt16.swift
@@ -398,7 +398,7 @@ FixedPointConversion_Release32_ToInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt32.swift
@@ -333,7 +333,7 @@ FixedPointConversion_Release32_ToInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt64.swift
@@ -272,7 +272,7 @@ FixedPointConversion_Release32_ToInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt8.swift
@@ -440,7 +440,7 @@ FixedPointConversion_Release32_ToInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt.swift
@@ -361,7 +361,7 @@ FixedPointConversion_Release32_ToUInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToUInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt16.swift
@@ -407,7 +407,7 @@ FixedPointConversion_Release32_ToUInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToUInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt32.swift
@@ -361,7 +361,7 @@ FixedPointConversion_Release32_ToUInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToUInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt64.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Release32_ToUInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToUInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt8.swift
@@ -430,7 +430,7 @@ FixedPointConversion_Release32_ToUInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release32_ToUInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
@@ -291,7 +291,7 @@ FixedPointConversion_Release64_ToInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
@@ -398,7 +398,7 @@ FixedPointConversion_Release64_ToInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
@@ -356,7 +356,7 @@ FixedPointConversion_Release64_ToInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
@@ -291,7 +291,7 @@ FixedPointConversion_Release64_ToInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
@@ -440,7 +440,7 @@ FixedPointConversion_Release64_ToInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Release64_ToUInt
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToUInt
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
@@ -407,7 +407,7 @@ FixedPointConversion_Release64_ToUInt16
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToUInt16
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
@@ -384,7 +384,7 @@ FixedPointConversion_Release64_ToUInt32
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToUInt32
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
@@ -338,7 +338,7 @@ FixedPointConversion_Release64_ToUInt64
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToUInt64
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
@@ -430,7 +430,7 @@ FixedPointConversion_Release64_ToUInt8
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 FixedPointConversion_Release64_ToUInt8
 .test("FromFloat16_NeverTraps")

--- a/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
+++ b/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
@@ -170,7 +170,7 @@ ${testSuite}
 %       if OtherName == 'Float16':
 %
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+if #available(SwiftStdlib 5.3, *) {
 
 %       elif OtherName == 'Float80':
 %

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -4672,7 +4672,7 @@ SetTestSuite.test("IndexValidation.RemoveAt.AfterGrow") {
 }
 
 #if _runtime(_ObjC)
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedNonverbatimBridge.Trap.String")
   .skip(.custom(
@@ -4695,7 +4695,7 @@ if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedNonverbatimBridge.Trap.Int")
   .skip(.custom(
@@ -4827,7 +4827,7 @@ SetTestSuite.test("ForcedVerbatimDowncast.Trap.Int")
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.String")
   .skip(.custom(
@@ -4851,7 +4851,7 @@ if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // https://github.com/apple/swift/pull/23174
   SetTestSuite.test("ForcedBridgingNonverbatimDowncast.Trap.Int")
   .skip(.custom(
@@ -4876,7 +4876,7 @@ if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
 #endif
 
 #if _runtime(_ObjC)
-if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) {
+if #available(SwiftStdlib 5.1, *) {
   // https://github.com/apple/swift/pull/23683
   SetTestSuite.test("Upcast.StringEqualityMismatch") {
     // Upcasting from NSString to String keys changes their concept of equality,

--- a/validation-test/stdlib/Stride.swift
+++ b/validation-test/stdlib/Stride.swift
@@ -9,7 +9,7 @@ var StrideTestSuite = TestSuite("Stride")
 StrideTestSuite.test("to") {
   checkSequence(Array(0...4), stride(from: 0, to: 5, by: 1))
   checkSequence(Array(1...5).reversed(), stride(from: 5, to: 0, by: -1))
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     // This used to crash before https://github.com/apple/swift/pull/34860
     checkSequence(stride(from: 0, to: 127, by: 3).map { Int8($0) },
       stride(from: 0, to: 127 as Int8, by: 3))
@@ -19,7 +19,7 @@ StrideTestSuite.test("to") {
 StrideTestSuite.test("through") {
   checkSequence(Array(0...5), stride(from: 0, through: 5, by: 1))
   checkSequence(Array(0...5).reversed(), stride(from: 5, through: 0, by: -1))
-  if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
+  if #available(SwiftStdlib 5.5, *) {
     // This used to crash before https://github.com/apple/swift/pull/34860
     checkSequence(stride(from: 0, through: 127, by: 3).map { Int8($0) },
                   stride(from: 0, through: 127 as Int8, by: 3))

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -378,7 +378,7 @@ UnsafeMutableBufferPointerTestSuite.test("initialize(from: Slice)") {
 }
 
 UnsafeMutableBufferPointerTestSuite.test("Slice.withContiguousStorageIfAvailable") {
-  guard #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
+  guard #available(SwiftStdlib 5.3, *) else {
     return
   }
 


### PR DESCRIPTION
In the stdlib codebase, replace explicit platform availability incantations of the form `macOS x.y, iOS x.y, watchOS x.y, tvOS x.y` with the availability macros defined in PR #39962.

Unfortunately availability macros do not currently work in `if #available` statements in inlinable function bodies, so leave those in place for now, adding a comment specifying the intended macro. (Fixing this isn't trivial, as it requires transforming code emitted into .swiftinterface files, and we aren't set up for that yet.)
