### PR TITLE
C++ Interop: support mutating attribute for C++ methods

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4351,7 +4351,14 @@ ClangImporter::instantiateCXXClassTemplate(
 
 bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
   return isa<clang::CXXConstructorDecl>(method) || !method->isConst() ||
-         method->getParent()->hasMutableFields();
+         method->getParent()->hasMutableFields() ||
+         (method->hasAttrs() &&
+          llvm::any_of(method->getAttrs(), [](clang::Attr *a) {
+            if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(a)) {
+              return swiftAttr->getAttribute() == "mutating";
+            }
+            return false;
+          }));
 }
 
 SwiftLookupTable *

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -53,6 +53,11 @@ module MutableMembers {
   requires cplusplus
 }
 
+module MutabilityAnnotations {
+  header "mutability-annotations.h"
+  requires cplusplus
+}
+
 module ProtocolConformance {
   header "protocol-conformance.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/Inputs/mutability-annotations.h
+++ b/test/Interop/Cxx/class/Inputs/mutability-annotations.h
@@ -1,0 +1,18 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MUTABILITY_ANNOTATIONS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_MUTABILITY_ANNOTATIONS_H
+
+struct HasConstMethodAnnotatedAsMutating {
+  int a;
+
+  int annotatedMutating() const __attribute__((__swift_attr__("mutating"))) {
+    const_cast<HasConstMethodAnnotatedAsMutating *>(this)->a++;
+    return a;
+  }
+
+  int annotatedMutatingWithOtherAttrs() const __attribute__((__swift_attr__("public"))) __attribute__((__swift_attr__("mutating"))) {
+    const_cast<HasConstMethodAnnotatedAsMutating *>(this)->a++;
+    return a;
+  }
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_MUTABILITY_ANNOTATIONS_H

--- a/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MutabilityAnnotations -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct HasConstMethodAnnotatedAsMutating {
+// CHECK:   mutating func annotatedMutating() -> Int32
+// CHECK:   mutating func annotatedMutatingWithOtherAttrs() -> Int32
+// CHECK:   var a: Int32
+// CHECK: }

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import MutabilityAnnotations
+
+let obj = HasConstMethodAnnotatedAsMutating(a: 42) // expected-note {{change 'let' to 'var' to make it mutable}}
+let i = obj.annotatedMutating() // expected-error {{cannot use mutating member on immutable value: 'obj' is a 'let' constant}}


### PR DESCRIPTION
This change teaches ClangImporter to import C++ methods marked with `__attribute__((__swift_attr__("mutating")))` as mutating in Swift. This is useful, for example, when a method mutates `this` despite being `const` in C++ (e.g. via `const_cast`).

This is a follow-up after https://github.com/apple/swift/pull/38618.