### PR TITLE
Relax warnings about interior ManagedBuffer pointers

### DIFF
--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -91,47 +91,26 @@ extension ManagedBuffer {
       firstElementAddress
     return realCapacity
   }
-  
-  /// Renamed to firstElementPointer for API.
-  @inlinable
-  internal final var firstElementAddress: UnsafeMutablePoiner<Element> { firstElementPointer }
 
-  /// A pointer to the first element in the buffer.
-  ///
-  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
   @inlinable
-  @available(swift 6.0)
-  public final var firstElementPointer: UnsafeMutablePointer<Element> {
+  internal final var firstElementAddress: UnsafeMutablePointer<Element> {
     return UnsafeMutablePointer(
       Builtin.projectTailElems(self, Element.self))
   }
-  
-  /// A pointer to the elements of the buffer.
-  ///
-  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
-  @inlinable
-  @available(OpenBSD, unavailable, message: "Use firstElementPointer and capacity provided at creation")
-  public final var elements: UnsafeMutableBufferPointer<Element> {
-    return UnsafeMutableBufferPointer(start: firstElementAddress, count: capacity)
-  }
 
-  /// Renamed to headerPointer for API.
-  @inlineable
-  internal final var headerAddress: UnsafeMutablePointer<Header> { headerPointer }
-  
-  /// A pointer to the buffer’s stored `Header`.
-  ///
-  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
   @inlinable
-  @available(swift 6.0)
-  public final var headerPointer: UnsafeMutablePointer<Header> {
+  internal final var headerAddress: UnsafeMutablePointer<Header> {
     return UnsafeMutablePointer<Header>(Builtin.addressof(&header))
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the stored
   /// `Header`.
+  ///
+  /// - Note: This pointer is fixed when the buffer is created, but it is only valid
+  ///   for the lifetime of the buffer. The buffer is guaranteed to live for the
+  ///   duration of the call to `body`, but may be deallocated immediately thereafter
+  ///   if its lifetime is not otherwise extended.
   @inlinable
-  @deprecated(swift 6.0, message: "Use headerPointer")
   public final func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
@@ -140,8 +119,12 @@ extension ManagedBuffer {
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
+  ///
+  /// - Note: This pointer is fixed when the buffer is created, but it is only valid
+  ///   for the lifetime of the buffer. The buffer is guaranteed to live for the
+  ///   duration of the call to `body`, but may be deallocated immediately thereafter
+  ///   if its lifetime is not otherwise extended.
   @inlinable
-  @deprecated(swift 6.0, message: "Use elements or firstElementPointer")
   public final func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
@@ -150,8 +133,12 @@ extension ManagedBuffer {
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
+  ///
+  /// - Note: These pointers are fixed when the buffer is created, but it is only valid
+  ///   for the lifetime of the buffer. The buffer is guaranteed to live for the
+  ///   duration of the call to `body`, but may be deallocated immediately thereafter
+  ///   if its lifetime is not otherwise extended.
   @inlinable
-  @deprecated(swift 6.0, message: "Use headerPointer and elements or firstElementPointer")
   public final func withUnsafeMutablePointers<R>(
     _ body: (UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -91,24 +91,47 @@ extension ManagedBuffer {
       firstElementAddress
     return realCapacity
   }
-
+  
+  /// Renamed to firstElementPointer for API.
   @inlinable
-  internal final var firstElementAddress: UnsafeMutablePointer<Element> {
+  internal final var firstElementAddress: UnsafeMutablePoiner<Element> { firstElementPointer }
+
+  /// A pointer to the first element in the buffer.
+  ///
+  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
+  @inlinable
+  @available(swift 6.0)
+  public final var firstElementPointer: UnsafeMutablePointer<Element> {
     return UnsafeMutablePointer(
       Builtin.projectTailElems(self, Element.self))
   }
-
+  
+  /// A pointer to the elements of the buffer.
+  ///
+  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
   @inlinable
-  internal final var headerAddress: UnsafeMutablePointer<Header> {
+  @available(OpenBSD, unavailable, message: "Use firstElementPointer and capacity provided at creation")
+  public final var elements: UnsafeMutableBufferPointer<Element> {
+    return UnsafeMutableBufferPointer(start: firstElementAddress, count: capacity)
+  }
+
+  /// Renamed to headerPointer for API.
+  @inlineable
+  internal final var headerAddress: UnsafeMutablePointer<Header> { headerPointer }
+  
+  /// A pointer to the buffer’s stored `Header`.
+  ///
+  /// This pointer is fixed for the lifetime of the `ManagedBuffer` object.
+  @inlinable
+  @available(swift 6.0)
+  public final var headerPointer: UnsafeMutablePointer<Header> {
     return UnsafeMutablePointer<Header>(Builtin.addressof(&header))
   }
 
   /// Call `body` with an `UnsafeMutablePointer` to the stored
   /// `Header`.
-  ///
-  /// - Note: This pointer is valid only for the duration of the
-  ///   call to `body`.
   @inlinable
+  @deprecated(swift 6.0, message: "Use headerPointer")
   public final func withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
@@ -117,10 +140,8 @@ extension ManagedBuffer {
 
   /// Call `body` with an `UnsafeMutablePointer` to the `Element`
   /// storage.
-  ///
-  /// - Note: This pointer is valid only for the duration of the
-  ///   call to `body`.
   @inlinable
+  @deprecated(swift 6.0, message: "Use elements or firstElementPointer")
   public final func withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
@@ -129,10 +150,8 @@ extension ManagedBuffer {
 
   /// Call `body` with `UnsafeMutablePointer`s to the stored `Header`
   /// and raw `Element` storage.
-  ///
-  /// - Note: These pointers are valid only for the duration of the
-  ///   call to `body`.
   @inlinable
+  @deprecated(swift 6.0, message: "Use headerPointer and elements or firstElementPointer")
   public final func withUnsafeMutablePointers<R>(
     _ body: (UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {


### PR DESCRIPTION
In order to be useful for large allocations, `ManagedBuffer` must guarantee the following:
- Its contents are never moved or reallocated. (Elements or header properties might be nontrivial to copy or move.)
- Its header is always located close to its first element. (In practice, ManagedBuffer lays out its storage as if it were a struct of `{Header, (Element, Element ...)}`.)

The documentation for the `withUnsafePointer...` methods creates serious doubt in the programmer’s mind about the validity of inferring these behaviors. Since the documentation implies that the validity of the `header` and `elements` pointers is tied to the duration of the call and not the lifetime of the object, that makes `ManagedBuffer` unsuitable for storing locks or atomic variables in either its `header` *or* `elements`, since these data types rely on the stability of their address in memory. Common wisdom seems to have arisen that it is in fact safe to rely on the location of `elements`, but not of `header`. This results in the unnecessarily complicated recommendation to allocate a heterogenous `ManagedBuffer<UInt8>` and manage its internal layout manually, rather than storing any locks or atomic variables in `header`.

Rather than continue to sow doubt, let’s just publicly commit to the stability of any given `ManagedBuffer`’s location and layout in memory.