### PR TITLE
Always weak-link symbols from the concurrency library when back-deploying

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -871,8 +871,18 @@ bool Decl::isStdlibDecl() const {
 AvailabilityContext Decl::getAvailabilityForLinkage() const {
   auto containingContext =
       AvailabilityInference::annotatedAvailableRange(this, getASTContext());
-  if (containingContext.hasValue())
+  if (containingContext.hasValue()) {
+    // If this entity comes from the concurrency module, adjust it's
+    // availability for linkage purposes up to Swift 5.5, so that we use
+    // weak references any time we reference those symbols when back-deploying
+    // concurrency.
+    ASTContext &ctx = getASTContext();
+    if (getModuleContext()->getName() == ctx.Id_Concurrency) {
+      containingContext->intersectWith(ctx.getConcurrencyAvailability());
+    }
+
     return *containingContext;
+  }
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->getAvailabilityForLinkage();

--- a/test/Concurrency/Backdeploy/weak_linking.swift
+++ b/test/Concurrency/Backdeploy/weak_linking.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -target x86_64-apple-macosx12.0 -module-name main -emit-ir -o %t/new.ir
+// RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
+// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -disable-availability-checking
+// RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir
+
+// REQUIRES: OS=macosx
+
+// NEW-NOT: extern_weak
+// OLD: @"$sScPMn" = extern_weak global
+// OLD: declare extern_weak swiftcc i8* @swift_task_alloc
+// OLD: declare extern_weak swiftcc %swift.metadata_response @"$sScPMa"
+// OLD: declare extern_weak swiftcc i8 @"$sScP8rawValues5UInt8Vvg"
+
+@available(macOS 12.0, *)
+public func g() async -> String { "hello" }
+
+@available(macOS 12.0, *)
+public func f() async {
+  Task {
+    print(await g())
+  }
+}


### PR DESCRIPTION
This allows applications that back-deploy but only use concurrency in
newer code to load and execute properly, even when the concurrency library
is not available. Fixes rdar://84877644.

Pair-programmed with @etcwilde 