### PR TITLE
Add ASTMangler.AllowStandardSubstitutions to allow using a stripped-down libswiftCore

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -57,6 +57,10 @@ protected:
   bool AllowSymbolicReferences = false;
 
   /// If enabled, allows the use of standard substitutions for types in the
+  /// standard library.
+  bool AllowStandardSubstitutions = true;
+
+  /// If enabled, allows the use of standard substitutions for types in the
   /// concurrency library.
   bool AllowConcurrencyStandardSubstitutions = true;
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -355,6 +355,10 @@ public:
   /// Whether to disable using mangled names for accessing concrete type metadata.
   unsigned DisableConcreteTypeMetadataMangledNameAccessors : 1;
 
+  /// Whether to disable referencing stdlib symbols via mangled names in
+  /// reflection mangling.
+  unsigned DisableStandardSubstitutionsInReflectionMangling : 1;
+
   unsigned EnableGlobalISel : 1;
 
   unsigned VirtualFunctionElimination : 1;
@@ -423,6 +427,7 @@ public:
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),
         DisableConcreteTypeMetadataMangledNameAccessors(false),
+        DisableStandardSubstitutionsInReflectionMangling(false),
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -627,6 +627,10 @@ def disable_debugger_shadow_copies : Flag<["-"], "disable-debugger-shadow-copies
 def disable_concrete_type_metadata_mangled_name_accessors : Flag<["-"], "disable-concrete-type-metadata-mangled-name-accessors">,
   HelpText<"Disable concrete type metadata access by mangled name">,
   Flags<[FrontendOption, HelpHidden]>;
+
+def disable_standard_substitutions_in_reflection_mangling : Flag<["-"], "disable-standard-substitutions-in-reflection-mangling">,
+  HelpText<"Disable referencing stdlib symbols via mangled names in reflection mangling">,
+  Flags<[FrontendOption, HelpHidden]>;
   
 def playground : Flag<["-"], "playground">,
   HelpText<"Apply the playground semantics and transformation">;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3023,6 +3023,9 @@ bool ASTMangler::tryAppendStandardSubstitution(const GenericTypeDecl *decl) {
       !dc->getParentModule()->hasStandardSubstitutions())
     return false;
 
+  if (!AllowStandardSubstitutions)
+    return false;
+
   if (isa<NominalTypeDecl>(decl)) {
     if (auto Subst = getStandardTypeSubst(
             decl->getName().str(), AllowConcurrencyStandardSubstitutions)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1742,6 +1742,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_concrete_type_metadata_mangled_name_accessors))
     Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
 
+  if (Args.hasArg(OPT_disable_standard_substitutions_in_reflection_mangling))
+    Opts.DisableStandardSubstitutionsInReflectionMangling = true;
+
   if (Args.hasArg(OPT_use_jit)) {
     Opts.UseJIT = true;
     if (const Arg *A = Args.getLastArg(OPT_dump_jit)) {
@@ -1972,32 +1975,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_llvm_vfe)) {
     Opts.VirtualFunctionElimination = true;
-
-    // FIXME(mracek): There are still some situations where we use mangled name
-    // without symbolic references, which means the dependency is not statically
-    // visible to the compiler/linker. Temporarily disable mangled accessors
-    // until we fix that.
-    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_enable_llvm_wme)) {
     Opts.WitnessMethodElimination = true;
-
-    // FIXME(mracek): There are still some situations where we use mangled name
-    // without symbolic references, which means the dependency is not statically
-    // visible to the compiler/linker. Temporarily disable mangled accessors
-    // until we fix that.
-    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_conditional_runtime_records)) {
     Opts.ConditionalRuntimeRecords = true;
-
-    // FIXME(mracek): There are still some situations where we use mangled name
-    // without symbolic references, which means the dependency is not statically
-    // visible to the compiler/linker. Temporarily disable mangled accessors
-    // until we fix that.
-    Opts.DisableConcreteTypeMetadataMangledNameAccessors = true;
   }
 
   if (Args.hasArg(OPT_internalize_at_link)) {

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -98,7 +98,8 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // The short-substitution types in the standard library have compact
       // manglings already, and the runtime ought to have a lookup table for
       // them. Symbolic referencing would be wasteful.
-      if (type->getModuleContext()->hasStandardSubstitutions()
+      if (AllowStandardSubstitutions
+          && type->getModuleContext()->hasStandardSubstitutions()
           && Mangle::getStandardTypeSubst(
                type->getName().str(), AllowConcurrencyStandardSubstitutions)) {
         return false;
@@ -158,6 +159,11 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
     if (*runtimeCompatVersion < llvm::VersionTuple(5, 5))
       AllowConcurrencyStandardSubstitutions = false;
   }
+
+  llvm::SaveAndRestore<bool> savedAllowStandardSubstitutions(
+      AllowStandardSubstitutions);
+  if (IGM.getOptions().DisableStandardSubstitutionsInReflectionMangling)
+    AllowStandardSubstitutions = false;
 
   llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(
       AllowMarkerProtocols, false);

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -494,6 +494,10 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-disable-autolinking-runtime-compatibility-concurrency")
   endif()
 
+  if(NOT SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS)
+    list(APPEND swift_flags "-Xfrontend" "-disable-standard-substitutions-in-reflection-mangling")
+  endif()
+
   if (SWIFTFILE_IS_STDLIB_CORE OR SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-warn-swift3-objc-inference-complete")
   endif()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -945,6 +945,10 @@ if run_vendor == 'apple':
         swift_execution_tests_extra_flags += \
                 ' -Xfrontend -disable-implicit-concurrency-module-import'
 
+        # To have visible references from symbolic manglings
+        swift_execution_tests_extra_flags += \
+                ' -Xfrontend -disable-standard-substitutions-in-reflection-mangling'
+
         # Link all "freestanding" tests with -dead_strip, which can effectively
         # even remove parts of the stdlib and runtime, if it's not needed. Since
         # it's a very desired behavior, let's enable it for all executable tests.


### PR DESCRIPTION
The 'freestanding' stdlib is built with dead-stripping of types based on what's used by client code (when linking the stdlib statically with the client). For that, we need references to the stdlib types to be statically visible. Let's add a mangling mode for that.