### PR TITLE
RequirementMachine: Implement -requirement-machine-protocol-signatures=verify

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4168,6 +4168,7 @@ class ProtocolDecl final : public NominalTypeDecl {
   friend class StructuralRequirementsRequest;
   friend class ProtocolDependenciesRequest;
   friend class RequirementSignatureRequest;
+  friend class RequirementSignatureRequestRQM;
   friend class ProtocolRequiresClassRequest;
   friend class ExistentialConformsToSelfRequest;
   friend class InheritedProtocolsRequest;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -406,6 +406,26 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Compute the requirements that describe a protocol using the
+/// RequirementMachine.
+class RequirementSignatureRequestRQM :
+    public SimpleRequest<RequirementSignatureRequestRQM,
+                         ArrayRef<Requirement>(ProtocolDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<Requirement>
+  evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Compute the requirements that describe a protocol.
 class RequirementSignatureRequest :
     public SimpleRequest<RequirementSignatureRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -225,6 +225,9 @@ SWIFT_REQUEST(TypeChecker, StructuralRequirementsRequest,
 SWIFT_REQUEST(TypeChecker, ProtocolDependenciesRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
               HasNearestLocation)
+SWIFT_REQUEST(TypeChecker, RequirementSignatureRequestRQM,
+              ArrayRef<Requirement>(ProtocolDecl *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest,
               ArrayRef<Requirement>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -54,8 +54,12 @@
 using namespace swift;
 using llvm::DenseMap;
 
-/// Define this to 1 to enable expensive assertions.
-#define SWIFT_GSB_EXPENSIVE_ASSERTIONS 0
+#define DEBUG_TYPE "Serialization"
+
+STATISTIC(NumLazyRequirementSignaturesLoaded,
+          "# of lazily-deserialized requirement signatures loaded");
+
+#undef DEBUG_TYPE
 
 namespace {
   typedef GenericSignatureBuilder::RequirementSource RequirementSource;
@@ -8701,4 +8705,72 @@ InferredGenericSignatureRequest::evaluate(
   auto result = std::move(builder).computeGenericSignature(
       allowConcreteGenericParams);
   return GenericSignatureWithError(result, hadError);
+}
+
+ArrayRef<Requirement>
+RequirementSignatureRequest::evaluate(Evaluator &evaluator,
+                                      ProtocolDecl *proto) const {
+  ASTContext &ctx = proto->getASTContext();
+
+  // First check if we have a deserializable requirement signature.
+  if (proto->hasLazyRequirementSignature()) {
+    ++NumLazyRequirementSignaturesLoaded;
+    // FIXME: (transitional) increment the redundant "always-on" counter.
+    if (ctx.Stats)
+      ++ctx.Stats->getFrontendCounters().NumLazyRequirementSignaturesLoaded;
+
+    auto contextData = static_cast<LazyProtocolData *>(
+        ctx.getOrCreateLazyContextData(proto, nullptr));
+
+    SmallVector<Requirement, 8> requirements;
+    contextData->loader->loadRequirementSignature(
+        proto, contextData->requirementSignatureData, requirements);
+    if (requirements.empty())
+      return None;
+    return ctx.AllocateCopy(requirements);
+  }
+
+  auto buildViaGSB = [&]() {
+    GenericSignatureBuilder builder(proto->getASTContext());
+
+    // Add all of the generic parameters.
+    for (auto gp : *proto->getGenericParams())
+      builder.addGenericParameter(gp);
+
+    // Add the conformance of 'self' to the protocol.
+    auto selfType =
+      proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
+    auto requirement =
+      Requirement(RequirementKind::Conformance, selfType,
+                  proto->getDeclaredInterfaceType());
+
+    builder.addRequirement(
+            requirement,
+            GenericSignatureBuilder::RequirementSource::forRequirementSignature(
+                                                        builder, selfType, proto),
+            nullptr);
+
+    auto reqSignature = std::move(builder).computeGenericSignature(
+                          /*allowConcreteGenericParams=*/false,
+                          /*requirementSignatureSelfProto=*/proto);
+    return reqSignature.getRequirements();
+  };
+
+  auto buildViaRQM = [&]() {
+    return evaluateOrDefault(
+        ctx.evaluator,
+        RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(proto)},
+        ArrayRef<Requirement>());
+  };
+
+  switch (ctx.LangOpts.RequirementMachineProtocolSignatures) {
+  case RequirementMachineMode::Disabled:
+    return buildViaGSB();
+
+  case RequirementMachineMode::Enabled:
+    return buildViaRQM();
+
+  case RequirementMachineMode::Verify:
+    abort();
+  }
 }

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -163,8 +163,13 @@ public:
 
   PropertyBag *lookUpProperties(const MutableTerm &key) const;
 
+  std::pair<CompletionResult, unsigned>
+  buildPropertyMap(unsigned maxIterations,
+                   unsigned maxDepth);
+
   void dump(llvm::raw_ostream &out) const;
 
+private:
   void clear();
   void addProperty(Term key, Symbol property,
                    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules);
@@ -173,7 +178,6 @@ public:
   void concretizeNestedTypesFromConcreteParents(
                    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const;
 
-private:
   void concretizeNestedTypesFromConcreteParent(
                    Term key, RequirementKind requirementKind,
                    CanType concreteType, ArrayRef<Term> substitutions,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -528,16 +528,16 @@ void RequirementMachine::computeCompletion(RewriteSystem::ValidityPolicy policy)
     // Check for failure.
     auto checkCompletionResult = [&]() {
       switch (result.first) {
-      case RewriteSystem::CompletionResult::Success:
+      case CompletionResult::Success:
         break;
 
-      case RewriteSystem::CompletionResult::MaxIterations:
+      case CompletionResult::MaxIterations:
         llvm::errs() << "Generic signature " << Sig
                      << " exceeds maximum completion step count\n";
         System.dump(llvm::errs());
         abort();
 
-      case RewriteSystem::CompletionResult::MaxDepth:
+      case CompletionResult::MaxDepth:
         llvm::errs() << "Generic signature " << Sig
                      << " exceeds maximum completion depth\n";
         System.dump(llvm::errs());
@@ -553,8 +553,7 @@ void RequirementMachine::computeCompletion(RewriteSystem::ValidityPolicy policy)
     // Build the property map, which also performs concrete term
     // unification; if this added any new rules, run the completion
     // procedure again.
-    result = System.buildPropertyMap(
-        Map,
+    result = Map.buildPropertyMap(
         RequirementMachineStepLimit,
         RequirementMachineDepthLimit);
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -18,6 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "RequirementMachine.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericSignature.h"
@@ -27,18 +28,8 @@
 #include "swift/Basic/Statistic.h"
 #include <vector>
 
-#include "../GenericSignatureBuilder.h" // FIXME: This is temporary
-#include "RequirementMachine.h"
-
 using namespace swift;
 using namespace rewriting;
-
-#define DEBUG_TYPE "Serialization"
-
-STATISTIC(NumLazyRequirementSignaturesLoaded,
-          "# of lazily-deserialized requirement signatures loaded");
-
-#undef DEBUG_TYPE
 
 namespace {
 
@@ -222,104 +213,54 @@ RequirementMachine::computeMinimalRequirements() {
 }
 
 ArrayRef<Requirement>
-RequirementSignatureRequest::evaluate(Evaluator &evaluator,
-                                      ProtocolDecl *proto) const {
+RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
+                                         ProtocolDecl *proto) const {
   ASTContext &ctx = proto->getASTContext();
 
   // First check if we have a deserializable requirement signature.
-  if (proto->hasLazyRequirementSignature()) {
-    ++NumLazyRequirementSignaturesLoaded;
-    // FIXME: (transitional) increment the redundant "always-on" counter.
-    if (ctx.Stats)
-      ++ctx.Stats->getFrontendCounters().NumLazyRequirementSignaturesLoaded;
+  assert(!proto->hasLazyRequirementSignature() &&
+         "Should be handled in RequirementSignatureRequest");
 
-    auto contextData = static_cast<LazyProtocolData *>(
-        ctx.getOrCreateLazyContextData(proto, nullptr));
+  // We build requirement signatures for all protocols in a strongly connected
+  // component at the same time.
+  auto *machine = ctx.getOrCreateRequirementMachine(proto);
+  auto requirements = machine->computeMinimalRequirements();
 
-    SmallVector<Requirement, 8> requirements;
-    contextData->loader->loadRequirementSignature(
-        proto, contextData->requirementSignatureData, requirements);
-    if (requirements.empty())
-      return None;
-    return ctx.AllocateCopy(requirements);
-  }
+  bool debug = machine->getDebugOptions().contains(DebugFlags::Minimization);
 
-  auto buildViaGSB = [&]() {
-    GenericSignatureBuilder builder(proto->getASTContext());
+  // The requirement signature for the actual protocol that the result
+  // was kicked off with.
+  ArrayRef<Requirement> result;
 
-    // Add all of the generic parameters.
-    for (auto gp : *proto->getGenericParams())
-      builder.addGenericParameter(gp);
+  for (const auto &pair : requirements) {
+    auto *otherProto = pair.first;
+    const auto &reqs = pair.second;
 
-    // Add the conformance of 'self' to the protocol.
-    auto selfType =
-      proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
-    auto requirement =
-      Requirement(RequirementKind::Conformance, selfType,
-                  proto->getDeclaredInterfaceType());
+    // setRequirementSignature() doesn't take ownership of the memory, so
+    // we have to make a copy of the std::vector temporary.
+    ArrayRef<Requirement> reqsCopy = ctx.AllocateCopy(reqs);
 
-    builder.addRequirement(
-            requirement,
-            GenericSignatureBuilder::RequirementSource::forRequirementSignature(
-                                                        builder, selfType, proto),
-            nullptr);
+    // Dump the result if requested.
+    if (debug) {
+      llvm::dbgs() << "Protocol " << otherProto->getName() << ": ";
 
-    auto reqSignature = std::move(builder).computeGenericSignature(
-                          /*allowConcreteGenericParams=*/false,
-                          /*requirementSignatureSelfProto=*/proto);
-    return reqSignature.getRequirements();
-  };
-
-  auto buildViaRQM = [&]() {
-    // We build requirement signatures for all protocols in a strongly connected
-    // component at the same time.
-    auto *machine = ctx.getOrCreateRequirementMachine(proto);
-    auto requirements = machine->computeMinimalRequirements();
-
-    bool debug = machine->getDebugOptions().contains(DebugFlags::Minimization);
-
-    // The requirement signature for the actual protocol that the result
-    // was kicked off with.
-    ArrayRef<Requirement> result;
-
-    for (const auto &pair : requirements) {
-      auto *otherProto = pair.first;
-      const auto &reqs = pair.second;
-
-      // setRequirementSignature() doesn't take ownership of the memory, so
-      // we have to make a copy of the std::vector temporary.
-      ArrayRef<Requirement> reqsCopy = ctx.AllocateCopy(reqs);
-
-      // Don't call setRequirementSignature() on the original proto; the
-      // request evaluator will do it for us.
-      if (otherProto == proto)
-        result = reqsCopy;
-      else
-        const_cast<ProtocolDecl *>(otherProto)->setRequirementSignature(reqsCopy);
-
-      // Dump the result if requested.
-      if (debug) {
-        llvm::dbgs() << "Protocol " << otherProto->getName() << ": ";
-
-        auto sig = GenericSignature::get(
-            otherProto->getGenericSignature().getGenericParams(),
-            reqsCopy);
-        llvm::dbgs() << sig << "\n";
-      }
+      auto sig = GenericSignature::get(
+          otherProto->getGenericSignature().getGenericParams(),
+          reqsCopy);
+      llvm::dbgs() << sig << "\n";
     }
 
-    // Return the result for the specific protocol this request was kicked off on.
-    return result;
-  };
-
-  switch (ctx.LangOpts.RequirementMachineProtocolSignatures) {
-  case RequirementMachineMode::Disabled:
-    return buildViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return buildViaRQM();
-
-  case RequirementMachineMode::Verify:
-    abort();
+    // Don't call setRequirementSignature() on the original proto; the
+    // request evaluator will do it for us.
+    if (otherProto == proto)
+      result = reqsCopy;
+    else {
+      ctx.evaluator.cacheOutput(
+        RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(otherProto)},
+        std::move(reqsCopy));
+    }
   }
+
+  // Return the result for the specific protocol this request was kicked off on.
+  return result;
 }

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -105,27 +105,27 @@ MutableTerm RewriteStep::applyAdjustment(RewritePathEvaluator &evaluator,
   auto &term = evaluator.getCurrentTerm();
 
   assert(Kind == AdjustConcreteType);
-  assert(EndOffset == 0);
-  assert(RuleID == 0);
 
   auto &ctx = system.getRewriteContext();
-  MutableTerm prefix(term.begin(), term.begin() + StartOffset);
+  MutableTerm prefix(term.begin() + StartOffset,
+                     term.begin() + StartOffset + RuleID);
 
   // We're either adding or removing the prefix to each concrete substitution.
   term.back() = term.back().transformConcreteSubstitutions(
     [&](Term t) -> Term {
       if (Inverse) {
         if (!std::equal(t.begin(),
-                        t.begin() + StartOffset,
+                        t.begin() + RuleID,
                         prefix.begin())) {
           llvm::errs() << "Invalid rewrite path\n";
           llvm::errs() << "- Term: " << term << "\n";
+          llvm::errs() << "- Substitution: " << t << "\n";
           llvm::errs() << "- Start offset: " << StartOffset << "\n";
           llvm::errs() << "- Expected subterm: " << prefix << "\n";
           abort();
         }
 
-        MutableTerm mutTerm(t.begin() + StartOffset, t.end());
+        MutableTerm mutTerm(t.begin() + RuleID, t.end());
         return Term::get(mutTerm, ctx);
       } else {
         MutableTerm mutTerm(prefix);
@@ -160,7 +160,6 @@ void RewriteStep::applyShift(RewritePathEvaluator &evaluator,
 void RewriteStep::applyDecompose(RewritePathEvaluator &evaluator,
                                  const RewriteSystem &system) const {
   assert(Kind == Decompose);
-  assert(StartOffset == 0);
   assert(EndOffset == 0);
 
   auto &ctx = system.getRewriteContext();
@@ -332,4 +331,3 @@ void RewriteLoop::dump(llvm::raw_ostream &out,
   if (isDeleted())
     out << " [deleted]";
 }
-

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -130,6 +130,9 @@ struct RewriteStep {
 
   /// If Kind is ApplyRewriteRule, the index of the rule in the rewrite system.
   ///
+  /// If Kind is AdjustConcreteType, the length of the prefix to add or remove
+  /// at the beginning of each concrete substitution.
+  ///
   /// If Kind is Concrete, the number of substitutions to push or pop.
   unsigned RuleID : 15;
 
@@ -156,8 +159,8 @@ struct RewriteStep {
   }
 
   static RewriteStep forAdjustment(unsigned offset, bool inverse) {
-    return RewriteStep(AdjustConcreteType, offset, /*endOffset=*/0,
-                       /*ruleID=*/0, inverse);
+    return RewriteStep(AdjustConcreteType, /*startOffset=*/0, /*endOffset=*/0,
+                       /*ruleID=*/offset, inverse);
   }
 
   static RewriteStep forShift(bool inverse) {

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -132,6 +132,20 @@ public:
   }
 };
 
+/// Result type for RewriteSystem::computeConfluentCompletion() and
+/// PropertyMap::buildPropertyMap().
+enum class CompletionResult {
+  /// Confluent completion was computed successfully.
+  Success,
+
+  /// Maximum number of iterations reached.
+  MaxIterations,
+
+  /// Completion produced a rewrite rule whose left hand side has a length
+  /// exceeding the limit.
+  MaxDepth
+};
+
 /// A term rewrite system for working with types in a generic signature.
 ///
 /// Out-of-line methods are documented in RewriteSystem.cpp.
@@ -248,18 +262,6 @@ public:
   /// Completion
   ///
   //////////////////////////////////////////////////////////////////////////////
-
-  enum class CompletionResult {
-    /// Confluent completion was computed successfully.
-    Success,
-
-    /// Maximum number of iterations reached.
-    MaxIterations,
-
-    /// Completion produced a rewrite rule whose left hand side has a length
-    /// exceeding the limit.
-    MaxDepth
-  };
 
   std::pair<CompletionResult, unsigned>
   computeConfluentCompletion(unsigned maxIterations,
@@ -384,17 +386,6 @@ public:
 
   void computeGeneratingConformances(
       llvm::DenseSet<unsigned> &redundantConformances);
-
-  //////////////////////////////////////////////////////////////////////////////
-  ///
-  /// Property map
-  ///
-  //////////////////////////////////////////////////////////////////////////////
-
-  std::pair<CompletionResult, unsigned>
-  buildPropertyMap(PropertyMap &map,
-                   unsigned maxIterations,
-                   unsigned maxDepth);
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -490,7 +490,7 @@ RewriteSystem::computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
 /// left hand side has a length exceeding \p maxDepth.
 ///
 /// Otherwise, the status is CompletionResult::Success.
-std::pair<RewriteSystem::CompletionResult, unsigned>
+std::pair<CompletionResult, unsigned>
 RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
                                           unsigned maxDepth) {
   assert(Initialized);


### PR DESCRIPTION
... and fix a couple of failures that came up. While we're getting closer, the stdlib still doesn't build; ArrayProtocol and StringProtocol are minimized incorrectly right now, because homotopy reduction don't model the property map's concrete type unification yet.