### PR TITLE
[stdlib] Optimize high-level Set operations

### DIFF
--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -369,3 +369,19 @@ extension _UnsafeBitset {
     }
   }
 }
+
+extension _UnsafeBitset {
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  internal static func withTemporaryCopy<R>(
+    of original: _UnsafeBitset,
+    body: (_UnsafeBitset) throws -> R
+  ) rethrows -> R {
+    try _withTemporaryUninitializedBitset(
+      wordCount: original.wordCount
+    ) { bitset in
+      bitset.words.initialize(from: original.words, count: original.wordCount)
+      return try body(bitset)
+    }
+  }
+}

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -42,7 +42,7 @@ internal struct _HashTable {
   @inlinable
   internal var bucketCount: Int {
     @inline(__always) get {
-      return bucketMask &+ 1
+      return _assumeNonNegative(bucketMask &+ 1)
     }
   }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -52,6 +52,17 @@ internal struct _HashTable {
       return _UnsafeBitset.wordCount(forCapacity: bucketCount)
     }
   }
+
+  /// Return a bitset representation of the occupied buckets in this table.
+  ///
+  /// Note that if we have only a single partial word in the hash table's
+  /// bitset, then its out-of-bounds bits are guaranteed to be all set. These
+  /// filler bits are there to speed up finding holes -- they don't correspond
+  /// to occupied buckets in the table.
+  @_alwaysEmitIntoClient
+  internal var bitset: _UnsafeBitset {
+    _UnsafeBitset(words: words, wordCount: wordCount)
+  }
 }
 
 extension _HashTable {

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -636,4 +636,25 @@ extension _NativeSet {
       return false
     }
   }
+
+  @_alwaysEmitIntoClient
+  internal func isStrictSuperset<S: Sequence>(of possibleSubset: S) -> Bool
+  where S.Element == Element {
+    _UnsafeBitset.withTemporaryBitset(capacity: self.bucketCount) { seen in
+      // Mark elements in self that we've seen in `possibleStrictSubset`.
+      var seenCount = 0
+      for element in possibleSubset {
+        let (bucket, found) = find(element)
+        guard found else { return false }
+        let inserted = seen.uncheckedInsert(bucket.offset)
+        if inserted {
+          seenCount += 1
+          if seenCount == self.count {
+            return false
+          }
+        }
+      }
+      return true
+    }
+  }
 }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -674,6 +674,7 @@ extension _NativeSet {
       count -= 1
       if count == 0 { break }
     }
+    _internalInvariant(result.count == bitset.count)
     return result
   }
 
@@ -709,6 +710,51 @@ extension _NativeSet {
       var count = 0
       for bucket in hashTable {
         if try isIncluded(uncheckedElement(at: bucket)) {
+          bitset.uncheckedInsert(bucket.offset)
+          count += 1
+        }
+      }
+      return extractSubset(using: bitset, count: count)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  internal __consuming func intersection(
+    _ other: _NativeSet<Element>
+  ) -> _NativeSet<Element> {
+    // Prefer to iterate over the smaller set. However, we must be careful to
+    // only include elements from `self`, not `other`.
+    guard self.count <= other.count else {
+      return genericIntersection(other)
+    }
+    // Rather than directly creating a new set, mark common elements in a bitset
+    // first. This minimizes hashing, and ensures that we'll have an exact count
+    // for the result set, preventing rehashings during insertions.
+    return _UnsafeBitset.withTemporaryBitset(capacity: bucketCount) { bitset in
+      var count = 0
+      for bucket in hashTable {
+        if other.find(uncheckedElement(at: bucket)).found {
+          bitset.uncheckedInsert(bucket.offset)
+          count += 1
+        }
+      }
+      return extractSubset(using: bitset, count: count)
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  internal __consuming func genericIntersection<S: Sequence>(
+    _ other: S
+  ) -> _NativeSet<Element>
+  where S.Element == Element {
+    // Rather than directly creating a new set, mark common elements in a bitset
+    // first. This minimizes hashing, and ensures that we'll have an exact count
+    // for the result set, preventing rehashings during insertions.
+    _UnsafeBitset.withTemporaryBitset(capacity: bucketCount) { bitset in
+      var count = 0
+      for element in other {
+        let (bucket, found) = find(element)
+        if found {
           bitset.uncheckedInsert(bucket.offset)
           count += 1
         }

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -674,7 +674,6 @@ extension _NativeSet {
       count -= 1
       if count == 0 { break }
     }
-    _internalInvariant(result.count == bitset.count)
     return result
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -740,9 +740,10 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSubset<S: Sequence>(of possibleStrictSuperset: S) -> Bool
   where S.Element == Element {
-    // FIXME: code duplication.
-    let other = Set(possibleStrictSuperset)
-    return isStrictSubset(of: other)
+    if let s = possibleStrictSuperset as? Set<Element> {
+      return isStrictSubset(of: s)
+    }
+    return _variant.convertedToNative.isStrictSubset(of: possibleStrictSuperset)
   }
 
   /// Returns a Boolean value that indicates whether the set is a superset of
@@ -1211,7 +1212,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSubset(of other: Set<Element>) -> Bool {
-    return other.isStrictSuperset(of: self)
+    return self.count < other.count && self.isSubset(of: other)
   }
 
   /// Returns a new set with the elements that are common to both this set and

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -796,8 +796,11 @@ extension Set: SetAlgebra {
   @inlinable
   public func isStrictSuperset<S: Sequence>(of possibleStrictSubset: S) -> Bool
   where S.Element == Element {
-    let other = Set(possibleStrictSubset)
-    return other.isStrictSubset(of: self)
+    if isEmpty { return false }
+    if let s = possibleStrictSubset as? Set<Element> {
+      return isStrictSuperset(of: s)
+    }
+    return _variant.convertedToNative.isStrictSuperset(of: possibleStrictSubset)
   }
 
   /// Returns a Boolean value that indicates whether the set has no members in
@@ -1191,7 +1194,7 @@ extension Set {
   ///   `other`; otherwise, `false`.
   @inlinable
   public func isStrictSuperset(of other: Set<Element>) -> Bool {
-    return self.isSuperset(of: other) && self != other
+    return self.count > other.count && other.isSubset(of: self)
   }
 
   /// Returns a Boolean value that indicates whether the set is a strict subset

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -763,7 +763,10 @@ extension Set: SetAlgebra {
   ///   otherwise, `false`.
   @inlinable
   public func isSuperset<S: Sequence>(of possibleSubset: __owned S) -> Bool
-    where S.Element == Element {
+  where S.Element == Element {
+    if let s = possibleSubset as? Set<Element> {
+      return isSuperset(of: s)
+    }
     for member in possibleSubset {
       if !contains(member) {
         return false

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -710,9 +710,11 @@ extension Set: SetAlgebra {
   public func isSubset<S: Sequence>(of possibleSuperset: S) -> Bool
   where S.Element == Element {
     guard !isEmpty else { return true }
-    
-    let other = Set(possibleSuperset)
-    return isSubset(of: other)
+    if self.count == 1 { return possibleSuperset.contains(self.first!) }
+    if let s = possibleSuperset as? Set<Element> {
+      return isSubset(of: s)
+    }
+    return _variant.convertedToNative.isSubset(of: possibleSuperset)
   }
 
   /// Returns a Boolean value that indicates whether the set is a strict subset
@@ -1081,7 +1083,7 @@ extension Set {
   public func isSubset(of other: Set<Element>) -> Bool {
     guard self.count <= other.count else { return false }
     for member in self {
-      if !other.contains(member) {
+      guard other.contains(member) else {
         return false
       }
     }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1158,6 +1158,16 @@ extension Set {
   /// - Returns: A new set.
   @inlinable
   public __consuming func subtracting(_ other: Set<Element>) -> Set<Element> {
+    // Heuristic: if `other` is small enough, it's better to make a copy of the
+    // set and remove each item one by one. (The best cutoff point depends on
+    // the `Element` type; the one below is an educated guess.) FIXME: Derive a
+    // better cutoff by benchmarking.
+    if other.count <= self.count / 8 {
+      var copy = self
+      copy._subtract(other)
+      return copy
+    }
+    // Otherwise do a regular subtraction using a temporary bitmap.
     return self._subtracting(other)
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -295,14 +295,7 @@ extension Set {
   public __consuming func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> Set {
-    // FIXME(performance): Eliminate rehashes by using a bitmap.
-    var result = Set()
-    for element in self {
-      if try isIncluded(element) {
-        result.insert(element)
-      }
-    }
-    return result
+    return try Set(_native: _variant.filter(isIncluded))
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -949,8 +949,10 @@ extension Set: SetAlgebra {
   @inlinable
   public __consuming func intersection<S: Sequence>(_ other: S) -> Set<Element>
   where S.Element == Element {
-    let otherSet = Set(other)
-    return intersection(otherSet)
+    if let other = other as? Set<Element> {
+      return self.intersection(other)
+    }
+    return Set(_native: _variant.convertedToNative.genericIntersection(other))
   }
 
   /// Removes the elements of the set that aren't also in the given sequence.
@@ -969,20 +971,10 @@ extension Set: SetAlgebra {
   @inlinable
   public mutating func formIntersection<S: Sequence>(_ other: S)
   where S.Element == Element {
-    // Because `intersect` needs to both modify and iterate over
-    // the left-hand side, the index may become invalidated during
-    // traversal so an intermediate set must be created.
-    //
-    // FIXME(performance): perform this operation at a lower level
-    // to avoid invalidating the index and avoiding a copy.
-    let result = self.intersection(other)
-
-    // The result can only have fewer or the same number of elements.
-    // If no elements were removed, don't perform a reassignment
-    // as this may cause an unnecessary uniquing COW.
-    if result.count != count {
-      self = result
-    }
+    // FIXME: This discards storage reserved with reserveCapacity.
+    // FIXME: Depending on the ratio of elements kept in the result, it may be
+    // faster to do the removals in place, in bulk.
+    self = self.intersection(other)
   }
 
   /// Returns a new set with the elements that are either in this set or in the
@@ -1233,15 +1225,7 @@ extension Set {
   /// - Returns: A new set.
   @inlinable
   public __consuming func intersection(_ other: Set<Element>) -> Set<Element> {
-    var newSet = Set<Element>()
-    let (smaller, larger) =
-      count < other.count ? (self, other) : (other, self)
-    for member in smaller {
-      if larger.contains(member) {
-        newSet.insert(member)
-      }
-    }
-    return newSet
+    Set(_native: _variant.intersection(other))
   }
 
   /// Removes the elements of the set that are also in the given sequence and

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -820,6 +820,9 @@ extension Set: SetAlgebra {
   @inlinable
   public func isDisjoint<S: Sequence>(with other: S) -> Bool
   where S.Element == Element {
+    if let s = other as? Set<Element> {
+      return isDisjoint(with: s)
+    }
     return _isDisjoint(with: other)
   }
 
@@ -1142,7 +1145,7 @@ extension Set {
     }
     return true
   }
-    
+
   @inlinable
   internal func _isDisjoint<S: Sequence>(with other: S) -> Bool
   where S.Element == Element {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -903,9 +903,7 @@ extension Set: SetAlgebra {
     _ other: S
   ) -> Set<Element>
   where S.Element == Element {
-    var newSet = self
-    newSet.subtract(other)
-    return newSet
+    return Set(_native: _variant.convertedToNative.subtracting(other))
   }
 
   /// Removes the elements of the given sequence from the set.

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -108,6 +108,14 @@ extension Set._Variant {
   }
 #endif
 
+  @_alwaysEmitIntoClient
+  internal var convertedToNative: _NativeSet<Element> {
+#if _runtime(_ObjC)
+    guard isNative else {  return _NativeSet<Element>(asCocoa) }
+#endif
+    return asNative
+  }
+
   /// Reserves enough space for the specified number of elements to be stored
   /// without reallocating additional storage.
   internal mutating func reserveCapacity(_ capacity: Int) {

--- a/stdlib/public/core/SetVariant.swift
+++ b/stdlib/public/core/SetVariant.swift
@@ -376,3 +376,24 @@ extension Set._Variant {
   }
 }
 
+extension Set._Variant {
+  @_alwaysEmitIntoClient
+  internal __consuming func filter(
+    _ isIncluded: (Element) throws -> Bool
+  ) rethrows -> _NativeSet<Element> {
+#if _runtime(_ObjC)
+    guard isNative else {
+      var result = _NativeSet<Element>()
+      for cocoaElement in asCocoa {
+        let nativeElement = _forceBridgeFromObjectiveC(
+          cocoaElement, Element.self)
+        if try isIncluded(nativeElement) {
+          result.insertNew(nativeElement, isUnique: true)
+        }
+      }
+      return result
+    }
+#endif
+    return try asNative.filter(isIncluded)
+  }
+}

--- a/validation-test/stdlib/SetOperations.swift.gyb
+++ b/validation-test/stdlib/SetOperations.swift.gyb
@@ -1,0 +1,556 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/SetOperations.swift
+// RUN: %line-directive %t/SetOperations.swift -- %target-build-swift %t/SetOperations.swift -o %t/SetOperations -Xfrontend -disable-access-control -swift-version 5
+// RUN: %target-codesign %t/SetOperations && %line-directive %t/SetOperations.swift -- %target-run %t/SetOperations
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdlibCollectionUnittest
+import SwiftPrivate
+
+#if _runtime(_ObjC)
+import Foundation
+#endif
+
+#if _runtime(_ObjC)
+class Value: NSObject {
+  let value: Int
+  let identity: Int
+
+  init(_ value: Int, identity: Int = 0) {
+    self.value = value
+    self.identity = identity
+  }
+
+  override func isEqual(_ other: Any?) -> Bool {
+    guard let other = other as? Value else { return false }
+    return self.value == other.value
+  }
+
+  override var hash: Int {
+    value.hashValue
+  }
+}
+#else
+class Value: Hashable {
+  let value: Int
+  let identity: Int
+
+  init(_ value: Int, identity: Int) {
+    self.value = value
+    self.identity = identity
+  }
+
+  static func ==(left: Value, right: Value) -> Bool {
+    left.value == right.value
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
+  }
+}
+#endif
+
+func makeNativeSet<S: Sequence>(
+  _ values: S,
+  identity: Int
+) -> Set<Value>
+where S.Element == Int {
+  let result = Set(values.map { Value($0, identity: identity) })
+  precondition(isNativeSet(result))
+  return result
+}
+
+func makeArray<S: Sequence>(
+  _ values: S,
+  identity: Int
+) -> Array<Value>
+where S.Element == Int {
+  return values.map { Value($0, identity: identity) }
+}
+
+func makeMinimalSequence<S: Sequence>(
+  _ values: S,
+  identity: Int
+) -> MinimalSequence<Value>
+where S.Element == Int {
+  return MinimalSequence(elements: values.map { Value($0, identity: identity) })
+}
+
+#if _runtime(_ObjC)
+func makeCocoaSet<S: Sequence>(
+  _ values: S,
+  identity: Int
+) -> Set<Value>
+where S.Element == Int {
+  let result = (NSSet(array: values.map { Value($0, identity: identity) })
+    as! Set<Value>)
+  precondition(!isNativeSet(result))
+  return result
+}
+#endif
+
+func isNativeSet<T : Hashable>(_ s: Set<T>) -> Bool {
+#if _runtime(_ObjC)
+  return s._variant.isNative
+#else
+  return true
+#endif
+}
+
+var suite = TestSuite("SetOperations")
+defer { runAllTests() }
+
+% inputKinds = {"native": "makeNativeSet", "cocoa": "makeCocoaSet"}
+% argumentKinds = {"native": "makeNativeSet", "cocoa": "makeCocoaSet", "array": "makeArray", "sequence": "makeMinimalSequence"}
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("union.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let c = a.union(b)
+  expectTrue(isNativeSet(c))
+  expectEqual(c.count, 15)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 0 ..< 15 {
+    guard let i = c.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v)")
+      continue
+    }
+    expectEqual(c[i].identity, v < 10 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("formUnion.${inputKind}.${argumentKind}") {
+  var a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  a.formUnion(b)
+  expectTrue(isNativeSet(a))
+  expectEqual(a.count, 15)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 0 ..< 15 {
+    guard let i = a.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v)")
+      continue
+    }
+    expectEqual(a[i].identity, v < 10 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("intersection.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let c = a.intersection(b)
+  expectTrue(isNativeSet(c))
+  expectEqual(c.count, 5)
+  // Check the resulting items and that they come from the correct input set.
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    expectFalse(c.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in 5 ..< 10 {
+    guard let i = c.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(c[i].identity, 1)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("formIntersection.${inputKind}.${argumentKind}") {
+  var a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  a.formIntersection(b)
+  expectTrue(isNativeSet(a))
+  expectEqual(a.count, 5)
+  // Check the resulting items and that they come from the correct input set.
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    expectFalse(a.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in 5 ..< 10 {
+    guard let i = a.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(a[i].identity, 1)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("symmetricDifference.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let c = a.symmetricDifference(b)
+  expectTrue(isNativeSet(c))
+  expectEqual(c.count, 10)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(c.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    guard let i = c.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(c[i].identity, v < 5 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("formIntersection.${inputKind}.${argumentKind}") {
+  var a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  a.formSymmetricDifference(b)
+  expectTrue(isNativeSet(a))
+  expectEqual(a.count, 10)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(a.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    guard let i = a.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(a[i].identity, v < 5 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("symmetricDifference.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let c = a.symmetricDifference(b)
+  expectTrue(isNativeSet(c))
+  expectEqual(c.count, 10)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(c.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    guard let i = c.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(c[i].identity, v < 5 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("formSymmetricDifference.${inputKind}.${argumentKind}") {
+  var a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  a.formSymmetricDifference(b)
+  expectTrue(isNativeSet(a))
+  expectEqual(a.count, 10)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(a.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in Array(0 ..< 5) + Array(10 ..< 15) {
+    guard let i = a.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(a[i].identity, v < 5 ? 1 : 2)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("subtracting.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let c = a.subtracting(b)
+  expectTrue(isNativeSet(c))
+  expectEqual(c.count, 5)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(c.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in 0 ..< 5 {
+    guard let i = c.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(c[i].identity, 1)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("subtract.${inputKind}.${argumentKind}") {
+  var a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = ${argumentGenerator}(5 ..< 15, identity: 2)
+  a.subtract(b)
+  expectTrue(isNativeSet(a))
+  expectEqual(a.count, 5)
+  // Check the resulting items and that they come from the correct input set.
+  for v in 5 ..< 10 {
+    expectFalse(a.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in 0 ..< 5 {
+    guard let i = a.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(a[i].identity, 1)
+  }
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   needsCocoa = inputKind == "cocoa"
+%   if needsCocoa:
+#if _runtime(_ObjC)
+%   end
+suite.test("filter.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b = a.filter { $0.value % 2 == 0 }
+  expectTrue(isNativeSet(b))
+  expectEqual(b.count, 5)
+  for v in [1, 3, 5, 7, 9] {
+    expectFalse(b.contains(Value(v)), "Found \(v) in result")
+  }
+  for v in [0, 2, 4, 6, 8] {
+    guard let i = b.firstIndex(of: Value(v)) else {
+      expectTrue(false, "Could not find \(v) in result")
+      continue
+    }
+    expectEqual(b[i].identity, 1)
+  }
+}
+%   if needsCocoa:
+#endif
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("isSubset.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b0 = ${argumentGenerator}(0 ..< 0, identity: 2)
+  let b1 = ${argumentGenerator}(0 ..< 10, identity: 2)
+  let b2 = ${argumentGenerator}(0 ..< 15, identity: 2)
+  let b3 = ${argumentGenerator}(1 ..< 11, identity: 2)
+  let b4 = ${argumentGenerator}(10 ..< 15, identity: 2)
+  expectFalse(a.isSubset(of: b0))
+  expectTrue(a.isSubset(of: b1))
+  expectTrue(a.isSubset(of: b2))
+  expectFalse(a.isSubset(of: b3))
+  expectFalse(a.isSubset(of: b4))
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("isStrictSubset.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b0 = ${argumentGenerator}(0 ..< 0, identity: 2)
+  let b1 = ${argumentGenerator}(0 ..< 10, identity: 2)
+  let b2 = ${argumentGenerator}(0 ..< 15, identity: 2)
+  let b3 = ${argumentGenerator}(1 ..< 11, identity: 2)
+  let b4 = ${argumentGenerator}(10 ..< 15, identity: 2)
+  expectFalse(a.isStrictSubset(of: b0))
+  expectFalse(a.isStrictSubset(of: b1))
+  expectTrue(a.isStrictSubset(of: b2))
+  expectFalse(a.isStrictSubset(of: b3))
+  expectFalse(a.isStrictSubset(of: b4))
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("isSuperset.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b0 = ${argumentGenerator}(0 ..< 0, identity: 2)
+  let b1 = ${argumentGenerator}(0 ..< 10, identity: 2)
+  let b2 = ${argumentGenerator}(0 ..< 15, identity: 2)
+  let b3 = ${argumentGenerator}(1 ..< 11, identity: 2)
+  let b4 = ${argumentGenerator}(0 ..< 5, identity: 2)
+  let b5 = ${argumentGenerator}(10 ..< 15, identity: 2)
+  expectTrue(a.isSuperset(of: b0))
+  expectTrue(a.isSuperset(of: b1))
+  expectFalse(a.isSuperset(of: b2))
+  expectFalse(a.isSuperset(of: b3))
+  expectTrue(a.isSuperset(of: b4))
+  expectFalse(a.isSuperset(of: b5))
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("isStrictSuperset.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b0 = ${argumentGenerator}(0 ..< 0, identity: 2)
+  let b1 = ${argumentGenerator}(0 ..< 10, identity: 2)
+  let b2 = ${argumentGenerator}(0 ..< 15, identity: 2)
+  let b3 = ${argumentGenerator}(1 ..< 11, identity: 2)
+  let b4 = ${argumentGenerator}(0 ..< 5, identity: 2)
+  let b5 = ${argumentGenerator}(10 ..< 15, identity: 2)
+  expectTrue(a.isStrictSuperset(of: b0))
+  expectFalse(a.isStrictSuperset(of: b1))
+  expectFalse(a.isStrictSuperset(of: b2))
+  expectFalse(a.isStrictSuperset(of: b3))
+  expectTrue(a.isStrictSuperset(of: b4))
+  expectFalse(a.isStrictSuperset(of: b5))
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end
+
+% for inputKind, inputGenerator in inputKinds.items():
+%   for argumentKind, argumentGenerator in argumentKinds.items():
+%     needsCocoa = inputKind == "cocoa" or argumentKind == "cocoa"
+%     if needsCocoa:
+#if _runtime(_ObjC)
+%     end
+suite.test("isStrictSuperset.${inputKind}.${argumentKind}") {
+  let a = ${inputGenerator}(0 ..< 10, identity: 1)
+  let b0 = ${argumentGenerator}(0 ..< 0, identity: 2)
+  let b1 = ${argumentGenerator}(0 ..< 10, identity: 2)
+  let b2 = ${argumentGenerator}(0 ..< 15, identity: 2)
+  let b3 = ${argumentGenerator}(5 ..< 15, identity: 2)
+  let b4 = ${argumentGenerator}(0 ..< 5, identity: 2)
+  let b5 = ${argumentGenerator}(10 ..< 15, identity: 2)
+  expectTrue(a.isDisjoint(with: b0))
+  expectFalse(a.isDisjoint(with: b1))
+  expectFalse(a.isDisjoint(with: b2))
+  expectFalse(a.isDisjoint(with: b3))
+  expectFalse(a.isDisjoint(with: b4))
+  expectTrue(a.isDisjoint(with: b5))
+}
+%     if needsCocoa:
+#endif
+%     end
+%   end
+% end

--- a/validation-test/stdlib/SetOperations.swift.gyb
+++ b/validation-test/stdlib/SetOperations.swift.gyb
@@ -36,7 +36,7 @@ class Value: Hashable {
   let value: Int
   let identity: Int
 
-  init(_ value: Int, identity: Int) {
+  init(_ value: Int, identity: Int = 0) {
     self.value = value
     self.identity = identity
   }


### PR DESCRIPTION
This revives and replaces #21300, dramatically speeding up some high-level `Set` operations while also restoring the (undocumented) behavior that `Set.intersection` always returns items from `self`, not its argument.

[As discussed on the forums](https://forums.swift.org/t/regression-in-set-with-swift-5-5/53130), Swift 5.5 changed `Set.intersection`'s behavior as an optimization (#36678). This method does not guarantee which input set it uses to construct its results, so arguably, code that relies on the original behavior is in the wrong. However, there is no reason to break such code: we can implement intersections even faster than #36678, while also preserving the original behavior. This PR does this and more. (rdar://84831592)

(I believe it would be worth documenting this behavior for both `Set.intersection` and `Set.union`. However, that is an API change that likely requires a Swift evolution proposal.)

This new incarnation of #21300 does not introduce a new type, which makes it possible to cleanly deploy these improvements to any shipping stdlib version. In exchange, the implementation turned slightly more complicated in places: the existing `_UnsafeBitset` type does not have a cached `count`, so we need to explicitly maintain it as a standalone variable. Temporary bitmaps are now allocated using the [new temporary allocation facility](https://github.com/apple/swift-evolution/blob/main/proposals/0322-temporary-buffers.md), so they will be in most cases allocated on the stack.

The primary drawback of all these optimizations is a code size increase. I believe the performance increase will be worth this extra cost, but let's keep on eye on benchmark reports.

The original PR promised the following improvements: (these are very rough numbers, and they depend on the contents/size of the set)

Operation | Speedup
---|---
`Set.isSubset<S>(of:)` | 3x
`Set.isStrictSubset<S>(of:)` | 3x
`Set.isSuperset<S>(of:)` | 4x
`Set.isStrictSuperset<S>(of:)` | 4x
`Set.isDisjoint<S>(with:)` | 4x
`Set.subtracting(_:)` | 1-4x
`Set.filter(_:)` | 1-4x
`Set.intersection<S>(_:)` | 4-6x
`Set.intersection(_:)` | 1-4x
