### PR TITLE
[AST] Simplify InterpolatedStringLiteralExpr

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -175,12 +175,6 @@ protected:
     IsSingleExtendedGraphemeCluster : 1
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(InterpolatedStringLiteralExpr, LiteralExpr, 32+20,
-    : NumPadBits,
-    InterpolationCount : 20,
-    LiteralCapacity : 32
-  );
-
   SWIFT_INLINE_BITFIELD(DeclRefExpr, Expr, 2+2+1+1,
     Semantics : 2, // an AccessSemantics
     FunctionRefKind : 2,
@@ -879,56 +873,12 @@ class InterpolatedStringLiteralExpr : public LiteralExpr {
   SourceLoc TrailingQuoteLoc;
   TapExpr *AppendingExpr;
 
-  // Set by Sema:
-  OpaqueValueExpr *interpolationExpr = nullptr;
-  ConcreteDeclRef builderInit;
-  Expr *interpolationCountExpr = nullptr;
-  Expr *literalCapacityExpr = nullptr;
-
 public:
-  InterpolatedStringLiteralExpr(SourceLoc Loc,
-                                SourceLoc TrailingQuoteLoc,
-                                unsigned LiteralCapacity,
-                                unsigned InterpolationCount,
+  InterpolatedStringLiteralExpr(SourceLoc Loc, SourceLoc TrailingQuoteLoc,
                                 TapExpr *AppendingExpr)
       : LiteralExpr(ExprKind::InterpolatedStringLiteral, /*Implicit=*/false),
-        Loc(Loc),
-        TrailingQuoteLoc(TrailingQuoteLoc),
-        AppendingExpr(AppendingExpr) {
-    Bits.InterpolatedStringLiteralExpr.InterpolationCount = InterpolationCount;
-    Bits.InterpolatedStringLiteralExpr.LiteralCapacity = LiteralCapacity;
-  }
-
-  // Sets the constructor for the interpolation type.
-  void setBuilderInit(ConcreteDeclRef decl) { builderInit = decl; }
-  ConcreteDeclRef getBuilderInit() const { return builderInit; }
-
-  /// Sets the OpaqueValueExpr that is passed into AppendingExpr as the SubExpr
-  /// that the tap operates on.
-  void setInterpolationExpr(OpaqueValueExpr *expr) { interpolationExpr = expr; }
-  OpaqueValueExpr *getInterpolationExpr() const { return interpolationExpr; }
-
-  /// Store a builtin integer literal expr wrapping getInterpolationCount().
-  /// This is an arg to builderInit.
-  void setInterpolationCountExpr(Expr *expr) { interpolationCountExpr = expr; }
-  Expr *getInterpolationCountExpr() const { return interpolationCountExpr; }
-
-  /// Store a builtin integer literal expr wrapping getLiteralCapacity().
-  /// This is an arg to builderInit.
-  void setLiteralCapacityExpr(Expr *expr) { literalCapacityExpr = expr; }
-  Expr *getLiteralCapacityExpr() const { return literalCapacityExpr; }
-
-  /// Retrieve the value of the literalCapacity parameter to the
-  /// initializer.
-  unsigned getLiteralCapacity() const {
-    return Bits.InterpolatedStringLiteralExpr.LiteralCapacity;
-  }
-
-  /// Retrieve the value of the interpolationCount parameter to the
-  /// initializer.
-  unsigned getInterpolationCount() const {
-    return Bits.InterpolatedStringLiteralExpr.InterpolationCount;
-  }
+        Loc(Loc), TrailingQuoteLoc(TrailingQuoteLoc),
+        AppendingExpr(AppendingExpr) {}
 
   /// A block containing expressions which call
   /// \c StringInterpolationProtocol methods to append segments to the

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1875,12 +1875,6 @@ public:
                   Ctx.SourceMgr);
       }
     }
-    PrintWithColorRAII(OS, LiteralValueColor)
-      << " literal_capacity="
-      << E->getLiteralCapacity() << " interpolation_count="
-      << E->getInterpolationCount();
-    PrintWithColorRAII(OS, LiteralValueColor) << " builder_init=";
-    E->getBuilderInit().dump(PrintWithColorRAII(OS, LiteralValueColor).getOS());
     PrintWithColorRAII(OS, LiteralValueColor) << " result_init=";
     E->getInitializer().dump(PrintWithColorRAII(OS, LiteralValueColor).getOS());
     OS << "\n";

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -780,26 +780,6 @@ public:
       OpaqueValues.erase(S->getElementExpr());
     }
 
-    bool shouldVerify(InterpolatedStringLiteralExpr *expr) {
-      if (!shouldVerify(cast<Expr>(expr)))
-        return false;
-
-      if (!expr->getInterpolationExpr())
-        return true;
-
-      assert(!OpaqueValues.count(expr->getInterpolationExpr()));
-      OpaqueValues[expr->getInterpolationExpr()] = 0;
-      return true;
-    }
-
-    void cleanup(InterpolatedStringLiteralExpr *expr) {
-      if (!expr->getInterpolationExpr())
-        return;
-
-      assert(OpaqueValues.count(expr->getInterpolationExpr()));
-      OpaqueValues.erase(expr->getInterpolationExpr());
-    }
-
     bool shouldVerify(OpenExistentialExpr *expr) {
       if (!shouldVerify(cast<Expr>(expr)))
         return false;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2470,52 +2470,7 @@ RValue RValueEmitter::visitAbstractClosureExpr(AbstractClosureExpr *e,
 RValue RValueEmitter::
 visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *E,
                                    SGFContext C) {
-  RValue interpolation;
-  {
-    TapExpr *ETap = E->getAppendingExpr();
-    // Inlined from TapExpr:
-    // TODO: This is only necessary because constant evaluation requires that
-    // the box for the var gets defined before the initializer happens.
-    auto Var = ETap->getVar();
-    auto VarType = ETap->getType()->getCanonicalType();
-
-    Scope outerScope(SGF, CleanupLocation(ETap));
-
-    // Initialize the var with our SubExpr.
-    auto VarInit =
-        SGF.emitInitializationForVarDecl(Var, /*forceImmutable=*/false);
-    {
-      // Modified from TapExpr to evaluate the SubExpr directly rather than
-      // indirectly through the OpaqueValue system.
-      PreparedArguments builderInitArgs;
-      RValue literalCapacity = visit(E->getLiteralCapacityExpr(), SGFContext());
-      RValue interpolationCount =
-          visit(E->getInterpolationCountExpr(), SGFContext());
-      builderInitArgs.emplace(
-          {AnyFunctionType::Param(literalCapacity.getType()),
-           AnyFunctionType::Param(interpolationCount.getType())});
-      builderInitArgs.add(E, std::move(literalCapacity));
-      builderInitArgs.add(E, std::move(interpolationCount));
-      RValue subexpr_result = SGF.emitApplyAllocatingInitializer(
-          E, E->getBuilderInit(), std::move(builderInitArgs), Type(),
-          SGFContext(VarInit.get()));
-      if (!subexpr_result.isInContext()) {
-        ArgumentSource(
-            SILLocation(E),
-            std::move(subexpr_result).ensurePlusOne(SGF, SILLocation(E)))
-            .forwardInto(SGF, VarInit.get());
-      }
-    }
-
-    // Emit the body and let it mutate the var if it chooses.
-    SGF.emitStmt(ETap->getBody());
-
-    // Retrieve and return the var, making it +1 so it survives the scope.
-    auto result = SGF.emitRValueForDecl(SILLocation(ETap), Var, VarType,
-                                        AccessSemantics::Ordinary, SGFContext());
-    result = std::move(result).ensurePlusOne(SGF, SILLocation(ETap));
-    interpolation = outerScope.popPreservingValue(std::move(result));
-  }
+  RValue interpolation = SGF.emitRValue(E->getAppendingExpr());
 
   PreparedArguments resultInitArgs;
   resultInitArgs.emplace(AnyFunctionType::Param(interpolation.getType()));

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1141,9 +1141,7 @@ namespace {
         auto appendingExprType = CS.getType(appendingExpr);
         auto appendingLocator = CS.getConstraintLocator(appendingExpr);
 
-        // Must be Conversion; if it's Equal, then in semi-rare cases, the 
-        // interpolation temporary variable cannot be @lvalue.
-        CS.addConstraint(ConstraintKind::Conversion, appendingExprType,
+        CS.addConstraint(ConstraintKind::Bind, appendingExprType,
                          interpolationTV, appendingLocator);
       }
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -147,16 +147,6 @@ public:
         return { false, OOE->getSubExpr()->walk(*this) };
       }
 
-      // Hacky, this behaves just like an OpenedExistential in that it changes
-      // the expr tree.
-      if (auto ISLE = dyn_cast<InterpolatedStringLiteralExpr>(expr)) {
-        if (auto subExpr = ISLE->getAppendingExpr()->getSubExpr()) {
-          if (auto opaqueValue = dyn_cast<OpaqueValueExpr>(subExpr)) {
-            ISLE->getAppendingExpr()->setSubExpr(nullptr);
-          }
-        }
-      }
-
       // Substitute OpaqueValue with its representing existental.
       if (auto OVE = dyn_cast<OpaqueValueExpr>(expr)) {
         auto value = OpenExistentials.find(OVE);

--- a/test/Constraints/interpolation_segments.swift
+++ b/test/Constraints/interpolation_segments.swift
@@ -6,7 +6,9 @@
 // has been assigned a type variable, but the calls inside the body have not.
 
 // CHECK: ---Initial constraints for the given expression---
-// CHECK: (interpolated_string_literal_expr type='$T
+// CHECK:     (interpolated_string_literal_expr type='$T
+// CHECK:       (unresolved_member_chain_expr implicit type='$T
+// CHECK-NEXT:    (call_expr implicit type='$T
 // CHECK-NOT: (call_expr implicit type='$T
 // CHECK: ---Solution---
 

--- a/test/Constraints/result_builder_one_way.swift
+++ b/test/Constraints/result_builder_one_way.swift
@@ -50,15 +50,15 @@ func tuplify<C: Collection, T>(_ collection: C, @TupleBuilder body: (C.Element) 
 
 // CHECK: ---Connected components---
 // CHECK-NEXT:   1: $T10 depends on 0
-// CHECK-NEXT:   0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T77 $T78 depends on 3
-// CHECK-NEXT:   3: $T12 $T17 $T28 $T42 $T53 $T54 $T55 $T56 $T57 $T58 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T68 $T69 $T70 $T71 $T72 $T73 $T74 $T75 $T76 depends on 2, 4, 5, 7, 10
-// CHECK-NEXT:   10: $T48 $T49 $T50 $T51 $T52 depends on 9
-// CHECK-NEXT:   9: $T43 $T44 $T45 $T46 $T47
-// CHECK-NEXT:   7: $T31 $T35 $T36 $T37 $T38 $T39 $T40 $T41 depends on 6, 8
-// CHECK-NEXT:   8: $T32 $T33 $T34
-// CHECK-NEXT:   6: $T30
-// CHECK-NEXT:   5: $T18 $T19 $T20 $T21 $T22 $T23 $T24 $T25 $T26 $T27
-// CHECK-NEXT:   4: $T15 $T16
+// CHECK-NEXT:   0: $T1 $T2 $T3 $T5 $T6 $T7 $T8 $T83 $T84 depends on 3
+// CHECK-NEXT:   3: $T12 $T23 $T34 $T48 $T59 $T60 $T61 $T62 $T63 $T64 $T65 $T66 $T67 $T68 $T69 $T70 $T71 $T72 $T74 $T75 $T76 $T77 $T78 $T79 $T80 $T81 $T82 depends on 2, 4, 5, 7, 10
+// CHECK-NEXT:   10: $T54 $T55 $T56 $T57 $T58 depends on 9
+// CHECK-NEXT:   9: $T49 $T50 $T51 $T52 $T53
+// CHECK-NEXT:   7: $T37 $T41 $T42 $T43 $T44 $T45 $T46 $T47 depends on 6, 8
+// CHECK-NEXT:   8: $T38 $T39 $T40
+// CHECK-NEXT:   6: $T36
+// CHECK-NEXT:   5: $T24 $T25 $T26 $T27 $T28 $T29 $T30 $T31 $T32 $T33
+// CHECK-NEXT:   4: $T15 $T16 $T17 $T18 $T19 $T20 $T21 $T22
 // CHECK-NEXT:   2: $T11
 let names = ["Alice", "Bob", "Charlie"]
 let b = true


### PR DESCRIPTION
Noticed this while implementing similar logic for regex literal emission.

Rather than gathering additional information in CSApply for custom SILGen emission, build an UnresolvedMemberExpr up-front as the initialization expr for the TapExpr. This can then be type-checked and emitted using the more general SILGen code paths.