### PR TITLE
[CS] Simplify getAlternativeLiteralTypes

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2290,10 +2290,6 @@ private:
   llvm::DenseMap<std::pair<Type, DeclNameRef>, Optional<LookupResult>>
     MemberLookups;
 
-  /// Cached sets of "alternative" literal types.
-  static const unsigned NumAlternativeLiteralTypes = 13;
-  Optional<ArrayRef<Type>> AlternativeLiteralTypes[NumAlternativeLiteralTypes];
-
   /// Folding set containing all of the locators used in this
   /// constraint system.
   llvm::FoldingSetVector<ConstraintLocator> ConstraintLocators;
@@ -3059,7 +3055,8 @@ public:
 
   /// Retrieve the set of "alternative" literal types that we'll explore
   /// for a given literal protocol kind.
-  ArrayRef<Type> getAlternativeLiteralTypes(KnownProtocolKind kind);
+  ArrayRef<Type> getAlternativeLiteralTypes(KnownProtocolKind kind,
+                                            SmallVectorImpl<Type> &scratch);
 
   /// Create a new type variable.
   TypeVariableType *createTypeVariable(ConstraintLocator *locator,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1709,7 +1709,8 @@ bool TypeVarBindingProducer::computeNext() {
     if (NumTries == 0 && binding.hasDefaultedLiteralProtocol()) {
       auto knownKind =
           *(binding.getDefaultedLiteralProtocol()->getKnownProtocolKind());
-      for (auto altType : CS.getAlternativeLiteralTypes(knownKind)) {
+      SmallVector<Type, 2> scratch;
+      for (auto altType : CS.getAlternativeLiteralTypes(knownKind, scratch)) {
         addNewBinding(binding.withSameSource(altType, BindingKind::Subtypes));
       }
     }


### PR DESCRIPTION
Caching the result here feels a little overkill as it's only useful for one protocol, and the `TypeChecker::getDefaultType` computation is cached by the request evaluator.
