### PR TITLE
[sil] Add SILValue::dump() for use in the debugger.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
@@ -642,6 +643,9 @@ public:
 
   /// Verify that this SILValue and its uses respects ownership invariants.
   void verifyOwnership(DeadEndBlocks *DEBlocks) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(void dump() const LLVM_ATTRIBUTE_USED,
+                            "Only for use in the debugger");
 };
 
 inline SILNodePointer::SILNodePointer(SILValue value) : node(value) { }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -134,6 +134,10 @@ SILLocation SILValue::getLoc() const {
   return Value->getFunction()->getLocation();
 }
 
+void SILValue::dump() const {
+  Value->dump();
+}
+
 //===----------------------------------------------------------------------===//
 //                               OwnershipKind
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
It just trampolines to calling ValueBase::dump(). The reason I added this is
sometimes one wants to do this in the debugger and confuses if one has a
ValueBase or a SILValue causing lldb to be unhappy. By mirroring this API, one
can do the same operation on either type and just move on with ones life.

I also wrapped this in LLVM_ATTRIBUTE_DEPRECATED with a msg saying only for use
in the debugger so people do not call dump() in the codebase by mistake.
