### PR TITLE
[NFC] Drop Written-But-Never-Read Error Bits

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1087,7 +1087,6 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
   case PatternKind::Typed: {
     TypedPattern *TP = cast<TypedPattern>(P);
     Type patternType = TypeChecker::typeCheckPattern(pattern);
-    bool hadError = false;
     if (!patternType->hasError()) {
       if (!type->isEqual(patternType) && !type->hasError()) {
         if (options & TypeResolutionFlags::OverrideType) {
@@ -1101,11 +1100,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
         } else {
           diags.diagnose(P->getLoc(), diag::pattern_type_mismatch_context,
                          type);
-          hadError = true;
         }
       }
-    } else {
-      hadError = true;
     }
 
     Pattern *sub = TP->getSubPattern();


### PR DESCRIPTION
AFAICT This code is dead as of 61ac253 and what really matters is not
that we've thrown an error but rather that coercing the pattern fails.