### PR TITLE
[Mem2Reg] Replaced loop with getSingleSuccessor.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1665,22 +1665,30 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     GraphNodeWorklist<SILBasicBlock *, 2> worklist;
     worklist.initialize(parentBlock);
     while (auto *block = worklist.pop()) {
+      assert(domInfo->dominates(parentBlock, block));
       auto *terminator = block->getTerminator();
       if (isa<UnreachableInst>(terminator)) {
         endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/terminator, ctx,
                                      runningVals->value);
         continue;
       }
-      bool endedLifetime = false;
-      for (auto *successor : block->getSuccessorBlocks()) {
-        if (!domInfo->dominates(parentBlock, successor)) {
-          endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/terminator,
-                                       ctx, runningVals->value);
-          endedLifetime = true;
-          break;
-        }
-      }
-      if (endedLifetime) {
+      SILBasicBlock *successor = nullptr;
+      // If any successor is not dominated by the parentBlock, then we must end
+      // the lifetime before that successor.
+      //
+      // Suppose that a successor is not dominated by parentBlock.  Recall that
+      // block _is_ dominated by parentBlock.  Thus that successor must have
+      // more than one predecessor: block, and at least one other.  (Otherwise
+      // it would be dominated by parentBlock contrary to our assumption.)
+      // Recall that SIL does not allow critical edges.  Therefore block has
+      // only a single successor.
+      //
+      // Use the above fact to only look for lack of domination of a successor
+      // if that successor is the single successor of block.
+      if ((successor = block->getSingleSuccessorBlock()) &&
+          (!domInfo->dominates(parentBlock, successor))) {
+        endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/terminator, ctx,
+                                     runningVals->value);
         continue;
       }
       for (auto *successor : block->getSuccessorBlocks()) {

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -666,6 +666,11 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
         runningVals = beginLexicalLifetimeAfterStore(asi, si);
         // Create a use of the newly created copy in order to keep phi pruning
         // from deleting our lifetime beginning instructions.
+        //
+        // TODO: Remove this hack, it is only necessary because erasePhiArgument
+        //       calls deleteEdgeValue which calls
+        //       deleteTriviallyDeadOperandsOfDeadArgument and deletes the copy
+        //       and borrow that we added and want not to have deleted.
         SILBuilderWithScope::insertAfter(
             runningVals->value.copy->getDefiningInstruction(),
             [&](auto builder) {

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1548,6 +1548,7 @@ entry(%instance : @owned $C):
 }
 
 
+// End lifetime before unreachable inst.
 // CHECK-LABEL: sil [ossa] @unreachable_5 : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
@@ -1567,6 +1568,7 @@ exit:
   unreachable
 }
 
+// Bail out if alloc_stack is in unreachable block.
 // CHECK-LABEL: sil [ossa] @unreachable_6 : $@convention(thin) (@owned C) -> () {
 // CHECK:         alloc_stack [lexical]
 // CHECK-LABEL: } // end sil function 'unreachable_6'
@@ -1585,6 +1587,7 @@ exit:
 }
 
 
+// Bail out if alloc_stack is in unreachable block.
 // CHECK-LABEL: sil [ossa] @unreachable_7 : $@convention(thin) (@owned C) -> () {
 // CHECK:         alloc_stack [lexical]
 // CHECK-LABEL: } // end sil function 'unreachable_7'
@@ -1606,7 +1609,7 @@ exit:
   return %res : $()
 }
 
-
+// Bail out if alloc_stack is in unreachable block.
 // CHECK-LABEL: sil [ossa] @unreachable_8 : $@convention(thin) (@owned C) -> () {
 // CHECK:         alloc_stack [lexical]
 // CHECK-LABEL: } // end sil function 'unreachable_8'
@@ -1632,7 +1635,7 @@ exit:
   return %res : $()
 }
 
-
+// End lifetime after loop which is followed by unreachable.
 // CHECK-LABEL: sil [ossa] @unreachable_loop_1 : $@convention(thin) () -> () {
 // CHECK:       {{bb[0-9]+}}:
 // CHECK:         [[GET_C:%[^,]+]] = function_ref @getC : $@convention(thin) () -> @owned C
@@ -1672,7 +1675,7 @@ die:
   unreachable
 }
 
-
+// Bail out if alloc_stack is in unreachable block.
 // CHECK-LABEL: sil [ossa] @unreachable_loop_2 : $@convention(thin) () -> () {
 // CHECK:         alloc_stack [lexical]
 // CHECK-LABEL: } // end sil function 'unreachable_loop_2'
@@ -1697,7 +1700,7 @@ die:
   unreachable
 }
 
-
+// Bail out if alloc_stack is in unreachable block.
 // CHECK-LABEL: sil [ossa] @unreachable_loop_3 : $@convention(thin) () -> () {
 // CHECK:         alloc_stack [lexical]
 // CHECK-LABEL: } // end sil function 'unreachable_loop_3'


### PR DESCRIPTION
Thanks to the lack of critical edges in SIL, if a block B dominated by P has a successor S which is not dominated by P, then B must have only a single successor.  Used this fact to replace a loop over successors to a call to getSinglePredecessor.

Also added an assertion that, in the notation above, B is dominated by P.
