### PR TITLE
[Diagnostics] Coercion warning shouldn't assume that IUO is always optional

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7677,8 +7677,11 @@ bool CoercibleOptionalCheckedCastFailure::diagnoseForcedCastExpr() const {
 
   bool isBridged = CastKind == CheckedCastKind::BridgingCoercion;
   if (isCastTypeIUO()) {
-    toType = toType->getOptionalObjectType();
-    extraFromOptionals++;
+    // IUO type could either be optional or unwrapped.
+    if (auto objType = toType->getOptionalObjectType()) {
+      extraFromOptionals++;
+      toType = objType;
+    }
   }
 
   std::string extraFromOptionalsStr(extraFromOptionals, '!');
@@ -7776,7 +7779,8 @@ bool NoopCheckedCast::diagnoseForcedCastExpr() const {
   auto diagLoc = expr->getLoc();
 
   if (isCastTypeIUO()) {
-    toType = toType->getOptionalObjectType();
+    if (auto objType = toType->getOptionalObjectType())
+      toType = objType;
   }
 
   if (fromType->isEqual(toType)) {

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83072606.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83072606.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+struct A {
+  var prop: Bool
+
+  func test() {
+    _ = AssertUnwrap(prop) as! Bool! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+    // expected-warning@-1 {{forced cast from 'Bool?' to 'Bool' only unwraps optionals; did you mean to use '!'?}}
+  }
+
+  @discardableResult
+  func AssertUnwrap<T>(_ optional: T?) -> T? {
+    return optional
+  }
+}


### PR DESCRIPTION
In situations like `_ = ... as! Bool!` the `to` type could either
be represented by an optional (default) or unwrapped. Coercion warnings
cannot assume that `to` (even though its IUO) is always represented
as an optional type.

Resolves: rdar://83072606

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
