### PR TITLE
Parse @_typeSequence in Generic Parameter Position

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -56,6 +56,7 @@ TYPE_ATTR(noDerivative)
 TYPE_ATTR(async)
 TYPE_ATTR(Sendable)
 TYPE_ATTR(unchecked)
+TYPE_ATTR(_typeSequence)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)
@@ -426,7 +427,12 @@ DECL_ATTR(_restatedObjCConformance, RestatedObjCConformance,
   NotSerialized |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   70)
-// NOTE: 71 is unused
+DECL_ATTR(_typeSequence, TypeSequence,
+  OnGenericTypeParam |
+  UserInaccessible |
+  NotSerialized |
+  ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  71)
 // NOTE: 72 is unused
 DECL_ATTR(_optimize, Optimize,
   OnAbstractFunction | OnSubscript | OnVar |

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2061,6 +2061,20 @@ public:
   }
 };
 
+/// The @_typeSequence attribute, which treats a generic param decl as a variadic
+/// sequence of value/type pairs.
+class TypeSequenceAttr : public DeclAttribute {
+  TypeSequenceAttr(SourceLoc atLoc, SourceRange Range);
+
+public:
+  static TypeSequenceAttr *create(ASTContext &Ctx, SourceLoc atLoc,
+                                  SourceRange Range);
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_TypeSequence;
+  }
+};
+
 /// Attributes that may be applied to declarations.
 class DeclAttributes {
   /// Linked list of declaration attributes.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6052,5 +6052,13 @@ ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
 ERROR(noimplicitcopy_attr_invalid_in_generic_context,
       none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
 
+//------------------------------------------------------------------------------
+// MARK: variadics
+//------------------------------------------------------------------------------
+
+ERROR(type_sequence_on_non_generic_param, none,
+      "'@_typeSequence' must appear on a generic parameter",
+      ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1144,6 +1144,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_TypeSequence: {
+    Printer.printAttrName("@_typeSequence");
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -1295,6 +1300,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "derivative";
   case DAK_Transpose:
     return "transpose";
+  case DAK_TypeSequence:
+    return "_typeSequence";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -2078,6 +2085,15 @@ bool CustomAttr::isArgUnsafe() const {
   }
 
   return isArgUnsafeBit;
+}
+
+TypeSequenceAttr::TypeSequenceAttr(SourceLoc atLoc, SourceRange range)
+    : DeclAttribute(DAK_TypeSequence, atLoc, range, /*Implicit=*/false) {}
+
+TypeSequenceAttr *TypeSequenceAttr::create(ASTContext &Ctx, SourceLoc atLoc,
+                                           SourceRange range) {
+  void *mem = Ctx.Allocate(sizeof(TypeSequenceAttr), alignof(TypeSequenceAttr));
+  return new (mem) TypeSequenceAttr(atLoc, range);
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2744,6 +2744,11 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
         name, AtLoc, range, /*implicit*/ false));
     break;
   }
+  case DAK_TypeSequence: {
+    auto range = SourceRange(Loc, Tok.getRange().getStart());
+    Attributes.add(TypeSequenceAttr::create(Context, AtLoc, range));
+    break;
+  }
   }
 
   if (DuplicateAttribute) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -244,6 +244,7 @@ public:
   void visitDynamicReplacementAttr(DynamicReplacementAttr *attr);
   void visitTypeEraserAttr(TypeEraserAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
+  void visitTypeSequenceAttr(TypeSequenceAttr *attr);
 
   void visitFrozenAttr(FrozenAttr *attr);
 
@@ -3287,6 +3288,13 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
   // FIXME: When compiling without library evolution enabled, this should also
   // check whether VD or any of its accessors need a new vtable entry, even if
   // it won't necessarily be able to say why.
+}
+
+void AttributeChecker::visitTypeSequenceAttr(TypeSequenceAttr *attr) {
+  if (!isa<GenericTypeParamDecl>(D)) {
+    attr->setInvalid();
+    diagnoseAndRemoveAttr(attr, diag::type_sequence_on_non_generic_param);
+  }
 }
 
 void AttributeChecker::visitNonEphemeralAttr(NonEphemeralAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1560,6 +1560,8 @@ namespace  {
     UNINTERESTING_ATTR(InheritActorContext)
     UNINTERESTING_ATTR(Isolated)
     UNINTERESTING_ATTR(NoImplicitCopy)
+
+    UNINTERESTING_ATTR(TypeSequence)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 639; // @_noImplicitCopy param
+const uint16_t SWIFTMODULE_VERSION_MINOR = 640; // @_typeSequence
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1976,6 +1976,8 @@ namespace decls_block {
     DeclIDField, // Original function declaration.
     BCArray<BCFixed<1>> // Transposed parameter indices' bitvector.
   >;
+
+  using TypeSequenceDeclAttrLayout = BCRecordLayout<TypeSequence_DECL_ATTR>;
 
 #define SIMPLE_DECL_ATTR(X, CLASS, ...)         \
   using CLASS##DeclAttrLayout = BCRecordLayout< \

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2740,6 +2740,12 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           origDeclID, paramIndicesVector);
       return;
     }
+
+    case DAK_TypeSequence: {
+      auto abbrCode = S.DeclTypeAbbrCodes[TypeSequenceDeclAttrLayout::Code];
+      TypeSequenceDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode);
+      return;
+    }
     }
   }
 

--- a/test/Parse/type_sequence.swift
+++ b/test/Parse/type_sequence.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+struct TupleStruct<First, @_typeSequence Rest> {
+  var first: First
+  var rest: Rest
+}
+
+func debugPrint<@_typeSequence T>(_ items: T...)
+  where T: CustomDebugStringConvertible
+{
+  /*for (item: T) in items {
+    stdout.write(item.debugDescription)
+  }*/
+}
+
+func max<@_typeSequence T>(_ values: T...) -> T?
+  where T: Comparable
+{
+  return nil
+}
+
+func min<@_typeSequence T: Comparable>(_ values: T...) -> T? {
+  return nil
+}
+
+func badParameter<T>(_ : @_typeSequence T) {} // expected-error {{attribute does not apply to type}}


### PR DESCRIPTION
Stage in the parsing for this attribute, nothing else.

Motivated by two important reasons:

1) The pitch for variadic generics does not lay down a concrete syntax
   for variadic generic parameters.
2) Parsing T... and T* needlessly complicate the lexer as we must now
   disambiguate them with respect to other internal operator characters
   (e.g. `T...>` must lex as `(T...)>` and not `T ...>`

Which itself adds another motivation

3) We need to start parsing this attribute *now* to avoid condfail'ing
   ourselves later.