### PR TITLE
[test] Handle missing availability macros better.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -432,9 +432,11 @@ lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
 # Define availability macros for known stdlib releases.
-for macro in lit_config.params.get('availability_macros', '').split(";"):
-    config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
-    config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
+availability_macros = lit_config.params.get('availability_macros', '')
+if availability_macros:
+    for macro in availability_macros.split(";"):
+        config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
+        config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
 
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
 if differentiable_programming is not None:

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -224,7 +224,7 @@ def expand_response_files(files):
     expanded_files = []
     for file_path in files:
         # Read a list of files from a response file.
-        if file_path[0] == '@':
+        if file_path and file_path[0] == '@':
             expanded_files.extend(read_response_file(file_path[1:]))
         else:
             expanded_files.append(file_path)


### PR DESCRIPTION
The lit param `availability_macros` appears to be set only from CMake.
Without this commit, when running `lit` manually, `utils/line-directive`
will throw an exception in `expand_response_files` because it is trying
to take the first character of `file_path`, however, this is `''`.

This happens because there is an empty string in the compiler flags,
`-Xfrontend ''` and this is traceable to the `availability_macros`
section of `lit.cfg`. If `availability_macros` is not present in the
params, we return `''`, but `''.split(";")` is `['']`, not `[]`.

Instead, when `availability_macros` is not present, avoid adding the
macro flags entirely. Also, avoid the first-character problem while
we are here as well, since `expand_response_files` is given all arguments
in the command line, and there may conceivably be some need to supply
an empty string argument in the future.