### PR TITLE
build: enable libswift bootstrapping by default

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -372,8 +372,6 @@ install-swiftpm
 install-swift-driver
 install-libcxx
 
-libswift=bootstrapping
-
 [preset: buildbot_incremental,tools=RA,stdlib=RA,apple_silicon]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
 
@@ -578,6 +576,9 @@ enable-asan
 
 swift-stdlib-build-type=RelWithDebInfo
 
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
+
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx]
 mixin-preset=
@@ -650,8 +651,8 @@ skip-build-benchmarks
 # Skip playground tests
 skip-test-playgroundsupport
 
-# Enable libswift
-libswift
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
@@ -1404,6 +1405,10 @@ debug-llvm
 debug-swift
 no-swift-stdlib-assertions
 
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
+
+
 [preset: buildbot_osx_package,tools=DA,stdlib=R,use_os_runtime]
 mixin-preset=
     buildbot_osx_package,tools=DA,stdlib=R
@@ -1555,8 +1560,8 @@ build-swift-stdlib-unittest-extra
 
 libcxx
 
-# Enable libswift
-libswift
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
 
 # Build llbuild & swiftpm here
 llbuild
@@ -2273,6 +2278,10 @@ assertions
 debug-llvm
 debug-swift
 
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
+
+
 #===------------------------------------------------------------------------===#
 # Swift Preset
 # Tools: DebInfo and Assertions
@@ -2289,6 +2298,10 @@ debug-swift
 
 swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
+
+# Don't do bootstrapping to speed up the build
+libswift=hosttools
+
 
 #===------------------------------------------------------------------------===#
 # Swift Coverage Preset

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -358,11 +358,11 @@ function true_false() {
 
 function to_libswift_buildmode() {
     case "$1" in
-        false | FALSE | 0 | "")
+        false | FALSE | 0)
             echo "OFF"
             ;;
-        true | TRUE | 1)
-            echo "HOSTTOOLS"
+        true | TRUE | 1 | "")
+            echo "BOOTSTRAPPING"
             ;;
         *)
             echo `toupper $1`


### PR DESCRIPTION
But use the "hosttools" mode for build presets, which compile tools in "Debug" configuration (to reduce build time).
