### PR TITLE
IRGen: avoid a truncation of the key data

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -121,7 +121,7 @@ namespace irgen {
       }
       llvm_unreachable("unhandled case");
     }
-    bool getCorrespondingDataKey() const {
+    unsigned getCorrespondingDataKey() const {
       assert(hasCodeKey());
       switch (getKey()) {
       case (unsigned)PointerAuthSchema::ARM8_3Key::ASIA:


### PR DESCRIPTION
This was flagged by MSVC as a truncation due to the cast from `unsigned`
to `bool`.  Correct the return type to match.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
