### PR TITLE
Disabling lexical-lifetimes.swift

### DIFF
--- a/validation-test/SILOptimizer/lexical-lifetimes.swift
+++ b/validation-test/SILOptimizer/lexical-lifetimes.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift -Xfrontend -enable-experimental-lexical-lifetimes -O -Xfrontend -enable-copy-propagation | %FileCheck %s
 
+// REQUIRES: rdar84984903
+
 // =============================================================================
 // = Declarations                                                           {{ =
 // =============================================================================


### PR DESCRIPTION
This test is failing on
Swift CI: 1. OSS - Swift (Tools Opt+Assert, Stdlib DebInfo+Assert, Test Device non_executable) (main).

This has been failing since the test was introduced in commit
3bb1766a5f5ecdfbf189b9f24cb69a2478ca5029.

rdar://84984903