### PR TITLE
[moveOnly] Add checker that validates that if a let copyable value has _move applied to it, the let doesn't have any later uses.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -633,6 +633,8 @@ ERROR(sil_keypath_index_operand_type_conflict,none,
 ERROR(sil_keypath_no_use_of_operand_in_pattern,none,
       "operand %0 is not referenced by any component in the pattern",
       (unsigned))
+ERROR(sil_movevalue_invalid_optional_attribute,none,
+      "Optional attribute '[%0]' can not be applied to move_value", (StringRef))
 
 // SIL Basic Blocks
 ERROR(expected_sil_block_name,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -733,5 +733,15 @@ ERROR(sil_moveonlychecker_value_consumed_more_than_once, none,
 NOTE(sil_moveonlychecker_consuming_use_here, none,
      "consuming use", ())
 
+// move kills copyable values checker diagnostics
+ERROR(sil_movekillscopyablevalue_value_consumed_more_than_once, none,
+      "'%0' used after being moved", (StringRef))
+NOTE(sil_movekillscopyablevalue_move_here, none,
+     "move here", ())
+NOTE(sil_movekillscopyablevalue_use_here, none,
+     "use here", ())
+NOTE(sil_movekillscopyablevalue_value_consumed_in_loop, none,
+     "cyclic move here. move will occur multiple times in the loop", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1731,9 +1731,10 @@ void SILCloner<ImplClass>::visitExplicitCopyValueInst(
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitMoveValueInst(MoveValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  recordClonedInstruction(
-      Inst, getBuilder().createMoveValue(getOpLocation(Inst->getLoc()),
-                                         getOpValue(Inst->getOperand())));
+  auto *MVI = getBuilder().createMoveValue(getOpLocation(Inst->getLoc()),
+                                           getOpValue(Inst->getOperand()));
+  MVI->setAllowsDiagnostics(Inst->getAllowDiagnostics());
+  recordClonedInstruction(Inst, MVI);
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7337,8 +7337,17 @@ class MoveValueInst
                                   SingleValueInstruction> {
   friend class SILBuilder;
 
+  /// If set to true, we should emit the kill diagnostic for this move_value. If
+  /// set to false, we shouldn't emit such a diagnostic. This is a short term
+  /// addition until we get MoveOnly wrapper types into the SIL type system.
+  bool allowDiagnostics = false;
+
   MoveValueInst(SILDebugLocation DebugLoc, SILValue operand)
       : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
+
+public:
+  bool getAllowDiagnostics() const { return allowDiagnostics; }
+  void setAllowsDiagnostics(bool newValue) { allowDiagnostics = newValue; }
 };
 
 /// Given an object reference, return true iff it is non-nil and refers

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -422,6 +422,9 @@ PASS(AssemblyVisionRemarkGenerator, "assembly-vision-remark-generator",
      "Emit assembly vision remarks that provide source level guidance of where runtime calls ended up")
 PASS(MoveOnlyChecker, "sil-move-only-checker",
      "Pass that enforces move only invariants on raw SIL")
+PASS(MoveKillsCopyableValuesChecker, "sil-move-kills-copyable-values-checker",
+     "Pass that checks that any copyable (non-move only) value that is passed "
+     "to _move do not have any uses later than the _move")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1884,6 +1884,8 @@ public:
   }
 
   void visitMoveValueInst(MoveValueInst *I) {
+    if (I->getAllowDiagnostics())
+      *this << "[allows_diagnostics] ";
     *this << getIDAndType(I->getOperand());
   }
 

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -80,6 +80,8 @@ void PrunedLiveness::updateForUse(SILInstruction *user, bool lifetimeEnding) {
   // Record all uses of blocks on the liveness boundary. For blocks marked
   // LiveWithin, the boundary is considered to be the last use in the block.
   if (!lifetimeEnding && useBlockLive == PrunedLiveBlocks::LiveOut) {
+    if (nonLifetimeEndingUsesInLiveOut)
+      nonLifetimeEndingUsesInLiveOut->insert(user);
     return;
   }
   // Note that a user may use the current value from multiple operands. If any
@@ -93,7 +95,7 @@ void PrunedLiveness::updateForUse(SILInstruction *user, bool lifetimeEnding) {
   //
   // This call is not considered the end of %val's lifetime. The @owned
   // argument must be copied.
-  auto iterAndSuccess = users.try_emplace(user, lifetimeEnding);
+  auto iterAndSuccess = users.insert({user, lifetimeEnding});
   if (!iterAndSuccess.second)
     iterAndSuccess.first->second &= lifetimeEnding;
 }

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(swiftSILOptimizer PRIVATE
   LowerHopToActor.cpp
   MandatoryInlining.cpp
   MoveOnlyChecker.cpp
+  MoveKillsCopyableValuesChecker.cpp
   NestedSemanticFunctionCheck.cpp
   OptimizeHopToExecutor.cpp
   PerformanceDiagnostics.cpp

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -1,0 +1,435 @@
+//===--- MoveKillsCopyableValuesChecker.cpp -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-move-kills-copyable-values-checker"
+
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/Basic/Defer.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/ClosureScope.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                            Diagnostic Utilities
+//===----------------------------------------------------------------------===//
+
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+//===----------------------------------------------------------------------===//
+//                             Canonical Liveness
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct CheckerLivenessInfo {
+  GraphNodeWorklist<SILValue, 8> defUseWorklist;
+  SmallSetVector<Operand *, 8> consumingUse;
+  SmallSetVector<SILInstruction *, 8> nonLifetimeEndingUsesInLiveOut;
+  SmallVector<Operand *, 8> interiorPointerTransitiveUses;
+  PrunedLiveness liveness;
+
+  CheckerLivenessInfo()
+      : nonLifetimeEndingUsesInLiveOut(),
+        liveness(nullptr, &nonLifetimeEndingUsesInLiveOut) {}
+
+  void initDef(SILValue def) { defUseWorklist.insert(def); }
+
+  /// Compute the liveness for any value currently in the defUseWorklist.
+  ///
+  /// Returns false if we found any escapes. Returns true if no escape uses were
+  /// found. NOTE: Even if we return false, we still visit all uses and compute
+  /// liveness normally. We may just be missing uses through the escaping use.
+  bool compute();
+
+  void clear() {
+    defUseWorklist.clear();
+    liveness.clear();
+    consumingUse.clear();
+    interiorPointerTransitiveUses.clear();
+    nonLifetimeEndingUsesInLiveOut.clear();
+  }
+};
+
+} // end anonymous namespace
+
+bool CheckerLivenessInfo::compute() {
+  bool foundEscapes = false;
+
+  LLVM_DEBUG(llvm::dbgs() << "LivenessVisitor Begin!\n");
+  while (SILValue value = defUseWorklist.pop()) {
+    LLVM_DEBUG(llvm::dbgs() << "New Value: " << value);
+    SWIFT_DEFER { LLVM_DEBUG(llvm::dbgs() << "Finished Value: " << value); };
+    for (Operand *use : value->getUses()) {
+      auto *user = use->getUser();
+      LLVM_DEBUG(llvm::dbgs() << "    User: " << *user);
+      // Recurse through copies.
+      if (auto *copy = dyn_cast<CopyValueInst>(user)) {
+        LLVM_DEBUG(llvm::dbgs() << "    Copy Value. Looking through it\n");
+        defUseWorklist.insert(copy);
+        continue;
+      }
+
+      LLVM_DEBUG(llvm::dbgs() << "    OperandOwnership: "
+                              << use->getOperandOwnership() << '\n');
+      switch (use->getOperandOwnership()) {
+      case OperandOwnership::NonUse:
+        break;
+      case OperandOwnership::TrivialUse:
+        llvm_unreachable("this operand cannot handle ownership");
+
+      // Conservatively treat a conversion to an unowned value as a pointer
+      // escape. Is it legal to canonicalize ForwardingUnowned?
+      case OperandOwnership::ForwardingUnowned:
+      case OperandOwnership::PointerEscape:
+        foundEscapes = true;
+        break;
+      case OperandOwnership::InstantaneousUse:
+      case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::BitwiseEscape:
+        liveness.updateForUse(user, /*lifetimeEnding*/ false);
+        break;
+      case OperandOwnership::ForwardingConsume:
+        consumingUse.insert(use);
+        liveness.updateForUse(user, /*lifetimeEnding*/ true);
+        break;
+      case OperandOwnership::DestroyingConsume:
+        // destroy_value does not force pruned liveness (but store etc. does).
+        if (!isa<DestroyValueInst>(user)) {
+          liveness.updateForUse(user, /*lifetimeEnding*/ true);
+        }
+        consumingUse.insert(use);
+        break;
+      case OperandOwnership::Borrow: {
+        bool failed = !liveness.updateForBorrowingOperand(use);
+        assert(!failed && "Shouldn't see reborrows this early in the pipeline");
+        break;
+      }
+      case OperandOwnership::ForwardingBorrow:
+        // A forwarding borrow is validated as part of its parent borrow. So
+        // just mark it as extending liveness and look through it.
+        liveness.updateForUse(user, /*lifetimeEnding*/ false);
+        for (SILValue result : user->getResults()) {
+          if (result.getOwnershipKind() == OwnershipKind::Guaranteed)
+            defUseWorklist.insert(result);
+        }
+        break;
+      case OperandOwnership::InteriorPointer: {
+        // An interior pointer user extends liveness until the end of the
+        // interior pointer section.
+        //
+        // TODO: We really should have all OperandOwnership::InteriorPointer
+        // instructions be valid to pass to InteriorPointerOperand. Some
+        // builtins do not do it today and it is probably a misuse of the
+        // system. That being said, lets do our best here.
+        if (auto operand = InteriorPointerOperand(use)) {
+          auto addrUseKind =
+              operand.findTransitiveUses(&interiorPointerTransitiveUses);
+          (void)addrUseKind;
+          while (!interiorPointerTransitiveUses.empty()) {
+            auto *addrUse = interiorPointerTransitiveUses.pop_back_val();
+            liveness.updateForUse(addrUse->getUser(), /*lifetimeEnding*/ false);
+          }
+        }
+        break;
+      }
+      case OperandOwnership::EndBorrow:
+        // Don't care about this use.
+        break;
+      case OperandOwnership::Reborrow:
+        // Reborrows do not occur this early in the pipeline.
+        llvm_unreachable(
+            "Reborrows do not occur until we optimize later in the pipeline");
+      }
+    }
+  }
+
+  // We succeeded if we did not find any escapes.
+  return !foundEscapes;
+}
+
+//===----------------------------------------------------------------------===//
+//                                 Main Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct MoveKillsCopyableValuesChecker {
+  SILFunction *fn;
+  CheckerLivenessInfo livenessInfo;
+  SmallSetVector<MoveValueInst *, 1> movesWithinLivenessBoundary;
+
+  MoveKillsCopyableValuesChecker(SILFunction *fn) : fn(fn) {}
+  bool check();
+
+  void emitDiagnosticForMove(SILValue borrowedValue,
+                             StringRef borrowedValueName, MoveValueInst *mvi);
+};
+
+} // namespace
+
+static SourceLoc getSourceLocFromValue(SILValue value) {
+  if (auto *defInst = value->getDefiningInstruction())
+    return defInst->getLoc().getSourceLoc();
+  if (auto *arg = dyn_cast<SILFunctionArgument>(value))
+    return arg->getDecl()->getLoc();
+  llvm_unreachable("Do not know how to get source loc for value?!");
+}
+
+void MoveKillsCopyableValuesChecker::emitDiagnosticForMove(
+    SILValue borrowedValue, StringRef borrowedValueName, MoveValueInst *mvi) {
+  auto &astContext = fn->getASTContext();
+
+  // First we emit the main error and then the note on where the move was.
+  diagnose(astContext, getSourceLocFromValue(borrowedValue),
+           diag::sil_movekillscopyablevalue_value_consumed_more_than_once,
+           borrowedValueName);
+  diagnose(astContext, mvi->getLoc().getSourceLoc(),
+           diag::sil_movekillscopyablevalue_move_here);
+
+  // Then we do a bit of work to figure out where /all/ of the later uses than
+  // mvi are so we can emit notes to the user telling them this is a problem
+  // use. We can do a little more work here since we are going to be emitting a
+  // fatalError ending the program.
+  auto *mviBlock = mvi->getParent();
+  auto mviBlockLiveness = livenessInfo.liveness.getBlockLiveness(mviBlock);
+  switch (mviBlockLiveness) {
+  case PrunedLiveBlocks::Dead:
+    llvm_unreachable("We should never see this");
+  case PrunedLiveBlocks::LiveWithin: {
+    // The boundary was within our block. We need to search for uses later than
+    // us and emit a diagnostic upon them. Then we return. We leave the rest of
+    // the function for the implementation of the LiveOutCase.
+    for (SILInstruction &inst :
+         make_range(std::next(mvi->getIterator()), mviBlock->end())) {
+      switch (livenessInfo.liveness.isInterestingUser(&inst)) {
+      case PrunedLiveness::NonUser:
+        break;
+      case PrunedLiveness::NonLifetimeEndingUse:
+      case PrunedLiveness::LifetimeEndingUse:
+        diagnose(astContext, inst.getLoc().getSourceLoc(),
+                 diag::sil_movekillscopyablevalue_use_here);
+        break;
+      }
+    }
+    return;
+  }
+  case PrunedLiveBlocks::LiveOut: {
+    // The boundary was later than us, we need to do a full on CFG search, which
+    // we do below.
+    break;
+  }
+  }
+
+  // Just to check for dumb mistakes, assert we are LiveOut here.
+  assert(mviBlockLiveness == PrunedLiveBlocks::LiveOut &&
+         "We are handling only the live out case here. The rest of the cases "
+         "were handled in the switch above and return early upon success");
+
+  BasicBlockWorklist worklist(mvi->getFunction());
+  for (auto *succBlock : mvi->getParent()->getSuccessorBlocks()) {
+    worklist.pushIfNotVisited(succBlock);
+  }
+
+  // In order to make sure that we do not miss uses that are within loops, we
+  // maintain a list of all user sets. The issue is that a block at a deeper
+  // loop level than our def, even if it contained the use that triggered the
+  // issue will be LiveOut. So when we see a live out block, we perform this
+  // extra check and emit a diagnostic if needed.
+  BasicBlockSet usesToCheckForInLiveOutBlocks(mvi->getFunction());
+  for (auto *user : livenessInfo.nonLifetimeEndingUsesInLiveOut)
+    usesToCheckForInLiveOutBlocks.insert(user->getParent());
+  for (auto *consumingUse : livenessInfo.consumingUse)
+    usesToCheckForInLiveOutBlocks.insert(consumingUse->getParentBlock());
+
+  while (auto *block = worklist.pop()) {
+    if (PrunedLiveBlocks::LiveOut ==
+        livenessInfo.liveness.getBlockLiveness(block)) {
+      // Make sure that if we have a liveout block that is at a lower level in
+      // the loop nest than our def and we have a use in that block, that we
+      // emit an error. We know it is after the move since we are visiting
+      // instructions in successors of move.
+      if (usesToCheckForInLiveOutBlocks.contains(block)) {
+        for (SILInstruction &inst : *block) {
+          if (livenessInfo.nonLifetimeEndingUsesInLiveOut.contains(&inst)) {
+            diagnose(astContext, inst.getLoc().getSourceLoc(),
+                     diag::sil_movekillscopyablevalue_use_here);
+            continue;
+          }
+          for (auto &op : inst.getAllOperands()) {
+            if (livenessInfo.consumingUse.contains(&op)) {
+              // If one of our in loop moves is ourselves, then we know that our
+              // original value is outside of the loop and thus we have a loop
+              // carry dataflow violation.
+              if (mvi == &inst) {
+                diagnose(
+                    astContext, inst.getLoc().getSourceLoc(),
+                    diag::sil_movekillscopyablevalue_value_consumed_in_loop);
+                continue;
+              }
+
+              diagnose(astContext, inst.getLoc().getSourceLoc(),
+                       diag::sil_movekillscopyablevalue_use_here);
+              continue;
+            }
+          }
+        }
+      }
+
+      for (auto *succBlock : block->getSuccessorBlocks()) {
+        worklist.pushIfNotVisited(succBlock);
+      }
+      continue;
+    }
+
+    // The boundary was within the block. We need to search for interesting uses
+    // in the block and then emit diagnostics upon them.
+    for (SILInstruction &inst : *block) {
+      switch (livenessInfo.liveness.isInterestingUser(&inst)) {
+      case PrunedLiveness::NonUser:
+        break;
+      case PrunedLiveness::NonLifetimeEndingUse:
+      case PrunedLiveness::LifetimeEndingUse:
+        diagnose(astContext, inst.getLoc().getSourceLoc(),
+                 diag::sil_movekillscopyablevalue_use_here);
+        break;
+      }
+    }
+  }
+}
+
+bool MoveKillsCopyableValuesChecker::check() {
+  SmallSetVector<SILValue, 32> valuesToCheck;
+
+  for (auto *arg : fn->getEntryBlock()->getSILFunctionArguments()) {
+    if (arg->getOwnershipKind() == OwnershipKind::Guaranteed ||
+        arg->getOwnershipKind() == OwnershipKind::Owned)
+      valuesToCheck.insert(arg);
+  }
+
+  for (auto &block : *fn) {
+    for (auto &ii : block) {
+      if (auto *bbi = dyn_cast<BeginBorrowInst>(&ii)) {
+        if (bbi->isLexical())
+          valuesToCheck.insert(bbi);
+        continue;
+      }
+    }
+  }
+
+  if (valuesToCheck.empty())
+    return false;
+
+  LLVM_DEBUG(llvm::dbgs() << "Visiting Function: " << fn->getName() << "\n");
+  auto valuesToProcess =
+      llvm::makeArrayRef(valuesToCheck.begin(), valuesToCheck.end());
+
+  while (!valuesToProcess.empty()) {
+    auto lexicalValue = valuesToProcess.front();
+    valuesToProcess = valuesToProcess.drop_front(1);
+    LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *lexicalValue);
+
+    // Before we do anything, see if we can find a name for our value. We do
+    // this early since we need this for all of our diagnostics below.
+    StringRef varName = "unknown";
+    if (auto *use = getSingleDebugUse(lexicalValue)) {
+      DebugVarCarryingInst debugVar(use->getUser());
+      if (auto varInfo = debugVar.getVarInfo()) {
+        varName = varInfo->Name;
+      } else {
+        if (auto *decl = debugVar.getDecl()) {
+          varName = decl->getBaseName().userFacingName();
+        }
+      }
+    }
+
+    // Then compute liveness.
+    SWIFT_DEFER { livenessInfo.clear(); };
+    livenessInfo.initDef(lexicalValue);
+    // We do not care if we find an escape. We just want to make sure that any
+    // non-escaping users obey our property. If the user does something unsafe
+    // that is on them to manage.
+    bool foundEscape = livenessInfo.compute();
+    (void)foundEscape;
+
+    // Then look at all of our found consuming uses. See if any of these are
+    // _move that are within the boundary.
+    SWIFT_DEFER { movesWithinLivenessBoundary.clear(); };
+    for (auto *use : livenessInfo.consumingUse) {
+      if (auto *mvi = dyn_cast<MoveValueInst>(use->getUser())) {
+        // Only emit diagnostics if our move value allows us to.
+        if (!mvi->getAllowDiagnostics())
+          continue;
+        LLVM_DEBUG(llvm::dbgs() << "Move Value: " << *mvi);
+        if (livenessInfo.liveness.isWithinBoundary(mvi)) {
+          LLVM_DEBUG(llvm::dbgs() << "    WithinBoundary: Yes!\n");
+          movesWithinLivenessBoundary.insert(mvi);
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "    WithinBoundary: No!\n");
+        }
+      }
+    }
+
+    // Ok, we found all of our moves that violate the boundary condition, lets
+    // emit diagnostics for each of them.
+    for (auto *mvi : movesWithinLivenessBoundary) {
+      emitDiagnosticForMove(lexicalValue, varName, mvi);
+    }
+  }
+
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MoveKillsCopyableValuesCheckerPass : public SILFunctionTransform {
+  void run() override {
+    auto *fn = getFunction();
+
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
+    assert(fn->getModule().getStage() == SILStage::Raw &&
+           "Should only run on Raw SIL");
+
+    MoveKillsCopyableValuesChecker checker(getFunction());
+
+    if (MoveKillsCopyableValuesChecker(getFunction()).check()) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // anonymous namespace
+
+SILTransform *swift::createMoveKillsCopyableValuesChecker() {
+  return new MoveKillsCopyableValuesCheckerPass();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -164,8 +164,10 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // dead allocations.
   P.addPredictableDeadAllocationElimination();
 
-  // Now perform move only checking.
-  P.addMoveOnlyChecker();
+  // Now perform move semantic checking.
+  P.addMoveKillsCopyableValuesChecker(); // No uses after _move of copyable
+                                         //   value.
+  P.addMoveOnlyChecker();                // Check noImplicitCopy isn't copied.
 
   P.addOptimizeHopToExecutor();
   P.addMandatoryGenericSpecializer();

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -682,8 +682,10 @@ void SILInlineCloner::visitBuiltinInst(BuiltinInst *Inst) {
         SILValue otherValue = getBuilder().emitLoadValueOperation(
             opLoc, otherSrcAddr, LoadOwnershipQualifier::Take);
 
+        // Create a move_value and set that we want it to be used for diagnostic
+        // emission.
         auto *mvi = getBuilder().createMoveValue(opLoc, otherValue);
-
+        mvi->setAllowsDiagnostics(true);
         getBuilder().emitStoreValueOperation(opLoc, mvi, otherResultAddr,
                                              StoreOwnershipQualifier::Init);
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1867,7 +1867,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   REFCOUNTING_INSTRUCTION(UnmanagedRetainValue)
   UNARY_INSTRUCTION(CopyValue)
   UNARY_INSTRUCTION(ExplicitCopyValue)
-  UNARY_INSTRUCTION(MoveValue)
   REFCOUNTING_INSTRUCTION(ReleaseValue)
   REFCOUNTING_INSTRUCTION(ReleaseValueAddr)
   REFCOUNTING_INSTRUCTION(UnmanagedReleaseValue)
@@ -1981,6 +1980,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         ResultKind);
+    break;
+  }
+
+  case SILInstructionKind::MoveValueInst: {
+    auto Ty = MF->getType(TyID);
+    auto AllowsDiagnostics = bool(Attr);
+    auto *MVI = Builder.createMoveValue(
+        Loc,
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+    MVI->setAllowsDiagnostics(AllowsDiagnostics);
+    ResultInst = MVI;
     break;
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 640; // @_typeSequence
+const uint16_t SWIFTMODULE_VERSION_MINOR = 641; // diagnostic move only
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1462,6 +1462,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Attr = ECMI->doKeepUnique();
     } else if (auto *BBI = dyn_cast<BeginBorrowInst>(&SI)) {
       Attr = BBI->isLexical();
+    } else if (auto *MVI = dyn_cast<MoveValueInst>(&SI)) {
+      Attr = MVI->getAllowDiagnostics();
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -58,10 +58,12 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0(%0 :
 // CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
+// CHECK-NEXT: %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
 // CHECK-NEXT: return
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing_non_ossa'
 sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : $Builtin.NativeObject):
   %1 = move_value %0 : $Builtin.NativeObject
-  return %1 : $Builtin.NativeObject
+  %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
 }

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -71,12 +71,14 @@ bb0:
 // CHECK-LABEL: sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0(%0 :
 // CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
+// CHECK-NEXT: %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
 // CHECK-NEXT: return
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing'
 sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = move_value %0 : $Builtin.NativeObject
-  return %1 : $Builtin.NativeObject
+  %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {

--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -27,7 +27,7 @@ class Klass {}
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
-// CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: [allows_diagnostics] move_value
 // CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADF'
@@ -55,7 +55,7 @@ func useMove(_ k: Klass) -> Klass {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
-// CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: [allows_diagnostics] move_value
 // CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxRlzClF'

--- a/test/SILOptimizer/move_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_operator_kills_copyable_values.swift
@@ -1,0 +1,237 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
+
+import Swift
+
+public class Klass {}
+
+//////////////////
+// Declarations //
+//////////////////
+
+func consumingUse(_ k: __owned Klass) {}
+var booleanValue: Bool { false }
+func nonConsumingUse(_ k: Klass) {}
+
+///////////
+// Tests //
+///////////
+
+//===---
+// Let + Non Consuming Use
+//
+
+public func simpleLinearUse(_ x: Klass) {
+    let y = x // expected-error {{'y' used after being moved}}
+    let _ = _move(y) // expected-note {{move here}}
+    nonConsumingUse(y) // expected-note {{use here}}
+}
+
+public func conditionalUse1(_ x: Klass) {
+    let y = x
+    if booleanValue {
+        let _ = _move(y)
+    } else {
+        nonConsumingUse(y)
+    }
+}
+
+public func loopUse1(_ x: Klass) {
+    let y = x  // expected-error {{'y' used after being moved}}
+    let _ = _move(y) // expected-note {{move here}}
+    for _ in 0..<1024 {
+        nonConsumingUse(y) // expected-note {{use here}}
+    }
+}
+
+//===---
+// Let + Consuming Use
+//
+
+public func simpleLinearConsumingUse(_ x: Klass) {
+    let y = x // expected-error {{'y' used after being moved}}
+    let _ = _move(y) // expected-note {{move here}}
+    consumingUse(y) // expected-note {{use here}}
+}
+
+public func conditionalUseOk1(_ x: Klass) {
+    let y = x
+    if booleanValue {
+        let _ = _move(y)
+    } else {
+        consumingUse(y)
+    }
+}
+
+// This test makes sure that in the case where we have two consuming uses, with
+// different first level copies, we emit a single diagnostic.
+public func conditionalBadConsumingUse(_ x: Klass) {
+    let y = x // expected-error {{'y' used after being moved}}
+    if booleanValue {
+        let _ = _move(y) // expected-note {{move here}}
+        // TODO: We should be able to also emit a note on the line
+        // below. Without this the user will have to compile multiple times to
+        // work through the errors. But this makes it simpler to implement a
+        // first version and is still safe.
+        consumingUse(y)
+    } else {
+        // We shouldn't get any diagnostic on this use.
+        consumingUse(y)
+    }
+
+    // But this one and the first consumingUse should get a diagnostic.
+    consumingUse(y) // expected-note {{use here}}
+}
+
+
+// This test makes sure that in the case where we have two consuming uses, with
+// different first level copies, we emit a single diagnostic.
+public func conditionalBadConsumingUseLoop(_ x: Klass) {
+    let y = x // expected-error {{'y' used after being moved}}
+    if booleanValue {
+        let _ = _move(y) // expected-note {{move here}}
+        // TODO: We should be able to also emit a note on the line
+        // below. Without this the user will have to compile multiple times to
+        // work through the errors. But this makes it simpler to implement a
+        // first version and is still safe.
+        consumingUse(y)
+    } else {
+        // We shouldn't get any diagnostic on this use.
+        consumingUse(y)
+    }
+
+    // But this one and the first consumingUse should get a diagnostic.
+    for _ in 0..<1024 {
+        consumingUse(y) // expected-note {{use here}}
+    }
+}
+
+//===
+// Parameters
+
+// This is ok, no uses after.
+public func simpleMoveOfParameter(_ x: Klass) -> () {
+    let _ = _move(x)
+}
+
+public func errorSimpleMoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    let _ = _move(x) // expected-note {{use here}}
+}
+
+public func errorSimple2MoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    let _ = consumingUse(x) // expected-note {{use here}}
+}
+
+// TODO: I wonder if we could do better for the 2nd error. At least we tell the
+// user it is due to the loop.
+public func errorLoopMultipleMove(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+                                                      // expected-error @-1 {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    for _ in 0..<1024 {
+        let _ = _move(x) // expected-note {{move here}}
+                         // expected-note @-1 {{cyclic move here. move will occur multiple times in the loop}}
+                         // expected-note @-2 {{use here}}
+    }
+}
+
+public func errorLoopMoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    for _ in 0..<1024 {
+        consumingUse(x) // expected-note {{use here}}
+    }
+}
+
+public func errorLoop2MoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    for _ in 0..<1024 {
+        nonConsumingUse(x) // expected-note {{use here}}
+    }
+}
+
+public func errorSimple2MoveOfParameterNonConsume(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    let _ = nonConsumingUse(x) // expected-note {{use here}}
+}
+
+public func errorLoopMoveOfParameterNonConsume(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    for _ in 0..<1024 {
+        nonConsumingUse(x) // expected-note {{use here}}
+    }
+}
+
+////////////////////////
+// Pattern Match Lets //
+////////////////////////
+
+public func patternMatchIfCaseLet(_ x: Klass?) {
+    if case let .some(y) = x { // expected-error {{'y' used after being moved}}
+        let _ = _move(y) // expected-note {{move here}}
+        nonConsumingUse(y) // expected-note {{use here}}
+    }
+}
+
+public func patternMatchSwitchLet(_ x: Klass?) {
+    switch x {
+    case .none:
+        break
+    case .some(let y): // expected-error {{'y' used after being moved}}
+        let _ = _move(y) // expected-note {{move here}}
+        nonConsumingUse(y) // expected-note {{use here}}
+    }
+}
+
+public func patternMatchSwitchLet2(_ x: (Klass?, Klass?)?) {
+    switch x {
+    case .some((.some(let y), _)): // expected-error {{'y' used after being moved}}
+        let _ = _move(y) // expected-note {{move here}}
+        nonConsumingUse(y) // expected-note {{use here}}
+    default:
+        break
+    }
+}
+
+public func patternMatchSwitchLet3(_ x: (Klass?, Klass?)?) { // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    switch x { // expected-note {{use here}}
+    case .some((.some(_), .some(let z))): // expected-error {{'z' used after being moved}}
+        let _ = _move(z) // expected-note {{move here}}
+        nonConsumingUse(z) // expected-note {{use here}}
+    default:
+        break
+    }
+}
+
+////////////////
+// Aggregates //
+////////////////
+
+public struct Pair {
+    var x: Klass
+    var y: Klass
+    var z: Int
+}
+
+// Current semantics is that we error on any use of any part of pair once we
+// have invalidated a part of pair. We can be less restrictive in the future.
+//
+// TODO: Why are we emitting two uses here.
+public func performMoveOnOneEltOfPair(_ p: Pair) { // expected-error {{'p' used after being moved}}
+    let _ = p.z // Make sure we don't crash when we access a trivial value from Pair.
+    let _ = _move(p.x) // expected-note {{move here}}
+    nonConsumingUse(p.y) // expected-note {{use here}}
+                         // expected-note @-1 {{use here}}
+}
+
+public class KlassPair {
+    var x = Klass()
+    var y = Klass()
+}
+
+// No error since we are not moving p itself, but are moving a copy of x that we
+// loaded from p and then destroying that.
+public func performMoveOnOneEltOfKlassPair(_ p: KlassPair) {
+    let _ = _move(p.x)
+    nonConsumingUse(p.y)
+}


### PR DESCRIPTION
This is just an initial prototype for people to play with. It is as always
behind the -enable-experimental-move-only flag.

rdar://83957028
