### PR TITLE
[CMake] Move the list of availability definitions out of CMake and into a standalone config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,17 +525,8 @@ if(SWIFT_ENABLE_DISPATCH AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   endif()
 endif()
 
-set(SWIFT_STDLIB_AVAILABILITY_DEFINITIONS
-  "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2"
-  "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0"
-  "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4"
-  "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"
-  "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5"
-  "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0"
-  "SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"
-  "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" # Unknown future release
-  CACHE STRING
-  "Availability macros for stdlib versions")
+file(STRINGS "utils/availability-macros.def" SWIFT_STDLIB_AVAILABILITY_DEFINITIONS)
+list(FILTER SWIFT_STDLIB_AVAILABILITY_DEFINITIONS EXCLUDE REGEX "^\\s*(#.*)?$")
 
 #
 # Include CMake modules

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,10 +385,6 @@ foreach(SDK ${SWIFT_SDKS})
           list(APPEND LIT_ARGS "--param" "distributed")
         endif()
 
-        # Define availability macros, escaping semicolons to get around CMake
-        string(REPLACE ";" "\\$<SEMICOLON>" availability_defs "${SWIFT_STDLIB_AVAILABILITY_DEFINITIONS}")
-        list(APPEND LIT_ARGS "--param" "availability_macros=${availability_defs}")
-
         foreach(test_subset ${TEST_SUBSETS})
           set(directories)
           set(dependencies ${test_dependencies})

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -431,8 +431,13 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
-# Define availability macros for known stdlib releases.
-for macro in lit_config.params.get('availability_macros', '').split(";"):
+# Load availability macros for known stdlib releases.
+def load_availability_macros():
+    path = os.path.join(os.path.dirname(__file__), "../utils/availability-macros.def")
+    lines = open(path, 'r').read().splitlines()
+    pattern = re.compile(r"\s*(#.*)?")
+    return filter(lambda l: pattern.fullmatch(l) is None, lines)
+for macro in load_availability_macros():
     config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
     config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
 

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -1,0 +1,37 @@
+# This file defines availability macros mapping Swift releases to ABI stable
+# OS releases that include the corresponding Swift Standard Library version.
+#
+# The macros defined here are available for use in all Swift libraries and swift
+# lit tests defined in this repository. They can be used in place of a full
+# version constraint list in `@available` attributes. That is to say, instead of
+#
+#     @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+#
+# we can write
+#
+#     @available(SwiftStdlib 5.2, *)
+#
+# Comments in this file start with `#`. Comments and empty lines are ignored.
+# Each of the remaining lines must define an availability macro in the same
+# format used by the `-define-availability` frontend command line option.
+
+# 9999 is the generic unknown future Swift release. It always needs to resolve
+# to the special placeholder version numbers 9999.
+
+SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+
+# The last entry in this list corresponds to the Swift version currently under
+# development. This usually resolves to placeholder version numbers (9999) until
+# the corresponding operating systems get announced.
+
+SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
+SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0
+SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4
+SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
+SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
+SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
+SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+
+# Local Variables:
+# mode: conf-unix
+# End:


### PR DESCRIPTION
This restores the ability to (easily) run lit tests outside of a CMake build.
