### PR TITLE
5.5 fix weak extended frame pointer flags

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1786,9 +1786,10 @@ void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
   // avoid optimizations.
   llvm::GlobalVariable *usage = new llvm::GlobalVariable(
       Module, extendedFramePointerFlagsWeakRef->getType(), false,
-      llvm::GlobalValue::PrivateLinkage,
+      llvm::GlobalValue::LinkOnceODRLinkage,
       static_cast<llvm::GlobalVariable *>(extendedFramePointerFlagsWeakRef),
       "_swift_async_extendedFramePointerFlagsUser");
+  usage->setVisibility(llvm::GlobalValue::HiddenVisibility);
   addUsedGlobal(usage);
 }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1778,6 +1778,18 @@ void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
   extendedFramePointerFlagsWeakRef = new llvm::GlobalVariable(Module, Int8PtrTy, false,
                                          llvm::GlobalValue::ExternalWeakLinkage, nullptr,
                                          symbolName);
+
+  // The weak imported extendedFramePointerFlagsWeakRef gets optimized out
+  // before being added back as a strong import.
+  // Declarations can't be added to the used list, so we create a little
+  // global that can't be used from the program, but can be in the used list to
+  // avoid optimizations.
+  llvm::GlobalVariable *usage = new llvm::GlobalVariable(
+      Module, extendedFramePointerFlagsWeakRef->getType(), false,
+      llvm::GlobalValue::PrivateLinkage,
+      static_cast<llvm::GlobalVariable *>(extendedFramePointerFlagsWeakRef),
+      "_swift_async_extendedFramePointerFlagsUser");
+  addUsedGlobal(usage);
 }
 
 bool IRGenModule::isConcurrencyAvailable() {

--- a/test/Concurrency/Backdeploy/weak_linking.swift
+++ b/test/Concurrency/Backdeploy/weak_linking.swift
@@ -3,6 +3,9 @@
 // RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
 // RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -disable-availability-checking
 // RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir
+// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -O -module-name main -emit-ir -o %t/optimized.ir -disable-availability-checking
+// RUN: %FileCheck %s --check-prefix=OPTIMIZED < %t/optimized.ir
+
 
 // REQUIRES: OS=macosx
 
@@ -11,6 +14,11 @@
 // OLD: declare extern_weak swiftcc i8* @swift_task_alloc
 // OLD: declare extern_weak swiftcc %swift.metadata_response @"$sScPMa"
 // OLD: declare extern_weak swiftcc i8 @"$sScP8rawValues5UInt8Vvg"
+
+// OPTIMIZED: @swift_async_extendedFramePointerFlags = extern_weak global i8*
+// OPTIMIZED: @_swift_async_extendedFramePointerFlagsUser = private global i8** @swift_async_extendedFramePointerFlags
+// OPTIMIZED: @llvm.used =
+// OPTIMIZED-SAME: (i8*** @_swift_async_extendedFramePointerFlagsUser to i8*)
 
 @available(macOS 12.0, *)
 public func g() async -> String { "hello" }

--- a/test/Concurrency/Backdeploy/weak_linking.swift
+++ b/test/Concurrency/Backdeploy/weak_linking.swift
@@ -16,7 +16,7 @@
 // OLD: declare extern_weak swiftcc i8 @"$sScP8rawValues5UInt8Vvg"
 
 // OPTIMIZED: @swift_async_extendedFramePointerFlags = extern_weak global i8*
-// OPTIMIZED: @_swift_async_extendedFramePointerFlagsUser = private global i8** @swift_async_extendedFramePointerFlags
+// OPTIMIZED: @_swift_async_extendedFramePointerFlagsUser = linkonce_odr hidden global i8** @swift_async_extendedFramePointerFlags
 // OPTIMIZED: @llvm.used =
 // OPTIMIZED-SAME: (i8*** @_swift_async_extendedFramePointerFlagsUser to i8*)
 


### PR DESCRIPTION
Cherry-pick of: https://github.com/apple/swift/pull/40035

The weakly-imported symbol was getting optimized out, then put back in
as a strongly-imported symbol. This is no good. The symbol is a
declaration though, so it can't be "used" directly. Instead, we assign
it to another global and "use" it. That avoids the optimizations and
should be fine. Even if that symbol is a nullptr because it doesn't
exist, we are taking the pointer to it, which should be fine for all
situations.

Fixes rdar://84877644.