### PR TITLE
[Distributed] Distributed tests should not run in backdeployment

### DIFF
--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -5,6 +5,7 @@
 // which expects the exit code of the program to be non-zero;
 // We then check stderr for the expected error message using filecheck as usual.
 
+// UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -enable-experimental-distributed | %IRGenFileCheck %s
+// UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
 // REQUIRES: distributed
 


### PR DESCRIPTION
Don't try to run Distributed/Runtime/distributed_no_transport_boom.swift on back-deployed concurrency

Resolves rdar://84992966