### PR TITLE
[Distributed] remove public default AnyActorTransport predefined typealias

### DIFF
--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -51,12 +51,6 @@ static SILValue emitActorPropertyReference(
     VarDecl *property) {
   Type formalType = SGF.F.mapTypeIntoContext(property->getInterfaceType());
   SILType loweredType = SGF.getLoweredType(formalType).getAddressType();
-#if false
-  if (!loweredType.isAddress()) {
-    loweredType = SILType::getPrimitiveAddressType(
-        formalType->getCanonicalType());
-  }
-#endif
   return SGF.B.createRefElementAddr(loc, actorSelf, property, loweredType);
 }
 

--- a/stdlib/public/Distributed/ActorTransport.swift
+++ b/stdlib/public/Distributed/ActorTransport.swift
@@ -108,6 +108,6 @@ public struct AnyActorTransport: ActorTransport {
   }
 }
 
-/// Use the existential wrapper as the default actor transport.
-@available(SwiftStdlib 5.6, *)
-public typealias DefaultActorTransport = AnyActorTransport
+///// Use the existential wrapper as the default actor transport.
+//@available(SwiftStdlib 5.6, *)
+//public typealias DefaultActorTransport = AnyActorTransport

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -35,7 +35,7 @@ public protocol AnyActor: Sendable, AnyObject {}
 /// distributed actor.
 @available(SwiftStdlib 5.6, *)
 public protocol DistributedActor:
-    AnyActor, Sendable, Identifiable, Hashable, Codable {
+    AnyActor, Identifiable, Hashable, Codable {
     /// The type of transport used to communicate with actors of this type.
     associatedtype Transport: ActorTransport
 

--- a/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
+++ b/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
@@ -15,6 +15,8 @@
 import _Distributed
 
 distributed actor DA {
+  typealias Transport = AnyActorTransport
+
   distributed func hello(other: DA) {}
 }
 

--- a/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_deinit_sil.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 class SomeClass {}
 
 distributed actor MyDistActor {

--- a/test/Distributed/SIL/distributed_actor_default_init_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 class SomeClass {}
 
 distributed actor MyDistActor {

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -32,7 +32,9 @@ struct E: Actor {
 
 // ==== -----------------------------------------------------------------------
 
-distributed actor DA: DistributedActor {} // ok
+distributed actor DA: DistributedActor {
+  typealias Transport = AnyActorTransport
+}
 
 actor A2: DistributedActor {
   // expected-error@-1{{non-distributed actor type 'A2' cannot conform to the 'DistributedActor' protocol}} {{1-1=distributed }}

--- a/test/Distributed/distributed_actor_basic.swift
+++ b/test/Distributed/distributed_actor_basic.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 distributed actor DA {
 }
 

--- a/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
+++ b/test/Distributed/distributed_actor_cannot_be_downcast_to_actor.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 @available(SwiftStdlib 5.6, *)
 extension Actor {
     func f() -> String { "Life is Study!" }

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 @available(SwiftStdlib 5.6, *)
 distributed actor D {
 

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 actor SomeActor { }
 
 // ==== ------------------------------------------------------------------------

--- a/test/Distributed/distributed_actor_initialization.swift
+++ b/test/Distributed/distributed_actor_initialization.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 distributed actor OK0 { }
 
 distributed actor OK1 {

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -7,6 +7,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 struct ActorAddress: ActorIdentity {
   let address: String
   init(parse address : String) {

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 struct SomeLogger {}
 struct Logger {
   let label: String

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 @available(SwiftStdlib 5.6, *)
 distributed actor DA {
 

--- a/test/Distributed/distributed_actor_protocol_isolation.swift
+++ b/test/Distributed/distributed_actor_protocol_isolation.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 // ==== ------------------------------------------------------------------------
 // MARK: Protocols
 

--- a/test/Distributed/distributed_actor_resolve.swift
+++ b/test/Distributed/distributed_actor_resolve.swift
@@ -4,20 +4,14 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+@available(SwiftStdlib 5.6, *)
+typealias DefaultActorTransport = AnyActorTransport
+
 @available(SwiftStdlib 5.6, *)
 distributed actor Capybara { }
-
-//@available(SwiftStdlib 5.6, *)
-//protocol Wheeker: DistributedActor { }
-//@available(SwiftStdlib 5.6, *)
-//distributed actor GuineaPing: Wheeker { }
 
 @available(SwiftStdlib 5.6, *)
 func test(identity: AnyActorIdentity, transport: AnyActorTransport) async throws {
   let _: Capybara = try Capybara.resolve(identity, using: transport)
-
-// TODO: implement resolve being able to be called on a distributed actor protocol
-//       (yes, normally it is not allowed to call such function... so we need to
-//        discuss and figure out how we want to expose the resolve of a protocol)
-//  let c: Wheeker = try Wheeker.resolve(.init(identity), using: transport)
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 // ==== -----------------------------------------------------------------------
 // MARK: Distributed actor protocols
 

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -10,5 +10,6 @@ import _Distributed
 
 @available(SwiftStdlib 5.6, *)
 public distributed actor MyActor {
-    // nothing
+  public typealias Transport = AnyActorTransport
+  // nothing
 }

--- a/test/SILGen/distributed_thunk.swift
+++ b/test/SILGen/distributed_thunk.swift
@@ -4,7 +4,9 @@
 
 import _Distributed
 
-distributed actor DA { }
+distributed actor DA {
+  typealias Transport = AnyActorTransport
+}
 
 extension DA {
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s17distributed_thunk2DAC1fyyFTE : $@convention(method) @async (@guaranteed DA) -> @error Error

--- a/test/Serialization/Inputs/def_distributed.swift
+++ b/test/Serialization/Inputs/def_distributed.swift
@@ -1,5 +1,8 @@
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 @available(SwiftStdlib 5.6, *)
 public distributed actor DA {
   public distributed func doSomethingDistributed(param: String) async -> Int {

--- a/test/TBD/distributed.swift
+++ b/test/TBD/distributed.swift
@@ -8,6 +8,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 // CHECK: @"$s4test1AC13_remote_helloyyYaKFTE" = hidden global %swift.async_func_pointer
 // CHECK: @"$s4test1AC13_remote_helloyyYaKFTETu" = hidden global %swift.async_func_pointer
 distributed actor SomeDistributedActor {

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -4,6 +4,9 @@
 
 import _Distributed
 
+/// Use the existential wrapper as the default actor transport.
+typealias DefaultActorTransport = AnyActorTransport
+
 distributed actor D1 {
   var x: Int = 17
 }


### PR DESCRIPTION
Specific libraries shall pick specific transports if they want.

Follow up to https://github.com/apple/swift/pull/39985