### PR TITLE
Workaround for rdar://84716758

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2629,15 +2629,10 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   if (auto *derivativeId = c.getDerivativeFunctionIdentifier()) {
     auto originalFnTy =
         makeConstantInterfaceType(c.asAutoDiffOriginalFunction());
-    // Protocol witness derivatives cannot have a derivative generic signature,
-    // but class method derivatives can.
-    GenericSignature derivativeGenSig = nullptr;
-    if (isa<ClassDecl>(c.getAbstractFunctionDecl()->getInnermostTypeContext()))
-      derivativeGenSig = derivativeId->getDerivativeGenericSignature();
     auto *derivativeFnTy = originalFnTy->getAutoDiffDerivativeFunctionType(
         derivativeId->getParameterIndices(), derivativeId->getKind(),
         LookUpConformanceInModule(&M),
-        derivativeGenSig);
+        derivativeId->getDerivativeGenericSignature());
     return cast<AnyFunctionType>(derivativeFnTy->getCanonicalType());
   }
 

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -requirement-machine=off %s | %FileCheck %s
+
+// FIXME(rdar://84987079)
 
 // Test derivative function vtable entries for `@differentiable` class members:
 // - Methods.

--- a/test/AutoDiff/compiler_crashers_fixed/rdar84716758-differentiable-protocol-witness-missing-requirements.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar84716758-differentiable-protocol-witness-missing-requirements.swift
@@ -5,15 +5,14 @@ import _Differentiation
 public protocol Layer {
   associatedtype Input: Differentiable
   associatedtype Output: Differentiable
+  @differentiable(reverse)
   func callAsFunction(_ input: Input) -> Output
 }
 
 public class Function<Input: Differentiable, Output: Differentiable>: Layer {
-  public typealias Body = @differentiable(reverse) (Input) -> Output
+  @noDerivative public let body: @differentiable(reverse) (Input) -> Output
 
-  @noDerivative public let body: Body
-
-  public init(_ body: @escaping Body) {
+  public init(_ body: @escaping @differentiable(reverse) (Input) -> Output) {
     self.body = body
   }
 


### PR DESCRIPTION
Revert part of #39505 that led to a latent bug to unblock some build.

This patch disables test/AutoDiff/SILGen/vtable.swift as the workaround fails a case of differentiable generic method in a class. rdar://84987079 tracks the fix for that.