### PR TITLE
[Test] Make KVOKeyPaths.swift work with un-nested Optionals.

### DIFF
--- a/test/stdlib/KVOKeyPaths.swift
+++ b/test/stdlib/KVOKeyPaths.swift
@@ -215,6 +215,6 @@ testObjectForOptionalKeyPath.optionalObject = nil
 testObjectForOptionalKeyPath.optionalObject = "foo"
 
 // CHECK-51-LABEL: observe keyPath with optional value
-// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
-// CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(nil)
+// CHECK-51-NEXT: oldValue = Optional(nil), newValue = {{Optional\(nil\)|nil}}
+// CHECK-51-NEXT: oldValue = Optional(nil), newValue = {{Optional\(nil\)|nil}}
 // CHECK-51-NEXT: oldValue = Optional(nil), newValue = Optional(Optional("foo"))


### PR DESCRIPTION
Older runtimes will un-nest nil Optionals when casting, which broke this test when running against older runtimes.

rdar://84992292