### PR TITLE
[Test] Only run objc-getClass.cpp against freshly built runtimes.

### DIFF
--- a/test/Demangle/objc-getclass.cpp
+++ b/test/Demangle/objc-getclass.cpp
@@ -6,6 +6,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 #include <objc/runtime.h>
 #include <dlfcn.h>
 #include <stdio.h>


### PR DESCRIPTION
This tests fixes that aren't available on older runtimes used for back deployment testing.

rdar://84995894