### PR TITLE
libswift: don't use the internal C++ namespace

### DIFF
--- a/libswift/Sources/SIL/BasicBlock.swift
+++ b/libswift/Sources/SIL/BasicBlock.swift
@@ -19,7 +19,8 @@ final public class BasicBlock : ListNode, CustomStringConvertible {
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    SILBasicBlock_debugDescription(bridged).string
+    var s = SILBasicBlock_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
 
   public var arguments: ArgumentArray { ArgumentArray(block: self) }

--- a/libswift/Sources/SIL/Function.swift
+++ b/libswift/Sources/SIL/Function.swift
@@ -18,7 +18,8 @@ final public class Function : CustomStringConvertible {
   }
 
   final public var description: String {
-    return SILFunction_debugDescription(bridged).string
+    var s = SILFunction_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
 
   public var entryBlock: BasicBlock {

--- a/libswift/Sources/SIL/GlobalVariable.swift
+++ b/libswift/Sources/SIL/GlobalVariable.swift
@@ -18,7 +18,8 @@ final public class GlobalVariable : CustomStringConvertible {
   }
 
   public var description: String {
-    return SILGlobalVariable_debugDescription(bridged).string
+    var s = SILGlobalVariable_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
 
   // TODO: initializer instructions

--- a/libswift/Sources/SIL/Instruction.swift
+++ b/libswift/Sources/SIL/Instruction.swift
@@ -30,7 +30,8 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   }
 
   final public var description: String {
-    SILNode_debugDescription(bridgedNode).string
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
   
   final public var operands: OperandArray {
@@ -123,7 +124,8 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    SILNode_debugDescription(bridgedNode).string
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
 
   public var instruction: Instruction {

--- a/libswift/Sources/SIL/Utils.swift
+++ b/libswift/Sources/SIL/Utils.swift
@@ -81,30 +81,6 @@ extension BridgedStringRef {
   }
 }
 
-#if os(Linux)
-
-extension std.__cxx11.string {
-  public var string: String {
-    // TODO: remove this once a new version of Swift is released (and call
-    // c_str() directly).
-    let mutableSelf = self
-    return String(cString: mutableSelf.c_str())
-  }
-}
-
-#else
-
-extension std.__1.string {
-  public var string: String {
-    // TODO: remove this once a new version of Swift is released (and call
-    // c_str() directly).
-    var mutableSelf = self
-    return String(cString: mutableSelf.c_str())
-  }
-}
-
-#endif
-
 extension String {
   public func withBridgedStringRef<T>(_ c: (BridgedStringRef) -> T) -> T {
     var str = self

--- a/libswift/Sources/SIL/Value.swift
+++ b/libswift/Sources/SIL/Value.swift
@@ -20,7 +20,8 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
 extension Value {
   public var description: String {
-    SILNode_debugDescription(bridgedNode).string
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
 
   public var uses: UseList {


### PR DESCRIPTION
Because this can be different in various C++ libraries.

Fixes a build problem on Ubuntu 20.04
