### PR TITLE
Fix a crash when diagnosing a missing "await" in a cross-actor call.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4490,6 +4490,10 @@ NOTE(actor_isolated_sync_func,none,
      "calls to %0 %1 from outside of its actor context are "
      "implicitly asynchronous",
      (DescriptiveDeclKind, DeclName))
+NOTE(actor_isolated_sync_func_value,none,
+     "calls function of type %0 from outside of its actor context are "
+     "implicitly asynchronous",
+     (Type))
 NOTE(note_distributed_actor_isolated_method,none,
      "distributed actor-isolated %0 %1 declared here",
      (DescriptiveDeclKind, DeclName))

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2862,8 +2862,14 @@ private:
            // Emit a tailored note if the call is implicitly async, meaning the
            // callee is isolated to an actor.
            auto callee = call->getCalledValue();
-           Ctx.Diags.diagnose(diag.expr.getStartLoc(), diag::actor_isolated_sync_func,
-                              callee->getDescriptiveKind(), callee->getName());
+           if (callee) {
+             Ctx.Diags.diagnose(diag.expr.getStartLoc(), diag::actor_isolated_sync_func,
+                                callee->getDescriptiveKind(), callee->getName());
+           } else {
+             Ctx.Diags.diagnose(
+                 diag.expr.getStartLoc(), diag::actor_isolated_sync_func_value,
+                 call->getFn()->getType());
+           }
          } else {
            Ctx.Diags.diagnose(diag.expr.getStartLoc(),
                               diag::async_access_without_await, 0);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -470,6 +470,12 @@ extension MyActor {
   }
 }
 
+func testBadImplicitGlobalActorClosureCall() async {
+  { @MainActor in  }() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-1{{calls function of type '@MainActor () -> ()' from outside of its actor context are implicitly asynchronous}}
+}
+
+
 @available(SwiftStdlib 5.1, *)
 struct GenericStruct<T> {
   @GenericGlobalActor<T> func f() { } // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}


### PR DESCRIPTION
We were assuming that the callee of a cross-actor call was always a
declaration, but it could also be a global-actor-qualified function.
Customize the diagnostic appropriately.

Fixes rdar://82545044.
