### PR TITLE
Make sure we propagate 'async' down to inherited designed initializes.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -662,6 +662,9 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
 
   Expr *expr = superclassCallExpr;
 
+  if (superclassCtor->hasAsync()) {
+    expr = new (ctx) AwaitExpr(SourceLoc(), expr, type, /*implicit=*/true);
+  }
   if (superclassCtor->hasThrows()) {
     expr = new (ctx) TryExpr(SourceLoc(), expr, type, /*implicit=*/true);
   }
@@ -777,7 +780,8 @@ createDesignatedInitOverride(ClassDecl *classDecl,
                               classDecl->getBraces().Start,
                               superclassCtor->isFailable(),
                               /*FailabilityLoc=*/SourceLoc(),
-                              /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+                              /*Async=*/superclassCtor->hasAsync(),
+                              /*AsyncLoc=*/SourceLoc(),
                               /*Throws=*/superclassCtor->hasThrows(),
                               /*ThrowsLoc=*/SourceLoc(),
                               bodyParams, overrideInfo.GenericParams,

--- a/validation-test/compiler_crashers_2_fixed/0211-rdar80353441.swift
+++ b/validation-test/compiler_crashers_2_fixed/0211-rdar80353441.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+// Properly make inherited initializers 'async' when needed.
+@available(SwiftStdlib 5.5, *)
+class Base {
+  required init() async { }
+}
+
+@available(SwiftStdlib 5.5, *)
+class Derived: Base { }
+
+
+@available(SwiftStdlib 5.5, *)
+class Base2 {
+  required init() async throws { }
+}
+
+@available(SwiftStdlib 5.5, *)
+class Derived2: Base2 { }
+


### PR DESCRIPTION
Fixes a crash reported via rdar://80353441.
