### PR TITLE
Make isolated parameter checking work with existential values.

### DIFF
--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -131,3 +131,16 @@ func testIsolatedClosureInference(a: A) {
     a2.f()
   }
 }
+
+// "isolated" existential parameters.
+protocol P2: Actor {
+  func m()
+}
+
+@available(SwiftStdlib 5.1, *)
+func testExistentialIsolated(a: isolated P2, b: P2) async {
+  a.m()
+  await b.m()
+  b.m() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  // expected-note@-1{{calls to instance method 'm()' from outside of its actor context are implicitly asynchronous}}
+}

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -18,9 +18,9 @@ protocol DistProtocol: DistributedActor {
   // FIXME(distributed): avoid issuing these warnings, these originate from the call on the DistProtocol where we marked this func as dist isolated,
   func local() -> String
   // (the note appears a few times, because we misuse the call many times)
-  // expected-note@-2{{calls to instance method 'local()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-3{{calls to instance method 'local()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-4{{calls to instance method 'local()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{distributed actor-isolated instance method 'local()' declared here}}
+  // expected-note@-3{{distributed actor-isolated instance method 'local()' declared here}}
+  // expected-note@-4{{distributed actor-isolated instance method 'local()' declared here}}
 
   distributed func dist() -> String
   distributed func dist(string: String) -> String


### PR DESCRIPTION
We needed to look through opaque value expressions.
Fixes rdar://84581926.
