### PR TITLE
[CursorInfo] Add a synthesized field

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_synthesized.swift
+++ b/test/SourceKit/CursorInfo/cursor_synthesized.swift
@@ -1,0 +1,33 @@
+struct Synthesized: Hashable {
+  let a: Int
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):10 %s -- %s -target %target-triple | %FileCheck -check-prefix=INT %s
+  // INT: Int
+  // INT-NEXT: s:Si
+  // INT-NOT: SYNTHESIZED
+}
+
+func synthesized(hasher: inout Hasher) {
+  let s = Synthesized(a: 1)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):11 %s -- %s -target %target-triple | %FileCheck -check-prefix=INIT %s
+  // INIT: Synthesized
+  // INIT-NEXT: s:18cursor_synthesized11SynthesizedV
+  // INIT-NOT: SYNTHESIZED
+  // INIT: SECONDARY SYMBOLS BEGIN
+  // INIT: init(a:)
+  // INIT-NEXT: s:18cursor_synthesized11SynthesizedV1aACSi_tcfc
+  // INIT: SYNTHESIZED
+  // INIT: -----
+  // INIT: SECONDARY SYMBOLS END
+
+  _ = s.hashValue
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):9 %s -- %s -target %target-triple | %FileCheck -check-prefix=HASH_VALUE %s
+  // HASH_VALUE: hashValue
+  // HASH_VALUE-NEXT: s:18cursor_synthesized11SynthesizedV9hashValueSivp
+  // HASH_VALUE: SYNTHESIZED
+
+  _ = s.hash(into: &hasher)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line-1):9 %s -- %s -target %target-triple | %FileCheck -check-prefix=HASH %s
+  // HASH: hash(into:)
+  // HASH-NEXT: s:18cursor_synthesized11SynthesizedV4hash4intoys6HasherVz_tF
+  // HASH: SYNTHESIZED
+}

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -486,6 +486,7 @@ struct CursorSymbolInfo {
 
   bool IsSystem = false;
   bool IsDynamic = false;
+  bool IsSynthesized = false;
 
   llvm::Optional<unsigned> ParentNameOffset;
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1114,6 +1114,8 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
 
   Symbol.IsSystem = DInfo.VD->getModuleContext()->isSystemModule();
   Symbol.IsDynamic = DInfo.IsDynamic;
+  Symbol.IsSynthesized = DInfo.VD->isImplicit();
+
   Symbol.ParentNameOffset = getParamParentNameOffset(DInfo.VD, CursorLoc);
 
   return llvm::Error::success();

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1711,6 +1711,7 @@ struct ResponseSymbolInfo {
   std::vector<const char *> ReceiverUSRs;
   bool IsSystem = false;
   bool IsDynamic = false;
+  bool IsSynthesized = false;
   unsigned ParentOffset = 0;
 
   static ResponseSymbolInfo read(sourcekitd_variant_t Info) {
@@ -1802,6 +1803,8 @@ struct ResponseSymbolInfo {
     Symbol.IsSystem = sourcekitd_variant_dictionary_get_bool(Info, KeyIsSystem);
     Symbol.IsDynamic =
         sourcekitd_variant_dictionary_get_bool(Info, KeyIsDynamic);
+    Symbol.IsSynthesized =
+        sourcekitd_variant_dictionary_get_bool(Info, KeyIsSynthesized);
 
     Symbol.ParentOffset =
         sourcekitd_variant_dictionary_get_int64(Info, KeyParentLoc);
@@ -1864,6 +1867,8 @@ struct ResponseSymbolInfo {
     }
     if (IsDynamic)
       OS << "DYNAMIC\n";
+    if (IsSynthesized)
+      OS << "SYNTHESIZED\n";
     if (ParentOffset) {
       OS << "PARENT OFFSET: " << ParentOffset << "\n";
     }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1910,6 +1910,8 @@ static void addCursorSymbolInfo(const CursorSymbolInfo &Symbol,
     Elem.setBool(KeyIsSystem, true);
   if (Symbol.IsDynamic)
     Elem.setBool(KeyIsDynamic, true);
+  if (Symbol.IsSynthesized)
+    Elem.setBool(KeyIsSynthesized, true);
 
   if (Symbol.ParentNameOffset)
     Elem.set(KeyParentLoc, Symbol.ParentNameOffset.getValue());

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -202,6 +202,7 @@ UID_KEYS = [
     # Before executing the actual request wait x ms. The request can be canceled
     # in this time. For cancellation testing purposes.
     KEY('SimulateLongRequest', 'key.simulate_long_request'),
+    KEY('IsSynthesized', 'key.is_synthesized'),
 ]
 
 


### PR DESCRIPTION
Mark implicit declarations with a `synthesized` field, since while we
still want them to have a cursor info result (eg. for their USR to find
possible overrides), it's likely that clients will want to treat them
differently to results that have a real location in source.

An alternative could be to remove the location entirely, but:
  - the module name would also have to be removed to prevent wasted
    lookups in the generated interface
  - having the location could still be useful as the location that
    caused the synthesized declaration (though at the moment only
    synthesized initializers have a location)

Resolves rdar://84990655