### PR TITLE
IRGen: use the accessor conformance on Windows

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -926,6 +926,12 @@ static bool isDependentConformance(
   if (!conformance)
     return false;
 
+  if (IGM.getOptions().LazyInitializeProtocolConformances) {
+    const auto *MD = rootConformance->getDeclContext()->getParentModule();
+    if (!(MD == IGM.getSwiftModule() || MD->isStaticLibrary()))
+      return true;
+  }
+
   // Check whether we've visited this conformance already.  If so,
   // optimistically assume it's fine --- we want the maximal fixed point.
   if (!visited.insert(conformance).second)

--- a/test/IRGen/conformance_resilience.swift
+++ b/test/IRGen/conformance_resilience.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
+// RUN: %target-swift-frontend -emit-module -static -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../Inputs/resilient_protocol.swift
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution %s | %FileCheck %s -DINT=i%target-ptrsize
 // RUN: %target-swift-frontend -I %t -emit-ir -enable-library-evolution -O %s
 

--- a/test/IRGen/lazy-root-conformance.swift
+++ b/test/IRGen/lazy-root-conformance.swift
@@ -21,5 +21,5 @@ extension E : Q {
 #endif
 
 // CHECK-DIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* bitcast (i8** @"$s1A1EOAA1PAAWP" to i8*)]
-// CHECK-INDIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* null]
+// CHECK-INDIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast ({{.*}}* @"$s1A1EO1B1QADMc" to i8*), i8* null]
 

--- a/test/IRGen/opaque_result_type_metadata_peephole.swift
+++ b/test/IRGen/opaque_result_type_metadata_peephole.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -enable-library-evolution -emit-module-path %t/opaque_result_type_metadata_external.swiftmodule %S/Inputs/opaque_result_type_metadata_external.swift
+// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -static -enable-library-evolution -emit-module-path %t/opaque_result_type_metadata_external.swiftmodule %S/Inputs/opaque_result_type_metadata_external.swift
 // RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=DEFAULT
 // RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-ir -I %t %s -enable-implicit-dynamic | %FileCheck %s --check-prefix=CHECK --check-prefix=IMPLICIT-DYNAMIC
 

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
+// RUN: %target-swift-frontend -emit-module -static -o %t %S/sil_witness_tables_external_conformance.swift
 // RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
+// RUN: %target-swift-frontend -emit-module -static %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
 // RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
 
 import Swift

--- a/test/IRGen/windows-lazy-initialize-conformance.swift
+++ b/test/IRGen/windows-lazy-initialize-conformance.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -S -emit-ir %s -o - | %FileCheck %s
+// REQUIRES: OS=windows-msvc
+
+class C {
+  static func encode(_ c: Encodable) throws {}
+}
+
+public protocol P: Codable {}
+
+extension String: P {}
+
+public enum E {
+  case associated(P)
+}
+
+extension E: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case .associated(let p):
+      try p.encode(to: encoder)
+    }
+  }
+}
+
+try? print(C.encode(E.associated("string")))
+
+// CHECK-NOT: store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$sSS4main1PAAWP", i32 0, i32 0), i8***

--- a/test/IRGen/windows-linking.swift
+++ b/test/IRGen/windows-linking.swift
@@ -56,7 +56,7 @@ struct Entry {
 // through the IAT.
 
 // CHECK-SHARED:       @"$s6module1EO4main1QADWP" = hidden constant [2 x i8*] [
-// CHECK-SHARED-SAME:      i8* bitcast (%swift.protocol_conformance_descriptor* @"$s6module1EO4main1QADMc" to i8*),
+// CHECK-SHARED-SAME:      i8* bitcast ({ i32, i32, i32, i32, i16, i16, i32, i32 }* @"$s6module1EO4main1QADMc" to i8*),
 // CHECK-SHARED-SAME:      i8* null
 // CHECK-SHARED-SAME:  ]
 


### PR DESCRIPTION
When building with lazy initialization of the root conformance, we need
to ensure that we are invoking the accessor to initialize the
conformance record.  We would previously generate a direct reference to
the conformance, which was uninitialized, resulting in a crash at
runtime.

The non-windows test changes here are to use/imply static linking for
the support modules.  This should have no difference on the non-Windows
targets, but makes a difference on Windows where this implies that
everything will be built into a single module, which permits the
non-indirect access to types.  Unfortunately, this does somewhat regress
the test coverage on Windows as we do not exercise as much of the shared
linkage paths which do change some of the code-generation to deal with
the moral equivalent of the GOT - the IAT.

Special thanks to @slavapestov for the pointer to
`isDependentConformance`.  This should eliminate the last known issue
with cross-module protocol conformances.

Fixes: SR-14807

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
