### PR TITLE
libswift: fixes and improvements for the bootstrapping build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,9 @@ cmake_dependent_option(LIBSWIFT_BUILD_MODE "How to build libswift. Possible valu
     HOSTTOOLS:     libswift is built with a pre-installed toolchain
     BOOTSTRAPPING: libswift is built with a 2-stage bootstrapping process
     BOOTSTRAPPING-WITH-HOSTLIBS:   libswift is built with a 2-stage bootstrapping process,
-                   but the compiler links against the host system swift libs (macOS only)"
+                   but the compiler links against the host system swift libs (macOS only)
+    CROSSCOMPILE-WITH-HOSTLIBS:    libswift is built with a bootstrapping-with-hostlibs compiled
+                                   compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`"
   OFF "NOT CMAKE_GENERATOR STREQUAL \"Xcode\"" OFF)
 
 # The following only works with the Ninja generator in CMake >= 3.0.
@@ -612,15 +614,19 @@ set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
   set(SWIFT_EXEC_FOR_LIBSWIFT "${CMAKE_Swift_COMPILER}")
-elseif(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING" OR LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+elseif(LIBSWIFT_BUILD_MODE MATCHES "BOOTSTRAPPING.*")
   # If cross-compiling we don't have to bootstrap. We can just use the previously
   # built native swiftc to build libswift.
-  message(STATUS "Building libswift with native host tools instead of bootstrapping")
-  set(LIBSWIFT_BUILD_MODE "HOSTTOOLS")
+  message(STATUS "Building libswift with previously built tools instead of bootstrapping")
   set(SWIFT_EXEC_FOR_LIBSWIFT "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
+  if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+    set(LIBSWIFT_BUILD_MODE "CROSSCOMPILE-WITH-HOSTLIBS")
+  else()
+    set(LIBSWIFT_BUILD_MODE "HOSTTOOLS")
+  endif()
 endif()
 
-if(LIBSWIFT_BUILD_MODE STREQUAL "HOSTTOOLS" OR LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+if(LIBSWIFT_BUILD_MODE MATCHES "HOSTTOOLS|.*-WITH-HOSTLIBS")
   if(SWIFT_ENABLE_ARRAY_COW_CHECKS)
     message(STATUS "array COW checks disabled when building libswift with host libraries")
     set(SWIFT_ENABLE_ARRAY_COW_CHECKS FALSE)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -747,6 +747,13 @@ function(add_libswift name)
     set(deployment_version "10.15") # TODO: once #38675 lands, replace this with
 #   set(deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
     set(sdk_option "-sdk" "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
+    if(${LIBSWIFT_BUILD_MODE} STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
+      # Let the cross-compiled compile don't pick up the compiled stdlib by providing
+      # an (almost) empty resource dir.
+      # The compiler will instead pick up the stdlib from the SDK.
+      get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
+      set(sdk_option ${sdk_option} "-resource-dir" "${swift_exec_bin_dir}/../bootstrapping0/lib/swift")
+    endif()
   endif()
   get_versioned_target_triple(target ${SWIFT_HOST_VARIANT_SDK}
       ${SWIFT_HOST_VARIANT_ARCH} "${deployment_version}")
@@ -878,6 +885,7 @@ function(add_swift_host_tool executable)
     # Please add each rpath separately below to the list, explaining why you are
     # adding it.
     set(RPATH_LIST)
+    set(sdk_dir "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift")
 
     # If we found a swift compiler and are going to use swift code in swift
     # host side tools but link with clang, add the appropriate -L paths so we
@@ -890,9 +898,24 @@ function(add_swift_host_tool executable)
         get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/macosx" ABSOLUTE)
         target_link_directories(${executable} PUBLIC ${TOOLCHAIN_LIB_DIR})
 
-        # Add in the SDK directory for the host platform.
-        target_link_directories(${executable} PRIVATE
-          ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift)
+        # Add the SDK directory for the host platform.
+        target_link_directories(${executable} PRIVATE "${sdk_dir}")
+
+        # Include the abi stable system stdlib in our rpath.
+        list(APPEND RPATH_LIST "/usr/lib/swift")
+
+      elseif(LIBSWIFT_BUILD_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
+
+        # Intentinally don't add the lib dir of the cross-compiled compiler, so that
+        # the stdlib is not picked up from there, but from the SDK.
+        # This requires to explicitly add all the needed compatibility libraries. We
+        # can take them from the current build.
+        set(vsuffix "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+        set(conctarget "swiftCompatibilityConcurrency${vsuffix}")
+        target_link_libraries(${executable} PUBLIC ${conctarget})
+
+        # Add the SDK directory for the host platform.
+        target_link_directories(${executable} PRIVATE "${sdk_dir}")
 
         # Include the abi stable system stdlib in our rpath.
         list(APPEND RPATH_LIST "/usr/lib/swift")
@@ -901,9 +924,8 @@ function(add_swift_host_tool executable)
         # Pick up the built libswiftCompatibility<n>.a libraries
         _link_built_compatibility_libs(${executable})
 
-        # Add in the SDK directory for the host platform.
-        target_link_directories(${executable} PRIVATE
-          ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift)
+        # Add the SDK directory for the host platform.
+        target_link_directories(${executable} PRIVATE "${sdk_dir}")
 
         # Include the abi stable system stdlib in our rpath.
         list(APPEND RPATH_LIST "/usr/lib/swift")
@@ -949,8 +971,7 @@ function(add_swift_host_tool executable)
       # NOTE: We do this /after/ target_link_directorying TOOLCHAIN_LIB_DIR to
       # ensure that we first find libraries from the toolchain, rather than from
       # the SDK.
-      target_link_directories(${executable} PRIVATE
-        ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift)
+      target_link_directories(${executable} PRIVATE "${sdk_dir}")
 
       # We also want to be able to find libraries from the base toolchain
       # directory. This is so swiftc can rely on its own host side dylibs that may

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -112,8 +112,7 @@ function(get_bootstrapping_swift_lib_dir bs_lib_dir bootstrapping)
 endfunction()
 
 function(add_bootstrapping_target bootstrapping)
-  if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
-     ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+  if(${LIBSWIFT_BUILD_MODE} MATCHES "BOOTSTRAPPING.*")
 
     set(target "bootstrapping${bootstrapping}-all")
     add_custom_target(${target})

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -117,6 +117,12 @@ function(add_bootstrapping_target bootstrapping)
     set(target "bootstrapping${bootstrapping}-all")
     add_custom_target(${target})
 
+    if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING")
+      set(lib_target "bootstrapping${bootstrapping}-corelib")
+      add_custom_target(${lib_target})
+      add_dependencies(${target} ${lib_target})
+    endif()
+
     if(SWIFT_PATH_TO_LIBICU_BUILD)
       # Need to symlink the libicu libraries to be able to run
       # the bootstrapping compiler with a custom library path.

--- a/libswift/CMakeLists.txt
+++ b/libswift/CMakeLists.txt
@@ -20,17 +20,16 @@ else()
 
   add_subdirectory(Sources)
 
-  if(${LIBSWIFT_BUILD_MODE} STREQUAL "HOSTTOOLS")
+  if(${LIBSWIFT_BUILD_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE-WITH-HOSTLIBS")
 
-    if (NOT CMAKE_Swift_COMPILER)
+    if (NOT SWIFT_EXEC_FOR_LIBSWIFT)
       message(FATAL_ERROR "Need a swift toolchain for building libswift")
     endif()
 
     add_libswift("libswift"
       SWIFT_EXEC "${SWIFT_EXEC_FOR_LIBSWIFT}")
 
-  elseif(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
-         ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+  elseif(${LIBSWIFT_BUILD_MODE} MATCHES "BOOTSTRAPPING.*")
 
     # Bootstrapping - stage 1, using the compiler from level 0
 
@@ -45,6 +44,12 @@ else()
         SWIFT_EXEC "${CMAKE_BINARY_DIR}/bootstrapping1/bin/swiftc"
         DEPENDS "bootstrapping1-all")
 
+    if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+      if(EXISTS "${CMAKE_BINARY_DIR}/bootstrapping0/lib/swift/macos/Swift.swiftmodule" OR
+         EXISTS "${CMAKE_BINARY_DIR}/bootstrapping1/lib/swift/macos/Swift.swiftmodule")
+        messsage(FATAL_ERROR "Please clean the ${CMAKE_BINARY_DIR}/bootstrapping[01] directories")
+      endif()
+    endif()
   else()
     message(FATAL_ERROR "Unknown LIBSWIFT_BUILD_MODE '${LIBSWIFT_BUILD_MODE}'")
   endif()

--- a/libswift/README.md
+++ b/libswift/README.md
@@ -42,13 +42,13 @@ With the compiler from step 1, a minimal subset of the standard library is built
 
 This library will be less optimized than the final library build.
 
-In case the build mode is `bootstrapping-with-hostlibs`, only the swiftmodule files of the library are built, but not the binaries. The binaries are not needed because the compiler (and `sil-opt`) link against the system swift libraries.
+This step is skipped when the build mode is `bootstrapping-with-hostlibs`.
 
 #### 3. The level-1 _libswift_
 
 The build outputs of level-1 are stored in the `bootstrapping1` directory under the main build directory.
 
-The _libswift_ library is built using the level-0 compiler and standard library from step 1. and 2.
+The _libswift_ library is built using the level-0 compiler and standard library from step 2 - or the OS libraries in case of `bootstrapping-with-hostlibs`.
 
 #### 4. The level-1 compiler
 
@@ -60,11 +60,13 @@ Unless the build mode is `bootstrapping-with-hostlibs`, the level-1 compiler dyn
 
 Like in step 2, a minimal subset of the standard library is built, using the level-1 compiler from step 4.
 
-Unless the build mode is `bootstrapping-with-hostlibs`, in this step, the build system redirects the compiler's dynamic library path to the level-0 library (by setting `DY/LD_LIBRARY_PATH` in  `SwiftSource.cmake`:`_compile_swift_files`). This is needed because the level-1 libraries are not built, yet.
+In this step, the build system redirects the compiler's dynamic library path to the level-0 library (by setting `DY/LD_LIBRARY_PATH` in  `SwiftSource.cmake`:`_compile_swift_files`). This is needed because the level-1 libraries are not built, yet.
+
+This step is skipped when the build mode is `bootstrapping-with-hostlibs`.
 
 #### 6. The final _libswift_
 
-The final _libswift_ is built with the level-1 compiler and standard library from step 4. and 5.
+The final _libswift_ is built with the level-1 compiler and standard library from step 5 - or the OS libraries in case of `bootstrapping-with-hostlibs`.
 
 #### 7. The final compiler
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -675,8 +675,7 @@ function(add_swift_target_library_single target name)
         MACCATALYST_BUILD_FLAVOR
         BACK_DEPLOYMENT_LIBRARY
         ENABLE_LTO
-        BOOTSTRAPPING
-        MODULE_DEPENDENCY_TARGET)  
+        BOOTSTRAPPING)
   set(SWIFTLIB_SINGLE_multiple_parameter_options
         C_COMPILE_FLAGS
         DEPENDS
@@ -864,10 +863,6 @@ function(add_swift_target_library_single target name)
       MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
       ${BOOTSTRAPPING_arg})
   add_swift_source_group("${SWIFTLIB_SINGLE_EXTERNAL_SOURCES}")
-
-  if(SWIFTLIB_SINGLE_MODULE_DEPENDENCY_TARGET)
-    set(${SWIFTLIB_SINGLE_MODULE_DEPENDENCY_TARGET} ${swift_module_dependency_target} PARENT_SCOPE)
-  endif()
 
   # If there were any swift sources, then a .swiftmodule may have been created.
   # If that is the case, then add a target which is an alias of the module files.

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -55,10 +55,12 @@ if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" AND
 
   add_swift_target_library_single(swiftDarwin-bootstrapping0 swiftDarwin
       ${swiftDarwin_common_bootstrapping_options}
+      FILE_DEPENDS bootstrapping0-corelib
       BOOTSTRAPPING 0)
 
   add_swift_target_library_single(swiftDarwin-bootstrapping1 swiftDarwin
       ${swiftDarwin_common_bootstrapping_options}
+      FILE_DEPENDS bootstrapping1-corelib
       BOOTSTRAPPING 1)
 
   add_dependencies(bootstrapping1-all swiftDarwin-bootstrapping1)

--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -24,17 +24,19 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTST
 
   add_swift_target_library_single(swiftSwiftOnoneSupport-bootstrapping0 swiftSwiftOnoneSupport
     ${swiftOnoneSupport_common_bootstrapping_options}
+    FILE_DEPENDS swiftCore-bootstrapping0
     BOOTSTRAPPING 0)
 
-  add_dependencies(bootstrapping0-all swiftSwiftOnoneSupport-bootstrapping0)
+  add_dependencies(bootstrapping0-corelib swiftSwiftOnoneSupport-bootstrapping0)
 
   # Bootstrapping - stage 1
 
   add_swift_target_library_single(swiftSwiftOnoneSupport-bootstrapping1 swiftSwiftOnoneSupport
     ${swiftOnoneSupport_common_bootstrapping_options}
+    FILE_DEPENDS swiftCore-bootstrapping1
     BOOTSTRAPPING 1)
 
-  add_dependencies(bootstrapping1-all swiftSwiftOnoneSupport-bootstrapping1)
+  add_dependencies(bootstrapping1-corelib swiftSwiftOnoneSupport-bootstrapping1)
 
 endif()
 

--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -10,10 +10,7 @@ set(swiftOnoneSupport_common_options
   SWIFT_COMPILE_FLAGS "-parse-stdlib" "-Xllvm" "-sil-inline-generics=false" "-Xfrontend" "-validate-tbd-against-ir=none" "-Xfrontend" "-check-onone-completeness" "-Xfrontend" "-disable-access-control" "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND
-   (${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
-    ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS"))
-    
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING")
 
   set(swiftOnoneSupport_common_bootstrapping_options
     SHARED
@@ -27,27 +24,17 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND
 
   add_swift_target_library_single(swiftSwiftOnoneSupport-bootstrapping0 swiftSwiftOnoneSupport
     ${swiftOnoneSupport_common_bootstrapping_options}
-    MODULE_DEPENDENCY_TARGET swiftOnoneSupport_module_bootstrapping0
     BOOTSTRAPPING 0)
 
-  if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
-    add_dependencies(bootstrapping0-all ${swiftOnoneSupport_module_bootstrapping0})
-  else()
-    add_dependencies(bootstrapping0-all swiftSwiftOnoneSupport-bootstrapping0)
-  endif()
+  add_dependencies(bootstrapping0-all swiftSwiftOnoneSupport-bootstrapping0)
 
   # Bootstrapping - stage 1
 
   add_swift_target_library_single(swiftSwiftOnoneSupport-bootstrapping1 swiftSwiftOnoneSupport
     ${swiftOnoneSupport_common_bootstrapping_options}
-    MODULE_DEPENDENCY_TARGET swiftOnoneSupport_module_bootstrapping1
     BOOTSTRAPPING 1)
 
-  if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
-    add_dependencies(bootstrapping1-all ${swiftOnoneSupport_module_bootstrapping1})
-  else()
-    add_dependencies(bootstrapping1-all swiftSwiftOnoneSupport-bootstrapping1)
-  endif()
+  add_dependencies(bootstrapping1-all swiftSwiftOnoneSupport-bootstrapping1)
 
 endif()
 

--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -156,27 +156,30 @@ if(NOT SWIFT_BUILT_STANDALONE)
   endforeach()
 endif()
 
-foreach(bootstrapping "0" "1")
-  get_bootstrapping_path(outdir ${SWIFTLIB_DIR} ${bootstrapping})
-  set(target_name "symlink-headers-bootstrapping${bootstrapping}")
+if(${LIBSWIFT_BUILD_MODE} MATCHES "BOOTSTRAPPING.*")
+  foreach(bootstrapping "0" "1")
+    get_bootstrapping_path(outdir ${SWIFTLIB_DIR} ${bootstrapping})
+    set(target_name "symlink-headers-bootstrapping${bootstrapping}")
 
-  add_custom_command_target(unused_var
-      COMMAND
-        "${CMAKE_COMMAND}" "-E" "make_directory" "${outdir}"
-      COMMAND
-        "${CMAKE_COMMAND}" "-E" ${cmake_symlink_option}
-        ${output_dir} "${outdir}/shims"
-      COMMAND
-        "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
-        "${clang_headers_location}"
-        "${outdir}/clang"
+    add_custom_command_target(unused_var
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "make_directory" "${outdir}"
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" ${cmake_symlink_option}
+          ${output_dir} "${outdir}/shims"
+        COMMAND
+          "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
+          "${clang_headers_location}"
+          "${outdir}/clang"
 
-      CUSTOM_TARGET_NAME ${target_name}
-      OUTPUT "${outdir}/shims" "${outdir}/clang"
-      COMMENT "Symlinking headers for bootstrapping0")
+        CUSTOM_TARGET_NAME ${target_name}
+        OUTPUT "${outdir}/shims" "${outdir}/clang"
+        COMMENT "Symlinking headers for bootstrapping0")
 
-  add_dependencies(${target_name} copy_shim_headers)
-endforeach()
+    add_dependencies(${target_name} copy_shim_headers)
+    add_dependencies(bootstrapping${bootstrapping}-all ${target_name})
+  endforeach()
+endif()
 
 swift_install_in_component(FILES ${sources}
                            DESTINATION "lib/swift/shims"

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -368,8 +368,8 @@ if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING")
                       symlink-headers-bootstrapping1 ${swiftCore_common_dependencies}
                     BOOTSTRAPPING 1)
 
-  add_dependencies(bootstrapping1-all swiftCore-bootstrapping1)
-  add_dependencies(bootstrapping0-all swiftCore-bootstrapping0)
+  add_dependencies(bootstrapping1-corelib swiftCore-bootstrapping1)
+  add_dependencies(bootstrapping0-corelib swiftCore-bootstrapping0)
 endif()
 
 add_swift_target_library(swiftCore

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -337,8 +337,7 @@ set(swiftCore_common_options
 set(swiftCore_common_dependencies
     copy_shim_headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE})
 
-if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
-   ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING")
 
   list(FIND SWIFT_STDLIB_LIBRARY_BUILD_TYPES "SHARED" index_of_shared)
   if(index_of_shared EQUAL -1)
@@ -359,7 +358,6 @@ if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
                     ${swiftCore_common_bootstrapping_options}
                     FILE_DEPENDS
                       symlink-headers-bootstrapping0 ${swiftCore_common_dependencies}
-                    MODULE_DEPENDENCY_TARGET swiftCore_module_bootstrapping0
                     BOOTSTRAPPING 0)
 
   # Bootstrapping - stage 1
@@ -368,18 +366,10 @@ if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
                     ${swiftCore_common_bootstrapping_options}
                     FILE_DEPENDS
                       symlink-headers-bootstrapping1 ${swiftCore_common_dependencies}
-                    MODULE_DEPENDENCY_TARGET swiftCore_module_bootstrapping1
                     BOOTSTRAPPING 1)
 
-  if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
-    # When linking swift-frontend against the system swift libraries, it's
-    # sufficient to create the swiftmodule files for bootstrapping.
-    add_dependencies(bootstrapping0-all ${swiftCore_module_bootstrapping0})
-    add_dependencies(bootstrapping1-all ${swiftCore_module_bootstrapping1})
-  else()
-    add_dependencies(bootstrapping1-all swiftCore-bootstrapping1)
-    add_dependencies(bootstrapping0-all swiftCore-bootstrapping0)
-  endif()
+  add_dependencies(bootstrapping1-all swiftCore-bootstrapping1)
+  add_dependencies(bootstrapping0-all swiftCore-bootstrapping0)
 endif()
 
 add_swift_target_library(swiftCore

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -1,7 +1,6 @@
 # The swift-frontend tool
 
-if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
-   ${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+if(${LIBSWIFT_BUILD_MODE} MATCHES "BOOTSTRAPPING.*")
 
   # Bootstrapping - level 0
   # For more information on how bootstrapping works, see libswift/README.md.
@@ -40,6 +39,8 @@ if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING" OR
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/bin")
 
+  add_dependencies(bootstrapping0-all swift-frontend-bootstrapping0)
+  add_dependencies(bootstrapping1-all swift-frontend-bootstrapping1)
 endif()
 
 add_swift_host_tool(swift-frontend


### PR DESCRIPTION
* fix some missing dependencies in the bootstrapping build mode
* improve the bootstrapping-with-hostlibs build mode: this reduces the build time overhead from 3min -> 30seconds.

For details see the commit messages