### PR TITLE
[NFC] Clean Up Unused Parameters in Unqualified Lookup

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -641,9 +641,7 @@ public:
   /// Look for members of a nominal type or extension scope.
   ///
   /// \return true if the lookup should be stopped at this point.
-  virtual bool
-  lookInMembers(DeclContext *const scopeDC,
-                NominalTypeDecl *const nominal) = 0;
+  virtual bool lookInMembers(const DeclContext *scopeDC) const = 0;
 
   /// Called for local VarDecls that might not yet be in scope.
   ///
@@ -680,8 +678,7 @@ public:
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   /// Eventually this functionality should move into ASTScopeLookup
-  bool lookInMembers(DeclContext *const,
-                     NominalTypeDecl *const) override {
+  bool lookInMembers(const DeclContext *) const override {
     return false;
   }
 

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -241,10 +241,9 @@ bool Portion::lookupMembersOf(const GenericTypeOrExtensionScope *,
 bool GenericTypeOrExtensionWhereOrBodyPortion::lookupMembersOf(
     const GenericTypeOrExtensionScope *scope,
     ASTScopeImpl::DeclConsumer consumer) const {
-  auto nt = scope->getCorrespondingNominalTypeDecl().getPtrOrNull();
-  if (!nt)
+  if (scope->getCorrespondingNominalTypeDecl().isNull())
     return false;
-  return consumer.lookInMembers(scope->getGenericContext(), nt);
+  return consumer.lookInMembers(scope->getGenericContext());
 }
 
 bool GenericTypeOrExtensionWherePortion::lookupMembersOf(

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -199,12 +199,20 @@ namespace {
   /// Used to gather lookup results
 class ASTScopeDeclConsumerForUnqualifiedLookup
     : public AbstractASTScopeDeclConsumer {
+private:
   UnqualifiedLookupFactory &factory;
 
   /// The 'self' parameter from the innermost scope containing the lookup
   /// location to be used when an instance member of a type is accessed,
-  /// or nullptr if instance members should not be 'self' qualified.
-  DeclContext *candidateSelfDC;
+  /// or \c nullptr if instance members should not be 'self' qualified.
+  ///
+  // FIXME: This field is currently reset to \c nullptr by `lookInMembers` as
+  // part of the lookup traversal of scopes. If, instead, consumers were
+  // created at each point in the traversal, this field would no longer need
+  // to be marked \c mutable.
+  mutable const DeclContext *candidateSelfDC;
+
+  void maybeUpdateSelfDC(VarDecl *var);
 
 public:
   ASTScopeDeclConsumerForUnqualifiedLookup(UnqualifiedLookupFactory &factory)
@@ -212,16 +220,12 @@ public:
 
   virtual ~ASTScopeDeclConsumerForUnqualifiedLookup() = default;
 
-  void maybeUpdateSelfDC(VarDecl *var);
-
   bool consume(ArrayRef<ValueDecl *> values,
                NullablePtr<DeclContext> baseDC = nullptr) override;
 
   bool consumePossiblyNotInScope(ArrayRef<VarDecl *> vars) override;
 
-  /// returns true if finished
-  bool lookInMembers(DeclContext *const scopeDC,
-                     NominalTypeDecl *const nominal) override;
+  bool lookInMembers(const DeclContext *) const override;
 
 #ifndef NDEBUG
   void startingNextLookupStep() override {
@@ -539,8 +543,7 @@ void UnqualifiedLookupFactory::lookInASTScopes() {
   ASTScope::unqualifiedLookup(DC->getParentSourceFile(), Loc, consumer);
 }
 
-void ASTScopeDeclConsumerForUnqualifiedLookup::maybeUpdateSelfDC(
-    VarDecl *var) {
+void ASTScopeDeclConsumerForUnqualifiedLookup::maybeUpdateSelfDC(VarDecl *var) {
   // We have a binding named 'self'.
   //
   // There are three possibilities:
@@ -649,8 +652,7 @@ bool ASTScopeDeclGatherer::consume(ArrayRef<ValueDecl *> valuesArg,
 
 // TODO: in future, migrate this functionality into ASTScopes
 bool ASTScopeDeclConsumerForUnqualifiedLookup::lookInMembers(
-    DeclContext *const scopeDC,
-    NominalTypeDecl *const nominal) {
+    const DeclContext *scopeDC) const {
   if (candidateSelfDC) {
     if (auto *afd = dyn_cast<AbstractFunctionDecl>(candidateSelfDC)) {
       assert(factory.isInsideBodyOfFunction(afd) && "Should be inside");
@@ -672,7 +674,7 @@ bool ASTScopeDeclConsumerForUnqualifiedLookup::lookInMembers(
   // We're done looking inside a nominal type declaration. It is possible
   // that this nominal type is nested inside of another type, in which case
   // we will visit the outer type next. Make sure to clear out the known
-  // 'self' parameeter context, since any members of the outer type are
+  // 'self' parameter context, since any members of the outer type are
   // not accessed via the innermost 'self' parameter.
   candidateSelfDC = nullptr;
 
@@ -820,8 +822,7 @@ public:
     return (!stopAfterInnermostBraceStmt && !results.empty());
   }
 
-  bool lookInMembers(DeclContext *const,
-                     NominalTypeDecl *const) override {
+  bool lookInMembers(const DeclContext *) const override {
     return true;
   }
 


### PR DESCRIPTION
* Drop some unused parameters
* const-qualify a consumption method that is logically const - though it
  isn't physically const given the mutating use in
  ASTScopeDeclConsumerForUnqualifiedLookup::lookInMembers
* Privatize some internal fields