### PR TITLE
Propagate actor isolation through dynamic replacement.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3344,6 +3344,13 @@ ActorIsolation ActorIsolationRequest::evaluate(
       return inferredIsolation(isolation);
   }
 
+  // If this is a dynamic replacement for another function, use the
+  // actor isolation of the function it replaces.
+  if (auto replacedDecl = value->getDynamicallyReplacedDecl()) {
+    if (auto isolation = getActorIsolation(replacedDecl))
+      return inferredIsolation(isolation);
+  }
+
   if (shouldInferAttributeInContext(value->getDeclContext())) {
     // If the declaration witnesses a protocol requirement that is isolated,
     // use that.

--- a/test/Concurrency/Inputs/dynamically_replaceable.swift
+++ b/test/Concurrency/Inputs/dynamically_replaceable.swift
@@ -1,0 +1,2 @@
+@MainActor
+public dynamic func dynamicOnMainActor() { }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,5 +1,8 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/dynamically_replaceable.swiftmodule -module-name dynamically_replaceable -warn-concurrency %S/Inputs/dynamically_replaceable.swift
+// RUN: %target-typecheck-verify-swift -I %t -disable-availability-checking
 // REQUIRES: concurrency
+import dynamically_replaceable
 
 actor SomeActor { }
 
@@ -551,4 +554,12 @@ func useFooInADefer() -> String {
   }
 
   return "hello"
+}
+
+// ----------------------------------------------------------------------
+// Dynamic replacement
+// ----------------------------------------------------------------------
+@_dynamicReplacement(for: dynamicOnMainActor)
+func replacesDynamicOnMainActor() {
+  onlyOnMainActor()
 }


### PR DESCRIPTION
Infer actor insolation through dynamic replacement, because we need
the same rules for the original and the replacements.
Fixes rdar://83153816.
