### PR TITLE
[ConstraintLocator] Allow simplification of constructor member with overloaded base

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5691,8 +5691,13 @@ SourceLoc constraints::getLoc(ASTNode anchor) {
     return anchor.getStartLoc();
   } else if (auto *S = anchor.dyn_cast<Stmt *>()) {
     return S->getStartLoc();
+  } else if (auto *P = anchor.dyn_cast<Pattern *>()) {
+    return P->getLoc();
+  } else if (auto *C = anchor.dyn_cast<StmtCondition *>()) {
+    return C->front().getStartLoc();
   } else {
-    return anchor.get<Pattern *>()->getLoc();
+    auto *I = anchor.get<CaseLabelItem *>();
+    return I->getStartLoc();
   }
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4410,11 +4410,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
     }
 
     case ConstraintLocator::ConstructorMember:
-      if (auto typeExpr = getAsExpr<TypeExpr>(anchor)) {
-        // This is really an implicit 'init' MemberRef, so point at the base,
-        // i.e. the TypeExpr.
+      // - This is really an implicit 'init' MemberRef, so point at the base,
+      //   i.e. the TypeExpr.
+      // - For re-declarations we'd get an overloaded reference
+      //   with multiple choices for the same type.
+      if (isExpr<TypeExpr>(anchor) || isExpr<OverloadedDeclRefExpr>(anchor)) {
         range = SourceRange();
-        anchor = typeExpr;
         path = path.slice(1);
         continue;
       }

--- a/validation-test/Sema/Inputs/rdar84879566_invalid_decls.swift
+++ b/validation-test/Sema/Inputs/rdar84879566_invalid_decls.swift
@@ -1,0 +1,11 @@
+struct MyView: Tupled { // expected-note {{found this candidate}}
+  var tuple: some Any {
+    ""
+  }
+}
+
+struct MyView: Tupled { // expected-note {{found this candidate}}
+  var tuple: some Any {
+    ""
+  }
+}

--- a/validation-test/Sema/rdar84879566.swift
+++ b/validation-test/Sema/rdar84879566.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -target x86_64-apple-macosx10.15 -swift-version 5 %S/Inputs/rdar84879566_invalid_decls.swift -primary-file %s -verify
+// REQUIRES: OS=macosx
+
+protocol Tupled {
+  associatedtype TupleType
+
+  @TupleBuilder var tuple: TupleType { get }
+}
+
+@resultBuilder
+struct TupleBuilder {
+  static func buildBlock() -> () {
+    return ()
+  }
+
+  static func buildBlock<T1>(_ t1: T1) -> (T1) {
+    return (t1)
+  }
+}
+
+struct MyApp: Tupled {
+  var tuple: some Any {
+    MyView() // expected-error {{ambiguous use of 'init()'}}
+  }
+}


### PR DESCRIPTION
`init` calls to redeclared types would end up diagnosed as ambiguity,
so locator simplification needs to account for the fact that "base"
of constructor might be overloaded type reference.

Resolves: rdar://84879566

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
