### PR TITLE
Shims: strongly link `swift_isStackAllocationSafe` on !Darwin

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -93,7 +93,10 @@ __swift_size_t _swift_stdlib_getHardwareConcurrency(void);
 ///
 /// This function is used by
 /// @c withUnsafeTemporaryAllocation(byteCount:alignment:_:).
-SWIFT_RUNTIME_STDLIB_API SWIFT_WEAK_IMPORT
+SWIFT_RUNTIME_STDLIB_API
+#if defined(__APPLE__) && defined(__MACH__)
+SWIFT_WEAK_IMPORT
+#endif
 __swift_bool swift_stdlib_isStackAllocationSafe(__swift_size_t byteCount,
                                                 __swift_size_t alignment);
 


### PR DESCRIPTION
Windows objects to the multiple different aliases for
`swift_isStackAllocationSafe`.  Use strong linkage on all non-ABI stable
targets.  This should repair the Windows build and matches the
conditional emission in the stdlib.

Thanks to @lorentey for the discussion around how to handle this and the
pointer to where this was getting introduced!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
