### PR TITLE
[cmake] Move a bunch of test binaries from install component 'tools' -> 'testsuite-tools'.

### DIFF
--- a/tools/lldb-moduleimport-test/CMakeLists.txt
+++ b/tools/lldb-moduleimport-test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_tool(lldb-moduleimport-test
   lldb-moduleimport-test.cpp
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
 )
 target_link_libraries(lldb-moduleimport-test
                       PRIVATE

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_tool(sil-passpipeline-dumper
   SILPassPipelineDumper.cpp
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
 )
 target_link_libraries(sil-passpipeline-dumper PRIVATE
   swiftFrontend

--- a/tools/swift-demangle-yamldump/CMakeLists.txt
+++ b/tools/swift-demangle-yamldump/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_host_tool(swift-demangle-yamldump
   swift-demangle-yamldump.cpp
   LLVM_LINK_COMPONENTS support
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
   )
 target_link_libraries(swift-demangle-yamldump
                       PRIVATE

--- a/tools/swift-reflection-fuzzer/CMakeLists.txt
+++ b/tools/swift-reflection-fuzzer/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_swift_fuzzer_host_tool(swift-reflection-fuzzer
   swift-reflection-fuzzer.cpp
   LLVM_LINK_COMPONENTS support
-  SWIFT_COMPONENT tools 
+  SWIFT_COMPONENT testsuite-tools
   )
 target_link_libraries(swift-reflection-fuzzer
                       PRIVATE

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_tool(swift-remoteast-test
   swift-remoteast-test.cpp
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
 )
 target_link_libraries(swift-remoteast-test
                       PRIVATE

--- a/tools/swift-syntax-parser-test/CMakeLists.txt
+++ b/tools/swift-syntax-parser-test/CMakeLists.txt
@@ -5,7 +5,7 @@ add_swift_host_tool(swift-syntax-parser-test
   swift-syntax-parser-test.cpp
   LLVM_LINK_COMPONENTS
     support
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
 )
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set_target_properties(swift-syntax-parser-test PROPERTIES

--- a/tools/swift-syntax-test/CMakeLists.txt
+++ b/tools/swift-syntax-test/CMakeLists.txt
@@ -2,7 +2,7 @@ add_swift_host_tool(swift-syntax-test
   swift-syntax-test.cpp
   LLVM_LINK_COMPONENTS
     Support
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
 )
 target_link_libraries(swift-syntax-test
                       PRIVATE

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -271,7 +271,7 @@ cmake^
     -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES^
     -DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES^
     -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES^
-    -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
+    -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;testsuite-tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
     -DSWIFT_PARALLEL_LINK_JOBS=8^
     -DPYTHON_EXECUTABLE:PATH=%PYTHON_HOME%\python.exe^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^


### PR DESCRIPTION
All of these are tools that are only meant to be used when testing swift. Thus
it doesn't make sense to include them in the catch all 'tools' install component
that distributions use to build all the tools.

I verified that all of the mac/linux presets in tree that have tools also has
testsuite-tools so this should be NFC. On Windows, I needed to add
testsuite-tools to build-windows.bat so should be NFC there as well.
