### PR TITLE
[CSGen] Don't walk into `??` in `LinkedExprAnalyzer`.

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -122,6 +122,10 @@ public:
            is(">") || is("<=") || is(">=");
   }
 
+  bool isNilCoalescingOperator() const {
+    return is("??");
+  }
+
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
   static bool isOperatorStartCodePoint(uint32_t C) {

--- a/test/Constraints/nil-coalescing-favoring.swift
+++ b/test/Constraints/nil-coalescing-favoring.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+
+struct B {
+  static var _none: B { B() }
+}
+
+struct A {
+  init(_ other: B) {}
+  // CHECK: constructor_decl{{.*}}interface type='(A.Type) -> (B?) -> A'
+  init(_ other: B?) {
+    // CHECK: dot_syntax_call_expr type='(B) -> A'
+    self.init(other ?? ._none)
+  }
+}


### PR DESCRIPTION
Attempting to favor the type of this expression based on operand types is wrong, because this operator attempts to unwrap its operand types.

Resolves: rdar://85045881