### PR TITLE
[CodeCompletion] `nil`/`[]`/`[:]` default arguments are "interesting"

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2739,10 +2739,17 @@ public:
     for (auto param : *func->getParameters()) {
       switch (param->getDefaultArgumentKind()) {
       case DefaultArgumentKind::Normal:
+      case DefaultArgumentKind::NilLiteral:
+      case DefaultArgumentKind::EmptyArray:
+      case DefaultArgumentKind::EmptyDictionary:
       case DefaultArgumentKind::StoredProperty:
       case DefaultArgumentKind::Inherited: // FIXME: include this?
         return true;
-      default:
+
+      case DefaultArgumentKind::None:
+#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+      case DefaultArgumentKind::NAME:
+#include "swift/AST/MagicIdentifierKinds.def"
         break;
       }
     }

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -16,7 +16,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_9 > %t
 // RUN: %FileCheck %s -check-prefix=DEFAULT_ARGS_9 < %t
 // RUN: %FileCheck %s -check-prefix=NEGATIVE_DEFAULT_ARGS_9 < %t
-//
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_10 | %FileCheck %s -check-prefix=DEFAULT_ARGS_10
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_1 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_2 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT_INTCONTEXT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARG_INIT_3 | %FileCheck %s -check-prefix=DEFAULT_ARG_INIT_INTCONTEXT
@@ -28,6 +30,9 @@ func freeFuncWithDefaultArgs1(
 func freeFuncWithDefaultArgs2(file: String = #file) {}
 func freeFuncWithDefaultArgs3(a: Int = 0) {}
 func freeFuncWithDefaultArgs4(_ a: Int, b: Int = 0, c: Int = 0) {}
+func freeFuncWithDefaultArgs5(a: Int? = nil) {}
+func freeFuncWithDefaultArgs6(a: [Int] = []) {}
+func freeFuncWithDefaultArgs7(a: [Int:Int] = [:]) {}
 
 struct A {
   func methodWithDefaultArgs1(a: Int = 0) {}
@@ -60,6 +65,12 @@ func testDefaultArgs1() {
 // DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs3({#a: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs4({#(a): Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs4({#(a): Int#}, {#b: Int#}, {#c: Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs5()[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs5({#a: Int?#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs6()[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs6({#a: [Int]#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs7()[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_1-DAG: Decl[FreeFunction]/CurrModule:      freeFuncWithDefaultArgs7({#a: [Int : Int]#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_1: End completions
 
 func testDefaultArgs2() {
@@ -130,6 +141,15 @@ func testDefaultArgs9(_ x: C2) {
 // DEFAULT_ARGS_9-DAG: Decl[InstanceMethod]/CurrNominal:      methodWithDefaultArgsInSub1({#(a): Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_9: End completions
 // NEGATIVE_DEFAULT_ARGS_9-NOT: methodWithDefaultArgs1()
+
+func testDefaultArgs10() {
+  freeFuncWithDefaultArgs5(#^DEFAULT_ARGS_10^#)
+// DEFAULT_ARGS_10: Begin completions
+// DEFAULT_ARGS_10-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['('][')'][#Void#]; name=
+// DEFAULT_ARGS_10-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#a: Int?#}[')'][#Void#]; name=a:
+// DEFAULT_ARGS_10: End completions
+
+}
 
 let globalVar = 1
 func testDefaultArgInit1(x = #^DEFAULT_ARG_INIT_1^#) { }


### PR DESCRIPTION
Code completion didn't suggest "without default argument" call pattern variant for functions with `nil` default arguments. e.g.
```swift
func foo(arg: Int? = nil)
```
This should suggest `foo(arg:)` as well as `foo()`.

rdar://85077605