### PR TITLE
AST: Make sure malscoped extensions get their extended nominal computed

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1245,9 +1245,14 @@ ExtensionDecl::takeConformanceLoaderSlow() {
 }
 
 NominalTypeDecl *ExtensionDecl::getExtendedNominal() const {
-  assert((hasBeenBound() || canNeverBeBound()) &&
-         "Extension must have already been bound (by bindExtensions)");
-  return ExtendedNominal.getPointer();
+  if (hasBeenBound()) {
+    return ExtendedNominal.getPointer();
+  } else if (canNeverBeBound()) {
+    return computeExtendedNominal();
+  }
+
+  llvm_unreachable(
+      "Extension must have already been bound (by bindExtensions)");
 }
 
 NominalTypeDecl *ExtensionDecl::computeExtendedNominal() const {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -37,6 +37,14 @@ protocol NestingTest5 {
 func nestingTest6() {
   extension Foo {} // expected-error {{declaration is only valid at file scope}}
 }
+extension Array {
+  func foo() {
+    extension Array { // expected-error {{declaration is only valid at file scope}}
+    // FIXME: Confusing error
+    // expected-error@-2 {{constrained extension must be declared on the unspecialized generic type 'Array' with constraints specified by a 'where' clause}}
+    }
+  }
+}
 
 //===--- Test that we only allow extensions only for nominal types.
 

--- a/validation-test/compiler_crashers_2_fixed/sr15447.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15447.swift
@@ -1,0 +1,13 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map { elt in
+            self[elt
+
+
+public extension Array where Element == Item {
+    mutating func toggle(item: Item) -> Bool {
+        _ = contains(item)
+    }
+}


### PR DESCRIPTION
An extension nested inside a closure would get its extended nominal queried by name lookup before it got explicitly computed by the declaration checker, causing it to fall out of sync with the extended type. To prevent this from happening, amend getExtendedNominal() to always compute itself for extensions with an invalid parent context. 

Resolves SR-15447