### PR TITLE
[CS] Don't favor based on tuple element types

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -238,10 +238,9 @@ namespace {
         return { false, expr };
       }      
 
-      // For exprs of a structural type that are not modeling argument lists,
-      // avoid merging the type variables. (We need to allow for cases like
+      // For exprs of a tuple, avoid favoring. (We need to allow for cases like
       // (Int, Int32).)
-      if (isa<TupleExpr>(expr) && !isa<ApplyExpr>(Parent.getAsExpr())) {
+      if (isa<TupleExpr>(expr)) {
         return { false, expr };
       }
 

--- a/test/Constraints/ranking_ambiguities.swift
+++ b/test/Constraints/ranking_ambiguities.swift
@@ -58,3 +58,18 @@ struct S4 {
     _ = S4() // expected-error {{ambiguous use of 'init'}}
   }
 }
+
+infix operator ^^^
+func ^^^ (lhs: (Int, Int), rhs: Int) -> Int { 0 }  // expected-note {{found this candidate}}
+func ^^^ (lhs: (Int, Int), rhs: Int) -> String { "" }  // expected-note {{found this candidate}}
+
+// We shouldn't favor based on the type of a tuple element.
+struct S5 {
+  init(_ x: Int) {}
+  init(_ x: String) {}
+
+  func testFavoring() {
+    let x = 0
+    _ = S5((x, 0) ^^^ 0) // expected-error {{ambiguous use of operator '^^^'}}
+  }
+}


### PR DESCRIPTION
Previously this check was guarding against this case, however with the argument list refactoring (#38836), it's now possible for regular tuples to have ApplyExpr parents. As such, broaden the check to handle any tuple expr.

Noticed by inspection.