### PR TITLE
[build-presets] Don't install sk-stress-test and swift-evolve into the nightly toolchains

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1223,8 +1223,6 @@ swift-driver
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 swiftsyntax
-skstresstester
-swiftevolve
 playgroundsupport
 libcxx
 indexstore-db
@@ -1273,8 +1271,6 @@ install-llbuild
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
-install-skstresstester
-install-swiftevolve
 install-playgroundsupport
 install-libcxx
 install-sourcekit-lsp


### PR DESCRIPTION
I don’t believe sk-stress-test and swift-evolve were used much and were adding ~20MB to the toolchain size. Let’s remove them.

rdar://85079653