### PR TITLE
[swift-stdlib-tool] use correct path when codesigning

### DIFF
--- a/tools/swift-stdlib-tool/swift-stdlib-tool.mm
+++ b/tools/swift-stdlib-tool/swift-stdlib-tool.mm
@@ -1168,7 +1168,7 @@ int main(int argc, const char *argv[])
                 }
 
                 NSString *lib = key;
-                NSString *dst = [dst_dir stringByAppendingPathComponent:lib];
+                NSString *dst = [dst_dir stringByAppendingPathComponent:lib.lastPathComponent];
 
                 // Get the code signature, and copy the dylib to the side
                 // to preserve it in case it does not change.  We can use


### PR DESCRIPTION
This PR updates the path used when codesigning bundled Swift stdlib dylibs. It looks like this was missed in https://github.com/apple/swift/pull/40026. `swiftLibs` are now absolute paths to Swift dylibs instead of library names, so we need to construct the destination path using the filename only.