### PR TITLE
Correct lifetime based cancellation of AsyncStream and AsyncThrowingStream

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -213,7 +213,7 @@ extension AsyncStream: AsyncSequence {
   /// concurrently and contends with another call to next is a programmer error
   /// and will fatalError.
   public struct Iterator: AsyncIteratorProtocol {
-    let produce: () async -> Element?
+    let context: _Context
 
     /// The next value from the AsyncStream.
     ///
@@ -225,13 +225,13 @@ extension AsyncStream: AsyncSequence {
     /// awaiting a value, this will terminate the AsyncStream and next may return nil
     /// immediately (or will return nil on subsequent calls)
     public mutating func next() async -> Element? {
-      await produce()
+      await context.produce()
     }
   }
 
   /// Construct an iterator.
   public func makeAsyncIterator() -> Iterator {
-    return Iterator(produce: context.produce)
+    return Iterator(context: context)
   }
 }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -186,16 +186,16 @@ extension AsyncThrowingStream: AsyncSequence {
   /// concurrently and contends with another call to next is a programmer error
   /// and will fatalError.
   public struct Iterator: AsyncIteratorProtocol {
-    let produce: () async throws -> Element?
+    let context: _Context
 
     public mutating func next() async throws -> Element? {
-      return try await produce()
+      return try await context.produce()
     }
   }
 
   /// Construct an iterator.
   public func makeAsyncIterator() -> Iterator {
-    return Iterator(produce: context.produce)
+    return Iterator(context: context)
   }
 }
 

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -153,13 +153,6 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   public init(
     unfolding produce: @escaping () async throws -> Element?
   ) where Failure == Error {
-    self.init(unfolding: produce, onCancel: nil)
-  }
-
-  public init(
-    unfolding produce: @escaping () async throws -> Element?, 
-    onCancel: (@Sendable () -> Void)?
-  ) where Failure == Error {
     let storage: _AsyncStreamCriticalStorage<Optional<() async throws -> Element?>>
       = .create(produce)
     context = _Context {
@@ -171,7 +164,6 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
         return result
       } onCancel: {
         storage.value = nil
-        onCancel?()
       }
     }
   }


### PR DESCRIPTION
This addresses an outstanding issue where AsyncStream and AsyncThrowingStream could not terminate in the case of indefinite sequences for a handler that lived by capture. AsyncStream and AsyncThrowingStream now hold a context that cancels on deinitialization. 

Resolves radar: rdar://82985344

Tests incoming soon.