### PR TITLE
Prefer witnesses with no difference effects to ones that have fewer effects

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -767,8 +767,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
   // Match the witness. If we don't succeed, throw away the inference
   // information.
   // FIXME: A renamed match might be useful to retain for the failure case.
-  if (matchWitness(dc, req, witness, setup, matchTypes, finalize)
-          .Kind != MatchKind::ExactMatch) {
+  if (!matchWitness(dc, req, witness, setup, matchTypes, finalize)
+          .isWellFormed()) {
     inferred.Inferred.clear();
   }
 

--- a/test/decl/protocol/async_requirements.swift
+++ b/test/decl/protocol/async_requirements.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+// Ensure that a protocol with async requirements can be conformed to by
+// non-async requirements, and that overloading works.
+protocol A {
+  func foo()
+  func foo() async
+
+  init()
+  init() async
+
+  var property: Int { get async }
+
+  func bar() throws
+  func bar() async throws
+}
+
+struct A1: A {
+  func foo() { }
+
+  var property: Int = 17
+
+  func bar() { }
+}
+
+struct A2: A {
+  func foo() { }
+  func foo() async { }
+
+  init() { }
+  init() async { }
+
+  var property: Int { get async { 5 } }
+
+  func bar() throws { }
+  func bar() async throws { }
+}


### PR DESCRIPTION
One can overload on async vs. non-async, and the constraint solver has a
preference rule based on context. Extend that preference rule to
witness matching, so we prefer a witness that exactly matches the
effects of the requirement to one that has fewer effects.

Fixes rdar://84034057.
