### PR TITLE
Actor isolation inference: @IBAction implies @MainActor(unsafe)

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3435,6 +3435,15 @@ ActorIsolation ActorIsolationRequest::evaluate(
     }
   }
 
+  // @IBAction implies @MainActor(unsafe).
+  if (value->getAttrs().hasAttribute<IBActionAttr>()) {
+    ASTContext &ctx = value->getASTContext();
+    if (Type mainActor = ctx.getMainActorType()) {
+      return inferredIsolation(
+          ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/true));
+    }
+  }
+
   // Default isolation for this member.
   return defaultIsolation;
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -518,6 +518,15 @@ func useUnsafeMainActor() {
 }
 
 // ----------------------------------------------------------------------
+// @IBAction implies @MainActor(unsafe)
+// ----------------------------------------------------------------------
+class SomeWidgetThing {
+  @IBAction func onTouch(_ object: AnyObject) {
+    onlyOnMainActor() // okay
+  }
+}
+
+// ----------------------------------------------------------------------
 // @_inheritActorContext
 // ----------------------------------------------------------------------
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -536,7 +536,7 @@ class d0170_TestAvailability {
 // PASS_COMMON-LABEL: {{^}}@objc class d0180_TestIBAttrs {{{$}}
 
   @IBAction func anAction(_: AnyObject) {}
-// PASS_COMMON-NEXT: {{^}}  @objc @IBAction func anAction(_: AnyObject){{$}}
+// PASS_COMMON-NEXT: {{^}}  @objc @IBAction @MainActor func anAction(_: AnyObject){{$}}
 
   @IBSegueAction func aSegueAction(_ coder: AnyObject, sender: AnyObject, identifier: AnyObject?) -> Any? { fatalError() }
 // PASS_COMMON-NEXT: {{^}}  @objc @IBSegueAction func aSegueAction(_ coder: AnyObject, sender: AnyObject, identifier: AnyObject?) -> Any?{{$}}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1868,7 +1868,7 @@ class HasIBOutlet {
 // CHECK-LABEL: {{^}}class HasIBAction {
 class HasIBAction {
   @IBAction func goodAction(_ sender: AnyObject?) { }
-  // CHECK: {{^}}  @objc @IBAction func goodAction(_ sender: AnyObject?) {
+  // CHECK: {{^}}  @objc @IBAction @MainActor func goodAction(_ sender: AnyObject?) {
 
   @IBAction func badAction(_ sender: PlainStruct?) { }
   // expected-error@-1{{method cannot be marked @IBAction because the type of the parameter cannot be represented in Objective-C}}


### PR DESCRIPTION
@IBAction calls are always delivered in the main thread, so reflect that
by inferring `@MainActor(unsafe)` for such methods whenever no other
actor isolation is provided.

Implements rdar://84474640.
