### PR TITLE
[ClangImporter] Don't expect unmodularized structs to appear in 2 modules

### DIFF
--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -17,5 +17,6 @@ let encoding: UInt = NSUTF8StringEncoding
 let viaTypedef: Redeclaration.NSPoint = AppKit.NSPoint(x: 0, y: 0)
 Redeclaration.NSStringToNSString(AppKit.NSStringToNSString("abc")) // expected-warning {{result of call to 'NSStringToNSString' is unused}}
 
-let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1()
+/// The following error should soon be introduced by https://github.com/apple/llvm-project/pull/3497.
+let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1() // expected-error * {{module 'AppKit' has no member named 'FooStruct1'}}
 let forwardDecl: Redeclaration.Tribool = AppKit.Tribool() // expected-error {{no type named 'Tribool' in module 'Redeclaration'}}


### PR DESCRIPTION
The clang fix at https://github.com/apple/llvm-project/pull/3497 implements better decl merging, this affects how unmodularized types are imported. This fix triggers an old test explicitly supporting unmodularized code. We believe this test should be updated as the new behavior will prevent possible miscompilations.

We should add an expected error here once the clang fix lands, until them just makes sure the test works both with and without the clang fix.