### PR TITLE
Isolate closures to their 'isolated' parameters.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2603,6 +2603,13 @@ namespace {
           return ClosureActorIsolation::forGlobalActor(globalActorType);
       }
 
+      // If a closure has an isolated parameter, it is isolated to that
+      // parameter.
+      for (auto param : *closure->getParameters()) {
+        if (param->isIsolated())
+          return ClosureActorIsolation::forActorInstance(param);
+      }
+
       // Sendable closures are actor-independent unless the closure has
       // specifically opted into inheriting actor isolation.
       if (isSendableClosure(closure, /*forActorIsolation=*/true))

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -144,3 +144,19 @@ func testExistentialIsolated(a: isolated P2, b: P2) async {
   b.m() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to instance method 'm()' from outside of its actor context are implicitly asynchronous}}
 }
+
+// "isolated" parameters of closures make the closure itself isolated.
+extension TestActor {
+  func isolatedMethod() { }
+}
+
+@available(SwiftStdlib 5.1, *)
+func isolatedClosures() {
+  let _: (isolated TestActor) -> Void = { (ta: isolated TestActor) in
+    ta.isolatedMethod() // okay, isolated to ta
+
+    _ = {
+      ta.isolatedMethod() // okay, isolated to ta
+    }
+  }
+}


### PR DESCRIPTION
When a closure has an isolated parameter, the closure itself is
isolated to that parameter. Capture this in the isolation of the
closure itself, so it is propagated to nested closures.

Fixes rdar://83733845.
