### PR TITLE
AST: Fix ReplaceOpaqueTypesWithUnderlyingTypes to handle nested types of opaque result types

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3215,7 +3215,14 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
                                   bool isContextWholeModule) {
   TypeDecl *typeDecl = ty->getAnyNominal();
   if (!typeDecl) {
-    // We also need to check that the opaque type descriptor is accessible.
+    // The referenced type might be a different opaque result type.
+
+    // First, unwrap any nested associated types to get the root archetype.
+    while (auto nestedTy = ty->getAs<NestedArchetypeType>())
+      ty = nestedTy->getParent();
+
+    // If the root archetype is an opaque result type, check that its
+    // descriptor is accessible.
     if (auto opaqueTy = ty->getAs<OpaqueTypeArchetypeType>())
       typeDecl = opaqueTy->getDecl();
   }

--- a/test/SILGen/Inputs/opaque_result_type_private_assoc_type_other.swift
+++ b/test/SILGen/Inputs/opaque_result_type_private_assoc_type_other.swift
@@ -1,0 +1,21 @@
+public protocol IteratorProtocol {
+  associatedtype Element
+
+  func next() -> Element?
+}
+
+public func doSomething() -> some IteratorProtocol {
+  return doSomethingInternal()
+}
+
+func doSomethingInternal() -> some IteratorProtocol {
+  return SomeIterator()
+}
+
+struct SomeIterator: IteratorProtocol {
+  public typealias Element = Int
+
+  public func next() -> Int? {
+    return nil
+  }
+}

--- a/test/SILGen/opaque_result_type_private_assoc_type.swift
+++ b/test/SILGen/opaque_result_type_private_assoc_type.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/opaque_result_type_private_assoc_type_other.swift -emit-module-path %t/opaque_result_type_private_assoc_type_other.swiftmodule -disable-availability-checking
+// RUN: %target-swift-emit-silgen -I %t %s | %FileCheck %s
+
+import opaque_result_type_private_assoc_type_other
+
+// CHECK-LABEL: sil hidden [ossa] @$s033opaque_result_type_private_assoc_C0028usesAssocTypeOfPrivateResultH0yyF : $@convention(thin) () -> () {
+func usesAssocTypeOfPrivateResultType() {
+  // CHECK: [[BOX:%.*]] = alloc_stack $Optional<@_opaqueReturnTypeOf("$s033opaque_result_type_private_assoc_C6_other11doSomethingQryF", 0) __.Element>
+  // CHECK: [[METHOD:%.*]] = witness_method $@_opaqueReturnTypeOf("$s033opaque_result_type_private_assoc_C6_other11doSomethingQryF", 0) __, #IteratorProtocol.next : <Self where Self : opaque_result_type_private_assoc_type_other.IteratorProtocol> (Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.Element>
+  // CHECK:  [[RESULT:%.*]] = apply [[METHOD]]<@_opaqueReturnTypeOf("$s033opaque_result_type_private_assoc_C6_other11doSomethingQryF", 0) __>([[BOX]], {{%.*}}) : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.Element>
+  let iterator = doSomething()
+  let _ = iterator.next()
+}


### PR DESCRIPTION
Fixes rdar://problem/85137685.