### PR TITLE
[cxx-interop] Allow extensions on namespaces.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1453,11 +1453,13 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
     DeclBaseName baseName(name.getBaseName());
 
     if (isa_and_nonnull<clang::NamespaceDecl>(decl->getClangDecl())) {
-      // Namespaces will never have any members so we can just return whatever
-      // the lookup finds.
-      return evaluateOrDefault(
+      auto allFound = evaluateOrDefault(
           ctx.evaluator, CXXNamespaceMemberLookup({cast<EnumDecl>(decl), name}),
           {});
+      for (auto found : allFound)
+        Table.addMember(found);
+
+      populateLookupTableEntryFromExtensions(ctx, Table, baseName, decl);
     } else if (isa_and_nonnull<clang::RecordDecl>(decl->getClangDecl())) {
       auto allFound = evaluateOrDefault(
           ctx.evaluator,

--- a/test/Interop/Cxx/namespace/Inputs/extensions.h
+++ b/test/Interop/Cxx/namespace/Inputs/extensions.h
@@ -1,0 +1,14 @@
+#ifndef TEST_INTEROP_CXX_NAMESPACE_INPUTS_EXTENSIONS_H
+#define TEST_INTEROP_CXX_NAMESPACE_INPUTS_EXTENSIONS_H
+
+namespace EmptyNamespace {}
+
+namespace EmptyRedeclaredNamespace {}
+
+namespace EmptyRedeclaredNamespace {}
+
+namespace ParentNamespace {
+namespace EmptyChildNamespace {}
+}
+
+#endif // TEST_INTEROP_CXX_NAMESPACE_INPUTS_EXTENSIONS_H

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -48,3 +48,8 @@ module TemplatesWithForwardDecl {
   header "templates-with-forward-decl.h"
   requires cplusplus
 }
+
+module Extensions {
+  header "extensions.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/namespace/extensions.swift
+++ b/test/Interop/Cxx/namespace/extensions.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Extensions
+
+extension EmptyNamespace {
+  static var a = "a"
+}
+
+extension EmptyNamespace {
+  static var b = "b"
+}
+
+fileprivate extension EmptyRedeclaredNamespace {
+  static var c = "c"
+}
+
+extension ParentNamespace.EmptyChildNamespace {
+  static var d = "d"
+
+  static func e() -> String { "e" }
+}
+
+var NamespacesTestSuite = TestSuite("Extensions on namespaces")
+
+NamespacesTestSuite.test("EmptyNamespace") {
+  expectEqual(EmptyNamespace.a, "a")
+  expectEqual(EmptyNamespace.b, "b")
+}
+
+NamespacesTestSuite.test("EmptyRedeclaredNamespace") {
+  expectEqual(EmptyRedeclaredNamespace.c, "c")
+}
+
+NamespacesTestSuite.test("Nested namespace") {
+  expectEqual(ParentNamespace.EmptyChildNamespace.d, "d")
+  expectEqual(ParentNamespace.EmptyChildNamespace.e(), "e")
+}
+
+runAllTests()
+


### PR DESCRIPTION
This used to work and broke with lazy member loading. This commit fixes it again.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
