### PR TITLE
fix SILGen bug for cross-module actor let accesses

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4215,7 +4215,7 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
         auto actorIso = component.asPhysical().takeActorIsolation();
 
         // If the load must happen in the context of an actor, do a hop first.
-        prevExecutor = emitHopToTargetActor(loc, actorIso, /*actorSelf=*/None);
+        prevExecutor = emitHopToTargetActor(loc, actorIso, addr);
         projection =
             emitLoad(loc, projection.getValue(), origFormalType,
                      substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);

--- a/test/Concurrency/Inputs/OtherActors.swift
+++ b/test/Concurrency/Inputs/OtherActors.swift
@@ -1,7 +1,9 @@
 public class SomeClass { }
+public final class SomeSendableClass: Sendable { }
 
 public actor OtherModuleActor {
   public let a: Int = 1
   public nonisolated let b: Int = 2
   public let c: SomeClass = SomeClass()
+  public let d: SomeSendableClass = SomeSendableClass()
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -822,6 +822,23 @@ func testCrossModuleLets(actor: OtherModuleActor) async {
   // expected-note@-1{{property access is 'async'}}
   // expected-warning@-2{{cannot use property 'c' with a non-sendable type 'SomeClass' across actors}}
   _ = await actor.c // expected-warning{{cannot use property 'c' with a non-sendable type 'SomeClass' across actors}}
+  _ = await actor.d // okay
+}
+
+func testCrossModuleAsIsolated(actor: isolated OtherModuleActor) {
+  _ = actor.a
+  _ = actor.b
+  _ = actor.c
+  _ = actor.d
+}
+
+extension OtherModuleActor {
+  func testCrossModuleInExtension() {
+    _ = self.a
+    _ = self.b
+    _ = self.c
+    _ = self.d
+  }
 }
 
 

--- a/test/Concurrency/cross_module_let_sil.swift
+++ b/test/Concurrency/cross_module_let_sil.swift
@@ -5,7 +5,7 @@
 
 import OtherActors
 
-// CHECK: sil hidden [ossa] @$s4test6check1ySi11OtherActors0C11ModuleActorCYaF : $@convention(thin) @async (@guaranteed OtherModuleActor) -> Int {
+// CHECK-LABEL: sil hidden [ossa] @$s4test6check1ySi11OtherActors0C11ModuleActorCYaF : $@convention(thin) @async (@guaranteed OtherModuleActor) -> Int {
 // CHECK:     bb0([[SELF:%[0-9]+]] : @guaranteed $OtherModuleActor):
 // CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[SELF]] : $OtherModuleActor, #OtherModuleActor.a
 // CHECK:       [[OLD:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
@@ -25,14 +25,17 @@ func check3(_ actor: OtherModuleActor) async -> Int {
   return actor.b
 }
 
-// CHECK: sil hidden [ossa] @$s4test6check4y11OtherActors17SomeSendableClassCAC0C11ModuleActorCYaF : $@convention(thin) @async (@guaranteed OtherModuleActor) -> @owned SomeSendableClass {
-// CHECK:     bb0([[SELF:%[0-9]+]] : @guaranteed $OtherModuleActor):
-// CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[SELF]] : $OtherModuleActor, #OtherModuleActor.d
+// CHECK-LABEL: sil hidden [ossa] @$s4test6check4y11OtherActors17SomeSendableClassCSgAC0C11ModuleActorCSgYaF : $@convention(thin) @async (@guaranteed Optional<OtherModuleActor>) -> @owned Optional<SomeSendableClass> {
+// CHECK:  bb0({{%[0-9]+}} : @guaranteed $Optional<OtherModuleActor>):
+// CHECK:       switch_enum {{%[0-9]+}} : $Optional<OtherModuleActor>, case #Optional.some!enumelt: [[SOME:bb[0-9]+]], case #Optional.none!enumelt: {{bb[0-9]+}}
+
+// CHECK:  [[SOME]]({{%[0-9]+}} : @owned $OtherModuleActor):
+// CHECK:       [[REF:%[0-9]+]] = ref_element_addr {{%[0-9]+}} : $OtherModuleActor, #OtherModuleActor.d
 // CHECK:       [[OLD:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
-// CHECK:       hop_to_executor [[SELF]] : $OtherModuleActor
+// CHECK:       hop_to_executor {{%[0-9]+}} : $OtherModuleActor
 // CHECK-NEXT:  load [copy] [[REF]]
-// CHECK-NEXT:  hop_to_executor [[OLD]] : $Optional<Builtin.Executor>
-// CHECK: } // end sil function '$s4test6check4y11OtherActors17SomeSendableClassCAC0C11ModuleActorCYaF'
-func check4(_ actor: OtherModuleActor) async -> SomeSendableClass {
-  return await actor.d
+// CHECK:       hop_to_executor [[OLD]] : $Optional<Builtin.Executor>
+// CHECK: } // end sil function '$s4test6check4y11OtherActors17SomeSendableClassCSgAC0C11ModuleActorCSgYaF'
+func check4(_ actor: OtherModuleActor?) async -> SomeSendableClass? {
+  return await actor?.d
 }

--- a/test/Concurrency/cross_module_let_sil.swift
+++ b/test/Concurrency/cross_module_let_sil.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-swift-emit-silgen -verify -module-name test -I %t -disable-availability-checking -warn-concurrency %s | %FileCheck %s --implicit-check-not=hop_to_executor --enable-var-scope
+// REQUIRES: concurrency
+
+import OtherActors
+
+// CHECK: sil hidden [ossa] @$s4test6check1ySi11OtherActors0C11ModuleActorCYaF : $@convention(thin) @async (@guaranteed OtherModuleActor) -> Int {
+// CHECK:     bb0([[SELF:%[0-9]+]] : @guaranteed $OtherModuleActor):
+// CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[SELF]] : $OtherModuleActor, #OtherModuleActor.a
+// CHECK:       [[OLD:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+// CHECK:       hop_to_executor [[SELF]] : $OtherModuleActor
+// CHECK-NEXT:  load [trivial] [[REF]]
+// CHECK-NEXT:  hop_to_executor [[OLD]] : $Optional<Builtin.Executor>
+// CHECK: } // end sil function '$s4test6check1ySi11OtherActors0C11ModuleActorCYaF'
+func check1(_ actor: OtherModuleActor) async -> Int {
+  return await actor.a
+}
+
+func check2(_ actor: isolated OtherModuleActor) -> Int {
+  return actor.a
+}
+
+func check3(_ actor: OtherModuleActor) async -> Int {
+  return actor.b
+}
+
+// CHECK: sil hidden [ossa] @$s4test6check4y11OtherActors17SomeSendableClassCAC0C11ModuleActorCYaF : $@convention(thin) @async (@guaranteed OtherModuleActor) -> @owned SomeSendableClass {
+// CHECK:     bb0([[SELF:%[0-9]+]] : @guaranteed $OtherModuleActor):
+// CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[SELF]] : $OtherModuleActor, #OtherModuleActor.d
+// CHECK:       [[OLD:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+// CHECK:       hop_to_executor [[SELF]] : $OtherModuleActor
+// CHECK-NEXT:  load [copy] [[REF]]
+// CHECK-NEXT:  hop_to_executor [[OLD]] : $Optional<Builtin.Executor>
+// CHECK: } // end sil function '$s4test6check4y11OtherActors17SomeSendableClassCAC0C11ModuleActorCYaF'
+func check4(_ actor: OtherModuleActor) async -> SomeSendableClass {
+  return await actor.d
+}


### PR DESCRIPTION
When trying to access a let-bound property of an actor across
a moudule boundary, the operation should be treated as async.
But, upon reaching SILGen, the compiler would crash when trying
to emit the needed hop, because the base of the element reference
was missing. This commit fixes that and adds regression coverage.

resolves rdar://81812013