### PR TITLE
Add a REQUIRES: optimized_stdlib to a test.

### DIFF
--- a/test/SILOptimizer/move_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_operator_kills_copyable_values.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
 
+// REQUIRES: optimized_stdlib
+
 import Swift
 
 public class Klass {}


### PR DESCRIPTION
I am pretty sure that this really depends on the stdlib having the
implementation of _move optimized.
