### PR TITLE
[Distributed] Mark all distributed calls as implicitly throwing in `async let` context

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1876,6 +1876,17 @@ public:
         !expression.pattern->isImplicit();
   }
 
+  /// Check whether this is an initializaion for `async let` pattern.
+  bool isAsyncLetInitializer() const {
+    if (!(kind == Kind::expression &&
+          expression.contextualPurpose == CTP_Initialization))
+      return false;
+
+    if (auto *PBD = getInitializationPatternBindingDecl())
+      return PBD->isAsyncLet();
+    return false;
+  }
+
   /// Whether to bind the types of any variables within the pattern via
   /// one-way constraints.
   bool shouldBindPatternVarsOneWay() const {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8286,12 +8286,9 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
 
   // For an async let, wrap the initializer appropriately to make it a child
   // task.
-  if (auto patternBinding = target.getInitializationPatternBindingDecl()) {
-    if (patternBinding->isAsyncLet()) {
-      resultTarget.setExpr(
-          wrapAsyncLetInitializer(
-            cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));
-    }
+  if (target.isAsyncLetInitializer()) {
+    resultTarget.setExpr(wrapAsyncLetInitializer(
+        cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));
   }
 
   return resultTarget;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7581,6 +7581,13 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     apply->setArgs(args);
     cs.setType(apply, fnType->getResult());
 
+    if (target && target->isAsyncLetInitializer()) {
+      if (auto *FD = dyn_cast_or_null<FuncDecl>(callee.getDecl())) {
+        if (FD->isDistributed())
+          apply->setImplicitlyThrows(true);
+      }
+    }
+
     solution.setExprTypes(apply);
     Expr *result = TypeChecker::substituteInputSugarTypeForResult(apply);
     cs.cacheExprTypes(result);

--- a/test/Distributed/distributed_actor_async_let.swift
+++ b/test/Distributed/distributed_actor_async_let.swift
@@ -1,4 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-distributed -disable-availability-checking
+
+// UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Distributed/distributed_actor_async_let.swift
+++ b/test/Distributed/distributed_actor_async_let.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-distributed -disable-availability-checking
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+
+func test_compute(_ v: Int) async -> Int { v }
+
+distributed actor Philosopher {
+  typealias Transport = AnyActorTransport
+
+  init(transport: AnyActorTransport) {
+  }
+
+  // `hi` is implicitly throwing
+  distributed func hi() -> String { "Hi!" }
+
+  distributed func compute() -> Int { 42 }
+
+  func test() async throws {
+    async let x = Philosopher(transport: self.actorTransport).hi() // Ok
+    async let y = Philosopher(transport: self.actorTransport).hi() // Ok
+
+    _ = try await y // Ok because `async let` is infer `throws` from distributed method
+    _ = await x // expected-error {{reading 'async let' can throw but is not marked with 'try'}}
+
+    async let z = test_compute(compute()) // Ok
+
+    _ = try await z
+    _ = await z // expected-error {{reading 'async let' can throw but is not marked with 'try'}}
+  }
+}


### PR DESCRIPTION
Call to a distributed method is implicitly throwing, so in `async let`
context `throws` should be propagated to the binding itself from the initializer.

Resolves: rdar://83610106

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
