### PR TITLE
[stdlib] use internal assertion functions in the Concurrency module

### DIFF
--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -40,7 +40,7 @@ extension AsyncSequence {
   public __consuming func dropFirst(
     _ count: Int = 1
   ) -> AsyncDropFirstSequence<Self> {
-    precondition(count >= 0, 
+    _precondition(count >= 0, 
       "Can't drop a negative number of elements from an async sequence")
     return AsyncDropFirstSequence(self, dropping: count)
   }
@@ -130,7 +130,7 @@ extension AsyncDropFirstSequence {
   ) -> AsyncDropFirstSequence<Base> {
     // If this is already a AsyncDropFirstSequence, we can just sum the current 
     // drop count and additional drop count.
-    precondition(count >= 0, 
+    _precondition(count >= 0,
       "Can't drop a negative number of elements from an async sequence")
     return AsyncDropFirstSequence(base, dropping: self.count + count)
   }

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -40,7 +40,7 @@ extension AsyncSequence {
   public __consuming func prefix(
     _ count: Int
   ) -> AsyncPrefixSequence<Self> {
-    precondition(count >= 0,
+    _precondition(count >= 0,
       "Can't prefix a negative number of elements from an async sequence")
     return AsyncPrefixSequence(self, count: count)
   }

--- a/stdlib/public/Concurrency/Deque.swift
+++ b/stdlib/public/Concurrency/Deque.swift
@@ -41,7 +41,7 @@ struct _Deque<Element> {
     }
     
     internal func slot(after slot: Int) -> Int {
-      assert(slot < capacity)
+      _internalInvariant(slot < capacity)
       let position = slot + 1
       if position >= capacity {
         return 0
@@ -51,7 +51,7 @@ struct _Deque<Element> {
 
     
     internal func slot(_ slot: Int, offsetBy delta: Int) -> Int {
-      assert(slot <= capacity)
+      _internalInvariant(slot <= capacity)
       let position = slot + delta
       if delta >= 0 {
         if position >= capacity { return position - capacity }
@@ -66,13 +66,13 @@ struct _Deque<Element> {
     }
     
     internal func uncheckedAppend(_ element: Element) {
-      assert(count < capacity)
+      _internalInvariant(count < capacity)
       ptr(at: endSlot).initialize(to: element)
       count += 1
     }
     
     internal func uncheckedRemoveFirst() -> Element {
-      assert(count > 0)
+      _internalInvariant(count > 0)
       let result = ptr(at: startSlot).move()
       startSlot = slot(after: startSlot)
       count -= 1
@@ -101,7 +101,7 @@ struct _Deque<Element> {
       ) {
         self.first = first
         self.second = second
-        assert(first.count > 0 || second == nil)
+        _internalInvariant(first.count > 0 || second == nil)
       }
 
       internal init(
@@ -135,7 +135,7 @@ struct _Deque<Element> {
       ) {
         self.first = first
         self.second = second?.count == 0 ? nil : second
-        assert(first.count > 0 || second == nil)
+        _internalInvariant(first.count > 0 || second == nil)
       }
 
       internal init(
@@ -180,7 +180,7 @@ struct _Deque<Element> {
     }
     
     func ptr(at slot: Int) -> UnsafeMutablePointer<Element> {
-      assert(slot >= 0 && slot <= capacity)
+      _internalInvariant(slot >= 0 && slot <= capacity)
       return _elements! + slot
     }
 
@@ -189,7 +189,7 @@ struct _Deque<Element> {
       at start: Int,
       from source: UnsafeBufferPointer<Element>
     ) -> Int {
-      assert(start + source.count <= capacity)
+      _internalInvariant(start + source.count <= capacity)
       guard source.count > 0 else { return start }
       ptr(at: start).initialize(from: source.baseAddress!, count: source.count)
       return start + source.count
@@ -200,7 +200,7 @@ struct _Deque<Element> {
       at start: Int,
       from source: UnsafeMutableBufferPointer<Element>
     ) -> Int {
-      assert(start + source.count <= capacity)
+      _internalInvariant(start + source.count <= capacity)
       guard source.count > 0 else { return start }
       ptr(at: start).moveInitialize(from: source.baseAddress!, count: source.count)
       return start + source.count
@@ -224,7 +224,7 @@ struct _Deque<Element> {
     
     internal func moveElements(minimumCapacity: Int) -> _Storage {
       let count = self.count
-      assert(minimumCapacity >= count)
+      _internalInvariant(minimumCapacity >= count)
       let object = _Storage._DequeBuffer.create(
         minimumCapacity: minimumCapacity,
         makingHeaderWith: {


### PR DESCRIPTION
This PR changes the assertion functions used in the Concurrency module to use the internal equivalents.
The advantages are that they're slightly more performant (they use `StaticString`) and, more importantly,
they map better to the notion of "debug mode" and "release mode" expected by user code.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://66301232 ("The core stdlib uses the public func precondition in some places").
