### PR TITLE
cmake: Don’t add -lobjc in linux builds

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -466,8 +466,7 @@ function(add_swift_host_library name)
         SHARED
         STATIC
         OBJECT
-        PURE_SWIFT
-        HAS_LIBSWIFT)
+        PURE_SWIFT)
   set(single_parameter_options)
   set(multiple_parameter_options
         LLVM_LINK_COMPONENTS)
@@ -519,12 +518,6 @@ function(add_swift_host_library name)
   endif()
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})
-
-  if (ASHL_HAS_LIBSWIFT AND LIBSWIFT_BUILD_MODE)
-    # Workaround for a linker crash related to autolinking: rdar://77839981
-    set_property(TARGET ${name} APPEND_STRING PROPERTY
-                 LINK_FLAGS " -lobjc ")
-  endif()
 
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #

--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -6,8 +6,13 @@ set(LLVM_EXPORTED_SYMBOL_FILE
 
 add_swift_host_library(libSwiftScan SHARED
   libSwiftScan.cpp
-  c-include-check.c
-  HAS_LIBSWIFT)
+  c-include-check.c)
+
+if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
+  # Workaround for a linker crash related to autolinking: rdar://77839981
+  set_property(TARGET libSwiftScan APPEND_STRING PROPERTY
+               LINK_FLAGS " -lobjc ")
+endif()
 
 add_dependencies(libSwiftScan
   clang


### PR DESCRIPTION
Fixes a linux build error.
It doesn’t make sense to let add HAS_LIBSWIFT to add_swift_host_library(). This was added to work around a linker bug (d22b348adb21f92a528b5586928c79adec021979). Instead do the workaround in libSwiftScan/CMakeLists.txt.
