### PR TITLE
[Frontend] Load standard libarary in CompilerInstance::setup

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -341,6 +341,9 @@ public:
     if (FrontendOpts.InputMode == FrontendOptions::ParseInputMode::SIL) {
       return ImplicitStdlibKind::None;
     }
+    if (FrontendOpts.InputsAndOutputs.shouldTreatAsLLVM()) {
+      return ImplicitStdlibKind::None;
+    }
     if (getParseStdlib()) {
       return ImplicitStdlibKind::Builtin;
     }
@@ -562,7 +565,7 @@ public:
   }
 
   /// Returns true if there was an error during setup.
-  bool setup(const CompilerInvocation &Invocation);
+  bool setup(const CompilerInvocation &Invocation, std::string &Error);
 
   const CompilerInvocation &getInvocation() const { return Invocation; }
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -313,6 +313,9 @@ struct ModuleInterfaceLoaderOptions {
     case FrontendOptions::ActionType::TypecheckModuleFromInterface:
       requestedAction = FrontendOptions::ActionType::Typecheck;
       break;
+    case FrontendOptions::ActionType::ScanDependencies:
+      requestedAction = Opts.RequestedAction;
+      break;
     default:
       requestedAction = FrontendOptions::ActionType::EmitModuleOnly;
       break;

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -20,6 +20,7 @@
 #include "swift/AST/Effects.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ASTPrinter.h"
+#include "swift/Frontend/FrontendOptions.h"
 #include "swift/IDE/SourceEntityWalker.h"
 #include "swift/Parse/Token.h"
 #include "llvm/ADT/StringRef.h"
@@ -85,7 +86,8 @@ SourceCompleteResult isSourceInputComplete(StringRef Text, SourceFileKind SFKind
 
 bool initCompilerInvocation(
     CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
-    DiagnosticEngine &Diags, StringRef UnresolvedPrimaryFile,
+    FrontendOptions::ActionType Action, DiagnosticEngine &Diags,
+    StringRef UnresolvedPrimaryFile,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     const std::string &runtimeResourcePath,
     const std::string &diagnosticDocumentationPath, time_t sessionTimestamp,

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2247,8 +2247,9 @@ swift::ide::api::getSDKNodeRoot(SDKContext &SDKCtx,
   // The PrintDiags is only responsible compiler errors, we should remove the
   // consumer immediately after importing is done.
   SWIFT_DEFER { CI.getDiags().removeConsumer(PrintDiags); };
-  if (CI.setup(Invocation)) {
-    llvm::errs() << "Failed to setup the compiler instance\n";
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return nullptr;
   }
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -194,7 +194,10 @@ DependencyScanningTool::initCompilerInstanceForScan(
   }
 
   // Setup the instance
-  Instance->setup(Invocation);
+  std::string InstanceSetupError;
+  if (Instance->setup(Invocation, InstanceSetupError)) {
+    return std::make_error_code(std::errc::not_supported);
+  }
   (void)Instance->getMainModule();
 
   return Instance;

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1093,7 +1093,8 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
             SourceLoc(), diag::scanner_arguments_invalid, entry.arguments);
         return true;
       }
-      if (pInstance->setup(subInvok)) {
+      std::string InstanceSetupError;
+      if (pInstance->setup(subInvok, InstanceSetupError)) {
         invocationInstance.getDiags().diagnose(
             SourceLoc(), diag::scanner_arguments_invalid, entry.arguments);
         return true;

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -1849,8 +1849,10 @@ static bool readBreakageAllowlist(SDKContext &Ctx, llvm::StringSet<> &lines,
   CompilerInstance instance;
   CompilerInvocation invok;
   invok.setModuleName("ForClangImporter");
-  if (instance.setup(invok))
+  std::string InstanceSetupError;
+  if (instance.setup(invok, InstanceSetupError)) {
     return 1;
+  }
   auto importer = ClangImporter::create(instance.getASTContext());
   SmallString<128> preprocessedFilePath;
   if (auto error = llvm::sys::fs::createTemporaryFile(

--- a/lib/DriverTool/swift_api_extract_main.cpp
+++ b/lib/DriverTool/swift_api_extract_main.cpp
@@ -197,8 +197,9 @@ public:
   }
 
   int extractAPI() {
-    if (Instance.setup(Invocation)) {
-      llvm::outs() << "Failed to setup compiler instance\n";
+    std::string InstanceSetupError;
+    if (Instance.setup(Invocation, InstanceSetupError)) {
+      llvm::outs() << InstanceSetupError << '\n';
       return 1;
     }
 

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -182,8 +182,9 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
             .Default(AccessLevel::Public);
   }
 
-  if (CI.setup(Invocation)) {
-    llvm::outs() << "Failed to setup compiler instance\n";
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::outs() << InstanceSetupError << '\n';
     return EXIT_FAILURE;
   }
 

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -218,13 +218,6 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     InputInfo.getPrimarySpecificPaths().SupplementaryOutputs;
     StringRef OutPath = OutputInfo.ModuleOutputPath;
 
-    // Bail out if we're going to use the standard library but can't load it. If
-    // we don't do this before we try to build the interface, we could end up
-    // trying to rebuild a broken standard library dozens of times due to
-    // multiple calls to `ASTContext::getStdlibModule()`.
-    if (SubInstance.loadStdlibIfNeeded())
-      return std::make_error_code(std::errc::not_supported);
-
     // Build the .swiftmodule; this is a _very_ abridged version of the logic
     // in performCompile in libFrontendTool, specialized, to just the one
     // module-serialization task we're trying to do here.

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1682,7 +1682,8 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
 
   ForwardingDiagnosticConsumer FDC(*Diags);
   subInstance.addDiagnosticConsumer(&FDC);
-  if (subInstance.setup(subInvocation)) {
+  std::string InstanceSetupError;
+  if (subInstance.setup(subInvocation, InstanceSetupError)) {
     return std::make_error_code(std::errc::not_supported);
   }
 

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -561,22 +561,14 @@ void CompletionInstance::performNewOperation(
 
     Invocation.setCodeCompletionPoint(completionBuffer, Offset);
 
-    if (CI.setup(Invocation)) {
+    std::string InstanceSetupError;
+    if (CI.setup(Invocation, InstanceSetupError)) {
       Callback(CancellableResult<CompletionInstanceResult>::failure(
-          "failed to setup compiler instance"));
+          InstanceSetupError));
       return;
     }
     CI.getASTContext().CancellationFlag = CancellationFlag;
     registerIDERequestFunctions(CI.getASTContext().evaluator);
-
-    // If we're expecting a standard library, but there either isn't one, or it
-    // failed to load, let's bail early and hand back an empty completion
-    // result to avoid any downstream crashes.
-    if (CI.loadStdlibIfNeeded()) {
-      Callback(CancellableResult<CompletionInstanceResult>::failure(
-          "failed to load the standard library"));
-      return;
-    }
 
     CI.performParseAndResolveImportsOnly();
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1200,8 +1200,9 @@ getNotableRegions(StringRef SourceText, unsigned NameOffset, StringRef Name,
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
 
   auto Instance = std::make_unique<swift::CompilerInstance>();
-  if (Instance->setup(Invocation))
-    llvm_unreachable("Failed setup");
+  std::string InstanceSetupError;
+  if (Instance->setup(Invocation, InstanceSetupError))
+    llvm_unreachable(InstanceSetupError.c_str());
 
   unsigned BufferId = Instance->getPrimarySourceFile()->getBufferID().getValue();
   SourceManager &SM = Instance->getSourceMgr();

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -273,7 +273,8 @@ public:
 
 bool ide::initCompilerInvocation(
     CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
-    DiagnosticEngine &Diags, StringRef UnresolvedPrimaryFile,
+    FrontendOptions::ActionType Action, DiagnosticEngine &Diags,
+    StringRef UnresolvedPrimaryFile,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     const std::string &runtimeResourcePath,
     const std::string &diagnosticDocumentationPath, time_t sessionTimestamp,

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -152,7 +152,8 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
   // rdar://78576743 - Reset LLVM global state for command-line arguments set
   // by prior calls to setup.
   llvm::cl::ResetAllOptionOccurrences();
-  if (Instance->setup(Invocation)) {
+  std::string InstanceSetupError;
+  if (Instance->setup(Invocation, InstanceSetupError)) {
     return nullptr;
   }
 

--- a/test/SourceKit/CodeComplete/complete_without_stdlib.swift
+++ b/test/SourceKit/CodeComplete/complete_without_stdlib.swift
@@ -16,4 +16,4 @@ class Str {
 // RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk == \
 // RUN:   -req=complete -pos=4:1 %s -- %s -resource-dir %t/rsrc -sdk %t/sdk 2>&1 | %FileCheck %s
 
-// CHECK: error response (Request Failed): failed to load the standard library
+// CHECK: error response (Request Failed): Loading the standard library failed

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1044,18 +1044,13 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     CompIns.getSourceMgr().setFileSystem(FileSystem);
   }
 
-  if (CompIns.setup(Invocation)) {
+  if (CompIns.setup(Invocation, Error)) {
     // FIXME: Report the diagnostic.
     LOG_WARN_FUNC("Compilation setup failed!!!");
     Error = "compilation setup failed";
     return nullptr;
   }
   CompIns.getASTContext().CancellationFlag = CancellationFlag;
-  if (CompIns.loadStdlibIfNeeded()) {
-    LOG_WARN_FUNC("Loading the stdlib failed");
-    Error = "Loading the stdlib failed";
-    return nullptr;
-  }
   registerIDERequestFunctions(CompIns.getASTContext().evaluator);
   if (TracedOp.enabled()) {
     TracedOp.start(TraceInfo);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -650,42 +650,43 @@ convertFileContentsToInputs(ArrayRef<FileContent> contents) {
 
 bool SwiftASTManager::initCompilerInvocation(
     CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
-    DiagnosticEngine &Diags, StringRef UnresolvedPrimaryFile,
-    std::string &Error) {
-  return initCompilerInvocation(Invocation, OrigArgs, Diags,
+    swift::FrontendOptions::ActionType Action, DiagnosticEngine &Diags,
+    StringRef UnresolvedPrimaryFile, std::string &Error) {
+  return initCompilerInvocation(Invocation, OrigArgs, Action, Diags,
                                 UnresolvedPrimaryFile,
-                                llvm::vfs::getRealFileSystem(),
-                                Error);
+                                llvm::vfs::getRealFileSystem(), Error);
 }
 
 bool SwiftASTManager::initCompilerInvocation(
     CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
-    DiagnosticEngine &Diags, StringRef UnresolvedPrimaryFile,
+    FrontendOptions::ActionType Action, DiagnosticEngine &Diags,
+    StringRef UnresolvedPrimaryFile,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
   return ide::initCompilerInvocation(
-      Invocation, OrigArgs, Diags, UnresolvedPrimaryFile, FileSystem,
+      Invocation, OrigArgs, Action, Diags, UnresolvedPrimaryFile, FileSystem,
       Impl.RuntimeResourcePath, Impl.DiagnosticDocumentationPath,
       Impl.SessionTimestamp, Error);
 }
 
-bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &CompInvok,
-                                             ArrayRef<const char *> OrigArgs,
-                                             StringRef PrimaryFile,
-                                             std::string &Error) {
+bool SwiftASTManager::initCompilerInvocation(
+    CompilerInvocation &CompInvok, ArrayRef<const char *> OrigArgs,
+    swift::FrontendOptions::ActionType Action, StringRef PrimaryFile,
+    std::string &Error) {
   DiagnosticEngine Diagnostics(Impl.SourceMgr);
-  return initCompilerInvocation(CompInvok, OrigArgs, Diagnostics, PrimaryFile,
-                                Error);
+  return initCompilerInvocation(CompInvok, OrigArgs, Action, Diagnostics,
+                                PrimaryFile, Error);
 }
 
 bool SwiftASTManager::initCompilerInvocationNoInputs(
     swift::CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
-    swift::DiagnosticEngine &Diags, std::string &Error, bool AllowInputs) {
+    swift::FrontendOptions::ActionType Action, swift::DiagnosticEngine &Diags,
+    std::string &Error, bool AllowInputs) {
 
   SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
   // Use stdin as a .swift input to satisfy the driver.
   Args.push_back("-");
-  if (initCompilerInvocation(Invocation, Args, Diags, "", Error))
+  if (initCompilerInvocation(Invocation, Args, Action, Diags, "", Error))
     return true;
 
   if (!AllowInputs &&
@@ -699,13 +700,15 @@ bool SwiftASTManager::initCompilerInvocationNoInputs(
   return false;
 }
 
-SwiftInvocationRef SwiftASTManager::getInvocation(
-    ArrayRef<const char *> OrigArgs, StringRef PrimaryFile, std::string &Error) {
-  return getInvocation(OrigArgs, PrimaryFile, llvm::vfs::getRealFileSystem(),
-                       Error);
+SwiftInvocationRef
+SwiftASTManager::getTypecheckInvocation(ArrayRef<const char *> OrigArgs,
+                                        StringRef PrimaryFile,
+                                        std::string &Error) {
+  return getTypecheckInvocation(OrigArgs, PrimaryFile,
+                                llvm::vfs::getRealFileSystem(), Error);
 }
 
-SwiftInvocationRef SwiftASTManager::getInvocation(
+SwiftInvocationRef SwiftASTManager::getTypecheckInvocation(
     ArrayRef<const char *> OrigArgs, StringRef PrimaryFile,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
@@ -716,8 +719,9 @@ SwiftInvocationRef SwiftASTManager::getInvocation(
   Diags.addConsumer(CollectDiagConsumer);
 
   CompilerInvocation CompInvok;
-  if (initCompilerInvocation(CompInvok, OrigArgs, Diags, PrimaryFile,
-                             FileSystem, Error)) {
+  if (initCompilerInvocation(CompInvok, OrigArgs,
+                             FrontendOptions::ActionType::Typecheck, Diags,
+                             PrimaryFile, FileSystem, Error)) {
     // We create a traced operation here to represent the failure to parse
     // arguments since we cannot reach `createAST` where that would normally
     // happen.

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -78,6 +78,7 @@
 #include "SourceKit/Core/LLVM.h"
 #include "SourceKit/Support/CancellationToken.h"
 #include "SwiftInvocation.h"
+#include "swift/Frontend/FrontendOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
@@ -238,12 +239,13 @@ public:
                            StringRef DiagnosticDocumentationPath);
   ~SwiftASTManager();
 
-  SwiftInvocationRef getInvocation(
-      ArrayRef<const char *> Args, StringRef PrimaryFile, std::string &Error);
+  SwiftInvocationRef getTypecheckInvocation(ArrayRef<const char *> Args,
+                                            StringRef PrimaryFile,
+                                            std::string &Error);
 
   /// Same as the previous `getInvocation`, but allows the caller to specify a
   /// custom `FileSystem` to be used throughout the invocation.
-  SwiftInvocationRef getInvocation(
+  SwiftInvocationRef getTypecheckInvocation(
       ArrayRef<const char *> Args, StringRef PrimaryFile,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       std::string &Error);
@@ -262,22 +264,25 @@ public:
   std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(StringRef Filename,
                                                       std::string &Error);
 
-  bool initCompilerInvocation(
-      swift::CompilerInvocation &Invocation, ArrayRef<const char *> Args,
-      swift::DiagnosticEngine &Diags, StringRef PrimaryFile, std::string &Error);
+  bool initCompilerInvocation(swift::CompilerInvocation &Invocation,
+                              ArrayRef<const char *> Args,
+                              swift::FrontendOptions::ActionType Action,
+                              swift::DiagnosticEngine &Diags,
+                              StringRef PrimaryFile, std::string &Error);
 
   /// Same as the previous `initCompilerInvocation`, but allows the caller to
   /// specify a custom `FileSystem` to be used throughout the invocation.
   bool initCompilerInvocation(
       swift::CompilerInvocation &Invocation, ArrayRef<const char *> Args,
-      swift::DiagnosticEngine &Diags, StringRef PrimaryFile,
+      swift::FrontendOptions::ActionType Action, swift::DiagnosticEngine &Diags,
+      StringRef PrimaryFile,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       std::string &Error);
 
   bool initCompilerInvocation(swift::CompilerInvocation &CompInvok,
                               ArrayRef<const char *> OrigArgs,
-                              StringRef PrimaryFile,
-                              std::string &Error);
+                              swift::FrontendOptions::ActionType Action,
+                              StringRef PrimaryFile, std::string &Error);
 
   /// Initializes \p Invocation as if for typechecking, but with no inputs.
   ///
@@ -285,6 +290,7 @@ public:
   /// input files.
   bool initCompilerInvocationNoInputs(swift::CompilerInvocation &Invocation,
                                       ArrayRef<const char *> OrigArgs,
+                                      swift::FrontendOptions::ActionType Action,
                                       swift::DiagnosticEngine &Diags,
                                       std::string &Error,
                                       bool AllowInputs = true);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -654,7 +654,7 @@ public:
   void setCompilerArgs(ArrayRef<const char *> Args) {
     if (auto ASTMgr = this->ASTMgr.lock()) {
       InvokRef =
-          ASTMgr->getInvocation(Args, Filename, CompilerArgsError);
+          ASTMgr->getTypecheckInvocation(Args, Filename, CompilerArgsError);
     }
   }
 
@@ -2015,8 +2015,8 @@ void SwiftEditorDocument::resetSyntaxInfo(ImmutableTextSnapshotRef Snapshot,
     Args.push_back("-");
     std::string Error;
     // Ignore possible error(s)
-    Lang.getASTManager()->
-      initCompilerInvocation(CompInv, Args, StringRef(), Error);
+    Lang.getASTManager()->initCompilerInvocation(
+        CompInv, Args, FrontendOptions::ActionType::Parse, StringRef(), Error);
   }
   CompInv.getLangOptions().BuildSyntaxTree = BuildSyntaxTree;
   CompInv.setMainFileSyntaxParsingCache(SyntaxCache);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -634,8 +634,9 @@ void SwiftLangSupport::editorOpenTypeInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
-                                             StringRef(), Error)) {
+  if (getASTManager()->initCompilerInvocation(
+          Invocation, Args, FrontendOptions::ActionType::Typecheck,
+          CI.getDiags(), StringRef(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
@@ -674,8 +675,9 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager()->initCompilerInvocationNoInputs(Invocation, Args,
-                                                     CI.getDiags(), Error)) {
+  if (getASTManager()->initCompilerInvocationNoInputs(
+          Invocation, Args, FrontendOptions::ActionType::Typecheck,
+          CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
@@ -740,7 +742,7 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(
     SourceKitCancellationToken CancellationToken,
     std::shared_ptr<EditorConsumer> Consumer) {
   std::string Error;
-  auto Invocation = ASTMgr->getInvocation(Args, SourceName, Error);
+  auto Invocation = ASTMgr->getTypecheckInvocation(Args, SourceName, Error);
   if (!Invocation) {
     Consumer->handleRequestError(Error.c_str());
     return;
@@ -769,8 +771,9 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   std::string Error;
 
   ArrayRef<const char *> SwiftArgs = UsingSwiftArgs ? Args : llvm::None;
-  if (getASTManager()->initCompilerInvocationNoInputs(Invocation, SwiftArgs,
-                                                     CI.getDiags(), Error)) {
+  if (getASTManager()->initCompilerInvocationNoInputs(
+          Invocation, SwiftArgs, FrontendOptions::ActionType::Typecheck,
+          CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
@@ -819,8 +822,9 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager()->initCompilerInvocation(Invocation, Args, CI.getDiags(),
-                                             StringRef(), Error)) {
+  if (getASTManager()->initCompilerInvocation(
+          Invocation, Args, FrontendOptions::ActionType::Typecheck,
+          CI.getDiags(), StringRef(), Error)) {
     return Receiver(RequestResult<InterfaceDocInfo>::fromError(Error));
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -225,7 +225,8 @@ static bool makeParserAST(CompilerInstance &CI, StringRef Text,
   Invocation.getFrontendOptions().InputsAndOutputs.addInput(
       InputFile(Buf.get()->getBufferIdentifier(), /*isPrimary*/false, Buf.get(),
                 file_types::TY_Swift));
-  return CI.setup(Invocation);
+  std::string InstanceSetupError;
+  return CI.setup(Invocation, InstanceSetupError);
 }
 
 static void reportSyntacticAnnotations(CompilerInstance &CI,
@@ -373,8 +374,7 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
   CI.addDiagnosticConsumer(&IFaceGenCtx->Impl.DiagConsumer);
 
   Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
-  if (CI.setup(Invocation)) {
-    ErrMsg = "Error during invocation setup";
+  if (CI.setup(Invocation, ErrMsg)) {
     return nullptr;
   }
 
@@ -432,8 +432,7 @@ SwiftInterfaceGenContext::createForTypeInterface(CompilerInvocation Invocation,
   // Display diagnostics to stderr.
   CI.addDiagnosticConsumer(&IFaceGenCtx->Impl.DiagConsumer);
 
-  if (CI.setup(Invocation)) {
-    ErrorMsg = "Error during invocation setup";
+  if (CI.setup(Invocation, ErrorMsg)) {
     return nullptr;
   }
   registerIDETypeCheckRequestFunctions(CI.getASTContext().evaluator);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -314,8 +314,11 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   }
 
   if (IsModuleIndexing) {
-    if (CI.setup(Invocation))
+    std::string InstanceSetupError;
+    if (CI.setup(Invocation, InstanceSetupError)) {
+      IdxConsumer.failed(InstanceSetupError);
       return;
+    }
     // Indexing needs IDE requests
     registerIDERequestFunctions(CI.getASTContext().evaluator);
     bool IsClangModule = (FileExt == ".pcm");
@@ -334,8 +337,11 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     return;
   }
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    IdxConsumer.failed(InstanceSetupError);
     return;
+  }
   // Indexing needs IDE requests
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   trace::TracedOperation TracedOp(trace::OperationKind::IndexSource);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -303,10 +303,12 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   bool Failed = true;
   if (IsModuleIndexing) {
     Failed = getASTManager()->initCompilerInvocationNoInputs(
-        Invocation, Args, CI.getDiags(), Error);
+        Invocation, Args, FrontendOptions::ActionType::Typecheck, CI.getDiags(),
+        Error);
   } else {
     Failed = getASTManager()->initCompilerInvocation(
-        Invocation, Args, CI.getDiags(), InputFile, Error);
+        Invocation, Args, FrontendOptions::ActionType::Typecheck, CI.getDiags(),
+        InputFile, Error);
   }
   if (Failed) {
     IdxConsumer.failed(Error);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1043,8 +1043,8 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   CompilerInvocation Invocation;
   std::string CompilerInvocationError;
   bool CreatingInvocationFailed = getASTManager()->initCompilerInvocation(
-      Invocation, Args, Diags, newBuffer->getBufferIdentifier(), FileSystem,
-      CompilerInvocationError);
+      Invocation, Args, FrontendOptions::ActionType::Typecheck, Diags,
+      newBuffer->getBufferIdentifier(), FileSystem, CompilerInvocationError);
   if (CreatingInvocationFailed) {
     PerformOperation(CancellableResult<CompletionLikeOperationParams>::failure(
         CompilerInvocationError));

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1860,7 +1860,7 @@ void SwiftLangSupport::getCursorInfo(
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getInvocation(Args, InputFile, fileSystem, Error);
+      ASTMgr->getTypecheckInvocation(Args, InputFile, fileSystem, Error);
   if (!Error.empty()) {
     LOG_WARN_FUNC("error creating ASTInvocation: " << Error);
   }
@@ -1887,8 +1887,8 @@ void SwiftLangSupport::getDiagnostics(
   }
 
   std::string InvocationError;
-  SwiftInvocationRef Invok =
-      ASTMgr->getInvocation(Args, InputFile, FileSystem, InvocationError);
+  SwiftInvocationRef Invok = ASTMgr->getTypecheckInvocation(
+      Args, InputFile, FileSystem, InvocationError);
   if (!InvocationError.empty()) {
     LOG_WARN_FUNC("error creating ASTInvocation: " << InvocationError);
   }
@@ -1913,7 +1913,8 @@ void SwiftLangSupport::getRangeInfo(
     return;
   }
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, InputFile, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<RangeInfo>::fromError(Error));
@@ -1956,7 +1957,8 @@ void SwiftLangSupport::getNameInfo(
   }
 
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, InputFile, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<NameTranslatingInfo>::fromError(Error));
@@ -2121,7 +2123,7 @@ void SwiftLangSupport::getCursorInfoFromUSR(
 
   std::string Error;
   SwiftInvocationRef Invok =
-      ASTMgr->getInvocation(Args, filename, fileSystem, Error);
+      ASTMgr->getTypecheckInvocation(Args, filename, fileSystem, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<CursorInfoData>::fromError(Error));
@@ -2241,7 +2243,8 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
     std::function<void(const RequestResult<RelatedIdentsInfo> &)> Receiver) {
 
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, InputFile, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, InputFile, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<RelatedIdentsInfo>::fromError(Error));
@@ -2363,7 +2366,8 @@ void SwiftLangSupport::semanticRefactoring(
     ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
     CategorizedEditsReceiver Receiver) {
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, Filename, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, Filename, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromError(Error));
@@ -2420,7 +2424,8 @@ void SwiftLangSupport::collectExpressionTypes(
     std::function<void(const RequestResult<ExpressionTypesInFile> &)>
         Receiver) {
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, FileName, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, FileName, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<ExpressionTypesInFile>::fromError(Error));
@@ -2480,7 +2485,8 @@ void SwiftLangSupport::collectVariableTypes(
     Optional<unsigned> Length, SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver) {
   std::string Error;
-  SwiftInvocationRef Invok = ASTMgr->getInvocation(Args, FileName, Error);
+  SwiftInvocationRef Invok =
+      ASTMgr->getTypecheckInvocation(Args, FileName, Error);
   if (!Invok) {
     LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<VariableTypesInFile>::fromError(Error));

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -316,8 +316,9 @@ int main(int argc, char **argv) {
     Invocation.setRuntimeResourcePath(ResourceDir);
   }
 
-  if (CI.setup(Invocation)) {
-    llvm::errs() << "error: Failed setup invocation!\n";
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
   }
 

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -283,8 +283,11 @@ int main(int argc, char **argv) {
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   CI.performSema();
 
   // If parsing produced an error, don't run any passes.

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -175,8 +175,11 @@ int main(int argc, char **argv) {
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
 
   std::error_code EC;
   llvm::raw_fd_ostream outStream(OutputFilename, EC, llvm::sys::fs::OF_None);

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -178,8 +178,11 @@ int main(int argc, char **argv) {
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   CI.performSema();
 
   // If parsing produced an error, don't run any passes.

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -584,8 +584,11 @@ int main(int argc, char **argv) {
     return retValue ? retValue : diagnosticsError;
   };
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return finishDiagProcessing(1);
+  }
 
   CI.performSema();
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -925,8 +925,11 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
 
   CompilerInstance CI;
   CI.addDiagnosticConsumer(&PDC);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   CI.performSema();
 
   PrintOptions Options = PrintOptions::printEverything();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1636,8 +1636,11 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   auto &ctx = CI.getASTContext();
   registerIDERequestFunctions(ctx.evaluator);
 
@@ -1847,8 +1850,11 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
   if (RunTypeChecker) {
     CompilerInstance CI;
     CI.addDiagnosticConsumer(&PrintDiags);
-    if (CI.setup(Invocation))
+    std::string InstanceSetupError;
+    if (CI.setup(Invocation, InstanceSetupError)) {
+      llvm::errs() << InstanceSetupError << '\n';
       return 1;
+    }
     CI.performSema();
 
     unsigned BufID = CI.getInputBufferIDs().back();
@@ -1922,8 +1928,11 @@ static int doDumpImporterLookupTables(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -2387,8 +2396,11 @@ static int doSemanticAnnotation(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -2451,8 +2463,11 @@ static int doPrintAST(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   std::unique_ptr<DebuggerClient> DebuggerClient;
   if (!DebugClientDiscriminator.empty()) {
@@ -2494,8 +2509,11 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return EXIT_FAILURE;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   std::vector<ExpressionTypeInfo> Scratch;
@@ -2549,8 +2567,11 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
   CompilerInstance CI;
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -2772,8 +2793,11 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -2839,8 +2863,11 @@ static int doPrintModuleMetaData(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -2906,8 +2933,11 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -2971,8 +3001,11 @@ static int doPrintHeaders(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -3024,8 +3057,11 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -3057,8 +3093,11 @@ static int doPrintDecls(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -3173,8 +3212,11 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -3398,8 +3440,11 @@ static int doDumpComments(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -3423,8 +3468,11 @@ static int doPrintComments(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -3447,8 +3495,11 @@ static int doPrintModuleComments(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -3485,8 +3536,11 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
 
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
@@ -3544,8 +3598,11 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI;
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   SourceFile *SF = nullptr;
@@ -3593,8 +3650,11 @@ static int doPrintTypeInterfaceForTypeUsr(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);
   CompilerInstance CI;
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   DeclContext *DC = CI.getMainModule()->getModuleContext();
@@ -3761,8 +3821,11 @@ static int doReconstructType(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   SourceFile *SF = nullptr;
@@ -3798,8 +3861,11 @@ static int doPrintRangeInfo(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   SourceFile *SF = nullptr;
@@ -3901,8 +3967,11 @@ static int doPrintIndexedSymbols(const CompilerInvocation &InitInvok,
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
 
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
   SourceFile *SF = nullptr;
@@ -3930,8 +3999,11 @@ static int doPrintIndexedSymbolsFromModule(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
@@ -3966,8 +4038,11 @@ static int doPrintUSRs(const CompilerInvocation &InitInvok,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
@@ -4114,6 +4189,8 @@ int main(int argc, char *argv[]) {
     llvm::EnableStatistics();
 
   CompilerInvocation InitInvok;
+
+  InitInvok.getFrontendOptions().RequestedAction = FrontendOptions::ActionType::Typecheck;
 
   for (auto &File : options::InputFilenames)
     InitInvok.getFrontendOptions().InputsAndOutputs.addInputFile(File);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -307,6 +307,7 @@ int main(int argc, char *argv[]) {
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
       options::SourceFilename);
+  Invocation.getFrontendOptions().RequestedAction = FrontendOptions::ActionType::Typecheck;
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().CollectParsedToken = true;
   Invocation.getLangOptions().BuildSyntaxTree = true;
@@ -325,8 +326,11 @@ int main(int argc, char *argv[]) {
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  if (CI.setup(Invocation))
+  std::string InstanceSetupError;
+  if (CI.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return 1;
+  }
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   switch (options::Action) {
     case RefactoringKind::GlobalRename:

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -595,8 +595,9 @@ int parseFile(
   PrintingDiagnosticConsumer DiagConsumer(DiagOS);
   CompilerInstance Instance;
   Instance.addDiagnosticConsumer(&DiagConsumer);
-  if (Instance.setup(Invocation)) {
-    llvm::errs() << "Unable to set up compiler instance";
+  std::string InstanceSetupError;
+  if (Instance.setup(Invocation, InstanceSetupError)) {
+    llvm::errs() << InstanceSetupError << '\n';
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Instead of checking that the stdlib can be loaded in a variety of places, check it when setting up the compiler instance. This required a couple more checks to avoid loading the stdlib in cases where it’s not needed.

To be able to differentiate stdlib loading failures from other setup errors, make `CompilerInstance::setup` return an error message on failure via an inout parameter. Consume that error on the call side, replacing a previous, more generic error message, adding error handling where appropriate or ignoring the error message, depending on the context.

--- 

Was discussed in https://github.com/apple/swift/pull/39631#discussion_r739175831