### PR TITLE
AssociatedTypeInference: Fix regression introduced in 1cf9622

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1185,7 +1185,9 @@ AssociatedTypeDecl *AssociatedTypeInference::completeSolution(
   for (const auto &witness : abstractTypeWitnesses) {
     Type type = witness.getType();
     if (type->hasTypeParameter()) {
-      if (witness.getKind() != AbstractTypeWitnessKind::GenericParam) {
+      if (witness.getKind() == AbstractTypeWitnessKind::GenericParam) {
+        type = type = dc->mapTypeIntoContext(type);
+      } else {
         // Replace type parameters with other known or tentative type witnesses.
         type = type.subst(
             [&](SubstitutableType *type) {
@@ -1200,23 +1202,26 @@ AssociatedTypeDecl *AssociatedTypeInference::completeSolution(
         if (type->hasError())
           return witness.getAssocType();
 
-        // FIXME: If we still have a type parameter and it isn't a generic
-        // parameter of the conforming nominal, it's either a cycle or a
-        // solution that is beyond the current algorithm, i.e.
-        //
+        // FIXME: If mapping into context yields an error, or we still have a
+        // type parameter despite not having a generic environment, then a type
+        // parameter was sent to a tentative type witness that itself is a type
+        // parameter, and the solution is cyclic, e.g. { A := B.A, B := A.B },
+        // or beyond the current algorithm, e.g.
         // protocol P {
         //   associatedtype A = B
         //   associatedtype B = C
         //   associatedtype C = Int
         // }
         // struct Conformer: P {}
-        if (type->hasTypeParameter() &&
-            !adoptee->getAnyNominal()->isGeneric()) {
+        if (dc->getGenericEnvironmentOfContext()) {
+          type = dc->mapTypeIntoContext(type);
+
+          if (type->hasError())
+            return witness.getAssocType();
+        } else if (type->hasTypeParameter()) {
           return witness.getAssocType();
         }
       }
-
-      type = dc->mapTypeIntoContext(type);
     }
 
     if (const auto &failed = checkTypeWitness(type, witness.getAssocType(),

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -120,3 +120,12 @@ protocol P13c: P13a, P13b where A == B {}
 struct S13: P13c { // OK, A == B == Never
   func foo(arg: Never) {}
 }
+
+protocol P14 {
+  associatedtype A = Array<Self>
+}
+do {
+  struct Outer<Element> {
+    struct Conformer: P14 {}
+  }
+}

--- a/test/decl/protocol/req/sr15460.swift
+++ b/test/decl/protocol/req/sr15460.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+public protocol P {}
+
+extension Array {
+  public struct Inner {}
+}
+
+extension Array.Inner:
+  BidirectionalCollection,
+  Collection,
+  MutableCollection,
+  RandomAccessCollection,
+  Sequence
+where Element: P {
+  public typealias Element = Array<Element>.Element
+  public typealias Index = Array<Element>.Index
+  public typealias Indices = Array<Element>.Indices
+  public typealias SubSequence = Array<Element>.SubSequence
+
+  public subscript(position: Array<Element>.Index) -> Element {
+    get {} set {}
+  }
+
+  public subscript(bounds: Range<Array<Element>.Index>) -> SubSequence {
+    get {} set {}
+  }
+
+  public var startIndex: Index {0}
+  public var endIndex: Index {0}
+}


### PR DESCRIPTION
The `_Differentation` dependency was definitely superfluous, so I removed it from the original test case. I also added a reduced one to easily pinpoint any regressions.

Resolves SR-15460
