### PR TITLE
[nfc] Fix leak after creating `ItaniumMangleContext`.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2085,8 +2085,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       auto &astContext = classTemplateSpecDecl->getASTContext();
       // Itanium mangler produces valid Swift identifiers, use it to generate a name for
       // this instantiation.
-      clang::MangleContext *mangler = clang::ItaniumMangleContext::create(
-          astContext, astContext.getDiagnostics());
+      std::unique_ptr<clang::MangleContext> mangler{
+          clang::ItaniumMangleContext::create(astContext,
+                                              astContext.getDiagnostics())};
       llvm::SmallString<128> storage;
       llvm::raw_svector_ostream buffer(storage);
       mangler->mangleTypeName(astContext.getRecordType(classTemplateSpecDecl),


### PR DESCRIPTION
We need to delete the `MangleContext` after we create it. This follows the existing use of `ItaniumMangleContext::create` in ASTMangler.cpp and a similar change in llvm here: llvm/llvm-project/commit/8b5783194ced98cabaa585678cacaf7c2e2763d8