### PR TITLE
[Diagnostics] Don't assume that contextual type for optional chain is optional

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4060,7 +4060,7 @@ bool ConstraintSystem::repairFailures(
       // optionality if needed.
       auto contextualTy = simplifyType(rhs)->getOptionalObjectType();
       if (!lhs->getOptionalObjectType() && !lhs->hasTypeVariable() &&
-          !contextualTy->isTypeVariableOrMember()) {
+          contextualTy && !contextualTy->isTypeVariableOrMember()) {
         conversionsOrFixes.push_back(IgnoreContextualType::create(
             *this, lhs, rhs, getConstraintLocator(OEE->getSubExpr())));
         return true;

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -499,3 +499,13 @@ func rdar75514153() {
   test_labeled(42, x: nil)   // expected-error {{no exact matches in call to local function 'test_labeled'}}
   test_labeled(42, x: (nil)) // expected-error {{no exact matches in call to local function 'test_labeled'}}
 }
+
+// rdar://85166519 - Crash dereferencing Null Type In Bogus Expression
+func rdar85166519() {
+  var v: Int? = nil
+
+  var _: [Int: AnyObject] = [ // expected-error {{dictionary of type '[Int : AnyObject]' cannot be initialized with array literal}}
+    // expected-note@-1 {{did you mean to use a dictionary literal instead?}}
+    v?.addingReportingOverflow(0) // expected-error {{cannot convert value of type '(partialValue: Int, overflow: Bool)?' to expected dictionary key type 'Int'}}
+  ]
+}


### PR DESCRIPTION
While checking validity of the optional chain, let's not assume
that the contextual type associated with is optional because
enclosing expression could too be invalid.

Resolves: rdar://85166519

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
