### PR TITLE
[gardening] Remove unused option: `disable-named-lazy-member-loading`.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -270,9 +270,6 @@ namespace swift {
     ///
     /// Flags for developers
     ///
-
-    /// Enable named lazy member loading.
-    bool NamedLazyMemberLoading = true;
     
     /// Whether to record request references for incremental builds.
     bool RecordRequestReferences = true;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1417,19 +1417,13 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
   const auto flags = desc.Options;
   auto *decl = desc.DC;
 
-  // We only use NamedLazyMemberLoading when a user opts-in and we have
-  // not yet loaded all the members into the IDC list in the first place.
   ASTContext &ctx = decl->getASTContext();
-  const bool useNamedLazyMemberLoading = (ctx.LangOpts.NamedLazyMemberLoading &&
-                                          decl->hasLazyMembers());
   const bool includeAttrImplements =
       flags.contains(NominalTypeDecl::LookupDirectFlags::IncludeAttrImplements);
 
   LLVM_DEBUG(llvm::dbgs() << decl->getNameStr() << ".lookupDirect("
                           << name << ")"
                           << ", hasLazyMembers()=" << decl->hasLazyMembers()
-                          << ", useNamedLazyMemberLoading="
-                          << useNamedLazyMemberLoading
                           << "\n");
 
   decl->prepareLookupTable();
@@ -1440,7 +1434,9 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
   decl->addLoadedExtensions();
 
   auto &Table = *decl->LookupTable;
-  if (!useNamedLazyMemberLoading) {
+  // We only use NamedLazyMemberLoading when we have not yet loaded all the
+  // members into the IDC list.
+  if (!decl->hasLazyMembers()) {
     // Make sure we have the complete list of members (in this nominal and in
     // all extensions).
     (void)decl->getMembers();

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -516,8 +516,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                                               /*default*/ false);
   Opts.UseClangFunctionTypes |= Args.hasArg(OPT_use_clang_function_types);
 
-  Opts.NamedLazyMemberLoading &= !Args.hasArg(OPT_disable_named_lazy_member_loading);
-
   if (Args.hasArg(OPT_verify_syntax_tree)) {
     Opts.BuildSyntaxTree = true;
     Opts.VerifySyntaxTree = true;


### PR DESCRIPTION
This option is not tested or used anywhere. It is also not well supported; some things, such as C++ interop, will not work correctly with this option.