### PR TITLE
SIL: More robust substituted function type lowering.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -953,7 +953,7 @@ public:
                 CanType subst,
                 ArchetypeType *upperBound,
                 ArrayRef<ProtocolConformanceRef> substConformances)> substFn);
-  
+
   /// Determines whether this type is similar to \p other as defined by
   /// \p matchOptions.
   bool matches(Type other, TypeMatchOptions matchOptions);

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1406,6 +1406,33 @@ public:
   /// is the corresponding value passed?
   CallingConventionKind getParameterConvention(TypeConverter &TC) const;
   
+  /// Generate the abstraction pattern for lowering the substituted SIL
+  /// function type for a function type matching this abstraction pattern.
+  ///
+  /// This abstraction pattern must be a function abstraction pattern, matching
+  /// \c substType .
+  ///
+  /// Where the abstraction pattern involves substitutable types, in order
+  /// to minimize function conversions, we extract those positions out into
+  /// fresh generic arguments, with the minimum set of constraints necessary
+  /// to maintain the calling convention (such as passed-directly or
+  /// passed-indirectly) as well as satisfy requirements of where the generic
+  /// argument structurally appears in the type.
+  /// The goal is for similar-shaped generic function types to remain
+  /// canonically equivalent, like `(T, U) -> ()`, `(T, T) -> ()`,
+  /// `(U, T) -> ()` or `(T, T.A) -> ()` when given substitutions that produce
+  /// the same function types.
+  ///
+  /// Returns a new AbstractionPattern to use for type lowering, as well as
+  /// the SubstitutionMap used to map `substType` into the new abstraction
+  /// pattern's generic environment, and the coroutine yield type mapped into
+  /// the generic environment of the new abstraction pattern.
+  std::tuple<AbstractionPattern, SubstitutionMap, AbstractionPattern>
+  getSubstFunctionTypePattern(CanAnyFunctionType substType,
+                              TypeConverter &TC,
+                              AbstractionPattern coroutineYieldOrigType,
+                              CanType coroutineYieldSubstType) const;
+  
   void dump() const LLVM_ATTRIBUTE_USED;
   void print(raw_ostream &OS) const;
   

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1738,7 +1738,8 @@ void IRGenerator::emitDynamicReplacements() {
   llvm::SmallSet<OpaqueTypeArchetypeType *, 8> origUniqueOpaqueTypes;
   for (auto *newFunc : DynamicReplacements) {
     auto newResultTy = newFunc->getLoweredFunctionType()
-             ->getAllResultsInterfaceType()
+             ->getAllResultsSubstType(newFunc->getModule(),
+                                      TypeExpansionContext::minimal())
              .getASTType();
     if (!newResultTy->hasOpaqueArchetype())
       continue;
@@ -1750,8 +1751,9 @@ void IRGenerator::emitDynamicReplacements() {
     auto *origFunc = newFunc->getDynamicallyReplacedFunction();
     assert(origFunc);
     auto origResultTy = origFunc->getLoweredFunctionType()
-                            ->getAllResultsInterfaceType()
-                            .getASTType();
+                  ->getAllResultsSubstType(origFunc->getModule(),
+                                           TypeExpansionContext::minimal())
+                  .getASTType();
     assert(origResultTy->hasOpaqueArchetype());
     origResultTy.visit([&](CanType ty) {
       if (auto opaque = ty->getAs<OpaqueTypeArchetypeType>())

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1401,7 +1401,8 @@ SILArgument *LoadableStorageAllocation::replaceArgType(SILBuilder &argBuilder,
 void LoadableStorageAllocation::insertIndirectReturnArgs() {
   GenericEnvironment *genEnv = getSubstGenericEnvironment(pass.F);
   auto loweredTy = pass.F->getLoweredFunctionType();
-  SILType resultStorageType = loweredTy->getAllResultsInterfaceType();
+  SILType resultStorageType = loweredTy->getAllResultsSubstType(pass.F->getModule(),
+                                                                pass.F->getTypeExpansionContext());
   auto canType = resultStorageType.getASTType();
   if (canType->hasTypeParameter()) {
     assert(genEnv && "Expected a GenericEnv");

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1148,228 +1148,6 @@ public:
   }
 };
 
-/// A structure for building the substituted generic signature of a lowered type.
-///
-/// Where the abstraction pattern for a lowered type involves substitutable types, we extract those positions
-/// out into generic arguments. This signature only needs to consider the general calling convention,
-/// so it can reduce away protocol and base class constraints aside from
-/// `AnyObject`. We want similar-shaped generic function types to remain
-/// canonically equivalent, like `(T, U) -> ()`, `(T, T) -> ()`,
-/// `(U, T) -> ()` or `(T, T.A) -> ()` when given substitutions that produce
-/// the same function types, so we also introduce a new generic argument for
-/// each position where we see a dependent type, and canonicalize the order in
-/// which we see independent generic arguments.
-class SubstFunctionTypeCollector {
-public:
-  TypeConverter &TC;
-  TypeExpansionContext Expansion;
-  CanGenericSignature GenericSig;
-  bool Enabled;
-  
-  SmallVector<GenericTypeParamType *, 4> substGenericParams;
-  SmallVector<Requirement, 4> substRequirements;
-  SmallVector<Type, 4> substReplacements;
-  SmallVector<ProtocolConformanceRef, 4> substConformances;
-  
-  SubstFunctionTypeCollector(TypeConverter &TC, TypeExpansionContext context,
-                             CanGenericSignature genericSig, bool enabled)
-    : TC(TC), Expansion(context), GenericSig(genericSig), Enabled(enabled) {
-    }
-  SubstFunctionTypeCollector(const SubstFunctionTypeCollector &) = delete;
-  
-  // Add a substitution for a fresh type variable, with the given replacement
-  // type and layout constraint.
-  CanType addSubstitution(LayoutConstraint layout,
-                          CanType substType,
-                          ArchetypeType *upperBound,
-                      ArrayRef<ProtocolConformanceRef> substTypeConformances) {
-    auto paramIndex = substGenericParams.size();
-    auto param = CanGenericTypeParamType::get(/*type sequence*/ false,
-                                              0, paramIndex, TC.Context);
-    
-    // Expand the bound type according to the expansion context.
-    if (Expansion.shouldLookThroughOpaqueTypeArchetypes()
-        && substType->hasOpaqueArchetype()) {
-      substType = substOpaqueTypesWithUnderlyingTypes(substType, Expansion);
-    }
-    
-    substGenericParams.push_back(param);
-    substReplacements.push_back(substType);
-    
-    LayoutConstraint upperBoundLayout;
-    Type upperBoundSuperclass;
-    ArrayRef<ProtocolDecl*> upperBoundConformances;
-    
-    // If the parameter is in a position with upper bound constraints, such
-    // as a generic nominal type with type constraints on its arguments, then
-    // preserve the constraints from that upper bound.
-    if (upperBound) {
-      upperBoundSuperclass = upperBound->getSuperclass();
-      upperBoundConformances = upperBound->getConformsTo();
-      upperBoundLayout = upperBound->getLayoutConstraint();
-    }
-    
-    if (upperBoundSuperclass) {
-      upperBoundSuperclass = upperBoundSuperclass->mapTypeOutOfContext();
-      substRequirements.push_back(
-       Requirement(RequirementKind::Superclass, param, upperBoundSuperclass));
-    }
-    
-    // Preserve the layout constraint, if any, on the archetype in the
-    // generic signature, generalizing away some constraints that
-    // shouldn't affect ABI substitutability.
-    if (layout) {
-      switch (layout->getKind()) {
-      // Keep these layout constraints as is.
-      case LayoutConstraintKind::RefCountedObject:
-      case LayoutConstraintKind::TrivialOfAtMostSize:
-        break;
-      
-      case LayoutConstraintKind::UnknownLayout:
-      case LayoutConstraintKind::Trivial:
-        // These constraints don't really constrain the ABI, so we can
-        // eliminate them.
-        layout = LayoutConstraint();
-        break;
-    
-      // Replace these specific constraints with one of the more general
-      // constraints above.
-      case LayoutConstraintKind::NativeClass:
-      case LayoutConstraintKind::Class:
-      case LayoutConstraintKind::NativeRefCountedObject:
-        // These can all be generalized to RefCountedObject.
-        layout = LayoutConstraint::getLayoutConstraint(
-                                   LayoutConstraintKind::RefCountedObject);
-        break;
-          
-      case LayoutConstraintKind::TrivialOfExactSize:
-        // Generalize to TrivialOfAtMostSize.
-        layout = LayoutConstraint::getLayoutConstraint(
-           LayoutConstraintKind::TrivialOfAtMostSize,
-           layout->getTrivialSizeInBits(),
-           layout->getAlignmentInBits(),
-           TC.Context);
-        break;
-      }
-      
-      if (layout) {
-        // Pick the more specific of the upper bound layout and the layout
-        // we chose above.
-        if (upperBoundLayout) {
-          layout = layout.merge(upperBoundLayout);
-        }
-        
-        substRequirements.push_back(
-                      Requirement(RequirementKind::Layout, param, layout));
-      }
-    }
-    
-    for (unsigned i : indices(upperBoundConformances)) {
-      auto proto = upperBoundConformances[i];
-      auto conformance = substTypeConformances[i];
-      substRequirements.push_back(Requirement(RequirementKind::Conformance, param,
-                                              proto->getDeclaredInterfaceType()));
-      substConformances.push_back(conformance);
-    }
-    
-    return param;
-  }
-  
-  /// Given the destructured original abstraction pattern and substituted type for a destructured
-  /// parameter or result, introduce substituted generic parameters and requirements as needed for
-  /// the lowered type, and return the substituted type in terms of the substituted generic signature.
-  CanType getSubstitutedInterfaceType(AbstractionPattern origType,
-                                      CanType substType) {
-    if (!Enabled)
-      return substType;
-    
-    // Replace every dependent type we see with a fresh type variable in
-    // the substituted signature, substituted by the corresponding concrete
-    // type.
-
-    // The entire original context could be a generic parameter.
-    if (origType.isTypeParameter() ||
-        origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
-      return addSubstitution(origType.getLayoutConstraint(), substType,
-                             nullptr, {});
-    }
-    
-    auto origContextType = origType.getType();
-    
-    // If the substituted type is a subclass of the abstraction pattern
-    // type, build substitutions for any type parameters in it. This only
-    // comes up when lowering override types for vtable entries.
-    auto areDifferentClasses = [](Type a, Type b) -> bool {
-      if (auto dynA = a->getAs<DynamicSelfType>()) {
-        a = dynA->getSelfType();
-      }
-      if (auto dynB = b->getAs<DynamicSelfType>()) {
-        b = dynB->getSelfType();
-      }
-      if (auto aClass = a->getClassOrBoundGenericClass()) {
-        if (auto bClass = b->getClassOrBoundGenericClass()) {
-          return aClass != bClass;
-        }
-      }
-      
-      return false;
-    };
-    
-    bool substituteBindingsInSubstType = false;
-    if (areDifferentClasses(substType, origContextType)) {
-      substituteBindingsInSubstType = true;
-    }
-    if (auto substMeta = dyn_cast<MetatypeType>(substType)) {
-      if (auto origMeta = dyn_cast<MetatypeType>(origContextType)) {
-        if (areDifferentClasses(substMeta->getInstanceType(),
-                                origMeta->getInstanceType())) {
-          substituteBindingsInSubstType = true;
-        }
-      }
-    }
-
-    CanGenericSignature origSig = origType.getGenericSignature();
-    if (substituteBindingsInSubstType) {
-      origContextType = substType;
-      origSig = TC.getCurGenericSignature();
-      assert((!substType->hasTypeParameter() || origSig) &&
-             "lowering mismatched interface types in a context without "
-             "a generic signature");
-    }
-    
-    if (!origContextType->hasTypeParameter()
-        && !origContextType->hasArchetype()) {
-      // If the abstraction pattern doesn't have substitutable positions, nor
-      // should the concrete type.
-      assert(!substType->hasTypeParameter()
-             && !substType->hasArchetype());
-      return substType;
-    }
-    
-    // Extract structural substitutions.
-    if (origContextType->hasTypeParameter()) {
-      origContextType = origSig.getGenericEnvironment()
-        ->mapTypeIntoContext(origContextType)
-        ->getCanonicalType();
-    }
-
-    auto result = origContextType
-      ->substituteBindingsTo(substType,
-        [&](ArchetypeType *archetype,
-            CanType binding,
-            ArchetypeType *upperBound,
-            ArrayRef<ProtocolConformanceRef> bindingConformances) -> CanType {
-          return addSubstitution(archetype->getLayoutConstraint(),
-                                 binding,
-                                 upperBound,
-                                 bindingConformances);
-        });
-    
-    assert(result && "substType was not bindable to abstraction pattern type?");
-    return result;
-  }
-};
-
 /// A visitor for breaking down formal result types into a SILResultInfo
 /// and possibly some number of indirect-out SILParameterInfos,
 /// matching the abstraction patterns of the original type.
@@ -1378,15 +1156,12 @@ class DestructureResults {
   const Conventions &Convs;
   SmallVectorImpl<SILResultInfo> &Results;
   TypeExpansionContext context;
-  SubstFunctionTypeCollector &Subst;
 
 public:
   DestructureResults(TypeExpansionContext context, TypeConverter &TC,
                      const Conventions &conventions,
-                     SmallVectorImpl<SILResultInfo> &results,
-                     SubstFunctionTypeCollector &subst)
-      : TC(TC), Convs(conventions), Results(results), context(context),
-        Subst(subst) {}
+                     SmallVectorImpl<SILResultInfo> &results)
+      : TC(TC), Convs(conventions), Results(results), context(context) {}
 
   void destructure(AbstractionPattern origType, CanType substType) {
     // Recur into tuples.
@@ -1401,12 +1176,9 @@ public:
       return;
     }
     
-    auto substInterfaceType = Subst.getSubstitutedInterfaceType(origType,
-                                                                substType);
-    
     auto &substResultTLForConvention = TC.getTypeLowering(
-        origType, substInterfaceType, TypeExpansionContext::minimal());
-    auto &substResultTL = TC.getTypeLowering(origType, substInterfaceType,
+        origType, substType, TypeExpansionContext::minimal());
+    auto &substResultTL = TC.getTypeLowering(origType, substType,
                                              context);
 
 
@@ -1573,7 +1345,6 @@ class DestructureInputs {
   Optional<ForeignSelfInfo> ForeignSelf;
   AbstractionPattern TopLevelOrigType = AbstractionPattern::getInvalid();
   SmallVectorImpl<SILParameterInfo> &Inputs;
-  SubstFunctionTypeCollector &Subst;
   unsigned NextOrigParamIndex = 0;
   Optional<SmallBitVector> NoImplicitCopyIndices;
 
@@ -1581,10 +1352,9 @@ public:
   DestructureInputs(TypeExpansionContext expansion, TypeConverter &TC,
                     const Conventions &conventions, const ForeignInfo &foreign,
                     SmallVectorImpl<SILParameterInfo> &inputs,
-                    SubstFunctionTypeCollector &subst,
                     Optional<SmallBitVector> noImplicitCopyIndices)
       : expansion(expansion), TC(TC), Convs(conventions), Foreign(foreign),
-        Inputs(inputs), Subst(subst),
+        Inputs(inputs),
         NoImplicitCopyIndices(noImplicitCopyIndices) {}
 
   void destructure(AbstractionPattern origType,
@@ -1684,12 +1454,9 @@ private:
 
     unsigned origParamIndex = NextOrigParamIndex++;
     
-    auto substInterfaceType =
-      Subst.getSubstitutedInterfaceType(origType, substType);
-
-    auto &substTLConv = TC.getTypeLowering(origType, substInterfaceType,
+    auto &substTLConv = TC.getTypeLowering(origType, substType,
                                        TypeExpansionContext::minimal());
-    auto &substTL = TC.getTypeLowering(origType, substInterfaceType, expansion);
+    auto &substTL = TC.getTypeLowering(origType, substType, expansion);
 
     ParameterConvention convention;
     if (ownership == ValueOwnership::InOut) {
@@ -1983,11 +1750,10 @@ static AccessorDecl *getAsCoroutineAccessor(Optional<SILDeclRef> constant) {
 }
 
 static void destructureYieldsForReadAccessor(TypeConverter &TC,
-                                             TypeExpansionContext expansion,
-                                             AbstractionPattern origType,
-                                             CanType valueType,
-                                          SmallVectorImpl<SILYieldInfo> &yields,
-                                          SubstFunctionTypeCollector &subst) {
+                                         TypeExpansionContext expansion,
+                                         AbstractionPattern origType,
+                                         CanType valueType,
+                                         SmallVectorImpl<SILYieldInfo> &yields){
   // Recursively destructure tuples.
   if (origType.isTuple()) {
     auto valueTupleType = cast<TupleType>(valueType);
@@ -1995,21 +1761,18 @@ static void destructureYieldsForReadAccessor(TypeConverter &TC,
       auto origEltType = origType.getTupleElementType(i);
       auto valueEltType = valueTupleType.getElementType(i);
       destructureYieldsForReadAccessor(TC, expansion, origEltType, valueEltType,
-                                       yields, subst);
+                                       yields);
     }
     return;
   }
 
-  auto valueInterfaceType =
-    subst.getSubstitutedInterfaceType(origType, valueType);
-  
   auto &tlConv =
-      TC.getTypeLowering(origType, valueInterfaceType,
+      TC.getTypeLowering(origType, valueType,
                          TypeExpansionContext::minimal());
   auto &tl =
-      TC.getTypeLowering(origType, valueInterfaceType, expansion);
+      TC.getTypeLowering(origType, valueType, expansion);
   auto convention = [&] {
-    if (isFormallyPassedIndirectly(TC, origType, valueInterfaceType, tlConv))
+    if (isFormallyPassedIndirectly(TC, origType, valueType, tlConv))
       return ParameterConvention::Indirect_In_Guaranteed;
     if (tlConv.isTrivial())
       return ParameterConvention::Direct_Unowned;
@@ -2022,59 +1785,28 @@ static void destructureYieldsForReadAccessor(TypeConverter &TC,
 
 static void destructureYieldsForCoroutine(TypeConverter &TC,
                                           TypeExpansionContext expansion,
-                                          Optional<SILDeclRef> origConstant,
                                           Optional<SILDeclRef> constant,
-                                          Optional<SubstitutionMap> reqtSubs,
-                                          Optional<GenericSignature> genericSig,
+                                          AbstractionPattern origType,
+                                          CanType canValueType,
                                           SmallVectorImpl<SILYieldInfo> &yields,
-                                          SILCoroutineKind &coroutineKind,
-                                          SubstFunctionTypeCollector &subst) {
-  assert(coroutineKind == SILCoroutineKind::None);
-  assert(yields.empty());
-
+                                          SILCoroutineKind &coroutineKind) {
   auto accessor = getAsCoroutineAccessor(constant);
   if (!accessor)
     return;
 
-  auto origAccessor = cast<AccessorDecl>(origConstant->getDecl());
-
-  // Coroutine accessors are implicitly yield-once coroutines, despite
-  // their function type.
-  coroutineKind = SILCoroutineKind::YieldOnce;
-
-  // Coroutine accessors are always native, so fetch the native
-  // abstraction pattern.
-  auto origStorage = origAccessor->getStorage();
-  auto origType = TC.getAbstractionPattern(origStorage, /*nonobjc*/ true)
-                    .getReferenceStorageReferentType();
-
-  auto storage = accessor->getStorage();
-  auto valueType = storage->getValueInterfaceType();
-
-  if (reqtSubs) {
-    valueType = valueType.subst(*reqtSubs);
-  }
-
-  auto canValueType = (genericSig
-                       ? valueType->getCanonicalType(*genericSig)
-                       : valueType->getCanonicalType());
-
   // 'modify' yields an inout of the target type.
   if (accessor->getAccessorKind() == AccessorKind::Modify) {
-    auto valueInterfaceType = subst.getSubstitutedInterfaceType(origType,
-                                                                canValueType);
     auto loweredValueTy =
-        TC.getLoweredType(origType, valueInterfaceType, expansion);
+        TC.getLoweredType(origType, canValueType, expansion);
     yields.push_back(SILYieldInfo(loweredValueTy.getASTType(),
                                   ParameterConvention::Indirect_Inout));
-    return;
+  } else {
+    // 'read' yields a borrowed value of the target type, destructuring
+    // tuples as necessary.
+    assert(accessor->getAccessorKind() == AccessorKind::Read);
+    destructureYieldsForReadAccessor(TC, expansion, origType, canValueType,
+                                     yields);
   }
-
-  // 'read' yields a borrowed value of the target type, destructuring
-  // tuples as necessary.
-  assert(accessor->getAccessorKind() == AccessorKind::Read);
-  destructureYieldsForReadAccessor(TC, expansion, origType, canValueType,
-                                   yields, subst);
 }
 
 /// Create the appropriate SIL function type for the given formal type
@@ -2168,17 +1900,46 @@ static CanSILFunctionType getSILFunctionType(
     errorResult = SILResultInfo(exnType.getASTType(),
                                 ResultConvention::Owned);
   }
+  
+  // Get the yield type for an accessor coroutine.
+  SILCoroutineKind coroutineKind = SILCoroutineKind::None;
+  AbstractionPattern coroutineOrigYieldType = AbstractionPattern::getInvalid();
+  CanType coroutineSubstYieldType;
+  
+  if (auto accessor = getAsCoroutineAccessor(constant)) {
+    auto origAccessor = cast<AccessorDecl>(origConstant->getDecl());
+    coroutineKind = SILCoroutineKind::YieldOnce;
+    
+    // Coroutine accessors are always native, so fetch the native
+    // abstraction pattern.
+    auto origStorage = origAccessor->getStorage();
+    coroutineOrigYieldType = TC.getAbstractionPattern(origStorage,
+                                                      /*nonobjc*/ true)
+                               .getReferenceStorageReferentType();
 
-  // Lower the result type.
-  AbstractionPattern origResultType = origType.getFunctionResultType();
-  CanType substFormalResultType = substFnInterfaceType.getResult();
+    auto storage = accessor->getStorage();
+    auto valueType = storage->getValueInterfaceType();
 
-  // If we have a foreign error and/or async convention, adjust the
-  // lowered result type.
-  updateResultTypeForForeignInfo(foreignInfo, genericSig, origResultType,
-                                 substFormalResultType);
+    if (reqtSubs) {
+      valueType = valueType.subst(*reqtSubs);
+    }
+
+    coroutineSubstYieldType = valueType->getCanonicalType(genericSig);
+  }
 
   bool shouldBuildSubstFunctionType = [&]{
+    // If there is no genericity in the abstraction pattern we're lowering
+    // against, we don't need to introduce substitutions into the lowered
+    // type.
+    if (!origType.isTypeParameterOrOpaqueArchetype()
+        && !origType.isOpaqueFunctionOrOpaqueDerivativeFunction()
+        && !origType.getType()->hasArchetype()
+        && !origType.getType()->hasOpaqueArchetype()
+        && !origType.getType()->hasTypeParameter()
+        && !isa<GenericFunctionType>(origType.getType())) {
+      return false;
+    }
+
     // We always use substituted function types for coroutines that are
     // being lowered in the context of another coroutine, which is to say,
     // for class override thunks.  This is required to make the yields
@@ -2192,7 +1953,7 @@ static CanSILFunctionType getSILFunctionType(
     // protocols.
     if (genericSig)
       return false;
-
+    
     // We only currently use substituted function types for function values,
     // which will have standard thin or thick representation. (Per the previous
     // comment, it would be useful to do so for generic methods on classes and
@@ -2201,32 +1962,60 @@ static CanSILFunctionType getSILFunctionType(
     return (rep == SILFunctionTypeRepresentation::Thick ||
             rep == SILFunctionTypeRepresentation::Thin);
   }();
+  
+  SubstitutionMap substFunctionTypeSubs;
+  
+  if (shouldBuildSubstFunctionType) {
+    // Generalize the generic signature in the abstraction pattern, so that
+    // abstraction patterns with the same general shape produce equivalent
+    // lowered function types.
+    AbstractionPattern origSubstPat = AbstractionPattern::getInvalid();
+    AbstractionPattern substYieldType = AbstractionPattern::getInvalid();
+    std::tie(origSubstPat, substFunctionTypeSubs, substYieldType)
+      = origType.getSubstFunctionTypePattern(substFnInterfaceType, TC,
+                                             coroutineOrigYieldType,
+                                             coroutineSubstYieldType);
 
-  SubstFunctionTypeCollector subst(TC, expansionContext, genericSig,
-                                   shouldBuildSubstFunctionType);
+    // We'll lower the abstraction pattern type against itself, and then apply
+    // those substitutions to form the substituted lowered function type.
+    origType = origSubstPat;
+    substFnInterfaceType = cast<AnyFunctionType>(origType.getType());
+    if (substYieldType.isValid()) {
+      coroutineOrigYieldType = substYieldType;
+      coroutineSubstYieldType = substYieldType.getType();
+    }
+  }
+
+  // Lower the result type.
+  AbstractionPattern origResultType = origType.getFunctionResultType();
+  CanType substFormalResultType = substFnInterfaceType.getResult();
+
+  // If we have a foreign error and/or async convention, adjust the
+  // lowered result type.
+  updateResultTypeForForeignInfo(foreignInfo, genericSig, origResultType,
+                                 substFormalResultType);
 
   // Destructure the input tuple type.
   SmallVector<SILParameterInfo, 8> inputs;
   {
     DestructureInputs destructurer(expansionContext, TC, conventions,
-                                   foreignInfo, inputs, subst,
+                                   foreignInfo, inputs,
                                    noImplicitCopyIndices);
     destructurer.destructure(origType, substFnInterfaceType.getParams(),
                              extInfoBuilder);
   }
 
   // Destructure the coroutine yields.
-  SILCoroutineKind coroutineKind = SILCoroutineKind::None;
   SmallVector<SILYieldInfo, 8> yields;
-  destructureYieldsForCoroutine(TC, expansionContext, origConstant, constant,
-                                reqtSubs, genericSig, yields, coroutineKind,
-                                subst);
+  destructureYieldsForCoroutine(TC, expansionContext, constant,
+                                coroutineOrigYieldType, coroutineSubstYieldType,
+                                yields, coroutineKind);
   
   // Destructure the result tuple type.
   SmallVector<SILResultInfo, 8> results;
   {
     DestructureResults destructurer(expansionContext, TC, conventions,
-                                    results, subst);
+                                    results);
     destructurer.destructure(origResultType, substFormalResultType);
   }
 
@@ -2273,24 +2062,11 @@ static CanSILFunctionType getSILFunctionType(
                         .withConcurrent(isSendable)
                         .withAsync(isAsync)
                         .build();
-
-  // Build the substituted generic signature we extracted.
-  SubstitutionMap substitutions;
-  if (subst.Enabled) {
-    if (!subst.substGenericParams.empty()) {
-      auto subSig = GenericSignature::get(subst.substGenericParams,
-                                          subst.substRequirements)
-                       .getCanonicalSignature();
-      substitutions = SubstitutionMap::get(subSig,
-                                   llvm::makeArrayRef(subst.substReplacements),
-                                   llvm::makeArrayRef(subst.substConformances));
-    }
-  }
   
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,
                               calleeConvention, inputs, yields,
                               results, errorResult,
-                              substitutions, SubstitutionMap(),
+                              substFunctionTypeSubs, SubstitutionMap(),
                               TC.Context, witnessMethodConformance);
 }
 
@@ -2319,7 +2095,7 @@ struct DeallocatorConventions : Conventions {
   ParameterConvention getCallee() const override {
     llvm_unreachable("Deallocators do not have callees");
   }
-
+	
   ResultConvention getResult(const TypeLowering &tl) const override {
     // TODO: Put an unreachable here?
     return ResultConvention::Owned;

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2157,6 +2157,7 @@ UncheckedRefCastInst *
 UncheckedRefCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                              SILType Ty, SILFunction &F,
                              ValueOwnershipKind forwardingOwnershipKind) {
+  assert(Operand->getType().getCategory() == SILValueCategory::Object);
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F, Ty.getASTType());

--- a/test/AutoDiff/SILGen/reabstraction.swift
+++ b/test/AutoDiff/SILGen/reabstraction.swift
@@ -55,12 +55,12 @@ func makeOpaque() {
 // CHECK:   [[ORIG_3:%.*]] = convert_function [[ORIG_2]]
 // CHECK:   [[JVP_0:%.*]] = differentiable_function_extract [jvp] [[BEFORE]]
 // CHECK:   [[JVP_1:%.*]] = copy_value [[JVP_0]]
-// CHECK:   [[JVP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[JVP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
 // CHECK:   [[JVP_2:%.*]] = partial_apply [callee_guaranteed] [[JVP_THUNK]]([[JVP_1]])
 // CHECK:   [[JVP_3:%.*]] = convert_function [[JVP_2]]
 // CHECK:   [[VJP_0:%.*]] = differentiable_function_extract [vjp] [[BEFORE]]
 // CHECK:   [[VJP_1:%.*]] = copy_value [[VJP_0]]
-// CHECK:   [[VJP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
+// CHECK:   [[VJP_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@out Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Float, Float>)
 // CHECK:   [[VJP_2:%.*]] = partial_apply [callee_guaranteed] [[VJP_THUNK]]([[VJP_1]])
 // CHECK:   [[VJP_3:%.*]] = convert_function [[VJP_2]]
 // CHECK:   [[AFTER:%.*]] = differentiable_function [parameters 0] [results 0] [[ORIG_3]] {{.*}} with_derivative {[[JVP_3]] {{.*}}, [[VJP_3]] {{.*}}}

--- a/test/SILGen/coroutine_subst_function_types.swift
+++ b/test/SILGen/coroutine_subst_function_types.swift
@@ -63,7 +63,7 @@ class ConcreteWithInt: Generic<Int> {
     set {}
   }
 
-  // CHECK-LABEL: sil private [thunk] [ossa] @$s3mod15ConcreteWithIntC12complexTupleSiSg_SDySSSiGtvMAA7GenericCADxSg_SDySSxGtvMTV : $@yield_once @convention(method) @substituted <τ_0_0, τ_0_1> (@guaranteed ConcreteWithInt) -> @yields @inout (Optional<τ_0_0>, Dictionary<String, τ_0_1>) for <Int, Int>
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s3mod15ConcreteWithIntC12complexTupleSiSg_SDySSSiGtvMAA7GenericCADxSg_SDySSxGtvMTV : $@yield_once @convention(method) @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_0 == τ_0_1, τ_0_2 == String, τ_0_3 == τ_0_4> (@guaranteed ConcreteWithInt) -> @yields @inout (Optional<τ_0_0>, Dictionary<String, τ_0_3>) for <Int, Int, String, Int, Int>
   override var complexTuple: (Int?, [String: Int]) {
     get { super.complexTuple }
     set {}
@@ -110,7 +110,7 @@ extension ConcreteWithInt : ProtoWithAssoc {
 
   //   var complexTuple
   // CHECK-LABEL: sil shared [ossa] @$s3mod15ConcreteWithIntC12complexTupleSiSg_SDySSSiGtvr : $@yield_once @convention(method) (@guaranteed ConcreteWithInt) -> (@yields Optional<Int>, @yields @guaranteed Dictionary<String, Int>)
-  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s3mod15ConcreteWithIntCAA05ProtoC5AssocA2aDP12complexTuple0F0QzSg_SDySSAHGtvMTW : $@yield_once @convention(witness_method: ProtoWithAssoc) @substituted <τ_0_0, τ_0_1, τ_0_2> (@inout τ_0_0) -> @yields @inout (Optional<τ_0_1>, Dictionary<String, τ_0_2>) for <ConcreteWithInt, Int, Int>
+  // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s3mod15ConcreteWithIntCAA05ProtoC5AssocA2aDP12complexTuple0F0QzSg_SDySSAHGtvMTW : $@yield_once @convention(witness_method: ProtoWithAssoc) @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_1 == τ_0_2, τ_0_3 == String, τ_0_4 == τ_0_5> (@inout τ_0_0) -> @yields @inout (Optional<τ_0_1>, Dictionary<String, τ_0_4>) for <ConcreteWithInt, Int, Int, String, Int, Int>
 }
 
 // CHECK-LABEL: sil_vtable ConcreteWithInt {

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -440,7 +440,7 @@ func convTupleToOptionalDirect(_ f: @escaping (Int) -> (Int, Int)) -> (Int) -> (
   return f
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s19function_conversion27convTupleToOptionalIndirectyx_xtSgxcx_xtxclF : $@convention(thin) <T> (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <T, T, T>) -> @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> @out Optional<(τ_0_1, τ_0_2)> for <T, T, T>
+// CHECK-LABEL: sil hidden [ossa] @$s19function_conversion27convTupleToOptionalIndirectyx_xtSgxcx_xtxclF : $@convention(thin) <T> (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <T, T, T>) -> @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_1 == (τ_0_2, τ_0_3)> (@in_guaranteed τ_0_0) -> @out Optional<(τ_0_2, τ_0_3)> for <T, (T, T), T, T>
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <T, T, T>):
 // CHECK:          [[FN:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT:     [[FN_CONV:%.*]] = convert_function [[FN]]

--- a/test/SILGen/function_type_lowering.swift
+++ b/test/SILGen/function_type_lowering.swift
@@ -36,16 +36,16 @@ func e<T: P>(_ x: (T.A) -> T) {}
 // Preserve class constraints, because they're less abstract for layout and
 // calling convention purposes than unconstrained types
 
-// CHECK-LABEL: sil {{.*}}1f{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1f{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func f<T: AnyObject, U>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1g{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1g{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func g<T: AnyObject, U>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1h{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1h{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
 func h<T: AnyObject, U: AnyObject>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1i{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1i{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func i<T: AnyObject, U: AnyObject>(_ x: (U) -> T) {}
 
 
@@ -53,19 +53,19 @@ func i<T: AnyObject, U: AnyObject>(_ x: (U) -> T) {}
 
 protocol PC: AnyObject { }
 
-// CHECK-LABEL: sil {{.*}}1j{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1j{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func j<T: PC, U>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1k{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1k{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func k<T: PC, U>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1l{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1l{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
 func l<T: PC, U: PC>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1m{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1m{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func m<T: PC, U: PC>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1n{{.*}} : $@convention(thin) <T where T : P, T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1n{{.*}} : $@convention(thin) <T where T : P, T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
 func n<T: P & PC>(_ x: (T) -> T.A) {}
 
 
@@ -73,7 +73,7 @@ func n<T: P & PC>(_ x: (T) -> T.A) {}
 
 class Base {}
 
-// CHECK-LABEL: sil {{.*}}1o{{.*}} : $@convention(thin) <T, U where T : Base> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1o{{.*}} : $@convention(thin) <T, U where T : Base> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func o<T: Base, U> (_ x: (T) -> U) {}
 
 
@@ -91,11 +91,11 @@ protocol PCAC: AnyObject {
   associatedtype A: AnyObject
 }
 
-// CHECK-LABEL: sil {{.*}}1p{{.*}} : $@convention(thin) <T where T : PCAO> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1p{{.*}} : $@convention(thin) <T where T : PCAO> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
 func p<T: PCAO> (_ x: (T) -> T.A) {}
-// CHECK-LABEL: sil {{.*}}1q{{.*}} : $@convention(thin) <T where T : POAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1q{{.*}} : $@convention(thin) <T where T : POAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
 func q<T: POAC> (_ x: (T) -> T.A) {}
-// CHECK-LABEL: sil {{.*}}1r{{.*}} : $@convention(thin) <T where T : PCAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1r{{.*}} : $@convention(thin) <T where T : PCAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
 func r<T: PCAC> (_ x: (T) -> T.A) {}
 
 
@@ -112,35 +112,35 @@ struct S<T, U> {
   }
 }
 
-// CHECK-LABEL: sil {{.*}}1t{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_1 : _RefCountedObject, τ_0_3 : _RefCountedObject> (S<τ_0_0, τ_0_1>) -> (@out τ_0_2, @owned τ_0_3) for <T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1t{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t<T, U: AnyObject>(_: (S<T, U>) -> (T, U)) {}
 
-// CHECK-LABEL: sil {{.*}}2t2{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_1 : _RefCountedObject, τ_0_2 : _RefCountedObject, τ_0_4 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>) -> (@out τ_0_3, @owned τ_0_4) for <T, U, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t2{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 : AnyObject, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
 func t2<T, U: AnyObject>(_: (S<T, U>.Nested<U>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t3{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_1 : _RefCountedObject, τ_0_2 : _RefCountedObject, τ_0_5 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NesNestedted<τ_0_3>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, U, T, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t3{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7, τ_0_8, τ_0_9 where τ_0_0 == τ_0_4, τ_0_1 : AnyObject, τ_0_1 == τ_0_5, τ_0_2 : AnyObject, τ_0_2 == τ_0_6, τ_0_3 == τ_0_7, τ_0_9 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NesNestedted<τ_0_3>) -> (@out τ_0_8, @owned τ_0_9) for <T, U, U, T, T, U, U, T, T, U>) -> ()
 func t3<T, U: AnyObject>(_: (S<T, U>.Nested<U>.NesNestedted<T>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t4{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_1 : _RefCountedObject, τ_0_2 : _RefCountedObject, τ_0_4 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NestedNonGeneric) -> (@out τ_0_3, @owned τ_0_4) for <T, U, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t4{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 : AnyObject, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NestedNonGeneric) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
 func t4<T, U: AnyObject>(_: (S<T, U>.Nested<U>.NestedNonGeneric) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t5{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_1 : _RefCountedObject, τ_0_3 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric) -> (@out τ_0_2, @owned τ_0_3) for <T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t5{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t5<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t6{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_1 : _RefCountedObject, τ_0_4 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NesNestedted<τ_0_2>) -> (@out τ_0_3, @owned τ_0_4) for <T, U, T, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t6{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NesNestedted<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, T, T, U, T, T, U>) -> ()
 func t6<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric.NesNestedted<T>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t7{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_1 : _RefCountedObject, τ_0_3 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NestedNonGeneric) -> (@out τ_0_2, @owned τ_0_3) for <T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t7{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t7<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric.NestedNonGeneric) -> (T, U)) {}
 
-// CHECK-LABEL: sil {{.*}}1u{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (S<τ_0_0, τ_0_1>) -> @out τ_0_2 for <T, T, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1u{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_0 == τ_0_2, τ_0_1 == τ_0_3> (S<τ_0_0, τ_0_1>) -> @out τ_0_4 for <T, T, T, T, T>) -> ()
 func u<T>(_: (S<T, T>) -> T) {}
 
 
 class C<T, U> {}
 
-// CHECK-LABEL: sil {{.*}}1v{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_1 : _RefCountedObject, τ_0_3 : _RefCountedObject> (@guaranteed C<τ_0_0, τ_0_1>) -> (@out τ_0_2, @owned τ_0_3) for <T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1v{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (@guaranteed C<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func v<T, U: AnyObject>(_: (C<T, U>) -> (T, U)) {}
 
-// CHECK-LABEL: sil {{.*}}1w{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@guaranteed C<τ_0_0, τ_0_1>) -> @out τ_0_2 for <T, T, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1w{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_0 == τ_0_2, τ_0_1 == τ_0_3> (@guaranteed C<τ_0_0, τ_0_1>) -> @out τ_0_4 for <T, T, T, T, T>) -> ()
 func w<T>(_: (C<T, T>) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1x{{.*}} : $@convention(thin) <T, U, V where V : C<T, U>> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> () for <V>) -> ()
+// CHECK-LABEL: sil {{.*}}1x{{.*}} : $@convention(thin) <T, U, V where V : C<T, U>> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> () for <V>) -> ()
 func x<T, U, V: C<T, U>>(_: (V) -> Void) {}
 
 // We can't generally lower away protocol constraints 
@@ -151,18 +151,18 @@ func x<T, U, V: C<T, U>>(_: (V) -> Void) {}
 struct SP<T: P> { var x: T.A }
 class CP<T: P> { }
 
-// CHECK-LABEL: sil {{.*}}1z{{.*}} : $@convention(thin) <T where T : P> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : P> (@in_guaranteed SP<τ_0_0>) -> () for <T>) -> ()
+// CHECK-LABEL: sil {{.*}}1z{{.*}} : $@convention(thin) <T where T : P> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : P, τ_0_0 == τ_0_1> (@in_guaranteed SP<τ_0_0>) -> () for <T, T>) -> ()
 func z<T: P>(_: (SP<T>) -> Void) {}
 
 struct SCP<T: P, U: CP<T>> {}
 
-// CHECK-LABEL: sil {{.*}}2z2{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : P, τ_0_1 : CP<τ_0_0>, τ_0_1 : _NativeClass> (SCP<τ_0_0, τ_0_1>) -> () for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2z2{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : P, τ_0_0 == τ_0_2, τ_0_1 : CP<τ_0_0>, τ_0_1 == τ_0_3> (SCP<τ_0_0, τ_0_1>) -> () for <T, U, T, U>) -> ()
 func z2<T: P, U: CP<T>>(_: (SCP<T, U>) -> Void) {}
 
-// CHECK-LABEL: sil {{.*}}3z2a{{.*}} : $@convention(thin) <T, U where T : AnyObject, T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_0 : P, τ_0_1 : CP<τ_0_0>, τ_0_1 : _NativeClass> (SCP<τ_0_0, τ_0_1>) -> () for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}3z2a{{.*}} : $@convention(thin) <T, U where T : AnyObject, T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : AnyObject, τ_0_0 : P, τ_0_0 == τ_0_2, τ_0_1 : CP<τ_0_0>, τ_0_1 == τ_0_3> (SCP<τ_0_0, τ_0_1>) -> () for <T, U, T, U>) -> ()
 func z2a<T: P & AnyObject, U: CP<T>>(_: (SCP<T, U>) -> Void) {}
 
-// CHECK-LABEL: sil {{.*}}2z3{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (S<τ_0_0, τ_0_1>) -> () for <U, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2z3{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : _NativeClass, τ_0_0 == τ_0_2, τ_0_1 : _NativeClass, τ_0_1 == τ_0_3> (S<τ_0_0, τ_0_1>) -> () for <U, U, U, U>) -> ()
 func z3<T: P, U: CP<T>>(_: (S<U, U>) -> Void) {}
 
 // Opaque types should not be extracted as substituted arguments because they
@@ -171,7 +171,7 @@ func z3<T: P, U: CP<T>>(_: (S<U, U>) -> Void) {}
 dynamic func opaqueAny() -> some Any { return C<Int, String>() }
 dynamic func opaqueObject() -> some AnyObject { return C<Int, String>() }
 
-// CHECK-LABEL: sil {{.*}}1y{{.*}} : $@convention(thin) (@noescape @callee_guaranteed (@in_guaranteed @_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) {{.*}}) -> @owned @_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) {{.*}}) -> ()
+// CHECK-LABEL: sil {{.*}}1y{{.*}} : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <τ_0_0, τ_0_1>) -> () for <@_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) __, @_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) __>
 func y(_: (@_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) X) -> (@_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) X)) {}
 
 // Make sure type lowering doesn't choke on override signatures.

--- a/test/SILGen/function_type_lowering_inherited_conformance.swift
+++ b/test/SILGen/function_type_lowering_inherited_conformance.swift
@@ -10,6 +10,6 @@ func foo<T: P>(_: (Butt<T>) -> ()) {}
 
 // CHECK-LABEL: sil{{.*}}3bar
 func bar(_ f: (Butt<D>) -> ()) {
-  // CHECK: convert_function {{.*}} $@noescape @callee_guaranteed (Butt<D>) -> () to $@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : P> (Butt<τ_0_0>) -> () for <D>
+  // CHECK: convert_function {{.*}} $@noescape @callee_guaranteed (Butt<D>) -> () to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : P, τ_0_0 == τ_0_1> (Butt<τ_0_0>) -> () for <D, D>
   foo(f)
 }

--- a/test/SILGen/function_type_lowering_objc.swift
+++ b/test/SILGen/function_type_lowering_objc.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-// CHECK-LABEL: sil {{.*}}3foo{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil {{.*}}3foo{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
 func foo<T: NSCopying>(f: (T) -> ()) {}
-// CHECK-LABEL: sil {{.*}}3bar{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _RefCountedObject> (@guaranteed Optional<τ_0_0>) -> ()
+// CHECK-LABEL: sil {{.*}}3bar{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_0 == τ_0_1> (@guaranteed Optional<τ_0_0>) -> ()
 func bar<T: NSCopying>(f: (T?) -> ()) {}

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -1,4 +1,3 @@
-
 // RUN: %target-swift-emit-silgen -module-name generic_closures  -parse-stdlib %s | %FileCheck %s
 
 import Swift
@@ -207,7 +206,7 @@ class Class {}
 protocol HasClassAssoc { associatedtype Assoc : Class }
 
 // CHECK-LABEL: sil hidden [ossa] @$s16generic_closures027captures_class_constrained_A0_1fyx_5AssocQzAEctAA08HasClassF0RzlF
-// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : @guaranteed $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T.Assoc, T.Assoc>):
+// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : @guaranteed $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _NativeClass, τ_0_1 : _NativeClass> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T.Assoc, T.Assoc>):
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @$s16generic_closures027captures_class_constrained_A0_1fyx_5AssocQzAEctAA08HasClassF0RzlFA2EcycfU_
 // CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
 // CHECK: [[CONCRETE_FN:%.*]] = partial_apply [callee_guaranteed] [[GENERIC_FN]]<T>([[ARG2_COPY]])

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -48,7 +48,7 @@ struct Lunch<T : Pizza> where T.Topping : CuredMeat {
 // CHECK-LABEL: sil private [ossa] @$s15nested_generics5LunchV6DinnerV15coolCombination1t1uy7ToppingQz_AA4DeliC7MustardOyAA6PepperV_GtF0A7GenericL_1x1yqd0___qd0_0_tqd0___qd0_0_tAA5PizzaRzAA6HotDogRd__AA9CuredMeatAJRQAQ9CondimentRtd__r__0_lF : $@convention(thin) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard><X, Y> (@in_guaranteed X, @in_guaranteed Y) -> (@out X, @out Y)
 
 // CHECK-LABEL: // nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: Swift.Optional<A1>, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
-// CHECK-LABEL: sil hidden [ossa] @$s15nested_generics5LunchV6DinnerV11firstCourse06secondF09leftovers14transformationAEyx_qd__Gx_qd__Sgxqd__xctcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
+// CHECK-LABEL: sil hidden [ossa] @$s15nested_generics5LunchV6DinnerV11firstCourse06secondF09leftovers14transformationAEyx_qd__Gx_qd__Sgxqd__xctcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
 
 // Non-generic nested inside generic
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -167,7 +167,7 @@ public class D {
     }()
 }
 
-// CHECK-LABEL: sil [ossa] @$s18opaque_result_type10tupleAsAnyQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s18opaque_result_type10tupleAsAnyQryF", 0) __ {
+// CHECK-LABEL: sil [ossa] @$s18opaque_result_type10tupleAsAnyQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s18opaque_result_type10tupleAsAnyQryF", 0) __> {
 public func tupleAsAny() -> some Any {
 // CHECK:      bb0(%0 : $*()):
 // CHECK-NEXT:   %1 = tuple ()

--- a/test/SILGen/opaque_result_type_inlinable.swift
+++ b/test/SILGen/opaque_result_type_inlinable.swift
@@ -2,9 +2,9 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -primary-file %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
 // RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s %S/Inputs/opaque_result_type_inlinable_other.swift | %FileCheck %s
 
-// CHECK-LABEL: sil [serialized] [ossa] @$s28opaque_result_type_inlinable6callerQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6callerQryF", 0) __ {
+// CHECK-LABEL: sil [serialized] [ossa] @$s28opaque_result_type_inlinable6callerQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6callerQryF", 0) __> {
 // CHECK: bb0(%0 : $*@_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6calleeQryF", 0) __):
-// CHECK: function_ref @$s28opaque_result_type_inlinable6calleeQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6calleeQryF", 0) __
+// CHECK: function_ref @$s28opaque_result_type_inlinable6calleeQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s28opaque_result_type_inlinable6calleeQryF", 0) __>
 
 @inlinable public func caller() -> some Any {
   return callee()

--- a/test/SILGen/opaque_result_type_private.swift
+++ b/test/SILGen/opaque_result_type_private.swift
@@ -4,16 +4,16 @@
 // CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 
 // CHECK: [[BOX:%.*]] = alloc_stack $PrivateClass
-// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) () -> @out PrivateClass
-// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) () -> @out PrivateClass
+// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <PrivateClass>
+// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <PrivateClass>
 // CHECK: [[RESULT:%.*]] = load [take] [[BOX]] : $*PrivateClass
 // CHECK: destroy_value [[RESULT]] : $PrivateClass
 // CHECK: dealloc_stack [[BOX]] : $*PrivateClass
 _ = returnPrivateOpaque()
 
 // CHECK: [[BOX:%.*]] = alloc_stack $LocalClass
-// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) () -> @out LocalClass
-// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) () -> @out LocalClass
+// CHECK: [[FN:%.*]] = function_ref @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <LocalClass>
+// CHECK: apply [[FN]]([[BOX]]) : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <LocalClass>
 // CHECK: [[RESULT:%.*]] = load [take] [[BOX]] : $*LocalClass
 // CHECK: destroy_value [[RESULT]] : $LocalClass
 // CHECK: dealloc_stack [[BOX]] : $*LocalClass
@@ -21,12 +21,12 @@ _ = returnLocalOpaque()
 
 fileprivate class PrivateClass {}
 
-// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s26opaque_result_type_private19returnPrivateOpaqueQryF", 0) __
+// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private19returnPrivateOpaqueQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s26opaque_result_type_private19returnPrivateOpaqueQryF", 0) __>
 func returnPrivateOpaque() -> some Any {
   return PrivateClass()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s26opaque_result_type_private17returnLocalOpaqueQryF", 0) __
+// CHECK-LABEL: sil hidden [ossa] @$s26opaque_result_type_private17returnLocalOpaqueQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s26opaque_result_type_private17returnLocalOpaqueQryF", 0) __>
 func returnLocalOpaque() -> some Any {
   class LocalClass {}
 

--- a/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
+++ b/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
@@ -22,7 +22,7 @@ func foo<T : P>(_ x: E<S<T>>) {
 }
 
 // CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}3bar
-// CHECK-SAME: @substituted <τ_0_0 where τ_0_0 : P> () -> @out E<S<τ_0_0>> for <T>
+// CHECK-SAME: @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == S<τ_0_1>, τ_0_1 : P, τ_0_1 == τ_0_2> () -> @out E<S<τ_0_1>> for <S<T>, T, T>
 func bar<T: P>(_: () -> E<S<T>>) {}
 
 // ---
@@ -48,6 +48,22 @@ func foo2<T : Q>(_ x: E2<S2<T>>) {
 }
 
 // CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}4bar2
-// CHECK-SAME: @substituted <τ_0_0 where τ_0_0 : Q> () -> @out E2<S2<τ_0_0>> for <T>
+// CHECK-SAME: @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == S2<τ_0_1>, τ_0_1 : Q, τ_0_1 == τ_0_2> () -> @out E2<S2<τ_0_1>> for <S2<T>, T, T>
 func bar2<T: Q>(_: () -> E2<S2<T>>) {}
 
+protocol P1 {
+  associatedtype Element
+  associatedtype Index
+}
+
+struct S3<Base> where Base: P1, Base.Element: P1 {
+  let x: Base.Element.Index
+}
+
+struct S4<Base> where Base : P1, Base.Element: P1 {
+// CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}2S4{{.*}}3foo{{.*}}F :
+// CHECK: @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : P1, τ_0_0 == τ_0_1, τ_0_0.Element : P1> (@in_guaranteed S3<τ_0_0>) -> () for <Base, Base>
+  func foo(index: S3<Base>?) {
+    _ = index.map({ _ = $0 })
+  }
+}

--- a/test/SILGen/variant_overrides.swift
+++ b/test/SILGen/variant_overrides.swift
@@ -7,7 +7,7 @@ class A {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s17variant_overrides1BC3foo5blockyyACyxGc_tF :
-// CHECK-SAME:    $@convention(method) <T> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <T>, @guaranteed B<T>) -> () 
+// CHECK-SAME:     $@convention(method) <T> (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed B<τ_0_0>) -> () for <T, T>, @guaranteed B<T>) -> ()
 class B<T> : A {
   override func foo(block: @escaping (B<T>) -> Void) {}
 }
@@ -16,9 +16,8 @@ class B<T> : A {
 func useAtGeneric<T>(b: B<T>) {
   // CHECK: [[CLOSURE_FUNC:%.*]] = function_ref @$s17variant_overrides12useAtGeneric1byAA1BCyxG_tlFyAFcfU_ : $@convention(thin) <τ_0_0> (@guaranteed B<τ_0_0>) -> ()
   // CHECK: [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_FUNC]]<T>() : $@convention(thin) <τ_0_0> (@guaranteed B<τ_0_0>) -> ()
-  // CHECK: [[CLOSURE_CONVERTED:%.*]] = convert_function [[CLOSURE]] : $@callee_guaranteed (@guaranteed B<T>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <T>
-  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<T>, #B.foo : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
-  // CHECK: apply [[METHOD]]<T>(%4, %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<T>, #B.foo : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed (@guaranteed B<τ_0_0>) -> (), @guaranteed B<τ_0_0>) -> ()
+  // CHECK: apply [[METHOD]]<T>([[CLOSURE]], %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed (@guaranteed B<τ_0_0>) -> (), @guaranteed B<τ_0_0>) -> ()
 
   b.foo {_ in ()}
 }
@@ -26,14 +25,12 @@ func useAtGeneric<T>(b: B<T>) {
 // CHECK-LABEL: sil hidden [ossa] @$s17variant_overrides13useAtConcrete1byAA1BCySiG_tF
 func useAtConcrete(b: B<Int>) {
   // CHECK: [[CLOSURE_FUNC:%.*]] = function_ref @$s17variant_overrides13useAtConcrete1byAA1BCySiG_tFyAFcfU_ :
-  // CHECK: [[CLOSURE_CONVERTED:%.*]] = convert_function [[CLOSURE_FUNC]] :
-  // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE_CONVERTED]] :
-  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<Int>, #B.foo : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
-  // CHECK: apply [[METHOD]]<Int>([[CLOSURE_THICK]], %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed @substituted <τ_0_0> (@guaranteed B<τ_0_0>) -> () for <τ_0_0>, @guaranteed B<τ_0_0>) -> ()
+  // CHECK: [[CLOSURE_THICK:%.*]] = thin_to_thick_function [[CLOSURE_FUNC]] :
+  // CHECK: [[METHOD:%.*]] =  class_method %0 : $B<Int>, #B.foo : <T> (B<T>) -> (@escaping (B<T>) -> ()) -> (), $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed (@guaranteed B<τ_0_0>) -> (), @guaranteed B<τ_0_0>) -> ()
+  // CHECK: apply [[METHOD]]<Int>([[CLOSURE_THICK]], %0) : $@convention(method) <τ_0_0> (@guaranteed @callee_guaranteed (@guaranteed B<τ_0_0>) -> (), @guaranteed B<τ_0_0>) -> ()
 
   b.foo {_ in ()}
 }
 
-//   FIXME: allowing this without a thunk silently reinterprets the function to a different abstraction!
 // CHECK-LABEL: sil_vtable B {
-// CHECK:          #A.foo: (A) -> (@escaping (A) -> ()) -> () : @$s17variant_overrides1BC3foo5blockyyACyxGc_tF [override]
+// CHECK:          #A.foo: (A) -> (@escaping (A) -> ()) -> () : @$s17variant_overrides1BC3foo5blockyyACyxGc_tFAA1ACAdEyyAHc_tFTV [override]

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -121,7 +121,7 @@ public func useExternal() {
 
 // CHECK-LABEL: sil @$s1A20useExternalResilientyyF
 // CHECK:  [[RES:%.*]] = alloc_stack $@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0)
-// CHECK:  [[FUN:%.*]] = function_ref @$s9External217externalResilientQryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0)
+// CHECK:  [[FUN:%.*]] = function_ref @$s9External217externalResilientQryF : $@convention(thin) @substituted {{.*}} for <@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) __>
 // CHECK:  apply [[FUN]]([[RES]])
 // CHECK:  witness_method
 // CHECK:  return
@@ -270,7 +270,7 @@ extension P3 {
 
 // CHECK-LABEL: sil @$s1A21useExternalResilient2yyF : $@convention(thin) () -> ()
 // CHECK:   [[RES:%.*]] = alloc_stack $Int64
-// CHECK:   [[FUN:%.*]] = function_ref @$s9External226inlinableExternalResilientQryF : $@convention(thin) () -> @out Int64
+// CHECK:   [[FUN:%.*]] = function_ref @$s9External226inlinableExternalResilientQryF : $@convention(thin) @substituted {{.*}} for <Int64>
 // CHECK:   apply [[FUN]]([[RES]])
 // CHECK:   return
 public func useExternalResilient2() {
@@ -281,7 +281,7 @@ public func useExternalResilient2() {
 // In this case we should only 'peel' one layer of opaque archetypes.
 // CHECK-LABEL: sil @$s1A21useExternalResilient3yyF
 // CHECK:  [[RES:%.*]] = alloc_stack $@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0)
-// CHECK:  [[FUN:%.*]] = function_ref @$s9External3031inlinableExternalResilientCallsD0QryF : $@convention(thin) () -> @out @_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0)
+// CHECK:  [[FUN:%.*]] = function_ref @$s9External3031inlinableExternalResilientCallsD0QryF : $@convention(thin) @substituted {{.*}} for <@_opaqueReturnTypeOf("$s9External217externalResilientQryF", 0) __>
 // CHECK:  apply [[FUN]]([[RES]])
 public func useExternalResilient3() {
   let e = inlinableExternalResilientCallsResilient()
@@ -291,7 +291,7 @@ public func useExternalResilient3() {
 // Check that we can look throught two layers of inlinable resilient functions.
 // CHECK-LABEL: sil @$s1A21useExternalResilient4yyF
 // CHECK:   [[RES:%.*]] = alloc_stack $Int64
-// CHECK:   [[FUN:%.*]] = function_ref @$s9External3040inlinableExternalResilientCallsInlinablecD0QryF : $@convention(thin) () -> @out Int64
+// CHECK:   [[FUN:%.*]] = function_ref @$s9External3040inlinableExternalResilientCallsInlinablecD0QryF : $@convention(thin) @substituted {{.*}} for <Int64>
 // CHECK:   apply [[FUN]]([[RES]])
 public func useExternalResilient4() {
   let e = inlinableExternalResilientCallsInlinableExternalResilient()

--- a/test/SILOptimizer/specialize_opaque_type_archetypes_multifile.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes_multifile.swift
@@ -18,7 +18,7 @@ func bar(_ x: Int) -> some P {
 }
 
 // CHECK-LABEL: sil @$s43specialize_opaque_type_archetypes_multifile4testyyF : $@convention(thin) () -> () {
-// CHECK: function_ref @$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF : $@convention(thin) (Int) -> @out @_opaqueReturnTypeOf("$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF", 0)
+// CHECK: function_ref @$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF : $@convention(thin) @substituted <τ_0_0> (Int) -> @out τ_0_0 for <@_opaqueReturnTypeOf("$s43specialize_opaque_type_archetypes_multifile4bar2yQrSiF", 0) __>
 public func test() {
   print(bar(5))
   print(bar2(5))

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -372,11 +372,11 @@ bb1:
   %6 = alloc_stack $UnfoldSequence<Element, State>
   copy_addr %1 to [initialization] %6 : $*UnfoldSequence<Element, State>
   %8 = struct_element_addr %6 : $*UnfoldSequence<Element, State>, #UnfoldSequence._next
-  %9 = load %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
+  %9 = load %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   %10 = alloc_stack $Optional<Element>
   %11 = struct_element_addr %1 : $*UnfoldSequence<Element, State>, #UnfoldSequence._state
-  strong_retain %9 : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
-  %13 = apply %9(%10, %11) : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
+  strong_retain %9 : $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
+  %13 = apply %9(%10, %11) : $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   switch_enum_addr %10 : $*Optional<Element>, case #Optional.some!enumelt: bb3, case #Optional.none!enumelt: bb2
 
 bb2:

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -444,11 +444,11 @@ bb1:
   %6 = alloc_stack $UnfoldSequence<Element, State>
   copy_addr %1 to [initialization] %6 : $*UnfoldSequence<Element, State>
   %8 = struct_element_addr %6 : $*UnfoldSequence<Element, State>, #UnfoldSequence._next
-  %9 = load [copy] %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
+  %9 = load [copy] %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   %10 = alloc_stack $Optional<Element>
   %11 = struct_element_addr %1 : $*UnfoldSequence<Element, State>, #UnfoldSequence._state
-  %13 = apply %9(%10, %11) : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
-  destroy_value %9 : $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element>
+  %13 = apply %9(%10, %11) : $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
+  destroy_value %9 : $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   switch_enum_addr %10 : $*Optional<Element>, case #Optional.some!enumelt: bb3, case #Optional.none!enumelt: bb2
 
 bb2:

--- a/test/stdlib/unmanaged_rc.swift
+++ b/test/stdlib/unmanaged_rc.swift
@@ -16,11 +16,11 @@ public func myPrint(_ k: Klass) { print(k) }
 
 // Check the codegen of _withUnsafeGuaranteedRef
 //
-// CHECK-LABEL: sil public_external [transparent] @$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF : $@convention(method) <Instance where Instance : AnyObject><Result> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, Unmanaged<Instance>) -> (@out Result, @error Error) {
-// CHECK: bb0([[RESULT:%.*]] : $*Result, [[FUNC:%.*]] : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, [[UNMANAGED:%.*]] : $Unmanaged<Instance>):
+// CHECK-LABEL: sil public_external [transparent] @$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF : $@convention(method) <Instance where Instance : AnyObject><Result> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, Unmanaged<Instance>) -> (@out Result, @error Error) {
+// CHECK: bb0([[RESULT:%.*]] : $*Result, [[FUNC:%.*]] : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, [[UNMANAGED:%.*]] : $Unmanaged<Instance>):
 // CHECK: [[UNMANAGED_REF:%.*]] = struct_extract [[UNMANAGED]]
 // CHECK: [[REF:%.*]] = unmanaged_to_ref [[UNMANAGED_REF]]
-// CHECK: try_apply {{%.*}}([[RESULT]], [[REF]]) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, normal bb2, error bb1
+// CHECK: try_apply {{%.*}}([[RESULT]], [[REF]]) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, normal bb2, error bb1
 // CHECK-NOT: destroy_value
 // CHECK: } // end sil function '$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF'
 


### PR DESCRIPTION
This change separates out the formation of the generic signature and
substitutions for a SIL substituted function type as a pre-pass
before doing the actual function type lowering. The only input we
really need to form this signature is the original abstraction pattern
that a type is being lowered against, and pre-computing it should make
the code less side-effecty and confusing. It also allows us to handle
generic nominal types in a more robust way; we transfer over all of
the nominal type requirements to the generalized generic signature,
then when recursively visiting the bindings, we same-type-constrain
the generic parameters used in those requirements to the newly-generalized
generic arguments. This ensures that the minimized signature preserves
any non-trivial requirements imposed by the nominal type, such as
conditional conformances on its type arguments, same-type constraints
among associated types, etc.


This approach does lead to less-than-optimal generalized generic
signatures getting generated, since nominal type generic arguments
get same-type-bound either to other generic arguments or fixed to
concrete types almost always. It would be useful to do a minimization
pass on the final generic signature to eliminate these unnecessary
generic arguments, but that can be done in a follow-up PR.

Addresses rdar://84827656 | SR-15254