### PR TITLE
[ClangImporter] Fix (lack of) name importing for ObjC ivars

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1672,6 +1672,12 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
   // Spcial case: unnamed/anonymous fields.
   if (auto field = dyn_cast<clang::FieldDecl>(D)) {
+    static_assert((clang::Decl::lastField - clang::Decl::firstField) == 2,
+                  "update logic for new FieldDecl subclasses");
+    if (isa<clang::ObjCIvarDecl>(D) || isa<clang::ObjCAtDefsFieldDecl>(D))
+      // These are not ordinary fields and are not imported into Swift.
+      return result;
+
     if (field->isAnonymousStructOrUnion() || field->getDeclName().isEmpty()) {
       // Generate a field name for anonymous fields, this will be used in
       // order to be able to expose the indirect fields injected from there

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1860,6 +1860,11 @@ SwiftNameLookupExtension::hashExtension(llvm::hash_code code) const {
 void importer::addEntryToLookupTable(SwiftLookupTable &table,
                                      clang::NamedDecl *named,
                                      NameImporter &nameImporter) {
+  clang::PrettyStackTraceDecl trace(
+      named, named->getLocation(),
+      nameImporter.getClangContext().getSourceManager(),
+      "while adding SwiftName lookup table entries for clang declaration");
+
   // Determine whether this declaration is suppressed in Swift.
   if (shouldSuppressDeclImport(named))
     return;

--- a/test/ClangImporter/Inputs/sdk-bridging-header.h
+++ b/test/ClangImporter/Inputs/sdk-bridging-header.h
@@ -2,7 +2,10 @@
 
 @class NSArray;
 
-@interface MyPredicate : NSObject
+@interface MyPredicate : NSObject {
+  int kind : 2;    // Should not cause crash in PCH processing (rdar://85173321)
+}
+
 + (nonnull MyPredicate *)truePredicate;
 + (nonnull MyPredicate *)not;
 + (nonnull MyPredicate *)and:(nonnull NSArray *)subpredicates;


### PR DESCRIPTION
When apple/swift#39664 moved the logic for generating anonymous fields' names from ImportDecl to ImportName, it inadvertently replaced a check that the decl was *precisely* `clang::FieldDecl` with a check that it was `FieldDecl` *or a subclass*. This could cause a crash when it tried to call `FieldDecl::getFieldIndex()`, which doesn't work properly on instance variables even though `ObjCIvarDecl` is a subclass of `FieldDecl`. The easiest way to reproduce this is to use a bit field in a class's instance variables, since clang inserts an anonymous instance variable after it for padding.

This commit adds a test of a bit field instance variable and fixes the bug. It also adds a PrettyStackTrace frame in the Swift lookup table preparation code, which should make other bugs like this easier to diagnose.

Fixes rdar://85173321.