### PR TITLE
Cherry-pick concurrency docs

### DIFF
--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-/// A type that that asychronously supplies the values of a sequence one at a
+/// A type that asynchronously supplies the values of a sequence one at a
 /// time.
 ///
 /// The `AsyncIteratorProtocol` defines the type returned by the

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -236,6 +236,8 @@ extension AsyncSequence {
   /// The predicate executes each time the asynchronous sequence produces an
   /// element, until either the predicate returns `false` or the sequence ends.
   ///
+  /// If the asynchronous sequence is empty, this method returns `true`.
+  ///
   /// - Parameter predicate: A closure that takes an element of the asynchronous
   ///   sequence as its argument and returns a Boolean value that indicates
   ///   whether the passed element satisfies a condition.

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -12,95 +12,179 @@
 
 import Swift
 
-/// An ordered, asynchronously generated sequence of elements.
+/// An asynchronous sequence generated from a closure that calls a continuation
+/// to produce new elements.
 ///
-/// AsyncStream is an interface type to adapt from code producing values to an
-/// asynchronous context iterating them. This is intended to be used to allow
-/// callback or delegation based APIs to participate with async/await.
+/// `AsyncStream` conforms to `AsyncSequence`, providing a convenient way to
+/// create an asynchronous sequence without manually implementing an
+/// asynchronous iterator. In particular, an asynchronous stream is well-suited
+/// to adapt callback- or delegation-based APIs to participate with
+/// `async`-`await`.
 ///
-/// When values are produced from a non async/await source there is a
-/// consideration that must be made on behavioral characteristics of how that
-/// production of values interacts with the iteration. AsyncStream offers a
-/// initialization strategy that provides a method of yielding values into
-/// iteration.
+/// You initialize an `AsyncStream` with a closure that receives an
+/// `AsyncStream.Continuation`. Produce elements in this closure, then provide
+/// them to the stream by calling the continuation's `yield(_:)` method. When
+/// there are no further elements to produce, call the continuation's
+/// `finish()` method. This causes the sequence iterator to produce a `nil`,
+/// which terminates the sequence. The continuation conforms to `Sendable`, which permits
+/// calling it from concurrent contexts external to the iteration of the
+/// `AsyncStream`.
 ///
-/// AsyncStream can be initialized with the option to buffer to a given limit.
-/// The default value for this limit is Int.max. The buffering is only for
-/// values that have yet to be consumed by iteration. Values can be yielded in
-/// case to the continuation passed into the build closure. That continuation
-/// is Sendable, in that it is intended to be used from concurrent contexts
-/// external to the iteration of the AsyncStream.
+/// An arbitrary source of elements can produce elements faster than they are
+/// consumed by a caller iterating over them. Because of this, `AsyncStream`
+/// defines a buffering behavior, allowing the stream to buffer a specific
+/// number of oldest or newest elements. By default, the buffer limit is
+/// `Int.max`, which means the value is unbounded.
 ///
-/// A trivial use case producing values from a detached task would work as such:
+/// ### Adapting Existing Code to Use Streams
 ///
-///     let digits = AsyncStream(Int.self) { continuation in
-///       detach {
-///         for digit in 0..<10 {
-///           continuation.yield(digit)
+/// To adapt existing callback code to use `async`-`await`, use the callbacks
+/// to provide values to the stream, by using the continuation's `yield(_:)`
+/// method.
+///
+/// Consider a hypothetical `QuakeMonitor` type that provides callers with
+/// `Quake` instances every time it detects an earthquake. To receive callbacks,
+/// callers set a custom closure as the value of the monitor's
+/// `quakeHandler` property, which the monitor calls back as necessary.
+///
+///     class QuakeMonitor {
+///         var quakeHandler: ((Quake) -> Void)?
+///
+///         func startMonitoring() {…}
+///         func stopMonitoring() {…}
+///     }
+///
+/// To adapt this to use `async`-`await`, extend the `QuakeMonitor` to add a
+/// `quakes` property, of type `AsyncStream<Quake>`. In the getter for this
+/// property, return an `AsyncStream`, whose `build` closure -- called at
+/// runtime to create the stream -- uses the continuation to perform the
+/// following steps:
+///
+/// 1. Creates a `QuakeMonitor` instance.
+/// 2. Sets the monitor's `quakeHandler` property to a closure that receives
+/// each `Quake` instance and forwards it to the stream by calling the
+/// continuation's `yield(_:)` method.
+/// 3. Sets the continuation's `onTermination` property to a closure that
+/// calls `stopMonitoring()` on the monitor.
+/// 4. Calls `startMonitoring` on the `QuakeMonitor`.
+///
+///     extension QuakeMonitor {
+///
+///         static var quakes: AsyncStream<Quake> {
+///             AsyncStream { continuation in
+///                 let monitor = QuakeMonitor()
+///                 monitor.quakeHandler = { quake in
+///                     continuation.yield(quake)
+///                 }
+///                 continuation.onTermination = { @Sendable _ in
+///                     monitor.stopMonitoring()
+///                 }
+///                 monitor.startMonitoring()
+///             }
 ///         }
-///         continuation.finish()
-///       }
 ///     }
 ///
-///     for await digit in digits {
-///       print(digit)
+/// Because the stream is an `AsyncSequence`, the call point can use the
+/// `for`-`await`-`in` syntax to process each `Quake` instance as the stream
+/// produces it:
+///
+///     for await quake in QuakeMonitor.quakes {
+///         print ("Quake: \(quake.date)")
 ///     }
+///     print ("Stream finished.")
 ///
 @available(SwiftStdlib 5.1, *)
 public struct AsyncStream<Element> {
+  /// A mechanism to interface between synchronous code and an asynchronous
+  /// stream.
+  ///
+  /// The closure you provide to the `AsyncStream` in
+  /// `init(_:bufferingPolicy:_:)` receives an instance of this type when
+  /// invoked. Use this continuation to provide elements to the stream by
+  /// calling one of the `yield` methods, then terminate the stream normally by
+  /// calling the `finish()` method.
+  ///
+  /// - Note: Unlike other continuations in Swift, `AsyncStream.Continuation`
+  /// supports escaping.
   public struct Continuation: Sendable {
-    /// Indication of the type of termination informed to
-    /// `onTermination`.
+    /// A type that indicates how the stream terminated.
+    ///
+    /// The `onTermination` closure receives an instance of this type.
     public enum Termination {
       
-      /// The stream was finished via the `finish` method
+      /// The stream finished as a result of calling the continuation's
+      ///  `finish` method.
       case finished
       
-      /// The stream was cancelled
+      /// The stream finished as a result of cancellation.
       case cancelled
     }
     
-    /// A result of yielding values.
+    /// A type that indicates the result of yielding a value to a client, by
+    /// way of the continuation.
+    ///
+    /// The various `yield` methods of `AsyncStream.Continuation` return this
+    /// type to indicate the success or failure of yielding an element to the
+    /// continuation.
     public enum YieldResult {
       
-      /// When a value is successfully enqueued, either buffered
-      /// or immediately consumed to resume a pending call to next
-      /// and a count of remaining slots available in the buffer at
-      /// the point in time of yielding. Note: transacting upon the
-      /// remaining count is only valid when then calls to yield are
-      /// mutually exclusive.
+      /// The stream successfully enqueued the element.
+      ///
+      /// This value represents the successful enqueueing of an element, whether
+      /// the stream buffers the element or delivers it immediately to a pending
+      /// call to `next()`. The associated value `remaining` is a hint that
+      /// indicates the number of remaining slots in the buffer at the time of
+      /// the `yield` call.
+      ///
+      /// - Note: From a thread safety point of view, `remaining` is a lower bound
+      /// on the number of remaining slots. This is because a subsequent call
+      /// that uses the `remaining` value could race on the consumption of
+      /// values from the stream.
       case enqueued(remaining: Int)
       
-      /// Yielding resulted in not buffering an element because the
-      /// buffer was full. The element is the dropped value.
+      /// The stream didn't enqueue the element because the buffer was full.
+      ///
+      /// The associated element for this case is the element dropped by the stream.
       case dropped(Element)
       
-      /// Indication that the continuation was yielded when the
-      /// stream was already in a terminal state: either by cancel or
-      /// by finishing.
+      /// The stream didn't enqueue the element because the stream was in a
+      /// terminal state.
+      ///
+      /// This indicates the stream terminated prior to calling `yield`, either
+      /// because the stream finished normally or through cancellation.
       case terminated
     }
     
     /// A strategy that handles exhaustion of a buffer’s capacity.
     public enum BufferingPolicy {
+      /// Continue to add to the buffer, without imposing a limit on the number
+      /// of buffered elements.
       case unbounded
       
       /// When the buffer is full, discard the newly received element.
-      /// This enforces keeping the specified amount of oldest values.
+      ///
+      /// This strategy enforces keeping at most the specified number of oldest
+      /// values.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
-      /// This enforces keeping the specified amount of newest values.
+      ///
+      /// This strategy enforces keeping at most the specified number of newest
+      /// values.
       case bufferingNewest(Int)
     }
 
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// normally from its suspension point or buffer the value if no awaiting
-    /// next iteration is active.
+    /// nomally from its suspension point with a given element.
     ///
     /// - Parameter value: The value to yield from the continuation.
+    /// - Returns: A `YieldResult` that indicates the success or failure of the
+    ///   yield operation.
+    ///
+    /// If nothing is awaiting the next value, this method attempts to buffer the
+    /// result's element.
     ///
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consumption from the iteration.
@@ -110,25 +194,27 @@ public struct AsyncStream<Element> {
     }
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// nil which signifies the end of the iteration.
+    /// nil, which signifies the end of the iteration.
     ///
-    /// Calling this function more than once is idempotent; i.e. finishing more
-    /// than once does not alter the state beyond the requirements of
-    /// AsyncSequence; which claims that all values past a terminal state are
-    /// nil.
+    /// Calling this function more than once has no effect. After calling
+    /// finish, the stream enters a terminal state and doesn't produces any additional
+    /// elements.
     public func finish() {
       storage.finish()
     }
 
-    /// A callback to invoke when iteration of a AsyncStream is cancelled.
+    /// A callback to invoke when canceling iteration of an asynchronous
+    /// stream.
     ///
-    /// If an `onTermination` callback is set, when iteration of a AsyncStream is
-    /// cancelled via task cancellation that callback is invoked. The callback
-    /// is disposed of after any terminal state is reached.
+    /// If an `onTermination` callback is set, using task cancellation to
+    /// terminate iteration of an `AsyncStream` results in a call to this
+    /// callback.
     ///
-    /// Cancelling an active iteration will first invoke the onTermination callback
-    /// and then resume yielding nil. This means that any cleanup state can be
-    /// emitted accordingly in the cancellation handler
+    /// Canceling an active iteration invokes the `onTermination` callback
+    /// first, then resumes by yielding `nil`. This means that you can perform
+    /// needed cleanup in the cancellation handler. After reaching a terminal
+    /// state as a result of cancellation, the `AsyncStream` sets the callback
+    /// to `nil`.
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
         return storage.getOnTermination()
@@ -141,22 +227,48 @@ public struct AsyncStream<Element> {
 
   let produce: () async -> Element?
 
-  /// Construct a AsyncStream buffering given an Element type.
+  /// Constructs an asynchronous stream for an element type, using the
+  /// specified buffering policy and element-producing closure.
   ///
-  /// - Parameter elementType: The type the AsyncStream will produce.
-  /// - Parameter maxBufferedElements: The maximum number of elements to
-  ///   hold in the buffer past any checks for continuations being resumed.
-  /// - Parameter build: The work associated with yielding values to the 
-  ///   AsyncStream.
+  /// - Parameters:
+  ///    - elementType: The type of element the `AsyncStream` produces.
+  ///    - bufferingPolicy: A `Continuation.BufferingPolicy` value to
+  ///       set the stream's buffering behavior. By default, the stream buffers an
+  ///       unlimited number of elements. You can also set the policy to buffer a
+  ///       specified number of oldest or newest elements.
+  ///    - build: A custom closure that yields values to the
+  ///       `AsyncStream`. This closure receives an `AsyncStream.Continuation`
+  ///       instance that it uses to provide elements to the stream and terminate the
+  ///       stream when finished.
   ///
-  /// The maximum number of pending elements limited by dropping the oldest
-  /// value when a new value comes in if the buffer would exceed the limit
-  /// placed upon it. By default this limit is unlimited.
+  /// The `AsyncStream.Continuation` received by the `build` closure is
+  /// appropriate for use in concurrent contexts. It is thread safe to send and
+  /// finish; all calls to the continuation are serialized. However, calling
+  /// this from multiple concurrent contexts could result in out-of-order
+  /// delivery.
   ///
-  /// The build closure passes in a Continuation which can be used in
-  /// concurrent contexts. It is thread safe to send and finish; all calls are
-  /// to the continuation are serialized, however calling this from multiple
-  /// concurrent contexts could result in out of order delivery.
+  /// The following example shows an `AsyncStream` created with this
+  /// initializer that produces 100 random numbers on a one-second interval,
+  /// calling `yield(_:)` to deliver each element to the awaiting call point.
+  /// When the `for` loop exits and the stream finishes by calling the
+  /// continuation's `finish()` method.
+  ///
+  ///     let stream = AsyncStream<Int>(Int.self,
+  ///                                   bufferingPolicy: .bufferingNewest(5)) { continuation in
+  ///             Task.detached {
+  ///                 for _ in 0..<100 {
+  ///                     await Task.sleep(1 * 1_000_000_000)
+  ///                     continuation.yield(Int.random(in: 1...10))
+  ///                 }
+  ///                 continuation.finish()
+  ///             }
+  ///         }
+  ///
+  ///     // Call point:
+  ///     for await random in stream {
+  ///         print ("\(random)")
+  ///     }
+  ///
   public init(
     _ elementType: Element.Type = Element.self,
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
@@ -167,7 +279,40 @@ public struct AsyncStream<Element> {
     build(Continuation(storage: storage))
   }
 
-  
+  /// Constructs an asynchronous stream from a given element-producing
+  /// closure, with an optional closure to handle cancellation.
+  ///
+  /// - Parameters:
+  ///   - produce: A closure that asynchronously produces elements for the
+  ///     stream.
+  ///   - onCancel: A closure to execute when canceling the stream's task.
+  ///
+  /// Use this convenience initializer when you have an asychronous function
+  /// that can produce elements for the stream, and don't want to invoke
+  /// a continuation manually. This initializer "unfolds" your closure into
+  /// an asynchronous stream. The created stream handles conformance
+  /// to the `AsyncSequence` protocol automatically, including termination
+  /// (either by cancellation or by returning `nil` from the closure to finish
+  /// iteration).
+  ///
+  /// The following example shows an `AsyncStream` created with this
+  /// initializer that produces random numbers on a one-second interval. This
+  /// example uses the Swift multiple trailing closure syntax, which omits
+  /// the `unfolding` parameter label.
+  ///
+  ///     let stream = AsyncStream<Int> {
+  ///             await Task.sleep(1 * 1_000_000_000)
+  ///             return Int.random(in: 1...10)
+  ///         }
+  ///         onCancel: { @Sendable () in print ("Canceled.") }
+  ///     )
+  ///
+  ///     // Call point:
+  ///     for await random in stream {
+  ///         print ("\(random)")
+  ///     }
+  ///
+  ///
   public init(
     unfolding produce: @escaping () async -> Element?, 
     onCancel: (@Sendable () -> Void)? = nil
@@ -191,30 +336,34 @@ public struct AsyncStream<Element> {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream: AsyncSequence {
-  /// The asynchronous iterator for iterating a AsyncStream.
+  /// The asynchronous iterator for iterating an asynchronous stream.
   ///
-  /// This type is specifically not Sendable. It is not intended to be used
-  /// from multiple concurrent contexts. Any such case that next is invoked
-  /// concurrently and contends with another call to next is a programmer error
-  /// and will fatalError.
+  /// This type doesn't conform to `Sendable`. Don't use it from multiple
+  /// concurrent contexts. It is a programmer error to invoke `next()` from a
+  /// concurrent context that contends with another such call, which
+  /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     let produce: () async -> Element?
 
-    /// The next value from the AsyncStream.
+    /// The next value from the asynchronous stream.
     ///
-    /// When next returns nil this signifies the end of the AsyncStream. Any 
-    /// such case that next is invoked concurrently and contends with another 
-    /// call to next is a programmer error and will fatalError.
+    /// When `next()` returns `nil`, this signifies the end of the
+    /// `AsyncStream`.
     ///
-    /// If the task this iterator is running in is canceled while next is
-    /// awaiting a value, this will terminate the AsyncStream and next may return nil
-    /// immediately (or will return nil on subsequent calls)
+    /// It is a programmer error to invoke `next()` from a
+    /// concurrent context that contends with another such call, which
+    /// results in a call to `fatalError()`.
+    ///
+    /// If you cancel the task this iterator is running in while `next()` is
+    /// awaiting a value, the `AsyncStream` terminates. In this case, `next()`
+    /// might return `nil` immediately, or return `nil` on subsequent calls.
     public mutating func next() async -> Element? {
       await produce()
     }
   }
 
-  /// Construct an iterator.
+  /// Creates the asynchronous iterator that produces elements of this
+  /// asynchronous sequence.
   public func makeAsyncIterator() -> Iterator {
     return Iterator(produce: produce)
   }
@@ -223,13 +372,17 @@ extension AsyncStream: AsyncSequence {
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream.Continuation {
   /// Resume the task awaiting the next iteration point by having it return
-  /// normally from its suspension point or buffer the value if no awaiting
-  /// next iteration is active.
+  /// normally from its suspension point with a given result's success value.
   ///
   /// - Parameter result: A result to yield from the continuation.
+  /// - Returns: A `YieldResult` that indicates the success or failure of the
+  ///   yield operation.
   ///
-  /// This can be called more than once and returns to the caller immediately
-  /// without blocking for any awaiting consumption from the iteration.
+  /// If nothing is awaiting the next value, the method attempts to buffer the
+  /// result's element.
+  ///
+  /// If you call this method repeatedly, each call returns immediately, without
+  /// blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield(
     with result: Result<Element, Never>
@@ -241,12 +394,17 @@ extension AsyncStream.Continuation {
   }
 
   /// Resume the task awaiting the next iteration point by having it return
-  /// normally from its suspension point or buffer the value if no awaiting
-  /// next iteration is active where the `Element` is `Void`.
+  /// normally from its suspension point.
   ///
-  /// This can be called more than once and returns to the caller immediately
-  /// without blocking for any awaiting consumption from the iteration.
-  /// without blocking for any awaiting consuption from the iteration.
+  /// - Returns: A `YieldResult` that indicates the success or failure of the
+  ///   yield operation.
+  ///
+  /// Use this method with `AsyncStream` instances whose `Element` type is
+  /// `Void`. In this case, the `yield()` call unblocks the awaiting
+  /// iteration; there is no value to return.
+  ///
+  /// If you call this method repeatedly, each call returns immediately, without
+  /// blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield() -> YieldResult where Element == Void {
     return storage.yield(())

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -279,7 +279,7 @@ public struct AsyncStream<Element> {
     build(Continuation(storage: storage))
   }
 
-   
+  
   /// Constructs an asynchronous stream from a given element-producing
   /// closure, with an optional closure to handle cancellation.
   ///

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -279,6 +279,7 @@ public struct AsyncStream<Element> {
     build(Continuation(storage: storage))
   }
 
+   
   /// Constructs an asynchronous stream from a given element-producing
   /// closure, with an optional closure to handle cancellation.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -43,7 +43,7 @@ extension AsyncSequence {
   ///     }
   ///     // Prints: 1  2  3  4  Error: MyError()
   ///
-  /// - Parameter isIncluded: A error-throwing closure that takes an element of
+  /// - Parameter predicate: A error-throwing closure that takes an element of
   ///   the asynchronous sequence as its argument and returns a Boolean value
   ///   that indicates whether to include the element in the modified sequence.
   /// - Returns: An asynchronous sequence that contains, in order, the elements

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -12,61 +12,201 @@
 
 import Swift
 
+/// An asynchronous sequence generated from an error-throwing closure that
+/// calls a continuation to produce new elements.
+///
+/// `AsyncThrowingStream` conforms to `AsyncSequence`, providing a convenient
+/// way to create an asynchronous sequence without manually implementing an
+/// asynchronous iterator. In particular, an asynchronous stream is well-suited
+/// to adapt callback- or delegation-based APIs to participate with
+/// `async`-`await`.
+///
+/// In contrast to `AsyncStream`, this type can throw an error from the awaited
+/// `next()`, which terminates the stream with the thrown error.
+///
+/// You initialize an `AsyncThrowingStream` with a closure that receives an
+/// `AsyncThrowingStream.Continuation`. Produce elements in this closure, then
+/// provide them to the stream by calling the continuation's `yield(_:)` method.
+/// When there are no further elements to produce, call the continuation's
+/// `finish()` method. This causes the sequence iterator to produce a `nil`,
+/// which terminates the sequence. If an error occurs, call the continuation's
+/// `finish(throwing:)` method, which causes the iterator's `next()` method to
+/// throw the error to the awaiting call point. The continuation is `Sendable`,
+/// which permits calling it from concurrent contexts external to the iteration
+/// of the `AsyncThrowingStream`.
+///
+/// An arbitrary source of elements can produce elements faster than they are
+/// consumed by a caller iterating over them. Because of this, `AsyncThrowingStream`
+/// defines a buffering behavior, allowing the stream to buffer a specific
+/// number of oldest or newest elements. By default, the buffer limit is
+/// `Int.max`, which means it's unbounded.
+///
+/// ### Adapting Existing Code to Use Streams
+///
+/// To adapt existing callback code to use `async`-`await`, use the callbacks
+/// to provide values to the stream, by using the continuation's `yield(_:)`
+/// method.
+///
+/// Consider a hypothetical `QuakeMonitor` type that provides callers with
+/// `Quake` instances every time it detects an earthquake. To receive callbacks,
+/// callers set a custom closure as the value of the monitor's
+/// `quakeHandler` property, which the monitor calls back as necessary. Callers
+/// can also set an `errorHandler` to receive asychronous error notifications,
+/// such as the monitor service suddenly becoming unavailable.
+///
+///     class QuakeMonitor {
+///         var quakeHandler: ((Quake) -> Void)?
+///         var errorHandler: ((Error) -> Void)?
+///
+///         func startMonitoring() {…}
+///         func stopMonitoring() {…}
+///     }
+///
+/// To adapt this to use `async`-`await`, extend the `QuakeMonitor` to add a
+/// `quakes` property, of type `AsyncThrowingStream<Quake>`. In the getter for
+/// this property, return an `AsyncThrowingStream`, whose `build` closure --
+/// called at runtime to create the stream -- uses the continuation to
+/// perform the following steps:
+///
+/// 1. Creates a `QuakeMonitor` instance.
+/// 2. Sets the monitor's `quakeHandler` property to a closure that receives
+/// each `Quake` instance and forwards it to the stream by calling the
+/// continuation's `yield(_:)` method.
+/// 3. Sets the monitor's `errorHandler` property to a closure that receives
+/// any error from the monitor and forwards it to the stream by calling the
+/// continuation's `finish(throwing:)` method. This causes the stream's
+/// iterator to throw the error and terminate the stream.
+/// 4. Sets the continuation's `onTermination` property to a closure that
+/// calls `stopMonitoring()` on the monitor.
+/// 5. Calls `startMonitoring` on the `QuakeMonitor`.
+///
+///     extension QuakeMonitor {
+///
+///         static var throwingQuakes: AsyncThrowingStream<Quake, Error> {
+///             AsyncThrowingStream { continuation in
+///                 let monitor = QuakeMonitor()
+///                 monitor.quakeHandler = { quake in
+///                     continuation.yield(quake)
+///                 }
+///                 monitor.errorHandler = { error in
+///                     continuation.finish(throwing: error)
+///                 }
+///                 continuation.onTermination = { @Sendable _ in
+///                     monitor.stopMonitoring()
+///                 }
+///                 monitor.startMonitoring()
+///             }
+///         }
+///     }
+///
+///
+/// Because the stream is an `AsyncSequence`, the call point uses the
+/// `for`-`await`-`in` syntax to process each `Quake` instance as produced by the stream:
+///
+///     do {
+///         for try await quake in quakeStream {
+///             print ("Quake: \(quake.date)")
+///         }
+///         print ("Stream done.")
+///     } catch {
+///         print ("Error: \(error)")
+///     }
+///
 @available(SwiftStdlib 5.1, *)
 public struct AsyncThrowingStream<Element, Failure: Error> {
+  /// A mechanism to interface between synchronous code and an asynchronous
+  /// stream.
+  ///
+  /// The closure you provide to the `AsyncThrowingStream` in
+  /// `init(_:bufferingPolicy:_:)` receives an instance of this type when
+  /// invoked. Use this continuation to provide elements to the stream by
+  /// calling one of the `yield` methods, then terminate the stream normally by
+  /// calling the `finish()` method. You can also use the continuation's
+  /// `finish(throwing:)` method to terminate the stream by throwing an error.
+  ///
+  /// - Note: Unlike other continuations in Swift,
+  /// `AsyncThrowingStream.Continuation` supports escaping.
   public struct Continuation: Sendable {
-    /// Indication of the type of termination informed to
-    /// `onTermination`.
+    /// A type that indicates how the stream terminated.
+    ///
+    /// The `onTermination` closure receives an instance of this type.
     public enum Termination {
       
-      /// The stream was finished via the `finish` method
+      /// The stream finished as a result of calling the continuation's
+      ///  `finish` method.
+      ///
+      ///  The associated `Failure` value provides the error that terminated
+      ///  the stream. If no error occurred, this value is `nil`.
       case finished(Failure?)
       
-      /// The stream was cancelled
+      /// The stream finished as a result of cancellation.
       case cancelled
     }
     
-    /// A result of yielding values.
+    /// A type that indicates the result of yielding a value to a client, by
+    /// way of the continuation.
+    ///
+    /// The various `yield` methods of `AsyncThrowingStream.Continuation` return
+    /// this type to indicate the success or failure of yielding an element to
+    /// the continuation.
     public enum YieldResult {
       
-      /// When a value is successfully enqueued, either buffered
-      /// or immediately consumed to resume a pending call to next
-      /// and a count of remaining slots available in the buffer at
-      /// the point in time of yielding. Note: transacting upon the
-      /// remaining count is only valid when then calls to yield are
-      /// mutually exclusive.
+      /// The stream successfully enqueued the element.
+      ///
+      /// This value represents the successful enqueueing of an element, whether
+      /// the stream buffers the element or delivers it immediately to a pending
+      /// call to `next()`. The associated value `remaining` is a hint that
+      /// indicates the number of remaining slots in the buffer at the time of
+      /// the `yield` call.
+      ///
+      /// - Note: From a thread safety perspective, `remaining` is a lower bound
+      /// on the number of remaining slots. This is because a subsequent call
+      /// that uses the `remaining` value could race on the consumption of
+      /// values from the stream.
       case enqueued(remaining: Int)
       
-      /// Yielding resulted in not buffering an element because the
-      /// buffer was full. The element is the dropped value.
+      /// The stream didn't enqueue the element because the buffer was full.
+      ///
+      /// The associated element for this case is the element that the stream
+      /// dropped.
       case dropped(Element)
       
-      /// Indication that the continuation was yielded when the
-      /// stream was already in a terminal state: either by cancel or
-      /// by finishing.
+      /// The stream didn't enqueue the element because the stream was in a
+      /// terminal state.
+      ///
+      /// This indicates the stream terminated prior to calling `yield`, either
+      /// because the stream finished normally or through cancellation, or
+      /// it threw an error.
       case terminated
     }
     
     /// A strategy that handles exhaustion of a buffer’s capacity.
     public enum BufferingPolicy {
+      /// Continue to add to the buffer, treating its capacity as infinite.
       case unbounded
       
       /// When the buffer is full, discard the newly received element.
-      /// This enforces keeping the specified amount of oldest values.
+      ///
+      /// This strategy enforces keeping the specified amount of oldest values.
       case bufferingOldest(Int)
       
       /// When the buffer is full, discard the oldest element in the buffer.
-      /// This enforces keeping the specified amount of newest values.
+      ///
+      /// This strategy enforces keeping the specified amount of newest values.
       case bufferingNewest(Int)
     }
 
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// normally from its suspension point or buffer the value if no awaiting
-    /// next iteration is active.
+    /// nomally from its suspension point with a given element.
     ///
     /// - Parameter value: The value to yield from the continuation.
+    /// - Returns: A `YieldResult` that indicates the success or failure of the
+    ///   yield operation.
+    ///
+    /// If nothing is awaiting the next value, the method attempts to buffer the
+    /// result's element.
     ///
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consumption from the iteration.
@@ -76,28 +216,29 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     }
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// nil or throw which signifies the end of the iteration.
+    /// nil, which signifies the end of the iteration.
     ///
-    /// - Parameter error: The error to throw or nil to signify termination.
+    /// - Parameter error: The error to throw, or `nil`, to finish normally.
     ///
-    /// Calling this function more than once is idempotent; i.e. finishing more
-    /// than once does not alter the state beyond the requirements of
-    /// AsyncSequence; which claims that all values past a terminal state are
-    /// nil.
+    /// Calling this function more than once has no effect. After calling
+    /// finish, the stream enters a terminal state and doesn't produce any additional
+    /// elements.
     public func finish(throwing error: __owned Failure? = nil) {
       storage.finish(throwing: error)
     }
 
-    /// A callback to invoke when iteration of a AsyncThrowingStream is 
-    /// cancelled.
+    /// A callback to invoke when canceling iteration of an asynchronous
+    /// stream.
     ///
-    /// If an `onTermination` callback is set, when iteration of a AsyncStream 
-    /// is cancelled via task cancellation that callback is invoked. The
-    /// callback is disposed of after any terminal state is reached.
+    /// If an `onTermination` callback is set, using task cancellation to
+    /// terminate iteration of an `AsyncThrowingStream` results in a call to this
+    /// callback.
     ///
-    /// Cancelling an active iteration will first invoke the onTermination 
-    /// callback and then resume yeilding nil. This means that any cleanup state
-    /// can be emitted accordingly in the cancellation handler
+    /// Canceling an active iteration invokes the `onTermination` callback
+    /// first, and then resumes by yielding `nil` or throwing an error from the
+    /// iterator. This means that you can perform needed cleanup in the
+    ///  cancellation handler. After reaching a terminal state, the
+    ///  `AsyncThrowingStream` disposes of the callback.
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
         return storage.getOnTermination()
@@ -110,22 +251,60 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
 
   let produce: () async throws -> Element?
 
-  /// Construct a AsyncThrowingStream buffering given an Element type.
+  /// Constructs an asynchronous stream for an element type, using the
+  /// specified buffering policy and element-producing closure.
   ///
-  /// - Parameter elementType: The type the AsyncStream will produce.
-  /// - Parameter maxBufferedElements: The maximum number of elements to
-  ///   hold in the buffer past any checks for continuations being resumed.
-  /// - Parameter build: The work associated with yielding values to the 
-  ///   AsyncStream.
+  /// - Parameters:
+  ///   - elementType: The type of element the `AsyncThrowingStream`
+  ///   produces.
+  ///   - limit: The maximum number of elements to
+  ///   hold in the buffer. By default, this value is unlimited. Use a
+  ///   `Continuation.BufferingPolicy` to buffer a specified number of oldest
+  ///   or newest elements.
+  ///   - build: A custom closure that yields values to the
+  ///   `AsyncThrowingStream`. This closure receives an
+  ///   `AsyncThrowingStream.Continuation` instance that it uses to provide
+  ///   elements to the stream and terminate the stream when finished.
   ///
-  /// The maximum number of pending elements limited by dropping the oldest
-  /// value when a new value comes in if the buffer would excede the limit
-  /// placed upon it. By default this limit is unlimited.
+  /// The `AsyncStream.Continuation` received by the `build` closure is
+  /// appopriate for use in concurrent contexts. It is thread safe to send and
+  /// finish; all calls are to the continuation are serialized. However, calling
+  /// this from multiple concurrent contexts could result in out-of-order
+  /// delivery.
   ///
-  /// The build closure passes in a Continuation which can be used in
-  /// concurrent contexts. It is thread safe to send and finish; all calls
-  /// to the continuation are serialized, however calling this from multiple
-  /// concurrent contexts could result in out of order delivery.
+  /// The following example shows an `AsyncStream` created with this
+  /// initializer that produces 100 random numbers on a one-second interval,
+  /// calling `yield(_:)` to deliver each element to the awaiting call point.
+  /// When the `for` loop exits and the stream finishes by calling the
+  /// continuation's `finish()` method. If the random number is divisble by 5
+  /// with no remainder, the stream throws a `MyRandomNumberError`.
+  ///
+  ///     let stream = AsyncThrowingStream<Int, Error>(Int.self,
+  ///                                                  bufferingPolicy: .bufferingNewest(5)) { continuation in
+  ///             Task.detached {
+  ///                 for _ in 0..<100 {
+  ///                     await Task.sleep(1 * 1_000_000_000)
+  ///                     let random = Int.random(in: 1...10)
+  ///                     if (random % 5 == 0) {
+  ///                         continuation.finish(throwing: MyRandomNumberError())
+  ///                         return
+  ///                     } else {
+  ///                         continuation.yield(random)
+  ///                     }
+  ///                 }
+  ///                 continuation.finish()
+  ///             }
+  ///         }
+  ///
+  ///     // Call point:
+  ///     do {
+  ///         for try await random in stream {
+  ///             print ("\(random)")
+  ///         }
+  ///     } catch {
+  ///         print ("\(error)")
+  ///     }
+  ///
   public init(
     _ elementType: Element.Type = Element.self,
     bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
@@ -136,6 +315,43 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     build(Continuation(storage: storage))
   }
   
+  /// Constructs an asynchronous throwing stream from a given element-producing
+  /// closure.
+  ///
+  /// - Parameters:
+  ///   - produce: A closure that asynchronously produces elements for the
+  ///    stream.
+  ///
+  /// Use this convenience initializer when you have an asychronous function
+  /// that can produce elements for the stream, and don't want to invoke
+  /// a continuation manually. This initializer "unfolds" your closure into
+  /// a full-blown asynchronous stream. The created stream handles adherence to
+  /// the `AsyncSequence` protocol automatically. To terminate the stream with
+  /// an error, throw the error from your closure.
+  ///
+  /// The following example shows an `AsyncThrowingStream` created with this
+  /// initializer that produces random numbers on a one-second interval. If the
+  /// random number is divisble by 5 with no remainder, the stream throws a
+  /// `MyRandomNumberError`.
+  ///
+  ///     let stream = AsyncThrowingStream<Int, Error> {
+  ///             await Task.sleep(1 * 1_000_000_000)
+  ///             let random = Int.random(in: 1...10)
+  ///             if (random % 5 == 0) {
+  ///                 throw MyRandomNumberError()
+  ///             }
+  ///             return random
+  ///         }
+  ///
+  ///     // Call point:
+  ///     do {
+  ///         for try await random in stream {
+  ///             print ("\(random)")
+  ///         }
+  ///     } catch {
+  ///         print ("\(error)")
+  ///     }
+  ///
   public init(
     unfolding produce: @escaping () async throws -> Element?
   ) where Failure == Error {
@@ -145,21 +361,35 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream: AsyncSequence {
-  /// The asynchronous iterator for iterating a AsyncThrowingStream.
+  /// The asynchronous iterator for iterating an asynchronous stream.
   ///
-  /// This type is specificially not Sendable. It is not intended to be used
-  /// from multiple concurrent contexts. Any such case that next is invoked
-  /// concurrently and contends with another call to next is a programmer error
-  /// and will fatalError.
+  /// This type is not `Sendable`. Don't use it from multiple
+  /// concurrent contexts. It is a programmer error to invoke `next()` from a
+  /// concurrent context that contends with another such call, which
+  /// results in a call to `fatalError()`.
   public struct Iterator: AsyncIteratorProtocol {
     let produce: () async throws -> Element?
 
+    /// The next value from the asynchronous stream.
+    ///
+    /// When `next()` returns `nil`, this signifies the end of the
+    /// `AsyncThrowingStream`.
+    ///
+    /// It is a programmer error to invoke `next()` from a concurrent context
+    /// that contends with another such call, which results in a call to
+    ///  `fatalError()`.
+    ///
+    /// If you cancel the task this iterator is running in while `next()` is
+    /// awaiting a value, the `AsyncThrowingStream` terminates. In this case,
+    /// `next()` may return `nil` immediately, or else return `nil` on
+    /// subsequent calls.
     public mutating func next() async throws -> Element? {
       return try await produce()
     }
   }
 
-  /// Construct an iterator.
+  /// Creates the asynchronous iterator that produces elements of this
+  /// asynchronous sequence.
   public func makeAsyncIterator() -> Iterator {
     return Iterator(produce: produce)
   }
@@ -168,13 +398,21 @@ extension AsyncThrowingStream: AsyncSequence {
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream.Continuation {
   /// Resume the task awaiting the next iteration point by having it return
-  /// normally from its suspension point or buffer the value if no awaiting
-  /// next iteration is active.
+  /// normally or throw, based on a given result.
   ///
-  /// - Parameter result: A result to yield from the continuation.
+  /// - Parameter result: A result to yield from the continuation. In the
+  ///   `.success(_:)` case, this returns the associated value from the
+  ///   iterator's `next()` method. If the result is the `failure(_:)` case,
+  ///   this call terminates the stream with the result's error, by calling
+  ///   `finish(throwing:)`.
+  /// - Returns: A `YieldResult` that indicates the success or failure of the
+  ///   yield operation.
   ///
-  /// This can be called more than once and returns to the caller immediately
-  /// without blocking for any awaiting consuption from the iteration.
+  /// If nothing is awaiting the next value and the result is success, this call
+  /// attempts to buffer the result's element.
+  ///
+  /// If you call this method repeatedly, each call returns immediately, without
+  /// blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield(
     with result: Result<Element, Failure>
@@ -189,11 +427,17 @@ extension AsyncThrowingStream.Continuation {
   }
 
   /// Resume the task awaiting the next iteration point by having it return
-  /// normally from its suspension point or buffer the value if no awaiting
-  /// next iteration is active where the `Element` is `Void`.
+  /// nomally from its suspension point.
   ///
-  /// This can be called more than once and returns to the caller immediately
-  /// without blocking for any awaiting consuption from the iteration.
+  /// - Returns: A `YieldResult` that indicates the success or failure of the
+  ///   yield operation.
+  ///
+  /// Use this method with `AsyncThrowingStream` instances whose `Element`
+  /// type is `Void`. In this case, the `yield()` call unblocks the
+  /// awaiting iteration; there is no value to return.
+  ///
+  /// If you call this method repeatedly, each call returns immediately,
+  /// without blocking for any awaiting consumption from the iteration.
   @discardableResult
   public func yield() -> YieldResult where Element == Void {
     storage.yield(())

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -83,49 +83,60 @@ internal final class CheckedContinuationCanary {
   }
 }
 
-/// A wrapper class for `UnsafeContinuation` that logs misuses of the
-/// continuation, logging a message if the continuation is resumed
-/// multiple times, or if an object is destroyed without its continuation
-/// ever being resumed.
+/// A mechanism to interface
+/// between synchronous and asynchronous code,
+/// logging correctness violations.
 ///
-/// Raw `UnsafeContinuation`, like other unsafe constructs, requires the
-/// user to apply it correctly in order to maintain invariants. The key
-/// invariant is that the continuation must be resumed exactly once,
-/// and bad things happen if this invariant is not upheld--if a continuation
-/// is abandoned without resuming the task, then the task will be stuck in
-/// the suspended state forever, and conversely, if the same continuation is
-/// resumed multiple times, it will put the task in an undefined state.
+/// A *continuation* is an opaque representation of program state.
+/// To create a continuation in asynchronous code,
+/// call the `withUnsafeContinuation(function:_:)` or
+/// `withUnsafeThrowingContinuation(function:_:)` function.
+/// To resume the asynchronous task,
+/// call the `resume(returning:)`,
+/// `resume(throwing:)`,
+/// `resume(with:)`,
+/// or `resume()` method.
 ///
-/// `UnsafeContinuation` avoids enforcing these invariants at runtime because
-/// it aims to be a low-overhead mechanism for interfacing Swift tasks with
-/// event loops, delegate methods, callbacks, and other non-`async` scheduling
-/// mechanisms. However, during development, being able to verify that the
+/// - Important: You must call a resume method exactly once
+///   on every execution path throughout the program.
+///
+/// Resuming from a continuation more than once is undefined behavior.
+/// Never resuming leaves the task in a suspended state indefinitely,
+/// and leaks any associated resources.
+/// `CheckedContinuation` logs a message
+/// if either of these invariants is violated.
+///
+/// `CheckedContinuation` performs runtime checks
+/// for missing or multiple resume operations.
+/// `UnsafeContinuation` avoids enforcing these invariants at runtime
+/// because it aims to be a low-overhead mechanism
+/// for interfacing Swift tasks with
+/// event loops, delegate methods, callbacks,
+/// and other non-`async` scheduling mechanisms.
+/// However, during development, the ability to verify that the
 /// invariants are being upheld in testing is important.
-///
-/// `CheckedContinuation` is designed to be a drop-in API replacement for
-/// `UnsafeContinuation` that can be used for testing purposes, at the cost of
-/// an extra allocation and indirection for the wrapper object. Changing a call
-/// of `withUnsafeContinuation` or `withUnsafeThrowingContinuation` into a call
-/// of `withCheckedContinuation` or `withCheckedThrowingContinuation` should be
-/// enough to obtain the extra checking without further source modification in
-/// most circumstances.
+/// Because both types have the same interface,
+/// you can replace one with the other in most circumstances,
+/// without making other changes.
 @available(SwiftStdlib 5.1, *)
 public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
   private let canary: CheckedContinuationCanary
   
-  /// Initialize a `CheckedContinuation` wrapper around an
-  /// `UnsafeContinuation`.
+  /// Creates a checked continuation from an unsafe continuation.
   ///
-  /// In most cases, you should use `withCheckedContinuation` or
-  /// `withCheckedThrowingContinuation` instead. You only need to initialize
+  /// Instead of calling this initializer,
+  /// most code calls the `withCheckedContinuation(function:_:)` or
+  /// `withCheckedThrowingContinuation(function:_:)` function instead.
+  /// You only need to initialize
   /// your own `CheckedContinuation<T, E>` if you already have an
   /// `UnsafeContinuation` you want to impose checking on.
   ///
   /// - Parameters:
-  ///   - continuation: a fresh `UnsafeContinuation` that has not yet
-  ///     been resumed. The `UnsafeContinuation` must not be used outside of
-  ///     this object once it's been given to the new object.
-  ///   - function: a string identifying the declaration that is the notional
+  ///   - continuation: An instance of `UnsafeContinuation`
+  ///     that hasn't yet been resumed.
+  ///     After passing the unsafe continuation to this initializer,
+  ///     don't use it outside of this object.
+  ///   - function: A string identifying the declaration that is the notional
   ///     source for the continuation, used to identify the continuation in
   ///     runtime diagnostics related to misuse of this continuation.
   public init(continuation: UnsafeContinuation<T, E>, function: String = #function) {
@@ -141,10 +152,10 @@ public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
   ///
   /// A continuation must be resumed exactly once. If the continuation has
   /// already been resumed through this object, then the attempt to resume
-  /// the continuation again will trap.
+  /// the continuation will trap.
   ///
-  /// After `resume` enqueues the task, control is immediately returned to
-  /// the caller. The task will continue executing when its executor is
+  /// After `resume` enqueues the task, control immediately returns to
+  /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(returning value: __owned T) {
     if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
@@ -161,10 +172,10 @@ public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
   ///
   /// A continuation must be resumed exactly once. If the continuation has
   /// already been resumed through this object, then the attempt to resume
-  /// the continuation again will trap.
+  /// the continuation will trap.
   ///
-  /// After `resume` enqueues the task, control is immediately returned to
-  /// the caller. The task will continue executing when its executor is
+  /// After `resume` enqueues the task, control immediately returns to
+  /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(throwing error: __owned E) {
     if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
@@ -186,10 +197,10 @@ extension CheckedContinuation {
   ///
   /// A continuation must be resumed exactly once. If the continuation has
   /// already been resumed through this object, then the attempt to resume
-  /// the continuation again will trap.
+  /// the continuation will trap.
   ///
-  /// After `resume` enqueues the task, control is immediately returned to
-  /// the caller. The task will continue executing when its executor is
+  /// After `resume` enqueues the task, control immediately returns to
+  /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   @_alwaysEmitIntoClient
   public func resume<Er: Error>(with result: Result<T, Er>) where E == Error {
@@ -210,10 +221,10 @@ extension CheckedContinuation {
   ///
   /// A continuation must be resumed exactly once. If the continuation has
   /// already been resumed through this object, then the attempt to resume
-  /// the continuation again will trap.
+  /// the continuation will trap.
   ///
-  /// After `resume` enqueues the task, control is immediately returned to
-  /// the caller. The task will continue executing when its executor is
+  /// After `resume` enqueues the task, control immediately returns to
+  /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   @_alwaysEmitIntoClient
   public func resume(with result: Result<T, E>) {
@@ -230,10 +241,10 @@ extension CheckedContinuation {
   ///
   /// A continuation must be resumed exactly once. If the continuation has
   /// already been resumed through this object, then the attempt to resume
-  /// the continuation again will trap.
+  /// the continuation will trap.
   ///
-  /// After `resume` enqueues the task, control is immediately returned to
-  /// the caller. The task will continue executing when its executor is
+  /// After `resume` enqueues the task, control immediately returns to
+  /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   @_alwaysEmitIntoClient
   public func resume() where T == Void {
@@ -241,6 +252,15 @@ extension CheckedContinuation {
   }
 }
 
+/// Suspends the current task,
+/// then calls the given closure with a checked continuation for the current task.
+///
+/// - Parameters:
+///   - function: A string identifying the declaration that is the notional
+///     source for the continuation, used to identify the continuation in
+///     runtime diagnostics related to misuse of this continuation.
+///   - body: A closure that takes a `CheckedContinuation` parameter.
+///     You must resume the continuation exactly once.
 @available(SwiftStdlib 5.1, *)
 public func withCheckedContinuation<T>(
     function: String = #function,
@@ -251,6 +271,18 @@ public func withCheckedContinuation<T>(
   }
 }
 
+/// Suspends the current task,
+/// then calls the given closure with a checked throwing continuation for the current task.
+///
+/// - Parameters:
+///   - function: A string identifying the declaration that is the notional
+///     source for the continuation, used to identify the continuation in
+///     runtime diagnostics related to misuse of this continuation.
+///   - body: A closure that takes an `UnsafeContinuation` parameter.
+///     You must resume the continuation exactly once.
+///
+/// If `resume(throwing:)` is called on the continuation,
+/// this function throws that error.
 @available(SwiftStdlib 5.1, *)
 public func withCheckedThrowingContinuation<T>(
     function: String = #function,

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -12,13 +12,13 @@
 
 import Swift
 
-/// A service which can execute jobs.
+/// A service that can execute jobs.
 @available(SwiftStdlib 5.1, *)
 public protocol Executor: AnyObject, Sendable {
   func enqueue(_ job: UnownedJob)
 }
 
-/// A service which can execute jobs.
+/// A service that executes jobs.
 @available(SwiftStdlib 5.1, *)
 public protocol SerialExecutor: Executor {
   // This requirement is repeated here as a non-override so that we

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -15,12 +15,12 @@ import Swift
 /// A type that represents a globally-unique actor that can be used to isolate
 /// various declarations anywhere in the program.
 ///
-/// A type that conforms to the `GlobalActor` protocol and is marked with the
+/// A type that conforms to the `GlobalActor` protocol and is marked with
 /// the `@globalActor` attribute can be used as a custom attribute. Such types
 /// are called global actor types, and can be applied to any declaration to
 /// specify that such types are isolated to that global actor type. When using
 /// such a declaration from another actor (or from nonisolated code),
-/// synchronization is performed through the \c shared actor instance to ensure
+/// synchronization is performed through the shared actor instance to ensure
 /// mutually-exclusive access to the declaration.
 @available(SwiftStdlib 5.1, *)
 public protocol GlobalActor {

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -15,26 +15,67 @@ import Swift
 
 // ==== Task -------------------------------------------------------------------
 
-/// An asynchronous task (just "Task" hereafter) is the analogue of a thread for
-/// asynchronous functions. All asynchronous functions run as part of some task.
+/// A unit of asynchronous work.
 ///
-/// An instance of `Task` always represents a top-level task. The instance
-/// can be used to await its completion, cancel the task, etc., The task will
-/// run to completion even if there are no other instances of the `Task`.
+/// When you create an instance of `Task`,
+/// you provide a closure that contains the work for that task to perform.
+/// Tasks can start running immediately after creation;
+/// you don't explicitly start or schedule them.
+/// After creating a task, you use the instance to interact with it ---
+/// for example, to wait for it to complete or to cancel it.
+/// It's not a programming error to discard a reference to a task
+/// without waiting for that task to finish or canceling it.
+/// A task runs regardless of whether you keep a reference to it.
+/// However, if you discard the reference to a task,
+/// you give up the ability
+/// to wait for that task's result or cancel the task.
 ///
-/// `Task` also provides appropriate context-sensitive static functions which
-/// operate on the "current" task, which might either be a detached task or
-/// a child task. Because all such functions are `async` they can only
-/// be invoked as part of an existing task, and therefore are guaranteed to be
-/// effective.
+/// To support operations on the current task,
+/// which can be either a detached task or child task,
+/// `Task` also exposes class methods like `yield()`.
+/// Because these methods are asynchronous,
+/// they're always invoked as part of an existing task.
 ///
-/// A task's execution can be seen as a series of periods where the task was
-/// running. Each such period ends at a suspension point or -- finally -- the
+/// Only code that's running as part of the task can interact with that task.
+/// To interact with the current task,
+/// you call one of the static methods on `Task`.
+///
+/// A task's execution can be seen as a series of periods where the task ran.
+/// Each such period ends at a suspension point or the
 /// completion of the task.
+/// These periods of execution are represented by instances of `PartialAsyncTask`.
+/// Unless you're implementing a custom executor,
+/// you don't directly interact with partial tasks.
 ///
-/// These partial periods towards the task's completion are
-/// individually schedulable as jobs.  Jobs are generally not interacted
-/// with by end-users directly, unless implementing a scheduler.
+/// For information about the language-level concurrency model that `Task` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
+///
+/// Task Cancellation
+/// =================
+///
+/// Tasks include a shared mechanism for indicating cancellation,
+/// but not a shared implementation for how to handle cancellation.
+/// Depending on the work you're doing in the task,
+/// the correct way to stop that work varies.
+/// Likewise,
+/// it's the responsibility of the code running as part of the task
+/// to check for cancellation whenever stopping is appropriate.
+/// In a long-task that includes multiple pieces,
+/// you might need to check for cancellation at several points,
+/// and handle cancellation differently at each point.
+/// If you only need to throw an error to stop the work,
+/// call the `Task.checkCancellation()` function to check for cancellation.
+/// Other responses to cancellation include
+/// returning the work completed so far, returning an empty result, or returning `nil`.
+///
+/// Cancellation is a purely Boolean state;
+/// there's no way to include additional information
+/// like the reason for cancellation.
+/// This reflects the fact that a task can be canceled for many reasons,
+/// and additional reasons can accrue during the cancellation process.
 @available(SwiftStdlib 5.1, *)
 @frozen
 public struct Task<Success: Sendable, Failure: Error>: Sendable {
@@ -49,55 +90,38 @@ public struct Task<Success: Sendable, Failure: Error>: Sendable {
 
 @available(SwiftStdlib 5.1, *)
 extension Task {
-  /// Wait for the task to complete, returning (or throwing) its result.
+  /// The result from a throwing task, after it completes.
   ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
+  /// If the task hasn't completed,
+  /// accessing this property waits for it to complete
+  /// and its priority increases to that of the current task.
+  /// Note that this might not be as effective as
+  /// creating the task with the correct priority,
+  /// depending on the executor's scheduling details.
   ///
-  /// ### Cancellation
-  /// If the awaited on task gets cancelled externally the `get()` will throw
-  /// a cancellation error.
+  /// If the task throws an error, this property propagates that error.
+  /// Tasks that respond to cancellation by throwing `Task.CancellationError`
+  /// have that error propagated here upon cancellation.
   ///
-  /// If the task gets cancelled internally, e.g. by checking for cancellation
-  /// and throwing a specific error or using `checkCancellation` the error
-  /// thrown out of the task will be re-thrown here.
+  /// - Returns: The task's result.
   public var value: Success {
     get async throws {
       return try await _taskFutureGetThrowing(_task)
     }
   }
 
-  /// Wait for the task to complete, returning (or throwing) its result.
+  /// The result or error from a throwing task, after it completes.
   ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
+  /// If the task hasn't completed,
+  /// accessing this property waits for it to complete
+  /// and its priority increases to that of the current task.
+  /// Note that this might not be as effective as
+  /// creating the task with the correct priority,
+  /// depending on the executor's scheduling details.
   ///
-  /// ### Cancellation
-  /// If the awaited on task gets cancelled externally the `get()` will throw
-  /// a cancellation error.
-  ///
-  /// If the task gets cancelled internally, e.g. by checking for cancellation
-  /// and throwing a specific error or using `checkCancellation` the error
-  /// thrown out of the task will be re-thrown here.
-
-  /// Wait for the task to complete, returning its `Result`.
-  ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
-  ///
-  /// ### Cancellation
-  /// If the awaited on task gets cancelled externally the `get()` will throw
-  /// a cancellation error.
-  ///
-  /// If the task gets cancelled internally, e.g. by checking for cancellation
-  /// and throwing a specific error or using `checkCancellation` the error
-  /// thrown out of the task will be re-thrown here.
+  /// - Returns: If the task succeeded,
+  ///   `.success` with the task's result as the associated value;
+  ///   otherwise, `.failure` with the error as the associated value.
   public var result: Result<Success, Failure> {
     get async {
       do {
@@ -108,14 +132,19 @@ extension Task {
     }
   }
 
-  /// Attempt to cancel the task.
+  /// Indicates that the task should stop running.
   ///
-  /// Whether this function has any effect is task-dependent.
+  /// Task cancellation is cooperative:
+  /// a task that supports cancellation
+  /// checks whether it has been canceled at various points during its work.
   ///
-  /// For a task to respect cancellation it must cooperatively check for it
-  /// while running. Many tasks will check for cancellation before beginning
-  /// their "actual work", however this is not a requirement nor is it guaranteed
-  /// how and when tasks check for cancellation in general.
+  /// Calling this method on a task that doesn't support cancellation
+  /// has no effect.
+  /// Likewise, if the task has already run
+  /// past the last point where it would stop early,
+  /// calling this method has no effect.
+  ///
+  /// - SeeAlso: `Task.checkCancellation()`
   public func cancel() {
     Builtin.cancelAsyncTask(_task)
   }
@@ -123,19 +152,18 @@ extension Task {
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
-  /// Wait for the task to complete, returning its result.
+  /// The result from a nonthrowing task, after it completes.
   ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
+  /// If the task hasn't completed yet,
+  /// accessing this property waits for it to complete
+  /// and its priority increases to that of the current task.
+  /// Note that this might not be as effective as
+  /// creating the task with the correct priority,
+  /// depending on the executor's scheduling details.
   ///
-  /// ### Cancellation
-  /// The task this refers to may check for cancellation, however
-  /// since it is not-throwing it would have to handle it using some other
-  /// way than throwing a `CancellationError`, e.g. it could provide a neutral
-  /// value of the `Success` type, or encode that cancellation has occurred in
-  /// that type itself.
+  /// Tasks that never throw an error can still check for cancellation,
+  /// but they need to use an approach like returning `nil`
+  /// instead of throwing an error.
   public var value: Success {
     get async {
       return await _taskFutureGet(_task)
@@ -160,38 +188,35 @@ extension Task: Equatable {
 
 // ==== Task Priority ----------------------------------------------------------
 
-/// Task priority may inform decisions an `Executor` makes about how and when
-/// to schedule tasks submitted to it.
+/// The priority of a task.
 ///
-/// ### Priority scheduling
-/// An executor MAY utilize priority information to attempt running higher
-/// priority tasks first, and then continuing to serve lower priority tasks.
-///
-/// The exact semantics of how priority is treated are left up to each
+/// The executor determines how priority information affects the way tasks are scheduled.
+/// The behavior varies depending on the executor currently being used.
+/// Typically, executors attempt to run tasks with a higher priority
+/// before tasks with a lower priority.
+/// However, the semantics of how priority is treated are left up to each
 /// platform and `Executor` implementation.
 ///
-/// ### Priority inheritance
 /// Child tasks automatically inherit their parent task's priority.
+/// Detached tasks created by `detach(priority:operation:)` don't inherit task priority
+/// because they aren't attached to the current task.
 ///
-/// Detached tasks (created by `Task.detached`) DO NOT inherit task priority,
-/// as they are "detached" from their parent tasks after all.
+/// In some situations the priority of a task is elevated ---
+/// that is, the task is treated as it if had a higher priority,
+/// without actually changing the priority of the task:
 ///
-/// ### Priority elevation
-/// In some situations the priority of a task must be elevated (or "escalated", "raised"):
+/// - If a task runs on behalf of an actor,
+///   and a new higher-priority task is enqueued to the actor,
+///   then the actor's current task is temporarily elevated
+///   to the priority of the enqueued task.
+///   This priority elevation allows the new task
+///   to be processed at the priority it was enqueued with.
+/// - If a a higher-priority task calls the `get()` method,
+///   then the priority of this task increases until the task completes.
 ///
-/// - if a `Task` running on behalf of an actor, and a new higher-priority
-///   task is enqueued to the actor, its current task must be temporarily
-///   elevated to the priority of the enqueued task, in order to allow the new
-///   task to be processed at--effectively-- the priority it was enqueued with.
-///   - this DOES NOT affect `Task.currentPriority()`.
-/// - if a task is created with a `Task.Handle`, and a higher-priority task
-///   calls the `await handle.get()` function the priority of this task must be
-///   permanently increased until the task completes.
-///   - this DOES affect `Task.currentPriority()`.
-///
-/// TODO: Define the details of task priority; It is likely to be a concept
-///       similar to Darwin Dispatch's QoS; bearing in mind that priority is not as
-///       much of a thing on other platforms (i.e. server side Linux systems).
+/// In both cases, priority elevation helps you prevent a low-priority task
+/// from blocking the execution of a high priority task,
+/// which is also known as *priority inversion*.
 @available(SwiftStdlib 5.1, *)
 public struct TaskPriority: RawRepresentable, Sendable {
   public typealias RawValue = UInt8
@@ -254,13 +279,13 @@ extension TaskPriority: Codable { }
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
 
-  /// Returns the `current` task's priority.
+  /// The current task's priority.
   ///
-  /// If no current `Task` is available, queries the system to determine the
-  /// priority at which the current function is running. If the system cannot
-  /// provide an appropriate priority, returns `Priority.default`.
-  ///
-  /// - SeeAlso: `TaskPriority`
+  /// If you access this property outside of any task,
+  /// this queries the system to determine the
+  /// priority at which the current function is running.
+  /// If the system can't provide a priority,
+  /// this property's value is `Priority.default`.
   public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.
@@ -424,22 +449,29 @@ func taskCreateFlags(
 // ==== Task Creation ----------------------------------------------------------
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
-  /// Run given `operation` as asynchronously in its own top-level task.
+  /// Runs the given nonthrowing operation asynchronously
+  /// as part of a new top-level task on behalf of the current actor.
   ///
-  /// The `async` function should be used when creating asynchronous work
+  /// Use this function when creating asynchronous work
   /// that operates on behalf of the synchronous function that calls it.
-  /// Like `Task.detached`, the async function creates a separate, top-level
-  /// task.
+  /// Like `Task.detached(priority:operation:)`,
+  /// this function creates a separate, top-level task.
+  /// Unlike `Task.detached(priority:operation:)`,
+  /// the task created by `Task.init(priority:operation:)`
+  /// inherits the priority and actor context of the caller,
+  /// so the operation is treated more like an asynchronous extension
+  /// to the synchronous operation.
   ///
-  /// Unlike `Task.detached`, the task creating by the `Task` initializer
-  /// inherits the priority and actor context of the caller, so the `operation`
-  /// is treated more like an asynchronous extension to the synchronous
-  /// operation.
+  /// You need to keep a reference to the task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task. If nil, the priority will come from
-  ///     Task.currentPriority.
-  ///   - operation: the operation to execute
+  ///   - priority: The priority of the task.
+  ///     Pass `nil` to use the priority from `Task.currentPriority`.
+  ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
@@ -465,18 +497,29 @@ extension Task where Failure == Never {
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Error {
-  /// Run given `operation` as asynchronously in its own top-level task.
+  /// Runs the given throwing operation asynchronously
+  /// as part of a new top-level task on behalf of the current actor.
   ///
-  /// This initializer creates asynchronous work on behalf of the synchronous function that calls it.
-  /// Like `Task.detached`, this initializer creates a separate, top-level task.
-  /// Unlike `Task.detached`, the task created inherits the priority and
-  /// actor context of the caller, so the `operation` is treated more like an
-  /// asynchronous extension to the synchronous operation.
+  /// Use this function when creating asynchronous work
+  /// that operates on behalf of the synchronous function that calls it.
+  /// Like `Task.detached(priority:operation:)`,
+  /// this function creates a separate, top-level task.
+  /// Unlike `detach(priority:operation:)`,
+  /// the task created by `Task.init(priority:operation:)`
+  /// inherits the priority and actor context of the caller,
+  /// so the operation is treated more like an asynchronous extension
+  /// to the synchronous operation.
+  ///
+  /// You need to keep a reference to the task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task. If nil, the priority will come from
-  ///     Task.currentPriority.
-  ///   - operation: the operation to execute
+  ///   - priority: The priority of the task.
+  ///     Pass `nil` to use the priority from `Task.currentPriority`.
+  ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
@@ -504,36 +547,26 @@ extension Task where Failure == Error {
 // ==== Detached Tasks ---------------------------------------------------------
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Never {
-  /// Run given throwing `operation` as part of a new top-level task.
+  /// Runs the given nonthrowing operation asynchronously
+  /// as part of a new top-level task.
   ///
-  /// Creating detached tasks should, generally, be avoided in favor of using
-  /// `async` functions, `async let` declarations and `await` expressions - as
-  /// those benefit from structured, bounded concurrency which is easier to reason
-  /// about, as well as automatically inheriting the parent tasks priority,
-  /// task-local storage, deadlines, as well as being cancelled automatically
-  /// when their parent task is cancelled. Detached tasks do not get any of those
-  /// benefits, and thus should only be used when an operation is impossible to
-  /// be modelled with child tasks.
+  /// Don't use a detached task if it's possible
+  /// to model the operation using structured concurrency features like child tasks.
+  /// Child tasks inherit the parent task's priority and task-local storage,
+  /// and canceling a parent task automatically cancels all of its child tasks.
+  /// You need to handle these considerations manually with a detached task.
   ///
-  /// ### Cancellation
-  /// A detached task always runs to completion unless it is explicitly cancelled.
-  /// Specifically, dropping a detached tasks `Task` does _not_ automatically
-  /// cancel given task.
-  ///
-  /// Cancelling a task must be performed explicitly via `cancel()`.
-  ///
-  /// - Note: it is generally preferable to use child tasks rather than detached
-  ///   tasks. Child tasks automatically carry priorities, task-local state,
-  ///   deadlines and have other benefits resulting from the structured
-  ///   concurrency concepts that they model. Consider using detached tasks only
-  ///   when strictly necessary and impossible to model operations otherwise.
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task
-  ///   - operation: the operation to execute
-  /// - Returns: handle to the task, allowing to `await get()` on the
-  ///     tasks result or `cancel` it. If the operation fails the handle will
-  ///     throw the error the operation has thrown when awaited on.
+  ///   - priority: The priority of the task.
+  ///   - operation: The operation to perform.
+  ///
+  /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
@@ -559,38 +592,28 @@ extension Task where Failure == Never {
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Failure == Error {
-  /// Run given throwing `operation` as part of a new top-level task.
+  /// Runs the given throwing operation asynchronously
+  /// as part of a new top-level task.
   ///
-  /// Creating detached tasks should, generally, be avoided in favor of using
-  /// `async` functions, `async let` declarations and `await` expressions - as
-  /// those benefit from structured, bounded concurrency which is easier to reason
-  /// about, as well as automatically inheriting the parent tasks priority,
-  /// task-local storage, deadlines, as well as being cancelled automatically
-  /// when their parent task is cancelled. Detached tasks do not get any of those
-  /// benefits, and thus should only be used when an operation is impossible to
-  /// be modelled with child tasks.
+  /// If the operation throws an error, this method propagates that error.
   ///
-  /// ### Cancellation
-  /// A detached task always runs to completion unless it is explicitly cancelled.
-  /// Specifically, dropping a detached tasks `Task.Handle` does _not_ automatically
-  /// cancel given task.
+  /// Don't use a detached task if it's possible
+  /// to model the operation using structured concurrency features like child tasks.
+  /// Child tasks inherit the parent task's priority and task-local storage,
+  /// and canceling a parent task automatically cancels all of its child tasks.
+  /// You need to handle these considerations manually with a detached task.
   ///
-  /// Cancelling a task must be performed explicitly via `handle.cancel()`.
-  ///
-  /// - Note: it is generally preferable to use child tasks rather than detached
-  ///   tasks. Child tasks automatically carry priorities, task-local state,
-  ///   deadlines and have other benefits resulting from the structured
-  ///   concurrency concepts that they model. Consider using detached tasks only
-  ///   when strictly necessary and impossible to model operations otherwise.
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task
-  ///   - executor: the executor on which the detached closure should start
-  ///               executing on.
-  ///   - operation: the operation to execute
-  /// - Returns: handle to the task, allowing to `await handle.get()` on the
-  ///     tasks result or `cancel` it. If the operation fails the handle will
-  ///     throw the error the operation has thrown when awaited on.
+  ///   - priority: The priority of the task.
+  ///   - operation: The operation to perform.
+  ///
+  /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
@@ -620,12 +643,13 @@ extension Task where Failure == Error {
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
 
-  /// Explicitly suspend the current task, potentially giving up execution actor
-  /// of current actor/task, allowing other tasks to execute.
+  /// Suspends the current task and allows other tasks to execute.
   ///
-  /// This is not a perfect cure for starvation;
-  /// if the task is the highest-priority task in the system, it might go
-  /// immediately back to executing.
+  /// A task can voluntarily suspend itself
+  /// in the middle of a long-running operation
+  /// that doesn't contain any suspension points,
+  /// to let other tasks run for a while
+  /// before execution returns to this task.
   ///
   /// If this task is the highest-priority task in the system,
   /// the executor immediately resumes execution of the same task.
@@ -643,22 +667,31 @@ extension Task where Success == Never, Failure == Never {
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
 
-/// Calls the given closure with the with the "current" task in which this
-/// function was invoked.
+/// Calls a closure with an unsafe reference to the current task.
 ///
-/// If invoked from an asynchronous function the task will always be non-nil,
-/// as an asynchronous function is always running within some task.
-/// However if invoked from a synchronous function the task may be nil,
-/// meaning that the function is not executing within a task, i.e. there is no
-/// asynchronous context available in the call stack.
+/// If you call this function from the body of an asynchronous function,
+/// the unsafe task handle passed to the closure is always non-`nil`
+/// because an asynchronous function always runs in the context of a task.
+/// However, if you call this function from the body of a synchronous function,
+/// and that function isn't executing in the context of any task,
+/// the unsafe task handle is `nil`.
 ///
-/// It is generally not safe to escape/store the `UnsafeCurrentTask` for future
-/// use, as some operations on it may only be performed from the same task
-/// that it is representing.
+/// Don't store an unsafe task reference
+/// for use outside this method's closure.
+/// Storing an unsafe reference doesn't affect the task's actual life cycle,
+/// and the behavior of accessing an unsafe task reference
+/// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
+/// Instead, use the `task` property of `UnsafeCurrentTask`
+/// to access an instance of `Task` that you can store long-term
+/// and interact with outside of the closure body.
 ///
-/// It is possible to obtain a `Task` fom the `UnsafeCurrentTask` which is safe
-/// to access from other tasks or even store for future reference e.g. equality
-/// checks.
+/// - Parameters:
+///   - body: A closure that takes an `UnsafeCurrentTask` parameter.
+///     If `body` has a return value,
+///     that value is also used as the return value
+///     for the `withUnsafeCurrentTask(body:)` function.
+///
+/// - Returns: The return value, if any, of the `body` closure.
 @available(SwiftStdlib 5.1, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) rethrows -> T {
   guard let _task = _getCurrentAsyncTask() else {
@@ -673,19 +706,28 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
   return try body(UnsafeCurrentTask(_task))
 }
 
-/// An *unsafe* 'current' task handle.
+/// An unsafe reference to the current task.
 ///
-/// An `UnsafeCurrentTask` should not be stored for "later" access.
+/// To get an instance of `UnsafeCurrentTask` for the current task,
+/// call the `withUnsafeCurrentTask(body:)` method.
+/// Don't store an unsafe task reference
+/// for use outside that method's closure.
+/// Storing an unsafe reference doesn't affect the task's actual life cycle,
+/// and the behavior of accessing an unsafe task reference
+/// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
 ///
-/// Storing an `UnsafeCurrentTask` has no implication on the task's actual lifecycle.
+/// Only APIs on `UnsafeCurrentTask` that are also part of `Task`
+/// are safe to invoke from a task other than
+/// the task that this `UnsafeCurrentTask` instance refers to.
+/// Calling other APIs from another task is undefined behavior,
+/// breaks invariants in other parts of the program running on this task,
+/// and may lead to crashes or data loss.
 ///
-/// The sub-set of APIs of `UnsafeCurrentTask` which also exist on `Task` are
-/// generally safe to be invoked from any task/thread.
+/// For information about the language-level concurrency model that `UnsafeCurrentTask` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
-/// All other APIs must not, be called 'from' any other task than the one
-/// represented by this handle itself. Doing so may result in undefined behavior,
-/// and most certainly will break invariants in other places of the program
-/// actively running on this task.
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
 @available(SwiftStdlib 5.1, *)
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
@@ -695,14 +737,17 @@ public struct UnsafeCurrentTask {
     self._task = task
   }
 
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// A Boolean value that indicates whether the current task was canceled.
+  ///
+  /// After the value of this property becomes `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
 
-  /// Returns the `current` task's priority.
+  /// The current task's priority.
   ///
   /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -15,18 +15,18 @@ import Swift
 
 // ==== Task Cancellation ------------------------------------------------------
 
-/// Execute an operation with cancellation handler which will immediately be
-/// invoked if the current task is cancelled.
+/// Execute an operation with a cancellation handler that's immediately
+/// invoked if the current task is canceled.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and
-/// _immediately_ invoked when the task is cancelled. For example, even if the
-/// operation is running code which never checks for cancellation, a cancellation
-/// handler still would run and give us a chance to run some cleanup code.
+/// _immediately_ invoked when the task is canceled. For example, even if the
+/// operation is running code that never checks for cancellation, a cancellation
+/// handler still runs and provides a chance to run some cleanup code.
 ///
-/// Does not check for cancellation, and always executes the passed `operation`.
+/// Doesn't check for cancellation, and always executes the passed `operation`.
 ///
-/// This function returns instantly and will never suspend.
+/// This function returns immediately and never suspends.
 @available(SwiftStdlib 5.1, *)
 public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
@@ -42,7 +42,10 @@ public func withTaskCancellationHandler<T>(
 
 @available(SwiftStdlib 5.1, *)
 extension Task {
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// A Boolean value that indicates whether the task should stop executing.
+  ///
+  /// After the value of this property becomes `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   @_transparent public var isCancelled: Bool {
@@ -52,10 +55,10 @@ extension Task {
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// A Boolean value that indicates whether the task should stop executing.
   ///
-  /// If no current `Task` is available, returns `false`, as outside of a task
-  /// context no task cancellation may be observed.
+  /// After the value of this property becomes `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   public static var isCancelled: Bool {
@@ -67,18 +70,9 @@ extension Task where Success == Never, Failure == Never {
 
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
-  /// Check if the task is cancelled and throw an `CancellationError` if it was.
+  /// Throws an error if the task was canceled.
   ///
-  /// It is intentional that no information is passed to the task about why it
-  /// was cancelled. A task may be cancelled for many reasons, and additional
-  /// reasons may accrue / after the initial cancellation (for example, if the
-  /// task fails to immediately exit, it may pass a deadline).
-  ///
-  /// The goal of cancellation is to allow tasks to be cancelled in a
-  /// lightweight way, not to be a secondary method of inter-task communication.
-  ///
-  /// ### Suspension
-  /// This function returns instantly and will never suspend.
+  /// The error is always an instance of `Task.CancellationError`.
   ///
   /// - SeeAlso: `isCancelled()`
   public static func checkCancellation() throws {
@@ -88,10 +82,10 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-/// The default cancellation thrown when a task is cancelled.
+/// An error that indicates a task was canceled.
 ///
 /// This error is also thrown automatically by `Task.checkCancellation()`,
-/// if the current task has been cancelled.
+/// if the current task has been canceled.
 @available(SwiftStdlib 5.1, *)
 public struct CancellationError: Error {
   // no extra information, cancellation is intended to be light-weight

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,52 +15,54 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
-/// Starts a new task group which provides a scope in which a dynamic number of
-/// tasks may be spawned.
+/// Starts a new scope that can contain a dynamic number of child tasks.
 ///
-/// Tasks added to the group by `group.spawn()` will automatically be awaited on
-/// when the scope exits. If the group exits by throwing, all added tasks will
-/// be cancelled and their results discarded.
+/// A group waits for all of its child tasks
+/// to complete or be canceled before it returns.
+/// After this function returns, the task group is always empty.
 ///
-/// ### Implicit awaiting
-/// When the group returns it will implicitly await for all spawned tasks to
-/// complete. The tasks are only cancelled if `cancelAll()` was invoked before
-/// returning, the groups' task was cancelled, or the group body has thrown.
+/// To collect the results of the group's child tasks,
+/// you can use a `for`-`await`-`in` loop:
 ///
-/// When results of tasks added to the group need to be collected, one can
-/// gather their results using the following pattern:
-///
-///     while let result = await group.next() {
-///       // some accumulation logic (e.g. sum += result)
+///     var sum = 0
+///     for await result in group {
+///         sum += result
 ///     }
 ///
-/// It is also possible to collect results from the group by using its
-/// `AsyncSequence` conformance, which enables its use in an asynchronous for-loop,
-/// like this:
+/// If you need more control or only a few results,
+/// you can call `next()` directly:
 ///
-///     for await result in group {
-///       // some accumulation logic (e.g. sum += result)
-///      }
+///     guard let first = await group.next() {
+///         group.cancelAll()
+///         return 0
+///     }
+///     let second = await group.next() ?? 0
+///     group.cancelAll()
+///     return first + second
 ///
-/// ### Cancellation
-/// If the task that the group is running in is cancelled, the group becomes 
-/// cancelled and all child tasks spawned in the group are cancelled as well.
-/// 
-/// Since the `withTaskGroup` provided group is specifically non-throwing,
-/// child tasks (or the group) cannot react to cancellation by throwing a 
-/// `CancellationError`, however they may interrupt their work and e.g. return 
-/// some best-effort approximation of their work. 
+/// Task Group Cancellation
+/// =======================
 ///
-/// If throwing is a good option for the kinds of tasks spawned by the group,
-/// consider using the `withThrowingTaskGroup` function instead.
+/// You can cancel a task group and all of its child tasks
+/// by calling the `cancellAll()` method on the task group,
+/// or by canceling the task in which the group is running.
 ///
-/// Postcondition:
-/// Once `withTaskGroup` returns it is guaranteed that the `group` is *empty*.
+/// If you call `async(priority:operation:)` to create a new task in a canceled group,
+/// that task is immediately canceled after creation.
+/// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
+/// which doesn't create the task if the group has already been canceled
+/// Choosing between these two functions
+/// lets you control how to react to cancellation within a group:
+/// some child tasks need to run regardless of cancellation,
+/// but other tasks are better not even being created
+/// when you know they can't produce useful results.
 ///
-/// This is achieved in the following way:
-/// - if the body returns normally:
-///   - the group will await any not yet complete tasks,
-///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
+/// Because the tasks you add to a group with this method are nonthrowing,
+/// those tasks can't respond to cancellation by throwing `CancellationError`.
+/// The tasks must handle cancellation in some other way,
+/// such as returning the work completed so far, returning an empty result, or returning `nil`.
+/// For tasks that need to handle cancellation by throwing an error,
+/// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
 @inlinable
@@ -87,60 +89,72 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
   #endif
 }
 
-/// Starts a new throwing task group which provides a scope in which a dynamic 
-/// number of tasks may be spawned.
+/// Starts a new scope that can contain a dynamic number of throwing child tasks.
 ///
-/// Tasks added to the group by `group.spawn()` will automatically be awaited on
-/// when the scope exits. If the group exits by throwing, all added tasks will
-/// be cancelled and their results discarded.
+/// A group waits for all of its child tasks
+/// to complete, throw an error, or be canceled before it returns.
+/// After this function returns, the task group is always empty.
 ///
-/// ### Implicit awaiting
-/// When the group returns it will implicitly await for all spawned tasks to
-/// complete. The tasks are only cancelled if `cancelAll()` was invoked before
-/// returning, the groups' task was cancelled, or the group body has thrown.
+/// To collect the results of the group's child tasks,
+/// you can use a `for`-`await`-`in` loop:
 ///
-/// When results of tasks added to the group need to be collected, one can
-/// gather their results using the following pattern:
-///
-///     while let result = await try group.next() {
-///       // some accumulation logic (e.g. sum += result)
+///     var sum = 0
+///     for await result in group {
+///         sum += result
 ///     }
 ///
-/// It is also possible to collect results from the group by using its
-/// `AsyncSequence` conformance, which enables its use in an asynchronous for-loop,
-/// like this:
+/// If you need more control or only a few results,
+/// you can call `next()` directly:
 ///
-///     for try await result in group {
-///       // some accumulation logic (e.g. sum += result)
-///      }
+///     guard let first = await group.next() {
+///         group.cancelAll()
+///         return 0
+///     }
+///     let second = await group.next() ?? 0
+///     group.cancelAll()
+///     return first + second
 ///
-/// ### Thrown errors
-/// When tasks are added to the group using the `group.spawn` function, they may
-/// immediately begin executing. Even if their results are not collected explicitly
-/// and such task throws, and was not yet cancelled, it may result in the `withTaskGroup`
-/// throwing.
+/// Task Group Cancellation
+/// =======================
 ///
-/// ### Cancellation
-/// If the task that the group is running in is cancelled, the group becomes 
-/// cancelled and all child tasks spawned in the group are cancelled as well.
-/// 
-/// If an error is thrown out of the task group, all of its remaining tasks
-/// will be cancelled and the `withTaskGroup` call will rethrow that error.
+/// You can cancel a task group and all of its child tasks
+/// by calling the `cancellAll()` method on the task group,
+/// or by canceling the task in which the group is running.
 ///
-/// Individual tasks throwing results in their corresponding `try group.next()`
-/// call throwing, giving a chance to handle individual errors or letting the
-/// error be rethrown by the group.
+/// If you call `async(priority:operation:)` to create a new task in a canceled group,
+/// that task is immediately canceled after creation.
+/// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
+/// which doesn't create the task if the group has already been canceled
+/// Choosing between these two functions
+/// lets you control how to react to cancellation within a group:
+/// some child tasks need to run regardless of cancellation,
+/// but other tasks are better not even being created
+/// when you know they can't produce useful results.
 ///
-/// Postcondition:
-/// Once `withThrowingTaskGroup` returns it is guaranteed that the `group` is *empty*.
+/// Throwing an error in one of the tasks of a task group
+/// doesn't immediately cancel the other tasks in that group.
+/// However,
+/// if you call `next()` in the task group and propagate its error,
+/// all other tasks are canceled.
+/// For example, in the code below,
+/// nothing is canceled and the group doesn't throw an error:
 ///
-/// This is achieved in the following way:
-/// - if the body returns normally:
-///   - the group will await any not yet complete tasks,
-///     - if any of those tasks throws, the remaining tasks will be cancelled,
-///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
-/// - if the body throws:
-///   - all tasks remaining in the group will be automatically cancelled.
+///     withThrowingTaskGroup { group in
+///         group.addTask { throw SomeError() }
+///     }
+///
+/// In contrast, this example throws `SomeError`
+/// and cancels all of the tasks in the group:
+///
+///     withThrowingTaskGroup { group in
+///         group.addTask { throw SomeError() }
+///         try group.next()
+///     }
+///
+/// An individual task throws its error
+/// in the corresponding call to `Group.next()`,
+/// which gives you a chance to handle the individual error
+/// or to let the group rethrow the error.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
 @inlinable
@@ -176,9 +190,24 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   #endif
 }
 
-/// A task group serves as storage for dynamically spawned tasks.
+/// A group that contains dynamically created child tasks.
 ///
-/// It is created by the `withTaskGroup` function.
+/// To create a task group,
+/// call the `withTaskGroup(of:returning:body:)` method.
+///
+/// Don't use a task group from outside the task where you created it.
+/// In most cases,
+/// the Swift type system prevents a task group from escaping like that
+/// because adding a child task to a task group is a mutating operation,
+/// and mutation operations can't be performed
+/// from a concurrent execution context like a child task.
+///
+/// For information about the language-level concurrency model that `TaskGroup` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
+///
 @available(SwiftStdlib 5.1, *)
 @frozen
 public struct TaskGroup<ChildTaskResult: Sendable> {
@@ -188,27 +217,19 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   @usableFromInline
   internal let _group: Builtin.RawPointer
 
-  /// No public initializers
+  // No public initializers
   @inlinable
   init(group: Builtin.RawPointer) {
     self._group = group
   }
 
-  /// Add a child task to the group.
-  ///
-  /// ### Error handling
-  /// Operations are allowed to `throw`, in which case the `try await next()`
-  /// invocation corresponding to the failed task will re-throw the given task.
-  ///
-  /// The `add` function will never (re-)throw errors from the `operation`.
-  /// Instead, the corresponding `next()` call will throw the error when necessary.
+  /// Adds a child task to the group.
   ///
   /// - Parameters:
-  ///   - overridingPriority: override priority of the operation task
-  ///   - operation: operation to execute and add to the group
-  /// - Returns:
-  ///   - `true` if the operation was added to the group successfully,
-  ///     `false` otherwise (e.g. because the group `isCancelled`)
+  ///   - overridingPriority: The priority of the operation task.
+  ///     Omit this parameter or pass `.unspecified`
+  ///     to set the child task's priority to the priority of the group.
+  ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func addTask(
     priority: TaskPriority? = nil,
@@ -228,21 +249,15 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 #endif
   }
 
-  /// Add a child task to the group.
-  ///
-  /// ### Error handling
-  /// Operations are allowed to `throw`, in which case the `try await next()`
-  /// invocation corresponding to the failed task will re-throw the given task.
-  ///
-  /// The `add` function will never (re-)throw errors from the `operation`.
-  /// Instead, the corresponding `next()` call will throw the error when necessary.
+  /// Adds a child task to the group, unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - overridingPriority: override priority of the operation task
-  ///   - operation: operation to execute and add to the group
-  /// - Returns:
-  ///   - `true` if the operation was added to the group successfully,
-  ///     `false` otherwise (e.g. because the group `isCancelled`)
+  ///   - overridingPriority: The priority of the operation task.
+  ///     Omit this parameter or pass `.unspecified`
+  ///     to set the child task's priority to the priority of the group.
+  ///   - operation: The operation to execute as part of the task group.
+  /// - Returns: `true` if the child task was added to the group;
+  ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
@@ -271,98 +286,95 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 #endif
   }
 
-  /// Wait for the a child task that was added to the group to complete,
-  /// and return (or rethrow) the value it completed with. If no tasks are
-  /// pending in the task group this function returns `nil`, allowing the
-  /// following convenient expressions to be written for awaiting for one
-  /// or all tasks to complete:
+  /// Wait for the next child task to complete,
+  /// and return the value it returned.
   ///
-  /// Await on a single completion:
+  /// The values returned by successive calls to this method
+  /// appear in the order that the tasks *completed*,
+  /// not in the order that those tasks were added to the task group.
+  /// For example:
+  ///
+  ///     group.addTask { 1 }
+  ///     group.addTask { 2 }
+  ///
+  ///     print(await group.next())
+  ///     // Prints either "2" or "1".
+  ///
+  /// If there aren't any pending tasks in the task group,
+  /// this method returns `nil`,
+  /// which lets you write the following
+  /// to wait for a single task to complete:
   ///
   ///     if let first = try await group.next() {
   ///        return first
   ///     }
   ///
-  /// Wait and collect all group child task completions:
+  /// It also lets you write code like the following
+  /// to wait for all the child tasks to complete,
+  /// collecting the values they returned:
   ///
   ///     while let first = try await group.next() {
   ///        collected += value
   ///     }
   ///     return collected
   ///
-  /// Awaiting on an empty group results in the immediate return of a `nil`
-  /// value, without the group task having to suspend.
+  /// Awaiting on an empty group
+  /// immediate returns `nil` without suspending.
   ///
-  /// It is also possible to use `for await` to collect results of a task groups:
+  /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///
   ///     for await try value in group {
   ///         collected += value
   ///     }
   ///
-  /// ### Thread-safety
-  /// Please note that the `group` object MUST NOT escape into another task.
-  /// The `group.next()` MUST be awaited from the task that had originally
-  /// created the group. It is not allowed to escape the group reference.
+  /// Don't call this method from outside the task
+  /// where you created this task group.
+  /// In most cases, the Swift type system prevents this mistake.
+  /// For example, because the `add(priority:operation:)` method is mutating,
+  /// that method can't be called from a concurrent execution context like a child task.
   ///
-  /// Note also that this is generally prevented by Swift's type-system,
-  /// as the `add` operation is `mutating`, and those may not be performed
-  /// from concurrent execution contexts, such as child tasks.
-  ///
-  /// ### Ordering
-  /// Order of values returned by next() is *completion order*, and not
-  /// submission order. I.e. if tasks are added to the group one after another:
-  ///
-  ///     group.spawn { 1 }
-  ///     group.spawn { 2 }
-  ///
-  ///     print(await group.next())
-  ///     /// Prints "1" OR "2"
-  ///
-  /// ### Errors
-  /// If an operation added to the group throws, that error will be rethrown
-  /// by the next() call corresponding to that operation's completion.
-  ///
-  /// It is possible to directly rethrow such error out of a `withTaskGroup` body
-  /// function's body, causing all remaining tasks to be implicitly cancelled.
+  /// - Returns: The value returned by the next child task that completes.
   public mutating func next() async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
     return try! await _taskGroupWaitNext(group: _group)
   }
 
-  /// Await all the remaining tasks on this group.
+  /// Await all of the remaining tasks on this group.
   @usableFromInline
   internal mutating func awaitAllRemainingTasks() async {
     while let _ = await next() {}
   }
 
-  /// Wait for all remaining tasks in the task group to complete before
-  /// returning.
+  /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
   public mutating func waitForAll() async {
     await awaitAllRemainingTasks()
   }
 
-  /// Query whether the group has any remaining tasks.
+  /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// Task groups are always empty upon entry to the `withTaskGroup` body, and
-  /// become empty again when `withTaskGroup` returns (either by awaiting on all
-  /// pending tasks or cancelling them).
+  /// At the start of the body of a `withTaskGroup(of:returning:body:)` call,
+  /// the task group is always empty.
+  /// It`s guaranteed to be empty when returning from that body
+  /// because a task group waits for all child tasks to complete before returning.
   ///
-  /// - Returns: `true` if the group has no pending tasks, `false` otherwise.
+  /// - Returns: `true` if the group has no pending tasks; otherwise `false`.
   public var isEmpty: Bool {
     _taskGroupIsEmpty(_group)
   }
 
-  /// Cancel all the remaining, and future, tasks in the group.
+  /// Cancel all of the remaining tasks in the group.
   ///
-  /// A cancelled group will not will create new tasks when the `asyncUnlessCancelled`,
-  /// function is used. It will, however, continue to create tasks when the plain `async`
-  /// function is used. Such tasks will be created yet immediately cancelled, allowing
-  /// the tasks to perform some short-cut implementation, if they are responsive to cancellation.
+  /// After cancellation,
+  /// any new results from the tasks in this group
+  /// are silently discarded.
   ///
-  /// This function may be called even from within child (or any other) tasks,
-  /// and will reliably cause the group to become cancelled.
+  /// If you add a task to a group after canceling the group,
+  /// that task is canceled immediately after being added to the group.
+  ///
+  /// There are no restrictions on where you can call this method.
+  /// Code inside a child task or even another task can cancel a group.
   ///
   /// - SeeAlso: `Task.isCancelled`
   /// - SeeAlso: `TaskGroup.isCancelled`
@@ -370,14 +382,13 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// Returns `true` if the group was cancelled, e.g. by `cancelAll`.
+  /// A Boolean value that indicates whether the group was canceled.
   ///
-  /// If the task currently running this group was cancelled, the group will
-  /// also be implicitly cancelled, which will be reflected in the return
-  /// value of this function as well.
+  /// To cancel a group, call the `TaskGroup.cancelAll()` method.
   ///
-  /// - Returns: `true` if the group (or its parent task) was cancelled,
-  ///            `false` otherwise.
+  /// If the task that's currently running this group is canceled,
+  /// the group is also implicitly canceled,
+  /// which is also reflected in this property's value.
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -402,10 +413,24 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 // proofing, in case we'd ever have typed errors, however unlikely this may be.
 // Today the throwing task group failure is simply automatically bound to `Error`.
 
-/// A task group serves as storage for dynamically spawned, potentially throwing,
-/// child tasks.
+/// A group that contains throwing, dynamically created child tasks.
 ///
-/// It is created by the `withTaskGroup` function.
+/// To create a throwing task group,
+/// call the `withThrowingTaskGroup(of:returning:body:)` method.
+///
+/// Don't use a task group from outside the task where you created it.
+/// In most cases,
+/// the Swift type system prevents a task group from escaping like that
+/// because adding a child task to a task group is a mutating operation,
+/// and mutation operations can't be performed
+/// from concurrent execution contexts like a child task.
+///
+/// For information about the language-level concurrency model that `ThrowingTaskGroup` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
+///
 @available(SwiftStdlib 5.1, *)
 @frozen
 public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
@@ -415,7 +440,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   @usableFromInline
   internal let _group: Builtin.RawPointer
 
-  /// No public initializers
+  // No public initializers
   @inlinable
   init(group: Builtin.RawPointer) {
     self._group = group
@@ -438,28 +463,21 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     while let _ = try await next() { }
   }
 
-  /// Wait for all remaining tasks in the task group to complete before
-  /// returning.
+  /// Wait for all of the group's remaining tasks to complete.
   @_alwaysEmitIntoClient
   public mutating func waitForAll() async throws {
     while let _ = try await next() { }
   }
 
-  /// Spawn, unconditionally, a child task in the group.
+  /// Adds a child task to the group.
   ///
-  /// ### Error handling
-  /// Operations are allowed to `throw`, in which case the `try await next()`
-  /// invocation corresponding to the failed task will re-throw the given task.
+  /// This method doesn't throw an error, even if the child task does.
+  /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
   ///
-  /// The `add` function will never (re-)throw errors from the `operation`.
-  /// Instead, the corresponding `next()` call will throw the error when necessary.
-  ///
-  /// - Parameters:
-  ///   - overridingPriority: override priority of the operation task
-  ///   - operation: operation to execute and add to the group
-  /// - Returns:
-  ///   - `true` if the operation was added to the group successfully,
-  ///     `false` otherwise (e.g. because the group `isCancelled`)
+  ///   - overridingPriority: The priority of the operation task.
+  ///     Omit this parameter or pass `.unspecified`
+  ///     to set the child task's priority to the priority of the group.
+  ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func addTask(
     priority: TaskPriority? = nil,
@@ -479,21 +497,18 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 #endif
   }
 
-  /// Add a child task to the group.
+  /// Adds a child task to the group, unless the group has been canceled.
   ///
-  /// ### Error handling
-  /// Operations are allowed to `throw`, in which case the `try await next()`
-  /// invocation corresponding to the failed task will re-throw the given task.
-  ///
-  /// The `add` function will never (re-)throw errors from the `operation`.
-  /// Instead, the corresponding `next()` call will throw the error when necessary.
+  /// This method doesn't throw an error, even if the child task does.
+  /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
   ///
   /// - Parameters:
-  ///   - overridingPriority: override priority of the operation task
-  ///   - operation: operation to execute and add to the group
-  /// - Returns:
-  ///   - `true` if the operation was added to the group successfully,
-  ///     `false` otherwise (e.g. because the group `isCancelled`)
+  ///   - overridingPriority: The priority of the operation task.
+  ///     Omit this parameter or pass `.unspecified`
+  ///     to set the child task's priority to the priority of the group.
+  ///   - operation: The operation to execute as part of the task group.
+  /// - Returns: `true` if the child task was added to the group;
+  ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
@@ -522,59 +537,64 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 #endif
   }
 
-  /// Wait for the a child task that was added to the group to complete,
-  /// and return (or rethrow) the value it completed with. If no tasks are
-  /// pending in the task group this function returns `nil`, allowing the
-  /// following convenient expressions to be written for awaiting for one
-  /// or all tasks to complete:
+  /// Wait for the next child task to complete,
+  /// and return the value it returned or rethrow the error it threw.
   ///
-  /// Await on a single completion:
+  /// The values returned by successive calls to this method
+  /// appear in the order that the tasks *completed*,
+  /// not in the order that those tasks were added to the task group.
+  /// For example:
+  ///
+  ///     group.addTask { 1 }
+  ///     group.addTask { 2 }
+  ///
+  ///     print(await group.next())
+  ///     // Prints either "2" or "1".
+  ///
+  /// If there aren't any pending tasks in the task group,
+  /// this method returns `nil`,
+  /// which lets you write the following
+  /// to wait for a single task to complete:
   ///
   ///     if let first = try await group.next() {
   ///        return first
   ///     }
   ///
-  /// Wait and collect all group child task completions:
+  /// It also lets you write code like the following
+  /// to wait for all the child tasks to complete,
+  /// collecting the values they returned:
   ///
   ///     while let first = try await group.next() {
   ///        collected += value
   ///     }
   ///     return collected
   ///
-  /// Awaiting on an empty group results in the immediate return of a `nil`
-  /// value, without the group task having to suspend.
+  /// Awaiting on an empty group
+  /// immediate returns `nil` without suspending.
   ///
-  /// It is also possible to use `for await` to collect results of a task groups:
+  /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///
   ///     for await try value in group {
   ///         collected += value
   ///     }
   ///
-  /// ### Thread-safety
-  /// Please note that the `group` object MUST NOT escape into another task.
-  /// The `group.next()` MUST be awaited from the task that had originally
-  /// created the group. It is not allowed to escape the group reference.
+  /// If the next child task throws an error
+  /// and you propagate that error from this method
+  /// out of the body of a call to the
+  /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
+  /// then all remaining child tasks in that group are implicitly canceled.
   ///
-  /// Note also that this is generally prevented by Swift's type-system,
-  /// as the `add` operation is `mutating`, and those may not be performed
-  /// from concurrent execution contexts, such as child tasks.
+  /// Don't call this method from outside the task
+  /// where this task group was created.
+  /// In most cases, the Swift type system prevents this mistake;
+  /// for example, because the `add(priority:operation:)` method is mutating,
+  /// that method can't be called from a concurrent execution context like a child task.
   ///
-  /// ### Ordering
-  /// Order of values returned by next() is *completion order*, and not
-  /// submission order. I.e. if tasks are added to the group one after another:
+  /// - Returns: The value returned by the next child task that completes.
   ///
-  ///     group.spawn { 1 }
-  ///     group.spawn { 2 }
+  /// - Throws: The error thrown by the next child task that completes.
   ///
-  ///     print(await group.next())
-  ///     /// Prints "1" OR "2"
-  ///
-  /// ### Errors
-  /// If an operation added to the group throws, that error will be rethrown
-  /// by the next() call corresponding to that operation's completion.
-  ///
-  /// It is possible to directly rethrow such error out of a `withTaskGroup` body
-  /// function's body, causing all remaining tasks to be implicitly cancelled.
+  /// - SeeAlso: `nextResult()`
   public mutating func next() async throws -> ChildTaskResult? {
     return try await _taskGroupWaitNext(group: _group)
   }
@@ -593,47 +613,82 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     }
   }
 
+  /// Wait for the next child task to complete,
+  /// and return a result containing either
+  /// the value that the child task returned or the error that it threw.
+  ///
+  /// The values returned by successive calls to this method
+  /// appear in the order that the tasks *completed*,
+  /// not in the order that those tasks were added to the task group.
+  /// For example:
+  ///
+  ///     group.addTask { 1 }
+  ///     group.addTask { 2 }
+  ///
+  ///     guard let result = await group.nextResult() else {
+  ///         return  // No task to wait on, which won't happen in this example.
+  ///     }
+  ///     
+  ///     switch result { 
+  ///     case .success(let value): print(value)
+  ///     case .failure(let error): print("Failure: \(error)")
+  ///     }
+  ///     // Prints either "2" or "1".
+  ///
+  /// If the next child task throws an error
+  /// and you propagate that error from this method
+  /// out of the body of a call to the
+  /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
+  /// then all remaining child tasks in that group are implicitly canceled.
+  ///
+  /// - Returns: A `Result.success` value
+  ///   containing the value that the child task returned,
+  ///   or a `Result.failure` value
+  ///   containing the error that the child task threw.
+  ///
   /// - SeeAlso: `next()`
   @_alwaysEmitIntoClient
   public mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
     return try! await nextResultForABI()
   }
 
-  /// Query whether the group has any remaining tasks.
+  /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
-  /// Task groups are always empty upon entry to the `withTaskGroup` body, and
-  /// become empty again when `withTaskGroup` returns (either by awaiting on all
-  /// pending tasks or cancelling them).
+  /// At the start of the body of a `withThrowingTaskGroup(of:returning:body:)` call,
+  /// the task group is always empty.
+  /// It's guaranteed to be empty when returning from that body
+  /// because a task group waits for all child tasks to complete before returning.
   ///
-  /// - Returns: `true` if the group has no pending tasks, `false` otherwise.
+  /// - Returns: `true` if the group has no pending tasks; otherwise `false`.
   public var isEmpty: Bool {
     _taskGroupIsEmpty(_group)
   }
 
-  /// Cancel all the remaining tasks in the group.
+  /// Cancel all of the remaining tasks in the group.
   ///
-  /// A cancelled group will not will NOT accept new tasks being added into it.
+  /// After cancellation,
+  /// any new results or errors from the tasks in this group
+  /// are silently discarded.
   ///
-  /// Any results, including errors thrown by tasks affected by this
-  /// cancellation, are silently discarded.
+  /// If you add a task to a group after canceling the group,
+  /// that task is canceled immediately after being added to the group.
   ///
-  /// This function may be called even from within child (or any other) tasks,
-  /// and will reliably cause the group to become cancelled.
+  /// There are no restrictions on where you can call this method.
+  /// Code inside a child task or even another task can cancel a group.
   ///
   /// - SeeAlso: `Task.isCancelled`
-  /// - SeeAlso: `TaskGroup.isCancelled`
+  /// - SeeAlso: `ThrowingTaskGroup.isCancelled`
   public func cancelAll() {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// Returns `true` if the group was cancelled, e.g. by `cancelAll`.
+  /// A Boolean value that indicates whether the group was canceled.
   ///
-  /// If the task currently running this group was cancelled, the group will
-  /// also be implicitly cancelled, which will be reflected in the return
-  /// value of this function as well.
+  /// To cancel a group, call the `ThrowingTaskGroup.cancelAll()` method.
   ///
-  /// - Returns: `true` if the group (or its parent task) was cancelled,
-  ///            `false` otherwise.
+  /// If the task that's currently running this group is canceled,
+  /// the group is also implicitly canceled,
+  /// which is also reflected in this property's value.
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -650,14 +705,25 @@ extension TaskGroup: AsyncSequence {
     return Iterator(group: self)
   }
 
-  /// Allows iterating over results of tasks added to the group.
+  /// A type that provides an iteration interface
+  /// over the results of tasks added to the group.
   ///
-  /// The order of elements returned by this iterator is the same as manually
-  /// invoking the `group.next()` function in a loop, meaning that results
-  /// are returned in *completion order*.
+  /// The elements returned by this iterator
+  /// appear in the order that the tasks *completed*,
+  /// not in the order that those tasks were added to the task group.
   ///
-  /// This iterator terminates after all tasks have completed successfully, or
-  /// after any task completes by throwing an error.
+  /// This iterator terminates after all tasks have completed.
+  /// After iterating over the results of each task,
+  /// it's valid to make a new iterator for the task group,
+  /// which you can use to iterate over the results of new tasks you add to the group.
+  /// For example:
+  ///
+  ///     group.addTask { 1 }
+  ///     for await r in group { print(r) }
+  ///
+  ///     // Add a new child task and iterate again.
+  ///     group.addTask { 2 }
+  ///     for await r in group { print(r) }
   ///
   /// - SeeAlso: `TaskGroup.next()`
   @available(SwiftStdlib 5.1, *)
@@ -675,9 +741,19 @@ extension TaskGroup: AsyncSequence {
       self.group = group
     }
 
-    /// Once this function returns `nil` this specific iterator is guaranteed to
-    /// never produce more values.
-    /// - SeeAlso: `TaskGroup.next()` for a detailed discussion its semantics.
+    /// Advances to and returns the result of the next child task.
+    ///
+    /// The elements returned from this method
+    /// appear in the order that the tasks *completed*,
+    /// not in the order that those tasks were added to the task group.
+    /// After this method returns `nil`,
+    /// this iterator is guaranteed to never produce more values.
+    ///
+    /// For more information about the iteration order and semantics,
+    /// see `TaskGroup.next()`.
+    ///
+    /// - Returns: The value returned by the next child task that completes,
+    ///   or `nil` if there are no remaining child tasks,
     public mutating func next() async -> Element? {
       guard !finished else { return nil }
       guard let element = await group.next() else {
@@ -703,15 +779,38 @@ extension ThrowingTaskGroup: AsyncSequence {
     return Iterator(group: self)
   }
 
-  /// Allows iterating over results of tasks added to the group.
+  /// A type that provides an iteration interface
+  /// over the results of tasks added to the group.
   ///
-  /// The order of elements returned by this iterator is the same as manually
-  /// invoking the `group.next()` function in a loop, meaning that results
-  /// are returned in *completion order*.
+  /// The elements returned by this iterator
+  /// appear in the order that the tasks *completed*,
+  /// not in the order that those tasks were added to the task group.
   ///
-  /// This iterator terminates after all tasks have completed successfully, or
-  /// after any task completes by throwing an error. If a task completes by
-  /// throwing an error, no further task results are returned.
+  /// This iterator terminates after all tasks have completed successfully,
+  /// or after any task completes by throwing an error.
+  /// If a task completes by throwing an error,
+  /// it doesn't return any further task results.
+  /// After iterating over the results of each task,
+  /// it's valid to make a new iterator for the task group,
+  /// which you can use to iterate over the results of new tasks you add to the group.
+  /// You can also make a new iterator to resume iteration
+  /// after a child task thows an error.
+  /// For example:
+  ///
+  ///     group.addTask { 1 }
+  ///     group.addTask { throw SomeError }
+  ///     group.addTask { 2 }
+  ///     
+  ///     do { 
+  ///         // Assuming the child tasks complete in order, this prints "1"
+  ///         // and then throws an error.
+  ///         for try await r in group { print(r) }
+  ///     } catch {
+  ///         // Resolve the error.
+  ///     }
+  ///     
+  ///     // Assuming the child tasks complete in order, this prints "2".
+  ///     for try await r in group { print(r) }
   ///
   /// - SeeAlso: `ThrowingTaskGroup.next()`
   @available(SwiftStdlib 5.1, *)
@@ -729,7 +828,21 @@ extension ThrowingTaskGroup: AsyncSequence {
       self.group = group
     }
 
-    /// - SeeAlso: `ThrowingTaskGroup.next()` for a detailed discussion its semantics.
+    /// Advances to and returns the result of the next child task.
+    ///
+    /// The elements returned from this method
+    /// appear in the order that the tasks *completed*,
+    /// not in the order that those tasks were added to the task group.
+    /// After this method returns `nil`,
+    /// this iterator is guaranteed to never produce more values.
+    ///
+    /// For more information about the iteration order and semantics,
+    /// see `ThrowingTaskGroup.next()` 
+    ///
+    /// - Throws: The error thrown by the next child task that completes.
+    ///
+    /// - Returns: The value returned by the next child task that completes,
+    ///   or `nil` if there are no remaining child tasks,
     public mutating func next() async throws -> Element? {
       guard !finished else { return nil }
       do {
@@ -769,8 +882,8 @@ func _taskGroupAddPendingTask(
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
-/// Checks ONLY if the group was specifically cancelled.
-/// The task itself being cancelled must be checked separately.
+/// Checks ONLY if the group was specifically canceled.
+/// The task itself being canceled must be checked separately.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -15,6 +15,10 @@ import Swift
 @available(SwiftStdlib 5.1, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, renamed: "Task.sleep(nanoseconds:)")
+  /// Suspends the current task for at least the given duration
+  /// in nanoseconds.
+  ///
+  /// This function doesn't block the underlying thread.
   public static func sleep(_ duration: UInt64) async {
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
       let job = _taskCreateNullaryContinuationJob(
@@ -39,10 +43,10 @@ extension Task where Success == Never, Failure == Never {
     /// The sleep has finished.
     case finished
 
-    /// The sleep was cancelled.
+    /// The sleep was canceled.
     case cancelled
 
-    /// The sleep was cancelled before it even got started.
+    /// The sleep was canceled before it even got started.
     case cancelledBeforeStarted
 
     /// Decode sleep state from the word of storage.
@@ -100,7 +104,7 @@ extension Task where Success == Never, Failure == Never {
   }
 
   /// Called when the sleep(nanoseconds:) operation woke up without being
-  /// cancelled.
+  /// canceled.
   private static func onSleepWake(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
@@ -143,7 +147,7 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  /// Called when the sleep(nanoseconds:) operation has been cancelled before
+  /// Called when the sleep(nanoseconds:) operation has been canceled before
   /// the sleep completed.
   private static func onSleepCancel(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
@@ -189,11 +193,13 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  /// Suspends the current task for _at least_ the given duration
-  /// in nanoseconds, unless the task is cancelled. If the task is cancelled,
-  /// throws \c CancellationError without waiting for the duration.
+  /// Suspends the current task for at least the given duration
+  /// in nanoseconds.
   ///
-  /// This function does _not_ block the underlying thread.
+  /// If the task is canceled before the time ends,
+  /// this function throws `CancellationError`.
+  ///
+  /// This function doesn't block the underlying thread.
   public static func sleep(nanoseconds duration: UInt64) async throws {
     // Allocate storage for the storage word.
     let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)


### PR DESCRIPTION
This PR incorporates the documentation changes to [async sequences](https://github.com/apple/swift/pull/38535) and [tasks](https://github.com/apple/swift/pull/38815) for Swift 5.5.  Since I ran into conflicts and other issues using `git cherry-pick` to bring over the specific commits from 'release/5.5', I manually compared the two branches and copied the changes inside `///` comments.

Confirmed that there are no unexpected changes outside of doc comments by running the following:

```
git diff github/main | grep '^+\|^-' | grep -v '^+++\|^---' \ |  grep -v '^- *///\|^+ *///'
```

In `Task.swift` a blank line was removed.  This was from removing what looks like a doc comment that got left behind after the symbol it goes to was removed.

In `TaskSleep.swift` the comment "No public initializers" was changed from a `///` comment to a regular `//` comment in to places.  This change was also made on 'release/5.5'.  It's a comment on a non-public symbol and isn't meant to be a documentation comment.

All of the documentation comments match what was on the Swift 5.5 release branch, except for a spelling mistake that had been corrected on 'main' but not on the release branch.  I made these comparisons when 'main' was at 9c5e5efc9e6052228418b4b18bd1742befd05b1b and 'release/5.5' was at 18a849ecece601331f7014d8f30b3564451444d2.