### PR TITLE
[SourceKit] Ignore references without a location

### DIFF
--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -226,7 +226,7 @@ bool CursorInfoResolver::visitDeclReference(ValueDecl *D,
                                             ReferenceMetaData Data) {
   if (isDone())
     return false;
-  if (Data.isImplicit)
+  if (Data.isImplicit || !Range.isValid())
     return true;
   return !tryResolve(D, CtorTyRef, ExtTyRef, Range.getStart(), /*IsRef=*/true, T);
 }

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -490,7 +490,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                             TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
                             Type T, ReferenceMetaData Data) override {
-      if (D == Target && !Data.isImplicit) {
+      if (D == Target && !Data.isImplicit && Range.isValid()) {
         Result = Range;
         return false;
       }

--- a/test/IDE/annotation.swift
+++ b/test/IDE/annotation.swift
@@ -366,3 +366,8 @@ func testDynamicMemberLookup(r: Lens<Rectangle>) {
   _ = r.bottomRight.y
   // CHECK: _ = <Param@[[@LINE-4]]:30>r</Param>.<Var@[[@LINE-6]]:7>bottomRight</Var>.<Var@[[@LINE-10]]:7>y</Var>
 }
+func keyPathTester<V>(keyPath: KeyPath<Lens<Rectangle>, V>) {}
+func testKeyPath() {
+  keyPathTester(keyPath: \.topLeft)
+  // CHECK: <Func@[[@LINE-3]]:6>keyPathTester</Func>(<Func@[[@LINE-3]]:6#keyPath>keyPath</Func>: \.<Var@[[@LINE-12]]:7>topLeft</Var>)
+}

--- a/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_keypath_member_lookup.swift
@@ -26,6 +26,12 @@ func test(r: Lens<Rectangle>) {
   _ = r.bottomRight.y
 }
 
+func keyPathTester<V>(keyPath: KeyPath<Lens<Rectangle>, V>) {}
+
+func testKeyPath() {
+  keyPathTester(keyPath: \.topLeft)
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=18:3 -cursor-action %s -- %s | %FileCheck -check-prefix=SUBSCRIPT %s
 // SUBSCRIPT: source.lang.swift.decl.function.subscript (18:3-18:12)
 // SUBSCRIPT: subscript(dynamicMember:)
@@ -60,3 +66,12 @@ func test(r: Lens<Rectangle>) {
 // YREF: ACTIONS BEGIN
 // YREF: source.refactoring.kind.rename.global
 // YREF: ACTIONS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=32:28 -cursor-action %s -- %s | %FileCheck -check-prefix=KEYPATH %s
+// KEYPATH: source.lang.swift.ref.var.instance
+// KEYPATH: topLeft
+// KEYPATH: Point
+// KEYPATH: ACTIONS BEGIN
+// KEYPATH: source.refactoring.kind.rename.global
+// KEYPATH: ACTIONS END
+

--- a/test/SourceKit/Sema/sema_dynamic_keypath.swift
+++ b/test/SourceKit/Sema/sema_dynamic_keypath.swift
@@ -1,0 +1,36 @@
+struct Point {
+  var x: Int
+  var y: Int
+}
+
+struct Rectangle {
+  var topLeft: Point
+  var bottomRight: Point
+}
+
+@dynamicMemberLookup
+struct Lens<T> {
+  var obj: T
+  init(_ obj: T) {
+    self.obj = obj
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+}
+
+func test(r: Lens<Rectangle>) {
+  _ = r.topLeft
+  _ = r.bottomRight.y
+}
+
+func keyPathTester<V>(keyPath: KeyPath<Lens<Rectangle>, V>) {}
+
+func testKeyPath() {
+  keyPathTester(keyPath: \.topLeft)
+}
+
+// RUN: %sourcekitd-test -req=sema %s -- %s > %t.response
+// RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/Sema/sema_dynamic_keypath.swift.response
+++ b/test/SourceKit/Sema/sema_dynamic_keypath.swift.response
@@ -1,0 +1,176 @@
+[
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 24,
+    key.length: 3,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 37,
+    key.length: 3,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 78,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 103,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 161,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 177,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 191,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 197,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 243,
+    key.length: 15,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 259,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 262,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 269,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 274,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 296,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 301,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 304,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 317,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 338,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 351,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 361,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 370,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 396,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 401,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 421,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 423,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.var.local,
+    key.offset: 437,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 439,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 451,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 487,
+    key.length: 7,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 495,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 500,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.offset: 512,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.function.free,
+    key.offset: 543,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.ref.var.instance,
+    key.offset: 568,
+    key.length: 7
+  }
+]

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1143,7 +1143,7 @@ public:
   bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
                           TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
                           ReferenceMetaData Data) override {
-    if (Data.isImplicit)
+    if (Data.isImplicit || !Range.isValid())
       return true;
     unsigned StartOffset = getOffset(Range.getStart());
     References.emplace_back(D, StartOffset, Range.getByteLength(), Ty);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -959,6 +959,9 @@ public:
   }
 
   void annotate(const Decl *D, bool IsRef, CharSourceRange Range) {
+    if (!Range.isValid())
+      return;
+
     unsigned ByteOffset = SM.getLocOffsetInBuffer(Range.getStart(), BufferID);
     unsigned Length = Range.getByteLength();
     auto Kind = CodeCompletionResult::getCodeCompletionDeclKind(D);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2230,6 +2230,9 @@ private:
   }
 
   void annotateSourceEntity(const SemanticSourceEntity &Entity) {
+    if (!Entity.Range.isValid())
+      return;
+
     const char *LocPtr =
         BufStart + SM.getLocOffsetInBuffer(Entity.Range.getStart(), BufferID);
 


### PR DESCRIPTION
A keypath using dynamic member lookup results in various `KeyPathExpr`
that have components with no location. Ignore these and any other
references that have a missing location.

Resolves rdar://85237365