### PR TITLE
libswift: on macOS, make the default build mode bootstrapping-with-hostlibs

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -667,8 +667,8 @@ endfunction()
 function(add_libswift_module module)
   cmake_parse_arguments(ALSM
                         ""
-                        "DEPENDS"
                         ""
+                        "DEPENDS"
                         ${ARGN})
   set(sources ${ALSM_UNPARSED_ARGUMENTS})
   list(TRANSFORM sources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
@@ -717,8 +717,8 @@ endfunction()
 function(add_libswift name)
   cmake_parse_arguments(ALS
                         ""
-                        "BOOTSTRAPPING;SWIFT_EXEC;DEPENDS"
-                        ""
+                        "BOOTSTRAPPING;SWIFT_EXEC"
+                        "DEPENDS"
                         ${ARGN})
 
   set(libswift_compile_options

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -192,7 +192,9 @@ skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
 
-libswift=bootstrapping-with-hostlibs
+# Test the full bootstrapping on at least some jobs
+# (the default is bootstrapping-with-hostlibs)
+libswift=bootstrapping
 
 [preset: buildbot,tools=RA,stdlib=RD,test=non_executable]
 mixin-preset=
@@ -216,7 +218,9 @@ skip-test-tvos-host
 skip-test-watchos-host
 check-incremental-compilation
 
-libswift=bootstrapping-with-hostlibs
+# Test the full bootstrapping on at least some jobs
+# (the default is bootstrapping-with-hostlibs)
+libswift=bootstrapping
 
 [preset: buildbot,tools=R,stdlib=RD,test=non_executable]
 mixin-preset=
@@ -652,9 +656,6 @@ skip-build-benchmarks
 
 # Skip playground tests
 skip-test-playgroundsupport
-
-# Don't do bootstrapping to speed up the build
-libswift=hosttools
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
@@ -1562,9 +1563,6 @@ assertions
 build-swift-stdlib-unittest-extra
 
 libcxx
-
-# Don't do bootstrapping to speed up the build
-libswift=hosttools
 
 # Build llbuild & swiftpm here
 llbuild

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -362,7 +362,11 @@ function to_libswift_buildmode() {
             echo "OFF"
             ;;
         true | TRUE | 1 | "")
-            echo "BOOTSTRAPPING"
+            if [[ "$(uname -s)" == "Darwin" ]] ; then
+              echo "BOOTSTRAPPING-WITH-HOSTLIBS"
+            else
+              echo "BOOTSTRAPPING"
+            fi
             ;;
         *)
             echo `toupper $1`

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -546,8 +546,6 @@ def create_argument_parser():
 
     option('--libswift', store('libswift_mode'),
            choices=['off', 'hosttools', 'bootstrapping', 'bootstrapping-with-hostlibs'],
-           const='hosttools',
-           default=None,
            help='The libswift build mode. For details see libswift/README.md')
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
This is much faster than the full "bootstrapping" mode.
On linux, the default stays "bootstrapping", because "bootstrapping-with-hostlibs" is not supported.

In CI:
* Build two presets with "bootstrapping", so that this mode is tested on macOS at least on some bots.
* Do the macOS smoke test also with "bootstrapping-with-hostlibs". It only adds ~30 sec compared to "hosttools" which was used previously.