### PR TITLE
build: allow building libswift with unified builds

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -786,7 +786,7 @@ function(add_libswift name)
               "-emit-module-path" "${build_dir}/${module}.swiftmodule"
               "-parse-as-library" ${sources}
               "-wmo" ${libswift_compile_options}
-              "-I" "${CMAKE_SOURCE_DIR}/include/swift"
+              "-I" "${SWIFT_SOURCE_DIR}/include/swift"
               "-I" "${build_dir}"
       COMMENT "Building libswift module ${module}")
 


### PR DESCRIPTION
When building with unified builds, `CMAKE_SOURCE_DIR` is not the Swift
repository.  Use the locally defined `SWIFT_SOURCE_DIR` variable to
reference the root of the Swift repository.  Because libswift uses
`project` in the CMakeLists, we cannot use `PROJECT_SOURCE_DIR` here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
