### PR TITLE
[5.5][Sema] Fix availability checking in `didSet` blocks with emit-module-separately

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -516,7 +516,7 @@ public:
   /// null if the context hierarchy has not been built yet. Use
   /// TypeChecker::getOrBuildTypeRefinementContext() to get a built
   /// root of the hierarchy.
-  TypeRefinementContext *getTypeRefinementContext();
+  TypeRefinementContext *getTypeRefinementContext() const;
 
   /// Set the root refinement context for the file.
   void setTypeRefinementContext(TypeRefinementContext *TRC);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2857,7 +2857,7 @@ SynthesizedFileUnit &SourceFile::getOrCreateSynthesizedFile() {
   return *SynthesizedFile;
 }
 
-TypeRefinementContext *SourceFile::getTypeRefinementContext() {
+TypeRefinementContext *SourceFile::getTypeRefinementContext() const {
   return TRC;
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1979,6 +1979,10 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
   if (tyOpts.DebugTimeFunctionBodies || tyOpts.WarnLongFunctionBodies)
     timer.emplace(AFD);
 
+  auto SF = AFD->getParentSourceFile();
+  if (SF)
+    TypeChecker::buildTypeRefinementContextHierarchyDelayed(*SF, AFD);
+
   BraceStmt *body = AFD->getBody();
   assert(body && "Expected body to type-check");
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -256,7 +256,6 @@ static void typeCheckDelayedFunctions(SourceFile &SF) {
          ++currentFunctionIdx) {
       auto *AFD = SF.DelayedFunctions[currentFunctionIdx];
       assert(!AFD->getDeclContext()->isLocalContext());
-      TypeChecker::buildTypeRefinementContextHierarchyDelayed(SF, AFD);
       (void)AFD->getTypecheckedBody();
     }
 

--- a/test/Sema/availability_and_delayed_parsing.swift
+++ b/test/Sema/availability_and_delayed_parsing.swift
@@ -17,6 +17,18 @@ public func foo() { }
 // TRC-API: (root versions=[10.10.0,+Inf)
 // TRC-API:   (decl versions=[10.12,+Inf) decl=foo()
 
+struct S {
+  fileprivate var actual: [String] = [] {
+    didSet {
+      if #available(macOS 10.15, *) {
+        foo()
+      }
+    }
+  }
+}
+// TRC-API:  (condition_following_availability versions=[10.15,+Inf)
+// TRC-API:  (if_then versions=[10.15,+Inf)
+
 @inlinable public func inlinableFunc() {
     if #available(macOS 10.12, *) {
         foo()


### PR DESCRIPTION
Fix an issue where `if #available(...)` conditions were ignored in emit-module-separately builds or when skipping non-inlinable function bodies (installAPI builds). The fix to handle functions for which parsing is delayed but type-checking is not delayed, move up building the delayed TRC to right before type-checking a function body.

* Origination: This bug was present since the original installAPI support, but triggered by using the same logic in emit-module-separately builds.
* Scope: This issue is affecting early adopters of explicit module builds.
* Risk: Low, affects only emit-module-separately and installAPI builds.
* Reviewed by Artem Chikin.
* Cherry-pick of #39337
* Resolves rdar://85265934