### PR TITLE
[SyntaxBuilder] Make `String` conform to `ExpressibleAs` protocols

### DIFF
--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -4,12 +4,20 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
         'MemberDeclListItem',
         'SyntaxBuildable'
     ],
-    'StmtBuildable': [
-        'CodeBlockItem',
-        'SyntaxBuildable'
-    ],
     'ExprList': [
         'ConditionElement',
+        'SyntaxBuildable'
+    ],
+    'IdentifierPattern': [
+        'PatternBuildable'
+    ],
+    'SimpleTypeIdentifier': [
+        'TypeAnnotation',
+        'TypeBuildable',
+        'TypeExpr'
+    ],
+    'StmtBuildable': [
+        'CodeBlockItem',
         'SyntaxBuildable'
     ]
 }


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/335