### PR TITLE
update_checkout (tests): Use 'main' for test branch

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -50,13 +50,13 @@ MOCK_CONFIG = {
             'remote': {'id': 'repo2'},
         },
     },
-    'default-branch-scheme': 'master',
+    'default-branch-scheme': 'main',
     'branch-schemes': {
-        'master': {
-            'aliases': ['master'],
+        'main': {
+            'aliases': ['main'],
             'repos': {
-                'repo1': 'master',
-                'repo2': 'master',
+                'repo1': 'main',
+                'repo2': 'main',
             }
         }
     }
@@ -101,7 +101,11 @@ def setup_mock_remote(base_dir):
         create_dir(remote_repo_path)
         create_dir(local_repo_path)
         call_quietly(['git', 'init', '--bare', remote_repo_path])
+        call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
+                     cwd=remote_repo_path)
         call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
+        call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
+                     cwd=local_repo_path)
         for (i, (filename, contents)) in enumerate(v):
             filename_path = os.path.join(local_repo_path, filename)
             with open(filename_path, 'w') as f:
@@ -109,7 +113,7 @@ def setup_mock_remote(base_dir):
             call_quietly(['git', 'add', filename], cwd=local_repo_path)
             call_quietly(['git', 'commit', '-m', 'Commit %d' % i],
                          cwd=local_repo_path)
-            call_quietly(['git', 'push', 'origin', 'master'],
+            call_quietly(['git', 'push', 'origin', 'main'],
                          cwd=local_repo_path)
 
     base_config = MOCK_CONFIG

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -53,7 +53,7 @@ class WorktreeTestCase(scheme_mock.SchemeMockTestCase):
         self.call([self.update_checkout_path,
                    '--config', self.config_path,
                    '--source-root', self.worktree_path,
-                   '--scheme', 'master'])
+                   '--scheme', 'main'])
 
     def setUp(self):
         super(WorktreeTestCase, self).setUp()


### PR DESCRIPTION
This updates the tests for `utils/update_checkout` to use `main` for the test branch names in git (as opposed to `master`).  In addition to following current best practices for inclusive terms, this also fixes an issue that occurs if a user has customized their local git config to use an alternate default branch name (using `init.defaultBranch`).

If a user has set `init.defaultBranch` in their git config to anything other than `master`, the tests fail. By updating the `git init` call to use `--initial-branch=main`, the user's setting will not affect the test.
