### PR TITLE
[CSApply/Distributed] Identify implicitly throwing calls while applying solution

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5300,6 +5300,9 @@ public:
   /// Returns true if the name is the self identifier and is implicit.
   bool isSelfParameter() const;
 
+  /// Check whether the variable is the "self" of an actor method.
+  bool isActorSelf() const;
+
   /// Determine whether this property will be part of the implicit memberwise
   /// initializer.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1879,6 +1879,17 @@ public:
         !expression.pattern->isImplicit();
   }
 
+  /// Check whether this is an initializaion for `async let` pattern.
+  bool isAsyncLetInitializer() const {
+    if (!(kind == Kind::expression &&
+          expression.contextualPurpose == CTP_Initialization))
+      return false;
+
+    if (auto *PBD = getInitializationPatternBindingDecl())
+      return PBD->isAsyncLet();
+    return false;
+  }
+
   /// Whether to bind the types of any variables within the pattern via
   /// one-way constraints.
   bool shouldBindPatternVarsOneWay() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6042,6 +6042,20 @@ bool VarDecl::isSelfParameter() const {
   return false;
 }
 
+bool VarDecl::isActorSelf() const {
+  if (!isSelfParameter() && !isSelfParamCapture())
+    return false;
+
+  auto *dc = getDeclContext();
+  while (!dc->isTypeContext() && !dc->isModuleScopeContext())
+    dc = dc->getParent();
+
+  // Check if this `self` parameter belogs to an actor declaration or
+  // extension.
+  auto nominal = dc->getSelfNominalTypeDecl();
+  return nominal && nominal->isActor();
+}
+
 /// Whether the given variable is the backing storage property for
 /// a declared property that is either `lazy` or has an attached
 /// property wrapper.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -679,6 +679,10 @@ namespace {
                                   LookUpConformanceInModule(cs.DC->getParentModule()));
     }
 
+    /// Determine whether the given reference is to a method on
+    /// a remote distributed actor in the given context.
+    bool isDistributedThunk(ConcreteDeclRef ref, Expr *context);
+
   public:
     /// Build a reference to the given declaration.
     Expr *buildDeclRef(SelectedOverload overload, DeclNameLoc loc,
@@ -7583,8 +7587,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
 
     // If this is a call to a distributed method thunk, let's mark the
     // call as implicitly throwing.
-    if (isDistributedThunk(callee, apply->getFn(), dc,
-                           target && target->isAsyncLetInitializer())) {
+    if (isDistributedThunk(callee, apply->getFn())) {
       auto *FD = cast<AbstractFunctionDecl>(callee.getDecl());
       if (!FD->hasThrows())
         apply->setImplicitlyThrows(true);
@@ -7665,6 +7668,90 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
 
   // Tail-recur to actually call the constructor.
   return finishApply(apply, openedType, locator, ctorLocator);
+}
+
+/// Determine whether this closure should be treated as Sendable.
+static bool isSendableClosure(ConstraintSystem &cs,
+                              const AbstractClosureExpr *closure) {
+  if (auto fnType = cs.getType(const_cast<AbstractClosureExpr *>(closure))
+                        ->getAs<FunctionType>()) {
+    if (fnType->isSendable())
+      return true;
+  }
+
+  return false;
+}
+
+bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
+  auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(ref.getDecl());
+  if (!(FD && FD->isInstanceMember() && FD->isDistributed()))
+    return false;
+
+  if (!isa<SelfApplyExpr>(context))
+    return false;
+
+  auto *actor = getReferencedParamOrCapture(
+      cast<SelfApplyExpr>(context)->getBase(),
+      [&](OpaqueValueExpr *opaqueValue) -> Expr * {
+        for (const auto &existential : OpenedExistentials) {
+          if (existential.OpaqueValue == opaqueValue)
+            return existential.ExistentialValue;
+        }
+        return nullptr;
+      });
+
+  if (!actor)
+    return false;
+
+  // If this is a method reference on an potentially isolated
+  // actor then it cannot be a remote thunk.
+  if (isPotentiallyIsolatedActor(actor, [&](ParamDecl *P) {
+        return P->isIsolated() ||
+               llvm::is_contained(solution.isolatedParams, P);
+      }))
+    return false;
+
+  bool isInAsyncLetInitializer = target && target->isAsyncLetInitializer();
+
+  auto isActorInitOrDeInitContext = [&](const DeclContext *dc) {
+    return ::isActorInitOrDeInitContext(
+        dc, [&](const AbstractClosureExpr *closure) {
+          return isSendableClosure(cs, closure);
+        });
+  };
+
+  switch (ActorIsolationRestriction::forDeclaration(ref, dc)) {
+  case ActorIsolationRestriction::CrossActorSelf: {
+    // Not a thunk if it's used in actor init or de-init.
+    if (!isInAsyncLetInitializer && isActorInitOrDeInitContext(dc))
+      return false;
+
+    // Here we know that the method could be used across actors
+    // and the actor it's used on is non-isolated, which means
+    // that it could be a thunk, so we have to be conservative
+    // about it.
+    return true;
+  }
+
+  case ActorIsolationRestriction::ActorSelf: {
+    // An instance member of an actor can be referenced from an actor's
+    // designated initializer or deinitializer.
+    if (actor->isActorSelf() && !isInAsyncLetInitializer) {
+      if (auto *fn = isActorInitOrDeInitContext(dc)) {
+        if (!(isa<ConstructorDecl>(fn) &&
+              cast<ConstructorDecl>(fn)->isConvenienceInit()))
+          return false;
+      }
+    }
+
+    // Call on a non-isolated actor in async context requires
+    // implicit thunk.
+    return isInAsyncLetInitializer || cs.isAsynchronousContext(dc);
+  }
+
+  default:
+    return false;
+  }
 }
 
 // Return the precedence-yielding parent of 'expr', along with the index of

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7581,6 +7581,15 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     apply->setArgs(args);
     cs.setType(apply, fnType->getResult());
 
+    // If this is a call to a distributed method thunk, let's mark the
+    // call as implicitly throwing.
+    if (isDistributedThunk(callee, apply->getFn(), dc,
+                           target && target->isAsyncLetInitializer())) {
+      auto *FD = cast<AbstractFunctionDecl>(callee.getDecl());
+      if (!FD->hasThrows())
+        apply->setImplicitlyThrows(true);
+    }
+
     solution.setExprTypes(apply);
     Expr *result = TypeChecker::substituteInputSugarTypeForResult(apply);
     cs.cacheExprTypes(result);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8279,12 +8279,9 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
 
   // For an async let, wrap the initializer appropriately to make it a child
   // task.
-  if (auto patternBinding = target.getInitializationPatternBindingDecl()) {
-    if (patternBinding->isAsyncLet()) {
-      resultTarget.setExpr(
-          wrapAsyncLetInitializer(
-            cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));
-    }
+  if (target.isAsyncLetInitializer()) {
+    resultTarget.setExpr(wrapAsyncLetInitializer(
+        cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));
   }
 
   return resultTarget;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1014,14 +1014,7 @@ namespace {
     bool isActorSelf() const {
       if (!actor)
         return false;
-
-      if (!actor->isSelfParameter() && !actor->isSelfParamCapture())
-        return false;
-
-      auto dc = actor->getDeclContext();
-      while (!dc->isTypeContext() && !dc->isModuleScopeContext())
-        dc = dc->getParent();
-      return getSelfActorDecl(dc);
+      return actor->isActorSelf();
     }
 
     explicit operator bool() const { return isIsolated(); }
@@ -1421,36 +1414,15 @@ namespace {
     /// Find the directly-referenced parameter or capture of a parameter for
     /// for the given expression.
     VarDecl *getReferencedParamOrCapture(Expr *expr) {
-      // Look through identity expressions and implicit conversions.
-      Expr *prior;
-      do {
-        prior = expr;
-
-        expr = expr->getSemanticsProvidingExpr();
-
-        if (auto conversion = dyn_cast<ImplicitConversionExpr>(expr))
-          expr = conversion->getSubExpr();
-
-        // Map opaque values.
-        if (auto opaqueValue = dyn_cast<OpaqueValueExpr>(expr)) {
-          for (const auto &known : opaqueValues) {
-            if (known.first == opaqueValue) {
-              expr = known.second;
-              break;
+      return ::getReferencedParamOrCapture(
+          expr, [&](OpaqueValueExpr *opaqueValue) -> Expr * {
+            for (const auto &known : opaqueValues) {
+              if (known.first == opaqueValue) {
+                return known.second;
+              }
             }
-          }
-        }
-      } while (prior != expr);
-
-      // 'super' references always act on a 'self' variable.
-      if (auto super = dyn_cast<SuperRefExpr>(expr))
-        return super->getSelf();
-
-      // Declaration references to a variable.
-      if (auto declRef = dyn_cast<DeclRefExpr>(expr))
-        return dyn_cast<VarDecl>(declRef->getDecl());
-
-      return nullptr;
+            return nullptr;
+          });
     }
 
     /// Find the isolated actor instance to which the given expression refers.
@@ -1458,31 +1430,7 @@ namespace {
       // Check whether this expression is an isolated parameter or a reference
       // to a capture thereof.
       auto var = getReferencedParamOrCapture(expr);
-      bool isPotentiallyIsolated = false;
-      if (!var) {
-        isPotentiallyIsolated = false;
-      } else if (var->getName().str().equals("__secretlyKnownToBeLocal")) {
-        // FIXME(distributed): we did a dynamic check and know that this actor is local,
-        //  but we can't express that to the type system; the real implementation
-        //  will have to mark 'self' as "known to be local" after an is-local check.
-        isPotentiallyIsolated = true;
-      } else if (auto param = dyn_cast<ParamDecl>(var)) {
-        isPotentiallyIsolated = param->isIsolated();
-      } else if (var->isSelfParamCapture()) {
-        // Find the "self" parameter that we captured and determine whether
-        // it is potentially isolated.
-        for (auto dc = var->getDeclContext(); dc; dc = dc->getParent()) {
-          if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-            if (auto selfDecl = func->getImplicitSelfDecl()) {
-              isPotentiallyIsolated = selfDecl->isIsolated();
-              break;
-            }
-          }
-
-          if (dc->isModuleScopeContext() || dc->isTypeContext())
-            break;
-        }
-      }
+      bool isPotentiallyIsolated = isPotentiallyIsolatedActor(var);
 
       // Walk the scopes between the variable reference and the variable
       // declaration to determine whether it is still isolated.
@@ -2341,42 +2289,12 @@ namespace {
       return diagnosed;
     }
 
-    /// Check whether we are in an actor's initializer or deinitializer.
-    /// \returns nullptr iff we are not in such a declaration. Otherwise,
-    ///          returns a pointer to the declaration.
-    static AbstractFunctionDecl const* isActorInitOrDeInitContext(const DeclContext *dc) {
-      while (true) {
-        // Non-Sendable closures are considered part of the enclosing context.
-        if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-          if (isSendableClosure(closure, /*forActorIsolation=*/false))
-            return nullptr;
-
-          dc = dc->getParent();
-          continue;
-        }
-
-        if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-          // If this is an initializer or deinitializer of an actor, we're done.
-          if ((isa<ConstructorDecl>(func) || isa<DestructorDecl>(func)) &&
-              getSelfActorDecl(dc->getParent()))
-            return func;
-
-          // Non-Sendable local functions are considered part of the enclosing
-          // context.
-          if (func->getDeclContext()->isLocalContext()) {
-            if (auto fnType =
-                    func->getInterfaceType()->getAs<AnyFunctionType>()) {
-              if (fnType->isSendable())
-                return nullptr;
-
-              dc = dc->getParent();
-              continue;
-            }
-          }
-        }
-
-        return nullptr;
-      }
+    static AbstractFunctionDecl const *
+    isActorInitOrDeInitContext(const DeclContext *dc) {
+      return ::isActorInitOrDeInitContext(
+          dc, [](const AbstractClosureExpr *closure) {
+            return isSendableClosure(closure, /*forActorIsolation=*/false);
+          });
     }
 
     static bool isConvenienceInit(AbstractFunctionDecl const* fn) {
@@ -2686,58 +2604,6 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
 
   // We hit the same context, so it won't execute concurrently.
   return false;
-}
-
-bool ActorIsolationChecker::isDistributedThunk(ConcreteDeclRef ref,
-                                               Expr *context,
-                                               bool isInAsyncLetInitializer) {
-  auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(ref.getDecl());
-  if (!(FD && FD->isInstanceMember() && FD->isDistributed()))
-    return false;
-
-  if (!isa<SelfApplyExpr>(context))
-    return false;
-
-  auto actor = getIsolatedActor(cast<SelfApplyExpr>(context)->getBase());
-
-  // If this is a method reference on an isolated or potentially isolated
-  // actor then it cannot be a remote thunk.
-  if (actor.isIsolated() || actor.isPotentiallyIsolated)
-    return false;
-
-  auto *dc = getDeclContext();
-
-  switch (ActorIsolationRestriction::forDeclaration(ref, dc)) {
-  case ActorIsolationRestriction::CrossActorSelf: {
-    // Not a thunk if it's used in actor init or de-init.
-    if (!isInAsyncLetInitializer && isActorInitOrDeInitContext(dc))
-      return false;
-
-    // Here we know that the method could be used across actors
-    // and the actor it's used on is non-isolated, which means
-    // that it could be a thunk, so we have to be conservative
-    // about it.
-    return true;
-  }
-
-  case ActorIsolationRestriction::ActorSelf: {
-    // An instance member of an actor can be referenced from an actor's
-    // designated initializer or deinitializer.
-    if (actor.isActorSelf() && !isInAsyncLetInitializer) {
-      if (auto fn = isActorInitOrDeInitContext(dc)) {
-        if (!isConvenienceInit(fn))
-          return false;
-      }
-    }
-
-    // Call on a non-isolated actor in async context requires
-    // implicit thunk.
-    return isInAsyncLetInitializer || isInAsynchronousContext();
-  }
-
-  default:
-    return false;
-  }
 }
 
 void swift::checkTopLevelActorIsolation(TopLevelCodeDecl *decl) {
@@ -4343,10 +4209,106 @@ bool swift::isAsynchronousContext(const DeclContext *dc) {
   return false;
 }
 
-bool swift::constraints::isDistributedThunk(ConcreteDeclRef ref,
-                                            Expr *context,
-                                            DeclContext *dc,
-                                            bool isInAsyncLetInitializer) {
-  ActorIsolationChecker checker(dc);
-  return checker.isDistributedThunk(ref, context, isInAsyncLetInitializer);
+AbstractFunctionDecl const *swift::isActorInitOrDeInitContext(
+    const DeclContext *dc,
+    llvm::function_ref<bool(const AbstractClosureExpr *)> isSendable) {
+  while (true) {
+    // Non-Sendable closures are considered part of the enclosing context.
+    if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+      if (isSendable(closure))
+        return nullptr;
+
+      dc = dc->getParent();
+      continue;
+    }
+
+    if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+      // If this is an initializer or deinitializer of an actor, we're done.
+      if ((isa<ConstructorDecl>(func) || isa<DestructorDecl>(func)) &&
+          getSelfActorDecl(dc->getParent()))
+        return func;
+
+      // Non-Sendable local functions are considered part of the enclosing
+      // context.
+      if (func->getDeclContext()->isLocalContext()) {
+        if (auto fnType = func->getInterfaceType()->getAs<AnyFunctionType>()) {
+          if (fnType->isSendable())
+            return nullptr;
+
+          dc = dc->getParent();
+          continue;
+        }
+      }
+    }
+
+    return nullptr;
+  }
+}
+
+/// Find the directly-referenced parameter or capture of a parameter for
+/// for the given expression.
+VarDecl *swift::getReferencedParamOrCapture(
+    Expr *expr,
+    llvm::function_ref<Expr *(OpaqueValueExpr *)> getExistentialValue) {
+  // Look through identity expressions and implicit conversions.
+  Expr *prior;
+
+  do {
+    prior = expr;
+
+    expr = expr->getSemanticsProvidingExpr();
+
+    if (auto conversion = dyn_cast<ImplicitConversionExpr>(expr))
+      expr = conversion->getSubExpr();
+
+    // Map opaque values.
+    if (auto opaqueValue = dyn_cast<OpaqueValueExpr>(expr)) {
+      if (auto *value = getExistentialValue(opaqueValue))
+        expr = value;
+    }
+  } while (prior != expr);
+
+  // 'super' references always act on a 'self' variable.
+  if (auto super = dyn_cast<SuperRefExpr>(expr))
+    return super->getSelf();
+
+  // Declaration references to a variable.
+  if (auto declRef = dyn_cast<DeclRefExpr>(expr))
+    return dyn_cast<VarDecl>(declRef->getDecl());
+
+  return nullptr;
+}
+
+bool swift::isPotentiallyIsolatedActor(
+    VarDecl *var, llvm::function_ref<bool(ParamDecl *)> isIsolated) {
+  if (!var)
+    return false;
+
+  if (var->getName().str().equals("__secretlyKnownToBeLocal")) {
+    // FIXME(distributed): we did a dynamic check and know that this actor is
+    // local,
+    //  but we can't express that to the type system; the real implementation
+    //  will have to mark 'self' as "known to be local" after an is-local check.
+    return true;
+  }
+
+  if (auto param = dyn_cast<ParamDecl>(var))
+    return isIsolated(param);
+
+  if (var->isSelfParamCapture()) {
+    // Find the "self" parameter that we captured and determine whether
+    // it is potentially isolated.
+    for (auto dc = var->getDeclContext(); dc; dc = dc->getParent()) {
+      if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+        if (auto selfDecl = func->getImplicitSelfDecl()) {
+          return selfDecl->isIsolated();
+        }
+      }
+
+      if (dc->isModuleScopeContext() || dc->isTypeContext())
+        break;
+    }
+  }
+
+  return false;
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1796,20 +1796,7 @@ namespace {
     }
 
     bool isInAsynchronousContext() const {
-      auto dc = getDeclContext();
-      if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-        return func->isAsyncContext();
-      }
-
-      if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-        if (auto type = closure->getType()) {
-          if (auto fnType = type->getAs<AnyFunctionType>()) {
-            return fnType->isAsync();
-          }
-        }
-      }
-
-      return false;
+      return isAsynchronousContext(getDeclContext());
     }
 
     enum class AsyncMarkingResult {
@@ -4281,4 +4268,20 @@ AnyFunctionType *swift::adjustFunctionTypeForConcurrency(
 
 bool swift::completionContextUsesConcurrencyFeatures(const DeclContext *dc) {
   return contextUsesConcurrencyFeatures(dc);
+}
+
+bool swift::isAsynchronousContext(const DeclContext *dc) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+    return func->isAsyncContext();
+  }
+
+  if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+    if (auto type = closure->getType()) {
+      if (auto fnType = type->getAs<AnyFunctionType>()) {
+        return fnType->isAsync();
+      }
+    }
+  }
+
+  return false;
 }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -329,10 +329,6 @@ bool isDispatchQueueOperationName(StringRef name);
 bool checkSendableConformance(
     ProtocolConformance *conformance, SendableCheck check);
 
-/// Check whether the given declaration context is asynchronous e.g.
-/// function or a closure declaration marked as `async`.
-bool isAsynchronousContext(const DeclContext *dc);
-
 /// Check whether we are in an actor's initializer or deinitializer.
 /// \returns nullptr iff we are not in such a declaration. Otherwise,
 ///          returns a pointer to the declaration.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -333,13 +333,24 @@ bool checkSendableConformance(
 /// function or a closure declaration marked as `async`.
 bool isAsynchronousContext(const DeclContext *dc);
 
-namespace constraints {
-/// Determine whether the given reference is to a method on
-/// a remote distributed actor in the given context.
-bool isDistributedThunk(ConcreteDeclRef ref, Expr *context,
-                        DeclContext *dc,
-                        bool isInAsyncLetInitializer);
-} // end namespace constraints
+/// Check whether we are in an actor's initializer or deinitializer.
+/// \returns nullptr iff we are not in such a declaration. Otherwise,
+///          returns a pointer to the declaration.
+AbstractFunctionDecl const *isActorInitOrDeInitContext(
+    const DeclContext *dc,
+    llvm::function_ref<bool(const AbstractClosureExpr *)> isSendable);
+
+/// Find the directly-referenced parameter or capture of a parameter for
+/// for the given expression.
+VarDecl *getReferencedParamOrCapture(
+    Expr *expr,
+    llvm::function_ref<Expr *(OpaqueValueExpr *)> getExistentialValue);
+
+/// Check whether given variable references to a potentially
+/// isolated actor.
+bool isPotentiallyIsolatedActor(
+    VarDecl *var, llvm::function_ref<bool(ParamDecl *)> isIsolated =
+                      [](ParamDecl *P) { return P->isIsolated(); });
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -333,6 +333,14 @@ bool checkSendableConformance(
 /// function or a closure declaration marked as `async`.
 bool isAsynchronousContext(const DeclContext *dc);
 
+namespace constraints {
+/// Determine whether the given reference is to a method on
+/// a remote distributed actor in the given context.
+bool isDistributedThunk(ConcreteDeclRef ref, Expr *context,
+                        DeclContext *dc,
+                        bool isInAsyncLetInitializer);
+} // end namespace constraints
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKCONCURRENCY_H */

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -328,6 +328,11 @@ bool isDispatchQueueOperationName(StringRef name);
 /// \returns true if an error occurred.
 bool checkSendableConformance(
     ProtocolConformance *conformance, SendableCheck check);
+
+/// Check whether the given declaration context is asynchronous e.g.
+/// function or a closure declaration marked as `async`.
+bool isAsynchronousContext(const DeclContext *dc);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKCONCURRENCY_H */

--- a/test/Distributed/distributed_actor_async_let.swift
+++ b/test/Distributed/distributed_actor_async_let.swift
@@ -1,0 +1,70 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-distributed -disable-availability-checking
+
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+
+distributed actor Philosopher {
+  let philosophy: String
+
+  typealias Transport = AnyActorTransport
+
+  init(transport: AnyActorTransport) {
+    philosophy = "Epistemology"
+  }
+
+  distributed func hi() -> String { "Hi!" }
+
+  func test(other: Philosopher) async throws {
+    // self --------------------------------------------------------------------
+    async let alet = self.hi() // none
+    _ = await alet // Ok - `self.hi()` isn't throwing
+
+    Task {
+      _ = self.hi() // none
+    }
+
+    Task.detached {
+      _ = await self.hi() // async
+    }
+
+    // other -------------------------------------------------------------------
+
+    async let otherLet = other.hi() // hi = async throws because of `other`
+    _ = try await otherLet
+
+    Task {
+      _ = try await other.hi() // hi = async throws
+    }
+
+    Task.detached {
+      _ = try await other.hi() // hi = async throws
+    }
+
+    // known to be local -------------------------------------------------------
+
+    // FIXME(distributed): relies on the "secretly known to be local" hack in typechecking
+    let _: String? = await other.whenLocal { __secretlyKnownToBeLocal in
+      // we're able to get state of what would otherwise be distributed-isolated:
+      __secretlyKnownToBeLocal.philosophy
+    }
+  }
+
+  static func test(iso: isolated Philosopher) async throws {
+    _ = iso.hi() // we're "in the actor" already, since isolated
+
+    // isolated parameter ------------------------------------------------------
+    async let otherLet = iso.hi() // async
+    _ = await otherLet
+
+    Task {
+      _ = await iso.hi() // none
+    }
+
+    Task.detached {
+      _ = await iso.hi() // async
+    }
+  }
+}


### PR DESCRIPTION
Calls to distributed actor methods could be pointing to a thunk for remote access,
such thunks are implicitly throwing. Their existence has to be identified early in order
for later steps of solution application to mark context as throwing e.g. implicitly
generated autoclosures for `async let` initializers rely on that to make closure as
throwing when necessary.

Resolves: rdar://83610106
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
