### PR TITLE
[TypeChecker] NFC: Allow perf test-case for rdar://74035425 to run on…

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
 
 struct Value {
   let debugDescription: String


### PR DESCRIPTION
…ly on macOS

Resolves: rdar://85267603

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
