### PR TITLE
[docs] clarify todo about deinitializing a single element

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -888,8 +888,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer, Sendable {
   @discardableResult
   public func deinitialize(count: Int) -> UnsafeMutableRawPointer {
     _debugPrecondition(count >= 0, "UnsafeMutablePointer.deinitialize with negative count")
-    // FIXME: optimization should be implemented, where if the `count` value
-    // is 1, the `Builtin.destroy(Pointee.self, _rawValue)` gets called.
+    // TODO: IRGen optimization when `count` value is statically known to be 1,
+    //       then call `Builtin.destroy(Pointee.self, _rawValue)` instead.
     Builtin.destroyArray(Pointee.self, _rawValue, count._builtinWordValue)
     return UnsafeMutableRawPointer(self)
   }


### PR DESCRIPTION
Clarify TODO item about deinitializing a single element in `UnsafeMutablePointer.deinitialize(count:)`.