### PR TITLE
update-checkout: Explicitly use python3

### DIFF
--- a/utils/update-checkout
+++ b/utils/update-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/utils/update_checkout/run_tests.py
+++ b/utils/update_checkout/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -12,9 +12,6 @@
 """
 Small script used to easily run the update_checkout module unit tests.
 """
-
-
-from __future__ import absolute_import, unicode_literals
 
 import os
 import shutil

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -8,8 +8,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-from __future__ import print_function
-
 import argparse
 import json
 import os


### PR DESCRIPTION
This changes the shebangs for the update_checkout executable files to specifically call Python 3. The code is already compatible and functional with python3, so this removes any implied backward compatibility, and removes any ambiguity based on the user's current environment, especially since some systems, like macOS, still link the `python` command to Python 2.

This also removes the now unnecessary `from __future__` imports.

This should be the first in a series of PRs to explicitly move to Python 3 and remove support for the now unsupported Python 2.
