### PR TITLE
[test] Fix expected error message with backdeployed runtimes

### DIFF
--- a/validation-test/stdlib/ArrayTrapsObjC.swift
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift
@@ -90,7 +90,8 @@ func hasBackdeployedConcurrencyRuntime() -> Bool {
   //
   // This makes the two tests below fall back to older, higher-level exclusivity
   // checks in the stdlib, which will still trap, but with a different message.
-  if #available(SwiftStdlib 5.5, *) { return false }
+  if #available(SwiftStdlib 5.5, *) { return false } // recent enough production stdlib
+  if #available(SwiftStdlib 9999, *) { return false } // dev stdlib
   return true
 }
 

--- a/validation-test/stdlib/ArrayTrapsObjC.swift
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift
@@ -83,6 +83,17 @@ ArrayTraps.test("bounds_with_downcast")
   _ = da[2]
 }
 
+func hasBackdeployedConcurrencyRuntime() -> Bool {
+  // If the stdlib we've loaded predates Swift 5.5, then we're running on a back
+  // deployed concurrency runtime, which has the side effect of disabling
+  // regular runtime exclusivity checks.
+  //
+  // This makes the two tests below fall back to older, higher-level exclusivity
+  // checks in the stdlib, which will still trap, but with a different message.
+  if #available(SwiftStdlib 5.5, *) { return false }
+  return true
+}
+
 var ArraySemanticOptzns = TestSuite("ArraySemanticOptzns" + testSuiteSuffix)
 
 class BaseClass {
@@ -131,8 +142,11 @@ ArraySemanticOptzns.test("inout_rule_violated_isNativeBuffer")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "Fatal access conflict detected." : "")
+  .crashOutputMatches(
+    !_isDebugAssertConfiguration() ? ""
+    : hasBackdeployedConcurrencyRuntime() ? "inout rules were violated"
+    : "Fatal access conflict detected."
+  )
   .code {
   let v = ViolateInoutSafetySwitchToObjcBuffer()
   expectCrashLater()
@@ -174,8 +188,11 @@ ArraySemanticOptzns.test("inout_rule_violated_needsElementTypeCheck")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-  .crashOutputMatches(_isDebugAssertConfiguration() ?
-    "Fatal access conflict detected." : "")
+  .crashOutputMatches(
+    !_isDebugAssertConfiguration() ? ""
+    : hasBackdeployedConcurrencyRuntime() ? "inout rules were violated"
+    : "Fatal access conflict detected."
+  )
   .code {
   let v = ViolateInoutSafetyNeedElementTypeCheck()
   expectCrashLater()


### PR DESCRIPTION
If the stdlib we've loaded predates Swift 5.5, then we're running on a back deployed concurrency runtime, which has the side effect of disabling regular runtime exclusivity checks.

This makes a couple of array trap tests fall back to older, higher-level exclusivity checks in the stdlib, which will still trap, but with a different message.

rdar://84992742