### PR TITLE
SIL: correct the definition of `SwiftInt`

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -141,7 +141,8 @@ typedef enum {
   MayHaveSideEffectsBehavior
 } BridgedMemoryBehavior;
 
-typedef long SwiftInt;
+
+typedef intptr_t SwiftInt;
 
 void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
 


### PR DESCRIPTION
`Int` in Swift is defined to be `intptr_t`.  `long` is equivalent, but
not portable as it relies on `LP64` which is not guaranteed (Windows is
LLP64, not LP64).  This corrects the definition to be more portable.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
