### PR TITLE
Don't force `SILGenName`, `CDecl`, and `Semantics` attrs to be implicit

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -487,7 +487,7 @@ public:
       Name(Name) {}
 
   SILGenNameAttr(StringRef Name, bool Implicit)
-    : SILGenNameAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+    : SILGenNameAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
 
   /// The symbol name.
   const StringRef Name;
@@ -505,7 +505,7 @@ public:
       Name(Name) {}
 
   CDeclAttr(StringRef Name, bool Implicit)
-    : CDeclAttr(Name, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+    : CDeclAttr(Name, SourceLoc(), SourceRange(), Implicit) {}
 
   /// The symbol name.
   const StringRef Name;
@@ -524,7 +524,7 @@ public:
   Value(Value) {}
 
   SemanticsAttr(StringRef Value, bool Implicit)
-  : SemanticsAttr(Value, SourceLoc(), SourceRange(), /*Implicit=*/true) {}
+  : SemanticsAttr(Value, SourceLoc(), SourceRange(), Implicit) {}
 
   /// The semantics tag value.
   const StringRef Value;


### PR DESCRIPTION
`SILGenNameAttr`, `CDeclAttr`, and `SemanticsAttr` all override whether the
attribute is implicit, specifying that they are always implicit when
using the shortened constructors. From what I can tell, these
constructors are mostly used by the deserialization process.
While it doesn't seem to have a huge effect on the final results, it's
probably a good idea to honor what the serialized form uses.

This is poking ancient code from 2014 and 2015.
I came across it while working on something, though ended up not actually needing it so it isn't actually affecting me, but still seemed like a reasonable cleanup, though I can understand hesitation to adjust it.
