### PR TITLE
Revert "Merge pull request #37116 from gmittert/Descaling"

### DIFF
--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -19,7 +19,6 @@
 
 #include "ClassLayout.h"
 #include "HeapTypeInfo.h"
-#include "TypeLayout.h"
 
 namespace swift {
 namespace irgen {
@@ -47,7 +46,7 @@ public:
   ClassTypeInfo(llvm::PointerType *irType, Size size, SpareBitVector spareBits,
                 Alignment align, ClassDecl *theClass,
                 ReferenceCounting refcount)
-      : HeapTypeInfo(refcount, irType, size, std::move(spareBits), align),
+      : HeapTypeInfo(irType, size, std::move(spareBits), align),
         TheClass(theClass), Refcount(refcount) {}
 
   ReferenceCounting getReferenceCounting() const { return Refcount; }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -16,7 +16,6 @@
 
 #include "GenArchetype.h"
 
-#include "TypeLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -127,11 +126,13 @@ class ClassArchetypeTypeInfo
 {
   ReferenceCounting RefCount;
 
-  ClassArchetypeTypeInfo(llvm::PointerType *storageType, Size size,
-                         const SpareBitVector &spareBits, Alignment align,
+  ClassArchetypeTypeInfo(llvm::PointerType *storageType,
+                         Size size, const SpareBitVector &spareBits,
+                         Alignment align,
                          ReferenceCounting refCount)
-      : HeapTypeInfo(refCount, storageType, size, spareBits, align),
-        RefCount(refCount) {}
+    : HeapTypeInfo(storageType, size, spareBits, align),
+      RefCount(refCount)
+  {}
 
 public:
   static const ClassArchetypeTypeInfo *create(llvm::PointerType *storageType,

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -53,8 +53,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                      ScalarKind::POD);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -120,7 +120,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     if (getFields().empty()) {
@@ -292,7 +292,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     if (getFields().empty()) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -98,7 +98,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TypeLayout.h"
 #define DEBUG_TYPE "enum-layout"
 #include "llvm/Support/Debug.h"
 
@@ -386,10 +385,9 @@ namespace {
          return IGM.typeLayoutCache.getEmptyEntry();
        if (!ElementsAreABIAccessible)
          return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
-
-       if (TIK >= Loadable && !IGM.getOptions().ForceStructTypeLayouts)
-         return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(getTypeInfo(),
-                                                                  T);
+       if (TIK >= Loadable) {
+         return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
+       }
 
        return getSingleton()->buildTypeLayoutEntry(IGM,
                                                    getSingletonType(IGM, T));
@@ -1081,8 +1079,7 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T,
-                                                        ScalarKind::POD);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
     }
 
 
@@ -1234,8 +1231,7 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T,
-                                                        ScalarKind::POD);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
     }
 
     /// \group Extra inhabitants for C-compatible enums.
@@ -3511,10 +3507,9 @@ namespace {
       if (!ElementsAreABIAccessible)
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
 
-      if (!IGM.getOptions().ForceStructTypeLayouts && (AllowFixedLayoutOptimizations && TIK >= Loadable)) {
+      if (AllowFixedLayoutOptimizations && TIK >= Loadable) {
         // The type layout entry code does not handle spare bits atm.
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(getTypeInfo(),
-                                                                 T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
       }
 
       unsigned emptyCases = ElementsWithNoPayload.size();

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -16,7 +16,6 @@
 
 #include "GenExistential.h"
 
-#include "TypeLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -29,7 +28,6 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "BitPatternBuilder.h"
@@ -685,16 +683,7 @@ namespace {
         IsOptional(isOptional) {} \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
                                           SILType T) const override { \
-      ScalarKind kind; \
-      switch (Refcounting) { \
-        case ReferenceCounting::Native:  kind = ScalarKind::NativeStrongReference; break; \
-        case ReferenceCounting::ObjC:    kind = ScalarKind::ObjCReference; break; \
-        case ReferenceCounting::Block:   kind = ScalarKind::BlockReference; break; \
-        case ReferenceCounting::Unknown: kind = ScalarKind::UnknownReference; break; \
-        case ReferenceCounting::Bridge:  kind = ScalarKind::BridgeReference; break; \
-        case ReferenceCounting::Error:   kind = ScalarKind::ErrorReference; break; \
-      } \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind); \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T); \
     } \
     void emitValueAssignWithCopy(IRGenFunction &IGF, \
                                  Address dest, Address src) const { \
@@ -742,16 +731,7 @@ namespace {
     } \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
                                           SILType T) const override { \
-      ScalarKind kind; \
-      switch (Refcounting) { \
-        case ReferenceCounting::Native:  kind = ScalarKind::NativeStrongReference; break; \
-        case ReferenceCounting::ObjC:    kind = ScalarKind::ObjCReference; break; \
-        case ReferenceCounting::Block:   kind = ScalarKind::BlockReference; break; \
-        case ReferenceCounting::Unknown: kind = ScalarKind::UnknownReference; break; \
-        case ReferenceCounting::Bridge:  kind = ScalarKind::BridgeReference; break; \
-        case ReferenceCounting::Error:   kind = ScalarKind::ErrorReference; break; \
-      } \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind); \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T); \
     } \
     llvm::Type *getValueType() const { \
       return ValueType; \
@@ -798,7 +778,7 @@ namespace {
                                       spareBits, align, IsPOD, IsFixedSize) {} \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
                                           SILType T) const override { \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, ScalarKind::POD); \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T); \
     } \
     const LoadableTypeInfo & \
     getValueTypeInfoForExtraInhabitants(IRGenModule &IGM) const { \
@@ -867,8 +847,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(
-        *this, T, ScalarKind::ExistentialReference);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   Address projectWitnessTable(IRGenFunction &IGF, Address obj,
@@ -1016,21 +995,7 @@ class ClassExistentialTypeInfo final
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    ScalarKind kind;
-    switch (Refcounting) {
-    case ReferenceCounting::Native:
-      kind = ScalarKind::NativeStrongReference;
-      break;
-    case ReferenceCounting::ObjC:
-      kind = ScalarKind::ObjCReference;
-      break;
-    case ReferenceCounting::Unknown:
-      kind = ScalarKind::UnknownReference;
-      break;
-    default:
-      llvm_unreachable("Unsupported refcounting style");
-    }
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   /// Given an explosion with multiple pointer elements in them, pack them
@@ -1362,8 +1327,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                      ScalarKind::POD);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   void emitValueRetain(IRGenFunction &IGF, llvm::Value *value,
@@ -1389,27 +1353,17 @@ class ErrorExistentialTypeInfo : public HeapTypeInfo<ErrorExistentialTypeInfo>
   ReferenceCounting Refcounting;
 
 public:
-  ErrorExistentialTypeInfo(llvm::PointerType *storage, Size size,
-                           SpareBitVector spareBits, Alignment align,
+  ErrorExistentialTypeInfo(llvm::PointerType *storage,
+                           Size size, SpareBitVector spareBits,
+                           Alignment align,
                            const ProtocolDecl *errorProto,
                            ReferenceCounting refcounting)
-      : HeapTypeInfo(refcounting, storage, size, spareBits, align),
-        ErrorProto(errorProto), Refcounting(refcounting) {}
+    : HeapTypeInfo(storage, size, spareBits, align), ErrorProto(errorProto),
+      Refcounting(refcounting) {}
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    ScalarKind kind;
-    switch (Refcounting) {
-    case ReferenceCounting::Native:
-      kind = ScalarKind::NativeStrongReference;
-      break;
-    case ReferenceCounting::Error:
-      kind = ScalarKind::ErrorReference;
-      break;
-    default:
-      llvm_unreachable("unsupported refcounting type");
-    }
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   ReferenceCounting getReferenceCounting() const {
@@ -2283,25 +2237,6 @@ void irgen::emitDeallocateBoxedOpaqueExistentialBuffer(
 
   auto *deallocateFun = getDeallocateBoxedOpaqueExistentialBufferFunction(
       IGF.IGM, existLayout);
-  auto *bufferAddr = IGF.Builder.CreateBitCast(
-      existentialContainer.getAddress(),
-      IGF.IGM.getExistentialPtrTy(existLayout.getNumTables()));
-  auto *call = IGF.Builder.CreateCall(deallocateFun, {bufferAddr});
-  call->setCallingConv(IGF.IGM.DefaultCC);
-  call->setDoesNotThrow();
-  return;
-}
-
-void irgen::emitDestroyBoxedOpaqueExistentialBuffer(
-    IRGenFunction &IGF, SILType existentialType, Address existentialContainer) {
-
-  // Project to the existential buffer in the existential container.
-  auto &existentialTI =
-      IGF.getTypeInfo(existentialType).as<OpaqueExistentialTypeInfo>();
-  OpaqueExistentialLayout existLayout = existentialTI.getLayout();
-
-  auto *deallocateFun =
-      getDestroyBoxedOpaqueExistentialBufferFunction(IGF.IGM, existLayout);
   auto *bufferAddr = IGF.Builder.CreateBitCast(
       existentialContainer.getAddress(),
       IGF.IGM.getExistentialPtrTy(existLayout.getNumTables()));

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -95,14 +95,6 @@ namespace irgen {
   void emitDeallocateBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
                                                   SILType existentialType,
                                                   Address existentialContainer);
-
-  /// Free the storage for an opaque existential in the existential
-  /// container.
-  /// If the value is not stored inline, this will free the box for the
-  /// value.
-  void emitDestroyBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
-                                               SILType existentialType,
-                                               Address existentialContainer);
   Address emitOpaqueBoxedExistentialProjection(
       IRGenFunction &IGF, OpenedExistentialAccess accessKind, Address base,
       SILType existentialType, CanArchetypeType openedArchetype);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -156,8 +156,7 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                        ScalarKind::POD);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
@@ -224,13 +223,7 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      if (isPOD(ResilienceExpansion::Maximal)) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                          ScalarKind::POD);
-      } else {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(
-            *this, T, ScalarKind::ThickFunc);
-      }
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     static Size getFirstElementSize(IRGenModule &IGM) {
@@ -392,19 +385,20 @@ namespace {
                         public FuncSignatureInfo
   {
   public:
-    BlockTypeInfo(CanSILFunctionType ty, llvm::PointerType *storageType,
+    BlockTypeInfo(CanSILFunctionType ty,
+                  llvm::PointerType *storageType,
                   Size size, SpareBitVector spareBits, Alignment align)
-        : HeapTypeInfo(ReferenceCounting::Block, storageType, size, spareBits,
-                       align),
-          FuncSignatureInfo(ty) {}
+      : HeapTypeInfo(storageType, size, spareBits, align),
+        FuncSignatureInfo(ty)
+    {
+    }
 
     ReferenceCounting getReferenceCounting() const {
       return ReferenceCounting::Block;
     }
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(
-          *this, T, ScalarKind::BlockReference);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
   };
   
@@ -426,8 +420,7 @@ namespace {
     
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(
-          *this, T, ScalarKind::BlockStorage);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
     // The lowered type should be an LLVM struct comprising the block header
     // (IGM.ObjCBlockStructTy) as its first element and the capture as its

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -23,12 +23,11 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Intrinsics.h"
 
-#include "TypeLayout.h"
+#include "swift/Basic/SourceLoc.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/IRGenOptions.h"
-#include "swift/Basic/SourceLoc.h"
 #include "swift/SIL/SILModule.h"
 
 #include "ConstantBuilder.h"
@@ -58,7 +57,7 @@ namespace {
   public: \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
                                         SILType T) const override { \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, ScalarKind::Nativeness##Name##Reference); \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T); \
     } \
     Nativeness##Name##ReferenceTypeInfo(llvm::Type *valueType, \
                                     llvm::Type *type, \
@@ -146,7 +145,7 @@ namespace {
     enum { IsScalarPOD = false }; \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,                    \
                                           SILType T) const override {          \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, ScalarKind::Nativeness##Name##Reference);             \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);             \
     } \
     llvm::Type *getScalarType() const { \
       return ValueTypeAndIsOptional.getPointer(); \
@@ -549,25 +548,26 @@ llvm::Value *IRGenFunction::emitUnmanagedAlloc(const HeapLayout &layout,
 }
 
 namespace {
-class BuiltinNativeObjectTypeInfo
+  class BuiltinNativeObjectTypeInfo
     : public HeapTypeInfo<BuiltinNativeObjectTypeInfo> {
-public:
-  BuiltinNativeObjectTypeInfo(llvm::PointerType *storage, Size size,
-                                 SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(ReferenceCounting::Native, storage, size, spareBits,
-                     align) {}
+  public:
+    BuiltinNativeObjectTypeInfo(llvm::PointerType *storage,
+                                 Size size, SpareBitVector spareBits,
+                                 Alignment align)
+    : HeapTypeInfo(storage, size, spareBits, align) {}
 
-  /// Builtin.NativeObject uses Swift native reference-counting.
-  ReferenceCounting getReferenceCounting() const {
-    return ReferenceCounting::Native;
-  }
-};
+    /// Builtin.NativeObject uses Swift native reference-counting.
+    ReferenceCounting getReferenceCounting() const {
+      return ReferenceCounting::Native;
+    }
+  };
 } // end anonymous namespace
 
 const LoadableTypeInfo *TypeConverter::convertBuiltinNativeObject() {
-  return new BuiltinNativeObjectTypeInfo(
-      IGM.RefCountedPtrTy, IGM.getPointerSize(), IGM.getHeapObjectSpareBits(),
-      IGM.getPointerAlignment());
+  return new BuiltinNativeObjectTypeInfo(IGM.RefCountedPtrTy,
+                                      IGM.getPointerSize(),
+                                      IGM.getHeapObjectSpareBits(),
+                                      IGM.getPointerAlignment());
 }
 
 unsigned IRGenModule::getReferenceStorageExtraInhabitantCount(
@@ -1405,9 +1405,9 @@ namespace {
 class BoxTypeInfo : public HeapTypeInfo<BoxTypeInfo> {
 public:
   BoxTypeInfo(IRGenModule &IGM)
-      : HeapTypeInfo(ReferenceCounting::Native, IGM.RefCountedPtrTy,
-                     IGM.getPointerSize(), IGM.getHeapObjectSpareBits(),
-                     IGM.getPointerAlignment()) {}
+    : HeapTypeInfo(IGM.RefCountedPtrTy, IGM.getPointerSize(),
+                   IGM.getHeapObjectSpareBits(), IGM.getPointerAlignment())
+  {}
 
   ReferenceCounting getReferenceCounting() const {
     // Boxes are always native-refcounted.
@@ -1590,11 +1590,11 @@ const TypeInfo *TypeConverter::convertBoxType(SILBoxType *T) {
   // For fixed-sized types, we can emit concrete box metadata.
   auto &fixedTI = cast<FixedTypeInfo>(eltTI);
 
-  // Because we assume in enum's that payloads with a Builtin.NativeReference
-  // which is also the type for indirect enum cases have extra inhabitants of
-  // pointers we can't have a nil pointer as a representation for an empty box
-  // type -- nil conflicts with the extra inhabitants. We return a static
-  // singleton empty box object instead.
+  // Because we assume in enum's that payloads with a Builtin.NativeObject which
+  // is also the type for indirect enum cases have extra inhabitants of pointers
+  // we can't have a nil pointer as a representation for an empty box type --
+  // nil conflicts with the extra inhabitants. We return a static singleton
+  // empty box object instead.
   if (fixedTI.isKnownEmpty(ResilienceExpansion::Maximal)) {
     if (!EmptyBoxTI)
       EmptyBoxTI = new EmptyBoxTypeInfo(IGM);

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -54,8 +54,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                      ScalarKind::POD);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -190,9 +190,9 @@ namespace {
   class UnknownTypeInfo : public HeapTypeInfo<UnknownTypeInfo> {
   public:
     UnknownTypeInfo(llvm::PointerType *storageType, Size size,
-                    SpareBitVector spareBits, Alignment align)
-        : HeapTypeInfo(ReferenceCounting::Unknown, storageType, size, spareBits,
-                       align) {}
+                 SpareBitVector spareBits, Alignment align)
+      : HeapTypeInfo(storageType, size, spareBits, align) {
+    }
 
     /// AnyObject requires ObjC reference-counting.
     ReferenceCounting getReferenceCounting() const {
@@ -219,9 +219,9 @@ namespace {
   class BridgeObjectTypeInfo : public HeapTypeInfo<BridgeObjectTypeInfo> {
   public:
     BridgeObjectTypeInfo(llvm::PointerType *storageType, Size size,
-                         SpareBitVector spareBits, Alignment align)
-        : HeapTypeInfo(ReferenceCounting::Bridge, storageType, size, spareBits,
-                       align) {}
+                 SpareBitVector spareBits, Alignment align)
+      : HeapTypeInfo(storageType, size, spareBits, align) {
+    }
 
     /// Builtin.BridgeObject uses its own specialized refcounting implementation.
     ReferenceCounting getReferenceCounting() const {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -358,7 +358,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
       if (!areFieldsABIAccessible()) {
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
@@ -545,7 +545,7 @@ namespace {
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts || getCXXDestructor(T) ||
           !areFieldsABIAccessible()) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
 
       std::vector<TypeLayoutEntry *> fields;
@@ -625,7 +625,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {
@@ -687,7 +687,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -235,7 +235,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();
@@ -280,7 +280,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1135,8 +1135,7 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                        ScalarKind::POD);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     unsigned getExplosionSize() const override {
@@ -1226,8 +1225,7 @@ namespace {
                          IsNotPOD, IsNotBitwiseTakable, IsFixedSize) {}
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
-                                                        ScalarKind::Immovable);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
     }
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
@@ -2301,7 +2299,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    llvm_unreachable("Cannot construct type layout for legacy types");
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
   }
 
   virtual unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -64,10 +64,9 @@ class HeapTypeInfo
 protected:
   using super::asDerived;
 public:
-  HeapTypeInfo(ReferenceCounting refcounting, llvm::PointerType *storage,
-               Size size, SpareBitVector spareBits, Alignment align)
-      : super(swift::irgen::refcountingToScalarKind(refcounting), storage, size, spareBits,
-              align) {}
+  HeapTypeInfo(llvm::PointerType *storage, Size size, SpareBitVector spareBits,
+               Alignment align)
+    : super(storage, size, spareBits, align) {}
 
   bool isSingleRetainablePointer(ResilienceExpansion expansion,
                                  ReferenceCounting *refcounting) const override {

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -240,9 +240,8 @@ class SingleScalarTypeInfoWithTypeLayout
     : public SingleScalarTypeInfo<Derived, Base> {
 protected:
   template <class... T>
-  SingleScalarTypeInfoWithTypeLayout(ScalarKind kind, T &&...args)
-      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...),
-        kind(kind) {}
+  SingleScalarTypeInfoWithTypeLayout(T &&... args)
+      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...) {}
 
   const Derived &asDerived() const {
     return static_cast<const Derived &>(*this);
@@ -253,11 +252,8 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T, kind);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
   }
-
-private:
-  ScalarKind kind;
 };
 
 /// PODSingleScalarTypeInfo - A further specialization of
@@ -293,8 +289,7 @@ private:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T,
-                                                      ScalarKind::POD);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
   }
 
 };

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -12,54 +12,16 @@
 #include "TypeLayout.h"
 #include "EnumPayload.h"
 #include "FixedTypeInfo.h"
-#include "GenExistential.h"
 #include "GenOpaque.h"
-#include "GenType.h"
 #include "IRGen.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "SwitchBuilder.h"
 #include "swift/ABI/MetadataValues.h"
-#include "swift/SIL/TypeLowering.h"
 #include "llvm/IR/DerivedTypes.h"
 
 using namespace swift;
 using namespace irgen;
-
-ScalarKind swift::irgen::refcountingToScalarKind(ReferenceCounting refCounting) {
-  switch (refCounting) {
-  case ReferenceCounting::Native:
-    return ScalarKind::NativeStrongReference;
-  case ReferenceCounting::Bridge:
-    return ScalarKind::BridgeReference;
-  case ReferenceCounting::Block:
-    return ScalarKind::BlockReference;
-  case ReferenceCounting::Error:
-    return ScalarKind::ErrorReference;
-  case ReferenceCounting::Unknown:
-    return ScalarKind::UnknownReference; 
-  case ReferenceCounting::ObjC:
-    return ScalarKind::ObjCReference;
-  }
-}
-
-static bool isNullableRefCounted(ScalarKind kind) {
-  switch (kind) {
-  case ScalarKind::ErrorReference:
-  case ScalarKind::NativeStrongReference:
-  case ScalarKind::NativeUnownedReference:
-  case ScalarKind::NativeWeakReference:
-  case ScalarKind::UnknownUnownedReference:
-  case ScalarKind::UnknownWeakReference:
-  case ScalarKind::UnknownReference:
-  case ScalarKind::BlockReference:
-  case ScalarKind::BridgeReference:
-  case ScalarKind::ObjCReference:
-    return true;
-  default:
-    return false;
-  }
-}
 
 TypeLayoutEntry::~TypeLayoutEntry() {}
 
@@ -732,7 +694,7 @@ llvm::Value *ScalarTypeLayoutEntry::size(IRGenFunction &IGF) const {
 bool ScalarTypeLayoutEntry::isFixedSize(IRGenModule &IGM) const { return true; }
 
 bool ScalarTypeLayoutEntry::isPOD() const {
-  return scalarKind == ScalarKind::POD;
+  return typeInfo.isPOD(ResilienceExpansion::Maximal);
 }
 
 bool ScalarTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
@@ -741,7 +703,7 @@ bool ScalarTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
 }
 
 bool ScalarTypeLayoutEntry::isSingleRetainablePointer() const {
-  return isNullableRefCounted(scalarKind);
+  return typeInfo.isSingleRetainablePointer(ResilienceExpansion::Maximal);
 }
 
 llvm::Optional<Size> ScalarTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
@@ -771,99 +733,12 @@ llvm::Value *ScalarTypeLayoutEntry::isBitwiseTakable(IRGenFunction &IGF) const {
 }
 
 void ScalarTypeLayoutEntry::destroy(IRGenFunction &IGF, Address addr) const {
-  switch (scalarKind) {
-  case ScalarKind::POD:
-    return;
-  case ScalarKind::Immovable:
-    llvm_unreachable("cannot opaquely manipulate immovable types!");
-  case ScalarKind::NativeStrongReference: {
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
-    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
-    IGF.emitNativeStrongRelease(val, IGF.getDefaultAtomicity());
-    return;
-  }
-  case ScalarKind::ErrorReference: {
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
-    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
-    IGF.emitErrorStrongRelease(val);
-    return;
-  }
-  case ScalarKind::NativeWeakReference: {
-    IGF.emitNativeWeakDestroy(addr);
-    return;
-  }
-  case ScalarKind::NativeUnownedReference: {
-    IGF.emitNativeUnownedDestroy(addr);
-    return;
-  }
-  case ScalarKind::BlockReference: {
-    IGF.emitBlockRelease(addr.getAddress());
-    return;
-  }
-  case ScalarKind::UnknownReference: {
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
-    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
-    IGF.emitUnknownStrongRelease(val, IGF.getDefaultAtomicity());
-    return;
-  }
-  case ScalarKind::UnknownUnownedReference: {
-    IGF.emitUnknownUnownedDestroy(addr);
-    return;
-  }
-  case ScalarKind::UnknownWeakReference: {
-    IGF.emitUnknownWeakDestroy(addr);
-    return;
-  }
-  case ScalarKind::BridgeReference: {
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
-    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
-    IGF.emitBridgeStrongRelease(val, IGF.getDefaultAtomicity());
-    return;
-  }
-  case ScalarKind::ObjCReference: {
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto &Builder = IGF.Builder;
-    addr = Address(Builder.CreateBitCast(addr.getAddress(), addressType),
-                   alignment);
-    llvm::Value *val =
-        IGF.Builder.CreateLoad(addr.getAddress(), alignment, "toDestroy");
-    IGF.emitObjCStrongRelease(val);
-    break;
-  }
-  case ScalarKind::BlockStorage: {
-    // The frontend will currently never emit copy_addr or destroy_addr for
-    // block storage.
-    IGF.unimplemented(SourceLoc(), "destroying @block_storage");
-    return;
-  }
-  case ScalarKind::ThickFunc: {
-    // A thick function is a pair of a function pointer and an optional
-    // ref counted opaque pointer. We don't need to do anything for the
-    // function pointer, but we need to release the opaque pointer.
-    auto alignment = typeInfo.getFixedAlignment();
-    auto addressType = typeInfo.getStorageType()->getPointerTo();
-    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
-    auto secondElement = IGF.Builder.CreateStructGEP(
-        Address(castAddr, alignment), 1, IGF.IGM.getPointerSize(),
-        addr->getName() + ".data");
-    auto pointer = IGF.Builder.CreateLoad(secondElement, "toDestroy");
-    IGF.emitNativeStrongRelease(pointer, IGF.getDefaultAtomicity());
-    return;
-  }
-  case ScalarKind::ExistentialReference: {
-    emitDestroyBoxedOpaqueExistentialBuffer(IGF, representative, addr);
-    return;
-  }
-  }
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  addr =
+      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
+  typeInfo.destroy(IGF, addr, representative, true);
 }
 
 void ScalarTypeLayoutEntry::assignWithCopy(IRGenFunction &IGF, Address dest,
@@ -936,10 +811,6 @@ void ScalarTypeLayoutEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
       Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
   typeInfo.storeEnumTagSinglePayload(IGF, tag, numEmptyCases, addr,
                                      representative, true);
-}
-
-bool ScalarTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
-  return entry->kind == TypeLayoutEntryKind::Scalar;
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -1392,10 +1263,6 @@ void AlignedGroupEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
       });
 }
 
-bool AlignedGroupEntry::classof(const TypeLayoutEntry *entry) {
-  return entry->kind == TypeLayoutEntryKind::AlignedGroup;
-}
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AlignedGroupEntry::dump() const {
     llvm::dbgs() << "{ aligned group:\n";
@@ -1505,10 +1372,6 @@ void ArchetypeLayoutEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
               addr.getAlignment());
 
   emitStoreEnumTagSinglePayloadCall(IGF, archetype, tag, numEmptyCases, addr);
-}
-
-bool ArchetypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
-  return entry->kind == TypeLayoutEntryKind::Archetype;
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -2610,10 +2473,6 @@ void EnumTypeLayoutEntry::destructiveInjectEnumTag(IRGenFunction &IGF,
   storeEnumTagMultipayload(IGF, tag, enumAddr);
 }
 
-bool EnumTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
-  return entry->kind == TypeLayoutEntryKind::Enum;
-}
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void EnumTypeLayoutEntry::dump() const {
     llvm::dbgs() << "{ enum emptycases: " << numEmptyCases << "\n";
@@ -2732,192 +2591,15 @@ void ResilientTypeLayoutEntry::storeEnumTagSinglePayload(
   emitStoreEnumTagSinglePayloadCall(IGF, ty, tag, numEmptyCases, addr);
 }
 
-bool ResilientTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
-  return entry->kind == TypeLayoutEntryKind::Resilient;
-}
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ResilientTypeLayoutEntry::dump() const {
   llvm::dbgs() << "{ resilient type: " << ty << " id: " << this << " }\n";
 }
 #endif
 
-void TypeInfoBasedTypeLayoutEntry::computeProperties() {
-  // does not add anything.
-}
-
-void TypeInfoBasedTypeLayoutEntry::Profile(llvm::FoldingSetNodeID &id) const {
-  ScalarTypeLayoutEntry::Profile(id, typeInfo, representative);
-}
-
-void TypeInfoBasedTypeLayoutEntry::Profile(llvm::FoldingSetNodeID &id,
-                                           const TypeInfo &ti, SILType ty) {
-  id.AddPointer(&ti);
-  id.AddPointer(ty.getASTType().getPointer());
-}
-
-TypeInfoBasedTypeLayoutEntry::~TypeInfoBasedTypeLayoutEntry() {}
-
-llvm::Value *
-TypeInfoBasedTypeLayoutEntry::alignmentMask(IRGenFunction &IGF) const {
-  return typeInfo.getAlignmentMask(IGF, representative);
-}
-
-llvm::Value *TypeInfoBasedTypeLayoutEntry::size(IRGenFunction &IGF) const {
-  return typeInfo.getSize(IGF, representative);
-}
-
-bool TypeInfoBasedTypeLayoutEntry::isFixedSize(IRGenModule &IGM) const {
-  return true;
-}
-
-llvm::Optional<Size>
-TypeInfoBasedTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
-  return typeInfo.getFixedSize();
-}
-
-llvm::Optional<Alignment>
-TypeInfoBasedTypeLayoutEntry::fixedAlignment(IRGenModule &IGM) const {
-  return typeInfo.getFixedAlignment();
-}
-
-llvm::Optional<uint32_t>
-TypeInfoBasedTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
-  return typeInfo.getFixedExtraInhabitantCount(IGM);
-}
-
-bool TypeInfoBasedTypeLayoutEntry::isPOD() const {
-  return typeInfo.isPOD(ResilienceExpansion::Maximal);
-}
-
-bool TypeInfoBasedTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
-    IRGenModule &IGM, unsigned index) const {
-  return typeInfo.canValueWitnessExtraInhabitantsUpTo(IGM, index);
-}
-
-bool TypeInfoBasedTypeLayoutEntry::isSingleRetainablePointer() const {
-  return typeInfo.isSingleRetainablePointer(ResilienceExpansion::Maximal);
-}
-
-llvm::Value *
-TypeInfoBasedTypeLayoutEntry::extraInhabitantCount(IRGenFunction &IGF) const {
-  auto &IGM = IGF.IGM;
-  auto fixedXICount =
-      cast<FixedTypeInfo>(typeInfo).getFixedExtraInhabitantCount(IGM);
-  return llvm::ConstantInt::get(IGM.Int32Ty, fixedXICount);
-}
-
-llvm::Value *
-TypeInfoBasedTypeLayoutEntry::isBitwiseTakable(IRGenFunction &IGF) const {
-  return llvm::ConstantInt::get(IGF.IGM.Int1Ty,
-                                cast<FixedTypeInfo>(typeInfo).isBitwiseTakable(
-                                    ResilienceExpansion::Maximal));
-}
-
-void TypeInfoBasedTypeLayoutEntry::destroy(IRGenFunction &IGF,
-                                           Address addr) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  addr =
-      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
-  typeInfo.destroy(IGF, addr, representative, true);
-}
-
-void TypeInfoBasedTypeLayoutEntry::assignWithCopy(IRGenFunction &IGF,
-                                                  Address dest,
-                                                  Address src) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  dest =
-      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
-  src =
-      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
-  typeInfo.assignWithCopy(IGF, dest, src, representative, true);
-}
-
-void TypeInfoBasedTypeLayoutEntry::assignWithTake(IRGenFunction &IGF,
-                                                  Address dest,
-                                                  Address src) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  dest =
-      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
-  src =
-      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
-  typeInfo.assignWithTake(IGF, dest, src, representative, true);
-}
-
-void TypeInfoBasedTypeLayoutEntry::initWithCopy(IRGenFunction &IGF,
-                                                Address dest,
-                                                Address src) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  dest =
-      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
-  src =
-      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
-  typeInfo.initializeWithCopy(IGF, dest, src, representative, true);
-}
-
-void TypeInfoBasedTypeLayoutEntry::initWithTake(IRGenFunction &IGF,
-                                                Address dest,
-                                                Address src) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  dest =
-      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
-  src =
-      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
-  typeInfo.initializeWithTake(IGF, dest, src, representative, true);
-}
-
-llvm::Value *TypeInfoBasedTypeLayoutEntry::getEnumTagSinglePayload(
-    IRGenFunction &IGF, llvm::Value *numEmptyCases, Address value) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  value = Address(Builder.CreateBitCast(value.getAddress(), addressType),
-                  alignment);
-  ;
-  return typeInfo.getEnumTagSinglePayload(IGF, numEmptyCases, value,
-                                          representative, true);
-}
-
-void TypeInfoBasedTypeLayoutEntry::storeEnumTagSinglePayload(
-    IRGenFunction &IGF, llvm::Value *tag, llvm::Value *numEmptyCases,
-    Address addr) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  addr =
-      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
-  typeInfo.storeEnumTagSinglePayload(IGF, tag, numEmptyCases, addr,
-                                     representative, true);
-}
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-LLVM_DUMP_METHOD void TypeInfoBasedTypeLayoutEntry::dump() const {
-  if (typeInfo.isFixedSize())
-    llvm::dbgs() << "{ scalar isFixedSize:" << (bool)typeInfo.isFixedSize()
-                 << " isLoadable: " << (bool)typeInfo.isLoadable() << " size: "
-                 << cast<FixedTypeInfo>(typeInfo).getFixedSize().getValue()
-                 << " alignment: "
-                 << cast<FixedTypeInfo>(typeInfo).getFixedAlignment().getValue()
-                 << " rep: " << representative << " id: " << this << " }\n";
-  if (!typeInfo.isFixedSize()) {
-    llvm::dbgs() << "{ scalar non-fixed rep: " << representative
-                 << " id: " << this << " }\n";
-  }
-}
-#endif
-
-ScalarTypeLayoutEntry *TypeLayoutCache::getOrCreateScalarEntry(
-    const TypeInfo &ti, SILType representative, ScalarKind kind) {
+ScalarTypeLayoutEntry *
+TypeLayoutCache::getOrCreateScalarEntry(const TypeInfo &ti,
+                                        SILType representative) {
   assert(ti.isFixedSize());
   llvm::FoldingSetNodeID id;
   ScalarTypeLayoutEntry::Profile(id, cast<FixedTypeInfo>(ti), representative);
@@ -2929,8 +2611,8 @@ ScalarTypeLayoutEntry *TypeLayoutCache::getOrCreateScalarEntry(
   // Otherwise, create a new one.
   auto bytes = sizeof(ScalarTypeLayoutEntry);
   auto mem = bumpAllocator.Allocate(bytes, alignof(ScalarTypeLayoutEntry));
-  auto newEntry = new (mem)
-      ScalarTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative, kind);
+  auto newEntry =
+      new (mem) ScalarTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative);
   scalarEntries.InsertNode(newEntry, insertPos);
   newEntry->computeProperties();
   return newEntry;
@@ -2953,7 +2635,7 @@ TypeLayoutCache::getOrCreateArchetypeEntry(SILType archetype) {
 }
 
 AlignedGroupEntry *TypeLayoutCache::getOrCreateAlignedGroupEntry(
-    const std::vector<TypeLayoutEntry *> &entries,
+    std::vector<TypeLayoutEntry *> &entries,
     Alignment::int_type minimumAlignment) {
   llvm::FoldingSetNodeID id;
   AlignedGroupEntry::Profile(id, entries, minimumAlignment);
@@ -3005,27 +2687,6 @@ TypeLayoutCache::getOrCreateResilientEntry(SILType ty) {
   return newEntry;
 }
 
-TypeInfoBasedTypeLayoutEntry *
-TypeLayoutCache::getOrCreateTypeInfoBasedEntry(const TypeInfo &ti,
-                                               SILType representative) {
-  assert(ti.isFixedSize());
-  llvm::FoldingSetNodeID id;
-  TypeInfoBasedTypeLayoutEntry::Profile(id, ti, representative);
-  // Grab the entry from the cache if we have one
-  void *insertPos;
-  if (auto *entry = typeInfoBasedEntries.FindNodeOrInsertPos(id, insertPos)) {
-    return entry;
-  }
-  // Otherwise, create a new one.
-  const auto bytes = sizeof(ScalarTypeLayoutEntry);
-  auto mem = bumpAllocator.Allocate(bytes, alignof(ScalarTypeLayoutEntry));
-  auto newEntry = new (mem)
-      TypeInfoBasedTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative);
-  typeInfoBasedEntries.InsertNode(newEntry, insertPos);
-  newEntry->computeProperties();
-  return newEntry;
-}
-
 TypeLayoutCache::~TypeLayoutCache() {
   for (auto &entry : scalarEntries) {
     entry.~ScalarTypeLayoutEntry();
@@ -3041,8 +2702,5 @@ TypeLayoutCache::~TypeLayoutCache() {
   }
   for (auto &entry : resilientEntries) {
     entry.~ResilientTypeLayoutEntry();
-  }
-  for (auto &entry : typeInfoBasedEntries) {
-    entry.~TypeInfoBasedTypeLayoutEntry();
   }
 }

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -31,29 +31,7 @@ enum class TypeLayoutEntryKind : uint8_t {
   AlignedGroup,
   Resilient,
   Enum,
-  TypeInfoBased,
 };
-
-enum class ScalarKind : uint8_t {
-  POD,
-  Immovable,
-  ErrorReference,
-  NativeStrongReference,
-  NativeUnownedReference,
-  NativeWeakReference,
-  UnknownReference,
-  UnknownUnownedReference,
-  UnknownWeakReference,
-  BlockReference,
-  BridgeReference,
-  ObjCReference,
-  BlockStorage,
-  ThickFunc,
-  ExistentialReference,
-};
-
-/// Convert a ReferenceCounting into the appropriate Scalar reference
-ScalarKind refcountingToScalarKind(ReferenceCounting refCounting);
 
 class TypeLayoutEntry {
 public:
@@ -166,12 +144,9 @@ public:
   const FixedTypeInfo &typeInfo;
   SILType representative;
 
-  ScalarKind scalarKind;
-
-  ScalarTypeLayoutEntry(const FixedTypeInfo &ti, SILType representative,
-                        ScalarKind scalarKind)
+  ScalarTypeLayoutEntry(const FixedTypeInfo &ti, SILType representative)
       : TypeLayoutEntry(TypeLayoutEntryKind::Scalar), typeInfo(ti),
-        representative(representative), scalarKind(scalarKind) {}
+        representative(representative) {}
 
   ~ScalarTypeLayoutEntry();
 
@@ -194,7 +169,6 @@ public:
   bool isSingleRetainablePointer() const override;
   llvm::Value *extraInhabitantCount(IRGenFunction &IGF) const override;
   llvm::Value *isBitwiseTakable(IRGenFunction &IGF) const override;
-  llvm::Type *getStorageType(IRGenFunction &IGF) const;
 
   void destroy(IRGenFunction &IGF, Address addr) const override;
 
@@ -215,8 +189,6 @@ public:
   void storeEnumTagSinglePayload(IRGenFunction &IGF, llvm::Value *tag,
                                  llvm::Value *numEmptyCases,
                                  Address enumAddr) const override;
-
-  static bool classof(const TypeLayoutEntry *entry);
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const override;
@@ -273,8 +245,6 @@ public:
                                  llvm::Value *numEmptyCases,
                                  Address enumAddr) const override;
 
-  static bool classof(const TypeLayoutEntry *entry);
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const override;
 #endif
@@ -329,8 +299,6 @@ public:
                                  llvm::Value *numEmptyCases,
                                  Address enumAddr) const override;
 
-  static bool classof(const TypeLayoutEntry *entry);
-
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const override;
 #endif
@@ -341,7 +309,7 @@ class AlignedGroupEntry : public TypeLayoutEntry, public llvm::FoldingSetNode {
   Alignment::int_type minimumAlignment;
 
 public:
-  AlignedGroupEntry(const std::vector<TypeLayoutEntry *> &entries,
+  AlignedGroupEntry(std::vector<TypeLayoutEntry *> &entries,
                     Alignment::int_type minimumAlignment)
       : TypeLayoutEntry(TypeLayoutEntryKind::AlignedGroup), entries(entries),
         minimumAlignment(minimumAlignment) {}
@@ -388,8 +356,6 @@ public:
   void storeEnumTagSinglePayload(IRGenFunction &IGF, llvm::Value *tag,
                                  llvm::Value *numEmptyCases,
                                  Address enumAddr) const override;
-
-  static bool classof(const TypeLayoutEntry *entry);
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const override;
@@ -587,69 +553,6 @@ private:
       llvm::function_ref<void(TypeLayoutEntry *payload, llvm::Value *tagIndex)>
           payloadFunction,
       llvm::function_ref<void()> noPayloadFunction) const;
-
-  static bool classof(const TypeLayoutEntry *entry);
-};
-
-/// TypeLayouts that defer to the existing typeinfo infrastructure in cases that
-/// type layouts don't have the functionality implemented yet (e.g. multi enum
-/// extra inhabitants).
-class TypeInfoBasedTypeLayoutEntry : public TypeLayoutEntry,
-                                     public llvm::FoldingSetNode {
-public:
-  const FixedTypeInfo &typeInfo;
-  SILType representative;
-
-  TypeInfoBasedTypeLayoutEntry(const FixedTypeInfo &ti, SILType representative)
-      : TypeLayoutEntry(TypeLayoutEntryKind::TypeInfoBased), typeInfo(ti),
-        representative(representative) {}
-
-  ~TypeInfoBasedTypeLayoutEntry();
-
-  void computeProperties() override;
-
-  // Support for FoldingSet.
-  void Profile(llvm::FoldingSetNodeID &id) const;
-  static void Profile(llvm::FoldingSetNodeID &ID, const TypeInfo &ti,
-                      SILType ty);
-
-  llvm::Value *alignmentMask(IRGenFunction &IGF) const override;
-  llvm::Value *size(IRGenFunction &IGF) const override;
-  llvm::Value *extraInhabitantCount(IRGenFunction &IGF) const override;
-  bool isPOD() const override;
-  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
-                                           unsigned index) const override;
-  bool isSingleRetainablePointer() const override;
-  llvm::Optional<Size> fixedSize(IRGenModule &IGM) const override;
-  bool isFixedSize(IRGenModule &IGM) const override;
-  llvm::Optional<Alignment> fixedAlignment(IRGenModule &IGM) const override;
-  llvm::Optional<uint32_t> fixedXICount(IRGenModule &IGM) const override;
-  llvm::Value *isBitwiseTakable(IRGenFunction &IGF) const override;
-  llvm::Type *getStorageType(IRGenFunction &IGF) const;
-
-  void destroy(IRGenFunction &IGF, Address addr) const override;
-
-  void assignWithCopy(IRGenFunction &IGF, Address dest,
-                      Address src) const override;
-  void assignWithTake(IRGenFunction &IGF, Address dest,
-                      Address src) const override;
-
-  void initWithCopy(IRGenFunction &IGF, Address dest,
-                    Address src) const override;
-  void initWithTake(IRGenFunction &IGF, Address dest,
-                    Address src) const override;
-
-  llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,
-                                       llvm::Value *numEmptyCases,
-                                       Address addr) const override;
-
-  void storeEnumTagSinglePayload(IRGenFunction &IGF, llvm::Value *tag,
-                                 llvm::Value *numEmptyCases,
-                                 Address enumAddr) const override;
-
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  void dump() const override;
-#endif
 };
 
 class TypeLayoutCache {
@@ -660,27 +563,22 @@ class TypeLayoutCache {
   llvm::FoldingSet<AlignedGroupEntry> alignedGroupEntries;
   llvm::FoldingSet<EnumTypeLayoutEntry> enumEntries;
   llvm::FoldingSet<ResilientTypeLayoutEntry> resilientEntries;
-  llvm::FoldingSet<TypeInfoBasedTypeLayoutEntry> typeInfoBasedEntries;
 
   TypeLayoutEntry emptyEntry;
 public:
   ~TypeLayoutCache();
   ScalarTypeLayoutEntry *getOrCreateScalarEntry(const TypeInfo &ti,
-                                                SILType representative,
-                                                ScalarKind kind);
+                                                SILType representative);
 
   ArchetypeLayoutEntry *getOrCreateArchetypeEntry(SILType archetype);
 
   AlignedGroupEntry *
-  getOrCreateAlignedGroupEntry(const std::vector<TypeLayoutEntry *> &entries,
+  getOrCreateAlignedGroupEntry(std::vector<TypeLayoutEntry *> &entries,
                                Alignment::int_type minimumAlignment);
 
   EnumTypeLayoutEntry *
   getOrCreateEnumEntry(unsigned numEmptyCase,
                        const std::vector<TypeLayoutEntry *> &nonEmptyCases);
-
-  TypeInfoBasedTypeLayoutEntry *
-  getOrCreateTypeInfoBasedEntry(const TypeInfo &ti, SILType representative);
 
   ResilientTypeLayoutEntry *getOrCreateResilientEntry(SILType ty);
 


### PR DESCRIPTION
This reverts commit 5ebb1b2fc63fa9aedf71e3c2614c3ea01eba5377, reversing
changes made to 76260c22355f7e716b159dfad4c952cb8c8566e7.

This commit causes compiler crashes when using protocol composition
types involving objc.

Repo:

```
import Foundation

public class SomeObject : NSObject {}

public protocol ProtoA{}

public protocol SomeProtoType { }
public typealias Composition = SomeObject & SomeProtoType

public struct Thing<T: ProtoA> {
    let a: Composition
    let b: T

    init(a: Composition,
         b: T
    ) {
        self.a = a
        self.b = b
    }
}

$ swiftc -c Repo.swift -O
```

While looking at this issue I noticed that it is not correct to use a
ScalarEntry of ObjCReference (or other ScalarKind::XXXReference) for
`AddressOnly##Name##ClassExistentialTypeInfo` types. These should be
calling `IGF.emit##Name##Destroy(addr, Refcounting)` functions not
objc_release.
It is probably best to use the macro facilities in a similar fashion like
lib/IRGen/GenExistential.cpp does or look at the preprocessor output for this file.

rdar://85269025

