### PR TITLE
Revert "Implement ClangImporter importSourceLoc and importSourceRange"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2265,13 +2265,14 @@ ClangImporter::Implementation::exportSourceLoc(SourceLoc loc) {
 
 SourceLoc
 ClangImporter::Implementation::importSourceLoc(clang::SourceLocation loc) {
-  return getBufferImporterForDiagnostics().resolveSourceLocation(
-      getClangASTContext().getSourceManager(), loc);
+  // FIXME: Implement!
+  return SourceLoc();
 }
 
 SourceRange
 ClangImporter::Implementation::importSourceRange(clang::SourceRange loc) {
-  return SourceRange(importSourceLoc(loc.getBegin()), importSourceLoc(loc.getEnd()));
+  // FIXME: Implement!
+  return SourceRange();
 }
 
 #pragma mark Importing names

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3376,11 +3376,8 @@ namespace {
       if (alreadyImportedResult != Impl.ImportedDecls.end())
         return alreadyImportedResult->second;
       result = Impl.createDeclWithClangNode<StructDecl>(
-          decl, AccessLevel::Public,
-          SourceLoc(), // FIXME: Impl.importSourceLoc(decl->getBeginLoc()) results in a bad import: SR-15440
-          name,
-          SourceLoc(), // FIXME: Impl.importSourceLoc(decl->getLocation()) result in a bad import: SR-15440
-          None, nullptr, dc);
+          decl, AccessLevel::Public, Impl.importSourceLoc(decl->getBeginLoc()),
+          name, Impl.importSourceLoc(decl->getLocation()), None, nullptr, dc);
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
       // FIXME: Figure out what to do with superclasses in C++. One possible
@@ -4218,7 +4215,7 @@ namespace {
         Impl.createDeclWithClangNode<VarDecl>(decl, AccessLevel::Public,
                               /*IsStatic*/ false,
                               VarDecl::Introducer::Var,
-                              SourceLoc(), // FIXME: Impl.importSourceLoc(decl->getLocation()) result in a bad import: SR-15440
+                              Impl.importSourceLoc(decl->getLocation()),
                               name, dc);
       if (decl->getType().isConstQualified()) {
         // Note that in C++ there are ways to change the values of const
@@ -6942,7 +6939,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
   assert(!importedName.getAsyncInfo());
   auto result = Impl.createDeclWithClangNode<ConstructorDecl>(
       objcMethod, AccessLevel::Public, importedName.getDeclName(),
-      /*NameLoc=*/Impl.importSourceLoc(objcMethod->getBeginLoc()), failability, /*FailabilityLoc=*/SourceLoc(),
+      /*NameLoc=*/SourceLoc(), failability, /*FailabilityLoc=*/SourceLoc(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/importedName.getErrorInfo().hasValue(),
       /*ThrowsLoc=*/SourceLoc(), bodyParams,


### PR DESCRIPTION
Reverts apple/swift#40010.

Verifying that this broke the source compatibility test suite. 