### PR TITLE
swift_build_support: Drop support for Python 2

### DIFF
--- a/utils/swift_build_support/run_tests.py
+++ b/utils/swift_build_support/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -8,13 +8,9 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
 """
 Small script used to easily run the swift_build_support module unit tests.
 """
-
-
-from __future__ import absolute_import, unicode_literals
 
 import os
 import sys

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -20,8 +20,6 @@ from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
 
-import six
-
 from swift_build_support.swift_build_support import products
 from swift_build_support.swift_build_support import shell
 from swift_build_support.swift_build_support import targets
@@ -494,7 +492,7 @@ class BuildScriptInvocation(object):
             try:
                 config = HostSpecificConfiguration(host_target, args)
             except argparse.ArgumentError as e:
-                exit_rejecting_arguments(six.text_type(e))
+                exit_rejecting_arguments(str(e))
 
             # Convert into `build-script-impl` style variables.
             options[host_target] = {
@@ -607,7 +605,7 @@ class BuildScriptInvocation(object):
         builder.add_product(products.SwiftDocC,
                             is_enabled=self.args.build_swiftdocc)
         builder.add_product(products.SwiftDocCRender,
-                            is_enabled=self.args.install_swiftdocc)                  
+                            is_enabled=self.args.install_swiftdocc)
 
         # Keep SwiftDriver at last.
         # swift-driver's integration with the build scripts is not fully
@@ -693,7 +691,7 @@ class BuildScriptInvocation(object):
             try:
                 config = HostSpecificConfiguration(host_target.name, self.args)
             except argparse.ArgumentError as e:
-                exit_rejecting_arguments(six.text_type(e))
+                exit_rejecting_arguments(str(e))
             print("Building the standard library for: {}".format(
                 " ".join(config.swift_stdlib_build_targets)))
             if config.swift_test_run_targets and (

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -14,15 +14,10 @@
 #
 # ----------------------------------------------------------------------------
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import re
 from numbers import Number
-
-import six
 
 from . import shell
 
@@ -46,7 +41,7 @@ class CMakeOptions(object):
             value = self.true_false(value)
         if value is None:
             value = ""
-        elif not isinstance(value, six.string_types + (Number,)):
+        elif not isinstance(value, (Number, str)):
             raise ValueError('define: invalid value for key %s: %s (%s)' %
                              (var, value, type(value)))
         self._options.append('-D%s=%s' % (var, value))
@@ -202,7 +197,7 @@ class CMake(object):
 
         elif args.cmake_generator == 'Xcode':
             build_args += ['-parallelizeTargets',
-                           '-jobs', six.text_type(jobs)]
+                           '-jobs', str(jobs)]
 
         return build_args
 

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -13,8 +13,6 @@ Centralized command line and file system interface for the build script.
 """
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import pipes
 import platform
@@ -132,12 +130,11 @@ def capture(command, stderr=None, env=None, dry_run=None, echo=True,
         _env = dict(os.environ)
         _env.update(env)
     try:
-        out = subprocess.check_output(command, env=_env, stderr=stderr)
-        # Coerce to `str` hack. not py3 `byte`, not py2 `unicode`.
-        return str(out.decode())
+        out = subprocess.check_output(command, env=_env, stderr=stderr, text=True)
+        return out
     except subprocess.CalledProcessError as e:
         if allow_non_zero_exit:
-            return str(e.output.decode())
+            return e.output
         if optional:
             return None
         _fatal_error(

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -14,8 +14,6 @@ Represent toolchain - the versioned executables.
 """
 # ----------------------------------------------------------------------------
 
-from __future__ import absolute_import
-
 import os
 import platform
 
@@ -24,7 +22,6 @@ from build_swift.build_swift.shell import which
 from build_swift.build_swift.wrappers import xcrun
 
 from . import shell
-
 
 __all__ = [
     'host_toolchain',

--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -10,8 +10,6 @@
 #
 # ===---------------------------------------------------------------------===#
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import sys
 
 

--- a/utils/swift_build_support/tests/products/test_cmark.py
+++ b/utils/swift_build_support/tests/products/test_cmark.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 # from swift_build_support import cmake
 from swift_build_support import shell

--- a/utils/swift_build_support/tests/products/test_earlyswiftdriver.py
+++ b/utils/swift_build_support/tests/products/test_earlyswiftdriver.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import EarlySwiftDriver

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import LLVM

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -16,12 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from build_swift.build_swift.wrappers import xcrun
 

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import Swift

--- a/utils/swift_build_support/tests/test_build_graph.py
+++ b/utils/swift_build_support/tests/test_build_graph.py
@@ -8,9 +8,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from swift_build_support import build_graph
@@ -56,4 +53,4 @@ class BuildGraphTestCase(unittest.TestCase):
         selectedProducts = [products['swiftpm']]
         schedule = build_graph.produce_scheduled_build(selectedProducts)
         names = [x.name for x in schedule[0]]
-        self.assertEquals(['cmark', 'llvm', 'swift', 'swiftpm'], names)
+        self.assertEqual(['cmark', 'llvm', 'swift', 'swiftpm'], names)

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -8,9 +8,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import unittest

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -16,12 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 


### PR DESCRIPTION
This converts the 'swift_build_support' module to support Python 3 (only). It removes all 'from __future__' imports and conditional python2 imports.

It also fixes an issue when attempting to get the length of a 'filter' result in productpipeline_list_builder.py, using a list comprehension instead.

It also removes the subprocess workaround for getting output as a  string, instead using the 'text=True' parameter.

This is part of the ongoing effort to explicitly move to Python 3 and remove any implied support for Python 2.
