### PR TITLE
[lit] Apply a different label for tests under validation-test/ than the ones under test/

### DIFF
--- a/validation-test/lit.cfg
+++ b/validation-test/lit.cfg
@@ -20,3 +20,4 @@ lit_config.load_config(config,
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
+config.name = 'Swift-validation(%s)' % config.variant_suffix[1:]


### PR DESCRIPTION
This will let us find the test file that produced a failure on the first attempt, saving the project at least three trillion cumulative person-seconds each year. 🙃 
