### PR TITLE
[5.5] async function pointer support for Windows

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -311,6 +311,7 @@ public:
   /// Used on Windows to avoid cross-module references.
   unsigned LazyInitializeClassMetadata : 1;
   unsigned LazyInitializeProtocolConformances : 1;
+  unsigned IndirectAsyncFunctionPointer : 1;
 
   /// Normally if the -read-legacy-type-info flag is not specified, we look for
   /// a file named "legacy-<arch>.yaml" in SearchPathOpts.RuntimeLibraryPath.
@@ -406,7 +407,8 @@ public:
         ValueNames(false), EnableReflectionMetadata(true),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
         ForcePublicLinkage(false), LazyInitializeClassMetadata(false),
-        LazyInitializeProtocolConformances(false), DisableLegacyTypeInfo(false),
+        LazyInitializeProtocolConformances(false),
+        IndirectAsyncFunctionPointer(false), DisableLegacyTypeInfo(false),
         PrespecializeGenericMetadata(false), UseIncrementalLLVMCodeGen(true),
         UseSwiftCall(false), UseTypeLayoutValueHandling(true),
         GenerateProfile(false), EnableDynamicReplacementChaining(false),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1700,6 +1700,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // witness.
   Opts.LazyInitializeProtocolConformances = Triple.isOSBinFormatCOFF();
 
+  // PE/COFF cannot deal with the cross-module reference to the
+  // AsyncFunctionPointer data block.  Force the use of indirect
+  // AsyncFunctionPointer access.
+  Opts.IndirectAsyncFunctionPointer = Triple.isOSBinFormatCOFF();
+
   if (Args.hasArg(OPT_disable_legacy_type_info)) {
     Opts.DisableLegacyTypeInfo = true;
   }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1977,6 +1977,46 @@ void IRGenFunction::emitAllExtractValues(llvm::Value *value,
     out.add(Builder.CreateExtractValue(value, i));
 }
 
+namespace {
+// TODO(compnerd) analyze if this should be out-lined via a runtime call rather
+// than be open-coded.  This needs to account for the fact that we are able to
+// statically optimize this often times due to CVP changing the select to a
+// `select i1 true, ...`.
+llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
+                                              llvm::Value *pointer) {
+  llvm::IntegerType *IntPtrTy = IGF.IGM.IntPtrTy;
+  llvm::Type *AsyncFunctionPointerPtrTy = IGF.IGM.AsyncFunctionPointerPtrTy;
+  llvm::Constant *Zero =
+      llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
+                                                      0));
+  llvm::Constant *One =
+      llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
+                                                      1));
+  llvm::Constant *NegativeOne =
+      llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
+                                                      -2));
+  swift::irgen::Alignment PointerAlignment = IGF.IGM.getPointerAlignment();
+
+  llvm::Value *PtrToInt = IGF.Builder.CreatePtrToInt(pointer, IntPtrTy);
+  llvm::Value *And = IGF.Builder.CreateAnd(PtrToInt, One);
+  llvm::Value *ICmp = IGF.Builder.CreateICmpEQ(And, Zero);
+
+  llvm::Value *BitCast =
+      IGF.Builder.CreateBitCast(pointer, AsyncFunctionPointerPtrTy);
+
+  llvm::Value *UntaggedPointer = IGF.Builder.CreateAnd(PtrToInt, NegativeOne);
+  llvm::Value *IntToPtr =
+      IGF.Builder.CreateIntToPtr(UntaggedPointer,
+                                 AsyncFunctionPointerPtrTy->getPointerTo());
+  llvm::Value *Load = IGF.Builder.CreateLoad(IntToPtr, PointerAlignment);
+
+  // (select (icmp eq, (and (ptrtoint %AsyncFunctionPointer), 1), 0),
+  //         (%AsyncFunctionPointer),
+  //         (inttoptr (and (ptrtoint %AsyncFunctionPointer), -2)))
+  return IGF.Builder.CreateSelect(ICmp, BitCast, Load);
+}
+}
+
 std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
     IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
     FunctionPointer functionPointer, llvm::Value *thickContext,
@@ -1998,9 +2038,11 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
       if (auto authInfo = functionPointer.getAuthInfo()) {
         ptr = emitPointerAuthAuth(IGF, ptr, authInfo);
       }
-      auto *afpPtr =
-          IGF.Builder.CreateBitCast(ptr, IGF.IGM.AsyncFunctionPointerPtrTy);
-      afpPtrValue = afpPtr;
+      afpPtrValue =
+          (IGF.IGM.getOptions().IndirectAsyncFunctionPointer)
+              ? emitIndirectAsyncFunctionPointer(IGF, ptr)
+              : IGF.Builder.CreateBitCast(ptr,
+                                          IGF.IGM.AsyncFunctionPointerPtrTy);
     }
     return *afpPtrValue;
   };
@@ -4800,6 +4842,8 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
     auto *fnPtr = Value;
     if (auto authInfo = AuthInfo) {
       fnPtr = emitPointerAuthAuth(IGF, fnPtr, authInfo);
+      if (IGF.IGM.getOptions().IndirectAsyncFunctionPointer)
+        fnPtr = emitIndirectAsyncFunctionPointer(IGF, fnPtr);
     }
     auto *descriptorPtr =
         IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.AsyncFunctionPointerPtrTy);

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -345,9 +345,34 @@ void IRGenModule::emitDispatchThunk(SILDeclRef declRef) {
 
 llvm::Constant *
 IRGenModule::getAddrOfAsyncFunctionPointer(LinkEntity entity) {
-  return getAddrOfLLVMVariable(
-    LinkEntity::forAsyncFunctionPointer(entity),
-    NotForDefinition, DebugTypeInfo());
+  llvm::Constant *Pointer =
+      getAddrOfLLVMVariable(LinkEntity::forAsyncFunctionPointer(entity),
+                            NotForDefinition, DebugTypeInfo());
+  if (!getOptions().IndirectAsyncFunctionPointer)
+    return Pointer;
+
+  // When the symbol does not have DLL Import storage, we must directly address
+  // it. Otherwise, we will form an invalid reference.
+  if (!Pointer->isDLLImportDependent())
+    return Pointer;
+
+  llvm::Constant *PointerPointer =
+      getOrCreateGOTEquivalent(Pointer,
+                               LinkEntity::forAsyncFunctionPointer(entity));
+  llvm::Constant *PointerPointerConstant =
+      llvm::ConstantExpr::getPtrToInt(PointerPointer, IntPtrTy);
+  llvm::Constant *Marker =
+      llvm::Constant::getIntegerValue(IntPtrTy, APInt(IntPtrTy->getBitWidth(),
+                                                      1));
+  // TODO(compnerd) ensure that the pointer alignment guarantees that bit-0 is
+  // cleared. We cannot use an `getOr` here as it does not form a relocatable
+  // expression.
+  llvm::Constant *Address =
+      llvm::ConstantExpr::getAdd(PointerPointerConstant, Marker);
+
+  IndirectAsyncFunctionPointers[entity] = Address;
+  return llvm::ConstantExpr::getIntToPtr(Address,
+                                         AsyncFunctionPointerTy->getPointerTo());
 }
 
 llvm::Constant *
@@ -371,6 +396,15 @@ IRGenModule::getSILFunctionForAsyncFunctionPointer(llvm::Constant *afp) {
   for (auto &entry : GlobalVars) {
     if (entry.getSecond() == afp) {
       auto entity = entry.getFirst();
+      return entity.getSILFunction();
+    }
+  }
+  for (auto &entry : IndirectAsyncFunctionPointers) {
+    if (entry.getSecond() == afp) {
+      auto entity = entry.getFirst();
+      assert(getOptions().IndirectAsyncFunctionPointer &&
+             "indirect async function found for non-indirect async function"
+             " target?");
       return entity.getSILFunction();
     }
   }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1097,6 +1097,7 @@ private:
                                            LinkEntity entity);
                                            
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalVars;
+  llvm::DenseMap<LinkEntity, llvm::Constant*> IndirectAsyncFunctionPointers;
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;
   llvm::DenseSet<const clang::Decl *> GlobalClangDecls;

--- a/test/IRGen/async-inheritance.swift
+++ b/test/IRGen/async-inheritance.swift
@@ -1,8 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(L)) -module-name L -emit-module -emit-module-path %t/L.swiftmodule %s -DL
-// RUN: %target-build-swift -I%t -L%t -lL -parse-as-library %s -module-name E -o %t/E %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(L)) -Xfrontend -disable-availability-checking -module-name L -emit-module -emit-module-path %t/L.swiftmodule %s -DL
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%t -L%t -lL -parse-as-library %s -module-name E -o %t/E %target-rpath(%t)
 // RUN: %target-codesign %t/E
 // RUN: %target-run %t/E %t/%target-library-name(L) | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
 
 #if L
 open class C {

--- a/test/IRGen/async-inheritance.swift
+++ b/test/IRGen/async-inheritance.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(L)) -module-name L -emit-module -emit-module-path %t/L.swiftmodule %s -DL
+// RUN: %target-build-swift -I%t -L%t -lL -parse-as-library %s -module-name E -o %t/E %target-rpath(%t)
+// RUN: %target-codesign %t/E
+// RUN: %target-run %t/E %t/%target-library-name(L) | %FileCheck %s
+
+#if L
+open class C {
+  public init() {}
+  open func f() async {
+    print("\(#function)")
+  }
+}
+#else
+import L
+class D: C {
+}
+
+@main
+struct S {
+  public static func main() async {
+    await D().f()
+  }
+}
+#endif
+
+// CHECK: f()

--- a/test/IRGen/async/class_resilience.swift
+++ b/test/IRGen/async/class_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-experimental-concurrency -disable-availability-checking -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class %S/Inputs/resilient_class.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-experimental-concurrency -disable-availability-checking -enable-library-evolution %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-experimental-concurrency -disable-availability-checking -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
 import resilient_class
@@ -42,7 +42,11 @@ open class MyBaseClass<T> {
 // CHECK-SAME: %swift.async_func_pointer* @"$s16class_resilience9MyDerivedC4waitSiyYaF010resilient_A09BaseClassCADxyYaFTVTu"
 
 // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYalF"(%swift.opaque* noalias nocapture %0, %swift.context* swiftasync %1{{.*}})
-// CHECK: %swift.async_func_pointer* @"$s15resilient_class9BaseClassC4waitxyYaFTjTu"
+// CHECK-DIRECT: %swift.async_func_pointer* @"$s15resilient_class9BaseClassC4waitxyYaFTjTu"
+// CHECK-INDIRECT: [[LOAD:%[0-9]+]] = load %swift.async_func_pointer*, %swift.async_func_pointer** inttoptr (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 -2) to %swift.async_func_pointer**), align {{4|8}}
+// CHECK-INDIRECT-NEXT: %14 = select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 1), i64 0),
+// CHECK-INDIRECT-SAME: %swift.async_func_pointer* inttoptr (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1) to %swift.async_func_pointer*),
+// CHECK-INDIRECT-SAME: %swift.async_func_pointer* [[LOAD]]
 // CHECK: ret void
 public func callsAwaitable<T>(_ c: BaseClass<T>) async -> T {
   return await c.wait()

--- a/test/IRGen/async/class_resilience.swift
+++ b/test/IRGen/async/class_resilience.swift
@@ -44,7 +44,7 @@ open class MyBaseClass<T> {
 // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYalF"(%swift.opaque* noalias nocapture %0, %swift.context* swiftasync %1{{.*}})
 // CHECK-DIRECT: %swift.async_func_pointer* @"$s15resilient_class9BaseClassC4waitxyYaFTjTu"
 // CHECK-INDIRECT: [[LOAD:%[0-9]+]] = load %swift.async_func_pointer*, %swift.async_func_pointer** inttoptr (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 -2) to %swift.async_func_pointer**), align {{4|8}}
-// CHECK-INDIRECT-NEXT: %14 = select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 1), i64 0),
+// CHECK-INDIRECT-NEXT: select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1), i64 1), i64 0),
 // CHECK-INDIRECT-SAME: %swift.async_func_pointer* inttoptr (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s15resilient_class9BaseClassC4waitxyYaFTjTu" to i64), i64 1) to %swift.async_func_pointer*),
 // CHECK-INDIRECT-SAME: %swift.async_func_pointer* [[LOAD]]
 // CHECK: ret void

--- a/test/IRGen/async/protocol_resilience.swift
+++ b/test/IRGen/async/protocol_resilience.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-experimental-concurrency -disable-availability-checking -g -enable-library-evolution -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/Inputs/resilient_protocol.swift
-// RUN: %target-swift-frontend -I %t -emit-ir -enable-experimental-concurrency -disable-availability-checking -g -enable-library-evolution %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-experimental-concurrency -disable-availability-checking -g -enable-library-evolution %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
 import resilient_protocol
@@ -27,7 +27,11 @@ public protocol MyAwaitable {
 // CHECK-SAME: %swift.async_func_pointer* @"$s19protocol_resilience19ConformsToAwaitableVyxG010resilient_A00E0AaeFP4wait6ResultQzyYaFTWTu"
 
 // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience14callsAwaitabley6ResultQzxYa010resilient_A00D0RzlF"(%swift.opaque* noalias nocapture %0, %swift.context* swiftasync %1, %swift.opaque* noalias nocapture %2, %swift.type* %T, i8** %T.Awaitable)
-// CHECK: %swift.async_func_pointer* @"$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu"
+// CHECK-DIRECT: %swift.async_func_pointer* @"$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu"
+// CHECK-INDIRECT: [[LOAD:%[0-9]+]] = load %swift.async_func_pointer*, %swift.async_func_pointer** inttoptr (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu" to i64), i64 1), i64 -2) to %swift.async_func_pointer**), align {{4|8}}
+// CHECK-INDIRECT: select i1 icmp eq (i64 and (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu" to i64), i64 1), i64 1), i64 0),
+// CHECK-INDIRECT-SAME: %swift.async_func_pointer* inttoptr (i64 add (i64 ptrtoint (%swift.async_func_pointer** @"\01__imp_$s18resilient_protocol9AwaitableP4wait6ResultQzyYaFTjTu" to i64), i64 1) to %swift.async_func_pointer*),
+// CHECK-INDIRECT-SAME: %swift.async_func_pointer* [[LOAD]]
 // CHECK: ret void
 public func callsAwaitable<T : Awaitable>(_ t: T) async -> T.Result {
   return await t.wait()

--- a/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
@@ -11,7 +11,6 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: windows
 
 import _Concurrency
 import NonresilientClass


### PR DESCRIPTION
I'm nominating this for Swift 5.5 on behalf of my team (XCTest) and the original PR author (@compnerd), since it supports Swift async test support. Our XCTest release manager @bcroom is out on vacation currently, but he approved this via Slack.

- Explanation: This fixes an issue leading to linker failures with open async functions on Windows. For detailed summary of the problem, see the original PR (#39998). The motivation for bringing it back to 5.5 is that this is one PR of several which support async XCTests, since this problem was identified as a blocker to landing the Corelibs XCTest changes for Windows.

- Scope: Limited. Affects code which has adopted async on Windows, and uses subclassing.

- SR Issue: SR-15399

- Risk: Low, only affecting PE/COFF (Windows), relatively new code which has adopted async, under narrow circumstances.

- Testing: New unit tests are included, it passes existing tests and smoke tests as well. Change has been on main for 2 weeks without issue. Also resolves an existing XFAIL’ed test on Windows.

- Reviewer: @aschwaighofer