### PR TITLE
[5.5][Index] Add an async symbol property for async functions

### DIFF
--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -249,6 +249,11 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
     info.Properties |= SymbolProperty::Local;
   }
 
+  if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
+    if (FD->hasAsync())
+      info.Properties |= SymbolProperty::SwiftAsync;
+  }
+
   return info;
 }
 

--- a/test/Index/async.swift
+++ b/test/Index/async.swift
@@ -1,0 +1,17 @@
+// REQUIRES: concurrency
+
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+func globalAsyncFunc() async {}
+// CHECK: [[@LINE-1]]:6 | function(swift_async)/Swift | globalAsyncFunc() | {{.*}} | Def | rel: 0
+
+struct MyStruct {
+  func asyncMethod() async {}
+  // CHECK: [[@LINE-1]]:8 | instance-method(swift_async)/Swift | asyncMethod() |
+}
+
+class XCTestCase {}
+class MyTestCase : XCTestCase {
+  func testSomeAsync() async {}
+  // CHECK: [[@LINE-1]]:8 | instance-method(test,swift_async)/Swift | testSomeAsync() |
+}


### PR DESCRIPTION
Cherry-pick b30e7b914d3f7148c2cc8920cad730010a855d56 (https://github.com/apple/swift/pull/39870)

Resolves SR-15476

-----

Resolves rdar://83780222