### PR TITLE
Add `_unavailableFromAsync` attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -634,3 +634,8 @@ calls a runtime function which allocates memory or locks, respectively.
 The `@_noLocks` attribute implies `@_noAllocation` because a memory allocation
 also locks.
 
+## `@_unavailableFromAsync`
+
+Marks a synchronous API as being unavailable from asynchronous contexts. Direct
+usage of annotated API from asynchronous contexts will result in a warning from
+the compiler.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -700,7 +700,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_const, CompileTimeConst,
   126)
 
 SIMPLE_DECL_ATTR(_unavailableFromAsync, UnavailableFromAsync,
-  OnFunc | OnConstructor |
+  OnFunc | OnConstructor | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove |
   APIBreakingToAdd | APIStableToRemove,
   127)

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -699,6 +699,12 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_const, CompileTimeConst,
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   126)
 
+SIMPLE_DECL_ATTR(_unavailableFromAsync, UnavailableFromAsync,
+  OnFunc | OnConstructor |
+  ABIStableToAdd | ABIStableToRemove |
+  APIBreakingToAdd | APIStableToRemove,
+  127)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -296,6 +296,9 @@ public:
   /// Returns the kind of context this is.
   DeclContextKind getContextKind() const;
 
+  /// Returns whether this context asynchronous
+  bool isAsyncContext() const;
+
   /// Returns whether this context has value semantics.
   bool hasValueSemantics() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4722,6 +4722,15 @@ ERROR(actor_isolation_superclass_mismatch,none,
       "%0 class %1 has different actor isolation from %2 superclass %3",
       (ActorIsolation, DeclName, ActorIsolation, DeclName))
 
+ERROR(async_decl_must_be_available_from_async,none,
+        "asynchronous %0 must be available from asynchronous contexts",
+        (DescriptiveDeclKind))
+ERROR(async_named_decl_must_be_available_from_async,none,
+        "asynchronous %0 %1 must be available from asynchronous contexts",
+        (DescriptiveDeclKind, DeclName))
+ERROR(async_unavailable_decl,none,
+      "%0 %1 is unavailable from asynchronous contexts", (DescriptiveDeclKind, DeclBaseName))
+
 //------------------------------------------------------------------------------
 // MARK: Type Check Types
 //------------------------------------------------------------------------------

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3601,6 +3601,13 @@ public:
   /// Only valid when \c hasSingleExpressionBody() is true.
   Expr *getSingleExpressionBody() const;
 
+  /// Whether this closure has a body
+  bool hasBody() const;
+
+  /// Returns the body of closures that have a body
+  /// returns nullptr if the closure doesn't have a body
+  BraceStmt *getBody() const;
+
   ClosureActorIsolation getActorIsolation() const { return actorIsolation; }
 
   void setActorIsolation(ClosureActorIsolation actorIsolation) {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1204,6 +1204,32 @@ bool DeclContext::isClassConstrainedProtocolExtension() const {
   return false;
 }
 
+bool DeclContext::isAsyncContext() const {
+  switch (getContextKind()) {
+  case DeclContextKind::Initializer:
+  case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::EnumElementDecl:
+  case DeclContextKind::ExtensionDecl:
+  case DeclContextKind::SerializedLocal:
+  case DeclContextKind::Module:
+  case DeclContextKind::FileUnit:
+  case DeclContextKind::GenericTypeDecl:
+    return false;
+  case DeclContextKind::AbstractClosureExpr:
+    return cast<AbstractClosureExpr>(this)->isBodyAsync();
+  case DeclContextKind::AbstractFunctionDecl: {
+    const AbstractFunctionDecl *function = cast<AbstractFunctionDecl>(this);
+    return function->hasAsync();
+  }
+  case DeclContextKind::SubscriptDecl: {
+    AccessorDecl *getter =
+        cast<SubscriptDecl>(this)->getAccessor(AccessorKind::Get);
+    return getter != nullptr && getter->hasAsync();
+  }
+  }
+  llvm_unreachable("Unhandled DeclContextKind switch");
+}
+
 SourceLoc swift::extractNearestSourceLoc(const DeclContext *dc) {
   switch (dc->getContextKind()) {
   case DeclContextKind::Module:

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1674,6 +1674,26 @@ void AbstractClosureExpr::setParameterList(ParameterList *P) {
     P->setDeclContextOfParamDecls(this);
 }
 
+bool AbstractClosureExpr::hasBody() const {
+  switch (getKind()) {
+    case ExprKind::Closure:
+    case ExprKind::AutoClosure:
+      return true;
+    default:
+      return false;
+  }
+}
+
+BraceStmt * AbstractClosureExpr::getBody() const {
+  if (!hasBody())
+    return nullptr;
+  if (const AutoClosureExpr *autocls = dyn_cast<AutoClosureExpr>(this))
+    return autocls->getBody();
+  if (const ClosureExpr *cls = dyn_cast<ClosureExpr>(this))
+    return cls->getBody();
+  llvm_unreachable("Unknown closure expression");
+}
+
 Type AbstractClosureExpr::getResultType(
     llvm::function_ref<Type(Expr *)> getType) const {
   auto *E = const_cast<AbstractClosureExpr *>(this);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2083,8 +2083,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   }
 
   auto where = ExportContext::forDeclSignature(D);
-  diagnoseDeclAvailability(mainFunction, attr->getRange(), nullptr, where, None,
-                           /*containingClosure*/ nullptr);
+  diagnoseDeclAvailability(mainFunction, attr->getRange(), nullptr, where, None);
 
   auto *const func = FuncDecl::createImplicit(
       context, StaticSpellingKind::KeywordStatic,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -27,6 +27,7 @@ namespace swift {
   class ApplyExpr;
   class AvailableAttr;
   class Expr;
+  class ClosureExpr;
   class InFlightDiagnostic;
   class Decl;
   class ProtocolConformanceRef;
@@ -232,7 +233,8 @@ diagnoseSubstitutionMapAvailability(SourceLoc loc,
 /// was emitted.
 bool diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
                               const Expr *call, const ExportContext &where,
-                              DeclAvailabilityFlags flags = None);
+                              DeclAvailabilityFlags flags = None,
+                              const ClosureExpr *singleExprClosure = nullptr);
 
 void diagnoseUnavailableOverride(ValueDecl *override,
                                  const ValueDecl *base,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -233,8 +233,7 @@ diagnoseSubstitutionMapAvailability(SourceLoc loc,
 /// was emitted.
 bool diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
                               const Expr *call, const ExportContext &where,
-                              DeclAvailabilityFlags flags = None,
-                              const ClosureExpr *singleExprClosure = nullptr);
+                              DeclAvailabilityFlags flags = None);
 
 void diagnoseUnavailableOverride(ValueDecl *override,
                                  const ValueDecl *base,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1559,6 +1559,7 @@ namespace  {
     UNINTERESTING_ATTR(InheritActorContext)
     UNINTERESTING_ATTR(Isolated)
     UNINTERESTING_ATTR(NoImplicitCopy)
+    UNINTERESTING_ATTR(UnavailableFromAsync)
 
     UNINTERESTING_ATTR(TypeSequence)
     UNINTERESTING_ATTR(CompileTimeConst)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 646; // hasHermeticSealAtLink option
+const uint16_t SWIFTMODULE_VERSION_MINOR = 647; // _unavailableFromAsync attr
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,9 +1,11 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -disable-availability-checking  %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
+
+if #available(SwiftStdlib 5.5, *) {
 
 @MainActor func onlyOnMainActor() { }
 
@@ -42,6 +44,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   let _: Int = await slowServer.bestName("hello")
   let _: Int = await slowServer.customize("hello")
+
+  slowServer.unavailableMethod() // expected-warning{{'unavailableMethod' is unavailable from asynchronous contexts}}
 
   let _: String = await slowServer.dance("slide")
   let _: String = await slowServer.__leap(17)
@@ -213,3 +217,5 @@ func testMirrored(instance: ClassWithAsync) async {
     }
   }
 }
+
+} // SwiftStdlib 5.5

--- a/test/Concurrency/Inputs/UnavailableFunction.swift
+++ b/test/Concurrency/Inputs/UnavailableFunction.swift
@@ -1,0 +1,2 @@
+@_unavailableFromAsync
+public func unavailableFunction() { }

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -1,0 +1,130 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/UnavailableFunction.swiftmodule -module-name UnavailableFunction -warn-concurrency %S/Inputs/UnavailableFunction.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %t %s
+
+// REQUIRES: concurrency
+
+import UnavailableFunction
+
+@available(SwiftStdlib 5.1, *)
+func okay() {}
+
+// expected-error@+1{{'@_unavailableFromAsync' attribute cannot be applied to this declaration}}
+@_unavailableFromAsync
+@available(SwiftStdlib 5.1, *)
+struct Foo { }
+
+// expected-error@+1{{'@_unavailableFromAsync' attribute cannot be applied to this declaration}}
+@_unavailableFromAsync
+@available(SwiftStdlib 5.1, *)
+extension Foo { }
+
+// expected-error@+1{{'@_unavailableFromAsync' attribute cannot be applied to this declaration}}
+@_unavailableFromAsync
+@available(SwiftStdlib 5.1, *)
+class Bar {
+  // expected-error@+1{{'@_unavailableFromAsync' attribute cannot be applied to this declaration}}
+  @_unavailableFromAsync
+  deinit { }
+}
+
+// expected-error@+1{{'@_unavailableFromAsync' attribute cannot be applied to this declaration}}
+@_unavailableFromAsync
+@available(SwiftStdlib 5.1, *)
+actor Baz { }
+
+@available(SwiftStdlib 5.1, *)
+struct Bop {
+  @_unavailableFromAsync
+  init() {}                 // expected-note 4 {{'init()' declared here}}
+
+  init(a: Int) { }
+}
+
+@available(SwiftStdlib 5.1, *)
+extension Bop {
+  @_unavailableFromAsync
+  func foo() {}             // expected-note 4 {{'foo()' declared here}}
+
+
+  @_unavailableFromAsync
+  mutating func muppet() { }  // expected-note 4 {{'muppet()' declared here}}
+}
+
+@_unavailableFromAsync
+@available(SwiftStdlib 5.1, *)
+func foo() {}               // expected-note 4 {{'foo()' declared here}}
+
+@available(SwiftStdlib 5.1, *)
+func makeAsyncClosuresSynchronously(bop: inout Bop) -> (() async -> Void) {
+  return { () async -> Void in
+    // Unavailable methods
+    _ = Bop()     // expected-warning@:9{{'init' is unavailable from asynchronous contexts}}
+    _ = Bop(a: 32)
+    bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
+    bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
+    unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
+
+    // Can use them from synchronous closures
+    _ = { Bop() }()
+    _ = { bop.foo() }()
+    _ = { bop.muppet() }()
+
+    // Unavailable global function
+    foo()         // expected-warning{{'foo' is unavailable from asynchronous contexts}}
+
+    // Okay function
+    okay()
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@_unavailableFromAsync
+func asyncFunc() async { // expected-error{{asynchronous global function 'asyncFunc()' must be available from asynchronous contexts}}
+
+  var bop = Bop(a: 32)
+  _ = Bop()     // expected-warning@:7{{'init' is unavailable from asynchronous contexts}}
+  bop.foo()     // expected-warning@:7{{'foo' is unavailable from asynchronous contexts}}
+  bop.muppet()  // expected-warning@:7{{'muppet' is unavailable from asynchronous contexts}}
+  unavailableFunction() // expected-warning@:3{{'unavailableFunction' is unavailable from asynchronous contexts}}
+
+  // Unavailable global function
+  foo()         // expected-warning{{'foo' is unavailable from asynchronous contexts}}
+
+  // Available function
+  okay()
+
+  _ = { () -> Void in
+    // Check unavailable things inside of a nested synchronous closure
+    _ = Bop()
+    foo()
+    bop.foo()
+    bop.muppet()
+    unavailableFunction()
+
+    _ = { () async -> Void in
+      // Check Unavailable things inside of a nested async closure
+      foo()           // expected-warning@:7{{'foo' is unavailable from asynchronous contexts}}
+      bop.foo()       // expected-warning@:11{{'foo' is unavailable from asynchronous contexts}}
+      bop.muppet()    // expected-warning@:11{{'muppet' is unavailable from asynchronous contexts}}
+      _ = Bop()       // expected-warning@:11{{'init' is unavailable from asynchronous contexts}}
+      unavailableFunction() // expected-warning@:7{{'unavailableFunction' is unavailable from asynchronous contexts}}
+    }
+  }
+
+  _ = { () async -> Void in
+    _ = Bop()     // expected-warning@:9{{'init' is unavailable from asynchronous contexts}}
+    foo()         // expected-warning@:5{{'foo' is unavailable from asynchronous contexts}}
+    bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
+    bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
+    unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
+
+    _ = {
+      foo()
+      bop.foo()
+      _ = Bop()
+      unavailableFunction()
+    }
+  }
+
+}

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -71,7 +71,8 @@ struct MyStruct {}
 // KEYWORD2-NEXT:             Keyword/None:                       derivative[#Func Attribute#]; name=derivative
 // KEYWORD2-NEXT:             Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // KEYWORD2-NEXT:             Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
-// KEYWORD2-NEXT:             Keyword/None:          Sendable[#Func Attribute#]; name=Sendable
+// KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
+// KEYWORD2-NEXT:             Keyword/None:                       _unavailableFromAsync[#Func Attribute#]; name=_unavailableFromAsync
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2:                  End completions
@@ -155,6 +156,7 @@ struct _S {
 // ON_INIT-DAG: Keyword/None:                       inlinable[#Constructor Attribute#]; name=inlinable
 // ON_INIT-DAG: Keyword/None:                       usableFromInline[#Constructor Attribute#]; name=usableFromInline
 // ON_INIT-DAG: Keyword/None:                       discardableResult[#Constructor Attribute#]; name=discardableResult
+// ON_INIT-DAG: Keyword/None:                       _unavailableFromAsync[#Constructor Attribute#]; name=_unavailableFromAsync
 // ON_INIT: End completions
 
   @#^ON_PROPERTY^# var foo
@@ -196,6 +198,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // ON_METHOD-DAG: Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
+// ON_METHOD-DAG: Keyword/None:                       _unavailableFromAsync[#Func Attribute#]; name=_unavailableFromAsync
 // ON_METHOD-NOT: Keyword
 // ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD: End completions
@@ -257,6 +260,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // ON_MEMBER_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // ON_MEMBER_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
+// ON_MEMBER_LAST-DAG: Keyword/None:                       _unavailableFromAsync[#Declaration Attribute#]; name=_unavailableFromAsync
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
@@ -307,6 +311,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // KEYWORD_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // KEYWORD_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
+// KEYWORD_LAST-DAG: Keyword/None:                       _unavailableFromAsync[#Declaration Attribute#]; name=_unavailableFromAsync
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST:                  End completions

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -72,7 +72,6 @@ struct MyStruct {}
 // KEYWORD2-NEXT:             Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // KEYWORD2-NEXT:             Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
-// KEYWORD2-NEXT:             Keyword/None:                       _unavailableFromAsync[#Func Attribute#]; name=_unavailableFromAsync
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2:                  End completions
@@ -156,7 +155,6 @@ struct _S {
 // ON_INIT-DAG: Keyword/None:                       inlinable[#Constructor Attribute#]; name=inlinable
 // ON_INIT-DAG: Keyword/None:                       usableFromInline[#Constructor Attribute#]; name=usableFromInline
 // ON_INIT-DAG: Keyword/None:                       discardableResult[#Constructor Attribute#]; name=discardableResult
-// ON_INIT-DAG: Keyword/None:                       _unavailableFromAsync[#Constructor Attribute#]; name=_unavailableFromAsync
 // ON_INIT: End completions
 
   @#^ON_PROPERTY^# var foo
@@ -198,7 +196,6 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // ON_METHOD-DAG: Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
-// ON_METHOD-DAG: Keyword/None:                       _unavailableFromAsync[#Func Attribute#]; name=_unavailableFromAsync
 // ON_METHOD-NOT: Keyword
 // ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD: End completions
@@ -260,7 +257,6 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // ON_MEMBER_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // ON_MEMBER_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
-// ON_MEMBER_LAST-DAG: Keyword/None:                       _unavailableFromAsync[#Declaration Attribute#]; name=_unavailableFromAsync
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
@@ -311,7 +307,6 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // KEYWORD_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // KEYWORD_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
-// KEYWORD_LAST-DAG: Keyword/None:                       _unavailableFromAsync[#Declaration Attribute#]; name=_unavailableFromAsync
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST:                  End completions

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -66,6 +66,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 
 -(void)customizedWithString:(NSString *)operation completionHandler:(void (^)(NSInteger))handler __attribute__((swift_name("customize(with:completionHandler:)"))) __attribute__((swift_async_name("customize(_:)")));
 
+-(void)unavailableMethod __attribute__((__swift_attr__("@_unavailableFromAsync")));
+
 -(void)dance:(NSString *)step andThen:(void (^)(NSString *))doSomething __attribute__((swift_async(not_swift_private,2)));
 -(void)leap:(NSInteger)height andThen:(void (^)(NSString *))doSomething __attribute__((swift_async(swift_private,2)));
 


### PR DESCRIPTION
This PR introduces a new underscored attribute `_unavailableFromAsync`, which marks synchronous API as being unavailable from asynchronous contexts. Using an annotated API directly in an asynchronous context will result in a compiler warning message.

https://forums.swift.org/t/discussion-unavailability-from-asynchronous-contexts/53088
rdar://70256865