### PR TITLE
Fix ambiguous call to report_fatal_error

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -506,6 +506,7 @@ ASTContext::getSwift5PlusAvailability(llvm::VersionTuple swiftVersion) {
     default: break;
     }
   }
-  llvm::report_fatal_error("Missing call to getSwiftXYAvailability for Swift " +
-                           swiftVersion.getAsString());
+  llvm::report_fatal_error(
+      Twine("Missing call to getSwiftXYAvailability for Swift ") +
+      swiftVersion.getAsString());
 }


### PR DESCRIPTION
report_fatal_error added a `const Twine &` overload a while ago, which
was fine since `const std::string &` was a better match.
`const std::string &` was recently removed, however, which then caused
an ambiguous match between `const Twine &` and `StringRef` overloads.