### PR TITLE
Update sourcekitd use of install_fatal_error_handler

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -338,11 +338,11 @@ static void sourcekitdServer_event_handler(xpc_connection_t peer) {
   });
 }
 
-static void fatal_error_handler(void *user_data, const std::string& reason,
+static void fatal_error_handler(void *user_data, const char *reason,
                                 bool gen_crash_diag) {
   // Write the result out to stderr avoiding errs() because raw_ostreams can
   // call report_fatal_error.
-  fprintf(stderr, "SOURCEKITD SERVER FATAL ERROR: %s\n", reason.c_str());
+  fprintf(stderr, "SOURCEKITD SERVER FATAL ERROR: %s\n", reason);
   if (gen_crash_diag)
     ::abort();
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -189,12 +189,12 @@ void sourcekitd::printResponse(sourcekitd_response_t Resp, raw_ostream &OS) {
     printVariant(sourcekitd_response_get_value(Resp), OS);
 }
 
-static void fatal_error_handler(void *user_data, const std::string& reason,
+static void fatal_error_handler(void *user_data, const char *reason,
                                 bool gen_crash_diag) {
   // Write the result out to stderr avoiding errs() because raw_ostreams can
   // call report_fatal_error.
   // FIXME: Put the error message in the crash report.
-  fprintf(stderr, "SOURCEKITD FATAL ERROR: %s\n", reason.c_str());
+  fprintf(stderr, "SOURCEKITD FATAL ERROR: %s\n", reason);
   ::abort();
 }
 


### PR DESCRIPTION
Cherry-pick from https://github.com/apple/swift/pull/40152 after I noticed these were also failing on next.

-----

e463b69736da8b0a950ecd937cf990401bdfcdeb changed `fatal_error_handler_t`
to use a `const char *` `reason` rather than `const std::string &`.
Update sourcekitd to use `const char *` for the handler instead.