### PR TITLE
[Serialization] Improve module loading performance

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -16,27 +16,155 @@
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/PathRemapper.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 #include <string>
 #include <vector>
 
 namespace swift {
 
+/// The kind of a module search path. The order of this enum is important
+/// because import search paths should be considered before framework search
+/// paths etc.
+enum class ModuleSearchPathKind {
+  Import,
+  Framework,
+  DarwinImplictFramework,
+  RuntimeLibrary,
+};
+
+/// A single module search path that can come from different sources, e.g.
+/// framework search paths, import search path etc.
+struct ModuleSearchPath {
+  /// The actual path of the module search path. References a search path string
+  /// stored inside \c SearchPathOptions, which must outlive this reference.
+  StringRef Path;
+
+  /// The kind of the search path.
+  ModuleSearchPathKind Kind;
+
+  bool IsSystem;
+
+  /// An index that describes the order this search path should be considered
+  /// in within its \c ModuleSearchPathKind. This allows us to reconstruct the
+  /// user-defined search path order when merging search paths containing
+  /// different file names in \c searchPathsContainingFile.
+  unsigned Index;
+
+  bool operator<(const ModuleSearchPath &Other) const {
+    if (this->Kind == Other.Kind) {
+      return this->Index < Other.Index;
+    } else {
+      return this->Kind < Other.Kind;
+    }
+  }
+};
+
+class SearchPathOptions;
+
+/// Maintains a mapping of filenames to search paths that contain a file with
+/// this name (non-recursively). E.g. if we have a directory structure as
+/// follows.
+///
+/// \code
+/// searchPath1/
+///   Module1.framework
+///
+/// searchPath2/
+///   Module1.framework
+///   Module2.swiftmodule
+/// \endcode
+///
+/// We have the following lookup table
+///
+/// \code
+/// Module1.framework -> [searchPath1, searchPath2]
+/// Module2.swiftmodule -> [searchPath2]
+/// \endcode
+///
+/// When searching for a module this allows an efficient search of only those
+/// search paths that are relevant. In a naive implementation, we would need
+/// to scan all search paths for every module we import.
+class ModuleSearchPathLookup {
+  /// Parameters for which the \c LookupTable has been built. If one if these
+  /// changes, the lookup table needs to be rebuilt. It is not expected that any
+  /// of these change frequently.
+  struct {
+    llvm::vfs::FileSystem *FileSystem;
+    bool IsOSDarwin;
+    bool IsPopulated;
+    const SearchPathOptions *Opts;
+  } State;
+
+  llvm::StringMap<SmallVector<ModuleSearchPath, 4>> LookupTable;
+
+  /// Scan the directory at \p SearchPath for files and add those files to the
+  /// lookup table. \p Kind specifies the search path kind and \p Index the
+  /// index of \p SearchPath within that search path kind. Search paths with
+  /// lower indicies are considered first.
+  /// The \p SearchPath is stored by as a \c StringRef, so the string backing it
+  /// must be alive as long as this lookup table is alive and not cleared.
+  void addFilesInPathToLookupTable(llvm::vfs::FileSystem *FS,
+                                   StringRef SearchPath,
+                                   ModuleSearchPathKind Kind, bool IsSystem,
+                                   unsigned Index);
+
+  /// Discard the current lookup table and rebuild a new one.
+  void rebuildLookupTable(const SearchPathOptions *Opts,
+                          llvm::vfs::FileSystem *FS, bool IsOsDarwin);
+
+  /// Discard the current lookup table.
+  void clearLookupTable() {
+    LookupTable.clear();
+    State.IsPopulated = false;
+    State.FileSystem = nullptr;
+    State.IsOSDarwin = false;
+    State.Opts = nullptr;
+  }
+
+public:
+  /// Called by \p SearchPathOptions when search paths indexed by this \c
+  /// SearchPathLookup have changed in an unknown way. Causes the lookup table
+  /// to be rebuilt at the next request.
+  void searchPathsDidChange() { clearLookupTable(); }
+
+  /// Called by \p SearchPathOptions when an import or framework search path has
+  /// been added.
+  /// \p Index is the index of the search path within its kind and is used to
+  /// make sure this search path is considered last (within its kind).
+  void searchPathAdded(llvm::vfs::FileSystem *FS, StringRef SearchPath,
+                       ModuleSearchPathKind Kind, bool IsSystem,
+                       unsigned Index) {
+    if (!State.IsPopulated) {
+      // If the lookup table hasn't been built yet, we will scan the search path
+      // once the lookup table is requested. Nothing to do yet.
+      return;
+    }
+    if (State.FileSystem != FS) {
+      // We would be using a different file system to augment the lookup table
+      // than we initially used to build it. Discard everything to be safe.
+      clearLookupTable();
+      return;
+    }
+    addFilesInPathToLookupTable(FS, SearchPath, Kind, IsSystem, Index);
+  }
+
+  /// Returns all search paths that non-recursively contain a file whose name
+  /// is in \p Filenames.
+  SmallVector<const ModuleSearchPath *, 4>
+  searchPathsContainingFile(const SearchPathOptions *Opts,
+                            llvm::ArrayRef<std::string> Filenames,
+                            llvm::vfs::FileSystem *FS, bool IsOSDarwin);
+};
+
 /// Options for controlling search path behavior.
 class SearchPathOptions {
-public:
-  /// Path to the SDK which is being built against.
-  std::string SDKPath;
-
-  /// Path(s) which should be searched for modules.
-  ///
-  /// Do not add values to this directly. Instead, use
+  /// To call \c addImportSearchPath and \c addFrameworkSearchPath from
   /// \c ASTContext::addSearchPath.
-  std::vector<std::string> ImportSearchPaths;
+  friend class ASTContext;
 
-  /// Path(s) to virtual filesystem overlay YAML files.
-  std::vector<std::string> VFSOverlayFiles;
-
+public:
   struct FrameworkSearchPath {
     std::string Path;
     bool IsSystem = false;
@@ -52,11 +180,115 @@ public:
       return !(LHS == RHS);
     }
   };
+
+private:
+  ModuleSearchPathLookup Lookup;
+
+  /// Path to the SDK which is being built against.
+  ///
+  /// Must me modified through setter to keep \c SearchPathLookup in sync.
+  std::string SDKPath;
+
+  /// Path(s) which should be searched for modules.
+  ///
+  /// Must me modified through setter to keep \c SearchPathLookup in sync.
+  std::vector<std::string> ImportSearchPaths;
+
   /// Path(s) which should be searched for frameworks.
   ///
-  /// Do not add values to this directly. Instead, use
-  /// \c ASTContext::addSearchPath.
+  /// Must me modified through setter to keep \c SearchPathLookup in sync.
   std::vector<FrameworkSearchPath> FrameworkSearchPaths;
+
+  /// Paths to search for stdlib modules. One of these will be
+  /// compiler-relative.
+  ///
+  /// Must me modified through setter to keep \c SearchPathLookup in sync.
+  std::vector<std::string> RuntimeLibraryImportPaths;
+
+  /// When on Darwin the framework paths that are implicitly imported.
+  /// $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
+  ///
+  /// On non-Darwin platforms these are populated, but ignored.
+  ///
+  /// Computed when the SDK path is set and cached so we can reference the
+  /// Darwin implicit framework search paths as \c StringRef from
+  /// \c ModuleSearchPath.
+  std::vector<std::string> DarwinImplicitFrameworkSearchPaths;
+
+  /// Add a single import search path. Must only be called from
+  /// \c ASTContext::addSearchPath.
+  void addImportSearchPath(StringRef Path, llvm::vfs::FileSystem *FS) {
+    ImportSearchPaths.push_back(Path.str());
+    Lookup.searchPathAdded(FS, ImportSearchPaths.back(),
+                           ModuleSearchPathKind::Import, /*isSystem=*/false,
+                           ImportSearchPaths.size() - 1);
+  }
+
+  /// Add a single framework search path. Must only be called from
+  /// \c ASTContext::addSearchPath.
+  void addFrameworkSearchPath(FrameworkSearchPath NewPath,
+                              llvm::vfs::FileSystem *FS) {
+    FrameworkSearchPaths.push_back(NewPath);
+    Lookup.searchPathAdded(FS, FrameworkSearchPaths.back().Path,
+                           ModuleSearchPathKind::Framework, NewPath.IsSystem,
+                           FrameworkSearchPaths.size() - 1);
+  }
+
+public:
+  StringRef getSDKPath() const { return SDKPath; }
+
+  void setSDKPath(std::string NewSDKPath) {
+    SDKPath = NewSDKPath;
+
+    // Compute Darwin implicit framework search paths.
+    SmallString<128> systemFrameworksScratch(NewSDKPath);
+    llvm::sys::path::append(systemFrameworksScratch, "System", "Library",
+                            "Frameworks");
+    SmallString<128> frameworksScratch(NewSDKPath);
+    llvm::sys::path::append(frameworksScratch, "Library", "Frameworks");
+    DarwinImplicitFrameworkSearchPaths = {systemFrameworksScratch.str().str(),
+                                          frameworksScratch.str().str()};
+
+    Lookup.searchPathsDidChange();
+  }
+
+  ArrayRef<std::string> getImportSearchPaths() const {
+    return ImportSearchPaths;
+  }
+
+  void setImportSearchPaths(std::vector<std::string> NewImportSearchPaths) {
+    ImportSearchPaths = NewImportSearchPaths;
+    Lookup.searchPathsDidChange();
+  }
+
+  ArrayRef<FrameworkSearchPath> getFrameworkSearchPaths() const {
+    return FrameworkSearchPaths;
+  }
+
+  void setFrameworkSearchPaths(
+      std::vector<FrameworkSearchPath> NewFrameworkSearchPaths) {
+    FrameworkSearchPaths = NewFrameworkSearchPaths;
+    Lookup.searchPathsDidChange();
+  }
+
+  /// The extra implicit framework search paths on Apple platforms:
+  /// $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
+  ArrayRef<std::string> getDarwinImplicitFrameworkSearchPaths() const {
+    return DarwinImplicitFrameworkSearchPaths;
+  }
+
+  ArrayRef<std::string> getRuntimeLibraryImportPaths() const {
+    return RuntimeLibraryImportPaths;
+  }
+
+  void setRuntimeLibraryImportPaths(
+      std::vector<std::string> NewRuntimeLibraryImportPaths) {
+    RuntimeLibraryImportPaths = NewRuntimeLibraryImportPaths;
+    Lookup.searchPathsDidChange();
+  }
+
+  /// Path(s) to virtual filesystem overlay YAML files.
+  std::vector<std::string> VFSOverlayFiles;
 
   /// Path(s) which should be searched for libraries.
   ///
@@ -69,9 +301,6 @@ public:
   /// Paths to search for compiler-relative stdlib dylibs, in order of
   /// preference.
   std::vector<std::string> RuntimeLibraryPaths;
-
-  /// Paths to search for stdlib modules. One of these will be compiler-relative.
-  std::vector<std::string> RuntimeLibraryImportPaths;
 
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;
@@ -107,6 +336,14 @@ public:
   /// original form.
   PathObfuscator DeserializedPathRecoverer;
 
+  /// Return all module search paths that (non-recursively) contain a file whose
+  /// name is in \p Filenames.
+  SmallVector<const ModuleSearchPath *, 4>
+  moduleSearchPathsContainingFile(llvm::ArrayRef<std::string> Filenames,
+                                  llvm::vfs::FileSystem *FS, bool IsOSDarwin) {
+    return Lookup.searchPathsContainingFile(this, Filenames, FS, IsOSDarwin);
+  }
+
 private:
   static StringRef
   pathStringFromFrameworkSearchPath(const FrameworkSearchPath &next) {
@@ -141,7 +378,6 @@ public:
                         DisableModulesValidateSystemDependencies);
   }
 };
-
 }
 
 #endif

--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -24,6 +24,7 @@
 #ifndef SWIFT_BASIC_PATHREMAPPER_H
 #define SWIFT_BASIC_PATHREMAPPER_H
 
+#include "swift/Basic/LLVM.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -170,20 +170,20 @@ public:
   }
 
   void setImportSearchPaths(const std::vector<std::string> &Paths) {
-    SearchPathOpts.ImportSearchPaths = Paths;
+    SearchPathOpts.setImportSearchPaths(Paths);
   }
 
   ArrayRef<std::string> getImportSearchPaths() const {
-    return SearchPathOpts.ImportSearchPaths;
+    return SearchPathOpts.getImportSearchPaths();
   }
 
   void setFrameworkSearchPaths(
              const std::vector<SearchPathOptions::FrameworkSearchPath> &Paths) {
-    SearchPathOpts.FrameworkSearchPaths = Paths;
+    SearchPathOpts.setFrameworkSearchPaths(Paths);
   }
 
   ArrayRef<SearchPathOptions::FrameworkSearchPath> getFrameworkSearchPaths() const {
-    return SearchPathOpts.FrameworkSearchPaths;
+    return SearchPathOpts.getFrameworkSearchPaths();
   }
 
   void setExtraClangArgs(const std::vector<std::string> &Args) {
@@ -229,9 +229,7 @@ public:
 
   void setSDKPath(const std::string &Path);
 
-  StringRef getSDKPath() const {
-    return SearchPathOpts.SDKPath;
-  }
+  StringRef getSDKPath() const { return SearchPathOpts.getSDKPath(); }
 
   LangOptions &getLangOptions() {
     return LangOpts;

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -110,14 +110,14 @@ namespace swift {
         }
       }
 
-      std::error_code findModuleFilesInDirectory(
-          ImportPath::Element ModuleID,
-          const SerializedModuleBaseName &BaseName,
-          SmallVectorImpl<char> *ModuleInterfacePath,
-          std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-          std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-          std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-          bool skipBuildingInterface, bool IsFramework) override;
+      virtual bool
+      findModule(ImportPath::Element moduleID,
+                 SmallVectorImpl<char> *moduleInterfacePath,
+                 std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
+                 std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+                 std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
+                 bool skipBuildingInterface, bool &isFramework,
+                 bool &isSystemModule) override;
 
       static bool classof(const ModuleDependencyScanner *MDS) {
         return MDS->getKind() == MDS_placeholder;

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -88,6 +88,7 @@ add_swift_host_library(swiftAST STATIC
   RequirementMachine/RewriteSystem.cpp
   RequirementMachine/Symbol.cpp
   RequirementMachine/Term.cpp
+  SearchPathOptions.cpp
   SILLayout.cpp
   Stmt.cpp
   SubstitutionMap.cpp

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2519,7 +2519,7 @@ ModuleLibraryLevelRequest::evaluate(Evaluator &evaluator,
 
     namespace path = llvm::sys::path;
     SmallString<128> scratch;
-    scratch = ctx.SearchPathOpts.SDKPath;
+    scratch = ctx.SearchPathOpts.getSDKPath();
     path::append(scratch, "System", "Library", "PrivateFrameworks");
     return hasPrefix(path::begin(modulePath), path::end(modulePath),
                      path::begin(scratch), path::end(scratch));

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -1,0 +1,107 @@
+//===----------------------- SearchPathOptions.cpp ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/SearchPathOptions.h"
+#include "llvm/ADT/SmallSet.h"
+
+using namespace swift;
+
+void ModuleSearchPathLookup::addFilesInPathToLookupTable(
+    llvm::vfs::FileSystem *FS, StringRef SearchPath, ModuleSearchPathKind Kind,
+    bool IsSystem, unsigned SearchPathIndex) {
+  std::error_code Error;
+  assert(llvm::all_of(LookupTable, [&](const auto &LookupTableEntry) {
+    return llvm::none_of(LookupTableEntry.second, [&](const ModuleSearchPath &ExistingSearchPath) -> bool {
+      return ExistingSearchPath.Kind == Kind && ExistingSearchPath.Index == SearchPathIndex;
+    });
+  }) && "Search path with this kind and index already exists");
+  for (auto Dir = FS->dir_begin(SearchPath, Error);
+       !Error && Dir != llvm::vfs::directory_iterator(); Dir.increment(Error)) {
+    StringRef Filename = llvm::sys::path::filename(Dir->path());
+    LookupTable[Filename].push_back(
+        {SearchPath, Kind, IsSystem, SearchPathIndex});
+  }
+}
+
+void ModuleSearchPathLookup::rebuildLookupTable(const SearchPathOptions *Opts,
+                                                llvm::vfs::FileSystem *FS,
+                                                bool IsOSDarwin) {
+  clearLookupTable();
+
+  for (auto Entry : llvm::enumerate(Opts->getImportSearchPaths())) {
+    addFilesInPathToLookupTable(FS, Entry.value(),
+                                ModuleSearchPathKind::Import,
+                                /*isSystem=*/false, Entry.index());
+  }
+
+  for (auto Entry : llvm::enumerate(Opts->getFrameworkSearchPaths())) {
+    addFilesInPathToLookupTable(FS, Entry.value().Path, ModuleSearchPathKind::Framework,
+                                Entry.value().IsSystem, Entry.index());
+  }
+
+  // Apple platforms have extra implicit framework search paths:
+  // $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
+  if (IsOSDarwin) {
+    for (auto Entry : llvm::enumerate(Opts->getDarwinImplicitFrameworkSearchPaths())) {
+      addFilesInPathToLookupTable(FS, Entry.value(),
+                                  ModuleSearchPathKind::DarwinImplictFramework,
+                                  /*isSystem=*/true, Entry.index());
+    }
+  }
+
+  for (auto Entry : llvm::enumerate(Opts->getRuntimeLibraryImportPaths())) {
+    addFilesInPathToLookupTable(FS, Entry.value(),
+                                ModuleSearchPathKind::RuntimeLibrary,
+                                /*isSystem=*/true, Entry.index());
+  }
+  State.FileSystem = FS;
+  State.IsOSDarwin = IsOSDarwin;
+  State.Opts = Opts;
+  State.IsPopulated = true;
+}
+
+SmallVector<const ModuleSearchPath *, 4>
+ModuleSearchPathLookup::searchPathsContainingFile(
+    const SearchPathOptions *Opts, llvm::ArrayRef<std::string> Filenames,
+    llvm::vfs::FileSystem *FS, bool IsOSDarwin) {
+  if (!State.IsPopulated || State.FileSystem != FS ||
+      State.IsOSDarwin != IsOSDarwin || State.Opts != Opts) {
+    rebuildLookupTable(Opts, FS, IsOSDarwin);
+  }
+
+  // Gather all search paths that include a file whose name is in Filenames.
+  // To make sure that we don't include the same search paths twice, keep track
+  // of which search paths have already been added to Result by their kind and
+  // Index in ResultIds.
+  // Note that if a search path is specified twice by including it twice in
+  // compiler arguments or by specifying it as different kinds (e.g. once as
+  // import and once as framework search path), these search paths are
+  // considered different (because they have different indicies/kinds and may
+  // thus still be included twice.
+  llvm::SmallVector<const ModuleSearchPath *, 4> Result;
+  llvm::SmallSet<std::pair<ModuleSearchPathKind, unsigned>, 4> ResultIds;
+
+  for (auto &Filename : Filenames) {
+    for (auto &Entry : LookupTable[Filename]) {
+      if (ResultIds.insert(std::make_pair(Entry.Kind, Entry.Index)).second) {
+        Result.push_back(&Entry);
+      }
+    }
+  }
+
+  // Make sure we maintain the same search paths order that we had used in
+  // populateLookupTableIfNecessary after merging results from
+  // different filenames.
+  llvm::sort(Result, [](const ModuleSearchPath *Lhs,
+                        const ModuleSearchPath *Rhs) { return *Lhs < *Rhs; });
+  return Result;
+}

--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -75,9 +75,9 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
   auto &searchOpts = invocation.getSearchPathOptions();
   out << "  \"paths\": {\n";
 
-  if (!searchOpts.SDKPath.empty()) {
+  if (!searchOpts.getSDKPath().empty()) {
     out << "    \"sdkPath\": \"";
-    out.write_escaped(searchOpts.SDKPath);
+    out.write_escaped(searchOpts.getSDKPath());
     out << "\",\n";
   }
 
@@ -95,7 +95,7 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
 
   outputPaths("runtimeLibraryPaths", searchOpts.RuntimeLibraryPaths);
   outputPaths("runtimeLibraryImportPaths",
-              searchOpts.RuntimeLibraryImportPaths);
+              searchOpts.getRuntimeLibraryImportPaths());
 
   out << "    \"runtimeResourcePath\": \"";
   out.write_escaped(searchOpts.RuntimeResourcePath);

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -87,12 +87,12 @@ llvm::ErrorOr<StringRef> ClangModuleDependenciesCacheImpl::getImportHackFile(Str
 static void addSearchPathInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx) {
   SearchPathOptions &searchPathOpts = ctx.SearchPathOpts;
-  for (const auto &framepath : searchPathOpts.FrameworkSearchPaths) {
+  for (const auto &framepath : searchPathOpts.getFrameworkSearchPaths()) {
     invocationArgStrs.push_back(framepath.IsSystem ? "-iframework" : "-F");
     invocationArgStrs.push_back(framepath.Path);
   }
 
-  for (auto path : searchPathOpts.ImportSearchPaths) {
+  for (const auto &path : searchPathOpts.getImportSearchPaths()) {
     invocationArgStrs.push_back("-I");
     invocationArgStrs.push_back(path);
   }
@@ -276,10 +276,12 @@ void ClangImporter::recordModuleDependencies(
     // the clang invocation to build PCMs because transitive headers can only
     // be found via search paths. Passing these headers as explicit inputs can
     // be quite challenging.
-    for (auto &path: Impl.SwiftContext.SearchPathOpts.ImportSearchPaths) {
+    for (const auto &path :
+         Impl.SwiftContext.SearchPathOpts.getImportSearchPaths()) {
       addClangArg("-I" + path);
     }
-    for (auto &path: Impl.SwiftContext.SearchPathOpts.FrameworkSearchPaths) {
+    for (const auto &path :
+         Impl.SwiftContext.SearchPathOpts.getFrameworkSearchPaths()) {
       addClangArg((path.IsSystem ? "-Fsystem": "-F") + path.Path);
     }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -160,38 +160,40 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
   if (Triple.isOSDarwin())
     SearchPathOpts.RuntimeLibraryPaths.push_back(DARWIN_OS_LIBRARY_PATH);
 
+  // If this is set, we don't want any runtime import paths.
+  if (SearchPathOpts.SkipRuntimeLibraryImportPaths) {
+    SearchPathOpts.setRuntimeLibraryImportPaths({});
+    return;
+  }
+
   // Set up the import paths containing the swiftmodules for the libraries in
   // RuntimeLibraryPath.
-  SearchPathOpts.RuntimeLibraryImportPaths.clear();
-
-  // If this is set, we don't want any runtime import paths.
-  if (SearchPathOpts.SkipRuntimeLibraryImportPaths)
-    return;
-
-  SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+  std::vector<std::string> RuntimeLibraryImportPaths;
+  RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
 
   // This is compatibility for <=5.3
   if (!Triple.isOSDarwin()) {
     llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
-    SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+    RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
   }
 
-  if (!SearchPathOpts.SDKPath.empty()) {
+  if (!SearchPathOpts.getSDKPath().empty()) {
     if (tripleIsMacCatalystEnvironment(Triple)) {
-      LibPath = SearchPathOpts.SDKPath;
+      LibPath = SearchPathOpts.getSDKPath();
       llvm::sys::path::append(LibPath, "System", "iOSSupport");
       llvm::sys::path::append(LibPath, "usr", "lib", "swift");
-      SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+      RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
     }
 
-    LibPath = SearchPathOpts.SDKPath;
+    LibPath = SearchPathOpts.getSDKPath();
     llvm::sys::path::append(LibPath, "usr", "lib", "swift");
     if (!Triple.isOSDarwin()) {
       llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
       llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
     }
-    SearchPathOpts.RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+    RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
   }
+  SearchPathOpts.setRuntimeLibraryImportPaths(RuntimeLibraryImportPaths);
 }
 
 static void
@@ -259,7 +261,7 @@ void CompilerInvocation::setTargetTriple(const llvm::Triple &Triple) {
 }
 
 void CompilerInvocation::setSDKPath(const std::string &Path) {
-  SearchPathOpts.SDKPath = Path;
+  SearchPathOpts.setSDKPath(Path);
   updateRuntimeLibraryPaths(SearchPathOpts, LangOpts.Target);
 }
 
@@ -1180,14 +1182,20 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
     return std::string(fullPath.str());
   };
 
+  std::vector<std::string> ImportSearchPaths(Opts.getImportSearchPaths());
   for (const Arg *A : Args.filtered(OPT_I)) {
-    Opts.ImportSearchPaths.push_back(resolveSearchPath(A->getValue()));
+    ImportSearchPaths.push_back(resolveSearchPath(A->getValue()));
   }
+  Opts.setImportSearchPaths(ImportSearchPaths);
 
+  std::vector<SearchPathOptions::FrameworkSearchPath> FrameworkSearchPaths(
+      Opts.getFrameworkSearchPaths());
   for (const Arg *A : Args.filtered(OPT_F, OPT_Fsystem)) {
-    Opts.FrameworkSearchPaths.push_back({resolveSearchPath(A->getValue()),
-                           /*isSystem=*/A->getOption().getID() == OPT_Fsystem});
+    FrameworkSearchPaths.push_back(
+        {resolveSearchPath(A->getValue()),
+         /*isSystem=*/A->getOption().getID() == OPT_Fsystem});
   }
+  Opts.setFrameworkSearchPaths(FrameworkSearchPaths);
 
   for (const Arg *A : Args.filtered(OPT_L)) {
     Opts.LibrarySearchPaths.push_back(resolveSearchPath(A->getValue()));
@@ -1198,7 +1206,7 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   }
 
   if (const Arg *A = Args.getLastArg(OPT_sdk))
-    Opts.SDKPath = A->getValue();
+    Opts.setSDKPath(A->getValue());
 
   if (const Arg *A = Args.getLastArg(OPT_resource_dir))
     Opts.RuntimeResourcePath = A->getValue();

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -74,7 +74,7 @@ bool ModuleInterfaceBuilder::collectDepsForSerialization(
   llvm::vfs::FileSystem &fs = *sourceMgr.getFileSystem();
 
   auto &Opts = SubInstance.getASTContext().SearchPathOpts;
-  SmallString<128> SDKPath(Opts.SDKPath);
+  SmallString<128> SDKPath(Opts.getSDKPath());
   path::native(SDKPath);
   SmallString<128> ResourcePath(Opts.RuntimeResourcePath);
   path::native(ResourcePath);
@@ -287,7 +287,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     SerializationOpts.UserModuleVersion = FEOpts.UserModuleVersion;
 
     // Record any non-SDK module interface files for the debug info.
-    StringRef SDKPath = SubInstance.getASTContext().SearchPathOpts.SDKPath;
+    StringRef SDKPath = SubInstance.getASTContext().SearchPathOpts.getSDKPath();
     if (!getRelativeDepPath(InPath, SDKPath))
       SerializationOpts.ModuleInterface = InPath;
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1894,7 +1894,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
                  ? createFile(SourcePath, {}, {})
                  : DBuilder.createFile(RemappedFile, RemappedDir);
 
-  StringRef Sysroot = IGM.Context.SearchPathOpts.SDKPath;
+  StringRef Sysroot = IGM.Context.SearchPathOpts.getSDKPath();
   StringRef SDK;
   {
     auto B = llvm::sys::path::rbegin(Sysroot);

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -148,7 +148,7 @@ static bool tryLoadLibrary(LinkLibrary linkLib,
 
     // Try user-provided framework search paths first; frameworks contain
     // binaries as well as modules.
-    for (auto &frameworkDir : searchPathOpts.FrameworkSearchPaths) {
+    for (const auto &frameworkDir : searchPathOpts.getFrameworkSearchPaths()) {
       path = frameworkDir.Path;
       llvm::sys::path::append(path, frameworkPart.str());
       success = loadRuntimeLib(path);

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -430,7 +430,7 @@ static void diagnoseNoSuchModule(ModuleDecl *importingModule,
     ctx.Diags.diagnose(importLoc, diagKind, modulePathStr);
   }
 
-  if (ctx.SearchPathOpts.SDKPath.empty() &&
+  if (ctx.SearchPathOpts.getSDKPath().empty() &&
       llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
     ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk);
     ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk_xcrun);

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -45,7 +45,7 @@ static FileOrError findModule(ASTContext &ctx, Identifier moduleID,
   // should be searched.
   StringRef moduleNameRef = ctx.getRealModuleName(moduleID).str();
 
-  for (auto Path : ctx.SearchPathOpts.ImportSearchPaths) {
+  for (const auto &Path : ctx.SearchPathOpts.getImportSearchPaths()) {
     inputFilename = Path;
     llvm::sys::path::append(inputFilename, moduleNameRef);
     inputFilename.append(".swift");

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -70,27 +70,23 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
   return dependencies.getError();
 }
 
-
-std::error_code PlaceholderSwiftModuleScanner::findModuleFilesInDirectory(
-    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
-    SmallVectorImpl<char> *ModuleInterfacePath,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool skipBuildingInterface, bool IsFramework) {
-  StringRef moduleName = Ctx.getRealModuleName(ModuleID.Item).str();
+bool PlaceholderSwiftModuleScanner::findModule(
+    ImportPath::Element moduleID, SmallVectorImpl<char> *moduleInterfacePath,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
+    bool skipBuildingInterface, bool &isFramework, bool &isSystemModule) {
+  StringRef moduleName = Ctx.getRealModuleName(moduleID.Item).str();
   auto it = PlaceholderDependencyModuleMap.find(moduleName);
-  // If no placeholder module stub path is given matches the name, return with an
-  // error code.
   if (it == PlaceholderDependencyModuleMap.end()) {
-    return std::make_error_code(std::errc::not_supported);
+    return false;
   }
   auto &moduleInfo = it->getValue();
   auto dependencies = ModuleDependencies::forPlaceholderSwiftModuleStub(
       moduleInfo.modulePath, moduleInfo.moduleDocPath,
       moduleInfo.moduleSourceInfoPath);
   this->dependencies = std::move(dependencies);
-  return std::error_code{};
+  return true;
 }
 
 static std::vector<std::string> getCompiledCandidates(ASTContext &ctx,

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -165,7 +165,7 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
     return error(status);
   }
 
-  StringRef SDKPath = ctx.SearchPathOpts.SDKPath;
+  StringRef SDKPath = ctx.SearchPathOpts.getSDKPath();
   if (SDKPath.empty() ||
       !Core->ModuleInputBuffer->getBufferIdentifier().startswith(SDKPath)) {
     for (const auto &searchPath : Core->SearchPaths) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1078,7 +1078,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
 
         const auto &PathRemapper = options.DebuggingOptionsPrefixMap;
         const auto &PathObfuscator = options.PathObfuscator;
-        auto sdkPath = M->getASTContext().SearchPathOpts.SDKPath;
+        auto sdkPath = M->getASTContext().SearchPathOpts.getSDKPath();
         SDKPath.emit(
             ScratchRecord,
             PathObfuscator.obfuscate(PathRemapper.remapPath(sdkPath)));
@@ -1164,10 +1164,10 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
     // Put the framework search paths first so that they'll be preferred upon
     // deserialization.
-    for (auto &framepath : searchPathOpts.FrameworkSearchPaths)
+    for (const auto &framepath : searchPathOpts.getFrameworkSearchPaths())
       SearchPath.emit(ScratchRecord, /*framework=*/true, framepath.IsSystem,
                       PathObfuscator.obfuscate(PathMapper.remapPath(framepath.Path)));
-    for (auto &path : searchPathOpts.ImportSearchPaths)
+    for (const auto &path : searchPathOpts.getImportSearchPaths())
       SearchPath.emit(ScratchRecord, /*framework=*/false, /*system=*/false,
                       PathObfuscator.obfuscate(PathMapper.remapPath(path)));
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -82,26 +82,21 @@ void forEachTargetModuleBasename(const ASTContext &Ctx,
   }
 }
 
-enum class SearchPathKind {
-  Import,
-  Framework,
-  RuntimeLibrary,
-};
-
 /// Apply \p body for each module search path in \p Ctx until \p body returns
 /// non-None value. Returns the return value from \p body, or \c None.
 Optional<bool> forEachModuleSearchPath(
     const ASTContext &Ctx,
-    llvm::function_ref<Optional<bool>(StringRef, SearchPathKind, bool isSystem)>
+    llvm::function_ref<Optional<bool>(StringRef, ModuleSearchPathKind,
+                                      bool isSystem)>
         callback) {
-  for (const auto &path : Ctx.SearchPathOpts.ImportSearchPaths)
+  for (const auto &path : Ctx.SearchPathOpts.getImportSearchPaths())
     if (auto result =
-            callback(path, SearchPathKind::Import, /*isSystem=*/false))
+            callback(path, ModuleSearchPathKind::Import, /*isSystem=*/false))
       return result;
 
-  for (const auto &path : Ctx.SearchPathOpts.FrameworkSearchPaths)
+  for (const auto &path : Ctx.SearchPathOpts.getFrameworkSearchPaths())
     if (auto result =
-            callback(path.Path, SearchPathKind::Framework, path.IsSystem))
+            callback(path.Path, ModuleSearchPathKind::Framework, path.IsSystem))
       return result;
 
   // Apple platforms have extra implicit framework search paths:
@@ -109,12 +104,14 @@ Optional<bool> forEachModuleSearchPath(
   if (Ctx.LangOpts.Target.isOSDarwin()) {
     for (const auto &path : Ctx.getDarwinImplicitFrameworkSearchPaths())
       if (auto result =
-          callback(path, SearchPathKind::Framework, /*isSystem=*/true))
+              callback(path, ModuleSearchPathKind::DarwinImplictFramework,
+                       /*isSystem=*/true))
         return result;
   }
 
-  for (auto importPath : Ctx.SearchPathOpts.RuntimeLibraryImportPaths) {
-    if (auto result = callback(importPath, SearchPathKind::RuntimeLibrary,
+  for (const auto &importPath :
+       Ctx.SearchPathOpts.getRuntimeLibraryImportPaths()) {
+    if (auto result = callback(importPath, ModuleSearchPathKind::RuntimeLibrary,
                                /*isSystem=*/true))
       return result;
   }
@@ -179,10 +176,10 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
     return false;
   };
 
-  forEachModuleSearchPath(Ctx, [&](StringRef searchPath, SearchPathKind Kind,
-                                   bool isSystem) {
+  forEachModuleSearchPath(Ctx, [&](StringRef searchPath,
+                                   ModuleSearchPathKind Kind, bool isSystem) {
     switch (Kind) {
-    case SearchPathKind::Import: {
+    case ModuleSearchPathKind::Import: {
       // Look for:
       // $PATH/{name}.swiftmodule/{arch}.{extension} or
       // $PATH/{name}.{extension}
@@ -206,7 +203,7 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
       });
       return None;
     }
-    case SearchPathKind::RuntimeLibrary: {
+    case ModuleSearchPathKind::RuntimeLibrary: {
       // Look for:
       // (Darwin OS) $PATH/{name}.swiftmodule/{arch}.{extension}
       // (Other OS)  $PATH/{name}.{extension}
@@ -233,7 +230,8 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
       });
       return None;
     }
-    case SearchPathKind::Framework: {
+    case ModuleSearchPathKind::Framework:
+    case ModuleSearchPathKind::DarwinImplictFramework: {
       // Look for:
       // $PATH/{name}.framework/Modules/{name}.swiftmodule/{arch}.{extension}
       forEachDirectoryEntryPath(searchPath, [&](StringRef path) {
@@ -561,10 +559,12 @@ SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
 
   llvm::SmallString<256> currPath;
 
+  enum class SearchResult { Found, NotFound, Error };
+
   /// Returns true if a target-specific module file was found, false if an error
   /// was diagnosed, or None if neither one happened and the search should
   /// continue.
-  auto findTargetSpecificModuleFiles = [&](bool IsFramework) -> Optional<bool> {
+  auto findTargetSpecificModuleFiles = [&](bool IsFramework) -> SearchResult {
     Optional<SerializedModuleBaseName> firstAbsoluteBaseName;
 
     for (const auto &targetSpecificBaseName : targetSpecificBaseNames) {
@@ -574,19 +574,16 @@ SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
       if (!firstAbsoluteBaseName.hasValue())
         firstAbsoluteBaseName.emplace(absoluteBaseName);
 
-      auto result = findModuleFilesInDirectory(moduleID,
-                        absoluteBaseName,
-                        moduleInterfacePath,
-                        moduleBuffer, moduleDocBuffer,
-                        moduleSourceInfoBuffer,
-                        skipBuildingInterface,
-                        IsFramework);
+      auto result = findModuleFilesInDirectory(
+          moduleID, absoluteBaseName, moduleInterfacePath, moduleBuffer,
+          moduleDocBuffer, moduleSourceInfoBuffer, skipBuildingInterface,
+          IsFramework);
       if (!result) {
-        return true;
+        return SearchResult::Found;
       } else if (result == std::errc::not_supported) {
-        return false;
+        return SearchResult::Error;
       } else if (result != std::errc::no_such_file_or_directory) {
-        return None;
+        return SearchResult::NotFound;
       }
     }
 
@@ -595,74 +592,98 @@ SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
     if (firstAbsoluteBaseName
         && maybeDiagnoseTargetMismatch(moduleID.Loc, moduleName,
                                        *firstAbsoluteBaseName)) {
-      return false;
+      return SearchResult::Error;
     } else {
-      return None;
+      return SearchResult::NotFound;
     }
   };
 
-  auto result = forEachModuleSearchPath(
-      Ctx,
-      [&](StringRef path, SearchPathKind Kind,
-          bool isSystem) -> Optional<bool> {
-        currPath = path;
-        isSystemModule = isSystem;
+  SmallVector<std::string, 4> InterestingFilenames = {
+      (moduleName + ".framework").str(),
+      genericBaseName.getName(file_types::TY_SwiftModuleInterfaceFile),
+      genericBaseName.getName(file_types::TY_PrivateSwiftModuleInterfaceFile),
+      genericBaseName.getName(file_types::TY_SwiftModuleFile)};
 
-        switch (Kind) {
-        case SearchPathKind::Import:
-        case SearchPathKind::RuntimeLibrary: {
-          isFramework = false;
+  auto searchPaths = Ctx.SearchPathOpts.moduleSearchPathsContainingFile(
+      InterestingFilenames, Ctx.SourceMgr.getFileSystem().get(),
+      Ctx.LangOpts.Target.isOSDarwin());
+  for (const auto &searchPath : searchPaths) {
+    currPath = searchPath->Path;
+    isSystemModule = searchPath->IsSystem;
 
-          // On Apple platforms, we can assume that the runtime libraries use
-          // target-specifi module files wihtin a `.swiftmodule` directory.
-          // This was not always true on non-Apple platforms, and in order to
-          // ease the transition, check both layouts.
-          bool checkTargetSpecificModule = true;
-          if (Kind != SearchPathKind::RuntimeLibrary ||
-              !Ctx.LangOpts.Target.isOSDarwin()) {
-            auto modulePath = currPath;
-            llvm::sys::path::append(modulePath, genericModuleFileName);
-            llvm::ErrorOr<llvm::vfs::Status> statResult = fs.status(modulePath);
+    switch (searchPath->Kind) {
+    case ModuleSearchPathKind::Import:
+    case ModuleSearchPathKind::RuntimeLibrary: {
+      isFramework = false;
 
-            // Even if stat fails, we can't just return the error; the path
-            // we're looking for might not be "Foo.swiftmodule".
-            checkTargetSpecificModule = statResult && statResult->isDirectory();
-          }
+      // On Apple platforms, we can assume that the runtime libraries use
+      // target-specific module files within a `.swiftmodule` directory.
+      // This was not always true on non-Apple platforms, and in order to
+      // ease the transition, check both layouts.
+      bool checkTargetSpecificModule = true;
+      if (searchPath->Kind != ModuleSearchPathKind::RuntimeLibrary ||
+          !Ctx.LangOpts.Target.isOSDarwin()) {
+        auto modulePath = currPath;
+        llvm::sys::path::append(modulePath, genericModuleFileName);
+        llvm::ErrorOr<llvm::vfs::Status> statResult = fs.status(modulePath);
 
-          if (checkTargetSpecificModule)
-            // A .swiftmodule directory contains architecture-specific files.
-            return findTargetSpecificModuleFiles(isFramework);
+        // Even if stat fails, we can't just return the error; the path
+        // we're looking for might not be "Foo.swiftmodule".
+        checkTargetSpecificModule = statResult && statResult->isDirectory();
+      }
 
-          SerializedModuleBaseName absoluteBaseName{currPath, genericBaseName};
-
-          auto result = findModuleFilesInDirectory(
-              moduleID, absoluteBaseName, moduleInterfacePath,
-              moduleBuffer, moduleDocBuffer, moduleSourceInfoBuffer,
-              skipBuildingInterface, isFramework);
-          if (!result)
-            return true;
-          else if (result == std::errc::not_supported)
-            return false;
-          else
-            return None;
+      if (checkTargetSpecificModule) {
+        // A .swiftmodule directory contains architecture-specific files.
+        switch (findTargetSpecificModuleFiles(isFramework)) {
+        case SearchResult::Found:
+          return true;
+        case SearchResult::NotFound:
+          continue;
+        case SearchResult::Error:
+          return false;
         }
-        case SearchPathKind::Framework: {
-          isFramework = true;
-          llvm::sys::path::append(currPath, moduleName + ".framework");
+      }
 
-          // Check if the framework directory exists.
-          if (!fs.exists(currPath))
-            return None;
+      SerializedModuleBaseName absoluteBaseName{currPath, genericBaseName};
 
-          // Frameworks always use architecture-specific files within a
-          // .swiftmodule directory.
-          llvm::sys::path::append(currPath, "Modules");
-          return findTargetSpecificModuleFiles(isFramework);
-        }
-        }
-        llvm_unreachable("covered switch");
-      });
-  return result.getValueOr(false);
+      auto result = findModuleFilesInDirectory(
+          moduleID, absoluteBaseName, moduleInterfacePath, moduleBuffer,
+          moduleDocBuffer, moduleSourceInfoBuffer, skipBuildingInterface,
+          isFramework);
+      if (!result) {
+        return true;
+      } else if (result == std::errc::not_supported) {
+        return false;
+      } else {
+        continue;
+      }
+    }
+    case ModuleSearchPathKind::Framework:
+    case ModuleSearchPathKind::DarwinImplictFramework: {
+      isFramework = true;
+      llvm::sys::path::append(currPath, moduleName + ".framework");
+
+      // Check if the framework directory exists.
+      if (!fs.exists(currPath)) {
+        continue;
+      }
+
+      // Frameworks always use architecture-specific files within a
+      // .swiftmodule directory.
+      llvm::sys::path::append(currPath, "Modules");
+      switch (findTargetSpecificModuleFiles(isFramework)) {
+      case SearchResult::Found:
+        return true;
+      case SearchResult::NotFound:
+        continue;
+      case SearchResult::Error:
+        return false;
+      }
+    }
+    }
+    llvm_unreachable("covered switch");
+  }
+  return false;
 }
 
 static std::pair<StringRef, clang::VersionTuple>
@@ -914,7 +935,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
                          missingNames);
     }
 
-    if (Ctx.SearchPathOpts.SDKPath.empty() &&
+    if (Ctx.SearchPathOpts.getSDKPath().empty() &&
         llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk);
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk_xcrun);
@@ -947,7 +968,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
   case serialization::Status::MissingUnderlyingModule: {
     Ctx.Diags.diagnose(diagLoc, diag::serialization_missing_underlying_module,
                        ModuleName);
-    if (Ctx.SearchPathOpts.SDKPath.empty() &&
+    if (Ctx.SearchPathOpts.getSDKPath().empty() &&
         llvm::Triple(llvm::sys::getProcessTriple()).isMacOSX()) {
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk);
       Ctx.Diags.diagnose(SourceLoc(), diag::sema_no_import_no_sdk_xcrun);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -511,9 +511,9 @@ bool SwiftInterfaceGenContext::matches(StringRef ModuleName,
 
   const SearchPathOptions &SPOpts = Invok.getSearchPathOptions();
   const SearchPathOptions &ImplSPOpts = Impl.Invocation.getSearchPathOptions();
-  if (SPOpts.ImportSearchPaths != ImplSPOpts.ImportSearchPaths)
+  if (SPOpts.getImportSearchPaths() != ImplSPOpts.getImportSearchPaths())
     return false;
-  if (SPOpts.FrameworkSearchPaths != ImplSPOpts.FrameworkSearchPaths)
+  if (SPOpts.getFrameworkSearchPaths() != ImplSPOpts.getFrameworkSearchPaths())
     return false;
 
   if (Invok.getClangImporterOptions().ExtraArgs !=
@@ -854,14 +854,14 @@ void SwiftLangSupport::findInterfaceDocument(StringRef ModuleName,
   addArgPair("-target", Invocation.getTargetTriple());
 
   const auto &SPOpts = Invocation.getSearchPathOptions();
-  addArgPair("-sdk", SPOpts.SDKPath);
-  for (auto &FramePath : SPOpts.FrameworkSearchPaths) {
+  addArgPair("-sdk", SPOpts.getSDKPath());
+  for (const auto &FramePath : SPOpts.getFrameworkSearchPaths()) {
     if (FramePath.IsSystem)
       addArgPair("-Fsystem", FramePath.Path);
     else
       addArgPair("-F", FramePath.Path);
   }
-  for (auto &Path : SPOpts.ImportSearchPaths)
+  for (const auto &Path : SPOpts.getImportSearchPaths())
     addArgPair("-I", Path);
 
   const auto &ClangOpts = Invocation.getClangImporterOptions();

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -53,8 +53,7 @@ public:
 
     SearchPathOpts.RuntimeResourcePath = SWIFTLIB_DIR;
     SearchPathOpts.RuntimeLibraryPaths.push_back(std::string(libDir.str()));
-    SearchPathOpts.RuntimeLibraryImportPaths.push_back(
-        std::string(libDir.str()));
+    SearchPathOpts.setRuntimeLibraryImportPaths({libDir.str().str()});
   }
 };
 


### PR DESCRIPTION
When looking for a Swift module on disk, we were scanning all module search paths if they contain the module we are searching for. In a setup where each module is contained in its own framework search path, this scaled quadratically with the number of modules being imported. E.g. a setup with 100 modules being imported form 100 module search paths could cause on the order of 10,000 checks of `FileSystem::exists`. While these checks are fairly fast (~10µs), they add up to ~100ms.

To improve this, perform a first scan of all module search paths and list the files they contain. From this, create a lookup map that maps filenames to the search paths they can be found in. E.g. for
```
searchPath1/
  Module1.framework

searchPath2/
  Module1.framework
  Module2.swiftmodule
```
we create the following lookup table
```
Module1.framework -> [searchPath1, searchPath2]
Module2.framework -> [searchPath2]
```

The initial scan is fairly fast (in O(files inside module search paths)) and afterwards finding a module in the framework search paths is in O(1) in the situation described above.
