### PR TITLE
Replace UnsafeSendable with @unchecked Sendable in the standard library.

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -53,7 +53,7 @@ func _unlock(_ ptr: UnsafeRawPointer)
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream {
-  internal final class _Storage: UnsafeSendable {
+  internal final class _Storage: @unchecked Sendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
 
     struct State {
@@ -285,7 +285,7 @@ extension AsyncStream {
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream {
-  internal final class _Storage: UnsafeSendable {
+  internal final class _Storage: @unchecked Sendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
     enum Terminal {
       case finished
@@ -543,7 +543,7 @@ extension AsyncThrowingStream {
 }
 
 // this is used to store closures; which are two words
-final class _AsyncStreamCriticalStorage<Contents>: UnsafeSendable {
+final class _AsyncStreamCriticalStorage<Contents>: @unchecked Sendable {
   var _value: Contents
   private init(_doNotCallMe: ()) {
     fatalError("_AsyncStreamCriticalStorage must be initialized by create")

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -110,7 +110,7 @@ internal final class CheckedContinuationCanary {
 /// enough to obtain the extra checking without further source modification in
 /// most circumstances.
 @available(SwiftStdlib 5.1, *)
-public struct CheckedContinuation<T, E: Error>: UnsafeSendable {
+public struct CheckedContinuation<T, E: Error>: @unchecked Sendable {
   private let canary: CheckedContinuationCanary
   
   /// Initialize a `CheckedContinuation` wrapper around an

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -111,7 +111,7 @@ internal func _enqueueOnDispatchQueue(_ job: UnownedJob,
 /// means a dispatch_queue_t, which is not the same as DispatchQueue
 /// on platforms where that is an instance of a wrapper class.
 @available(SwiftStdlib 5.1, *)
-internal final class DispatchQueueShim: UnsafeSendable, SerialExecutor {
+internal final class DispatchQueueShim: @unchecked Sendable, SerialExecutor {
   func enqueue(_ job: UnownedJob) {
     _enqueueOnDispatchQueue(job, queue: self)
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1990,4 +1990,4 @@ internal struct _ArrayAnyHashableBox<Element: Hashable>
   }
 }
 
-extension Array: Sendable, UnsafeSendable where Element: Sendable { }
+extension Array: @unchecked Sendable where Element: Sendable { }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -693,6 +693,6 @@ extension _ArrayBuffer {
   }
 }
 
-extension _ArrayBuffer: Sendable, UnsafeSendable
+extension _ArrayBuffer: @unchecked Sendable
   where Element: Sendable { }
 #endif

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1506,7 +1506,7 @@ extension ArraySlice {
   }
 }
 
-extension ArraySlice: Sendable, UnsafeSendable
+extension ArraySlice: @unchecked Sendable
   where Element: Sendable { }
 
 #if INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1426,5 +1426,5 @@ extension ContiguousArray {
   }
 }
 
-extension ContiguousArray: Sendable, UnsafeSendable
+extension ContiguousArray: @unchecked Sendable
   where Element: Sendable { }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2101,17 +2101,17 @@ public typealias DictionaryIndex<Key: Hashable, Value> =
 public typealias DictionaryIterator<Key: Hashable, Value> =
   Dictionary<Key, Value>.Iterator
 
-extension Dictionary: Sendable, UnsafeSendable
+extension Dictionary: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Keys: Sendable, UnsafeSendable
+extension Dictionary.Keys: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Values: Sendable, UnsafeSendable
+extension Dictionary.Values: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Keys.Iterator: Sendable, UnsafeSendable
+extension Dictionary.Keys.Iterator: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Values.Iterator: Sendable, UnsafeSendable
+extension Dictionary.Values.Iterator: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Index: Sendable, UnsafeSendable
+extension Dictionary.Index: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }
-extension Dictionary.Iterator: Sendable, UnsafeSendable
+extension Dictionary.Iterator: @unchecked Sendable
   where Key: Sendable, Value: Sendable { }

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -140,6 +140,5 @@ extension KeyValuePairs: CustomDebugStringConvertible {
   }
 }
 
-// TODO: Remove UnsafeSendable when we have tuples conforming
-extension KeyValuePairs: Sendable, UnsafeSendable
+extension KeyValuePairs: Sendable
     where Key: Sendable, Value: Sendable { }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1639,9 +1639,9 @@ extension Set {
 public typealias SetIndex<Element: Hashable> = Set<Element>.Index
 public typealias SetIterator<Element: Hashable> = Set<Element>.Iterator
 
-extension Set: Sendable, UnsafeSendable
+extension Set: @unchecked Sendable
   where Element: Sendable { }
-extension Set.Index: Sendable, UnsafeSendable
+extension Set.Index: @unchecked Sendable
   where Element: Sendable { }
-extension Set.Iterator: Sendable, UnsafeSendable
+extension Set.Iterator: @unchecked Sendable
   where Element: Sendable { }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -18,7 +18,7 @@ import SwiftShims
 //
 @frozen
 public // SPI(corelibs-foundation)
-struct _StringGuts: UnsafeSendable {
+struct _StringGuts: @unchecked Sendable {
   @usableFromInline
   internal var _object: _StringObject
 

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -27,7 +27,7 @@ var tests = TestSuite("AsyncStream")
 @main struct Main {
   static func main() async {
     if #available(SwiftStdlib 5.5, *) {
-      final class Expectation: UnsafeSendable {
+      final class Expectation: @unchecked Sendable {
         var fulfilled = false
       }
 

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -52,4 +52,5 @@
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
+Struct CheckedContinuation has removed conformance to UnsafeSendable
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
This eliminates a bunch of warnings when building the standard library and concurrency library, but otherwise has no effect.