### PR TITLE
[SourceKit] Support cancellation of code completion like requests

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -273,6 +273,15 @@ public:
   /// Diags - The diagnostics engine.
   DiagnosticEngine &Diags;
 
+  /// If the shared pointer is not a \c nullptr and the pointee is \c true,
+  /// all operations working on this ASTContext should be aborted at the next
+  /// possible opportunity.
+  /// This is used by SourceKit to cancel requests for which the result is no
+  /// longer of interest.
+  /// The returned result will be discarded, so the operation that acknowledges
+  /// the cancellation might return with any result.
+  std::shared_ptr<std::atomic<bool>> CancellationFlag = nullptr;
+
   TypeCheckCompletionCallback *CompletionCallback = nullptr;
 
   /// The request-evaluator that is used to process various requests.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -606,12 +606,6 @@ namespace swift {
     /// than this many seconds.
     unsigned ExpressionTimeoutThreshold = 600;
 
-    /// If the shared pointer is not a \c nullptr and the pointee is \c true,
-    /// typechecking should be aborted at the next possible opportunity.
-    /// This is used by SourceKit to cancel requests for which the result is no
-    /// longer of interest.
-    std::shared_ptr<std::atomic<bool>> CancellationFlag = nullptr;
-
     /// If non-zero, abort the switch statement exhaustiveness checker if
     /// the Space::minus function is called more than this many times.
     ///

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -106,6 +106,7 @@ class CompletionInstance {
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<CompletionInstanceResult>)>
           Callback);
 
@@ -119,6 +120,7 @@ class CompletionInstance {
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<CompletionInstanceResult>)>
           Callback);
 
@@ -129,6 +131,14 @@ class CompletionInstance {
   /// In case of failure or cancellation, the callback receives the
   /// corresponding failed or cancelled result.
   ///
+  /// If \p CancellationFlag is not \c nullptr, code completion can be cancelled
+  /// by setting the flag to \c true.
+  /// IMPORTANT: If \p CancellationFlag is not \c nullptr, then completion might
+  /// be cancelled in the secon pass that's invoked inside \p Callback.
+  /// Therefore, \p Callback MUST check whether completion was cancelled before
+  /// interpreting the results, since invalid results may be returned in case
+  /// of cancellation.
+  ///
   /// NOTE: \p Args is only used for checking the equaity of the invocation.
   /// Since this function assumes that it is already normalized, exact the same
   /// arguments including their order is considered as the same invocation.
@@ -137,6 +147,7 @@ class CompletionInstance {
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<CompletionInstanceResult>)>
           Callback);
 
@@ -155,6 +166,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC, ide::CodeCompletionContext &CompletionContext,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<CodeCompleteResult>)> Callback);
 
   void typeContextInfo(
@@ -162,6 +174,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<TypeContextInfoResult>)>
           Callback);
 
@@ -170,6 +183,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC, ArrayRef<const char *> ExpectedTypeNames,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<ConformingMethodListResults>)>
           Callback);
 };

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5176,7 +5176,7 @@ public:
     if (isExpressionAlreadyTooComplex)
       return true;
 
-    auto CancellationFlag = getASTContext().TypeCheckerOpts.CancellationFlag;
+    auto CancellationFlag = getASTContext().CancellationFlag;
     if (CancellationFlag && CancellationFlag->load(std::memory_order_relaxed))
       return true;
 

--- a/test/SourceKit/CodeComplete/cancellation.swift
+++ b/test/SourceKit/CodeComplete/cancellation.swift
@@ -1,0 +1,32 @@
+// Try and schedule the cancel the cancellation as fast as possible to cancel during the first pass
+// RUN: not %sourcekitd-test -req=complete -pos 15:35 %s -id=complete -async -- %s == -cancel=complete 2>&1 | %FileCheck --check-prefix=CANCEL_NO_CACHE %s
+
+// Wait 1 second for the first pass to complet and try to cancel during the second pass. This relies on the fact that the expression in line 12 is slow to type check (rdar://80582770)
+// RUN: not %sourcekitd-test -req=complete -pos 15:35 %s -id=complete -async -- %s == -shell -- sleep 1 == -cancel=complete 2>&1 | %FileCheck --check-prefix=CANCEL_NO_CACHE %s
+
+// Built an AST inside `fast(a:)` then complete the slow operation and try to cancel it.
+// RUN: not %sourcekitd-test -req=complete -pos 23:7 %s -- %s == -req=complete -pos 15:35 %s -id=complete -async -- %s == -cancel=complete 2>&1 | %FileCheck --check-prefix=CANCEL_CACHED %s
+
+// Same as above but sleep 1 second before cancelling to make sure we are actually cancelling during the second pass.
+// RUN: not %sourcekitd-test -req=complete -pos 23:7 %s -- %s == -req=complete -pos 15:35 %s -id=complete -async -- %s == -shell -- sleep 1 == -cancel=complete 2>&1 | %FileCheck --check-prefix=CANCEL_CACHED %s
+
+class Foo {
+  func slow(x: Invalid1, y: Invalid2) {
+    x / y / x / y / x / y / x / y.
+  }
+
+  struct Foo {
+    let fooMember: String
+  }
+
+  func fast(a: Foo) {
+    a.
+  }
+}
+
+// CANCEL_NO_CACHE: error response (Request Cancelled)
+
+// CANCEL_CACHED: key.results: [
+// CANCEL_CACHED:   fooMember
+// CANCEL_CACHED: ]
+// CANCEL_CACHED: error response (Request Cancelled)

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -749,24 +749,27 @@ public:
                            IndexingConsumer &Consumer,
                            ArrayRef<const char *> Args) = 0;
 
-  virtual void
-  codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
-               OptionsDictionary *options,
-               CodeCompletionConsumer &Consumer, ArrayRef<const char *> Args,
-               Optional<VFSOptions> vfsOptions) = 0;
+  virtual void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
+                            OptionsDictionary *options,
+                            CodeCompletionConsumer &Consumer,
+                            ArrayRef<const char *> Args,
+                            Optional<VFSOptions> vfsOptions,
+                            SourceKitCancellationToken CancellationToken) = 0;
 
-  virtual void codeCompleteOpen(StringRef name, llvm::MemoryBuffer *inputBuf,
-                                unsigned offset, OptionsDictionary *options,
-                                ArrayRef<FilterRule> filterRules,
-                                GroupedCodeCompletionConsumer &consumer,
-                                ArrayRef<const char *> args,
-                                Optional<VFSOptions> vfsOptions) = 0;
+  virtual void
+  codeCompleteOpen(StringRef name, llvm::MemoryBuffer *inputBuf,
+                   unsigned offset, OptionsDictionary *options,
+                   ArrayRef<FilterRule> filterRules,
+                   GroupedCodeCompletionConsumer &consumer,
+                   ArrayRef<const char *> args, Optional<VFSOptions> vfsOptions,
+                   SourceKitCancellationToken CancellationToken) = 0;
 
   virtual void codeCompleteClose(StringRef name, unsigned offset,
                                  GroupedCodeCompletionConsumer &consumer) = 0;
 
   virtual void codeCompleteUpdate(StringRef name, unsigned offset,
                                   OptionsDictionary *options,
+                                  SourceKitCancellationToken CancellationToken,
                                   GroupedCodeCompletionConsumer &consumer) = 0;
 
   virtual void codeCompleteCacheOnDisk(StringRef path) = 0;
@@ -923,20 +926,17 @@ public:
                           ArrayRef<const char *> Args,
                           DocInfoConsumer &Consumer) = 0;
 
-  virtual void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf,
-                                        unsigned Offset,
-                                        OptionsDictionary *options,
-                                        ArrayRef<const char *> Args,
-                                        TypeContextInfoConsumer &Consumer,
-                                        Optional<VFSOptions> vfsOptions) = 0;
+  virtual void getExpressionContextInfo(
+      llvm::MemoryBuffer *inputBuf, unsigned Offset, OptionsDictionary *options,
+      ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+      TypeContextInfoConsumer &Consumer, Optional<VFSOptions> vfsOptions) = 0;
 
-  virtual void getConformingMethodList(llvm::MemoryBuffer *inputBuf,
-                                       unsigned Offset,
-                                       OptionsDictionary *options,
-                                       ArrayRef<const char *> Args,
-                                       ArrayRef<const char *> ExpectedTypes,
-                                       ConformingMethodListConsumer &Consumer,
-                                       Optional<VFSOptions> vfsOptions) = 0;
+  virtual void getConformingMethodList(
+      llvm::MemoryBuffer *inputBuf, unsigned Offset, OptionsDictionary *options,
+      ArrayRef<const char *> Args, ArrayRef<const char *> ExpectedTypes,
+      SourceKitCancellationToken CancellationToken,
+      ConformingMethodListConsumer &Consumer,
+      Optional<VFSOptions> vfsOptions) = 0;
 
   virtual void getStatistics(StatisticsReceiver) = 0;
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1079,7 +1079,6 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
       Invocation, convertFileContentsToInputs(Contents));
 
   Invocation.getLangOptions().CollectParsedToken = true;
-  Invocation.getTypeCheckerOptions().CancellationFlag = CancellationFlag;
 
   if (FileSystem != llvm::vfs::getRealFileSystem()) {
     CompIns.getSourceMgr().setFileSystem(FileSystem);
@@ -1091,6 +1090,7 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     Error = "compilation setup failed";
     return nullptr;
   }
+  CompIns.getASTContext().CancellationFlag = CancellationFlag;
   if (CompIns.loadStdlibIfNeeded()) {
     LOG_WARN_FUNC("Loading the stdlib failed");
     Error = "Loading the stdlib failed";

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -158,6 +158,7 @@ void SwiftLangSupport::getConformingMethodList(
     llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
     OptionsDictionary *optionsDict, ArrayRef<const char *> Args,
     ArrayRef<const char *> ExpectedTypeNames,
+    SourceKitCancellationToken CancellationToken,
     SourceKit::ConformingMethodListConsumer &SKConsumer,
     Optional<VFSOptions> vfsOptions) {
   std::string error;
@@ -175,13 +176,14 @@ void SwiftLangSupport::getConformingMethodList(
   }
 
   performWithParamsToCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, fileSystem,
+      UnresolvedInputFile, Offset, Args, fileSystem, CancellationToken,
       [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
         ParmsResult.mapAsync<ConformingMethodListResults>(
             [&](auto &Params, auto DeliverTransformed) {
               getCompletionInstance()->conformingMethodList(
                   Params.Invocation, Args, fileSystem, Params.completionBuffer,
-                  Offset, Params.DiagC, ExpectedTypeNames, DeliverTransformed);
+                  Offset, Params.DiagC, ExpectedTypeNames,
+                  Params.CancellationFlag, DeliverTransformed);
             },
             [&](auto Result) { deliverResults(SKConsumer, Result); });
       });

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -469,6 +469,7 @@ public:
     swift::CompilerInvocation &Invocation;
     llvm::MemoryBuffer *completionBuffer;
     swift::DiagnosticConsumer *DiagC;
+    std::shared_ptr<std::atomic<bool>> CancellationFlag;
   };
 
   /// Execute \p PerformOperation sychronously with the parameters necessary to
@@ -477,6 +478,7 @@ public:
       llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
       ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      SourceKitCancellationToken CancellationToken,
       llvm::function_ref<
           void(swift::ide::CancellableResult<CompletionLikeOperationParams>)>
           PerformOperation);
@@ -492,24 +494,27 @@ public:
   void indexSource(StringRef Filename, IndexingConsumer &Consumer,
                    ArrayRef<const char *> Args) override;
 
-  void codeComplete(
-      llvm::MemoryBuffer *InputBuf, unsigned Offset,
-      OptionsDictionary *options,
-      SourceKit::CodeCompletionConsumer &Consumer, ArrayRef<const char *> Args,
-      Optional<VFSOptions> vfsOptions) override;
+  void codeComplete(llvm::MemoryBuffer *InputBuf, unsigned Offset,
+                    OptionsDictionary *options,
+                    SourceKit::CodeCompletionConsumer &Consumer,
+                    ArrayRef<const char *> Args,
+                    Optional<VFSOptions> vfsOptions,
+                    SourceKitCancellationToken CancellationToken) override;
 
   void codeCompleteOpen(StringRef name, llvm::MemoryBuffer *inputBuf,
                         unsigned offset, OptionsDictionary *options,
                         ArrayRef<FilterRule> rawFilterRules,
                         GroupedCodeCompletionConsumer &consumer,
                         ArrayRef<const char *> args,
-                        Optional<VFSOptions> vfsOptions) override;
+                        Optional<VFSOptions> vfsOptions,
+                        SourceKitCancellationToken CancellationToken) override;
 
   void codeCompleteClose(StringRef name, unsigned offset,
                          GroupedCodeCompletionConsumer &consumer) override;
 
   void codeCompleteUpdate(StringRef name, unsigned offset,
                           OptionsDictionary *options,
+                          SourceKitCancellationToken CancellationToken,
                           GroupedCodeCompletionConsumer &consumer) override;
 
   void codeCompleteCacheOnDisk(StringRef path) override;
@@ -662,6 +667,7 @@ public:
   void getExpressionContextInfo(llvm::MemoryBuffer *inputBuf, unsigned Offset,
                                 OptionsDictionary *options,
                                 ArrayRef<const char *> Args,
+                                SourceKitCancellationToken CancellationToken,
                                 TypeContextInfoConsumer &Consumer,
                                 Optional<VFSOptions> vfsOptions) override;
 
@@ -669,6 +675,7 @@ public:
                                OptionsDictionary *options,
                                ArrayRef<const char *> Args,
                                ArrayRef<const char *> ExpectedTypes,
+                               SourceKitCancellationToken CancellationToken,
                                ConformingMethodListConsumer &Consumer,
                                Optional<VFSOptions> vfsOptions) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -128,6 +128,7 @@ static void deliverResults(SourceKit::TypeContextInfoConsumer &SKConsumer,
 void SwiftLangSupport::getExpressionContextInfo(
     llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
     OptionsDictionary *optionsDict, ArrayRef<const char *> Args,
+    SourceKitCancellationToken CancellationToken,
     SourceKit::TypeContextInfoConsumer &SKConsumer,
     Optional<VFSOptions> vfsOptions) {
   std::string error;
@@ -145,14 +146,14 @@ void SwiftLangSupport::getExpressionContextInfo(
   }
 
   performWithParamsToCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, fileSystem,
+      UnresolvedInputFile, Offset, Args, fileSystem, CancellationToken,
       [&](CancellableResult<CompletionLikeOperationParams> ParamsResult) {
         ParamsResult.mapAsync<TypeContextInfoResult>(
             [&](auto &CIParams, auto DeliverTransformed) {
               getCompletionInstance()->typeContextInfo(
                   CIParams.Invocation, Args, fileSystem,
                   CIParams.completionBuffer, Offset, CIParams.DiagC,
-                  DeliverTransformed);
+                  CIParams.CancellationFlag, DeliverTransformed);
             },
             [&](auto Result) { deliverResults(SKConsumer, Result); });
       });

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -590,7 +590,7 @@ sourcekitd_response_t
 sourcekitd_send_request_sync(sourcekitd_object_t req);
 
 /// Used to cancel a request that has been invoked asynchronously.
-typedef void *sourcekitd_request_handle_t;
+typedef const void *sourcekitd_request_handle_t;
 
 #if SOURCEKITD_HAS_BLOCKS
 /// Receives the response of an asynchronous request or notification.

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -961,6 +961,7 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
         CompletionInst.typeContextInfo(
             Params.Invocation, Params.Args, Params.FileSystem,
             Params.CompletionBuffer, Params.Offset, Params.DiagC,
+            /*CancellationFlag=*/nullptr,
             [&](CancellableResult<TypeContextInfoResult> Result) {
               ExitCode = printTypeContextInfo(Result);
             });
@@ -1032,6 +1033,7 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
         CompletionInst.conformingMethodList(
             Params.Invocation, Params.Args, Params.FileSystem,
             Params.CompletionBuffer, Params.Offset, Params.DiagC, typeNames,
+            /*CancellationFlag=*/nullptr,
             [&](CancellableResult<ConformingMethodListResults> Result) {
               ExitCode = printConformingMethodList(Result);
             });
@@ -1158,7 +1160,7 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
         Inst.codeComplete(
             Params.Invocation, Params.Args, Params.FileSystem,
             Params.CompletionBuffer, Params.Offset, Params.DiagC,
-            CompletionContext,
+            CompletionContext, /*CancellationFlag=*/nullptr,
             [&](CancellableResult<CodeCompleteResult> Result) {
               ExitCode = printCodeCompletionResults(
                   Result, CodeCompletionKeywords, CodeCompletionComments,
@@ -1487,6 +1489,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
     CompletionInst.codeComplete(
         Invocation, /*Args=*/{}, FileSystem, completionBuffer.get(), Offset,
         CodeCompletionDiagnostics ? &PrintDiags : nullptr, CompletionContext,
+        /*CancellationFlag=*/nullptr,
         [&](CancellableResult<CodeCompleteResult> Result) {
           CallbackCalled = true;
           switch (Result.getKind()) {


### PR DESCRIPTION
This PR performs a few refactorings first (which I could also pull out to a separate PR):
- Moving the cancellation flag from `TypeCheckerOption` to `ASTContext`
- Make `sourcektid_request_handle_t` `const void*`

After that, what remains to be done is just to wire up cancellation tokens and cancellation flags for `CompletionInstance` and make sure to return `CancellableResult::cancelled()` when cancellation is detected.

rdar://83391488