### PR TITLE
SIL: Generalize layout constraints again in subst function type lowering.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -996,6 +996,9 @@ public:
 
   bool requiresClass() const;
   LayoutConstraint getLayoutConstraint() const;
+  /// True if the abstraction pattern has a layout constraint that would
+  /// give it a fixed size and loadable representation.
+  bool hasLoadableLayoutConstraint() const;
 
   /// Return the Swift type which provides structure for this
   /// abstraction pattern.

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -282,6 +282,27 @@ LayoutConstraint AbstractionPattern::getLayoutConstraint() const {
   }
 }
 
+bool AbstractionPattern::hasLoadableLayoutConstraint() const {
+  auto layout = getLayoutConstraint();
+  if (!layout)
+    return false;
+  
+  switch (layout->getKind()) {
+  case LayoutConstraintKind::Class:
+  case LayoutConstraintKind::TrivialOfExactSize:
+  case LayoutConstraintKind::TrivialOfAtMostSize:
+  case LayoutConstraintKind::NativeRefCountedObject:
+  case LayoutConstraintKind::RefCountedObject:
+  case LayoutConstraintKind::NativeClass:
+    return true;
+      
+  case LayoutConstraintKind::Trivial:
+  case LayoutConstraintKind::UnknownLayout:
+    return false;
+  }
+  llvm_unreachable("uncovered switch");
+}
+
 bool AbstractionPattern::matchesTuple(CanTupleType substType) {
   switch (getKind()) {
   case Kind::Invalid:
@@ -1412,11 +1433,6 @@ public:
       // Look at the layout constraint on this position in the abstraction pattern
       // and carry it over, with some generalization to the point it affects
       // calling convention.
-      // TODO: We should do this once we surface more interesting layout
-      // constraints in the language. There are several places in type lowering
-      // that need to be changed to allow for this and generate correct calling
-      // convention lowering.
-#if WE_MAKE_LAYOUT_CONSTRAINTS_AVAILABLE_IN_THE_SURFACE_LANGUAGE
       switch (layout->getKind()) {
       // Keep these layout constraints as is.
       case LayoutConstraintKind::RefCountedObject:
@@ -1446,10 +1462,9 @@ public:
            LayoutConstraintKind::TrivialOfAtMostSize,
            layout->getTrivialSizeInBits(),
            layout->getAlignmentInBits(),
-           C);
+           TC.Context);
         break;
       }
-#endif
       
       if (layout) {
         substRequirements.push_back(

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1223,7 +1223,7 @@ public:
     // unsubstituted type.
     if ((origType.isTypeParameter()
          && !origType.isConcreteType()
-         && !origType.requiresClass())
+         && !origType.hasLoadableLayoutConstraint())
         || substTL.isAddressOnly()) {
       return true;
 
@@ -1307,7 +1307,7 @@ static bool isFormallyPassedIndirectly(TypeConverter &TC,
   // If the substituted type is passed indirectly, so must the
   // unsubstituted type.
   if ((origType.isTypeParameter() && !origType.isConcreteType()
-       && !origType.requiresClass())
+       && !origType.hasLoadableLayoutConstraint())
       || substTL.isAddressOnly()) {
     return true;
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -403,13 +403,32 @@ namespace {
                                      IsTypeExpansionSensitive_t isSensitive) {
       if (origType.isTypeParameterOrOpaqueArchetype() ||
           origType.isOpaqueFunctionOrOpaqueDerivativeFunction()) {
-        if (origType.requiresClass()) {
-          return asImpl().handleReference(
-              type, getReferenceRecursiveProperties(isSensitive));
-        } else {
-          return asImpl().handleAddressOnly(
-              type, getOpaqueRecursiveProperties(isSensitive));
+        // Some layout constraints allow us to use more efficient type lowerings
+        // than fully opaque.
+        if (auto layout = origType.getLayoutConstraint()) {
+          switch (layout->getKind()) {
+          case LayoutConstraintKind::Class:
+          case LayoutConstraintKind::RefCountedObject:
+          case LayoutConstraintKind::NativeClass:
+          case LayoutConstraintKind::NativeRefCountedObject:
+            return asImpl().handleReference(
+                type, getReferenceRecursiveProperties(isSensitive));
+              
+          case LayoutConstraintKind::TrivialOfExactSize:
+          case LayoutConstraintKind::TrivialOfAtMostSize:
+            return asImpl().handleTrivial(
+                type, getTrivialRecursiveProperties(isSensitive));
+          
+          case LayoutConstraintKind::Trivial:
+            // TODO: We could handle these as trivial with opaque value SIL.
+            LLVM_FALLTHROUGH;
+          case LayoutConstraintKind::UnknownLayout:
+            /*fall into below*/;
+          }
         }
+
+        return asImpl().handleAddressOnly(
+            type, getOpaqueRecursiveProperties(isSensitive));
       } else {
         // If the abstraction pattern provides a concrete type, lower as that
         // type. This can occur if the abstraction pattern provides a more

--- a/test/SILGen/function_type_lowering.swift
+++ b/test/SILGen/function_type_lowering.swift
@@ -36,16 +36,16 @@ func e<T: P>(_ x: (T.A) -> T) {}
 // Preserve class constraints, because they're less abstract for layout and
 // calling convention purposes than unconstrained types
 
-// CHECK-LABEL: sil {{.*}}1f{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1f{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func f<T: AnyObject, U>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1g{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1g{{.*}} : $@convention(thin) <T, U where T : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func g<T: AnyObject, U>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1h{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1h{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
 func h<T: AnyObject, U: AnyObject>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1i{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1i{{.*}} : $@convention(thin) <T, U where T : AnyObject, U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func i<T: AnyObject, U: AnyObject>(_ x: (U) -> T) {}
 
 
@@ -53,19 +53,19 @@ func i<T: AnyObject, U: AnyObject>(_ x: (U) -> T) {}
 
 protocol PC: AnyObject { }
 
-// CHECK-LABEL: sil {{.*}}1j{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1j{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func j<T: PC, U>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1k{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1k{{.*}} : $@convention(thin) <T, U where T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func k<T: PC, U>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1l{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1l{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, U>) -> ()
 func l<T: PC, U: PC>(_ x: (T) -> U) {}
 
-// CHECK-LABEL: sil {{.*}}1m{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
+// CHECK-LABEL: sil {{.*}}1m{{.*}} : $@convention(thin) <T, U where T : PC, U : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <U, T>) -> ()
 func m<T: PC, U: PC>(_ x: (U) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1n{{.*}} : $@convention(thin) <T where T : P, T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1n{{.*}} : $@convention(thin) <T where T : P, T : PC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
 func n<T: P & PC>(_ x: (T) -> T.A) {}
 
 
@@ -73,7 +73,7 @@ func n<T: P & PC>(_ x: (T) -> T.A) {}
 
 class Base {}
 
-// CHECK-LABEL: sil {{.*}}1o{{.*}} : $@convention(thin) <T, U where T : Base> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1o{{.*}} : $@convention(thin) <T, U where T : Base> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>) -> ()
 func o<T: Base, U> (_ x: (T) -> U) {}
 
 
@@ -91,11 +91,11 @@ protocol PCAC: AnyObject {
   associatedtype A: AnyObject
 }
 
-// CHECK-LABEL: sil {{.*}}1p{{.*}} : $@convention(thin) <T where T : PCAO> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1p{{.*}} : $@convention(thin) <T where T : PCAO> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, T.A>) -> ()
 func p<T: PCAO> (_ x: (T) -> T.A) {}
-// CHECK-LABEL: sil {{.*}}1q{{.*}} : $@convention(thin) <T where T : POAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1q{{.*}} : $@convention(thin) <T where T : POAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
 func q<T: POAC> (_ x: (T) -> T.A) {}
-// CHECK-LABEL: sil {{.*}}1r{{.*}} : $@convention(thin) <T where T : PCAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_1 : AnyObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
+// CHECK-LABEL: sil {{.*}}1r{{.*}} : $@convention(thin) <T where T : PCAC> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T, T.A>) -> ()
 func r<T: PCAC> (_ x: (T) -> T.A) {}
 
 
@@ -112,20 +112,20 @@ struct S<T, U> {
   }
 }
 
-// CHECK-LABEL: sil {{.*}}1t{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1t{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_3, τ_0_5 : _RefCountedObject> (S<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t<T, U: AnyObject>(_: (S<T, U>) -> (T, U)) {}
 
-// CHECK-LABEL: sil {{.*}}2t2{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 : AnyObject, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t2{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_4, τ_0_2 : _RefCountedObject, τ_0_2 == τ_0_5, τ_0_7 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
 func t2<T, U: AnyObject>(_: (S<T, U>.Nested<U>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t3{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7, τ_0_8, τ_0_9 where τ_0_0 == τ_0_4, τ_0_1 : AnyObject, τ_0_1 == τ_0_5, τ_0_2 : AnyObject, τ_0_2 == τ_0_6, τ_0_3 == τ_0_7, τ_0_9 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NesNestedted<τ_0_3>) -> (@out τ_0_8, @owned τ_0_9) for <T, U, U, T, T, U, U, T, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t3{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7, τ_0_8, τ_0_9 where τ_0_0 == τ_0_4, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_5, τ_0_2 : _RefCountedObject, τ_0_2 == τ_0_6, τ_0_3 == τ_0_7, τ_0_9 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NesNestedted<τ_0_3>) -> (@out τ_0_8, @owned τ_0_9) for <T, U, U, T, T, U, U, T, T, U>) -> ()
 func t3<T, U: AnyObject>(_: (S<T, U>.Nested<U>.NesNestedted<T>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t4{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 : AnyObject, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NestedNonGeneric) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t4{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_4, τ_0_2 : _RefCountedObject, τ_0_2 == τ_0_5, τ_0_7 : _RefCountedObject> (S<τ_0_0, τ_0_1>.Nested<τ_0_2>.NestedNonGeneric) -> (@out τ_0_6, @owned τ_0_7) for <T, U, U, T, U, U, T, U>) -> ()
 func t4<T, U: AnyObject>(_: (S<T, U>.Nested<U>.NestedNonGeneric) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t5{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t5{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_3, τ_0_5 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t5<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t6{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : AnyObject, τ_0_1 == τ_0_4, τ_0_2 == τ_0_5, τ_0_7 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NesNestedted<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, T, T, U, T, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t6{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5, τ_0_6, τ_0_7 where τ_0_0 == τ_0_3, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_4, τ_0_2 == τ_0_5, τ_0_7 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NesNestedted<τ_0_2>) -> (@out τ_0_6, @owned τ_0_7) for <T, U, T, T, U, T, T, U>) -> ()
 func t6<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric.NesNestedted<T>) -> (T, U)) {}
-// CHECK-LABEL: sil {{.*}}2t7{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2t7{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_3, τ_0_5 : _RefCountedObject> (S<τ_0_0, τ_0_1>.NestedNonGeneric.NestedNonGeneric) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func t7<T, U: AnyObject>(_: (S<T, U>.NestedNonGeneric.NestedNonGeneric) -> (T, U)) {}
 
 // CHECK-LABEL: sil {{.*}}1u{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_0 == τ_0_2, τ_0_1 == τ_0_3> (S<τ_0_0, τ_0_1>) -> @out τ_0_4 for <T, T, T, T, T>) -> ()
@@ -134,13 +134,13 @@ func u<T>(_: (S<T, T>) -> T) {}
 
 class C<T, U> {}
 
-// CHECK-LABEL: sil {{.*}}1v{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : AnyObject, τ_0_1 == τ_0_3, τ_0_5 : AnyObject> (@guaranteed C<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}1v{{.*}} : $@convention(thin) <T, U where U : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == τ_0_2, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_3, τ_0_5 : _RefCountedObject> (@guaranteed C<τ_0_0, τ_0_1>) -> (@out τ_0_4, @owned τ_0_5) for <T, U, T, U, T, U>) -> ()
 func v<T, U: AnyObject>(_: (C<T, U>) -> (T, U)) {}
 
 // CHECK-LABEL: sil {{.*}}1w{{.*}} : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4 where τ_0_0 == τ_0_2, τ_0_1 == τ_0_3> (@guaranteed C<τ_0_0, τ_0_1>) -> @out τ_0_4 for <T, T, T, T, T>) -> ()
 func w<T>(_: (C<T, T>) -> T) {}
 
-// CHECK-LABEL: sil {{.*}}1x{{.*}} : $@convention(thin) <T, U, V where V : C<T, U>> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> () for <V>) -> ()
+// CHECK-LABEL: sil {{.*}}1x{{.*}} : $@convention(thin) <T, U, V where V : C<T, U>> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> () for <V>) -> ()
 func x<T, U, V: C<T, U>>(_: (V) -> Void) {}
 
 // We can't generally lower away protocol constraints 
@@ -159,10 +159,10 @@ struct SCP<T: P, U: CP<T>> {}
 // CHECK-LABEL: sil {{.*}}2z2{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : P, τ_0_0 == τ_0_2, τ_0_1 : CP<τ_0_0>, τ_0_1 == τ_0_3> (SCP<τ_0_0, τ_0_1>) -> () for <T, U, T, U>) -> ()
 func z2<T: P, U: CP<T>>(_: (SCP<T, U>) -> Void) {}
 
-// CHECK-LABEL: sil {{.*}}3z2a{{.*}} : $@convention(thin) <T, U where T : AnyObject, T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : AnyObject, τ_0_0 : P, τ_0_0 == τ_0_2, τ_0_1 : CP<τ_0_0>, τ_0_1 == τ_0_3> (SCP<τ_0_0, τ_0_1>) -> () for <T, U, T, U>) -> ()
+// CHECK-LABEL: sil {{.*}}3z2a{{.*}} : $@convention(thin) <T, U where T : AnyObject, T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : _RefCountedObject, τ_0_0 : P, τ_0_0 == τ_0_2, τ_0_1 : CP<τ_0_0>, τ_0_1 == τ_0_3> (SCP<τ_0_0, τ_0_1>) -> () for <T, U, T, U>) -> ()
 func z2a<T: P & AnyObject, U: CP<T>>(_: (SCP<T, U>) -> Void) {}
 
-// CHECK-LABEL: sil {{.*}}2z3{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : _NativeClass, τ_0_0 == τ_0_2, τ_0_1 : _NativeClass, τ_0_1 == τ_0_3> (S<τ_0_0, τ_0_1>) -> () for <U, U, U, U>) -> ()
+// CHECK-LABEL: sil {{.*}}2z3{{.*}} : $@convention(thin) <T, U where T : P, U : CP<T>> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : _RefCountedObject, τ_0_0 == τ_0_2, τ_0_1 : _RefCountedObject, τ_0_1 == τ_0_3> (S<τ_0_0, τ_0_1>) -> () for <U, U, U, U>) -> ()
 func z3<T: P, U: CP<T>>(_: (S<U, U>) -> Void) {}
 
 // Opaque types should not be extracted as substituted arguments because they
@@ -171,7 +171,7 @@ func z3<T: P, U: CP<T>>(_: (S<U, U>) -> Void) {}
 dynamic func opaqueAny() -> some Any { return C<Int, String>() }
 dynamic func opaqueObject() -> some AnyObject { return C<Int, String>() }
 
-// CHECK-LABEL: sil {{.*}}1y{{.*}} : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : AnyObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <τ_0_0, τ_0_1>) -> () for <@_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) __, @_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) __>
+// CHECK-LABEL: sil {{.*}}1y{{.*}} : $@convention(thin) @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_1 : _RefCountedObject> (@in_guaranteed τ_0_0) -> @owned τ_0_1 for <τ_0_0, τ_0_1>) -> () for <@_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) __, @_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) __>
 func y(_: (@_opaqueReturnTypeOf("$s4main9opaqueAnyQryF", 0) X) -> (@_opaqueReturnTypeOf("$s4main12opaqueObjectQryF", 0) X)) {}
 
 // Make sure type lowering doesn't choke on override signatures.

--- a/test/SILGen/function_type_lowering_objc.swift
+++ b/test/SILGen/function_type_lowering_objc.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-// CHECK-LABEL: sil {{.*}}3foo{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil {{.*}}3foo{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> ()
 func foo<T: NSCopying>(f: (T) -> ()) {}
-// CHECK-LABEL: sil {{.*}}3bar{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject, τ_0_0 == τ_0_1> (@guaranteed Optional<τ_0_0>) -> ()
+// CHECK-LABEL: sil {{.*}}3bar{{.*}} : $@convention(thin) <T where T : NSCopying> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_0 == τ_0_1> (@guaranteed Optional<τ_0_0>) -> ()
 func bar<T: NSCopying>(f: (T?) -> ()) {}

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -206,7 +206,7 @@ class Class {}
 protocol HasClassAssoc { associatedtype Assoc : Class }
 
 // CHECK-LABEL: sil hidden [ossa] @$s16generic_closures027captures_class_constrained_A0_1fyx_5AssocQzAEctAA08HasClassF0RzlF
-// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : @guaranteed $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _NativeClass, τ_0_1 : _NativeClass> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T.Assoc, T.Assoc>):
+// CHECK: bb0([[ARG1:%.*]] : $*T, [[ARG2:%.*]] : @guaranteed $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject, τ_0_1 : _RefCountedObject> (@guaranteed τ_0_0) -> @owned τ_0_1 for <T.Assoc, T.Assoc>):
 // CHECK: [[GENERIC_FN:%.*]] = function_ref @$s16generic_closures027captures_class_constrained_A0_1fyx_5AssocQzAEctAA08HasClassF0RzlFA2EcycfU_
 // CHECK: [[ARG2_COPY:%.*]] = copy_value [[ARG2]]
 // CHECK: [[CONCRETE_FN:%.*]] = partial_apply [callee_guaranteed] [[GENERIC_FN]]<T>([[ARG2_COPY]])

--- a/test/SILGen/nested_generics.swift
+++ b/test/SILGen/nested_generics.swift
@@ -48,7 +48,7 @@ struct Lunch<T : Pizza> where T.Topping : CuredMeat {
 // CHECK-LABEL: sil private [ossa] @$s15nested_generics5LunchV6DinnerV15coolCombination1t1uy7ToppingQz_AA4DeliC7MustardOyAA6PepperV_GtF0A7GenericL_1x1yqd0___qd0_0_tqd0___qd0_0_tAA5PizzaRzAA6HotDogRd__AA9CuredMeatAJRQAQ9CondimentRtd__r__0_lF : $@convention(thin) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard><X, Y> (@in_guaranteed X, @in_guaranteed Y) -> (@out X, @out Y)
 
 // CHECK-LABEL: // nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: Swift.Optional<A1>, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
-// CHECK-LABEL: sil hidden [ossa] @$s15nested_generics5LunchV6DinnerV11firstCourse06secondF09leftovers14transformationAEyx_qd__Gx_qd__Sgxqd__xctcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
+// CHECK-LABEL: sil hidden [ossa] @$s15nested_generics5LunchV6DinnerV11firstCourse06secondF09leftovers14transformationAEyx_qd__Gx_qd__Sgxqd__xctcfC : $@convention(method) <T where T : Pizza, T.Topping : CuredMeat><U where U : HotDog, U.Condiment == Deli<Pepper>.Mustard> (@owned T, @in Optional<U>, @owned T, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> @out τ_0_1 for <T, U>, @thin Lunch<T>.Dinner<U>.Type) -> @out Lunch<T>.Dinner<U>
 
 // Non-generic nested inside generic
 

--- a/test/stdlib/unmanaged_rc.swift
+++ b/test/stdlib/unmanaged_rc.swift
@@ -16,11 +16,11 @@ public func myPrint(_ k: Klass) { print(k) }
 
 // Check the codegen of _withUnsafeGuaranteedRef
 //
-// CHECK-LABEL: sil public_external [transparent] @$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF : $@convention(method) <Instance where Instance : AnyObject><Result> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, Unmanaged<Instance>) -> (@out Result, @error Error) {
-// CHECK: bb0([[RESULT:%.*]] : $*Result, [[FUNC:%.*]] : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, [[UNMANAGED:%.*]] : $Unmanaged<Instance>):
+// CHECK-LABEL: sil public_external [transparent] @$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF : $@convention(method) <Instance where Instance : AnyObject><Result> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, Unmanaged<Instance>) -> (@out Result, @error Error) {
+// CHECK: bb0([[RESULT:%.*]] : $*Result, [[FUNC:%.*]] : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, [[UNMANAGED:%.*]] : $Unmanaged<Instance>):
 // CHECK: [[UNMANAGED_REF:%.*]] = struct_extract [[UNMANAGED]]
 // CHECK: [[REF:%.*]] = unmanaged_to_ref [[UNMANAGED_REF]]
-// CHECK: try_apply {{%.*}}([[RESULT]], [[REF]]) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, normal bb2, error bb1
+// CHECK: try_apply {{%.*}}([[RESULT]], [[REF]]) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : _RefCountedObject> (@guaranteed τ_0_0) -> (@out τ_0_1, @error Error) for <Instance, Result>, normal bb2, error bb1
 // CHECK-NOT: destroy_value
 // CHECK: } // end sil function '$ss9UnmanagedV24_withUnsafeGuaranteedRefyqd__qd__xKXEKlF'
 


### PR DESCRIPTION
To minimize unnecessary abstraction changes, we only want to represent
differences in types that provide interesting representation diversity,
such as between concrete function types with indirect arguments and
generic function types, but not so much between differently-generic
function types. The original subst function type lowering would
handle layout constraints by generalizing them to the most abstract
form that has a similar calling convention, such as
AnyObject -> _RefCountedObject. However, the new implementation
in #40112 moved the generic signature formation for function types
earlier in the type lowering process, and much of type lowering was
unaware of layout constraints other than `requiresClass`, so I
backed off on that optimization to be able to land it. This
adds the optimization back, and generalizes type lowering in
other places to correctly handle other layout constraints.