### PR TITLE
Fix printing of 'isolated' parameters.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3414,9 +3414,6 @@ void PrintAST::printOneParameter(const ParamDecl *param,
 
   printAttributes(param);
 
-  if (param->isIsolated())
-    Printer << "isolated ";
-
   printArgName();
 
   TypeLoc TheTypeLoc;

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -15,6 +15,9 @@
 @available(SwiftStdlib 5.1, *)
 public actor SomeActor {
   nonisolated func maine() { }
+
+  // CHECK: nonisolated public func takesIsolated(other: isolated {{(Test.)?}}SomeActor)
+  public nonisolated func takesIsolated(other: isolated SomeActor) { }
 }
 
 // CHECK: @globalActor public struct SomeGlobalActor


### PR DESCRIPTION
Fixes rdar://83316058.
