### PR TITLE
[semantic-arc] Eliminate a borrow pattern from PMO that Copy Propagation can not handle yet.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1264,6 +1264,25 @@ public:
     }
   }
 
+  /// Returns true if this instruction only has a single non-trivial argument
+  /// that influences the resulting ownership.
+  ///
+  /// This is useful in a situation where one is trying to process structs with
+  /// a single "owning" non-trivial field.
+  bool forwardsSingleNonTrivialArgument() const {
+    bool foundNonTrivialArg = false;
+
+    for (auto opValue : getOperandValues()) {
+      if (!opValue->getType().isTrivial(*getFunction())) {
+        if (foundNonTrivialArg)
+          return false;
+        foundNonTrivialArg = true;
+      }
+    }
+
+    return foundNonTrivialArg;
+  }
+
   static bool classof(const SILInstruction *inst) {
     return classof(inst->getKind());
   }

--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -18,13 +18,18 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "sil-semantic-arc-opts"
+
 #include "Context.h"
 #include "SemanticARCOptVisitor.h"
+#include "llvm/ADT/iterator_range.h"
 
 using namespace swift;
 using namespace swift::semanticarc;
 
 bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
+  using OwnershipMergeInst = AllArgOwnershipForwardingSingleValueInst;
+
   // Quickly check if we are supposed to perform this transformation.
   if (!ctx.shouldPerform(ARCTransformKind::RedundantBorrowScopeElimPeephole))
     return false;
@@ -34,13 +39,27 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   if (bbi->isLexical())
     return false;
 
+  LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *bbi);
+
   auto kind = bbi->getOperand().getOwnershipKind();
+  SmallVector<Operand *, 8> initialAggregatesUseList;
   SmallVector<EndBorrowInst *, 16> endBorrows;
   for (auto *op : bbi->getUses()) {
     if (!op->isLifetimeEnding()) {
       // Make sure that this operand can accept our arguments kind.
       if (op->canAcceptKind(kind))
         continue;
+
+      if (auto *mergeInst = dyn_cast<OwnershipMergeInst>(op->getUser())) {
+        if (mergeInst->hasOneUse() &&
+            mergeInst->forwardsSingleNonTrivialArgument()) {
+          initialAggregatesUseList.push_back(op);
+          continue;
+        }
+      }
+
+      // If we can't accept our argument and we don't have a simple mergeInst
+      // that we might be able to hoist a copy out of.
       return false;
     }
 
@@ -54,14 +73,96 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
     endBorrows.push_back(ebi);
   }
 
-  // At this point, we know that the begin_borrow's operand can be
-  // used as an argument to all non-end borrow uses. Eliminate the
-  // begin borrow and end borrows.
+  if (initialAggregatesUseList.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "    Eliminating!\n");
+    // At this point, we know that the begin_borrow's operand can be
+    // used as an argument to all non-end borrow uses. Eliminate the
+    // begin borrow and end borrows.
+    while (!endBorrows.empty()) {
+      auto *ebi = endBorrows.pop_back_val();
+      eraseInstruction(ebi);
+    }
+
+    eraseAndRAUWSingleValueInstruction(bbi, bbi->getOperand());
+    return true;
+  }
+
+  // See if we can eliminate all of our uses that cannot escape. This currently
+  // just supports single forwarding operations. We would need a larger, non
+  // peephole optimization to handle more complex cases. But at least this
+  // allows for arbitrary single non-trivial element construction.
+  SmallVector<OwnershipMergeInst *, 32> simpleAggregateInstsToFix;
+  SmallVector<CopyValueInst *, 32> copiesToRemove;
+
+  // We already checked earlier while we populated initialAggregatesUseList has
+  // one use and forwards single non trivial argument, so we do not need to
+  // check it here again.
+  SmallVector<Operand *, 32> worklist;
+  for (auto *use : initialAggregatesUseList) {
+    bool foundCopyUse = false;
+    worklist.push_back(use);
+    while (!worklist.empty()) {
+      auto *use = worklist.pop_back_val();
+
+      // If we have an aggregate that forwards our value that is only consumed
+      // once, look through it. This from an ownership perspective creates a
+      // linear chain that we can fix up.
+      if (auto *aggregate = dyn_cast<OwnershipMergeInst>(use->getUser())) {
+        if (auto *oneUse = aggregate->getSingleUse()) {
+          if (aggregate->forwardsSingleNonTrivialArgument()) {
+            simpleAggregateInstsToFix.push_back(aggregate);
+            worklist.push_back(oneUse);
+            continue;
+          }
+        }
+      }
+
+      // Otherwise, see if we have a single copy_value. We support this
+      // case. Otherwise, return false. We are being very conservative on
+      // purpose so we handle a very specific type of pattern.
+      if (auto *cvi = dyn_cast<CopyValueInst>(use->getUser())) {
+        if (foundCopyUse)
+          return false;
+        foundCopyUse = true;
+        copiesToRemove.push_back(cvi);
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "    Eliminating!\n");
+
+  for (auto *use : initialAggregatesUseList) {
+    auto *user = use->getUser();
+    SILBuilderWithScope builder(user->getIterator());
+    auto *cvi = builder.createCopyValue(user->getLoc(), bbi->getOperand());
+    getCallbacks().setUseValue(use, cvi);
+    cast<OwnershipMergeInst>(user)->setForwardingOwnershipKind(
+        OwnershipKind::Owned);
+  }
+
+  while (!simpleAggregateInstsToFix.empty()) {
+    auto *inst = simpleAggregateInstsToFix.pop_back_val();
+    inst->setForwardingOwnershipKind(OwnershipKind::Owned);
+  }
+
+  while (!copiesToRemove.empty()) {
+    auto *cvi = copiesToRemove.pop_back_val();
+    eraseAndRAUWSingleValueInstruction(cvi, cvi->getOperand());
+  }
+
+  // At this point, we know that the begin_borrow's operand can be used as an
+  // argument to all non-end borrow uses. We have also handled all of the cases
+  // of copy aggregate formation if it was possible. Now it is safe to eliminate
+  // the begin borrow and end borrows.
   while (!endBorrows.empty()) {
     auto *ebi = endBorrows.pop_back_val();
     eraseInstruction(ebi);
   }
 
   eraseAndRAUWSingleValueInstruction(bbi, bbi->getOperand());
+
   return true;
 }

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.cpp
@@ -17,6 +17,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "sil-semantic-arc-opts"
+
 #include "SemanticARCOptVisitor.h"
 #include "swift/Basic/Defer.h"
 #include "swift/SIL/DebugUtils.h"
@@ -107,6 +109,7 @@ bool SemanticARCOptVisitor::processWorklist() {
     // Otherwise, if we have a single value instruction (to be expanded later
     // perhaps), try to visit that value recursively.
     if (auto *svi = dyn_cast<SingleValueInstruction>(next)) {
+      LLVM_DEBUG(llvm::dbgs() << "Worklist Visiting: " << *svi);
       bool madeSingleChange = visit(svi);
       assert((!madeSingleChange || !ctx.assumingAtFixedPoint) &&
              "Assumed was at fixed point and modified state?!");

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -74,9 +74,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
                                           SILValue newValue) {
     worklist.insert(newValue);
     for (auto *use : i->getUses()) {
-      for (SILValue result : use->getUser()->getResults()) {
-        worklist.insert(result);
-      }
+      addInstructionResultsToWorklist(use->getUser());
     }
     i->replaceAllUsesWith(newValue);
     eraseInstructionAndAddOperandsToWorklist(i);
@@ -86,10 +84,14 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   /// i. Assumes that the instruction doesnt have users.
   void eraseInstructionAndAddOperandsToWorklist(SILInstruction *i) {
     // Then copy all operands into the worklist for future processing.
+    addInstructionResultsToWorklist(i);
+    eraseInstruction(i);
+  }
+
+  void addInstructionResultsToWorklist(SILInstruction *i) {
     for (SILValue v : i->getOperandValues()) {
       worklist.insert(v);
     }
-    eraseInstruction(i);
   }
 
   /// Pop values off of visitedSinceLastMutation, adding .some values to the

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -57,7 +57,10 @@ final class Klass {
 extension Klass : MyFakeAnyObject {
   func myFakeMethod()
 }
+
+sil @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
 sil @guaranteed_klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+sil @guaranteed_klass_user_product_owned : $@convention(thin) (@guaranteed Klass) -> ()
 sil @guaranteed_fakeoptional_klass_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 sil @guaranteed_fakeoptional_classlet_user : $@convention(thin) (@guaranteed FakeOptional<ClassLet>) -> ()
 
@@ -69,6 +72,14 @@ struct StructWithDataAndOwner {
   var data : Builtin.Int32
   var owner : Klass
 }
+
+struct Struct2WithDataAndOwner {
+  var owner : StructWithDataAndOwner
+  var data : Builtin.Int64
+}
+
+sil @guaranteed_use_structwithdataowner : $@convention(thin) (@guaranteed StructWithDataAndOwner) -> ()
+sil @guaranteed_use_struct2withdataowner : $@convention(thin) (@guaranteed Struct2WithDataAndOwner) -> ()
 
 struct StructMemberTest {
   var c : Klass
@@ -1497,3 +1508,261 @@ bb3:
   return %9999 : $()
 }
 
+// Predictable Mem Opts (or PMO) tends to produce code that looks like the
+// following. Make sure that we can eliminate the begin_borrow below and only
+// hvae a single copy_value.
+//
+// CHECK-LABEL: sil [ossa] @pmoOutputExample : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+// CHECK-NOT: begin_borrow
+// CHECK: copy_value
+// CHECK-NOT: begin_borrow
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'pmoOutputExample'
+sil [ossa] @pmoOutputExample : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  %15 = copy_value %14 : $StructWithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $StructWithDataAndOwner
+  destroy_value %15 : $StructWithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $StructWithDataAndOwner
+}
+
+// CHECK-LABEL: sil [ossa] @pmoOutputExampleWithUnreachable : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+// CHECK-NOT: begin_borrow
+// CHECK: } // end sil function 'pmoOutputExampleWithUnreachable'
+sil [ossa] @pmoOutputExampleWithUnreachable : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %15 = copy_value %14 : $StructWithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $StructWithDataAndOwner
+  destroy_value %15 : $StructWithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $StructWithDataAndOwner
+}
+
+// CHECK-LABEL: sil [ossa] @pmoOutputExampleWithOtherBlocks : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+// CHECK-NOT: begin_borrow
+// CHECK: } // end sil function 'pmoOutputExampleWithOtherBlocks'
+sil [ossa] @pmoOutputExampleWithOtherBlocks : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %15 = copy_value %14 : $StructWithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $StructWithDataAndOwner
+  destroy_value %15 : $StructWithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $StructWithDataAndOwner
+}
+
+// CHECK-LABEL: sil [ossa] @pmoOutputExampleChained : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+// CHECK-NOT: begin_borrow
+// CHECK: } // end sil function 'pmoOutputExampleChained'
+sil [ossa] @pmoOutputExampleChained : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32, %arg2 : $Builtin.Int64):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %14a = struct $Struct2WithDataAndOwner (%14 : $StructWithDataAndOwner, %arg2 : $Builtin.Int64)
+  %15 = copy_value %14a : $Struct2WithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $Struct2WithDataAndOwner
+}
+
+// In this case, one of our structs has an additional use that isnt a copy and
+// isnt in the chain.
+//
+// CHECK-LABEL: sil [ossa] @pmoOutputExampleChainedFail : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+// CHECK: begin_borrow
+// CHECK: } // end sil function 'pmoOutputExampleChainedFail'
+sil [ossa] @pmoOutputExampleChainedFail : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32, %arg2 : $Builtin.Int64):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %f = function_ref @guaranteed_use_structwithdataowner : $@convention(thin) (@guaranteed StructWithDataAndOwner) -> ()
+  apply %f(%14) : $@convention(thin) (@guaranteed StructWithDataAndOwner) -> ()
+  %14a = struct $Struct2WithDataAndOwner (%14 : $StructWithDataAndOwner, %arg2 : $Builtin.Int64)
+  %15 = copy_value %14a : $Struct2WithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $Struct2WithDataAndOwner
+}
+
+// CHECK-LABEL: sil [ossa] @pmoOutputExampleChainedFail1 : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+// CHECK: begin_borrow
+// CHECK: } // end sil function 'pmoOutputExampleChainedFail1'
+sil [ossa] @pmoOutputExampleChainedFail1 : $@convention(method) (@owned Klass, Builtin.Int32, Builtin.Int64) -> @owned Struct2WithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32, %arg2 : $Builtin.Int64):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  cond_br undef, bb1, bb2
+
+bb1:
+  unreachable
+
+bb2:
+  %14a = struct $Struct2WithDataAndOwner (%14 : $StructWithDataAndOwner, %arg2 : $Builtin.Int64)
+  %f = function_ref @guaranteed_use_struct2withdataowner : $@convention(thin) (@guaranteed Struct2WithDataAndOwner) -> ()
+  apply %f(%14a) : $@convention(thin) (@guaranteed Struct2WithDataAndOwner) -> ()
+  %15 = copy_value %14a : $Struct2WithDataAndOwner
+  end_borrow %13 : $Klass
+  %17 = copy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %15 : $Struct2WithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $Struct2WithDataAndOwner
+}
+
+// CHECK-LABEL: sil [ossa] @pmoOutputMultipleExample : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+// CHECK-NOT: begin_borrow
+// CHECK: } // end sil function 'pmoOutputMultipleExample'
+sil [ossa] @pmoOutputMultipleExample : $@convention(method) (@owned Klass, Builtin.Int32) -> @owned StructWithDataAndOwner {
+bb0(%0 : @owned $Klass, %1 : $Builtin.Int32):
+  %2 = alloc_stack $StructWithDataAndOwner, var, name "self"
+  debug_value %0 : $Klass, let, name "rawValue", argno 1
+  %4 = copy_value %0 : $Klass
+  %5 = function_ref @guaranteed_klass_owned_result : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> @owned Klass
+  %7 = begin_access [modify] [static] %2 : $*StructWithDataAndOwner
+  %8 = struct_element_addr %7 : $*StructWithDataAndOwner, #StructWithDataAndOwner.owner
+  %9 = copy_value %6 : $Klass
+  store %6 to [init] %8 : $*Klass
+  end_access %7 : $*StructWithDataAndOwner
+  destroy_value %4 : $Klass
+  %13 = begin_borrow %9 : $Klass
+  %14 = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13 : $Klass)
+  %15 = copy_value %14 : $StructWithDataAndOwner
+  end_borrow %13 : $Klass
+  %13a = begin_borrow %9 : $Klass
+  %14a = struct $StructWithDataAndOwner (%1 : $Builtin.Int32, %13a : $Klass)
+  %15a = copy_value %14a : $StructWithDataAndOwner
+  end_borrow %13a : $Klass
+
+  %17 = copy_value %15 : $StructWithDataAndOwner
+  destroy_value %15 : $StructWithDataAndOwner
+  destroy_value %15a : $StructWithDataAndOwner
+  destroy_value %9 : $Klass
+  destroy_value %0 : $Klass
+  destroy_addr %2 : $*StructWithDataAndOwner
+  dealloc_stack %2 : $*StructWithDataAndOwner
+  return %17 : $StructWithDataAndOwner
+}


### PR DESCRIPTION
PMO promotes loads from available loads by forming a borrowed aggregate from the
struct's components and then copy that. Thus you get this sort of pattern:

```
  %1 = begin_borrow %arg0 : $Klass
  ...
  %2 = struct $StructWithDataAndOwner (%arg1 : $Builtin.Int32, %1 : $Klass)
  ...
  %3 = struct $Struct2WithDataAndOwner2 (%arg2 : $Builtin.Int64, %2 : $StructWithDataAndOwner)
  ...
  %4 = copy_value %3 : $Struct2WithDataAndOwner2
  ...
  end_borrow %1 : $Klass
```

Our transform is to eliminate the borrow scope and hoist the copy_value /before/
the StructWithDataAndOwner, e.x.:

```
  // begin_borrow was here
  ...
  %4 = copy_value %arg0 : $Klass
  %5 = struct $StructWithDataAndOwner (%arg1 : $Builtin.Int32, %4 : $Klass)
  ...
  ...
  %6 = struct $Struct2WithDataAndOwner2 (%arg2 : $Builtin.Int64, %2 : $StructWithDataAndOwner)
  // copy_value was here
  ...
  // end_borrow was here
```

This is safe since:

* We know that %arg0 is already alive at %2 due to the properties of %1 being
  borrowed from %arg0. Thus, we know that arg0 will be live at that point.

* We restrict our optimization only to linear chains of structs that have a
  single non-trivial field. This hits the common case of trivial data + owning
  non-trivial value (e.x.: String).

* Our linear chain of structs must have that each subsequent struct has a single
  use, the next struct except for the last struct element. The last struct
  element must have all uses that can accept owned ownership, or we bail. We
  allow for as many initial struct formation from our original base borrow
  value. This makes sense since we are essentially hoisting chains of copies. I
  added tests to check this behavior.

We may need to add a more general way of eliminating these chains of borrows for
types with multiple non-trivial types. That would be more complicated than what
I am trying to do here and may not be needed if copy propagation can eventually
handle that case. If not, it would just require a more complicated algorithm.

rdar://75370082
