### PR TITLE
Remove @_assemblyVision marker that snuck into ChaCha.

### DIFF
--- a/benchmark/single-source/ChaCha.swift
+++ b/benchmark/single-source/ChaCha.swift
@@ -363,7 +363,6 @@ func checkResult(_ plaintext: [UInt8]) {
 }
 
 @inline(never)
-@_assemblyVision
 public func run_ChaCha(_ n: Int) {
   let key = Array(repeating: UInt8(1), count: 32)
   let nonce = Array(repeating: UInt8(2), count: 12)


### PR DESCRIPTION
I think I was using this as part of a demo at some point and it snuck into
tree.