### PR TITLE
[test][stdlib] Beef up Unicode.Scalar.Properties testing

### DIFF
--- a/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_target_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD
   # filename.
   StdlibUnicodeUnittest.swift
   Collation.swift
+  UnicodeScalarProperties.swift
 
   SWIFT_MODULE_DEPENDS StdlibUnittest
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
@@ -1,0 +1,167 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// Cache of opened files 
+var cachedFiles: [String: String] = [:]
+
+func readInputFile(_ index: Int) -> String {
+  let file = CommandLine.arguments[index]
+
+  do {
+    guard let cache = cachedFiles[file] else {
+      return try String(contentsOfFile: file, encoding: .utf8)
+    }
+
+    return cache
+  } catch {
+    fatalError(error.localizedDescription)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Binary Properties
+//===----------------------------------------------------------------------===//
+
+// Note: If one ever updates this list, be it adding new properties, removing,
+// etc., please update the same list found in:
+// 'stdlib/public/core/UnicodeScalarProperties.swift'.
+let availableBinaryProperties: Set<String> = [
+  "Alphabetic",
+  "ASCII_Hex_Digit",
+  "Bidi_Control",
+  "Bidi_Mirrored",
+  "Cased",
+  "Case_Ignorable",
+  "Changes_When_Casefolded",
+  "Changes_When_Casemapped",
+  "Changes_When_Lowercased",
+  "Changes_When_NFKC_Casefolded",
+  "Changes_When_Titlecased",
+  "Changes_When_Uppercased",
+  "Dash",
+  "Default_Ignorable_Code_Point",
+  "Deprecated",
+  "Diacritic",
+  "Emoji",
+  "Emoji_Modifier",
+  "Emoji_Modifier_Base",
+  "Emoji_Presentation",
+  "Extender",
+  "Full_Composition_Exclusion",
+  "Grapheme_Base",
+  "Grapheme_Extend",
+  "Hex_Digit",
+  "ID_Continue",
+  "ID_Start",
+  "Ideographic",
+  "IDS_Binary_Operator",
+  "IDS_Trinary_Operator",
+  "Join_Control",
+  "Logical_Order_Exception",
+  "Lowercase",
+  "Math",
+  "Noncharacter_Code_Point",
+  "Other_Alphabetic",
+  "Other_Default_Ignorable_Code_Point",
+  "Other_Grapheme_Extend",
+  "Other_ID_Continue",
+  "Other_ID_Start",
+  "Other_Lowercase",
+  "Other_Math",
+  "Other_Uppercase",
+  "Pattern_Syntax",
+  "Pattern_White_Space",
+  "Quotation_Mark",
+  "Radical",
+  "Sentence_Terminal",
+  "Soft_Dotted",
+  "Terminal_Punctuation",
+  "Unified_Ideograph",
+  "Uppercase",
+  "Variation_Selector",
+  "White_Space",
+  "XID_Continue",
+  "XID_Start"
+]
+
+func parseBinaryProperties(
+  _ data: String,
+  into result: inout [String: Set<Unicode.Scalar>]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+    
+    // Get the property first because we may not care about it.
+    let filteredProperty = components[1].filter { !$0.isWhitespace }
+    
+    guard availableBinaryProperties.contains(filteredProperty) else {
+      continue
+    }
+    
+    let scalars: ClosedRange<UInt32>
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+
+    // If we have . appear, it means we have a legitimate range. Otherwise,
+    // it's a singular scalar.
+    if filteredScalars.contains(".") {
+      let range = filteredScalars.split(separator: ".")
+
+      scalars = UInt32(range[0], radix: 16)! ... UInt32(range[1], radix: 16)!
+    } else {
+      let scalar = UInt32(filteredScalars, radix: 16)!
+
+      scalars = scalar ... scalar
+    }
+
+    for scalar in scalars {
+      result[filteredProperty, default: []].insert(Unicode.Scalar(scalar)!)
+    }
+  }
+}
+
+// A dictionary of all currently exposed Unicode Scalar Properties. Keyed by
+// the literal property name and values being the set of scalars who all conform
+// to said property.
+public let binaryProperties: [String: Set<Unicode.Scalar>] = {
+  var result: [String: Set<Unicode.Scalar>] = [:]
+
+  // DerivedCoreProperties.txt
+  let derivedCoreProps = readInputFile(2)
+  parseBinaryProperties(derivedCoreProps, into: &result)
+
+  // DerivedNormalizationProps.txt
+  let derivedNormalizationProps = readInputFile(3)
+  parseBinaryProperties(derivedNormalizationProps, into: &result)
+
+  // DerivedBinaryProperties.txt
+  let derivedBinaryProperties = readInputFile(4)
+  parseBinaryProperties(derivedBinaryProperties, into: &result)
+
+  // PropList.txt
+  let propList = readInputFile(5)
+  parseBinaryProperties(propList, into: &result)
+
+  // emoji-data.txt
+  let emojiData = readInputFile(6)
+  parseBinaryProperties(emojiData, into: &result)
+
+  return result
+}()

--- a/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
@@ -15,17 +15,33 @@ import Foundation
 // Cache of opened files 
 var cachedFiles: [String: String] = [:]
 
-func readInputFile(_ index: Int) -> String {
-  let file = CommandLine.arguments[index]
+func readInputFile(_ filename: String) -> String {
+  let path = CommandLine.arguments[2]
 
   do {
-    guard let cache = cachedFiles[file] else {
-      return try String(contentsOfFile: file, encoding: .utf8)
+    guard let cache = cachedFiles[filename] else {
+      let contents = try String(contentsOfFile: path + filename, encoding: .utf8)
+      cachedFiles[filename] = contents
+      return contents
     }
 
     return cache
   } catch {
     fatalError(error.localizedDescription)
+  }
+}
+
+func parseScalars(_ string: String) -> ClosedRange<UInt32> {
+  // If we have . appear, it means we have a legitimate range. Otherwise,
+  // it's a singular scalar.
+  if string.contains(".") {
+    let range = string.split(separator: ".")
+
+    return UInt32(range[0], radix: 16)! ... UInt32(range[1], radix: 16)!
+  } else {
+    let scalar = UInt32(string, radix: 16)!
+
+    return scalar ... scalar
   }
 }
 
@@ -114,22 +130,10 @@ func parseBinaryProperties(
     guard availableBinaryProperties.contains(filteredProperty) else {
       continue
     }
-    
-    let scalars: ClosedRange<UInt32>
 
     let filteredScalars = components[0].filter { !$0.isWhitespace }
 
-    // If we have . appear, it means we have a legitimate range. Otherwise,
-    // it's a singular scalar.
-    if filteredScalars.contains(".") {
-      let range = filteredScalars.split(separator: ".")
-
-      scalars = UInt32(range[0], radix: 16)! ... UInt32(range[1], radix: 16)!
-    } else {
-      let scalar = UInt32(filteredScalars, radix: 16)!
-
-      scalars = scalar ... scalar
-    }
+    let scalars = parseScalars(String(filteredScalars))
 
     for scalar in scalars {
       result[filteredProperty, default: []].insert(Unicode.Scalar(scalar)!)
@@ -143,25 +147,488 @@ func parseBinaryProperties(
 public let binaryProperties: [String: Set<Unicode.Scalar>] = {
   var result: [String: Set<Unicode.Scalar>] = [:]
 
-  // DerivedCoreProperties.txt
-  let derivedCoreProps = readInputFile(2)
+  #if canImport(Darwin)
+  let derivedCoreProps = readInputFile("Apple/DerivedCoreProperties.txt")
+  #else
+  let derivedCoreProps = readInputFile("DerivedCoreProperties.txt")
+  #endif
   parseBinaryProperties(derivedCoreProps, into: &result)
 
-  // DerivedNormalizationProps.txt
-  let derivedNormalizationProps = readInputFile(3)
+  let derivedNormalizationProps = readInputFile("DerivedNormalizationProps.txt")
   parseBinaryProperties(derivedNormalizationProps, into: &result)
 
-  // DerivedBinaryProperties.txt
-  let derivedBinaryProperties = readInputFile(4)
+  let derivedBinaryProperties = readInputFile("DerivedBinaryProperties.txt")
   parseBinaryProperties(derivedBinaryProperties, into: &result)
 
-  // PropList.txt
-  let propList = readInputFile(5)
+  let propList = readInputFile("PropList.txt")
   parseBinaryProperties(propList, into: &result)
 
-  // emoji-data.txt
-  let emojiData = readInputFile(6)
+  let emojiData = readInputFile("emoji-data.txt")
   parseBinaryProperties(emojiData, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Numeric Properties
+//===----------------------------------------------------------------------===//
+
+func parseNumericTypes(
+  _ data: String,
+  into result: inout [Unicode.Scalar: Unicode.NumericType]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+    
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+    
+    let filteredProperty = components[1].filter { !$0.isWhitespace }
+    
+    let numericType: Unicode.NumericType
+
+    switch filteredProperty {
+    case "Numeric":
+      numericType = .numeric
+    case "Decimal":
+      numericType = .decimal
+    case "Digit":
+      numericType = .digit
+    default:
+      continue
+    }
+    
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+    
+    let scalars = parseScalars(String(filteredScalars))
+
+    for scalar in scalars {
+      result[Unicode.Scalar(scalar)!] = numericType
+    }
+  }
+}
+
+func parseNumericValues(
+  _ data: String,
+  into result: inout [Unicode.Scalar: Double]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+    
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+    
+    let filteredProperty = components[3].filter { !$0.isWhitespace }
+    
+    let value: Double
+
+    // If we have a division, split the numerator and denominator and perform
+    // the division ourselves to get the correct double value.
+    if filteredProperty.contains("/") {
+      let splitDivision = filteredProperty.split(separator: "/")
+
+      let numerator = Double(splitDivision[0])!
+      let denominator = Double(splitDivision[1])!
+
+      value = numerator / denominator
+    } else {
+      value = Double(filteredProperty)!
+    }
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+    
+    let scalars = parseScalars(String(filteredScalars))
+
+    for scalar in scalars {
+      result[Unicode.Scalar(scalar)!] = value
+    }
+  }
+}
+
+// A dictionary of every scalar who has a numeric type and it's value.
+public let numericTypes: [Unicode.Scalar: Unicode.NumericType] = {
+  var result: [Unicode.Scalar: Unicode.NumericType] = [:]
+
+  let derivedNumericType = readInputFile("DerivedNumericType.txt")
+  parseNumericTypes(derivedNumericType, into: &result)
+
+  return result
+}()
+
+// A dictionary of scalar to numeric value.
+public let numericValues: [Unicode.Scalar: Double] = {
+  var result: [Unicode.Scalar: Double] = [:]
+
+  let derivedNumericValues = readInputFile("DerivedNumericValues.txt")
+  parseNumericValues(derivedNumericValues, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Scalar Mappings
+//===----------------------------------------------------------------------===//
+
+func parseMappings(
+  _ data: String,
+  into result: inout [Unicode.Scalar: [String: String]]
+) {
+  for line in data.split(separator: "\n") {
+    let components = line.split(separator: ";", omittingEmptySubsequences: false)
+    
+    let scalarStr = components[0]
+    guard let scalar = Unicode.Scalar(UInt32(scalarStr, radix: 16)!) else {
+      continue
+    }
+
+    if let upper = UInt32(components[12], radix: 16) {
+      let mapping = String(Unicode.Scalar(upper)!)
+
+      result[scalar, default: [:]]["upper"] = mapping
+    }
+
+    if let lower = UInt32(components[13], radix: 16) {
+      let mapping = String(Unicode.Scalar(lower)!)
+
+      result[scalar, default: [:]]["lower"] = mapping
+    }
+    
+    if let title = UInt32(components[14], radix: 16) {
+      let mapping = String(Unicode.Scalar(title)!)
+
+      result[scalar, default: [:]]["title"] = mapping
+    }
+  }
+}
+
+func parseSpecialMappings(
+  _ data: String,
+  into result: inout [Unicode.Scalar: [String: String]]
+) {
+  for line in data.split(separator: "\n") {
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+    
+    let components = line.split(separator: ";", omittingEmptySubsequences: false)
+    
+    // Conditional mappings have an extra component with the conditional name.
+    // Ignore those.
+    guard components.count == 5 else {
+      continue
+    }
+    
+    guard let scalar = Unicode.Scalar(UInt32(components[0], radix: 16)!) else {
+      continue
+    }
+    
+    let lower = components[1].split(separator: " ").map {
+      Character(Unicode.Scalar(UInt32($0, radix: 16)!)!)
+    }
+    
+    let title = components[2].split(separator: " ").map {
+      Character(Unicode.Scalar(UInt32($0, radix: 16)!)!)
+    }
+    
+    let upper = components[3].split(separator: " ").map {
+      Character(Unicode.Scalar(UInt32($0, radix: 16)!)!)
+    }
+
+    if lower.count != 1 {
+      result[scalar, default: [:]]["lower"] = String(lower)
+    }
+
+    if title.count != 1 {
+      result[scalar, default: [:]]["title"] = String(title)
+    }
+
+    if upper.count != 1 {
+      result[scalar, default: [:]]["upper"] = String(upper)
+    }
+  }
+}
+
+// A dictionary of every scalar mapping keyed by the scalar and returning another
+// dictionary who is then keyed by either "lower", "upper", or "title".
+public let mappings: [Unicode.Scalar: [String: String]] = {
+  var result: [Unicode.Scalar: [String: String]] = [:]
+
+  #if canImport(Darwin)
+  let unicodeData = readInputFile("Apple/UnicodeData.txt")
+  #else
+  let unicodeData = readInputFile("UnicodeData.txt")
+  #endif
+  
+  let specialCasing = readInputFile("SpecialCasing.txt")
+
+  parseMappings(unicodeData, into: &result)
+  parseSpecialMappings(specialCasing, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Scalar Age
+//===----------------------------------------------------------------------===//
+
+func parseAge(
+  _ data: String,
+  into result: inout [Unicode.Scalar: Unicode.Version]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+
+    let scalars = parseScalars(String(filteredScalars))
+
+    let version = components[1].filter { !$0.isWhitespace }
+    let parts = version.split(separator: ".")
+
+    let major = Int(parts[0])!
+    let minor = Int(parts[1])!
+
+    for scalar in scalars {
+      guard let scalar = Unicode.Scalar(scalar) else {
+        continue
+      }
+
+      result[scalar] = (major, minor)
+    }
+  }
+}
+
+public let ages: [Unicode.Scalar: Unicode.Version] = {
+  var result: [Unicode.Scalar: Unicode.Version] = [:]
+
+  let derivedAge = readInputFile("DerivedAge.txt")
+  parseAge(derivedAge, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Scalar General Category
+//===----------------------------------------------------------------------===//
+
+func parseGeneralCategory(
+  _ data: String,
+  into result: inout [Unicode.Scalar: Unicode.GeneralCategory]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+
+    let filteredCategory = components[1].filter { !$0.isWhitespace }
+
+    let category: Unicode.GeneralCategory
+
+    switch filteredCategory {
+    case "Lu":
+      category = .uppercaseLetter
+    case "Ll":
+      category = .lowercaseLetter
+    case "Lt":
+      category = .titlecaseLetter
+    case "Lm":
+      category = .modifierLetter
+    case "Lo":
+      category = .otherLetter
+    case "Mn":
+      category = .nonspacingMark
+    case "Mc":
+      category = .spacingMark
+    case "Me":
+      category = .enclosingMark
+    case "Nd":
+      category = .decimalNumber
+    case "Nl":
+      category = .letterNumber
+    case "No":
+      category = .otherNumber
+    case "Pc":
+      category = .connectorPunctuation
+    case "Pd":
+      category = .dashPunctuation
+    case "Ps":
+      category = .openPunctuation
+    case "Pe":
+      category = .closePunctuation
+    case "Pi":
+      category = .initialPunctuation
+    case "Pf":
+      category = .finalPunctuation
+    case "Po":
+      category = .otherPunctuation
+    case "Sm":
+      category = .mathSymbol
+    case "Sc":
+      category = .currencySymbol
+    case "Sk":
+      category = .modifierSymbol
+    case "So":
+      category = .otherSymbol
+    case "Zs":
+      category = .spaceSeparator
+    case "Zl":
+      category = .lineSeparator
+    case "Zp":
+      category = .paragraphSeparator
+    case "Cc":
+      category = .control
+    case "Cf":
+      category = .format
+    case "Cs":
+      category = .surrogate
+    case "Co":
+      category = .privateUse
+    case "Cn":
+      category = .unassigned
+    default:
+      continue
+    }
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+
+    let scalars = parseScalars(String(filteredScalars))
+
+    for scalar in scalars {
+      guard let scalar = Unicode.Scalar(scalar) else {
+        continue
+      }
+
+      result[scalar] = category
+    }
+  }
+}
+
+public let generalCategories: [Unicode.Scalar: Unicode.GeneralCategory] = {
+  var result: [Unicode.Scalar: Unicode.GeneralCategory] = [:]
+
+  let derivedGeneralCategory = readInputFile("DerivedGeneralCategory.txt")
+  parseGeneralCategory(derivedGeneralCategory, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Scalar Name Alias
+//===----------------------------------------------------------------------===//
+
+func parseNameAliases(
+  _ data: String,
+  into result: inout [Unicode.Scalar: String]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+
+    // Name aliases are only found with correction attribute.
+    guard components[2] == "correction" else {
+      continue
+    }
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+
+    guard let scalar = Unicode.Scalar(UInt32(filteredScalars, radix: 16)!) else {
+      continue
+    }
+
+    let nameAlias = String(components[1])
+
+    result[scalar] = nameAlias
+  }
+}
+
+public let nameAliases: [Unicode.Scalar: String] = {
+  var result: [Unicode.Scalar: String] = [:]
+
+  let nameAliases = readInputFile("NameAliases.txt")
+  parseNameAliases(nameAliases, into: &result)
+
+  return result
+}()
+
+//===----------------------------------------------------------------------===//
+// Scalar Name
+//===----------------------------------------------------------------------===//
+
+func parseNames(
+  _ data: String,
+  into result: inout [Unicode.Scalar: String]
+) {
+  for line in data.split(separator: "\n") {
+    // Skip comments
+    guard !line.hasPrefix("#") else {
+      continue
+    }
+
+    let info = line.split(separator: "#")
+    let components = info[0].split(separator: ";")
+
+    let filteredScalars = components[0].filter { !$0.isWhitespace }
+
+    let scalars = parseScalars(String(filteredScalars))
+
+    // If our scalar is a range of scalars, then the name is usually something
+    // like NAME-HERE-* where * is the scalar value.
+    if scalars.count > 1 {
+      for scalar in scalars {
+        guard let scalar = Unicode.Scalar(scalar) else {
+          continue
+        }
+
+        var name = String(components[1])
+        // There's leftover spacing in the beginning of the name that we need to
+        // get rid of.
+        name.removeFirst()
+        name.removeLast()
+        name += "\(String(scalar.value, radix: 16, uppercase: true))"
+
+        result[scalar] = name
+      }
+    } else {
+      guard let scalar = Unicode.Scalar(scalars.lowerBound) else {
+        continue
+      }
+
+      var name = String(components[1])
+      // There's leftover spacing in the beginning of the name that we need to
+      // get rid of.
+      name.removeFirst()
+
+      result[scalar] = name
+    }
+  }
+}
+
+public let names: [Unicode.Scalar: String] = {
+  var result: [Unicode.Scalar: String] = [:]
+
+  let derivedName = readInputFile("DerivedName.txt")
+  parseNames(derivedName, into: &result)
 
   return result
 }()

--- a/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
+++ b/stdlib/private/StdlibUnicodeUnittest/UnicodeScalarProperties.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Unicode scalar tests are currently only avaible on Darwin, awaiting a sensible
+// file API...
+#if _runtime(_ObjC)
 import Foundation
 
 // Cache of opened files 
@@ -632,3 +635,4 @@ public let names: [Unicode.Scalar: String] = {
 
   return result
 }()
+#endif

--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // REQUIRES: long_test
 // REQUIRES: optimized_stdlib
+// REQUIRES: objc_interop
 
 import StdlibUnittest
 import StdlibUnicodeUnittest

--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -1,0 +1,87 @@
+// RUN: %target-run-simple-swift %S/../../utils/gen-unicode-data/Data/DerivedCoreProperties.txt %S/../../utils/gen-unicode-data/Data/DerivedNormalizationProps.txt %S/../../utils/gen-unicode-data/Data/DerivedBinaryProperties.txt %S/../../utils/gen-unicode-data/Data/PropList.txt %S/../../utils/gen-unicode-data/Data/emoji-data.txt
+// REQUIRES: executable_test
+// REQUIRES: long_test
+// REQUIRES: optimized_stdlib
+
+import StdlibUnittest
+import StdlibUnicodeUnittest
+
+var UnicodeScalarPropertiesTest = TestSuite("UnicodeScalarProperties")
+
+//===----------------------------------------------------------------------===//
+// Binary Properties
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Binary Properties") {
+    // First, check that we correctly parsed the unicode data tables to be able
+    // to test against.
+
+    // We have 48 properties, but some properties have 'Other_' properties which
+    // are included in them, so count those as well.
+    expectEqual(56, binaryProperties.keys.count)
+
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      func check(_ property: String) -> Bool {
+        binaryProperties[property]!.contains(scalar)
+      }
+
+      let props = scalar.properties
+
+      expectEqual(props.isAlphabetic, check("Alphabetic") || check("Other_Alphabetic"))
+      expectEqual(props.isASCIIHexDigit, check("ASCII_Hex_Digit"))
+      expectEqual(props.isBidiControl, check("Bidi_Control"))
+      expectEqual(props.isBidiMirrored, check("Bidi_Mirrored"))
+      expectEqual(props.isCased, check("Cased"))
+      expectEqual(props.isCaseIgnorable, check("Case_Ignorable"))
+      expectEqual(props.changesWhenCaseFolded, check("Changes_When_Casefolded"))
+      expectEqual(props.changesWhenCaseMapped, check("Changes_When_Casemapped"))
+      expectEqual(props.changesWhenLowercased, check("Changes_When_Lowercased"))
+      expectEqual(props.changesWhenNFKCCaseFolded, check("Changes_When_NFKC_Casefolded"))
+      expectEqual(props.changesWhenTitlecased, check("Changes_When_Titlecased"))
+      expectEqual(props.changesWhenUppercased, check("Changes_When_Uppercased"))
+      expectEqual(props.isDash, check("Dash"))
+      expectEqual(props.isDefaultIgnorableCodePoint, check("Default_Ignorable_Code_Point") || check("Other_Default_Ignorable_Code_Point"))
+      expectEqual(props.isDeprecated, check("Deprecated"))
+      expectEqual(props.isDiacritic, check("Diacritic"))
+      expectEqual(props.isEmoji, check("Emoji"))
+      expectEqual(props.isEmojiModifier, check("Emoji_Modifier"))
+      expectEqual(props.isEmojiModifierBase, check("Emoji_Modifier_Base"))
+      expectEqual(props.isEmojiPresentation, check("Emoji_Presentation"))
+      expectEqual(props.isExtender, check("Extender"))
+      expectEqual(props.isFullCompositionExclusion, check("Full_Composition_Exclusion"))
+      expectEqual(props.isGraphemeBase, check("Grapheme_Base"))
+      expectEqual(props.isGraphemeExtend, check("Grapheme_Extend") || check("Other_Grapheme_Extend"))
+      expectEqual(props.isHexDigit, check("Hex_Digit"))
+      expectEqual(props.isIDContinue, check("ID_Continue") || check("Other_ID_Continue"))
+      expectEqual(props.isIDStart, check("ID_Start") || check("Other_ID_Start"))
+      expectEqual(props.isIdeographic, check("Ideographic"))
+      expectEqual(props.isIDSBinaryOperator, check("IDS_Binary_Operator"))
+      expectEqual(props.isIDSTrinaryOperator, check("IDS_Trinary_Operator"))
+      expectEqual(props.isJoinControl, check("Join_Control"))
+      expectEqual(props.isLogicalOrderException, check("Logical_Order_Exception"))
+      expectEqual(props.isLowercase, check("Lowercase") || check("Other_Lowercase"))
+      expectEqual(props.isMath, check("Math") || check("Other_Math"))
+      expectEqual(props.isNoncharacterCodePoint, check("Noncharacter_Code_Point"))
+      expectEqual(props.isPatternSyntax, check("Pattern_Syntax"))
+      expectEqual(props.isPatternWhitespace, check("Pattern_White_Space"))
+      expectEqual(props.isQuotationMark, check("Quotation_Mark"))
+      expectEqual(props.isRadical, check("Radical"))
+      expectEqual(props.isSentenceTerminal, check("Sentence_Terminal"))
+      expectEqual(props.isSoftDotted, check("Soft_Dotted"))
+      expectEqual(props.isTerminalPunctuation, check("Terminal_Punctuation"))
+      expectEqual(props.isUnifiedIdeograph, check("Unified_Ideograph"))
+      expectEqual(props.isUppercase, check("Uppercase") || check("Other_Uppercase"))
+      expectEqual(props.isVariationSelector, check("Variation_Selector"))
+      expectEqual(props.isWhitespace, check("White_Space"))
+      expectEqual(props.isXIDContinue, check("XID_Continue"))
+      expectEqual(props.isXIDStart, check("XID_Start"))
+    }
+  }
+}
+
+runAllTests()

--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift %S/../../utils/gen-unicode-data/Data/DerivedCoreProperties.txt %S/../../utils/gen-unicode-data/Data/DerivedNormalizationProps.txt %S/../../utils/gen-unicode-data/Data/DerivedBinaryProperties.txt %S/../../utils/gen-unicode-data/Data/PropList.txt %S/../../utils/gen-unicode-data/Data/emoji-data.txt
+// RUN: %target-run-simple-swift %S/../../utils/gen-unicode-data/Data/
 // REQUIRES: executable_test
 // REQUIRES: long_test
 // REQUIRES: optimized_stdlib
@@ -80,6 +80,114 @@ if #available(SwiftStdlib 5.6, *) {
       expectEqual(props.isWhitespace, check("White_Space"))
       expectEqual(props.isXIDContinue, check("XID_Continue"))
       expectEqual(props.isXIDStart, check("XID_Start"))
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Numeric Properties
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Numeric Properties") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      expectEqual(scalar.properties.numericType, numericTypes[scalar])
+      expectEqual(scalar.properties.numericValue, numericValues[scalar])
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Scalar Mappings
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Scalar Mappings") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      if let upper = mappings[scalar]?["upper"] {
+        expectEqual(scalar.properties.uppercaseMapping, upper)
+      }
+
+      if let lower = mappings[scalar]?["lower"] {
+        expectEqual(scalar.properties.lowercaseMapping, lower)
+      }
+
+      if let title = mappings[scalar]?["title"] {
+        expectEqual(scalar.properties.titlecaseMapping, title)
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Scalar Age
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Scalar Age") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      expectEqual(scalar.properties.age?.major, ages[scalar]?.major)
+      expectEqual(scalar.properties.age?.minor, ages[scalar]?.minor)
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Scalar General Category
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Scalar General Category") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      expectEqual(scalar.properties.generalCategory, generalCategories[scalar])
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Scalar Name Alias
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Scalar Name Alias") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      expectEqual(scalar.properties.nameAlias, nameAliases[scalar])
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Scalar Name
+//===----------------------------------------------------------------------===//
+
+if #available(SwiftStdlib 5.6, *) {
+  UnicodeScalarPropertiesTest.test("Scalar Name") {
+    for i in 0x0 ... 0x10FFFF {
+      guard let scalar = Unicode.Scalar(i) else {
+        continue
+      }
+
+      expectEqual(scalar.properties.name, names[scalar])
     }
   }
 }


### PR DESCRIPTION
Right now, this is depending on https://github.com/apple/swift/pull/39597 landing first before testing this PR.

Adds a new test that reads the Unicode data files and compares answers for all scalar properties for every scalar. Obviously this is marked as a `long_test`, but in this way we can ensure that we aren't returning incorrect information with our data structures storing the Unicode data.