### PR TITLE
[SwiftSyntax] Replace ExpressibleAs protocols by ExpressibleBy protocols

### DIFF
--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -1,18 +1,18 @@
-SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
-    'ExpressibleAsConditionElement': [
-        'ExpressibleAsConditionElementList'
+SYNTAX_BUILDABLE_EXPRESSIBLE_BY_CONFORMANCES = {
+    'ExpressibleByConditionElement': [
+        'ExpressibleByConditionElementList'
     ],
-    'ExpressibleAsDeclBuildable': [
-        'ExpressibleAsCodeBlockItem',
-        'ExpressibleAsMemberDeclListItem',
-        'ExpressibleAsSyntaxBuildable'
+    'ExpressibleByDeclBuildable': [
+        'ExpressibleByCodeBlockItem',
+        'ExpressibleByMemberDeclListItem',
+        'ExpressibleBySyntaxBuildable'
     ],
-    'ExpressibleAsStmtBuildable': [
-        'ExpressibleAsCodeBlockItem',
-        'ExpressibleAsSyntaxBuildable'
+    'ExpressibleByStmtBuildable': [
+        'ExpressibleByCodeBlockItem',
+        'ExpressibleBySyntaxBuildable'
     ],
-    'ExpressibleAsExprList': [
-        'ExpressibleAsConditionElement',
-        'ExpressibleAsSyntaxBuildable'
+    'ExpressibleByExprList': [
+        'ExpressibleByConditionElement',
+        'ExpressibleBySyntaxBuildable'
     ]
 }


### PR DESCRIPTION
The protocols in the standard library are called `ExpressibleBy*` and SwiftSyntax should follow the same naming convention.