### PR TITLE
[doc] Remove redundant ordinals in `enumerated` list

### DIFF
--- a/docs/RequirementMachine/RequirementMachine.tex
+++ b/docs/RequirementMachine/RequirementMachine.tex
@@ -519,8 +519,8 @@ $\genericparam{S2}.\namesym{Iterator}.\namesym{Element}$, respectively.
 
 In order for this application of \texttt{==} to be valid, the type checker must prove two things:
 \begin{enumerate}
-\item first, $\genericparam{S1}.\namesym{Iterator}.\namesym{Element}$ and $\genericparam{S2}.\namesym{Iterator}.\namesym{Element}$ must be the same type;
-\item second, that either one or the other (since they're the same type!) must conform to $\proto{Equatable}$.
+\item $\genericparam{S1}.\namesym{Iterator}.\namesym{Element}$ and $\genericparam{S2}.\namesym{Iterator}.\namesym{Element}$ must be the same type;
+\item that either one or the other (since they're the same type!) must conform to $\proto{Equatable}$.
 \end{enumerate}
 Both facts can be proven as follows:
 \begin{itemize}


### PR DESCRIPTION
"1. first, ..." and "2. second, ..." use redundant ordinals, so it seems right to remove "first" and "second". Alternatively, the list can be `itemized` instead of `enumerated`, but then it might visually clash with the `itemized` list below it.