### PR TITLE
[CopyPropagation] Add ShrinkBorrowScope.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -16,11 +16,8 @@
 /// deleted, which in turn allows canonicalization of the outer owned values
 /// (via CanonicalizeOSSALifetime).
 ///
-/// This does not shrink borrow scopes; it does not rewrite end_borrows.
-///
-/// TODO: A separate utility to shrink borrow scopes should eventually run
-/// before this utility. It should hoist end_borrow up to the latest "destroy
-/// barrier" whenever the scope does not contain a PointerEscape.
+/// This does not shrink borrow scopes; it does not rewrite end_borrows.  For
+/// that, see ShrinkBorrowScope.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/SILOptimizer/Utils/ShrinkBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/ShrinkBorrowScope.h
@@ -1,0 +1,49 @@
+//===--- ShrinkBorrowScope.h - Shrink OSSA borrow scopes --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This utility shrinks borrow scopes by rewriting end_borrows.
+///
+/// It hoists end_borrows up to just after the latest "deinit barrier".
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_SHRINKBORROWSCOPES_H
+#define SWIFT_SILOPTIMIZER_UTILS_SHRINKBORROWSCOPES_H
+
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+
+namespace swift {
+
+//===----------------------------------------------------------------------===//
+//                       MARK: ShrinkBorrowScope
+//===----------------------------------------------------------------------===//
+
+class ShrinkBorrowScope {
+  // The borrow that begins this scope.
+  BorrowedValue borrowedValue;
+
+  InstructionDeleter &deleter;
+
+public:
+  ShrinkBorrowScope(InstructionDeleter &deleter) : deleter(deleter) {}
+
+  BorrowedValue getBorrowedValue() const { return borrowedValue; }
+
+  InstructionDeleter &getDeleter() { return deleter; }
+
+  bool shrinkBorrowScope(BorrowedValue borrow);
+};
+
+} // namespace swift
+
+#endif // SWIFT_SILOPTIMIZER_UTILS_SHRINKBORROWSCOPES_H

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(swiftSILOptimizer PRIVATE
   OptimizerStatsUtils.cpp
   PartialApplyCombiner.cpp
   PerformanceInlinerUtils.cpp
+  ShrinkBorrowScope.cpp
   SILInliner.cpp
   SILSSAUpdater.cpp
   SpecializationMangler.cpp

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -1,0 +1,183 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#include "swift/AST/Builtins.h"
+#define DEBUG_TYPE "copy-propagation"
+
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SILOptimizer/Utils/ShrinkBorrowScope.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                           MARK: Local utilities
+//===----------------------------------------------------------------------===//
+
+// TODO: Move to be member function on SILInstruction.
+static SILInstruction *getPreviousInstruction(SILInstruction *inst) {
+  auto *block = inst->getParent();
+  if (inst == &*block->begin()) {
+    return nullptr;
+  }
+  return &*std::prev(inst->getIterator());
+};
+
+// TODO: Move to be member function on SILInstruction.
+static SILInstruction *getNextInstruction(SILInstruction *inst) {
+  auto *block = inst->getParent();
+  if (inst == &*block->getTerminator()) {
+    return nullptr;
+  }
+  return &*std::next(inst->getIterator());
+};
+
+//===----------------------------------------------------------------------===//
+//                        MARK: Rewrite borrow scopes
+//===----------------------------------------------------------------------===//
+
+bool ShrinkBorrowScope::shrinkBorrowScope(BorrowedValue borrow) {
+  if (!borrow.isLocalScope())
+    return false;
+  llvm::SmallVector<SILInstruction *, 16> scopeEndingInsts;
+  borrow.getLocalScopeEndingInstructions(scopeEndingInsts);
+
+  SmallVector<Operand *, 16> usePoints;
+  SmallPtrSet<SILInstruction *, 16> users;
+  for (auto *usePoint : usePoints) {
+    users.insert(usePoint->getUser());
+  }
+  auto isDeinitBarrier = [&](SILInstruction *instruction,
+                             SILValue value) -> bool {
+    // TODO: Implement this to mean
+    //           maySynchronize || mayAccessPointer || mayLoadWeak.
+    return true;
+  };
+
+  // The list of blocks to look for new points at which to insert end_borrows
+  // in.  A block must not be processed if all of its successors have not yet
+  // been.  For that reason, it is necessary to allow the same block to be
+  // visited multiple times, at most once for each predecessor.
+  SmallVector<SILBasicBlock *, 8> worklist;
+  SmallPtrSet<SILBasicBlock *, 8> blocksWithReachedTops;
+  SmallPtrSet<SILBasicBlock *, 8> blocksToEndAtTop;
+  auto reachedTopOfAllSuccessors = [&](SILBasicBlock *block) {
+    return llvm::all_of(block->getSuccessorBlocks(), [=](auto *successor) {
+      return blocksWithReachedTops.contains(successor);
+    });
+  };
+
+  // Form a map of the scopeEndingInsts, keyed off the block they occur in.  If
+  // a scope ending instruction is not an end_borrow, bail out.
+  llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *> startingInstructions;
+  for (auto *instruction : scopeEndingInsts) {
+    if (!isa<EndBorrowInst>(instruction))
+      return false;
+    auto *block = instruction->getParent();
+    worklist.push_back(block);
+    startingInstructions[block] = instruction;
+  }
+
+  // Walk the cfg backwards from the blocks containing scope ending
+  // instructions, visiting only the initial blocks (which contained those
+  // instructions) and those blocks all of whose successors have already been
+  // visited.
+  //
+  // TODO: Handle loops.
+  llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *> barrierInstructions;
+  while (!worklist.empty()) {
+    auto *block = worklist.pop_back_val();
+    auto *startingInstruction = startingInstructions.lookup(block);
+    if (!startingInstruction && !reachedTopOfAllSuccessors(block)) {
+      continue;
+    }
+    if (!startingInstruction) {
+      // This block was walked to--it was not one containing one of the initial
+      // end_borrow instructions.  Check whether it forwards the ownership of
+      // the borrowed value (either directly or indirectly).  If it does, we
+      // must not hoist the end_borrow above it.
+      //
+      // TODO: Do this without forming the list of all guaranteed reference
+      //       roots--we don't need the list and we don't want to keep looking
+      //       once we see that a root matches borrow.value.
+      TermInst *terminator = block->getTerminator();
+      auto operandValues =
+          terminator->getOperandValues(/*skipTypeDependentOperands=*/true);
+      bool bail = false;
+      for (auto operand : operandValues) {
+        SmallVector<SILValue, 4> roots;
+        findGuaranteedReferenceRoots(operand, roots);
+        if (llvm::find(roots, borrow.value) != roots.end()) {
+          bail = true;
+          break;
+        }
+      }
+      if (bail) {
+        continue;
+      }
+    }
+    for (auto *successor : block->getSuccessorBlocks()) {
+      blocksToEndAtTop.erase(successor);
+    }
+
+    // We either have processed all successors of block or else it is a block
+    // which contained one of the original scope-ending instructions.  Scan the
+    // block backwards, looking for the first deinit barrier.  If we've visited
+    // all successors, start scanning from the terminator.  If block contained
+    // an original scope-ending instruction, start scanning from it.
+    SILInstruction *instruction =
+        startingInstruction ? startingInstruction : block->getTerminator();
+    SILInstruction *barrier = nullptr;
+    while ((instruction = getPreviousInstruction(instruction))) {
+      if (instruction == borrow->getDefiningInstruction()) {
+        barrier = instruction;
+      }
+      if (isDeinitBarrier(instruction, borrow.value)) {
+        barrier = instruction;
+        break;
+      }
+    }
+
+    if (barrier) {
+      barrierInstructions[block] = barrier;
+    } else {
+      blocksWithReachedTops.insert(block);
+      blocksToEndAtTop.insert(block);
+      for (auto *predecessor : block->getPredecessorBlocks()) {
+        worklist.push_back(predecessor);
+      }
+    }
+  }
+
+  // Remove all the original end_borrow instructions.
+  for (auto pair : startingInstructions) {
+    deleter.forceDelete(pair.getSecond());
+  }
+
+  // Insert the new end_borrow instructions that occur after deinit barriers.
+  for (auto pair : barrierInstructions) {
+    auto *insertionPoint = getNextInstruction(pair.getSecond());
+    auto builder = SILBuilderWithScope(insertionPoint);
+    builder.createEndBorrow(
+        RegularLocation::getAutoGeneratedLocation(insertionPoint->getLoc()),
+        borrow.value);
+  }
+
+  // Insert the new end_borrow instructions that occur at the beginning of
+  // blocks which we couldn't hoist out of.
+  for (auto *block : blocksToEndAtTop) {
+    auto *insertionPoint = &*block->begin();
+    auto builder = SILBuilderWithScope(insertionPoint);
+    builder.createEndBorrow(
+        RegularLocation::getAutoGeneratedLocation(insertionPoint->getLoc()),
+        borrow.value);
+  }
+
+  return true;
+}

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -416,14 +416,10 @@ bb0(%0 : @owned $T):
 }
 
 // CHECK-TRACE-LABEL: *** CopyPropagation: testCopyBorrow
-// CHECK-TRACE:  Removing   destroy_value %1 : $T
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value %0 : $T
 // CHECK-TRACE-NOT: Removing
 //
 // CHECK-LABEL: sil [ossa] @testCopyBorrow : $@convention(thin) <T> (@in T) -> () {
 // CHECK:       bb0(%0 : @owned $T):
-// CHECK-NEXT:  %1 = begin_borrow %0 : $T
-// CHECK-NEXT:  end_borrow %1 : $T
 // CHECK-NEXT:  destroy_value %0 : $T
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -1,0 +1,400 @@
+// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s
+
+import Swift
+
+// =============================================================================
+// = DECLARATIONS                                                             {{
+// =============================================================================
+
+class C {
+    weak var d: D?
+}
+class D {}
+
+struct CDCase {
+    var c: C
+    var d: D
+}
+
+enum OneOfThree { case one, two, three }
+
+sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+
+// =============================================================================
+// = DECLARATIONS                                                             }}
+// =============================================================================
+
+// =============================================================================
+// branching tests                                                            {{
+// =============================================================================
+
+// Hoist over br.
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_1'
+sil [ossa] @hoist_over_branch_1 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    br bl1
+bl1:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// Hoist over cond_br.
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         cond_br undef, [[BL1:bb[0-9]+]], [[BL2:bb[0-9]+]]
+// CHECK:       [[BL1]]:
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BL2]]:
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_2'
+sil [ossa] @hoist_over_branch_2 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, bl1, bl2
+bl1:
+    end_borrow %lifetime : $C
+    br exit
+bl2:
+    end_borrow %lifetime : $C
+    br exit
+exit:
+    return %instance : $C
+}
+
+// Hoist over two brs.
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_3 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         cond_br undef, [[BL1:bb[0-9]+]], [[BL2:bb[0-9]+]]
+// CHECK:       [[BL1]]:
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BL2]]:
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_3'
+sil [ossa] @hoist_over_branch_3 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, bl1, bl2
+bl1:
+    br exit
+bl2:
+    br exit
+exit:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// Don't hoist over 1 / 2 brs.
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         cond_br undef, [[BL1:bb[0-9]+]], [[BL2:bb[0-9]+]]
+// CHECK:       [[BL1]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BL2]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_4'
+sil [ossa] @hoist_over_branch_4 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    cond_br undef, bl1, bl2
+bl1:
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    br exit
+bl2:
+    br exit
+exit:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// Hoist over switch_enum destinations.
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C, [[CASE:%[^,]+]] : $OneOfThree):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[0-9]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         switch_enum [[CASE]] : $OneOfThree, case #OneOfThree.one!enumelt: [[ONE_DEST:bb[0-9]+]], case #OneOfThree.two!enumelt: [[TWO_DEST:bb[0-9]+]], case #OneOfThree.three!enumelt: [[THREE_DEST:bb[0-9]+]]
+// CHECK:       [[ONE_DEST]]:
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[TWO_DEST]]:
+// CHECK:         br [[EXIT]]
+// CHECK:       [[THREE_DEST]]:
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_5'
+sil [ossa] @hoist_over_branch_5 : $(@owned C, OneOfThree) -> @owned C {
+entry(%instance: @owned $C, %case : $OneOfThree):
+    %lifetime = begin_borrow %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    switch_enum %case : $OneOfThree, case #OneOfThree.one!enumelt: one_dest, case #OneOfThree.two!enumelt: two_dest, case #OneOfThree.three!enumelt: three_dest
+one_dest:
+    br exit
+two_dest:
+    br exit
+three_dest:
+    br exit
+exit:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// Don't hoist over transformation terminator which forwards ownership of 
+// borrowed value.
+// CHECK-LABEL: sil [ossa] @hoist_over_terminator_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Optional<C>):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         switch_enum [[LIFETIME]] : $Optional<C>, case #Optional.some!enumelt: [[SOME_DEST:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_DEST:bb[0-9]+]]
+// CHECK:       [[SOME_DEST]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[NONE_DEST]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_terminator_1'
+sil [ossa] @hoist_over_terminator_1 : $@convention(thin) (@owned Optional<C>) -> @owned Optional<C> {
+entry(%instance_c : @owned $Optional<C>):
+    %lifetime_c = begin_borrow %instance_c : $Optional<C>
+    switch_enum %lifetime_c : $Optional<C>, case #Optional.some!enumelt: some_dest, case #Optional.none!enumelt: none_dest
+
+some_dest(%lifetime_c_2 : @guaranteed $C):
+    br exit
+
+none_dest:
+    br exit
+
+exit:
+    end_borrow %lifetime_c : $Optional<C>
+    return %instance_c : $Optional<C>
+}
+
+// Hoist over brs but don't hoist over transformation terminator which forwards
+// ownership of guaranteed value which itself had forwarding ownership of the
+// original borrow.
+// CHECK-LABEL: sil [ossa] @hoist_over_terminator_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[MAYBE:%[^,]+]] = enum $Optional<C>, #Optional.some!enumelt, [[LIFETIME]]
+// CHECK:         switch_enum [[MAYBE]] : $Optional<C>, case #Optional.some!enumelt: [[SOME_DEST:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_DEST:bb[0-9]+]] 
+// CHECK:       [[SOME_DEST]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[BASIC_BLOCK3:bb[0-9]+]]
+// CHECK:       [[NONE_DEST]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[BASIC_BLOCK3]]
+// CHECK:       [[BASIC_BLOCK3]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_terminator_2'
+sil [ossa] @hoist_over_terminator_2 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance_c : @owned $C):
+    %lifetime_c = begin_borrow %instance_c : $C
+    %maybe_c = enum $Optional<C>, #Optional.some!enumelt, %lifetime_c : $C
+    switch_enum %maybe_c : $Optional<C>, case #Optional.some!enumelt: some_dest, case #Optional.none!enumelt: none_dest
+
+some_dest(%lifetime_c_2 : @guaranteed $C):
+    br exit
+
+none_dest:
+    br exit
+
+exit:
+    end_borrow %lifetime_c : $C
+    return %instance_c : $C
+}
+
+// Hoist over transformation terminator which forwards ownership of guaranteed
+// value which itself had forwarding ownership of the original borrow.
+// CHECK-LABEL: sil [ossa] @hoist_over_terminator_3 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[MAYBE:%[^,]+]] = enum $Optional<C>, #Optional.some!enumelt, [[LIFETIME]]
+// CHECK:         switch_enum [[MAYBE]] : $Optional<C>, case #Optional.some!enumelt: [[SOME_DEST:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_DEST:bb[0-9]+]] 
+// CHECK:       [[SOME_DEST]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[NONE_DEST]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_terminator_3'
+sil [ossa] @hoist_over_terminator_3 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance_c : @owned $C):
+    %lifetime_c = begin_borrow %instance_c : $C
+    %maybe_c = enum $Optional<C>, #Optional.some!enumelt, %lifetime_c : $C
+    switch_enum %maybe_c : $Optional<C>, case #Optional.some!enumelt: some_dest, case #Optional.none!enumelt: none_dest
+
+some_dest(%lifetime_c_2 : @guaranteed $C):
+    end_borrow %lifetime_c : $C
+    br exit
+
+none_dest:
+    end_borrow %lifetime_c : $C
+    br exit
+
+exit:
+    return %instance_c : $C
+}
+
+// Don't hoist over terminator that reborrows.
+// CHECK-LABEL: sil [ossa] @hoist_over_terminator_4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         br [[WORK:bb[0-9]+]]([[LIFETIME]] : $C)
+// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_terminator_4'
+sil [ossa] @hoist_over_terminator_4 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance_c : @owned $C):
+    %lifetime_c_0 = begin_borrow %instance_c : $C
+    br work(%lifetime_c_0 : $C)
+
+work(%lifetime_c : @guaranteed $C):
+    cond_br undef, left, right
+
+left:
+    end_borrow %lifetime_c : $C
+    br exit
+
+right:
+    end_borrow %lifetime_c : $C
+    br exit
+
+exit:
+    return %instance_c : $C
+}
+
+// =============================================================================
+// branching tests                                                            }}
+// =============================================================================
+
+// =============================================================================
+// loop tests                                                                 {{
+// =============================================================================
+// Don't hoist over loop without uses.
+// TODO: Eventually, we should hoist over such loops.
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         br [[LOOP_HEADER:bb[0-9]+]]
+// CHECK:       [[LOOP_HEADER]]:
+// CHECK:         br [[LOOP_BODY:bb[0-9]+]]
+// CHECK:       [[LOOP_BODY]]:
+// CHECK:         br [[LOOP_LATCH:bb[0-9]+]]
+// CHECK:       [[LOOP_LATCH]]:
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[LOOP_BACKEDGE:bb[0-9]+]]
+// CHECK:       [[LOOP_BACKEDGE]]:
+// CHECK:         br [[LOOP_HEADER]]
+// CHECK:       [[EXIT]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_1'
+sil [ossa] @hoist_over_loop_1 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    br loop_header
+loop_header:
+    br loop_body
+loop_body:
+    br loop_latch
+loop_latch:
+    cond_br undef, exit, loop_backedge
+loop_backedge:
+    br loop_header
+exit:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// Don't hoist over loop with uses.
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         br [[LOOP_HEADER:bb[0-9]+]]
+// CHECK:       [[LOOP_HEADER]]:
+// CHECK:         br [[LOOP_BODY:bb[0-9]+]]
+// CHECK:       [[LOOP_BODY]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME]])
+// CHECK:         br [[LOOP_LATCH:bb[0-9]+]]
+// CHECK:       [[LOOP_LATCH]]:
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[LOOP_BACKEDGE:bb[0-9]+]]
+// CHECK:       [[LOOP_BACKEDGE]]:
+// CHECK:         br [[LOOP_HEADER]]
+// CHECK:       [[EXIT]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         return [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_2'
+sil [ossa] @hoist_over_loop_2 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow %instance : $C
+    br loop_header
+loop_header:
+    br loop_body
+loop_body:
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    br loop_latch
+loop_latch:
+    cond_br undef, exit, loop_backedge
+loop_backedge:
+    br loop_header
+exit:
+    end_borrow %lifetime : $C
+    return %instance : $C
+}
+
+// =============================================================================
+// loop tests                                                                 }}
+// =============================================================================


### PR DESCRIPTION
When canonicalizing borrow scopes (for which -canonical-ossa-rewrite-borrows must still be passed), also try to shrink borrow scopes by hoisting end_borrows using the newly added ShrinkBorrowScope utility.  Here, that utility just has a worklist that walks the control-flow graph backwards starting at the end_borrow instructions.  Eventually it will hoist over instructions which are not deinit barriers--and a predicate named isDeinitBarrier is added here-- but for now it does not hoist over any instructions except branches--and isDeinitBarrier always returns true.  It hoists over branches whenever none of the operands of a branch have as guaranteed roots the borrowed value.

Tweaked CopyPropagation to look at begin_borrow instructions even when the guaranteed value they produce is not copied.

First patch towards shrinking of borrow scopes, including lexical borrow scopes:

rdar://79149830
