### PR TITLE
Parse/expand multiple flags from SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS/SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS/SWIFT_EXPERIMENTAL_EXTRA_FLAGS

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -367,7 +367,9 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING")
   endif()
 
-  list(APPEND result ${SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS})
+  set(extra_flags ${SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS})
+  separate_arguments(extra_flags)
+  list(APPEND result ${extra_flags})
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)
 endfunction()

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -506,9 +506,13 @@ function(_compile_swift_files
     list(APPEND swift_flags "-experimental-hermetic-seal-at-link")
   endif()
 
-  list(APPEND swift_flags ${SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS})
+  set(extra_flags ${SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS})
+  separate_arguments(extra_flags)
+  list(APPEND swift_flags ${extra_flags})
 
-  list(APPEND swift_flags ${SWIFT_EXPERIMENTAL_EXTRA_FLAGS})
+  set(extra_flags ${SWIFT_EXPERIMENTAL_EXTRA_FLAGS})
+  separate_arguments(extra_flags)
+  list(APPEND swift_flags ${extra_flags})
 
   if(SWIFTFILE_OPT_FLAGS)
     list(APPEND swift_flags ${SWIFTFILE_OPT_FLAGS})


### PR DESCRIPTION
I realized that without `separate_arguments`, I can't pass more than a single flag because spaces are not expanded into multiple flags.