### PR TITLE
use swift-cmark/gfm instead of /main

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -230,7 +230,7 @@ macro(swift_common_standalone_build_config_cmark product)
   get_filename_component(CMARK_LIBRARY_DIR "${${product}_CMARK_LIBRARY_DIR}"
     ABSOLUTE)
 
-  set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src")
+  set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src/include")
   set(CMARK_BUILD_INCLUDE_DIR "${PATH_TO_CMARK_BUILD}/src")
 
   file(TO_CMAKE_PATH "${CMARK_MAIN_INCLUDE_DIR}" CMARK_MAIN_INCLUDE_DIR)
@@ -290,7 +290,7 @@ macro(swift_common_unified_build_config product)
       ABSOLUTE)
 
     set(CMARK_BUILD_INCLUDE_DIR "${PATH_TO_CMARK_BUILD}/src")
-    set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src")
+    set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src/include")
   endif()
 
   include_directories(

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -3,7 +3,7 @@ add_swift_host_library(swiftMarkup STATIC
   LineList.cpp
   Markup.cpp)
 target_link_libraries(swiftMarkup PRIVATE
-  libcmark_static)
+  libcmark-gfm_static)
 target_compile_definitions(swiftMarkup
                            PRIVATE
                              CMARK_STATIC_DEFINE)

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -6,5 +6,5 @@ target_link_libraries(swiftMarkup PRIVATE
   libcmark-gfm_static)
 target_compile_definitions(swiftMarkup
                            PRIVATE
-                             CMARK_STATIC_DEFINE)
+                           CMARK_GFM_STATIC_DEFINE)
 

--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -15,7 +15,7 @@
 #include "swift/AST/Comment.h"
 #include "swift/Markup/LineList.h"
 #include "swift/Markup/Markup.h"
-#include "cmark.h"
+#include "cmark-gfm.h"
 
 using namespace swift;
 using namespace markup;

--- a/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
+++ b/tools/SourceKit/lib/SwiftLang/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(SourceKitSwiftLang PRIVATE
   swiftSyntax
   swiftOption
   swiftSymbolGraphGen
-  libcmark_static
+  libcmark-gfm_static
   # Clang dependencies.
   clangIndex
   clangFormat

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -52,6 +52,8 @@ class CMark(cmake_product.CMakeProduct):
         self.cmake_options.define('CMAKE_BUILD_TYPE:STRING',
                                   self.args.cmark_build_variant)
 
+        self.cmake_options.define('CMARK_THREADING', 'ON')
+
         (platform, arch) = host_target.split('-')
 
         common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -89,7 +89,7 @@
             "repos": {
                 "llvm-project": "stable/20211026",
                 "swift": "main",
-                "cmark": "main",
+                "cmark": "gfm",
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
@@ -131,7 +131,7 @@
             "repos": {
                 "llvm-project": "stable/20211026",
                 "swift": "rebranch",
-                "cmark": "main",
+                "cmark": "gfm",
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
@@ -282,7 +282,7 @@
             "repos": {
                 "llvm-project": "next",
                 "swift": "next",
-                "cmark": "main",
+                "cmark": "gfm",
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",


### PR DESCRIPTION
Resolves rdar://90461181

This PR (and its related PRs on swift-cmark/gfm) switches the branch used by swiftMarkup to the `gfm` branch of swift-cmark, to unify the development effort on swift-cmark. Note that this PR does not remove the second clone of swift-cmark - that will happen later, as it requires a simultaneous PR in Swift-Markdown. This PR is primarily to allow `gfm` to be built in the toolchain in the `cmark` clone.