### PR TITLE
[move-operator] Specify if LexicalLifetimes is enabled using an enum instead of a bool.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -30,6 +30,17 @@
 
 namespace swift {
 
+enum class LexicalLifetimesOption : uint8_t {
+  // Do not insert any lexical lifetimes.
+  Off = 0,
+
+  // Insert lexical lifetimes and do not remove them until OSSA is lowered. This
+  // is experimental.
+  ExperimentalLate,
+};
+
+class SILModule;
+
 class SILOptions {
 public:
   /// Controls the aggressiveness of the performance inliner.
@@ -45,7 +56,7 @@ public:
   bool RemoveRuntimeAsserts = false;
 
   /// Enable experimental support for emitting defined borrow scopes.
-  bool EnableExperimentalLexicalLifetimes = false;
+  LexicalLifetimesOption LexicalLifetimes = LexicalLifetimesOption::Off;
 
   /// Force-run SIL copy propagation to shorten object lifetime in whatever
   /// optimization pipeline is currently used.
@@ -226,6 +237,12 @@ public:
   bool shouldOptimize() const {
     return OptMode > OptimizationMode::NoOptimization;
   }
+
+  /// Returns true if we support inserting lexical lifetimes given the current
+  /// SIL stage.
+  ///
+  /// Defined in SILModule.h.
+  bool supportsLexicalLifetimes(const SILModule &mod) const;
 };
 
 } // end namespace swift

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -255,9 +255,15 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
+def disable_lexical_lifetimes :
+  Flag<["-"], "disable-lexical-lifetimes">,
+  HelpText<"Disables early lexical lifetimes. Mutually exclusive with "
+           "-enable-experimental-lexical-lifetimes">;
+
 def enable_experimental_lexical_lifetimes :
   Flag<["-"], "enable-experimental-lexical-lifetimes">,
-  HelpText<"Enable experimental lexical lifetimes">;
+  HelpText<"Enable experimental lexical lifetimes. Mutually exclusive with "
+           "-disable-early-lexical-lifetimes">;
 
 def enable_experimental_move_only :
   Flag<["-"], "enable-experimental-move-only">,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -908,6 +908,22 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
   return OS;
 }
 
+inline bool SILOptions::supportsLexicalLifetimes(const SILModule &mod) const {
+  switch (mod.getStage()) {
+  case SILStage::Raw:
+    // In Raw SIL, we support lexical lifetimes as long as lexical lifetimes is
+    // not turned off all the way.
+    return LexicalLifetimes != LexicalLifetimesOption::Off;
+  case SILStage::Canonical:
+    // In Canonical SIL, we only support lexical lifetimes when in experimental
+    // late mode.
+    return LexicalLifetimes == LexicalLifetimesOption::ExperimentalLate;
+  case SILStage::Lowered:
+    // We do not support OSSA in Lowered SIL, so this is always false.
+    return false;
+  }
+}
+
 /// Print a simple description of a SILModule for the request evaluator.
 void simple_display(llvm::raw_ostream &out, const SILModule *M);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -540,7 +540,7 @@ public:
       address = value;
     SILLocation PrologueLoc(vd);
 
-    if (SGF.getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
+    if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule()) &&
         value->getOwnershipKind() != OwnershipKind::None) {
       if (!SGF.getASTContext().LangOpts.EnableExperimentalMoveOnly) {
         value = SILValue(
@@ -1760,7 +1760,7 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
     return;
   }
 
-  if (!getASTContext().SILOpts.EnableExperimentalLexicalLifetimes ||
+  if (!getASTContext().SILOpts.supportsLexicalLifetimes(getModule()) ||
       Val->getOwnershipKind() == OwnershipKind::None) {
     B.emitDestroyValueOperation(silLoc, Val);
     return;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -273,7 +273,8 @@ struct ArgumentInitHelper {
     SILValue value = argrv.getValue();
     SILDebugVariable varinfo(pd->isImmutable(), ArgNo);
     if (!argrv.getType().isAddress()) {
-      if (SGF.getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
+      if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(
+              SGF.getModule()) &&
           value->getOwnershipKind() == OwnershipKind::Owned) {
         bool isNoImplicitCopy = false;
         if (auto *arg = dyn_cast<SILFunctionArgument>(value))

--- a/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
@@ -26,9 +26,11 @@ class LexicalLifetimeEliminatorPass : public SILFunctionTransform {
     if (fn->wasDeserializedCanonical())
       return;
 
-    // If we have experimental lexical lifetimes enabled, we do not want to run
-    // this pass since we want lexical lifetimes to exist later in the pipeline.
-    if (fn->getModule().getOptions().EnableExperimentalLexicalLifetimes)
+    // If we have experimental late lexical lifetimes enabled, we do not want to
+    // run this pass since we want lexical lifetimes to exist later in the
+    // pipeline.
+    if (fn->getModule().getOptions().LexicalLifetimes ==
+        LexicalLifetimesOption::ExperimentalLate)
       return;
 
     bool madeChange = false;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -19,6 +19,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/SILOptions.h"
 #define DEBUG_TYPE "sil-passpipeline-plan"
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/AST/ASTContext.h"
@@ -138,7 +139,8 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
     P.addSILSkippingChecker();
 #endif
 
-  if (Options.shouldOptimize() && !Options.EnableExperimentalLexicalLifetimes) {
+  if (Options.shouldOptimize() &&
+      Options.LexicalLifetimes != LexicalLifetimesOption::ExperimentalLate) {
     P.addDestroyHoisting();
   }
   P.addMandatoryInlining();
@@ -171,7 +173,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   // Now that we have finished performing diagnostics that rely on lexical
   // scopes, if lexical lifetimes are not enabled, eliminate lexical lfietimes.
-  if (!Options.EnableExperimentalLexicalLifetimes) {
+  if (Options.LexicalLifetimes != LexicalLifetimesOption::ExperimentalLate) {
     P.addLexicalLifetimeEliminator();
   }
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -533,10 +533,8 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   SILBuilderWithScope Builder(ABI);
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
-  bool isLexical = ABI->getFunction()
-                       ->getModule()
-                       .getASTContext()
-                       .SILOpts.EnableExperimentalLexicalLifetimes;
+  auto &mod = ABI->getFunction()->getModule();
+  bool isLexical = mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
   auto *ASI = Builder.createAllocStack(
       ABI->getLoc(),
       getSILBoxFieldType(TypeExpansionContext(*ABI->getFunction()),

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -314,9 +314,10 @@ static SILValue createValueForEmptyTuple(SILType ty,
 static bool shouldAddLexicalLifetime(AllocStackInst *asi) {
   return asi->getFunction()->hasOwnership() &&
          asi->getFunction()
-             ->getModule()
-             .getASTContext()
-             .SILOpts.EnableExperimentalLexicalLifetimes &&
+                 ->getModule()
+                 .getASTContext()
+                 .SILOpts.LexicalLifetimes ==
+             LexicalLifetimesOption::ExperimentalLate &&
          asi->isLexical() &&
          !asi->getElementType().isTrivial(*asi->getFunction());
 }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -578,10 +578,9 @@ void SILInlineCloner::postFixUp(SILFunction *calleeFunction) {
 
 SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
                                                  FullApplySite AI) {
-  auto enableLexicalLifetimes = Apply.getFunction()
-                                    ->getModule()
-                                    .getASTContext()
-                                    .SILOpts.EnableExperimentalLexicalLifetimes;
+  auto &mod = Apply.getFunction()->getModule();
+  auto enableLexicalLifetimes =
+      mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
   auto argOwnershipRequiresBorrow = [&]() {
     auto kind = callArg.getOwnershipKind();
     if (enableLexicalLifetimes) {


### PR DESCRIPTION
The reason why I am doing this is that we are going to be enabling lexical
lifetimes early in the pipeline so that I can use it for the move operator's
diagnostics.

To make it easy for passes to know whether or not they should support lexical
lifetimes, I included a query on SILOptions called
supportsLexicalLifetimes. This will return true if the pass (given the passed in
option) should insert the lexical lifetime flag. This ensures that passes that
run in both pipelines (e.x.: AllocBoxToStack) know whether or not to set the
lexical lifetime flag without having to locally reason about it.

This is just chopping off layers of a larger patch I am upstreaming.

NOTE: This is technically NFC since it leaves the default alone of not inserting
lexical lifetimes at all.
