### PR TITLE
Make (Unsafe|Checked)Continuation's Sendable conformance conditional.

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -19,7 +19,7 @@ internal func logFailedCheck(_ message: UnsafeRawPointer)
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.
 @available(SwiftStdlib 5.1, *)
-internal final class CheckedContinuationCanary {
+internal final class CheckedContinuationCanary: @unchecked Sendable {
   // The instance state is stored in tail-allocated raw memory, so that
   // we can atomically check the continuation state.
 
@@ -110,7 +110,7 @@ internal final class CheckedContinuationCanary {
 /// enough to obtain the extra checking without further source modification in
 /// most circumstances.
 @available(SwiftStdlib 5.1, *)
-public struct CheckedContinuation<T, E: Error>: @unchecked Sendable {
+public struct CheckedContinuation<T, E: Error> {
   private let canary: CheckedContinuationCanary
   
   /// Initialize a `CheckedContinuation` wrapper around an
@@ -174,6 +174,9 @@ public struct CheckedContinuation<T, E: Error>: @unchecked Sendable {
     }
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+extension CheckedContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension CheckedContinuation {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -34,7 +34,7 @@ public struct UnownedJob: Sendable {
 
 @available(SwiftStdlib 5.1, *)
 @frozen
-public struct UnsafeContinuation<T, E: Error>: Sendable {
+public struct UnsafeContinuation<T, E: Error> {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
 
   @_alwaysEmitIntoClient
@@ -105,6 +105,9 @@ public struct UnsafeContinuation<T, E: Error>: Sendable {
 #endif
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+extension UnsafeContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension UnsafeContinuation {

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -87,6 +87,23 @@ func test_unsafeThrowingContinuations() async throws {
   // TODO: Potentially could offer some warnings if we know that a continuation was resumed or escaped at all in a closure?
 }
 
+// ==== Sendability ------------------------------------------------------------
+class NotSendable { }
+// expected-note@-1{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+@available(SwiftStdlib 5.1, *)
+func test_nonsendableContinuation() async throws {
+  let _: NotSendable = try await withUnsafeThrowingContinuation { continuation in
+    continuation.resume(returning: NotSendable())
+  }
+
+  let _: NotSendable = try await withUnsafeThrowingContinuation { continuation in
+    Task {
+      continuation.resume(returning: NotSendable()) // expected-warning{{cannot use parameter 'continuation' with a non-sendable type 'UnsafeContinuation<NotSendable, Error>' from concurrently-executed code}}
+    }
+  }
+}
+
 // ==== Detached Tasks ---------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
Make the continuation type's conformances to the `Sendable` protocol
conditional on the sendability of the result yielded when the
resumption is performed. This ensures that one cannot silently escape
a continuation's result out of a task or actor, closing a safety hole
in Sendable checking.

Fixes rdar://85419546.
