### PR TITLE
SILVerifier - allow rebind_memory token to cross functions

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6789,9 +6789,15 @@ void IRGenSILFunction::visitCopyAddrInst(swift::CopyAddrInst *i) {
 // bind_memory and rebind_memory are no-ops because Swift TBAA info is not
 // lowered to LLVM IR TBAA, and the output token is ignored except for
 // verification.
-void IRGenSILFunction::visitBindMemoryInst(swift::BindMemoryInst *) {}
+void IRGenSILFunction::visitBindMemoryInst(swift::BindMemoryInst *i) {
+  LoweredValue &token = getUndefLoweredValue(i->getType());
+  setLoweredValue(i, std::move(token));
+}
 
-void IRGenSILFunction::visitRebindMemoryInst(swift::RebindMemoryInst *) {}
+void IRGenSILFunction::visitRebindMemoryInst(swift::RebindMemoryInst *i) {
+  LoweredValue &token = getUndefLoweredValue(i->getType());
+  setLoweredValue(i, std::move(token));
+}
 
 void IRGenSILFunction::visitDestroyAddrInst(swift::DestroyAddrInst *i) {
   SILType addrTy = i->getOperand()->getType();

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2387,6 +2387,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::EndCOWMutationInst:
   case SILInstructionKind::BeginUnpairedAccessInst:
   case SILInstructionKind::BindMemoryInst:
+  case SILInstructionKind::RebindMemoryInst:
   case SILInstructionKind::CheckedCastValueBranchInst:
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::CopyBlockInst:

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3046,9 +3046,6 @@ public:
     requireSameType(rbi->getInToken()->getType(),
                     SILType::getBuiltinWordType(F.getASTContext()),
                     "rebind_memory token must be a Builtin.Int64");
-    require(isa<BindMemoryInst>(rbi->getInToken())
-            || isa<RebindMemoryInst>(rbi->getInToken()),
-            "rebind_memory token must originate from bind_memory");
   }
 
   void checkIndexAddrInst(IndexAddrInst *IAI) {


### PR DESCRIPTION
Remove a completely unnecessary assertion to handle reasonable use
cases.
