### PR TITLE
Revert "[SwiftSyntax] Replace ExpressibleAs protocols by ExpressibleBy protocols"

### DIFF
--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -1,18 +1,18 @@
-SYNTAX_BUILDABLE_EXPRESSIBLE_BY_CONFORMANCES = {
-    'ExpressibleByConditionElement': [
-        'ExpressibleByConditionElementList'
+SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
+    'ExpressibleAsConditionElement': [
+        'ExpressibleAsConditionElementList'
     ],
-    'ExpressibleByDeclBuildable': [
-        'ExpressibleByCodeBlockItem',
-        'ExpressibleByMemberDeclListItem',
-        'ExpressibleBySyntaxBuildable'
+    'ExpressibleAsDeclBuildable': [
+        'ExpressibleAsCodeBlockItem',
+        'ExpressibleAsMemberDeclListItem',
+        'ExpressibleAsSyntaxBuildable'
     ],
-    'ExpressibleByStmtBuildable': [
-        'ExpressibleByCodeBlockItem',
-        'ExpressibleBySyntaxBuildable'
+    'ExpressibleAsStmtBuildable': [
+        'ExpressibleAsCodeBlockItem',
+        'ExpressibleAsSyntaxBuildable'
     ],
-    'ExpressibleByExprList': [
-        'ExpressibleByConditionElement',
-        'ExpressibleBySyntaxBuildable'
+    'ExpressibleAsExprList': [
+        'ExpressibleAsConditionElement',
+        'ExpressibleAsSyntaxBuildable'
     ]
 }


### PR DESCRIPTION
Reverts apple/swift#40182

---

Stupid me, the protocols actually describe that these types are expressible as other types and not by other types.