### PR TITLE
Avoid changing mtime on source list files (<SHA1>.txt) to improve incremental builds

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -834,7 +834,11 @@ function(_compile_swift_files
   # Windows doesn't support long command line paths, of 8191 chars or over. We
   # need to work around this by avoiding long command line arguments. This can
   # be achieved by writing the list of file paths to a file, then reading that
-  # list in the Python script.
+  # list in the Python script. Note that we write the list into a file with a
+  # file name that is a SHA1 hash of its own content, which means we don't need
+  # to specify the list as a dependency on commands that use it (because its
+  # content is immutable) and that also helps avoid unneccessary recompilations
+  # because the list gets a timestamp bump every time a CMake configure happens.
   string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
   string(SHA1 file_name "'${source_files_quoted}'")
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
@@ -865,7 +869,6 @@ function(_compile_swift_files
       OUTPUT ${standard_outputs}
       DEPENDS
         "${line_directive_tool}"
-        "${file_path}"
         ${swift_compiler_tool_dep}
         ${source_files} ${SWIFTFILE_DEPENDS}
         ${swift_ide_test_dependency}
@@ -907,7 +910,6 @@ function(_compile_swift_files
         OUTPUT ${module_outputs}
         DEPENDS
           "${line_directive_tool}"
-          "${file_path}"
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${swift_ide_test_dependency}
@@ -969,7 +971,6 @@ function(_compile_swift_files
           ${maccatalyst_module_outputs}
         DEPENDS
           "${line_directive_tool}"
-          "${file_path}"
           ${swift_compiler_tool_dep}
           ${source_files}
           ${SWIFTFILE_DEPENDS}
@@ -998,7 +999,6 @@ function(_compile_swift_files
         OUTPUT ${sib_outputs}
         DEPENDS
           "${line_directive_tool}"
-          "${file_path}"
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}
@@ -1018,7 +1018,6 @@ function(_compile_swift_files
         OUTPUT ${sibopt_outputs}
         DEPENDS
           "${line_directive_tool}"
-          "${file_path}"
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}
@@ -1039,7 +1038,6 @@ function(_compile_swift_files
         OUTPUT ${sibgen_outputs}
         DEPENDS
           "${line_directive_tool}"
-          "${file_path}"
           ${swift_compiler_tool_dep}
           ${source_files} ${SWIFTFILE_DEPENDS}
           ${create_dirs_dependency_target}


### PR DESCRIPTION
In CMake, `file(WRITE ...)` always writes the file content, always bumping the mtime on it. Thus, each re-configure triggers a rebuild of libswiftCore, even when nothing changes.

Per CMake docs, `file(GENERATE ...)` looks like what we want:

> file(GENERATE OUTPUT output-file
     <INPUT input-file|CONTENT content>
    ...
    )
> Generated files are modified and their timestamp updated on subsequent cmake runs only if their content is changed.
