### PR TITLE
Update python_lint shebang to 'python3'

### DIFF
--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #


### PR DESCRIPTION
With the Python 3 changes to the repo, the linter now needs to be called with `python3` explicitly, so that there are no syntax errors.
