### PR TITLE
[build] Don't overwrite user NINJA_STATUS

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -105,8 +105,9 @@ def initialize_runtime_environment():
             'WATCHOS_DEPLOYMENT_TARGET']:
         os.environ.pop(v, None)
 
-    # Set NINJA_STATUS to format ninja output
-    os.environ['NINJA_STATUS'] = '[%f/%t][%p][%es] '
+    # Provide a default NINJA_STATUS to format ninja output.
+    if 'NINJA_STATUS' not in os.environ:
+        os.environ['NINJA_STATUS'] = '[%f/%t][%p][%es] '
 
 
 class JSONDumper(json.JSONEncoder):


### PR DESCRIPTION
Treat the build-script custom `NINJA_STATUS` as a default. If the user has set a value, leave it, otherwise use the build-script default. The list of ninja status keys are here https://ninja-build.org/manual.html#_environment_variables