### PR TITLE
[CSGen] Rework nil-coalescing operator handling in `LinkedExprAnalyzer`

### DIFF
--- a/validation-test/Sema/rdar85277993.swift
+++ b/validation-test/Sema/rdar85277993.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import simd
+import CoreGraphics
+
+let m = simd_float3x3(1)
+
+func foo(point: SIMD2<Float>, depth: Float, a: simd_float3x3? = nil) -> SIMD3<Float> {
+  (a ?? m) * float3(point.x, point.y, 1) * depth
+}


### PR DESCRIPTION
Allow `LinkedExprAnalyzer` to capture `??` operator and walk into
its arguments, because they could have valuable type information,
but don't attempt to favor or link operators if `??` is present in a chain.

Resolves: rdar://85277993

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
