### PR TITLE
[ConstraintSystem] Extend the early type variable binding heuristic to builtin types.

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1010,7 +1010,8 @@ bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
           }
         }
 
-        return type->is<StructType>() || type->is<EnumType>();
+        return type->is<StructType>() || type->is<EnumType>() ||
+               type->is<BuiltinType>();
       })) {
     // Result type of subscript could be l-value so we can't bind it early.
     if (!TypeVar->getImpl().isSubscriptResultType() &&


### PR DESCRIPTION
There's no subtyping for built-in types, so there's no reason not to attempt type variable bindings to built-in types before disjunctions.