### PR TITLE
Include missing `_getMainExecutor` and `_asyncMainDrainQueue` in concurrency swiftinterface

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -959,6 +959,25 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
 
   // Start Main loop!
   FuncDecl *drainQueueFuncDecl = SGM.getAsyncMainDrainQueue();
+  if (!drainQueueFuncDecl) {
+    // If it doesn't exist, we can conjure one up instead of crashing
+    // @available(SwiftStdlib 5.5, *)
+    // @_silgen_name("swift_task_asyncMainDrainQueue")
+    // internal func _asyncMainDrainQueue() -> Never
+    ParameterList *emptyParams = ParameterList::createEmpty(getASTContext());
+    drainQueueFuncDecl = FuncDecl::createImplicit(
+        getASTContext(), StaticSpellingKind::None,
+        DeclName(
+            getASTContext(),
+            DeclBaseName(getASTContext().getIdentifier("_asyncMainDrainQueue")),
+            /*Arguments*/ emptyParams),
+        {}, /*async*/ false, /*throws*/ false, {}, emptyParams,
+        getASTContext().getNeverType(),
+        entryPoint.getDecl()->getModuleContext());
+    drainQueueFuncDecl->getAttrs().add(new (getASTContext()) SILGenNameAttr(
+        "swift_task_asyncMainDrainQueue", /*implicit*/ true));
+  }
+
   SILFunction *drainQueueSILFunc = SGM.getFunction(
       SILDeclRef(drainQueueFuncDecl, SILDeclRef::Kind::Func), NotForDefinition);
   SILValue drainQueueFunc =

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -752,10 +752,12 @@ func _enqueueJobGlobal(_ task: Builtin.Job)
 func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_asyncMainDrainQueue")
 internal func _asyncMainDrainQueue() -> Never
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_getMainExecutor")
 internal func _getMainExecutor() -> Builtin.Executor
 


### PR DESCRIPTION
While the API are in swift modules and in the standard library, they are not included in the swift interface file because they are internal. By marking the API as `@usableFromInline`, they are included in the swift interface file.

I added the ability to generate the declaration for `_getMainExecutor` in https://github.com/apple/swift/pull/39941, I missed `_asyncMainDrainQueue`, so I've added that here. It shouldn't be necessary when the compiler is paired up with the correct version of the standard library, but it appears that's not always happening, so this is taking care of both of those issues.

I've manually inspected the resulting swift interface file generated locally and have ensured that the correct declarations are emitted:
```swift
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@usableFromInline
@_silgen_name("swift_task_asyncMainDrainQueue")
internal func _asyncMainDrainQueue() -> Swift.Never

#if compiler(>=5.3) && $BuiltinExecutor
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@usableFromInline
@_silgen_name("swift_task_getMainExecutor")
internal func _getMainExecutor() -> Builtin.Executor
#endif
```