### PR TITLE
[CS] Restore a type variable for compatibility with rdar://85263844

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1191,6 +1191,10 @@ WARNING(coercion_may_fail_warning,none,
         "coercion from %0 to %1 may fail; use 'as?' or 'as!' instead",
         (Type, Type))
 
+WARNING(tuple_label_mismatch_warning,none,
+        "tuple conversion from %0 to %1 mismatches labels",
+        (Type, Type))
+
 ERROR(missing_explicit_conversion,none,
       "%0 is not implicitly convertible to %1; "
       "did you mean to use 'as' to explicitly convert?", (Type, Type))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -376,6 +376,9 @@ enum class FixKind : uint8_t {
   /// Ignore a type mismatch between deduced element type and externally
   /// imposed one.
   IgnoreCollectionElementContextualMismatch,
+
+  /// Produce a warning for a tuple label mismatch.
+  AllowTupleLabelMismatch,
 };
 
 class ConstraintFix {
@@ -2795,6 +2798,27 @@ public:
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() ==
            FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype;
+  }
+};
+
+/// Emit a warning for mismatched tuple labels.
+class AllowTupleLabelMismatch final : public ContextualMismatch {
+  AllowTupleLabelMismatch(ConstraintSystem &cs, Type fromType, Type toType,
+                          ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AllowTupleLabelMismatch, fromType,
+                           toType, locator, /*warning*/ true) {}
+
+public:
+  std::string getName() const override { return "allow tuple label mismatch"; }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowTupleLabelMismatch *create(ConstraintSystem &cs, Type fromType,
+                                         Type toType,
+                                         ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowTupleLabelMismatch;
   }
 };
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -213,6 +213,12 @@ enum class ConstraintKind : char {
   /// one type - type variable representing type of a node, other side is
   /// the AST node to infer the type for.
   ClosureBodyElement,
+  /// Do not add new uses of this, it only exists to retain compatibility for
+  /// rdar://85263844.
+  ///
+  /// Binds the RHS type to a tuple of the params of a function typed LHS. Note
+  /// this discards function parameter flags.
+  BindTupleOfFunctionParams
 };
 
 /// Classification of the different kinds of constraints.
@@ -685,6 +691,7 @@ public:
     case ConstraintKind::KeyPath:
     case ConstraintKind::KeyPathApplication:
     case ConstraintKind::Defaultable:
+    case ConstraintKind::BindTupleOfFunctionParams:
       return ConstraintClassification::TypeProperty;
 
     case ConstraintKind::Disjunction:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4748,6 +4748,12 @@ private:
                                          TypeMatchOptions flags,
                                          ConstraintLocatorBuilder locator);
 
+  /// Attempt to simplify a BindTupleOfFunctionParams constraint.
+  SolutionKind
+  simplifyBindTupleOfFunctionParamsConstraint(Type first, Type second,
+                                              TypeMatchOptions flags,
+                                              ConstraintLocatorBuilder locator);
+
   /// Attempt to simplify the ApplicableFunction constraint.
   SolutionKind simplifyApplicableFnConstraint(
       Type type1, Type type2,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1378,6 +1378,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::KeyPath:
   case ConstraintKind::ClosureBodyElement:
   case ConstraintKind::Conjunction:
+  case ConstraintKind::BindTupleOfFunctionParams:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7867,6 +7867,12 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
   return true;
 }
 
+bool TupleLabelMismatchWarning::diagnoseAsError() {
+  emitDiagnostic(diag::tuple_label_mismatch_warning, getFromType(), getToType())
+      .highlight(getSourceRange());
+  return true;
+}
+
 bool SwiftToCPointerConversionInInvalidContext::diagnoseAsError() {
   auto argInfo = getFunctionArgApplyInfo(getLocator());
   if (!argInfo)

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2620,6 +2620,16 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Emit a warning for mismatched tuple labels.
+class TupleLabelMismatchWarning final : public ContextualFailure {
+public:
+  TupleLabelMismatchWarning(const Solution &solution, Type fromType,
+                            Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose situations where Swift -> C pointer implicit conversion
 /// is attempted on a Swift function instead of one imported from C header.
 ///

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2024,6 +2024,20 @@ AllowNonOptionalWeak *AllowNonOptionalWeak::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) AllowNonOptionalWeak(cs, locator);
 }
 
+AllowTupleLabelMismatch *
+AllowTupleLabelMismatch::create(ConstraintSystem &cs, Type fromType,
+                                Type toType, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowTupleLabelMismatch(cs, fromType, toType, locator);
+}
+
+bool AllowTupleLabelMismatch::diagnose(const Solution &solution,
+                                       bool asNote) const {
+  TupleLabelMismatchWarning warning(solution, getFromType(), getToType(),
+                                    getLocator());
+  return warning.diagnose(asNote);
+}
+
 bool AllowSwiftToCPointerConversion::diagnose(const Solution &solution,
                                               bool asNote) const {
   SwiftToCPointerConversionInInvalidContext failure(solution, getLocator());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1525,6 +1525,19 @@ namespace {
         auto methodTy =
             CS.createTypeVariable(memberTypeLoc, TVO_CanBindToNoEscape);
 
+        // HACK: Bind the function's parameter list as a tuple to a type
+        // variable. This only exists to preserve compatibility with
+        // rdar://85263844, as it can affect the prioritization of bindings,
+        // which can affect behavior for tuple matching as tuple subtyping is
+        // currently a *weaker* constraint than tuple conversion.
+        if (!CS.getASTContext().isSwiftVersionAtLeast(6)) {
+          auto paramTypeVar = CS.createTypeVariable(
+              CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument),
+              TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape);
+          CS.addConstraint(ConstraintKind::BindTupleOfFunctionParams, methodTy,
+                           paramTypeVar, CS.getConstraintLocator(expr));
+        }
+
         CS.addValueMemberConstraint(
             baseTy, expr->getName(), methodTy, CurDC,
             expr->getFunctionRefKind(),

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -77,6 +77,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
+  case ConstraintKind::BindTupleOfFunctionParams:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -161,6 +162,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::BindTupleOfFunctionParams:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -303,6 +305,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
+  case ConstraintKind::BindTupleOfFunctionParams:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -503,6 +506,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     Out << " can default to ";
     break;
 
+  case ConstraintKind::BindTupleOfFunctionParams:
+    Out << " bind tuple of function params to ";
+    break;
+
   case ConstraintKind::Disjunction:
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
@@ -663,6 +670,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
+  case ConstraintKind::BindTupleOfFunctionParams:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -268,6 +268,7 @@ func test_that_optionality_of_closure_result_is_preserved() {
 // rdar://85263844 - initializer 'init(_:)' requires the types be equivalent
 func rdar85263844(arr: [(q: String, a: Int)]) -> AnySequence<(question: String, answer: Int)> {
   AnySequence(arr.map { $0 })
+  // expected-warning@-1 {{tuple conversion from '(q: String, a: Int)' to '(question: String, answer: Int)' mismatches labels}}
 }
 
 // Another case for rdar://85263844
@@ -284,9 +285,11 @@ public struct S4<T> {
 extension S4 where T == (outer: Int, y: Int) {
   init(arr: [Int]) {
     self.init(arr.map { (inner: $0, y: $0) })
+    // expected-warning@-1 {{tuple conversion from '(inner: Int, y: Int)' to '(outer: Int, y: Int)' mismatches labels}}
   }
 }
 
 public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
   S4(x.map { (inner: $0, y: $0) })
+  // expected-warning@-1 {{tuple conversion from '(inner: Int, y: Int)' to '(outer: Int, y: Int)' mismatches labels}}
 }

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -267,6 +267,26 @@ func test_that_optionality_of_closure_result_is_preserved() {
 
 // rdar://85263844 - initializer 'init(_:)' requires the types be equivalent
 func rdar85263844(arr: [(q: String, a: Int)]) -> AnySequence<(question: String, answer: Int)> {
-  AnySequence(arr.map { $0 }) // FIXME: This is supposed to type-check.
-  // expected-error@-1 {{initializer 'init(_:)' requires the types '(question: String, answer: Int)' and '(q: String, a: Int)' be equivalent}}
+  AnySequence(arr.map { $0 })
+}
+
+// Another case for rdar://85263844
+protocol P {
+  associatedtype Element
+}
+extension Array : P {}
+
+public struct S4<T> {
+  init<S : P>(_ x: S) where S.Element == T {}
+  init(_ x: Int) {}
+}
+
+extension S4 where T == (outer: Int, y: Int) {
+  init(arr: [Int]) {
+    self.init(arr.map { (inner: $0, y: $0) })
+  }
+}
+
+public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
+  S4(x.map { (inner: $0, y: $0) })
 }

--- a/test/Constraints/rdar85263844_swift6.swift
+++ b/test/Constraints/rdar85263844_swift6.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// '-swift-version 6' is currently asserts-only
+// REQUIRES: asserts
+
+// rdar://85263844 - initializer 'init(_:)' requires the types be equivalent
+func rdar85263844(arr: [(q: String, a: Int)]) -> AnySequence<(question: String, answer: Int)> {
+  AnySequence(arr.map { $0 })
+  // expected-error@-1 {{initializer 'init(_:)' requires the types '(question: String, answer: Int)' and '(q: String, a: Int)' be equivalent}}
+}
+
+// Another case for rdar://85263844
+protocol P {
+  associatedtype Element
+}
+extension Array : P {}
+
+public struct S4<T> {
+  init<S : P>(_ x: S) where S.Element == T {}
+  init(_ x: Int) {}
+}
+
+extension S4 where T == (outer: Int, y: Int) {
+  init(arr: [Int]) {
+    // FIXME: This ideally shouldn't compile either, but because of the way we
+    // generate constraints for it, it continues to compile. We should fix
+    // tuple subtyping for Swift 6 mode to not accept label mismatches.
+    self.init(arr.map { (inner: $0, y: $0) })
+  }
+}
+
+public func rdar85263844_2(_ x: [Int]) -> S4<(outer: Int, y: Int)> {
+  // FIXME: Bad error message.
+  S4(x.map { (inner: $0, y: $0) }) // expected-error {{type of expression is ambiguous without more context}}
+}

--- a/test/Constraints/rdar85263844_swift6.swift
+++ b/test/Constraints/rdar85263844_swift6.swift
@@ -26,6 +26,7 @@ extension S4 where T == (outer: Int, y: Int) {
     // generate constraints for it, it continues to compile. We should fix
     // tuple subtyping for Swift 6 mode to not accept label mismatches.
     self.init(arr.map { (inner: $0, y: $0) })
+    // expected-warning@-1 {{tuple conversion from '(inner: Int, y: Int)' to '(outer: Int, y: Int)' mismatches labels}}
   }
 }
 


### PR DESCRIPTION
This bit of logic was removed in #39543. However it turns out that despite this type variable being otherwise disconnected from the constraint system, it's possible for it to affect how we type-check tuple matches in certain cases.

This is due to the fact that:
- It can have a lower type variable ID than an opened generic parameter type, so becomes the representative when merged with it. And because it has a different locator, this can influence binding prioritization.
- Tuple subtyping is broken, as it's currently a *weaker* relationship than conversion due to allowing labeling mismatches.

Therefore, temporarily restore this bit of logic for language versions < 6. In addition, start warning on cases where we currently permit tuple label mismatches in subtyping. If possible, we should try and fix tuple subtying in Swift 6 mode to not accept label mismatches, so that it's not more permissive than tuple conversion.

rdar://85263844