### PR TITLE
[build-script] Update ClangVersionType to match SwiftVersionType

### DIFF
--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -139,9 +139,10 @@ class ClangVersionType(RegexType):
     """
 
     ERROR_MESSAGE = ('Invalid version value, must be '
-                     '"MAJOR.MINOR.PATCH" or "MAJOR.MINOR.PATCH.PATCH"')
+                     '"MAJOR.MINOR.PATCH", "MAJOR.MINOR.PATCH.PATCH"'
+                     ', or "MAJOR.MINOR.PATCH.PATCH.PATCH".')
 
-    VERSION_REGEX = r'^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$'
+    VERSION_REGEX = r'^(\d+)\.(\d+)\.(\d+)(\.(\d+))?(\.(\d+))?$'
 
     def __init__(self):
         super(ClangVersionType, self).__init__(

--- a/utils/build_swift/tests/build_swift/argparse/test_types.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_types.py
@@ -157,10 +157,15 @@ class TestClangVersionType(unittest.TestCase):
         self.assertIsInstance(version, types.Version)
         self.assertEqual(version.components, (1, 0, 0, 1))
 
+        version = clang_version_type('1.0.0.1.2')
+        self.assertIsInstance(version, types.Version)
+        self.assertEqual(version.components, (1, 0, 0, 1, 2))
+
         clang_version_type('1.0.0')
         clang_version_type('3.0.2.1')
         clang_version_type('200.0.56.3')
         clang_version_type('100000.0.0.1')
+        clang_version_type('5.6.0.994.2')
 
     def test_invalid_clang_version(self):
         clang_version_type = types.ClangVersionType()
@@ -170,9 +175,9 @@ class TestClangVersionType(unittest.TestCase):
         with self.assertRaises(ArgumentTypeError):
             clang_version_type('3.0')
         with self.assertRaises(ArgumentTypeError):
-            clang_version_type('1.8.0.2.1')
+            clang_version_type('1.8.0.2.1.3')
         with self.assertRaises(ArgumentTypeError):
-            clang_version_type('100.0.56.1.1')
+            clang_version_type('100.0.56.1.1.1')
 
 
 class TestSwiftVersionType(unittest.TestCase):


### PR DESCRIPTION
SwiftVersionType needs 5 components, and ClangVersionType needs to match SwiftVersionType because some build automation wants to mark the clang version as being the same as the Swift version while generating version numbers.

Fixes rdar://85508050