### PR TITLE
[FrontendTool] Explicitly free the SILModule before generating code.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1645,6 +1645,10 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   if (validateTBDIfNeeded(Invocation, MSF, *IRModule.getModule()))
     return true;
 
+  // Free up some resources now that we're about to generate code.
+  // At this point, the SILModule is no longer needed, so it can be freed.
+  SM.reset();
+
   return generateCode(Instance, OutputFilename, IRModule.getModule(),
                       HashGlobal);
 }


### PR DESCRIPTION
To ensure the compiler does not use too much memory when running the backend,
the `generateCode` function tries to free the ASTContext.

However, `performCompileStepsPostSILGen` owns something else memory-intensive:
the SILModule. As a result, before calling `generateCode`,
`performCompileStepsPostSILGen` needs to free the SILModule.

This ensures that the backend can run with as much memory available as
possible, which can alleviate memory issues when running in resource-constrained
environments.

This addresses <rdar://problem/85510822>.