### PR TITLE
[build-script] Set the type for a couple of LTO-related arguments cor…

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -506,12 +506,14 @@ def create_argument_parser():
     option('--llvm-max-parallel-lto-link-jobs', store_int,
            default=defaults.LLVM_MAX_PARALLEL_LTO_LINK_JOBS,
            metavar='COUNT',
+           type=int,
            help='the maximum number of parallel link jobs to use when '
                 'compiling llvm')
 
     option('--swift-tools-max-parallel-lto-link-jobs', store_int,
            default=defaults.SWIFT_MAX_PARALLEL_LTO_LINK_JOBS,
            metavar='COUNT',
+           type=int,
            help='the maximum number of parallel link jobs to use when '
                 'compiling swift tools.')
 


### PR DESCRIPTION
…rectly.

This allows users of build-script to actually manually limit the number of LTO jobs that are spawned simultaneously.

This addresses <rdar://problem/85510897>.