### PR TITLE
[build-script-impl] Move a skip install check earlier so it affects t…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3064,6 +3064,11 @@ for host in "${ALL_HOSTS[@]}"; do
     host_install_destdir=$(get_host_install_destdir ${host})
     host_install_prefix=$(get_host_install_prefix ${host})
 
+    # Skip this pass if flag is set and we are cross compiling and it's the local host.
+    if [[ "${SKIP_LOCAL_HOST_INSTALL}" ]] && [[ $(has_cross_compile_hosts) ]] && [[ ${host} == ${LOCAL_HOST} ]]; then
+        continue
+    fi
+
     # Identify the destdirs to pass to lipo. Must happen even if the install action
     # is to be skipped.
     if [[ $(should_include_host_in_lipo ${host}) ]]; then
@@ -3072,11 +3077,6 @@ for host in "${ALL_HOSTS[@]}"; do
 
     # Skip this pass when the only action to execute can't match.
     if ! [[ $(should_execute_host_actions_for_phase ${host} install) ]]; then
-        continue
-    fi
-
-    # Skip this pass if flag is set and we are cross compiling and it's the local host.
-    if [[ "${SKIP_LOCAL_HOST_INSTALL}" ]] && [[ $(has_cross_compile_hosts) ]] && [[ ${host} == ${LOCAL_HOST} ]]; then
         continue
     fi
 


### PR DESCRIPTION
…he merge-lipo action.

This allows `SKIP_LOCAL_HOST_INSTALL` to actually affect the merge-lipo action.
This in turn permits cross-compilation which doesn't want the local host's tools installed to generate a DSTROOT without a `merged-hosts` directory reliably.

This addresses <rdar://problem/85511320>.