### PR TITLE
Silence Some Warnings

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2206,8 +2206,8 @@ ClangImporter::Implementation::Implementation(
       EnableClangSPI(ctx.ClangImporterOpts.EnableClangSPI),
       IsReadingBridgingPCH(false),
       CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
-      BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       BuffersForDiagnostics(ctx.SourceMgr),
+      BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       platformAvailability(ctx.LangOpts), nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
       DWARFImporter(dwarfImporterDelegate) {}

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -91,9 +91,10 @@ static bool isRequirement(Node::Kind kind) {
 // Public utility functions    //
 //////////////////////////////////
 
-LLVM_NODISCARD void swift::Demangle::failAssert(const char *file, unsigned line,
-                                                NodePointer node,
-                                                const char *expr) {
+LLVM_ATTRIBUTE_NORETURN void swift::Demangle::failAssert(const char *file,
+                                                         unsigned line,
+                                                         NodePointer node,
+                                                         const char *expr) {
   fprintf(stderr, "%s:%u: assertion failed for Node %p: %s", file, line, node,
           expr);
   abort();

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -51,8 +51,8 @@ namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE
 
-LLVM_NODISCARD void failAssert(const char *file, unsigned line,
-                               NodePointer node, const char *expr);
+LLVM_ATTRIBUTE_NORETURN void failAssert(const char *file, unsigned line,
+                                        NodePointer node, const char *expr);
 
 SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle


### PR DESCRIPTION
- Correct field initialization order in the clang importer
- Swap LLVM_NODISCARD for LLVM_ATTRIBUTE_NORETURN in a few places where it was mis-applied.