### PR TITLE
[build-script] Add some standalone stdlib asan variants.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2412,6 +2412,12 @@ no-assertions
 
 verbose-build
 
+[preset: stdlib_RD_standalone,build,asan]
+mixin-preset=stdlib_RD_standalone,build
+
+build-subdir=stdlib_RD_standalone_asan
+enable-asan
+
 [preset: stdlib_RD_standalone,build,test]
 mixin-preset=stdlib_RD_standalone,build
 
@@ -2426,6 +2432,12 @@ release
 assertions
 
 verbose-build
+
+[preset: stdlib_RA_standalone,build,asan]
+mixin-preset=stdlib_RA_standalone,build
+
+build-subdir=stdlib_RA_standalone_asan
+enable-asan
 
 [preset: stdlib_RA_standalone,build,test]
 mixin-preset=stdlib_RA_standalone,build
@@ -2442,6 +2454,12 @@ assertions
 
 verbose-build
 
+[preset: stdlib_RDA_standalone,build,asan]
+mixin-preset=stdlib_RDA_standalone,build
+
+build-subdir=stdlib_RDA_standalone_asan
+enable-asan
+
 [preset: stdlib_RDA_standalone,build,test]
 mixin-preset=stdlib_RDA_standalone,build
 
@@ -2456,6 +2474,12 @@ debug
 assertions
 
 verbose-build
+
+[preset: stdlib_DA_standalone,build,asan]
+mixin-preset=stdlib_DA_standalone,build
+
+build-subdir=stdlib_DA_standalone_asan
+enable-asan
 
 [preset: stdlib_DA_standalone,build,test]
 mixin-preset=stdlib_DA_standalone,build


### PR DESCRIPTION
This is useful if one wants to quickly compile a stdlib with asan enabled
without recompiling the toolchain.
