### PR TITLE
Do not import objc_direct constructors

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8788,10 +8788,22 @@ void ClangImporter::Implementation::importAttributes(
     if (method->isDirectMethod() && !AnyUnavailable) {
       assert(isa<AbstractFunctionDecl>(MappedDecl) &&
              "objc_direct declarations are expected to be an AbstractFunctionDecl");
-      MappedDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
-      if (auto accessorDecl = dyn_cast<AccessorDecl>(MappedDecl)) {
-        auto attr = new (C) FinalAttr(/*isImplicit=*/true);
-        accessorDecl->getStorage()->getAttrs().add(attr);
+      if (isa<ConstructorDecl>(MappedDecl)) {
+        // TODO: Teach Swift how to directly call these functions.
+        auto attr = AvailableAttr::createPlatformAgnostic(
+            C,
+            "Swift cannot call Objective-C initializers marked with "
+            "'objc_direct'",
+            /*Rename*/ "",
+            PlatformAgnosticAvailabilityKind::UnavailableInSwift);
+        MappedDecl->getAttrs().add(attr);
+        AnyUnavailable = true;
+      } else {
+        MappedDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
+        if (auto accessorDecl = dyn_cast<AccessorDecl>(MappedDecl)) {
+          auto attr = new (C) FinalAttr(/*isImplicit=*/true);
+          accessorDecl->getStorage()->getAttrs().add(attr);
+        }
       }
     }
   }

--- a/test/ClangImporter/objc_direct.swift
+++ b/test/ClangImporter/objc_direct.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: objc_interop
 
+let _ = Bar(value: 4)               // expected-error {{'init(value:)' is unavailable in Swift}}
+let _ = Bar.init(value: 5)          // expected-error {{'init(value:)' is unavailable in Swift}}
 var something = Bar() as AnyObject
 
 something.directProperty = 123      // expected-error {{value of type 'AnyObject' has no member 'directProperty'}}

--- a/test/Inputs/objc_direct.h
+++ b/test/Inputs/objc_direct.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
 @interface Bar : NSObject
++ (instancetype)barWithValue:(int)value __attribute__((objc_direct));
+- (instancetype)initWithValue:(int)value __attribute__((objc_direct));
 @property(direct) int directProperty;
 - (int)objectAtIndexedSubscript:(int)i __attribute__((objc_direct));
 - (void)setObject:(int)obj atIndexedSubscript:(int)i __attribute__((objc_direct));


### PR DESCRIPTION
Unlike normal Objective-C functions, Swift does not directly call
Objective-C constructors because it creates a thunk to allocate the
object and call then constructor dynamically. This can be fixed, but for
now emit a compile-time error rather than a runtime error.