### PR TITLE
[CMake] Fix a couple SourceKit CMake issues.

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -52,8 +52,6 @@ include(AddSwiftSourceKit)
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   # Choose a deployment target if none was set.
-  set(SOURCEKIT_DEPLOYMENT_TARGET "" CACHE STRING
-      "Deployment target for SourceKit.")
   if (NOT SOURCEKIT_DEPLOYMENT_TARGET)
     execute_process(COMMAND sw_vers -productVersion
                     OUTPUT_VARIABLE SOURCEKIT_DEPLOYMENT_TARGET

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -55,9 +55,9 @@ target_link_libraries(sourcekitdInProc PRIVATE
 # that is in the same directory as the swift library directory.
 if (SOURCEKITD_BUILD_STATIC_INPROC)
   add_sourcekit_library(sourcekitdInProc_Static
+    ${sourcekitdInProc_args}
     HEADERS
       ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
-    ${sourcekitdInProc_args}
   )
   target_link_libraries(sourcekitdInProc_Static PRIVATE
     SourceKitSwiftLang


### PR DESCRIPTION
[CMake] Correctly order the arguments when setting up sourcekitdInProc_Static.

The shared arguments should come first, followed by the headers.
Otherwise, things don't work correctly, and CMake thinks there are no sources in sourcekitdInProc_Static.

This is for <rdar://problem/85511244>.

---

[CMake] Removed an overwrite of the SOURCEKIT_DEPLOYMENT_TARGET setting.

This setting is set early in SourceKit's CMake logic to match Swift's CMake settings.
However, it was then reset back to the empty string. The CMake logic would then see that it was unset and use the host OS as the deployment target.

Thankfully, the compiled binaries have been correct without this change, but sourcekitd.framework's Info.plist when building for iOS was incorrect.
By removing the reset, the correct value propagates to the right places.

This is for <rdar://problem/85511244> and addresses <rdar://problem/68656762>.