### PR TITLE
Fixes in SILGen and SILOptimizer to add destroy_addrs on non-payloaded paths of switch_enum_addrs

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2126,15 +2126,6 @@ void PatternMatchEmission::emitEnumElementDispatch(
         }
       }
 
-      // Forward src along this path so we don't emit a destroy_addr on our
-      // subject value for this case.
-      //
-      // FIXME: Do we actually want to do this? SILGen tests today assume this
-      // pattern. It might be worth leaving the destroy_addr there to create
-      // additional liveness information. For now though, we maintain the
-      // current behavior.
-      src.getFinalManagedValue().forward(SGF);
-
       SILValue result;
       if (hasNonAny) {
         result = SGF.emitEmptyTuple(loc);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1208,6 +1208,9 @@ void StmtEmitter::visitAsyncForEachStmt(ForEachStmt *S) {
       createBasicBlock(), failExitingBlock,
       [&](ManagedValue inputValue, SwitchCaseFullExpr &&scope) {
         assert(!inputValue && "None should not be passed an argument!");
+        if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
+          SGF.enterDestroyCleanup(addrOnlyBuf);
+        }
         scope.exitAndBranch(S);
       },
       SGF.loadProfilerCount(S));
@@ -1445,6 +1448,9 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
       createBasicBlock(), failExitingBlock,
       [&](ManagedValue inputValue, SwitchCaseFullExpr &&scope) {
         assert(!inputValue && "None should not be passed an argument!");
+        if (nextResultTyIsAddressOnly) {
+          SGF.enterDestroyCleanup(addrOnlyBuf);
+        }
         scope.exitAndBranch(S);
       },
       SGF.loadProfilerCount(S));

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -418,6 +418,7 @@ CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
     Builder.createSwitchEnumAddr(Loc, outOptionalParam, nullptr, CaseBBs);
 
     Builder.setInsertionPoint(FailureBB->begin());
+    Builder.createDestroyAddr(Loc, Tmp);
     Builder.createDeallocStack(Loc, Tmp);
 
     Builder.setInsertionPoint(BridgeSuccessBB);

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -162,11 +162,6 @@ bool swift::isInstructionTriviallyDead(SILInstruction *inst) {
   if (isa<DebugValueInst>(inst))
     return false;
 
-  // These invalidate enums so "write" memory, but that is not an essential
-  // operation so we can remove these if they are trivially dead.
-  if (isa<UncheckedTakeEnumDataAddrInst>(inst))
-    return true;
-
   // An ossa end scope instruction is trivially dead if its operand has
   // OwnershipKind::None. This can occur after CFG simplification in the
   // presence of non-payloaded or trivial payload cases of non-trivial enums.

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -15,9 +15,11 @@ import resilient_enum
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb3:

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -20,9 +20,11 @@
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb3:

--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -45,6 +45,7 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -117,6 +118,7 @@ bb4:
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -188,6 +190,7 @@ bb4:
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB:bb[0-9]+]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
@@ -258,6 +261,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -325,6 +329,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -394,6 +399,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -464,6 +470,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -531,6 +538,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -600,6 +608,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -670,6 +679,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -737,6 +747,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -806,6 +817,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -876,6 +888,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -943,6 +956,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -1012,6 +1026,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -165,6 +165,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -233,6 +234,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCAST_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCAST_INPUT:%.*]] to [init] [[INPUT]]
@@ -305,6 +307,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -375,6 +378,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -443,6 +447,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -515,6 +520,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -585,6 +591,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -653,6 +660,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -725,6 +733,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -795,6 +804,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -863,6 +873,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -935,6 +946,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //


### PR DESCRIPTION
Currently, SILGen does not generate destroy_addrs on non-payloaded paths of switch_enum_addr
as a micro optimization. This causes a lot of complexity for verification.

MemoryLifetimeVerifier currently has special logic to avoid raising errors for such missing destroy_addrs.
With OSSA, there can be optimizations which convert switch_enum_addr to switch_enum, and eliminate load_borrows and loads with mem2reg. The ownership verifier then raises errors about missing destroy_values.

We don't want to replicate special logic to identify such cases in the ownership verifier,
and instead remove this special logic from MemoryLifetimeVerifier as well, to enforce destroy_addrs on non-payloaded flowpaths as well.
This PR is a first step towards that.