### PR TITLE
[rebranch] Replace `LLVM_ATTRIBUTE_NORETURN` with `[[noreturn]]`

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -91,10 +91,8 @@ static bool isRequirement(Node::Kind kind) {
 // Public utility functions    //
 //////////////////////////////////
 
-LLVM_ATTRIBUTE_NORETURN void swift::Demangle::failAssert(const char *file,
-                                                         unsigned line,
-                                                         NodePointer node,
-                                                         const char *expr) {
+void swift::Demangle::failAssert(const char *file, unsigned line,
+                                 NodePointer node, const char *expr) {
   fprintf(stderr, "%s:%u: assertion failed for Node %p: %s", file, line, node,
           expr);
   abort();

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -51,8 +51,8 @@ namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE
 
-LLVM_ATTRIBUTE_NORETURN void failAssert(const char *file, unsigned line,
-                                        NodePointer node, const char *expr);
+[[noreturn]] void failAssert(const char *file, unsigned line, NodePointer node,
+                             const char *expr);
 
 SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle


### PR DESCRIPTION
llvm-project 09529892b518c8df8c24395e68e0a7a5e8bda5fb removed
`LLVM_ATTRIBUTE_NORETURN` in favour of the C++11 `[[noreturn]]`.