### PR TITLE
[Runtime] Replace std::max_align_t with MaximumAlignment from MetadataValues.h.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1372,7 +1372,7 @@ public:
       // For now, we won't try to walk the allocations in the slab, we'll just
       // provide the whole thing as one big chunk.
       size_t HeaderSize =
-          llvm::alignTo(sizeof(*Slab), llvm::Align(alignof(std::max_align_t)));
+          llvm::alignTo(sizeof(*Slab), llvm::Align(MaximumAlignment));
       AsyncTaskAllocationChunk Chunk;
 
       Chunk.Start = SlabPtr + HeaderSize;

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -51,7 +51,6 @@
 
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20160726
 #include <stddef.h>
-namespace std { using ::max_align_t; }
 #endif
 
 using namespace swift;

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -274,7 +274,7 @@ _tryCastFromClassToObjCBridgeable(
 
   // The extra byte is for the tag on the T?
   const std::size_t inlineValueSize = 3 * sizeof(void*);
-  alignas(std::max_align_t) char inlineBuffer[inlineValueSize + 1];
+  alignas(MaximumAlignment) char inlineBuffer[inlineValueSize + 1];
   void *optDestBuffer;
   if (destType->getValueWitnesses()->getStride() <= inlineValueSize) {
     // Use the inline buffer.

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/ABI/MetadataValues.h"
 #include "swift/Runtime/Debug.h"
 #include "llvm/Support/Alignment.h"
 #include <cstddef>
@@ -67,7 +68,7 @@ private:
   bool firstSlabIsPreallocated;
 
   /// The minimal alignment of allocated memory.
-  static constexpr size_t alignment = alignof(std::max_align_t);
+  static constexpr size_t alignment = MaximumAlignment;
   
   /// If set to true, memory allocations are checked for buffer overflows and
   /// use-after-free, similar to guard-malloc.


### PR DESCRIPTION
On Windows, `std::max_align_t` is only 8-byte aligned, but Swift assumes 16-byte alignment. `MaximumAlignment` is our notion of the maximum alignment of a type, so use that instead.