### PR TITLE
Remove spurious rethrows from Async[Throwing]PrefixWhileSequence

### DIFF
--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -41,7 +41,7 @@ extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
     while predicate: @escaping (Element) async -> Bool
-  ) rethrows -> AsyncPrefixWhileSequence<Self> {
+  ) -> AsyncPrefixWhileSequence<Self> {
     return AsyncPrefixWhileSequence(self, predicate: predicate)
   }
 }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -53,7 +53,7 @@ extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
     while predicate: @escaping (Element) async throws -> Bool
-  ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
+  ) -> AsyncThrowingPrefixWhileSequence<Self> {
     return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `rethrows` marker is unnecessary in these two locations.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-15494.](https://bugs.swift.org/browse/SR-15494)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
