### PR TITLE
[CMake] Added support for disabling building the SourceKit XPC service.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,10 +2,14 @@ include(CheckIncludeFiles)
 check_include_files("xpc/xpc.h" HAVE_XPC_H)
 
 if(HAVE_XPC_H AND SWIFT_BUILD_SOURCEKIT)
-  set(BUILD_SOURCEKIT_XPC_SERVICE TRUE)
+  set(BUILD_SOURCEKIT_XPC_SERVICE_default TRUE)
 else()
-  set(BUILD_SOURCEKIT_XPC_SERVICE FALSE)
+  set(BUILD_SOURCEKIT_XPC_SERVICE_default FALSE)
 endif()
+
+option(BUILD_SOURCEKIT_XPC_SERVICE
+  "Whether or not the SourceKit XPC service should be built"
+  ${BUILD_SOURCEKIT_XPC_SERVICE_default})
 
 # Add generated libSyntax headers to global dependencies.
 list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)


### PR DESCRIPTION
Made `BUILD_SOURCEKIT_XPC_SERVICE` into a cache variable so it can be set
externally. It continues to default to `TRUE` if
`HAVE_XPC_H AND SWIFT_BUILD_SOURCEKIT` is true, and `FALSE` otherwise, but this
allows a client to disable this ahead of time and build a sourcekitd.framework
without the XPC service.

This addresses <rdar://problem/85511711>.