### PR TITLE
[Doc] Fix unescaped reference in  'Substring.base' summary.

### DIFF
--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -122,7 +122,7 @@ public struct Substring: Sendable {
 }
 
 extension Substring {
-  /// Returns the underlying string from which this Substring was derived.
+  /// Returns the underlying string from which this substring was derived.
   @_alwaysEmitIntoClient
   public var base: String { return _slice.base }
 


### PR DESCRIPTION
There is an unescaped reference to type `Substring`.  I think a plain lowercased reference would read better.  Alternatively we could escape it with backquotes.

Resolves rdar://85574572.