### PR TITLE
Add isReadOnlyConstantEvaluableCall to handle stdlib asserts

### DIFF
--- a/include/swift/SILOptimizer/Utils/ConstExpr.h
+++ b/include/swift/SILOptimizer/Utils/ConstExpr.h
@@ -26,6 +26,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
+#include "swift/SIL/ApplySite.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
@@ -210,6 +211,9 @@ public:
 bool hasConstantEvaluableAnnotation(SILFunction *fun);
 
 bool isConstantEvaluable(SILFunction *fun);
+
+/// Return true iff the \p applySite is constant-evaluable and read-only.
+bool isReadOnlyConstantEvaluableCall(FullApplySite applySite);
 
 /// Return true if and only if the given function \p fun is specially modeled
 /// by the constant evaluator. These are typically functions in the standard

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5219,3 +5219,22 @@ bb0(%0 : @owned $Klass, %1 : $Builtin.Word):
   destroy_value %0 : $Klass
   return %11 : $AnyObject
 }
+
+// Test that DCE during SILCombine does not remove traps.
+// Tests isReadOnlyConstantEvaluable().
+sil hidden [noinline] [_semantics "programtermination_point"] @trapWrapper : $@convention(thin) () -> () {
+bb0:
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @testTrap : $@convention(thin) () -> () {
+// CHECK: apply
+// CHECK-LABEL: } // end sil function 'testTrap'
+sil [ossa] @testTrap : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @trapWrapper : $@convention(thin) () -> ()
+  %1 = apply %0() : $@convention(thin) () -> ()
+  %2 = tuple ()
+  return %2 : $()
+}


### PR DESCRIPTION
Fix isScopeAffectingInstructionDead to use this new API. A stdlib assert, which has "program_termination" semantics, should not be considered read-only.

isReadOnlyConstantEvaluableCall API:
    /// Return true iff the \p applySite is constant-evaluable and read-only.
    ///
    /// Functions annotated as "constant_evaluable" are assumed to be "side-effect
    /// free", unless their signature and substitution map indicates otherwise. A
    /// constant_evaluable function call is read only unless it:
    ///   (1) has generic parameters
    ///   (2) has inout parameters
    ///   (3) has indirect results
    ///
    /// Read-only constant evaluable functions can do only the following and
    /// nothing else:
    ///   (1) The call may read any memory location.
    ///   (2) The call may destroy owned parameters i.e., consume them.
    ///   (3) The call may write into memory locations newly created by the call.
    ///   (4) The call may use assertions, which traps at runtime on failure.
    ///   (5) The call may return a non-generic value.
    ///
    /// Essentially, these are calls whose "effect" is visible only in their return
    /// value or through the parameters that are destroyed. The return value
    /// is also guaranteed to have value semantics as it is non-generic and
    /// reference semantics is not constant evaluable.