### PR TITLE
⚠️ Do Not Merge ⚠️ Drop Support for -serialize-options-for-debugging

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -836,11 +836,6 @@ public:
 
   /// Returns an approximation of whether the given module could be
   /// redistributed and consumed by external clients.
-  ///
-  /// FIXME: The scope of this computation should be limited entirely to
-  /// RenamedDeclRequest. Unfortunately, it has been co-opted to support the
-  /// \c SerializeOptionsForDebugging hack. Once this information can be
-  /// transferred from module files to the dSYMs, remove this.
   bool isExternallyConsumed() const;
 
   SourceRange getSourceRange() const { return SourceRange(); }

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -87,6 +87,13 @@ public:
   /// as the context loading it.
   bool EnableSameSDKCheck = true;
 
+  /// When \c true, any modules loaded by this frontend will have the content of
+  /// their search path block appended to the list of search paths of this
+  /// frontend.
+  ///
+  /// This option exists solely for use by LLDB.
+  bool LoadSerializedSearchPathsForDebugging = false;
+
   /// A set of compiled modules that may be ready to use.
   std::vector<std::string> CandidateCompiledModules;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -392,12 +392,8 @@ public:
   /// Given the current configuration of this frontend invocation, a set of
   /// supplementary output paths, and a module, compute the appropriate set of
   /// serialization options.
-  ///
-  /// FIXME: The \p module parameter supports the
-  /// \c SerializeOptionsForDebugging hack.
   SerializationOptions
-  computeSerializationOptions(const SupplementaryOutputPaths &outs,
-                              const ModuleDecl *module) const;
+  computeSerializationOptions(const SupplementaryOutputPaths &outs) const;
 };
 
 /// A class which manages the state and execution of the compiler.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -177,11 +177,6 @@ public:
   /// Ignore .swiftsourceinfo file when trying to get source locations from module imported decls.
   bool IgnoreSwiftSourceInfo = false;
 
-  /// When true, emitted module files will always contain options for the
-  /// debugger to use. When unset, the options will only be present if the
-  /// module appears to not be a public module.
-  Optional<bool> SerializeOptionsForDebugging;
-
   /// When true the debug prefix map entries will be applied to debugging
   /// options before serialization. These can be reconstructed at debug time by
   /// applying the inverse map in SearchPathOptions.SearchPathRemapper.

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -103,9 +103,17 @@ struct ValidationInfo {
 ///
 /// \sa validateSerializedAST()
 class ExtendedValidationInfo {
+  struct SearchPath {
+    StringRef Path;
+    bool IsFramework;
+    bool IsSystem;
+  };
+
   SmallVector<StringRef, 4> ExtraClangImporterOpts;
   StringRef SDKPath;
   StringRef ModuleABIName;
+  std::vector<SearchPath> SearchPaths;
+
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
@@ -123,6 +131,13 @@ public:
   void setSDKPath(StringRef path) {
     assert(SDKPath.empty());
     SDKPath = path;
+  }
+
+  llvm::ArrayRef<SearchPath> getSerializedSearchPaths() const {
+    return SearchPaths;
+  }
+  void addSerializedSearchPath(StringRef path, bool isFramework, bool isSystem) {
+    SearchPaths.push_back({ path, isFramework, isSystem  });
   }
 
   ArrayRef<StringRef> getExtraClangImporterOptions() const {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -260,12 +260,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_access_notes_path))
     Opts.AccessNotesPath = A->getValue();
 
-  if (const Arg *A = Args.getLastArg(OPT_serialize_debugging_options,
-                                     OPT_no_serialize_debugging_options)) {
-    Opts.SerializeOptionsForDebugging =
-        A->getOption().matches(OPT_serialize_debugging_options);
-  }
-
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2259,6 +2259,21 @@ CompilerInvocation::loadFromSerializedAST(StringRef data) {
   for (StringRef Arg : extendedInfo.getExtraClangImporterOptions())
     extraClangArgs.push_back(Arg.str());
 
+  if (!getSearchPathOptions().LoadSerializedSearchPathsForDebugging)
+    return info.status;
+  
+  for (const auto &searchPath : extendedInfo.getSerializedSearchPaths()) {
+    if (searchPath.IsFramework) {
+      getSearchPathOptions().FrameworkSearchPaths.push_back({
+        getSearchPathOptions().SearchPathRemapper.remapPath(searchPath.Path),
+        searchPath.IsSystem
+      });
+    } else {
+      getSearchPathOptions().ImportSearchPaths.push_back(
+          getSearchPathOptions().SearchPathRemapper.remapPath(searchPath.Path));
+    }
+  }
+
   return info.status;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -136,7 +136,7 @@ CompilerInvocation::getPrivateModuleInterfaceOutputPathForWholeModule() const {
 }
 
 SerializationOptions CompilerInvocation::computeSerializationOptions(
-    const SupplementaryOutputPaths &outs, const ModuleDecl *module) const {
+    const SupplementaryOutputPaths &outs) const {
   const FrontendOptions &opts = getFrontendOptions();
 
   SerializationOptions serializationOpts;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -157,15 +157,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   if (!getIRGenOptions().ForceLoadSymbolName.empty())
     serializationOpts.AutolinkForceLoad = true;
 
-  // Options contain information about the developer's computer,
-  // so only serialize them if the module isn't going to be shipped to
-  // the public.
-  serializationOpts.SerializeOptionsForDebugging =
-      opts.SerializeOptionsForDebugging.getValueOr(
-          !module->isExternallyConsumed());
-
-  if (serializationOpts.SerializeOptionsForDebugging &&
-      opts.DebugPrefixSerializedDebuggingOptions) {
+  if (opts.DebugPrefixSerializedDebuggingOptions) {
     serializationOpts.DebuggingOptionsPrefixMap =
         getIRGenOptions().DebugPrefixMap;
     auto &remapper = serializationOpts.DebuggingOptionsPrefixMap;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1532,7 +1532,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
       return;
 
     SerializationOptions serializationOpts =
-        Invocation.computeSerializationOptions(outs, Instance.getMainModule());
+        Invocation.computeSerializationOptions(outs);
 
     // Infer if this is an emit-module job part of an incremental build,
     // vs a partial emit-module job (with primary files) or other kinds.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -164,11 +164,13 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
     status = Status::SDKMismatch;
     return error(status);
   }
-
-  for (const auto &searchPath : Core->SearchPaths) {
-    ctx.addSearchPath(
-        ctx.SearchPathOpts.SearchPathRemapper.remapPath(searchPath.Path),
-        searchPath.IsFramework, searchPath.IsSystem);
+  
+  if (ctx.SearchPathOpts.LoadSerializedSearchPathsForDebugging) {
+    for (const auto &searchPath : Core->SearchPaths) {
+      ctx.addSearchPath(
+          ctx.SearchPathOpts.SearchPathRemapper.remapPath(searchPath.Path),
+          searchPath.IsFramework, searchPath.IsSystem);
+    }
   }
 
   auto clangImporter = static_cast<ClangImporter *>(ctx.getClangModuleLoader());

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1067,40 +1067,38 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         IsConcurrencyChecked.emit(ScratchRecord);
       }
 
-      if (options.SerializeOptionsForDebugging) {
-        options_block::SDKPathLayout SDKPath(Out);
-        options_block::XCCLayout XCC(Out);
+      options_block::SDKPathLayout SDKPath(Out);
+      options_block::XCCLayout XCC(Out);
 
-        const auto &PathRemapper = options.DebuggingOptionsPrefixMap;
-        SDKPath.emit(
-            ScratchRecord,
-            PathRemapper.remapPath(M->getASTContext().SearchPathOpts.SDKPath));
-        auto &Opts = options.ExtraClangOptions;
-        for (auto Arg = Opts.begin(), E = Opts.end(); Arg != E; ++Arg) {
-          StringRef arg(*Arg);
-          if (arg.startswith("-ivfsoverlay")) {
-            // FIXME: This is a hack and calls for a better design.
-            //
-            // Filter out any -ivfsoverlay options that include an
-            // unextended-module-overlay.yaml overlay. By convention the Xcode
-            // buildsystem uses these while *building* mixed Objective-C and
-            // Swift frameworks; but they should never be used to *import* the
-            // module defined in the framework.
-            auto Next = std::next(Arg);
-            if (Next != E &&
-                StringRef(*Next).endswith("unextended-module-overlay.yaml")) {
-              ++Arg;
-              continue;
-            }
-          } else if (arg.startswith("-fdebug-prefix-map=")) {
-            // We don't serialize the debug prefix map flags as these
-            // contain absoute paths that are not usable on different
-            // machines. These flags are not necessary to compile the
-            // clang modules again so are safe to remove.
+      const auto &PathRemapper = options.DebuggingOptionsPrefixMap;
+      SDKPath.emit(
+          ScratchRecord,
+          PathRemapper.remapPath(M->getASTContext().SearchPathOpts.SDKPath));
+      auto &Opts = options.ExtraClangOptions;
+      for (auto Arg = Opts.begin(), E = Opts.end(); Arg != E; ++Arg) {
+        StringRef arg(*Arg);
+        if (arg.startswith("-ivfsoverlay")) {
+          // FIXME: This is a hack and calls for a better design.
+          //
+          // Filter out any -ivfsoverlay options that include an
+          // unextended-module-overlay.yaml overlay. By convention the Xcode
+          // buildsystem uses these while *building* mixed Objective-C and
+          // Swift frameworks; but they should never be used to *import* the
+          // module defined in the framework.
+          auto Next = std::next(Arg);
+          if (Next != E &&
+              StringRef(*Next).endswith("unextended-module-overlay.yaml")) {
+            ++Arg;
             continue;
           }
-          XCC.emit(ScratchRecord, arg);
+        } else if (arg.startswith("-fdebug-prefix-map=")) {
+          // We don't serialize the debug prefix map flags as these
+          // contain absoute paths that are not usable on different
+          // machines. These flags are not necessary to compile the
+          // clang modules again so are safe to remove.
+          continue;
         }
+        XCC.emit(ScratchRecord, arg);
       }
     }
   }
@@ -1151,18 +1149,16 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   input_block::DependencyDirectoryLayout DependencyDirectory(Out);
   input_block::ModuleInterfaceLayout ModuleInterface(Out);
 
-  if (options.SerializeOptionsForDebugging) {
-    const auto &PathMapper = options.DebuggingOptionsPrefixMap;
-    const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
-    // Put the framework search paths first so that they'll be preferred upon
-    // deserialization.
-    for (auto &framepath : searchPathOpts.FrameworkSearchPaths)
-      SearchPath.emit(ScratchRecord, /*framework=*/true, framepath.IsSystem,
-                      PathMapper.remapPath(framepath.Path));
-    for (auto &path : searchPathOpts.ImportSearchPaths)
-      SearchPath.emit(ScratchRecord, /*framework=*/false, /*system=*/false,
-                      PathMapper.remapPath(path));
-  }
+  const auto &PathMapper = options.DebuggingOptionsPrefixMap;
+  const SearchPathOptions &searchPathOpts = M->getASTContext().SearchPathOpts;
+  // Put the framework search paths first so that they'll be preferred upon
+  // deserialization.
+  for (auto &framepath : searchPathOpts.FrameworkSearchPaths)
+    SearchPath.emit(ScratchRecord, /*framework=*/true, framepath.IsSystem,
+                    PathMapper.remapPath(framepath.Path));
+  for (auto &path : searchPathOpts.ImportSearchPaths)
+    SearchPath.emit(ScratchRecord, /*framework=*/false, /*system=*/false,
+                    PathMapper.remapPath(path));
 
   // Note: We're not using StringMap here because we don't need to own the
   // strings.

--- a/test/DebugInfo/search-paths.swift
+++ b/test/DebugInfo/search-paths.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: echo "public let a0 = 0"  >%t/TransitiveDependencies.swift
+
+// RUN: %target-build-swift %t/TransitiveDependencies.swift -emit-module -emit-module-path %t/TransitiveDependencies.swiftmodule -F %t/transitive/framework/search/path -I %t/transitive/normal/search/path
+// RUN: %target-build-swift -emit-executable %s -g -o %t/SearchPathParty -emit-module -I %t -F %t/framework/search/path -I %t/normal/search/path
+// RUN: %lldb-moduleimport-test -verbose %t/SearchPathParty | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_tools_extra
+
+// Make sure the way LLDB loads modules can handle loading transitive
+// dependencies and (in particular) their embedded search paths into the AST
+// context. However, we do not want to explicitly propagate those paths into
+// this module, hence the negative checks below. N.B. Framework search paths
+// are explicitly placed before normal search paths by swift module
+// serialization.
+import TransitiveDependencies
+
+// CHECK-LABEL: - Serialized search paths:
+// CHECK: {{.*}}/framework/search/path (framework)
+// CHECK-NOT: {{.*}}/transitive/framework/search/path (framework)
+// CHECK: {{.*}}/normal/search/path
+// CHECK-NOT: {{.*}}/transitive/normal/search/path
+// CHECK: Importing SearchPathParty... ok!


### PR DESCRIPTION
-serialize-options-for-debugging provides (among many things) a way for
external tools that load swiftmodules to recover the search paths that
were used to build the module file in the first place. Its one and only
client is LLDB, which reads search paths either directly from
a serialized swiftmodule file or out of the embedded AST section of
a dylib that has been linked with that option.

Historically, the Swift frontend would load each module, check to see if
-serialize-options-for-debugging was set, then buffer in the search
paths in that section. After that, the frontend would append those
search paths to its own search paths (!!). When building in an entirely
local context, this meant a whole bunch of buildroot paths would wind up
embedded into modules. And, since those modules were (probably) just
built, any attempts to reach into the search paths loaded from them
would succeed - or at least if they were to fail they would fail fast.

There are two aspects of this design that combine to make for
a problematic experience:

1) Search paths are written in terms of either the SDK or a local build
   root. This implies that those paths cannot be loaded by frontends
   that are not on the machine that built the module. In and of itself
   this is not a problem - especially SDK paths which are emitted with
   a magical relative path prefix.
2) Those local search paths propagate transitively.

Imagine a remote CI service that builds and distributes a swiftmodule.
It has paths onto a network mount (or any other high-latency shared
storage device) into which it points its buildroot. Those swiftmodule
files are then built into an SDK image and distributed to local testers.
When those testers create applications that import those built modules,
they will see search paths into the network mount. The compiler can then
be made to stat the network mount, sometimes many many times since
search paths propagate recursively from dependent modules. This can
drastically inflate build times in pathological cases.

The solution is three-fold:
1) Remove the conditional options serialization path. Always include search paths in
    the module file but
2) Break the transitive search path appending behavior for the frontends
   and make it an option that must be explicitly requested so the
   debugger remains happy. A new flag for this will follow.
3) Allow the path that "validates" a swiftmodule file to pick those
   paths up and insert them explicitly into the search path options.

These two components will appear in follow-up commits.

The end goal is not necessarily to eliminate the slow search path
behavior entirely, but rather to eliminate it *at build time*. LLDB will
still have to reckon with these slow search paths when it loads these
modules.

rdar://85231378