### PR TITLE
GSB: Tweak condition under which we perform conditional requirement inference

### DIFF
--- a/lib/AST/GenericSignatureBuilder.h
+++ b/lib/AST/GenericSignatureBuilder.h
@@ -338,7 +338,8 @@ private:
   /// \returns the requirement source for the resolved conformance, or nullptr
   /// if the conformance could not be resolved.
   const RequirementSource *resolveConcreteConformance(ResolvedType type,
-                                                      ProtocolDecl *proto);
+                                                      ProtocolDecl *proto,
+                                                      bool explicitConformance);
 
   /// Retrieve the constraint source conformance for the superclass constraint
   /// of the given potential archetype (if present) to the given protocol.
@@ -347,7 +348,8 @@ private:
   ///
   /// \param proto The protocol to which we are establishing conformance.
   const RequirementSource *resolveSuperConformance(ResolvedType type,
-                                                   ProtocolDecl *proto);
+                                                   ProtocolDecl *proto,
+                                                   bool explicitConformance);
 
 public:
   /// Add a new conformance requirement specifying that the given

--- a/test/Generics/conditional_requirement_inference.swift
+++ b/test/Generics/conditional_requirement_inference.swift
@@ -8,6 +8,11 @@ struct EquatableBox<T : Equatable> {
   func withArray<U>(_: U) where T == Array<U> {}
 }
 
+struct EquatableSequenceBox<T : Sequence> where T.Element : Equatable {
+  // CHECK: Generic signature: <T, U where T == Array<Array<U>>, U : Equatable>
+  func withArrayArray<U>(_: U) where T == Array<Array<U>> {}
+}
+
 
 // A very elaborate invalid example (see comment in mergeP1AndP2())
 struct G<T> {}

--- a/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
+++ b/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
@@ -67,3 +67,30 @@ struct S4<Base> where Base : P1, Base.Element: P1 {
     _ = index.map({ _ = $0 })
   }
 }
+
+struct T0<X> {}
+
+extension T0: P1 where X: P1 {
+  typealias Element = X.Element
+  typealias Index = T0<X.Index>
+}
+
+struct T1<X, Y>: P1 where X: P1 {
+  typealias Element = Y
+  typealias Index = X.Index
+}
+
+struct T2<X> where X: P1, X.Element: P1 {
+  let field: X.Element.Index
+}
+
+struct T3<X> where X: P1 {
+  func callee(_: T2<T1<X, T0<X>>>) {}
+
+  // CHECK-LABEL: {{^}}sil {{.*}}2T3{{.*}}6caller{{.*}}F :
+  // CHECK: @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2, τ_0_3, τ_0_4, τ_0_5 where τ_0_0 == T1<τ_0_1, T0<τ_0_4>>, τ_0_1 : P1, τ_0_1 == τ_0_3, τ_0_2 == T0<τ_0_4>, τ_0_4 : P1, τ_0_4 == τ_0_5> (T2<T1<τ_0_1, T0<τ_0_4>>>) -> () for <T1<X, T0<X>>, X, T0<X>, X, X, X>
+  func caller() {
+    _ = { (x: T2<T1<X, T0<X>>>) in callee(x) }
+  }
+}
+


### PR DESCRIPTION
For SIL substituted generic signature construction to work, we must
perform this step if either the conformance requirement or the
concrete type requirement is explicit. Previously, we only did it
if the concrete type requirement was explicit.

This is still somewhat unprincipled and I need to think about it
some more before porting it over to the requirement machine.

Fixes https://bugs.swift.org/browse/SR-15254 / rdar://problem/84827656.