### PR TITLE
[Test] Use `--leading-lines` for `split-file`

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/frameworks/LibA.framework/Modules/LibA.swiftmodule %t/mods %t/mods
-// RUN: split-file %s %t
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend -module-name LibB -emit-module -emit-module-path %t/mods/LibB.swiftmodule -emit-module-source-info-path %t/mods/LibB.swiftsourceinfo %t/libB.swift
 // RUN: %target-swift-frontend -module-name LibC -emit-module -emit-module-path %t/mods/LibC.swiftmodule %t/libC.swift


### PR DESCRIPTION
Cherry-picks the corresponding fix from rebranch so that this test will pass after https://github.com/apple/llvm-project/pull/3564 is merged.

-----

split-file now uses `--no-leading-lines` as the default for
`split-file`. Add the new arg so that we have leading lines again.