### PR TITLE
Add a feature flag for Builtin.stackAlloc and friends

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -56,6 +56,7 @@ LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building built
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "MainActor executor building builtin", true)
 LANGUAGE_FEATURE(BuiltinMove, 0, "Builtin.move()", true)
 LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()", true)
+LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
 LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
 
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2866,6 +2866,10 @@ static bool usesFeatureImplicitSelfCapture(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinStackAlloc(Decl *decl) {
+  return false;
+}
+
 /// Determine the set of "new" features used on a given declaration.
 ///
 /// Note: right now, all features we check for are "new". At some point, we'll

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -60,6 +60,7 @@ internal func _byteCountForTemporaryAllocation<T>(
 ///   `byteCount` bytes of memory.
 @_alwaysEmitIntoClient @_transparent
 internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
+#if compiler(>=5.5) && $BuiltinStackAlloc
   // PRECONDITIONS: Non-positive alignments are nonsensical, as are
   // non-power-of-two alignments.
   if _isComputed(alignment) {
@@ -94,6 +95,9 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
     return false
   }
   return swift_stdlib_isStackAllocationSafe(byteCount, alignment)
+#else
+  fatalError("unsupported compiler")
+#endif
 }
 
 /// Provides scoped access to a raw buffer pointer with the specified byte count
@@ -142,6 +146,7 @@ internal func _withUnsafeTemporaryAllocation<T, R>(
   // notice and complain.)
   let result: R
   
+#if compiler(>=5.5) && $BuiltinStackAlloc
   let stackAddress = Builtin.stackAlloc(
     capacity._builtinWordValue,
     MemoryLayout<T>.stride._builtinWordValue,
@@ -160,6 +165,9 @@ internal func _withUnsafeTemporaryAllocation<T, R>(
     Builtin.stackDealloc(stackAddress)
     throw error
   }
+#else
+  fatalError("unsupported compiler")
+#endif
 }
 
 // MARK: - Public interface


### PR DESCRIPTION
... and use it in inlinable code so older compilers don't break on
newer standard libraries, fixing rdar://85574956.
