### PR TITLE
Change base build presets to use libswift=hosttools

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -33,6 +33,9 @@ compiler-vendor=apple
 verbose-build
 build-ninja
 
+# Build with hosttools unless overridden, to avoid some condfail problems
+libswift=hosttools
+
 build-swift-stdlib-unittest-extra
 
 install-llvm
@@ -320,6 +323,9 @@ reconfigure
 verbose-build
 build-ninja
 skip-test-cmark
+
+# Build with hosttools unless overridden, to avoid some condfail problems
+libswift=hosttools
 
 [preset: buildbot_incremental_base_all_platforms]
 mixin-preset=buildbot_incremental_base
@@ -1234,6 +1240,9 @@ swiftdocc
 
 # Build concurrency back-deployment binaries
 back-deploy-concurrency
+
+# Build with hosttools unless overridden, to avoid some condfail problems
+libswift=hosttools
 
 # Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
 # are checked in.


### PR DESCRIPTION
This is intended to resolve some condfail issues we've been experiencing from the default `bootstrapping-with-hostlibs` setting due to module mismatches.