### PR TITLE
Concurrency: fix UB in DefaultActor initialization

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -698,7 +698,7 @@ public:
   void initialize(bool isDistributedRemote = false) {
     auto flags = Flags();
     flags.setIsDistributedRemote(isDistributedRemote);
-    new (&CurrentState) std::atomic<State>(State{JobRef(), flags});
+    new (&CurrentState) swift::atomic<State>(State{JobRef(), flags});
     JobStorageHeapObject.metadata = nullptr;
   }
 

--- a/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
+++ b/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
@@ -7,9 +7,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME(distributed): remote functions dont seem to work on windows?
-// XFAIL: OS=windows-msvc
-
 import _Distributed
 
 distributed actor LocalWorker {

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -8,9 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME(distributed): remote functions dont seem to work on windows?
-// XFAIL: OS=windows-msvc
-
 import _Distributed
 
 @available(SwiftStdlib 5.6, *)


### PR DESCRIPTION
This fixes a latent UB instance in the `DefaultActor` implementation
that has haunted the Windows target.  The shared constructor for the
type caused an errant typo that happened to compile which introduced
UB but happened to work for the non-Windows cases.  This happened to
work for the other targets as `swift::atomic` had a `std::atomic` at
on most configurations, and the C delegate for the Actor initializer
happened to overlap and initialize the memory properly.  The Windows
case used an inline pointer width value but would be attempted to be
initialized as a `std::atomic`.  Relying on the overlap is unsafe to
assume, and we should use the type's own constructor which delegates
appropriately.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
