### PR TITLE
Revert "Support __available__((swift_attr("@Sendable")))"

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -605,7 +605,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(async, Async,
   106)
 
 SIMPLE_DECL_ATTR(Sendable, Sendable,
-  OnFunc | OnConstructor | OnAccessor | OnAnyClangDecl |
+  OnFunc | OnConstructor | OnAccessor |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   107)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -168,9 +168,8 @@ protected:
     );
 
     SWIFT_INLINE_BITFIELD(SynthesizedProtocolAttr, DeclAttribute,
-                          NumKnownProtocolKindBits+1,
-      kind : NumKnownProtocolKindBits,
-      isUnchecked : 1
+                          NumKnownProtocolKindBits,
+      kind : NumKnownProtocolKindBits
     );
   } Bits;
 
@@ -289,9 +288,6 @@ public:
 
     /// Whether this attribute is only valid when distributed is enabled.
     DistributedOnly = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 17),
-
-    /// Whether this attribute is valid on additional decls in ClangImporter.
-    OnAnyClangDecl = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 18),
   };
 
   LLVM_READNONE
@@ -1280,23 +1276,17 @@ class SynthesizedProtocolAttr : public DeclAttribute {
 
 public:
   SynthesizedProtocolAttr(KnownProtocolKind protocolKind,
-                          LazyConformanceLoader *Loader,
-                          bool isUnchecked)
+                          LazyConformanceLoader *Loader)
     : DeclAttribute(DAK_SynthesizedProtocol, SourceLoc(), SourceRange(),
                     /*Implicit=*/true), Loader(Loader)
   {
     Bits.SynthesizedProtocolAttr.kind = unsigned(protocolKind);
-    Bits.SynthesizedProtocolAttr.isUnchecked = unsigned(isUnchecked);
   }
 
   /// Retrieve the known protocol kind naming the protocol to be
   /// synthesized.
   KnownProtocolKind getProtocolKind() const {
     return KnownProtocolKind(Bits.SynthesizedProtocolAttr.kind);
-  }
-
-  bool isUnchecked() const {
-    return bool(Bits.SynthesizedProtocolAttr.isUnchecked);
   }
 
   /// Retrieve the lazy loader that will be used to populate the
@@ -2225,15 +2215,6 @@ public:
       if (Attr->getKind() == DK && (Attr->isValid() || AllowInvalid))
         return Attr;
     return nullptr;
-  }
-
-  /// Returns the "winning" \c NonSendableAttr or \c SendableAttr in this
-  /// attribute list, or \c nullptr if there are none.
-  const DeclAttribute *getEffectiveSendableAttr() const;
-
-  DeclAttribute *getEffectiveSendableAttr() {
-    return const_cast<DeclAttribute *>(
-         const_cast<const DeclAttributes *>(this)->getEffectiveSendableAttr());
   }
 
 private:

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -85,10 +85,6 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
 WARNING(clang_swift_attr_unhandled,none,
         "Ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
-WARNING(clang_error_code_must_be_sendable,none,
-        "cannot make error code type '%0' non-sendable because Swift errors "
-        "are always sendable", (StringRef))
-
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -17,11 +17,7 @@
 #include "swift/AST/RawComment.h"
 #include "swift/Basic/BasicSourceInfo.h"
 
-#include "llvm/ADT/PointerIntPair.h"
-
 namespace swift {
-class SynthesizedFileUnit;
-
 /// A container for module-scope declarations that itself provides a scope; the
 /// smallest unit of code organization.
 ///
@@ -37,24 +33,18 @@ class FileUnit : public DeclContext, public ASTAllocated<FileUnit> {
   friend class DirectOperatorLookupRequest;
   friend class DirectPrecedenceGroupLookupRequest;
 
-  // The pointer is FileUnit insted of SynthesizedFileUnit to break circularity.
-  llvm::PointerIntPair<FileUnit *, 3, FileUnitKind> SynthesizedFileAndKind;
+  // FIXME: Stick this in a PointerIntPair.
+  const FileUnitKind Kind;
 
 protected:
   FileUnit(FileUnitKind kind, ModuleDecl &M)
-    : DeclContext(DeclContextKind::FileUnit, &M),
-      SynthesizedFileAndKind(nullptr, kind) {
+    : DeclContext(DeclContextKind::FileUnit, &M), Kind(kind) {
   }
 
 public:
   FileUnitKind getKind() const {
-    return SynthesizedFileAndKind.getInt();
+    return Kind;
   }
-
-  /// Returns the synthesized file for this source file, if it exists.
-  SynthesizedFileUnit *getSynthesizedFile() const;
-
-  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   /// Look up a (possibly overloaded) value set at top-level scope
   /// (but with the specified access path, which may come from an import decl)

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -235,10 +235,6 @@ struct PrintOptions {
   /// Whether to print unavailable parts of the AST.
   bool SkipUnavailable = false;
 
-  /// Whether to print synthesized extensions created by '@_nonSendable', even
-  /// if SkipImplicit or SkipUnavailable is set.
-  bool AlwaysPrintNonSendableExtensions = true;
-
   bool SkipSwiftPrivateClangDecls = false;
 
   /// Whether to skip internal stdlib declarations.
@@ -671,7 +667,6 @@ struct PrintOptions {
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     PO.PrintParameterSpecifiers = true;
     PO.SkipImplicit = true;
-    PO.AlwaysPrintNonSendableExtensions = false;
     PO.AlwaysTryPrintParameterLabels = true;
     return PO;
   }

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -514,13 +514,6 @@ public:
     return ContextAndBits.getInt() & UncheckedFlag;
   }
 
-  /// Mark the conformance as unchecked (equivalent to the @unchecked
-  /// conformance attribute).
-  void setUnchecked() {
-    // OK to mutate because the flags are not part of the folding set node ID.
-    ContextAndBits.setInt(ContextAndBits.getInt() | UncheckedFlag);
-  }
-
   /// Get the kind of source from which this conformance comes.
   ConformanceEntryKind getSourceKind() const {
     return SourceKindAndImplyingConformance.getInt();

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -89,6 +89,9 @@ private:
   /// same module.
   mutable Identifier PrivateDiscriminator;
 
+  /// A synthesized file corresponding to this file, created on-demand.
+  SynthesizedFileUnit *SynthesizedFile = nullptr;
+
   /// The root TypeRefinementContext for this SourceFile.
   ///
   /// This is set during type checking.
@@ -405,6 +408,11 @@ public:
   Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
   Optional<ExternalSourceLocs::RawLocs>
   getExternalRawLocsForDecl(const Decl *D) const override;
+
+  /// Returns the synthesized file for this source file, if it exists.
+  SynthesizedFileUnit *getSynthesizedFile() const { return SynthesizedFile; };
+
+  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   virtual bool walk(ASTWalker &walker) override;
 

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -18,12 +18,14 @@
 
 namespace swift {
 
+class SourceFile;
+
 /// A container for synthesized declarations, attached to a `SourceFile`.
 ///
 /// Currently, only module-level synthesized declarations are supported.
 class SynthesizedFileUnit final : public FileUnit {
   /// The parent source file.
-  FileUnit &FU;
+  SourceFile &SF;
 
   /// Synthesized top level declarations.
   TinyPtrVector<Decl *> TopLevelDecls;
@@ -34,11 +36,11 @@ class SynthesizedFileUnit final : public FileUnit {
   mutable Identifier PrivateDiscriminator;
 
 public:
-  SynthesizedFileUnit(FileUnit &FU);
+  SynthesizedFileUnit(SourceFile &SF);
   ~SynthesizedFileUnit() = default;
 
   /// Returns the parent source file.
-  FileUnit &getFileUnit() const { return FU; }
+  SourceFile &getSourceFile() const { return SF; }
 
   /// Add a synthesized top-level declaration.
   void addTopLevelDecl(Decl *D) { TopLevelDecls.push_back(D); }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -131,8 +131,6 @@ DeclAttrKind DeclAttribute::getAttrKindFromString(StringRef Str) {
 
 /// Returns true if this attribute can appear on the specified decl.
 bool DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind DK, const Decl *D) {
-  if ((getOptions(DK) & OnAnyClangDecl) && D->hasClangNode())
-    return true;
   return canAttributeAppearOnDeclKind(DK, D->getKind());
 }
 
@@ -699,13 +697,6 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
         DeclAttribute::isUserInaccessible(DA->getKind()))
       continue;
     if (Options.excludeAttrKind(DA->getKind()))
-      continue;
-
-    // If this attribute is only allowed because this is a Clang decl, don't
-    // print it.
-    if (D && D->hasClangNode()
-        && !DeclAttribute::canAttributeAppearOnDeclKind(
-                               DA->getKind(), D->getKind()))
       continue;
 
     // Be careful not to coalesce `@available(swift 5)` with other short
@@ -2109,23 +2100,6 @@ TypeSequenceAttr *TypeSequenceAttr::create(ASTContext &Ctx, SourceLoc atLoc,
                                            SourceRange range) {
   void *mem = Ctx.Allocate(sizeof(TypeSequenceAttr), alignof(TypeSequenceAttr));
   return new (mem) TypeSequenceAttr(atLoc, range);
-}
-
-const DeclAttribute *
-DeclAttributes::getEffectiveSendableAttr() const {
-  const NonSendableAttr *assumedAttr = nullptr;
-
-  for (auto attr : getAttributes<NonSendableAttr>()) {
-    if (attr->Specificity == NonSendableKind::Specific)
-      return attr;
-    if (!assumedAttr)
-      assumedAttr = attr;
-  }
-
-  if (auto sendableAttr = getAttribute<SendableAttr>())
-    return sendableAttr;
-
-  return assumedAttr;
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -904,8 +904,6 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
           // Set the conformance loader to the loader stashed inside
           // the attribute.
           normalConf->setLazyLoader(attr->getLazyLoader(), /*context=*/0);
-          if (attr->isUnchecked())
-            normalConf->setUnchecked();
           break;
         }
       }

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -121,13 +121,21 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
     return;
   }
 
+  const ASTContext &ctx = ImporterImpl.SwiftContext;
+  ClangSourceBufferImporter &bufferImporter =
+      ImporterImpl.getBufferImporterForDiagnostics();
+
   if (clangDiag.getID() == clang::diag::err_module_not_built &&
       CurrentImport && clangDiag.getArgStdStr(0) == CurrentImport->getName()) {
-    HeaderLoc loc(clangDiag.getLocation(), DiagLoc,
-                  &clangDiag.getSourceManager());
-    ImporterImpl.diagnose(loc, diag::clang_cannot_build_module,
-                          ImporterImpl.SwiftContext.LangOpts.EnableObjCInterop,
-                          CurrentImport->getName());
+    SourceLoc loc = DiagLoc;
+    if (clangDiag.getLocation().isValid()) {
+      loc = bufferImporter.resolveSourceLocation(clangDiag.getSourceManager(),
+                                                 clangDiag.getLocation());
+    }
+
+    ctx.Diags.diagnose(loc, diag::clang_cannot_build_module,
+                       ctx.LangOpts.EnableObjCInterop,
+                       CurrentImport->getName());
     return;
   }
 
@@ -138,9 +146,10 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
     DiagnosticConsumer::HandleDiagnostic(clangDiagLevel, clangDiag);
 
   // FIXME: Map over source ranges in the diagnostic.
-  auto emitDiag = [this](clang::FullSourceLoc clangNoteLoc,
-                         clang::DiagnosticsEngine::Level clangDiagLevel,
-                         StringRef message) {
+  auto emitDiag =
+      [&ctx, &bufferImporter](clang::FullSourceLoc clangNoteLoc,
+                              clang::DiagnosticsEngine::Level clangDiagLevel,
+                              StringRef message) {
     decltype(diag::error_from_clang) diagKind;
     switch (clangDiagLevel) {
     case clang::DiagnosticsEngine::Ignored:
@@ -161,9 +170,11 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
       break;
     }
 
-    HeaderLoc noteLoc(clangNoteLoc, SourceLoc(),
-              clangNoteLoc.hasManager() ? &clangNoteLoc.getManager() : nullptr);
-    ImporterImpl.diagnose(noteLoc, diagKind, message);
+    SourceLoc noteLoc;
+    if (clangNoteLoc.isValid())
+      noteLoc = bufferImporter.resolveSourceLocation(clangNoteLoc.getManager(),
+                                                     clangNoteLoc);
+    ctx.Diags.diagnose(noteLoc, diagKind, message);
   };
 
   llvm::SmallString<128> message;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -467,14 +467,6 @@ getGlibcModuleMapPath(SearchPathOptions& Opts, llvm::Triple triple,
   return None;
 }
 
-static bool clangSupportsPragmaAttributeWithSwiftAttr() {
-  clang::AttributeCommonInfo swiftAttrInfo(clang::SourceRange(),
-     clang::AttributeCommonInfo::AT_SwiftAttr,
-     clang::AttributeCommonInfo::AS_GNU);
-  auto swiftAttrParsedInfo = clang::ParsedAttrInfo::get(swiftAttrInfo);
-  return swiftAttrParsedInfo.IsSupportedByPragmaAttribute;
-}
-
 void
 importer::getNormalInvocationArguments(
     std::vector<std::string> &invocationArgStrs,
@@ -617,12 +609,6 @@ importer::getNormalInvocationArguments(
       // '__swift__'.
       "-DSWIFT_CLASS_EXTRA=",
     });
-
-    // Indicate that using '__attribute__((swift_attr))' with '@Sendable' and
-    // '@_nonSendable' on Clang declarations is fully supported, including the
-    // 'attribute push' pragma.
-    if (clangSupportsPragmaAttributeWithSwiftAttr())
-      invocationArgStrs.push_back( "-D__SWIFT_ATTR_SUPPORTS_SENDABLE_DECLS=1");
 
     // Get the version of this compiler and pass it to C/Objective-C
     // declarations.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -160,17 +160,15 @@ createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
   return {var, patternBinding};
 }
 
-static FuncDecl *createFuncOrAccessor(ClangImporter::Implementation &impl,
-                                      SourceLoc funcLoc,
+static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
                                       Optional<AccessorInfo> accessorInfo,
                                       DeclName name, SourceLoc nameLoc,
                                       GenericParamList *genericParams,
                                       ParameterList *bodyParams, Type resultTy,
                                       bool async, bool throws, DeclContext *dc,
                                       ClangNode clangNode) {
-  FuncDecl *decl;
   if (accessorInfo) {
-    decl = AccessorDecl::create(impl.SwiftContext, funcLoc,
+    return AccessorDecl::create(ctx, funcLoc,
                                 /*accessorKeywordLoc*/ SourceLoc(),
                                 accessorInfo->Kind, accessorInfo->Storage,
                                 /*StaticLoc*/ SourceLoc(),
@@ -180,12 +178,10 @@ static FuncDecl *createFuncOrAccessor(ClangImporter::Implementation &impl,
                                 genericParams, bodyParams,
                                 resultTy, dc, clangNode);
   } else {
-    decl = FuncDecl::createImported(impl.SwiftContext, funcLoc, name, nameLoc,
-                                    async, throws, bodyParams, resultTy,
-                                    genericParams, dc, clangNode);
+    return FuncDecl::createImported(ctx, funcLoc, name, nameLoc, async, throws,
+                                    bodyParams, resultTy, genericParams, dc,
+                                    clangNode);
   }
-  impl.importSwiftAttrAttributes(decl);
-  return decl;
 }
 
 static void makeComputed(AbstractStorageDecl *storage,
@@ -1472,12 +1468,10 @@ createValueConstructor(ClangImporter::Implementation &Impl,
 static void addSynthesizedProtocolAttrs(
     ClangImporter::Implementation &Impl,
     NominalTypeDecl *nominal,
-    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-    bool isUnchecked = false) {
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs) {
   for (auto kind : synthesizedProtocolAttrs) {
     nominal->getAttrs().add(new (Impl.SwiftContext)
-                                 SynthesizedProtocolAttr(kind, &Impl,
-                                                         isUnchecked));
+                                 SynthesizedProtocolAttr(kind, &Impl));
   }
 }
 
@@ -4105,7 +4099,7 @@ namespace {
         auto resultTy = importedType.getType();
 
         FuncDecl *func =
-            createFuncOrAccessor(Impl, loc, accessorInfo, name,
+            createFuncOrAccessor(Impl.SwiftContext, loc, accessorInfo, name,
                                  nameLoc, genericParams, bodyParams, resultTy,
                                  /*async=*/false, /*throws=*/false, dc,
                                  clangNode);
@@ -4917,7 +4911,7 @@ namespace {
         }
       }
 
-      auto result = createFuncOrAccessor(Impl,
+      auto result = createFuncOrAccessor(Impl.SwiftContext,
                                          /*funcLoc*/ SourceLoc(), accessorInfo,
                                          importedName.getDeclName(),
                                          /*nameLoc*/ SourceLoc(),
@@ -8405,140 +8399,6 @@ Optional<bool> swift::importer::isMainActorAttr(
   return None;
 }
 
-void
-ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
-  auto ClangDecl =
-      dyn_cast_or_null<clang::NamedDecl>(MappedDecl->getClangDecl());
-  if (!ClangDecl)
-    return;
-
-  // Subscripts are special-cased since there isn't a 1:1 mapping
-  // from its accessor(s) to the subscript declaration.
-  if (isa<SubscriptDecl>(MappedDecl))
-    return;
-
-  if (auto maybeDefinition = getDefinitionForClangTypeDecl(ClangDecl))
-    if (maybeDefinition.getValue())
-      ClangDecl = cast<clang::NamedDecl>(maybeDefinition.getValue());
-
-  Optional<const clang::SwiftAttrAttr *> SeenMainActorAttr;
-  PatternBindingInitializer *initContext = nullptr;
-
-  //
-  // __attribute__((swift_attr("attribute")))
-  //
-  for (auto swiftAttr : ClangDecl->specific_attrs<clang::SwiftAttrAttr>()) {
-    // FIXME: Hard-code @MainActor and @UIActor, because we don't have a
-    // point at which to do name lookup for imported entities.
-    if (auto isMainActor = isMainActorAttr(SwiftContext, swiftAttr)) {
-      bool isUnsafe = *isMainActor;
-
-      if (SeenMainActorAttr) {
-        // Cannot add main actor annotation twice. We'll keep the first
-        // one and raise a warning about the duplicate.
-        HeaderLoc attrLoc(swiftAttr->getLocation());
-        diagnose(attrLoc, diag::import_multiple_mainactor_attr,
-                 swiftAttr->getAttribute(),
-                 SeenMainActorAttr.getValue()->getAttribute());
-        continue;
-      }
-
-      if (Type mainActorType = SwiftContext.getMainActorType()) {
-        auto typeExpr = TypeExpr::createImplicit(mainActorType, SwiftContext);
-        auto attr = CustomAttr::create(SwiftContext, SourceLoc(), typeExpr);
-        attr->setArgIsUnsafe(isUnsafe);
-        MappedDecl->getAttrs().add(attr);
-        SeenMainActorAttr = swiftAttr;
-      }
-
-      continue;
-    }
-
-    // Hard-code @actorIndependent, until Objective-C clients start
-    // using nonisolated.
-    if (swiftAttr->getAttribute() == "@actorIndependent") {
-      auto attr = new (SwiftContext) NonisolatedAttr(/*isImplicit=*/true);
-      MappedDecl->getAttrs().add(attr);
-      continue;
-    }
-
-    // Dig out a buffer with the attribute text.
-    unsigned bufferID = getClangSwiftAttrSourceBuffer(
-        swiftAttr->getAttribute());
-
-    // Dig out a source file we can use for parsing.
-    auto &sourceFile = getClangSwiftAttrSourceFile(
-        *MappedDecl->getDeclContext()->getParentModule());
-
-    // Spin up a parser.
-    swift::Parser parser(
-        bufferID, sourceFile, &SwiftContext.Diags, nullptr, nullptr);
-    // Prime the lexer.
-    parser.consumeTokenWithoutFeedingReceiver();
-
-    bool hadError = false;
-    SourceLoc atLoc;
-    if (parser.consumeIf(tok::at_sign, atLoc)) {
-      hadError = parser.parseDeclAttribute(
-          MappedDecl->getAttrs(), atLoc, initContext,
-          /*isFromClangAttribute=*/true).isError();
-    } else {
-      SourceLoc staticLoc;
-      StaticSpellingKind staticSpelling;
-      hadError = parser.parseDeclModifierList(
-          MappedDecl->getAttrs(), staticLoc, staticSpelling,
-          /*isFromClangAttribute=*/true);
-    }
-
-    if (hadError) {
-      // Complain about the unhandled attribute or modifier.
-      HeaderLoc attrLoc(swiftAttr->getLocation());
-      diagnose(attrLoc, diag::clang_swift_attr_unhandled,
-               swiftAttr->getAttribute());
-    }
-  }
-
-  // The rest of this concerns '@Sendable' and '@_nonSendable`. These don't
-  // affect typealiases, even when there's an underlying nominal type in clang.
-  if (isa<TypeAliasDecl>(MappedDecl))
-    return;
-
-  // Some types have an implicit '@Sendable' attribute.
-  if (ClangDecl->hasAttr<clang::SwiftNewTypeAttr>() ||
-      ClangDecl->hasAttr<clang::EnumExtensibilityAttr>() ||
-      ClangDecl->hasAttr<clang::FlagEnumAttr>() ||
-      ClangDecl->hasAttr<clang::NSErrorDomainAttr>())
-    MappedDecl->getAttrs().add(
-                          new (SwiftContext) SendableAttr(/*isImplicit=*/true));
-
-  // 'Error' conforms to 'Sendable', so error wrappers have to be 'Sendable'
-  // and it doesn't make sense for the 'Code' enum to be non-'Sendable'.
-  if (ClangDecl->hasAttr<clang::NSErrorDomainAttr>()) {
-    // If any @_nonSendable attributes are running the show, invalidate and
-    // diagnose them.
-    while (NonSendableAttr *attr = dyn_cast_or_null<NonSendableAttr>(
-                           MappedDecl->getAttrs().getEffectiveSendableAttr())) {
-      assert(attr->Specificity == NonSendableKind::Specific &&
-             "didn't we just add an '@Sendable' that should beat this "
-             "'@_nonSendable(_assumed)'?");
-      attr->setInvalid();
-      diagnose(HeaderLoc(ClangDecl->getLocation()),
-               diag::clang_error_code_must_be_sendable,
-               ClangDecl->getNameAsString());
-    }
-  }
-
-  // Now that we've collected all @Sendable and @_nonSendable attributes, we
-  // can see if we should synthesize a Sendable conformance.
-  if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl)) {
-    auto sendability = nominal->getAttrs().getEffectiveSendableAttr();
-    if (isa_and_nonnull<SendableAttr>(sendability)) {
-      addSynthesizedProtocolAttrs(*this, nominal, {KnownProtocolKind::Sendable},
-                                  /*isUnchecked=*/true);
-    }
-  }
-}
-
 static bool isUsingMacroName(clang::SourceManager &SM,
                              clang::SourceLocation loc,
                              StringRef MacroName) {
@@ -8578,6 +8438,8 @@ void ClangImporter::Implementation::importAttributes(
 
   // Scan through Clang attributes and map them onto Swift
   // equivalents.
+  PatternBindingInitializer *initContext = nullptr;
+  Optional<const clang::SwiftAttrAttr *> SeenMainActorAttr;
   bool AnyUnavailable = MappedDecl->getAttrs().isUnavailable(C);
   for (clang::NamedDecl::attr_iterator AI = ClangDecl->attr_begin(),
        AE = ClangDecl->attr_end(); AI != AE; ++AI) {
@@ -8732,8 +8594,88 @@ void ClangImporter::Implementation::importAttributes(
       MappedDecl->getAttrs().add(AvAttr);
     }
 
-    // __attribute__((swift_attr("attribute"))) are handled by
-    // importSwiftAttrAttributes(). Other attributes are ignored.
+    // __attribute__((swift_attr("attribute")))
+    //
+    if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(*AI)) {
+      // FIXME: Hard-code @MainActor and @UIActor, because we don't have a
+      // point at which to do name lookup for imported entities.
+      if (auto isMainActor = isMainActorAttr(SwiftContext, swiftAttr)) {
+        bool isUnsafe = *isMainActor;
+
+        if (SeenMainActorAttr) {
+          // Cannot add main actor annotation twice. We'll keep the first
+          // one and raise a warning about the duplicate.
+          auto &clangSrcMgr = getClangASTContext().getSourceManager();
+          ClangSourceBufferImporter &bufferImporter =
+              getBufferImporterForDiagnostics();
+          SourceLoc attrLoc = bufferImporter.resolveSourceLocation(
+              clangSrcMgr, swiftAttr->getLocation());
+
+          diagnose(attrLoc, diag::import_multiple_mainactor_attr,
+                   swiftAttr->getAttribute(),
+                   SeenMainActorAttr.getValue()->getAttribute());
+          continue;
+        }
+
+        if (Type mainActorType = SwiftContext.getMainActorType()) {
+          auto typeExpr = TypeExpr::createImplicit(mainActorType, SwiftContext);
+          auto attr = CustomAttr::create(SwiftContext, SourceLoc(), typeExpr);
+          attr->setArgIsUnsafe(isUnsafe);
+          MappedDecl->getAttrs().add(attr);
+          SeenMainActorAttr = swiftAttr;
+        }
+
+        continue;
+      }
+
+      // Hard-code @actorIndependent, until Objective-C clients start
+      // using nonisolated.
+      if (swiftAttr->getAttribute() == "@actorIndependent") {
+        auto attr = new (SwiftContext) NonisolatedAttr(/*isImplicit=*/true);
+        MappedDecl->getAttrs().add(attr);
+        continue;
+      }
+
+      // Dig out a buffer with the attribute text.
+      unsigned bufferID = getClangSwiftAttrSourceBuffer(
+          swiftAttr->getAttribute());
+
+      // Dig out a source file we can use for parsing.
+      auto &sourceFile = getClangSwiftAttrSourceFile(
+          *MappedDecl->getDeclContext()->getParentModule());
+
+      // Spin up a parser.
+      swift::Parser parser(
+          bufferID, sourceFile, &SwiftContext.Diags, nullptr, nullptr);
+      // Prime the lexer.
+      parser.consumeTokenWithoutFeedingReceiver();
+
+      bool hadError = false;
+      SourceLoc atLoc;
+      if (parser.consumeIf(tok::at_sign, atLoc)) {
+        hadError = parser.parseDeclAttribute(
+            MappedDecl->getAttrs(), atLoc, initContext,
+            /*isFromClangAttribute=*/true).isError();
+      } else {
+        SourceLoc staticLoc;
+        StaticSpellingKind staticSpelling;
+        hadError = parser.parseDeclModifierList(
+            MappedDecl->getAttrs(), staticLoc, staticSpelling,
+            /*isFromClangAttribute=*/true);
+      }
+
+      if (hadError) {
+        // Complain about the unhandled attribute or modifier.
+        auto &clangSrcMgr = getClangASTContext().getSourceManager();
+        ClangSourceBufferImporter &bufferImporter =
+          getBufferImporterForDiagnostics();
+        SourceLoc attrLoc = bufferImporter.resolveSourceLocation(
+          clangSrcMgr, swiftAttr->getLocation());
+        diagnose(attrLoc, diag::clang_swift_attr_unhandled,
+                 swiftAttr->getAttribute());
+      }
+      continue;
+    }
   }
 
   if (auto method = dyn_cast<clang::ObjCMethodDecl>(ClangDecl)) {
@@ -9302,13 +9244,19 @@ ClangImporter::Implementation::importDeclForDeclContext(
   if (!contextDeclsWarnedAbout.insert(contextDecl).second)
     return nullptr;
 
+  auto convertLoc = [&](clang::SourceLocation clangLoc) {
+    return getBufferImporterForDiagnostics()
+      .resolveSourceLocation(getClangASTContext().getSourceManager(),
+                             clangLoc);
+  };
+
   auto getDeclName = [](const clang::Decl *D) -> StringRef {
     if (auto ND = dyn_cast<clang::NamedDecl>(D))
       return ND->getName();
     return "<anonymous>";
   };
 
-  HeaderLoc loc(importingDecl->getLocation());
+  SourceLoc loc = convertLoc(importingDecl->getLocation());
   diagnose(loc, diag::swift_name_circular_context_import,
            writtenName, getDeclName(importingDecl));
 
@@ -9316,7 +9264,7 @@ ClangImporter::Implementation::importDeclForDeclContext(
   for (auto entry : make_range(contextDeclsBeingImported.rbegin(), iter)) {
     auto otherDecl = std::get<0>(entry);
     auto otherWrittenName = std::get<1>(entry);
-    diagnose(HeaderLoc(otherDecl->getLocation()),
+    diagnose(convertLoc(otherDecl->getLocation()),
              diag::swift_name_circular_context_import_other,
              otherWrittenName, getDeclName(otherDecl));
   }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2579,15 +2579,20 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
   if (importedName.hasCustomName() && argNames.size() != swiftParams.size()) {
     // Note carefully: we're emitting a warning in the /Clang/ buffer.
-    if (clangDecl->getLocation().isValid()) {
-      HeaderLoc methodLoc(clangDecl->getLocation());
+    auto &srcMgr = getClangASTContext().getSourceManager();
+    ClangSourceBufferImporter &bufferImporter =
+        getBufferImporterForDiagnostics();
+    SourceLoc methodLoc =
+        bufferImporter.resolveSourceLocation(srcMgr, clangDecl->getLocation());
+    if (methodLoc.isValid()) {
       diagnose(methodLoc, diag::invalid_swift_name_method,
-               swiftParams.size() < argNames.size(),
-               swiftParams.size(), argNames.size());
+                                  swiftParams.size() < argNames.size(),
+                                  swiftParams.size(), argNames.size());
       ModuleDecl *parentModule = dc->getParentModule();
       if (parentModule != ImportedHeaderUnit->getParentModule()) {
-        diagnose(methodLoc, diag::unresolvable_clang_decl_is_a_framework_bug,
-                 parentModule->getName().str());
+        diagnose(
+            methodLoc, diag::unresolvable_clang_decl_is_a_framework_bug,
+            parentModule->getName().str());
       }
     }
     return {Type(), false};

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -68,9 +68,10 @@ TinyPtrVector<FileUnit *> IRGenDescriptor::getFilesToEmit() const {
   TinyPtrVector<FileUnit *> files;
   files.push_back(primary);
 
-  if (auto *synthesizedFile = primary->getSynthesizedFile())
-    files.push_back(synthesizedFile);
-
+  if (auto *SF = dyn_cast<SourceFile>(primary)) {
+    if (auto *synthesizedFile = SF->getSynthesizedFile())
+      files.push_back(synthesizedFile);
+  }
   return files;
 }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1203,8 +1203,10 @@ void TBDGenVisitor::visit(const TBDGenDescriptor &desc) {
     visitFile(singleFile);
 
     // Visit synthesized file, if it exists.
-    if (auto *synthesizedFile = singleFile->getSynthesizedFile())
-      visitFile(synthesizedFile);
+    if (auto *SF = dyn_cast<SourceFile>(singleFile)) {
+      if (auto *synthesizedFile = SF->getSynthesizedFile())
+        visitFile(synthesizedFile);
+    }
     return;
   }
 

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -124,7 +124,7 @@ class ObjCTest {
 #endif
 
 // HEADER: struct TestError : _BridgedStoredNSError {
-// HEADER:   enum Code : Int32, _ErrorCodeProtocol, @unchecked Sendable {
+// HEADER:   enum Code : Int32, _ErrorCodeProtocol {
 // HEADER:     init?(rawValue: Int32)
 // HEADER:     var rawValue: Int32 { get }
 // HEADER:     typealias _ErrorType = TestError
@@ -136,7 +136,7 @@ class ObjCTest {
 // HEADER: func getErr() -> TestError.Code
 
 // HEADER-NO-PRIVATE: struct TestError : CustomNSError, Hashable, Error {
-// HEADER-NO-PRIVATE:   enum Code : Int32, @unchecked Sendable, Equatable {
+// HEADER-NO-PRIVATE:   enum Code : Int32, Equatable {
 // HEADER-NO-PRIVATE:     init?(rawValue: Int32)
 // HEADER-NO-PRIVATE:     var rawValue: Int32 { get }
 // HEADER-NO-PRIVATE:     typealias _ErrorType = TestError

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -disable-availability-checking  %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -disable-availability-checking  %s -verify
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
@@ -109,40 +109,6 @@ func testSendableInAsync() async {
     x = 42 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
-}
-
-func testSendableAttrs(
-  sendableClass: SendableClass, nonSendableClass: NonSendableClass,
-  sendableEnum: SendableEnum, nonSendableEnum: NonSendableEnum,
-  sendableOptions: SendableOptions, nonSendableOptions: NonSendableOptions,
-  sendableError: SendableError, nonSendableError: NonSendableError,
-  sendableStringEnum: SendableStringEnum, nonSendableStringEnum: NonSendableStringEnum,
-  sendableStringStruct: SendableStringStruct, nonSendableStringStruct: NonSendableStringStruct
-) async {
-  func takesSendable<T: Sendable>(_: T) {}
-
-  takesSendable(sendableClass)        // no-error
-  takesSendable(nonSendableClass)     // expected-FIXME-warning{{something about missing conformance}}
-
-  doSomethingConcurrently {
-    print(sendableClass)               // no-error
-    print(nonSendableClass)            // expected-warning{{cannot use parameter 'nonSendableClass' with a non-sendable type 'NonSendableClass' from concurrently-executed code}}
-
-    print(sendableEnum)                // no-error
-    print(nonSendableEnum)             // expected-warning{{cannot use parameter 'nonSendableEnum' with a non-sendable type 'NonSendableEnum' from concurrently-executed code}}
-
-    print(sendableOptions)             // no-error
-    print(nonSendableOptions)          // expected-warning{{cannot use parameter 'nonSendableOptions' with a non-sendable type 'NonSendableOptions' from concurrently-executed code}}
-
-    print(sendableError)               // no-error
-    print(nonSendableError)            // no-error--we don't respect `@_nonSendable` on `ns_error_domain` types because all errors are Sendable
-
-    print(sendableStringEnum)          // no-error
-    print(nonSendableStringEnum)       // expected-warning{{cannot use parameter 'nonSendableStringEnum' with a non-sendable type 'NonSendableStringEnum' from concurrently-executed code}}
-
-    print(sendableStringStruct)        // no-error
-    print(nonSendableStringStruct)     // expected-warning{{cannot use parameter 'nonSendableStringStruct' with a non-sendable type 'NonSendableStringStruct' from concurrently-executed code}}
-  }
 }
 
 // Check import of attributes

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
 // REQUIRES: objc_interop
 
-// PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -26,7 +26,7 @@
 // PRINT-NEXT:  extension Food {
 // PRINT-NEXT:    static let err: ErrorDomain
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
@@ -37,14 +37,14 @@
 // PRINT-NEXT:    static let secondEntry: ClosedEnum
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
@@ -56,7 +56,7 @@
 // PRINT-NEXT:    static let version: MyFloat{{$}}
 // PRINT-NEXT:  }
 //
-// PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: Int32)
 // PRINT-NEXT:    init(rawValue: Int32)
 // PRINT-NEXT:    let rawValue: Int32
@@ -83,7 +83,7 @@
 // PRINT-NEXT:  let Notification: String
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
-// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -97,7 +97,7 @@
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
 //
-// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -114,7 +114,7 @@
 // PRINT-NEXT:  func takeMyABIOldType(_: MyABIOldType!)
 // PRINT-NEXT:  func takeMyABINewTypeNonNull(_: MyABINewType)
 // PRINT-NEXT:  func takeMyABIOldTypeNonNull(_: MyABIOldType)
-// PRINT-LABEL: struct MyABINewTypeNS : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyABINewTypeNS : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -133,7 +133,7 @@
 // PRINT-NEXT:    var i: Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext {
-// PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:      init(_ rawValue: String)
 // PRINT-NEXT:      init(rawValue: String)
 // PRINT-NEXT:      var rawValue: String { get }
@@ -145,13 +145,13 @@
 // PRINT-NEXT:    static let myContextName: NSSomeContext.Name
 // PRINT-NEXT:  }
 //
-// PRINT-NEXT: struct TRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct TRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
 // PRINT-NEXT:   typealias RawValue = OpaquePointer
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct ConstTRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
@@ -169,13 +169,13 @@
 // PRINT-NEXT:   func use()
 // PRINT-NEXT: }
 //
-// PRINT-NEXT: struct TRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct TRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:   init(_ rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT:   typealias RawValue = UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct ConstTRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
 // PRINT-NEXT:   init(_ rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafePointer<OpaquePointer>

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -5,21 +5,21 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-LABEL: enum Normal : Int, @unchecked Sendable {
+// CHECK: enum Normal : Int {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK-LABEL: enum SwiftEnum : Int, @unchecked Sendable {
+// CHECK: enum SwiftEnum : Int {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK-LABEL: enum SwiftEnumTwo : Int, @unchecked Sendable {
+// CHECK: enum SwiftEnumTwo : Int {
 // CHECK-NOT: {{^}}}
 // CHECK: case SwiftEnumTwoA
 // CHECK-NEXT: case SwiftEnumTwoB

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -99,8 +99,8 @@ import _Concurrency
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: nonisolated func independentMethod()
 // CHECK-NEXT: nonisolated func nonisolatedMethod()
-// CHECK-NEXT: {{^}} @MainActor @objc func mainActorMethod()
-// CHECK-NEXT: {{^}} @MainActor @objc func uiActorMethod()
+// CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
+// CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
 // CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 
@@ -108,4 +108,4 @@ import _Concurrency
 
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
 
-// CHECK: @MainActor @objc protocol TripleMainActor {
+// CHECK: @MainActor protocol TripleMainActor {

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -1,9 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false > %t/ObjCConcurrency.printed.txt
-// RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
-// RUN: %FileCheck -check-prefix NEGATIVE -input-file %t/ObjCConcurrency.printed.txt %s
-
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false  | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
@@ -15,70 +12,3 @@ import _Concurrency
 // CHECK-NOT: @available
 // CHECK: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK: func doSomethingSlow(_ operation: String) async -> Int
-
-// NEGATIVE-NOT: @Sendable{{.+}}class
-// NEGATIVE-NOT: @_nonSendable{{.+}}class
-
-// CHECK-LABEL: class SendableClass :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: class NonSendableClass
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableClass : @unchecked Sendable {
-
-// CHECK-LABEL: class AuditedSendable :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: class AuditedNonSendable
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension AuditedNonSendable : @unchecked Sendable {
-
-// CHECK-LABEL: class AuditedBoth
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
-
-// CHECK-LABEL: enum SendableEnum :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: enum NonSendableEnum :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableEnum : @unchecked Sendable {
-
-// CHECK-LABEL: struct SendableOptions :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: struct NonSendableOptions :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableOptions : @unchecked Sendable {
-
-// CHECK-LABEL: public struct SendableError :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: public enum Code :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: public struct NonSendableError :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: public enum Code :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: struct SendableStringEnum :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: struct NonSendableStringEnum :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableStringEnum : @unchecked Sendable {
-
-// CHECK-LABEL: struct SendableStringStruct :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: struct NonSendableStringStruct :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableStringStruct : @unchecked Sendable {
-

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -5,29 +5,7 @@
 
 #define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
 
-#ifdef __SWIFT_ATTR_SUPPORTS_SENDABLE_DECLS
-  #define SENDABLE __attribute__((__swift_attr__("@Sendable")))
-  #define NONSENDABLE __attribute__((__swift_attr__("@_nonSendable")))
-  #define ASSUME_NONSENDABLE_BEGIN _Pragma("clang attribute ASSUME_NONSENDABLE.push (__attribute__((swift_attr(\"@_nonSendable(_assumed)\"))), apply_to = any(objc_interface, record, enum))")
-  #define ASSUME_NONSENDABLE_END _Pragma("clang attribute ASSUME_NONSENDABLE.pop")
-#else
-  // If we take this #else, we should see minor failures of some subtests,
-  // but not systematic failures of everything that uses this header.
-  #define SENDABLE
-  #define NONSENDABLE
-  #define ASSUME_NONSENDABLE_BEGIN
-  #define ASSUME_NONSENDABLE_END
-#endif
-
-#define NS_ENUM(_type, _name) enum _name : _type _name; \
-  enum __attribute__((enum_extensibility(open))) _name : _type
-#define NS_OPTIONS(_type, _name) enum _name : _type _name; \
-  enum __attribute__((enum_extensibility(open), flag_enum)) _name : _type
-#define NS_ERROR_ENUM(_type, _name, _domain)  \
-  enum _name : _type _name; enum __attribute__((ns_error_domain(_domain))) _name : _type
-#define NS_STRING_ENUM __attribute((swift_newtype(enum)))
-#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)))
-
+#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)));
 typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
 
 @protocol ServiceProvider
@@ -188,7 +166,7 @@ __attribute__((__swift_attr__("@MainActor(unsafe)")))
 @end
 
 // Do something concurrently, but without escaping.
-void doSomethingConcurrently(__attribute__((noescape)) SENDABLE void (^block)(void));
+void doSomethingConcurrently(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void));
 
 
 
@@ -206,46 +184,5 @@ MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor(unsafe)"))) @pro
 @interface ClassWithAsync: NSObject <ProtocolWithAsync>
 - (void)instanceMethodWithCompletionHandler:(void (^)(void))completionHandler __attribute__((swift_async_name("instanceAsync()")));
 @end
-
-SENDABLE @interface SendableClass : NSObject @end
-
-NONSENDABLE @interface NonSendableClass : NSObject @end
-
-ASSUME_NONSENDABLE_BEGIN
-
-SENDABLE @interface AuditedSendable : NSObject @end
-@interface AuditedNonSendable : NSObject @end
-NONSENDABLE SENDABLE @interface AuditedBoth : NSObject @end
-
-typedef NS_ENUM(unsigned, SendableEnum) {
-  SendableEnumFoo, SendableEnumBar
-};
-typedef NS_ENUM(unsigned, NonSendableEnum) {
-  NonSendableEnumFoo, NonSendableEnumBar
-} NONSENDABLE;
-
-typedef NS_OPTIONS(unsigned, SendableOptions) {
-  SendableOptionsFoo = 1 << 0, SendableOptionsBar = 1 << 1
-};
-typedef NS_OPTIONS(unsigned, NonSendableOptions) {
-  NonSendableOptionsFoo = 1 << 0, NonSendableOptionsBar = 1 << 1
-} NONSENDABLE;
-
-NSString *SendableErrorDomain, *NonSendableErrorDomain;
-typedef NS_ERROR_ENUM(unsigned, SendableErrorCode, SendableErrorDomain) {
-  SendableErrorCodeFoo, SendableErrorCodeBar
-};
-typedef NS_ERROR_ENUM(unsigned, NonSendableErrorCode, NonSendableErrorDomain) {
-  NonSendableErrorCodeFoo, NonSendableErrorCodeBar
-} NONSENDABLE;
-// expected-warning@-3 {{cannot make error code type 'NonSendableErrorCode' non-sendable because Swift errors are always sendable}}
-
-typedef NSString *SendableStringEnum NS_STRING_ENUM;
-typedef NSString *NonSendableStringEnum NS_STRING_ENUM NONSENDABLE;
-
-typedef NSString *SendableStringStruct NS_EXTENSIBLE_STRING_ENUM;
-typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE;
-
-ASSUME_NONSENDABLE_END
 
 #pragma clang assume_nonnull end

--- a/test/Interop/Cxx/class/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access-specifiers-module-interface.swift
@@ -17,7 +17,7 @@
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:   }
-// CHECK-NEXT:   @frozen enum PublicClosedEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   @frozen enum PublicClosedEnum : [[ENUM_UNDERLYING_TYPE]] {
 // CHECK-NEXT:     init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -25,7 +25,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicClosedEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   enum PublicOpenEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   enum PublicOpenEnum : [[ENUM_UNDERLYING_TYPE]] {
 // CHECK-NEXT:     init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -33,7 +33,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicOpenEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct PublicFlagEnum : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   struct PublicFlagEnum : OptionSet {
 // CHECK-NEXT:     init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     let rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]

--- a/test/Serialization/Recovery/private-conformances.swift
+++ b/test/Serialization/Recovery/private-conformances.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -emit-module -DPROTOCOL_LIB -DAFTER %s -module-name protocol_lib -emit-module-path %t/protocol_lib.swiftmodule
 
 // The conforming library's types should still deserialize.
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print conforms_lib -I %t -allow-compiler-errors | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print conforms_lib -I %t | %FileCheck %s
 
 // Protocols that use a missing protocol have to disappear (see the FileCheck
 // lines).

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -4,7 +4,7 @@
 // RUN: %FileCheck -input-file=%t.response %s
 
 // CHECK: struct MyError : CustomNSError, Hashable, Error {
-// CHECK:     enum Code : Int32, @unchecked Sendable, Equatable {
+// CHECK:     enum Code : Int32, Equatable {
 // CHECK:         case errFirst
 // CHECK:         case errSecond
 // CHECK:     }

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -6,6 +6,5 @@ target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
-                        swiftClangImporter
-                        swiftSema)
+                        swiftClangImporter)
 


### PR DESCRIPTION
Reverts apple/swift#40170

This broke the Windows build: https://ci-external.swift.org/job/swift-PR-windows/18665/console

The tests on the PR indicated that it was part of the change..  This should be easy to fix, there is a missing symbol (either a missing dependency or function).  However, given the imminent freeze, I'd like to get the tree green.