### PR TITLE
[5.5] Concurrency: fix UB in DefaultActor initialization

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -685,7 +685,7 @@ public:
 
   /// Properly construct an actor, except for the heap header.
   void initialize() {
-    new (&CurrentState) std::atomic<State>(State{JobRef(), Flags()});
+    new (&CurrentState) swift::atomic<State>(State{JobRef(), Flags()});
     JobStorageHeapObject.metadata = nullptr;
   }
 


### PR DESCRIPTION
This fixes a latent UB instance in the `DefaultActor` implementation
that has haunted the Windows target.  The shared constructor for the
type caused an errant typo that happened to compile which introduced
UB but happened to work for the non-Windows cases.  This happened to
work for the other targets as `swift::atomic` had a `std::atomic` at
on most configurations, and the C delegate for the Actor initializer
happened to overlap and initialize the memory properly.  The Windows
case used an inline pointer width value but would be attempted to be
initialized as a `std::atomic`.  Relying on the overlap is unsafe to
assume, and we should use the type's own constructor which delegates
appropriately.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
