### PR TITLE
[5.5] IRGen: use the accessor conformance on Windows

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -910,6 +910,12 @@ static bool isDependentConformance(
   if (!conformance)
     return false;
 
+  if (IGM.getOptions().LazyInitializeProtocolConformances) {
+    const auto *MD = rootConformance->getDeclContext()->getParentModule();
+    if (MD != IGM.getSwiftModule())
+      return true;
+  }
+
   // Check whether we've visited this conformance already.  If so,
   // optimistically assume it's fine --- we want the maximal fixed point.
   if (!visited.insert(conformance).second)

--- a/test/IRGen/conformance_resilience.swift
+++ b/test/IRGen/conformance_resilience.swift
@@ -22,7 +22,7 @@ public func getConformance<T>(_ w: Wrapper<T>) {
 public func getConformance(_ w: ConcreteWrapper) {
   // CHECK: [[RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s18resilient_protocol15ConcreteWrapperVMa"([[INT]] 0)
   // CHECK: [[META:%.*]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
-  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* [[META]], i8** @"$s18resilient_protocol15ConcreteWrapperVAA22OtherResilientProtocolAAWP")
+  // CHECK: call swiftcc void @"$s22conformance_resilience14useConformanceyyx18resilient_protocol22OtherResilientProtocolRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* [[META]], i8** {{%[0-9]+|@"\$s18resilient_protocol15ConcreteWrapperVAA22OtherResilientProtocolAAWP"}})
   // CHECK: ret void
   useConformance(w)
 }

--- a/test/IRGen/lazy-root-conformance.swift
+++ b/test/IRGen/lazy-root-conformance.swift
@@ -21,5 +21,5 @@ extension E : Q {
 #endif
 
 // CHECK-DIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* bitcast (i8** @"$s1A1EOAA1PAAWP" to i8*)]
-// CHECK-INDIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast (%swift.protocol_conformance_descriptor* @"$s1A1EO1B1QADMc" to i8*), i8* null]
+// CHECK-INDIRECT: @"$s1A1EO1B1QADWP" ={{( dllexport)?}}{{( protected)?}} constant [2 x i8*] [i8* bitcast ({{.*}}* @"$s1A1EO1B1QADMc" to i8*), i8* null]
 

--- a/test/IRGen/opaque_result_type_metadata_peephole.swift
+++ b/test/IRGen/opaque_result_type_metadata_peephole.swift
@@ -42,25 +42,25 @@ dynamic var replaceable_opaque_var: some P {
 // CHECK-LABEL: define {{.*}} @"$s36opaque_result_type_metadata_peephole26testOpaqueMetadataAccessesyyF"
 public func testOpaqueMetadataAccesses() {
   // We can look through, since it's internal
-  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** {{%[0-9]+|@"\$sSi36opaque_result_type_metadata_external1PAAWP"}})
   // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
   bar(x: foo())
   // We can look through, since it's internal
-  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** {{%[0-9]+|@"\$sSi36opaque_result_type_metadata_external1PAAWP"}})
   // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
   bar(x: foo2())
   // We can't look through, since it's resilient
   // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %[[EXTERNAL_OPAQUE_METADATA:.*]], i8** %[[EXTERNAL_OPAQUE_PROTO:.*]])
   bar(x: external_opaque())
   // We can look through, since it's inlinable
-  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // CHECK: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** {{%[0-9]+|@"\$sSi36opaque_result_type_metadata_external1PAAWP"}})
   bar(x: external_inlinable())
   // We can look through to the wrapped resilient opaque type
   // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %[[EXTERNAL_OPAQUE_METADATA]], i8** %[[EXTERNAL_OPAQUE_PROTO]])
   // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
   bar(x: external_opaque_wrap())
   // We can look all the way through to the inlinable underlying type
-  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** @"$sSi36opaque_result_type_metadata_external1PAAWP")
+  // DEFAULT: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* @"$sSiN", i8** {{%[0-9]+|@"\$sSi36opaque_result_type_metadata_external1PAAWP"}})
   // IMPLICIT-DYNAMIC: call {{.*}}3bar{{.*}}(%swift.opaque* {{.*}}, %swift.type* %{{.*}}, i8** %{{.*}})
   bar(x: external_inlinable_wrap())
 

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/sil_witness_tables_external_conformance.swift
-// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-import-type
 
 // REQUIRES: CPU=x86_64
 
@@ -36,7 +36,7 @@ struct Conformer: Q, QQ {
   func qMethod() {}
 }
 
-// CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@"\$s39sil_witness_tables_external_conformance17ExternalConformerVAA0F1PAAWP"]] = external{{( dllimport)?}} global i8*, align 8
+// CHECK-DIRECT: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@"\$s39sil_witness_tables_external_conformance17ExternalConformerVAA0F1PAAWP"]] = external{{( dllimport)?}} global i8*, align 8
 // CHECK: [[CONFORMER_Q_WITNESS_TABLE:@"\$s18sil_witness_tables9ConformerVAA1QAAWP"]] = hidden constant [3 x i8*] [
 // CHECK:   i8* bitcast ([5 x i8*]* [[CONFORMER_P_WITNESS_TABLE:@"\$s18sil_witness_tables9ConformerVAA1PAAWP"]] to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$s18sil_witness_tables9ConformerVAA1QA2aDP7qMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)
@@ -66,7 +66,8 @@ func erasure(c: Conformer) -> QQ {
 
 // CHECK-LABEL: define hidden swiftcc void @"$s18sil_witness_tables15externalErasure1c0a1_b1_c1_D12_conformance9ExternalP_pAD0G9ConformerV_tF"(%T39sil_witness_tables_external_conformance9ExternalPP* noalias nocapture sret({{.*}}) %0)
 // CHECK:         [[WITNESS_TABLE_ADDR:%.*]] = getelementptr inbounds %T39sil_witness_tables_external_conformance9ExternalPP, %T39sil_witness_tables_external_conformance9ExternalPP* %0, i32 0, i32 2
-// CHECK-NEXT:    store i8** [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE]], i8*** %2, align 8
+// CHECK-DIRECT-NEXT:    store i8** [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE]], i8*** %2, align 8
+// CHECK-INDIRECT-NEXT:    store i8** %2, i8*** %3, align 8
 func externalErasure(c: ExternalConformer) -> ExternalP {
   return c
 }

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sil_witness_tables_external_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
-// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-import-type
 
 import Swift
 
 // CHECK: @"$ss1XVN" = external {{(dllimport )?}}global %swift.type
-// CHECK: @"$ss1XVs1PsWP" = external {{(dllimport )?}}global i8*
+// CHECK-DIRECT: @"$ss1XVs1PsWP" = external {{(dllimport )?}}global i8*
+// CHECK-INDIRECT-NOT: @"$ss1XVs1PsWP" = external {{(dllimport )?}}global i8*
 
 func doSomething<T : P>(_ t : T) -> Y {
   return t.doSomething()

--- a/test/IRGen/windows-lazy-initialize-conformance.swift
+++ b/test/IRGen/windows-lazy-initialize-conformance.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -S -emit-ir %s -o - | %FileCheck %s
+// REQUIRES: OS=windows-msvc
+
+class C {
+  static func encode(_ c: Encodable) throws {}
+}
+
+public protocol P: Codable {}
+
+extension String: P {}
+
+public enum E {
+  case associated(P)
+}
+
+extension E: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case .associated(let p):
+      try p.encode(to: encoder)
+    }
+  }
+}
+
+try? print(C.encode(E.associated("string")))
+
+// CHECK-NOT: store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$sSS4main1PAAWP", i32 0, i32 0), i8***

--- a/test/IRGen/windows-linking.swift
+++ b/test/IRGen/windows-linking.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -emit-module -emit-module-path %t/module.swiftmodule -module-name module -DMODULE %s
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-as-library -parse-stdlib -S -emit-ir %s -module-name main -o - -I%t | %FileCheck %s -check-prefix CHECK-SHARED
+
+#if MODULE
+
+public struct S {}
+public var value: S {
+  S()
+}
+
+public func f(_ s: S) {}
+
+public protocol P {
+}
+
+public enum E: P {
+}
+
+#else
+
+import module
+
+protocol Q: P {
+}
+
+extension E: Q {
+}
+
+@main
+struct Entry {
+  public static func main() {
+    f(value)
+  }
+}
+
+#endif
+
+
+// Ensure that shared linking does mark the functions as being indirected
+// through the IAT.
+
+// CHECK-SHARED:       @"$s6module1EO4main1QADWP" = hidden constant [2 x i8*] [
+// CHECK-SHARED-SAME:      i8* bitcast ({ i32, i32, i32, i32, i16, i16, i32, i32 }* @"$s6module1EO4main1QADMc" to i8*),
+// CHECK-SHARED-SAME:      i8* null
+// CHECK-SHARED-SAME:  ]
+
+// CHECK-SHARED: declare dllimport swiftcc void @"$s6module5valueAA1SVvg"()
+
+// CHECK-SHARED: declare dllimport swiftcc void @"$s6module1fyyAA1SVF"()


### PR DESCRIPTION
When building with lazy initialization of the root conformance, we need
to ensure that we are invoking the accessor to initialize the
conformance record.  We would previously generate a direct reference to
the conformance, which was uninitialized, resulting in a crash at
runtime.

The non-windows test changes here are to use/imply static linking for
the support modules.  This should have no difference on the non-Windows
targets, but makes a difference on Windows where this implies that
everything will be built into a single module, which permits the
non-indirect access to types.  Unfortunately, this does somewhat regress
the test coverage on Windows as we do not exercise as much of the shared
linkage paths which do change some of the code-generation to deal with
the moral equivalent of the GOT - the IAT.

Special thanks to @slavapestov for the pointer to
`isDependentConformance`.  This should eliminate the last known issue
with cross-module protocol conformances.

Fixes: SR-14807

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
