### PR TITLE
[Concurrency] Make task IDs 64-bit.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -250,7 +250,7 @@ public:
     : Job(flags, run, metadata, captureCurrentVoucher),
       ResumeContext(initialContext) {
     assert(flags.isAsyncTask());
-    Id = getNextTaskId();
+    setTaskId();
   }
 
   /// Create a task with "immortal" reference counts.
@@ -265,10 +265,13 @@ public:
     : Job(flags, run, metadata, immortal, captureCurrentVoucher),
       ResumeContext(initialContext) {
     assert(flags.isAsyncTask());
-    Id = getNextTaskId();
+    setTaskId();
   }
 
   ~AsyncTask();
+
+  /// Set the task's ID field to the next task ID.
+  void setTaskId();
 
   /// Given that we've already fully established the job context
   /// in the current thread, start running this task.  To establish
@@ -565,14 +568,6 @@ private:
   AsyncTask *&getNextWaitingTask() {
     return reinterpret_cast<AsyncTask *&>(
         SchedulerPrivate[NextWaitingTaskIndex]);
-  }
-
-  /// Get the next non-zero Task ID.
-  uint32_t getNextTaskId() {
-    static std::atomic<uint32_t> Id(1);
-    uint32_t Next = Id.fetch_add(1, std::memory_order_relaxed);
-    if (Next == 0) Next = Id.fetch_add(1, std::memory_order_relaxed);
-    return Next;
   }
 };
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -243,6 +243,19 @@ AsyncTask::~AsyncTask() {
   Private.destroy();
 }
 
+void AsyncTask::setTaskId() {
+  static std::atomic<uint64_t> NextId(1);
+
+  // We want the 32-bit Job::Id to be non-zero, so loop if we happen upon zero.
+  uint64_t Fetched;
+  do {
+    Fetched = NextId.fetch_add(1, std::memory_order_relaxed);
+    Id = Fetched & 0xffffffff;
+  } while (Id == 0);
+
+  _private().Id = (Fetched >> 32) & 0xffffffff;
+}
+
 SWIFT_CC(swift)
 static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   auto task = static_cast<AsyncTask*>(obj);

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -294,6 +294,9 @@ struct AsyncTask::PrivateStorage {
   /// state.
   uintptr_t ExclusivityAccessSet[2] = {0, 0};
 
+  /// The top 32 bits of the task ID. The bottom 32 bits are in Job::Id.
+  uint32_t Id;
+
   PrivateStorage(JobFlags flags)
       : Status(ActiveTaskStatus(flags)), Local(TaskLocal::Storage()) {}
 


### PR DESCRIPTION
The 32-bit identifier in Job is locked down at this point, so we expand the ID by storing the top 32 bits separately inside AsyncTask::PrivateStorage.

rdar://85167409