### PR TITLE
[Sema] Fix spurious trailing closure warning

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3509,6 +3509,13 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
+    std::pair<bool, ArgumentList *>
+    walkToArgumentListPre(ArgumentList *args) override {
+      // Don't walk into an explicit argument list, as trailing closures that
+      // appear in child arguments are fine.
+      return {args->isImplicit(), args};
+    }
+
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
       switch (E->getKind()) {
       case ExprKind::Paren:

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -466,3 +466,12 @@ class TrailingDerived : TrailingBase {
     super.init(x: x) {}
   }
 }
+
+// rdar://85343171 - Spurious warning on trailing closure in argument list.
+func rdar85343171() {
+  func foo(_ i: Int) -> Bool { true }
+  func bar(_ fn: () -> Void) -> Int { 0 }
+
+  // Okay, as trailing closure is nested in argument list.
+  if foo(bar {}) {}
+}


### PR DESCRIPTION
With the argument list refactoring, it's no longer sufficient to stop walking when we encounter an explicit tuple or paren. Add an additional check to stop walking when we encounter an explicit argument list.

rdar://85343171