### PR TITLE
[Re-merge] Support __available__((swift_attr("@Sendable")))

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -605,7 +605,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(async, Async,
   106)
 
 SIMPLE_DECL_ATTR(Sendable, Sendable,
-  OnFunc | OnConstructor | OnAccessor |
+  OnFunc | OnConstructor | OnAccessor | OnAnyClangDecl |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   107)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -168,8 +168,9 @@ protected:
     );
 
     SWIFT_INLINE_BITFIELD(SynthesizedProtocolAttr, DeclAttribute,
-                          NumKnownProtocolKindBits,
-      kind : NumKnownProtocolKindBits
+                          NumKnownProtocolKindBits+1,
+      kind : NumKnownProtocolKindBits,
+      isUnchecked : 1
     );
   } Bits;
 
@@ -1276,17 +1277,23 @@ class SynthesizedProtocolAttr : public DeclAttribute {
 
 public:
   SynthesizedProtocolAttr(KnownProtocolKind protocolKind,
-                          LazyConformanceLoader *Loader)
+                          LazyConformanceLoader *Loader,
+                          bool isUnchecked)
     : DeclAttribute(DAK_SynthesizedProtocol, SourceLoc(), SourceRange(),
                     /*Implicit=*/true), Loader(Loader)
   {
     Bits.SynthesizedProtocolAttr.kind = unsigned(protocolKind);
+    Bits.SynthesizedProtocolAttr.isUnchecked = unsigned(isUnchecked);
   }
 
   /// Retrieve the known protocol kind naming the protocol to be
   /// synthesized.
   KnownProtocolKind getProtocolKind() const {
     return KnownProtocolKind(Bits.SynthesizedProtocolAttr.kind);
+  }
+
+  bool isUnchecked() const {
+    return bool(Bits.SynthesizedProtocolAttr.isUnchecked);
   }
 
   /// Retrieve the lazy loader that will be used to populate the

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2231,6 +2231,11 @@ public:
   /// attribute list, or \c nullptr if there are none.
   const DeclAttribute *getEffectiveSendableAttr() const;
 
+  DeclAttribute *getEffectiveSendableAttr() {
+    return const_cast<DeclAttribute *>(
+         const_cast<const DeclAttributes *>(this)->getEffectiveSendableAttr());
+  }
+
 private:
   /// Predicate used to filter MatchingAttributeRange.
   template <typename ATTR, bool AllowInvalid> struct ToAttributeKind {

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -289,6 +289,9 @@ public:
 
     /// Whether this attribute is only valid when distributed is enabled.
     DistributedOnly = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 17),
+
+    /// Whether this attribute is valid on additional decls in ClangImporter.
+    OnAnyClangDecl = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 18),
   };
 
   LLVM_READNONE
@@ -2223,6 +2226,10 @@ public:
         return Attr;
     return nullptr;
   }
+
+  /// Returns the "winning" \c NonSendableAttr or \c SendableAttr in this
+  /// attribute list, or \c nullptr if there are none.
+  const DeclAttribute *getEffectiveSendableAttr() const;
 
 private:
   /// Predicate used to filter MatchingAttributeRange.

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -85,6 +85,10 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
 WARNING(clang_swift_attr_unhandled,none,
         "Ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
+WARNING(clang_error_code_must_be_sendable,none,
+        "cannot make error code type '%0' non-sendable because Swift errors "
+        "are always sendable", (StringRef))
+
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -17,7 +17,11 @@
 #include "swift/AST/RawComment.h"
 #include "swift/Basic/BasicSourceInfo.h"
 
+#include "llvm/ADT/PointerIntPair.h"
+
 namespace swift {
+class SynthesizedFileUnit;
+
 /// A container for module-scope declarations that itself provides a scope; the
 /// smallest unit of code organization.
 ///
@@ -33,18 +37,24 @@ class FileUnit : public DeclContext, public ASTAllocated<FileUnit> {
   friend class DirectOperatorLookupRequest;
   friend class DirectPrecedenceGroupLookupRequest;
 
-  // FIXME: Stick this in a PointerIntPair.
-  const FileUnitKind Kind;
+  // The pointer is FileUnit insted of SynthesizedFileUnit to break circularity.
+  llvm::PointerIntPair<FileUnit *, 3, FileUnitKind> SynthesizedFileAndKind;
 
 protected:
   FileUnit(FileUnitKind kind, ModuleDecl &M)
-    : DeclContext(DeclContextKind::FileUnit, &M), Kind(kind) {
+    : DeclContext(DeclContextKind::FileUnit, &M),
+      SynthesizedFileAndKind(nullptr, kind) {
   }
 
 public:
   FileUnitKind getKind() const {
-    return Kind;
+    return SynthesizedFileAndKind.getInt();
   }
+
+  /// Returns the synthesized file for this source file, if it exists.
+  SynthesizedFileUnit *getSynthesizedFile() const;
+
+  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   /// Look up a (possibly overloaded) value set at top-level scope
   /// (but with the specified access path, which may come from an import decl)

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -758,7 +758,9 @@ public:
   /// The order of the results is not guaranteed to be meaningful.
   ///
   /// This can differ from \c getTopLevelDecls, e.g. it returns decls from a
-  /// shadowed clang module.
+  /// shadowed clang module. It does not force synthesized top-level decls that
+  /// should be printed to be added; use \c swift::getTopLevelDeclsForDisplay()
+  /// for that.
   void getDisplayDecls(SmallVectorImpl<Decl*> &results) const;
 
   using LinkLibraryCallback = llvm::function_ref<void(LinkLibrary)>;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -235,6 +235,10 @@ struct PrintOptions {
   /// Whether to print unavailable parts of the AST.
   bool SkipUnavailable = false;
 
+  /// Whether to print synthesized extensions created by '@_nonSendable', even
+  /// if SkipImplicit or SkipUnavailable is set.
+  bool AlwaysPrintNonSendableExtensions = true;
+
   bool SkipSwiftPrivateClangDecls = false;
 
   /// Whether to skip internal stdlib declarations.
@@ -667,6 +671,7 @@ struct PrintOptions {
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     PO.PrintParameterSpecifiers = true;
     PO.SkipImplicit = true;
+    PO.AlwaysPrintNonSendableExtensions = false;
     PO.AlwaysTryPrintParameterLabels = true;
     return PO;
   }

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -514,6 +514,13 @@ public:
     return ContextAndBits.getInt() & UncheckedFlag;
   }
 
+  /// Mark the conformance as unchecked (equivalent to the @unchecked
+  /// conformance attribute).
+  void setUnchecked() {
+    // OK to mutate because the flags are not part of the folding set node ID.
+    ContextAndBits.setInt(ContextAndBits.getInt() | UncheckedFlag);
+  }
+
   /// Get the kind of source from which this conformance comes.
   ConformanceEntryKind getSourceKind() const {
     return SourceKindAndImplyingConformance.getInt();

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -89,9 +89,6 @@ private:
   /// same module.
   mutable Identifier PrivateDiscriminator;
 
-  /// A synthesized file corresponding to this file, created on-demand.
-  SynthesizedFileUnit *SynthesizedFile = nullptr;
-
   /// The root TypeRefinementContext for this SourceFile.
   ///
   /// This is set during type checking.
@@ -408,11 +405,6 @@ public:
   Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
   Optional<ExternalSourceLocs::RawLocs>
   getExternalRawLocsForDecl(const Decl *D) const override;
-
-  /// Returns the synthesized file for this source file, if it exists.
-  SynthesizedFileUnit *getSynthesizedFile() const { return SynthesizedFile; };
-
-  SynthesizedFileUnit &getOrCreateSynthesizedFile();
 
   virtual bool walk(ASTWalker &walker) override;
 

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -18,14 +18,12 @@
 
 namespace swift {
 
-class SourceFile;
-
 /// A container for synthesized declarations, attached to a `SourceFile`.
 ///
 /// Currently, only module-level synthesized declarations are supported.
 class SynthesizedFileUnit final : public FileUnit {
   /// The parent source file.
-  SourceFile &SF;
+  FileUnit &FU;
 
   /// Synthesized top level declarations.
   TinyPtrVector<Decl *> TopLevelDecls;
@@ -36,11 +34,11 @@ class SynthesizedFileUnit final : public FileUnit {
   mutable Identifier PrivateDiscriminator;
 
 public:
-  SynthesizedFileUnit(SourceFile &SF);
+  SynthesizedFileUnit(FileUnit &FU);
   ~SynthesizedFileUnit() = default;
 
   /// Returns the parent source file.
-  SourceFile &getSourceFile() const { return SF; }
+  FileUnit &getFileUnit() const { return FU; }
 
   /// Add a synthesized top-level declaration.
   void addTopLevelDecl(Decl *D) { TopLevelDecls.push_back(D); }

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -140,6 +140,13 @@ namespace swift {
   LookupResult
   lookupSemanticMember(DeclContext *DC, Type ty, DeclName name);
 
+  /// Get all of the top-level declarations that should be printed as part of
+  /// this module. This may force synthesis of top-level declarations that
+  /// \c ModuleDecl::getDisplayDecls() would only return if previous
+  /// work happened to have synthesized them.
+  void
+  getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results);
+
   struct ExtensionInfo {
     // The extension with the declarations to apply.
     ExtensionDecl *Ext;

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1,7 +1,8 @@
 #include "llvm/ADT/STLExtras.h"
-#include "swift/Basic/Defer.h"
-#include "swift/SIL/SILDeclRef.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/Basic/Defer.h"
+#include "swift/Sema/IDETypeChecking.h"
+#include "swift/SIL/SILDeclRef.h"
 #include <swift/APIDigester/ModuleAnalyzerNodes.h>
 #include <algorithm>
 
@@ -1872,7 +1873,7 @@ void SwiftDeclCollector::printTopLevelNames() {
 void SwiftDeclCollector::lookupVisibleDecls(ArrayRef<ModuleDecl *> Modules) {
   for (auto M: Modules) {
     llvm::SmallVector<Decl*, 512> Decls;
-    M->getDisplayDecls(Decls);
+    swift::getTopLevelDeclsForDisplay(M, Decls);
     for (auto D : Decls) {
       if (Ctx.shouldIgnore(D))
         continue;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5906,6 +5906,7 @@ swift::getInheritedForPrinting(
   // Collect synthesized conformances.
   auto &ctx = decl->getASTContext();
   llvm::SetVector<ProtocolDecl *> protocols;
+  llvm::TinyPtrVector<ProtocolDecl *> uncheckedProtocols;
   for (auto attr : decl->getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
     if (auto *proto = ctx.getProtocol(attr->getProtocolKind())) {
       // The SerialExecutor conformance is only synthesized on the root
@@ -5918,11 +5919,14 @@ swift::getInheritedForPrinting(
           cast<EnumDecl>(decl)->hasRawType())
         continue;
       protocols.insert(proto);
+      if (attr->isUnchecked())
+        uncheckedProtocols.push_back(proto);
     }
   }
 
   for (size_t i = 0; i < protocols.size(); i++) {
     auto proto = protocols[i];
+    bool isUnchecked = llvm::is_contained(uncheckedProtocols, proto);
 
     if (!options.shouldPrint(proto)) {
       // If private stdlib protocols are skipped and this is a private stdlib
@@ -5933,12 +5937,14 @@ swift::getInheritedForPrinting(
           proto->isPrivateStdlibDecl(!options.SkipUnderscoredStdlibProtocols)) {
         auto inheritedProtocols = proto->getInheritedProtocols();
         protocols.insert(inheritedProtocols.begin(), inheritedProtocols.end());
+        if (isUnchecked)
+          copy(inheritedProtocols, std::back_inserter(uncheckedProtocols));
       }
       continue;
     }
 
     Results.push_back({TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
-                       /*isUnchecked=*/false});
+                       isUnchecked});
   }
 }
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -904,6 +904,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
           // Set the conformance loader to the loader stashed inside
           // the attribute.
           normalConf->setLazyLoader(attr->getLazyLoader(), /*context=*/0);
+          if (attr->isUnchecked())
+            normalConf->setUnchecked();
           break;
         }
       }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -909,28 +909,6 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
 void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
   // FIXME: Should this do extra access control filtering?
   FORWARD(getDisplayDecls, (Results));
-
-  // Force Sendable on all types, which might synthesize some extensions.
-  // FIXME: We can remove this if @_nonSendable stops creating extensions.
-  for (auto result : Results) {
-    if (auto NTD = dyn_cast<NominalTypeDecl>(result))
-      (void)swift::isSendableType(const_cast<ModuleDecl *>(this),
-                                  NTD->getDeclaredInterfaceType());
-  }
-
-  // Re-add anything from synthesized file units...
-  auto oldCutoff = Results.size();
-  for (auto file : getFiles())
-    if (auto synthFile = dyn_cast<SynthesizedFileUnit>(file))
-      synthFile->getDisplayDecls(Results);
-
-  // And then remove anything that was already in the results.
-  auto oldResults = makeArrayRef(Results).take_front(oldCutoff);
-  auto uniqueEnd = std::remove_if(Results.begin() + oldCutoff, Results.end(),
-                                   [&](auto result) {
-    return llvm::is_contained(oldResults, result);
-  });
-  Results.erase(uniqueEnd, Results.end());
 }
 
 ProtocolConformanceRef

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -909,6 +909,28 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
 void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
   // FIXME: Should this do extra access control filtering?
   FORWARD(getDisplayDecls, (Results));
+
+  // Force Sendable on all types, which might synthesize some extensions.
+  // FIXME: We can remove this if @_nonSendable stops creating extensions.
+  for (auto result : Results) {
+    if (auto NTD = dyn_cast<NominalTypeDecl>(result))
+      (void)swift::isSendableType(const_cast<ModuleDecl *>(this),
+                                  NTD->getDeclaredInterfaceType());
+  }
+
+  // Re-add anything from synthesized file units...
+  auto oldCutoff = Results.size();
+  for (auto file : getFiles())
+    if (auto synthFile = dyn_cast<SynthesizedFileUnit>(file))
+      synthFile->getDisplayDecls(Results);
+
+  // And then remove anything that was already in the results.
+  auto oldResults = makeArrayRef(Results).take_front(oldCutoff);
+  auto uniqueEnd = std::remove_if(Results.begin() + oldCutoff, Results.end(),
+                                   [&](auto result) {
+    return llvm::is_contained(oldResults, result);
+  });
+  Results.erase(uniqueEnd, Results.end());
 }
 
 ProtocolConformanceRef

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -121,21 +121,13 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
     return;
   }
 
-  const ASTContext &ctx = ImporterImpl.SwiftContext;
-  ClangSourceBufferImporter &bufferImporter =
-      ImporterImpl.getBufferImporterForDiagnostics();
-
   if (clangDiag.getID() == clang::diag::err_module_not_built &&
       CurrentImport && clangDiag.getArgStdStr(0) == CurrentImport->getName()) {
-    SourceLoc loc = DiagLoc;
-    if (clangDiag.getLocation().isValid()) {
-      loc = bufferImporter.resolveSourceLocation(clangDiag.getSourceManager(),
-                                                 clangDiag.getLocation());
-    }
-
-    ctx.Diags.diagnose(loc, diag::clang_cannot_build_module,
-                       ctx.LangOpts.EnableObjCInterop,
-                       CurrentImport->getName());
+    HeaderLoc loc(clangDiag.getLocation(), DiagLoc,
+                  &clangDiag.getSourceManager());
+    ImporterImpl.diagnose(loc, diag::clang_cannot_build_module,
+                          ImporterImpl.SwiftContext.LangOpts.EnableObjCInterop,
+                          CurrentImport->getName());
     return;
   }
 
@@ -146,10 +138,9 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
     DiagnosticConsumer::HandleDiagnostic(clangDiagLevel, clangDiag);
 
   // FIXME: Map over source ranges in the diagnostic.
-  auto emitDiag =
-      [&ctx, &bufferImporter](clang::FullSourceLoc clangNoteLoc,
-                              clang::DiagnosticsEngine::Level clangDiagLevel,
-                              StringRef message) {
+  auto emitDiag = [this](clang::FullSourceLoc clangNoteLoc,
+                         clang::DiagnosticsEngine::Level clangDiagLevel,
+                         StringRef message) {
     decltype(diag::error_from_clang) diagKind;
     switch (clangDiagLevel) {
     case clang::DiagnosticsEngine::Ignored:
@@ -170,11 +161,9 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
       break;
     }
 
-    SourceLoc noteLoc;
-    if (clangNoteLoc.isValid())
-      noteLoc = bufferImporter.resolveSourceLocation(clangNoteLoc.getManager(),
-                                                     clangNoteLoc);
-    ctx.Diags.diagnose(noteLoc, diagKind, message);
+    HeaderLoc noteLoc(clangNoteLoc, SourceLoc(),
+              clangNoteLoc.hasManager() ? &clangNoteLoc.getManager() : nullptr);
+    ImporterImpl.diagnose(noteLoc, diagKind, message);
   };
 
   llvm::SmallString<128> message;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -467,6 +467,14 @@ getGlibcModuleMapPath(SearchPathOptions& Opts, llvm::Triple triple,
   return None;
 }
 
+static bool clangSupportsPragmaAttributeWithSwiftAttr() {
+  clang::AttributeCommonInfo swiftAttrInfo(clang::SourceRange(),
+     clang::AttributeCommonInfo::AT_SwiftAttr,
+     clang::AttributeCommonInfo::AS_GNU);
+  auto swiftAttrParsedInfo = clang::ParsedAttrInfo::get(swiftAttrInfo);
+  return swiftAttrParsedInfo.IsSupportedByPragmaAttribute;
+}
+
 void
 importer::getNormalInvocationArguments(
     std::vector<std::string> &invocationArgStrs,
@@ -609,6 +617,12 @@ importer::getNormalInvocationArguments(
       // '__swift__'.
       "-DSWIFT_CLASS_EXTRA=",
     });
+
+    // Indicate that using '__attribute__((swift_attr))' with '@Sendable' and
+    // '@_nonSendable' on Clang declarations is fully supported, including the
+    // 'attribute push' pragma.
+    if (clangSupportsPragmaAttributeWithSwiftAttr())
+      invocationArgStrs.push_back( "-D__SWIFT_ATTR_SUPPORTS_SENDABLE_DECLS=1");
 
     // Get the version of this compiler and pass it to C/Objective-C
     // declarations.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8607,12 +8607,7 @@ void ClangImporter::Implementation::importAttributes(
         if (SeenMainActorAttr) {
           // Cannot add main actor annotation twice. We'll keep the first
           // one and raise a warning about the duplicate.
-          auto &clangSrcMgr = getClangASTContext().getSourceManager();
-          ClangSourceBufferImporter &bufferImporter =
-              getBufferImporterForDiagnostics();
-          SourceLoc attrLoc = bufferImporter.resolveSourceLocation(
-              clangSrcMgr, swiftAttr->getLocation());
-
+          HeaderLoc attrLoc(swiftAttr->getLocation());
           diagnose(attrLoc, diag::import_multiple_mainactor_attr,
                    swiftAttr->getAttribute(),
                    SeenMainActorAttr.getValue()->getAttribute());
@@ -8668,11 +8663,7 @@ void ClangImporter::Implementation::importAttributes(
 
       if (hadError) {
         // Complain about the unhandled attribute or modifier.
-        auto &clangSrcMgr = getClangASTContext().getSourceManager();
-        ClangSourceBufferImporter &bufferImporter =
-          getBufferImporterForDiagnostics();
-        SourceLoc attrLoc = bufferImporter.resolveSourceLocation(
-          clangSrcMgr, swiftAttr->getLocation());
+        HeaderLoc attrLoc(swiftAttr->getLocation());
         diagnose(attrLoc, diag::clang_swift_attr_unhandled,
                  swiftAttr->getAttribute());
       }
@@ -9246,19 +9237,13 @@ ClangImporter::Implementation::importDeclForDeclContext(
   if (!contextDeclsWarnedAbout.insert(contextDecl).second)
     return nullptr;
 
-  auto convertLoc = [&](clang::SourceLocation clangLoc) {
-    return getBufferImporterForDiagnostics()
-      .resolveSourceLocation(getClangASTContext().getSourceManager(),
-                             clangLoc);
-  };
-
   auto getDeclName = [](const clang::Decl *D) -> StringRef {
     if (auto ND = dyn_cast<clang::NamedDecl>(D))
       return ND->getName();
     return "<anonymous>";
   };
 
-  SourceLoc loc = convertLoc(importingDecl->getLocation());
+  HeaderLoc loc(importingDecl->getLocation());
   diagnose(loc, diag::swift_name_circular_context_import,
            writtenName, getDeclName(importingDecl));
 
@@ -9266,7 +9251,7 @@ ClangImporter::Implementation::importDeclForDeclContext(
   for (auto entry : make_range(contextDeclsBeingImported.rbegin(), iter)) {
     auto otherDecl = std::get<0>(entry);
     auto otherWrittenName = std::get<1>(entry);
-    diagnose(convertLoc(otherDecl->getLocation()),
+    diagnose(HeaderLoc(otherDecl->getLocation()),
              diag::swift_name_circular_context_import_other,
              otherWrittenName, getDeclName(otherDecl));
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1468,10 +1468,12 @@ createValueConstructor(ClangImporter::Implementation &Impl,
 static void addSynthesizedProtocolAttrs(
     ClangImporter::Implementation &Impl,
     NominalTypeDecl *nominal,
-    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs) {
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+    bool isUnchecked = false) {
   for (auto kind : synthesizedProtocolAttrs) {
     nominal->getAttrs().add(new (Impl.SwiftContext)
-                                 SynthesizedProtocolAttr(kind, &Impl));
+                                 SynthesizedProtocolAttr(kind, &Impl,
+                                                         isUnchecked));
   }
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8497,6 +8497,16 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
                swiftAttr->getAttribute());
     }
   }
+
+  // Now that we've collected all @Sendable and @_nonSendable attributes, we
+  // can see if we should synthesize a Sendable conformance.
+  if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl)) {
+    auto sendability = nominal->getAttrs().getEffectiveSendableAttr();
+    if (isa_and_nonnull<SendableAttr>(sendability)) {
+      addSynthesizedProtocolAttrs(*this, nominal, {KnownProtocolKind::Sendable},
+                                  /*isUnchecked=*/true);
+    }
+  }
 }
 
 static bool isUsingMacroName(clang::SourceManager &SM,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2579,20 +2579,15 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
   if (importedName.hasCustomName() && argNames.size() != swiftParams.size()) {
     // Note carefully: we're emitting a warning in the /Clang/ buffer.
-    auto &srcMgr = getClangASTContext().getSourceManager();
-    ClangSourceBufferImporter &bufferImporter =
-        getBufferImporterForDiagnostics();
-    SourceLoc methodLoc =
-        bufferImporter.resolveSourceLocation(srcMgr, clangDecl->getLocation());
-    if (methodLoc.isValid()) {
+    if (clangDecl->getLocation().isValid()) {
+      HeaderLoc methodLoc(clangDecl->getLocation());
       diagnose(methodLoc, diag::invalid_swift_name_method,
-                                  swiftParams.size() < argNames.size(),
-                                  swiftParams.size(), argNames.size());
+               swiftParams.size() < argNames.size(),
+               swiftParams.size(), argNames.size());
       ModuleDecl *parentModule = dc->getParentModule();
       if (parentModule != ImportedHeaderUnit->getParentModule()) {
-        diagnose(
-            methodLoc, diag::unresolvable_clang_decl_is_a_framework_bug,
-            parentModule->getName().str());
+        diagnose(methodLoc, diag::unresolvable_clang_decl_is_a_framework_bug,
+                 parentModule->getName().str());
       }
     }
     return {Type(), false};

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1465,8 +1465,15 @@ public:
     D->setAccess(access);
     if (auto ASD = dyn_cast<AbstractStorageDecl>(D))
       ASD->setSetterAccess(access);
+
+    // SwiftAttrs on ParamDecls are interpreted by applyParamAttributes().
+    if (!isa<ParamDecl>(D))
+      importSwiftAttrAttributes(D);
+
     return D;
   }
+
+  void importSwiftAttrAttributes(Decl *decl);
 
   /// Find the lookup table that corresponds to the given Clang module.
   ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -317,6 +317,19 @@ public:
   explicit operator bool() const { return type.getPointer() != nullptr; }
 };
 
+/// Wraps a Clang source location with additional optional information used to
+/// resolve it for diagnostics.
+struct HeaderLoc {
+  clang::SourceLocation clangLoc;
+  SourceLoc fallbackLoc;
+  const clang::SourceManager *sourceMgr;
+
+  explicit HeaderLoc(clang::SourceLocation clangLoc,
+                     SourceLoc fallbackLoc = SourceLoc(),
+                     const clang::SourceManager *sourceMgr = nullptr)
+    : clangLoc(clangLoc), fallbackLoc(fallbackLoc), sourceMgr(sourceMgr) {}
+};
+
 /// Implementation of the Clang importer.
 class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation 
   : public LazyMemberLoader,
@@ -776,6 +789,31 @@ public:
     }
 
     SwiftContext.Diags.diagnose(loc, std::forward<Args>(args)...);
+  }
+
+  /// Emit a diagnostic at a clang source location, falling back to a Swift
+  /// location if the clang one is invalid.
+  ///
+  /// The diagnostic will appear in the header file rather than in a generated
+  /// interface. Use this to diagnose issues with declarations that are not
+  /// imported or that are not reflected in a generated interface.
+  template<typename ...Args>
+  void diagnose(HeaderLoc loc, Args &&...args) {
+    // If we're in the middle of pretty-printing, suppress diagnostics.
+    if (SwiftContext.Diags.isPrettyPrintingDecl()) {
+      return;
+    }
+
+    auto swiftLoc = loc.fallbackLoc;
+    if (loc.clangLoc.isValid()) {
+      auto &clangSrcMgr = loc.sourceMgr ? *loc.sourceMgr
+                        : getClangASTContext().getSourceManager();
+      auto &bufferImporter = getBufferImporterForDiagnostics();
+      swiftLoc = bufferImporter.resolveSourceLocation(clangSrcMgr,
+                                                      loc.clangLoc);
+    }
+
+    SwiftContext.Diags.diagnose(swiftLoc, std::forward<Args>(args)...);
   }
 
   /// Import the given Clang identifier into Swift.

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -59,6 +59,8 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
   llvm::SetVector<StringRef> Modules;
 
   // Find the imports in the main Swift code.
+  // We don't need `getTopLevelDeclsForDisplay()` here because we only care
+  // about `ImportDecl`s.
   llvm::SmallVector<Decl *, 32> Decls;
   mainModule->getDisplayDecls(Decls);
   for (auto D : Decls) {

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -399,12 +399,12 @@ static std::pair<ArrayRef<Decl*>, ArrayRef<Decl*>>
 getDeclsFromCrossImportOverlay(ModuleDecl *Overlay, ModuleDecl *Declaring,
                                SmallVectorImpl<Decl *> &Decls,
                                AccessLevel AccessFilter) {
-  Overlay->getDisplayDecls(Decls);
+  swift::getTopLevelDeclsForDisplay(Overlay, Decls);
 
   // Collect the imports of the underlying module so we can filter them out.
   SmallPtrSet<ModuleDecl *, 8> PrevImported;
   SmallVector<Decl*, 1> DeclaringDecls;
-  Declaring->getDisplayDecls(DeclaringDecls);
+  swift::getTopLevelDeclsForDisplay(Declaring, DeclaringDecls);
   for (auto *D: DeclaringDecls) {
     if (auto *ID = dyn_cast<ImportDecl>(D))
       PrevImported.insert(ID->getModule());
@@ -548,7 +548,7 @@ void swift::ide::printModuleInterface(
   adjustPrintOptions(AdjustedOptions);
 
   SmallVector<Decl *, 1> Decls;
-  TopLevelMod->getDisplayDecls(Decls);
+  swift::getTopLevelDeclsForDisplay(TopLevelMod, Decls);
 
   SmallVector<ImportDecl *, 1> ImportDecls;
   llvm::DenseSet<const clang::Module *> ClangModulesForImports;

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -68,10 +68,9 @@ TinyPtrVector<FileUnit *> IRGenDescriptor::getFilesToEmit() const {
   TinyPtrVector<FileUnit *> files;
   files.push_back(primary);
 
-  if (auto *SF = dyn_cast<SourceFile>(primary)) {
-    if (auto *synthesizedFile = SF->getSynthesizedFile())
-      files.push_back(synthesizedFile);
-  }
+  if (auto *synthesizedFile = primary->getSynthesizedFile())
+    files.push_back(synthesizedFile);
+
   return files;
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3946,8 +3946,8 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
       nominal->addExtension(extension);
 
       // Make it accessible to getTopLevelDecls()
-      if (auto sf = dyn_cast<SourceFile>(nominal->getModuleScopeContext()))
-        sf->getOrCreateSynthesizedFile().addTopLevelDecl(extension);
+      if (auto file = dyn_cast<FileUnit>(nominal->getModuleScopeContext()))
+        file->getOrCreateSynthesizedFile().addTopLevelDecl(extension);
 
       conformanceDC = extension;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3963,9 +3963,6 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
     return conformance;
   };
 
-  if (auto nonSendable = nominal->getAttrs().getAttribute<NonSendableAttr>())
-    return formConformance(nonSendable);
-
   // A non-protocol type with a global actor is implicitly Sendable.
   if (nominal->getGlobalActorAttr()) {
     // If this is a class, check the superclass. We won't infer Sendable
@@ -3984,6 +3981,12 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
 
     // Form the implicit conformance to Sendable.
     return formConformance(nullptr);
+  }
+
+  if (auto attr = nominal->getAttrs().getEffectiveSendableAttr()) {
+    assert(!isa<SendableAttr>(attr) &&
+           "Conformance should have been added by SynthesizedProtocolAttr!");
+    return formConformance(cast<NonSendableAttr>(attr));
   }
 
   // Only structs and enums can get implicit Sendable conformances by

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3932,6 +3932,8 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
       auto inherits = ctx.AllocateCopy(makeArrayRef(
           InheritedEntry(TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
                          /*isUnchecked*/true)));
+      // If you change the use of AtLoc in the ExtensionDecl, make sure you
+      // update isNonSendableExtension() in ASTPrinter.
       auto extension = ExtensionDecl::create(ctx, attrMakingUnavailable->AtLoc,
                                              nullptr, inherits,
                                              nominal->getModuleScopeContext(),

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Support/Path.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/FileSystem.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/SymbolGraphGen/SymbolGraphGen.h"
 
 #include "SymbolGraphASTWalker.h"
@@ -56,7 +57,7 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
                                          const SymbolGraphOptions &Options) {
   SymbolGraphASTWalker Walker(*M, Options);
   SmallVector<Decl *, 64> ModuleDecls;
-  M->getDisplayDecls(ModuleDecls);
+  swift::getTopLevelDeclsForDisplay(M, ModuleDecls);
 
   if (Options.PrintMessages)
     llvm::errs() << ModuleDecls.size()

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1203,10 +1203,8 @@ void TBDGenVisitor::visit(const TBDGenDescriptor &desc) {
     visitFile(singleFile);
 
     // Visit synthesized file, if it exists.
-    if (auto *SF = dyn_cast<SourceFile>(singleFile)) {
-      if (auto *synthesizedFile = SF->getSynthesizedFile())
-        visitFile(synthesizedFile);
-    }
+    if (auto *synthesizedFile = singleFile->getSynthesizedFile())
+      visitFile(synthesizedFile);
     return;
   }
 

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -124,7 +124,7 @@ class ObjCTest {
 #endif
 
 // HEADER: struct TestError : _BridgedStoredNSError {
-// HEADER:   enum Code : Int32, _ErrorCodeProtocol {
+// HEADER:   enum Code : Int32, _ErrorCodeProtocol, @unchecked Sendable {
 // HEADER:     init?(rawValue: Int32)
 // HEADER:     var rawValue: Int32 { get }
 // HEADER:     typealias _ErrorType = TestError
@@ -136,7 +136,7 @@ class ObjCTest {
 // HEADER: func getErr() -> TestError.Code
 
 // HEADER-NO-PRIVATE: struct TestError : CustomNSError, Hashable, Error {
-// HEADER-NO-PRIVATE:   enum Code : Int32, Equatable {
+// HEADER-NO-PRIVATE:   enum Code : Int32, @unchecked Sendable, Equatable {
 // HEADER-NO-PRIVATE:     init?(rawValue: Int32)
 // HEADER-NO-PRIVATE:     var rawValue: Int32 { get }
 // HEADER-NO-PRIVATE:     typealias _ErrorType = TestError

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
 // REQUIRES: objc_interop
 
-// PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -26,7 +26,7 @@
 // PRINT-NEXT:  extension Food {
 // PRINT-NEXT:    static let err: ErrorDomain
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
@@ -37,14 +37,14 @@
 // PRINT-NEXT:    static let secondEntry: ClosedEnum
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
@@ -56,7 +56,7 @@
 // PRINT-NEXT:    static let version: MyFloat{{$}}
 // PRINT-NEXT:  }
 //
-// PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: Int32)
 // PRINT-NEXT:    init(rawValue: Int32)
 // PRINT-NEXT:    let rawValue: Int32
@@ -83,7 +83,7 @@
 // PRINT-NEXT:  let Notification: String
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
-// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -97,7 +97,7 @@
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
 //
-// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -114,7 +114,7 @@
 // PRINT-NEXT:  func takeMyABIOldType(_: MyABIOldType!)
 // PRINT-NEXT:  func takeMyABINewTypeNonNull(_: MyABINewType)
 // PRINT-NEXT:  func takeMyABIOldTypeNonNull(_: MyABIOldType)
-// PRINT-LABEL: struct MyABINewTypeNS : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-LABEL: struct MyABINewTypeNS : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -133,7 +133,7 @@
 // PRINT-NEXT:    var i: Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext {
-// PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:      init(_ rawValue: String)
 // PRINT-NEXT:      init(rawValue: String)
 // PRINT-NEXT:      var rawValue: String { get }
@@ -145,13 +145,13 @@
 // PRINT-NEXT:    static let myContextName: NSSomeContext.Name
 // PRINT-NEXT:  }
 //
-// PRINT-NEXT: struct TRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT: struct TRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
 // PRINT-NEXT:   typealias RawValue = OpaquePointer
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT: struct ConstTRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
@@ -169,13 +169,13 @@
 // PRINT-NEXT:   func use()
 // PRINT-NEXT: }
 //
-// PRINT-NEXT: struct TRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT: struct TRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT:   typealias RawValue = UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {
+// PRINT-NEXT: struct ConstTRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafePointer<OpaquePointer>

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -5,21 +5,21 @@
 
 // REQUIRES: objc_interop
 
-// CHECK: enum Normal : Int {
+// CHECK-LABEL: enum Normal : Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK: enum SwiftEnum : Int {
+// CHECK-LABEL: enum SwiftEnum : Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK: enum SwiftEnumTwo : Int {
+// CHECK-LABEL: enum SwiftEnumTwo : Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case SwiftEnumTwoA
 // CHECK-NEXT: case SwiftEnumTwoB

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -99,8 +99,8 @@ import _Concurrency
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: nonisolated func independentMethod()
 // CHECK-NEXT: nonisolated func nonisolatedMethod()
-// CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
-// CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
+// CHECK-NEXT: {{^}} @MainActor @objc func mainActorMethod()
+// CHECK-NEXT: {{^}} @MainActor @objc func uiActorMethod()
 // CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 
@@ -108,4 +108,4 @@ import _Concurrency
 
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
 
-// CHECK: @MainActor protocol TripleMainActor {
+// CHECK: @MainActor @objc protocol TripleMainActor {

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -23,6 +23,7 @@ import _Concurrency
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class NonSendableClass
+// CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension NonSendableClass : @unchecked Sendable {
 
@@ -30,10 +31,54 @@ import _Concurrency
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class AuditedNonSendable
+// CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension AuditedNonSendable : @unchecked Sendable {
 
 // CHECK-LABEL: class AuditedBoth
+// CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
+
+// CHECK-LABEL: enum SendableEnum :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: enum NonSendableEnum :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableEnum : @unchecked Sendable {
+
+// CHECK-LABEL: struct SendableOptions :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: struct NonSendableOptions :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableOptions : @unchecked Sendable {
+
+// CHECK-LABEL: public struct SendableError :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: public enum Code :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: public struct NonSendableError :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: public enum Code :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: struct SendableStringEnum :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: struct NonSendableStringEnum :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableStringEnum : @unchecked Sendable {
+
+// CHECK-LABEL: struct SendableStringStruct :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: struct NonSendableStringStruct :
+// CHECK-NOT: @unchecked Sendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableStringStruct : @unchecked Sendable {
 

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false  | %FileCheck %s
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false > %t/ObjCConcurrency.printed.txt
+// RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
+// RUN: %FileCheck -check-prefix NEGATIVE -input-file %t/ObjCConcurrency.printed.txt %s
+
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
@@ -12,3 +15,18 @@ import _Concurrency
 // CHECK-NOT: @available
 // CHECK: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK: func doSomethingSlow(_ operation: String) async -> Int
+
+// NEGATIVE-NOT: @Sendable{{.+}}class
+// NEGATIVE-NOT: @_nonSendable{{.+}}class
+
+// CHECK-LABEL: class SendableClass :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: class NonSendableClass
+
+// CHECK-LABEL: class AuditedSendable :
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: class AuditedNonSendable
+
+// CHECK-LABEL: class AuditedBoth

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -23,10 +23,17 @@ import _Concurrency
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class NonSendableClass
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableClass : @unchecked Sendable {
 
 // CHECK-LABEL: class AuditedSendable :
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class AuditedNonSendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension AuditedNonSendable : @unchecked Sendable {
 
 // CHECK-LABEL: class AuditedBoth
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
+

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -19,8 +19,15 @@
   #define ASSUME_NONSENDABLE_END
 #endif
 
+#define NS_ENUM(_type, _name) enum _name : _type _name; \
+  enum __attribute__((enum_extensibility(open))) _name : _type
+#define NS_OPTIONS(_type, _name) enum _name : _type _name; \
+  enum __attribute__((enum_extensibility(open), flag_enum)) _name : _type
+#define NS_ERROR_ENUM(_type, _name, _domain)  \
+  enum _name : _type _name; enum __attribute__((ns_error_domain(_domain))) _name : _type
+#define NS_STRING_ENUM __attribute((swift_newtype(enum)))
+#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)))
 
-#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)));
 typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
 
 @protocol ServiceProvider
@@ -209,6 +216,35 @@ ASSUME_NONSENDABLE_BEGIN
 SENDABLE @interface AuditedSendable : NSObject @end
 @interface AuditedNonSendable : NSObject @end
 NONSENDABLE SENDABLE @interface AuditedBoth : NSObject @end
+
+typedef NS_ENUM(unsigned, SendableEnum) {
+  SendableEnumFoo, SendableEnumBar
+};
+typedef NS_ENUM(unsigned, NonSendableEnum) {
+  NonSendableEnumFoo, NonSendableEnumBar
+} NONSENDABLE;
+
+typedef NS_OPTIONS(unsigned, SendableOptions) {
+  SendableOptionsFoo = 1 << 0, SendableOptionsBar = 1 << 1
+};
+typedef NS_OPTIONS(unsigned, NonSendableOptions) {
+  NonSendableOptionsFoo = 1 << 0, NonSendableOptionsBar = 1 << 1
+} NONSENDABLE;
+
+NSString *SendableErrorDomain, *NonSendableErrorDomain;
+typedef NS_ERROR_ENUM(unsigned, SendableErrorCode, SendableErrorDomain) {
+  SendableErrorCodeFoo, SendableErrorCodeBar
+};
+typedef NS_ERROR_ENUM(unsigned, NonSendableErrorCode, NonSendableErrorDomain) {
+  NonSendableErrorCodeFoo, NonSendableErrorCodeBar
+} NONSENDABLE;
+// expected-warning@-3 {{cannot make error code type 'NonSendableErrorCode' non-sendable because Swift errors are always sendable}}
+
+typedef NSString *SendableStringEnum NS_STRING_ENUM;
+typedef NSString *NonSendableStringEnum NS_STRING_ENUM NONSENDABLE;
+
+typedef NSString *SendableStringStruct NS_EXTENSIBLE_STRING_ENUM;
+typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE;
 
 ASSUME_NONSENDABLE_END
 

--- a/test/Interop/Cxx/class/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access-specifiers-module-interface.swift
@@ -17,7 +17,7 @@
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:   }
-// CHECK-NEXT:   @frozen enum PublicClosedEnum : [[ENUM_UNDERLYING_TYPE]] {
+// CHECK-NEXT:   @frozen enum PublicClosedEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -25,7 +25,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicClosedEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   enum PublicOpenEnum : [[ENUM_UNDERLYING_TYPE]] {
+// CHECK-NEXT:   enum PublicOpenEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -33,7 +33,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     static var Value1: PublicPrivate.PublicOpenEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct PublicFlagEnum : OptionSet {
+// CHECK-NEXT:   struct PublicFlagEnum : OptionSet, @unchecked Sendable {
 // CHECK-NEXT:     init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     let rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     typealias RawValue = [[ENUM_UNDERLYING_TYPE]]

--- a/test/Serialization/Recovery/private-conformances.swift
+++ b/test/Serialization/Recovery/private-conformances.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -emit-module -DPROTOCOL_LIB -DAFTER %s -module-name protocol_lib -emit-module-path %t/protocol_lib.swiftmodule
 
 // The conforming library's types should still deserialize.
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print conforms_lib -I %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print conforms_lib -I %t -allow-compiler-errors | %FileCheck %s
 
 // Protocols that use a missing protocol have to disappear (see the FileCheck
 // lines).

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -4,7 +4,7 @@
 // RUN: %FileCheck -input-file=%t.response %s
 
 // CHECK: struct MyError : CustomNSError, Hashable, Error {
-// CHECK:     enum Code : Int32, Equatable {
+// CHECK:     enum Code : Int32, @unchecked Sendable, Equatable {
 // CHECK:         case errFirst
 // CHECK:         case errSecond
 // CHECK:     }

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -6,5 +6,6 @@ target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
-                        swiftClangImporter)
+                        swiftClangImporter
+                        swiftSema)
 

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -6,6 +6,5 @@ target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
-                        swiftClangImporter
-                        swiftSema)
+                        swiftClangImporter)
 

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -18,6 +18,7 @@
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/YAMLTraits.h"
@@ -877,7 +878,7 @@ public:
 
 std::shared_ptr<sma::Module> createSMAModel(ModuleDecl *M) {
   SmallVector<Decl *, 1> Decls;
-  M->getDisplayDecls(Decls);
+  swift::getTopLevelDeclsForDisplay(M, Decls);
 
   SMAModelGenerator Generator;
   for (auto *D : Decls) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2793,7 +2793,7 @@ static int doPrintModuleGroups(const CompilerInvocation &InitInvok,
     {
       GroupNamesPrinter Printer(llvm::outs());
       llvm::SmallVector<Decl*, 256> Results;
-      M->getDisplayDecls(Results);
+      swift::getTopLevelDeclsForDisplay(M, Results);
       for (auto R : Results) {
         Printer.addDecl(R);
       }


### PR DESCRIPTION
Attempting to merge #40170 again with a fix for the Windows build issue after it was reverted by #40262.

> This PR implements most of the sendability auditing support for ClangImporter. Specifically:
> 
> * `__attribute__((swift_attr("@Sendable")))` is now allowed on Clang decls, even when it would not be allowed on equivalent Swift decls.
> * A Clang type declaration is imported with a synthesized `@unchecked Sendable` conformance if it:
>     * Has `@Sendable`, but not plain `@_nonSendable`.
>     * Has the `enum_extensibility`, `flag_enum`, `swift_newtype`, or `swift_wrapper` Clang attributes, but not plain `@_nonSendable`.
>     * Has the `ns_error_domain` Clang attribute, **regardless of the presence** of plain `@_nonSendable`. (`Error` is always `Sendable`, so error codes must also be `Sendable`.)
> * We now force implicit `Sendable` conformances before printing the contents of a module, and we print the extensions generated by `@_nonSendable` even if we would normally skip unavailable or implicit extensions.
> * When ClangImporter is using a clang that supports https://reviews.llvm.org/D112773 (see apple/llvm-project#3547), it will define `__SWIFT_ATTR_SUPPORTS_SENDABLE_DECLS` to be `1`.
> 
> It includes a number of related refactorings:
> 
> * `SynthesizedProtocolAttr`s can now create `@unchecked` conformances.
> * `SynthesizedFileUnit`s can now be attached to any `FileUnit`, not just `SourceFile`.
> * `ClangImporter::Implementation::diagnose()` has been overloaded so that, if a `HeaderLoc` (wrapping a `clang::SourceLocation` and related info) is passed in place of a `SourceLoc`, it will emit a diagnostic in the header file. This replaces several lines of boilerplate per use site.
> 
> Fixes rdar://84431708. It does not implement two things that I will defer to 85569247:
> 
> * `@_nonSendable` in parameter position.
> * Implicit `@Sendable` (probably `@_unsafeSendable` in practice) on completion handler parameters.
> 
> Some tests will not pass without https://reviews.llvm.org/D112773, which I am in the process of cherry-picking to our clang branches.
> 
> This should only cause language behavior changes if you consume headers that include the currently-invalid `__attribute__((swift_attr("@Sendable")))`, `__attribute__((swift_attr("@_nonSendable")))`, or  `__attribute__((swift_attr("@_nonSendable(_assumed)")))` attributes.