### PR TITLE
Updates to `@_predatesConcurrency`

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -68,6 +68,8 @@ protected:
   bool AllowMarkerProtocols = true;
 
   /// Whether the mangling predates concurrency, and therefore shouldn't
+  /// include concurrency features such as global actors or @Sendable
+  /// function types.
   bool PredatesConcurrency = false;
 
 public:

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -67,6 +67,9 @@ protected:
   /// If enabled, marker protocols can be encoded in the mangled name.
   bool AllowMarkerProtocols = true;
 
+  /// Whether the mangling predates concurrency, and therefore shouldn't
+  bool PredatesConcurrency = false;
+
 public:
   using SymbolicReferent = llvm::PointerUnion<const NominalTypeDecl *,
                                               const OpaqueTypeDecl *>;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1189,6 +1189,15 @@ public:
   /// types.
   Type lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals);
 
+  /// Remove concurrency-related types and constraints from the given
+  /// type
+  ///
+  /// \param recurse Whether to recurse into function types.
+  ///
+  /// \param dropGlobalActor Whether to drop a global actor from a function
+  /// type.
+  Type stripConcurrency(bool recurse, bool dropGlobalActor);
+
   /// Whether this is the AnyObject type.
   bool isAnyObject();
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3803,6 +3803,10 @@ namespace {
       printFlag(T->isAsync(), "async");
       printFlag(T->isThrowing(), "throws");
 
+      if (Type globalActor = T->getGlobalActor()) {
+        printField("global_actor", globalActor.getString());
+      }
+
       OS << "\n";
       Indent += 2;
       // [TODO: Improve-Clang-type-printing]
@@ -3813,10 +3817,6 @@ namespace {
           ->getClangASTContext();
         T->getClangTypeInfo().dump(os, ctx);
         printField("clang_type", os.str());
-      }
-
-      if (Type globalActor = T->getGlobalActor()) {
-        printField("global_actor", globalActor.getString());
       }
 
       printAnyFunctionParams(T->getParams(), "input");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2969,6 +2969,13 @@ CanType ASTMangler::getDeclTypeForMangling(
 
   Type ty = decl->getInterfaceType()->getReferenceStorageReferent();
 
+  // If this declaration predates concurrency, adjust its type to not
+  // contain type features that were not available pre-concurrency. This
+  // cannot alter the ABI in any way.
+  if (decl->predatesConcurrency()) {
+    ty = ty->stripConcurrency(/*recurse=*/true, /*dropGlobalActor=*/true);
+  }
+
   auto canTy = ty->getCanonicalType();
 
   if (auto gft = dyn_cast<GenericFunctionType>(canTy)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -46,6 +46,7 @@
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/Basic/Defer.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Lexer.h" // FIXME: Bad dependency
 #include "clang/Lex/MacroInfo.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -719,7 +720,14 @@ Optional<CustomAttrNominalPair> Decl::getGlobalActorAttr() const {
 }
 
 bool Decl::predatesConcurrency() const {
-  return getAttrs().hasAttribute<PredatesConcurrencyAttr>();
+  if (getAttrs().hasAttribute<PredatesConcurrencyAttr>())
+    return true;
+
+  // Imported C declarations always predate concurrency.
+  if (isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext()))
+    return true;
+
+  return false;
 }
 
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1726,7 +1726,7 @@ Type ClangImporter::Implementation::applyParamAttributes(
       continue;
 
     // Map the main-actor attribute.
-    if (isMainActorAttr(SwiftContext, swiftAttr)) {
+    if (isMainActorAttr(swiftAttr)) {
       if (Type mainActor = SwiftContext.getMainActorType()) {
         type = applyToFunctionType(type, [&](ASTExtInfo extInfo) {
           return extInfo.withGlobalActor(mainActor);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1663,11 +1663,7 @@ public:
 
 /// Determines whether the given swift_attr attribute describes the main
 /// actor.
-///
-/// \returns None if this is not a main-actor attribute, and a Boolean
-/// indicating whether (unsafe) was provided in the attribute otherwise.
-Optional<bool> isMainActorAttr(
-    ASTContext &ctx, const clang::SwiftAttrAttr *swiftAttr);
+bool isMainActorAttr(const clang::SwiftAttrAttr *swiftAttr);
 
 }
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -90,16 +90,14 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
   _ = slowServer.allOperations
 }
 
-func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicitly non-sendable}}
-  doSomethingConcurrently(fn)
-  // expected-error@-1{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
+func testSendable(fn: () -> Void) {
+  doSomethingConcurrently(fn) // okay, due to implicit @_predatesConcurrency
   doSomethingConcurrentlyButUnsafe(fn) // okay, @Sendable not part of the type
 
   var x = 17
   doSomethingConcurrently {
-    print(x) // expected-error{{reference to captured var 'x' in concurrently-executing code}}
-    x = x + 1 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
-    // expected-error@-1{{reference to captured var 'x' in concurrently-executing code}}
+    print(x)
+    x = x + 1
   }
 }
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -178,7 +178,7 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
 #define MAGIC_NUMBER 42
 
 
-__attribute__((__swift_attr__("@MainActor(unsafe)")))
+__attribute__((__swift_attr__("@MainActor")))
 @interface NXView : NSObject
 -(void)onDisplay;
 @end
@@ -195,7 +195,7 @@ void doSomethingConcurrently(__attribute__((noescape)) SENDABLE void (^block)(vo
 void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void));
 
 
-MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor(unsafe)"))) @protocol TripleMainActor
+MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor"))) @protocol TripleMainActor
 @end
 
 @protocol ProtocolWithAsync

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -107,7 +107,7 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)asyncImportSame:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 
--(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR void (^ _Nullable)(NSString *))completion __attribute__((swift_attr("@_predatesConcurrency")));
+-(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR void (^ _Nullable)(NSString *))completion;
 - (void)obtainClosureWithCompletionHandler:(void (^)(void (^_Nullable)(void),
                                                      NSError *_Nullable,
                                                      BOOL))completionHandler
@@ -192,7 +192,7 @@ void doSomethingConcurrently(__attribute__((noescape)) SENDABLE void (^block)(vo
 
 
 
-void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void)) __attribute__((swift_attr("@_predatesConcurrency")));
+void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void));
 
 
 MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor(unsafe)"))) @protocol TripleMainActor

--- a/test/SILGen/mangling_predates_concurrency.swift
+++ b/test/SILGen/mangling_predates_concurrency.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+
+// CHECK: sil [ossa] @$s29mangling_predates_concurrency16excitingFunction5value4bodyyycx_yycSgtlF : $@convention(thin) <T where T : Sendable> (@in_guaranteed T, @guaranteed Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned @callee_guaranteed () -> ()
+@_predatesConcurrency
+public func excitingFunction<T: Sendable>(value: T, body: (@Sendable () -> Void)?) -> (@MainActor () -> Void) {
+  { }
+}


### PR DESCRIPTION
Implement a few remaining pieces of the `@_predatesConcurrency` attribute:

* Adjust the mangled type of `@_predatesConcurrency` declarations to drop `Sendable`, `@Sendable`, and global actor annotations
* All imported C declarations are `@_predatesConcurrency` by default