### PR TITLE
[ClangImporter] Handle allowing PCM/PCH errors

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -856,10 +856,12 @@ bool ClangImporter::canReadPCH(StringRef PCHFilename) {
       std::make_shared<clang::CompilerInvocation>(*Impl.Invocation);
   invocation->getPreprocessorOpts().DisablePCHOrModuleValidation =
       clang::DisableValidationForModuleKind::None;
-  invocation->getPreprocessorOpts().AllowPCHWithCompilerErrors = false;
   invocation->getHeaderSearchOpts().ModulesValidateSystemHeaders = true;
   invocation->getLangOpts()->NeededByPCHOrCompilationUsesPCH = true;
   invocation->getLangOpts()->CacheGeneratedPCH = true;
+  // If the underlying invocation is allowing PCH errors, then it "can be read",
+  // even if it has its error bit set. Thus, don't override
+  // `AllowPCHWithCompilerErrors`.
 
   // ClangImporter::create adds a remapped MemoryBuffer that we don't need
   // here.  Moreover, it's a raw pointer owned by the preprocessor options; if
@@ -1365,7 +1367,8 @@ bool ClangImporter::Implementation::importHeader(
   // Don't even try to load the bridging header if the Clang AST is in a bad
   // state. It could cause a crash.
   auto &clangDiags = getClangASTContext().getDiagnostics();
-  if (clangDiags.hasUnrecoverableErrorOccurred())
+  if (clangDiags.hasUnrecoverableErrorOccurred() &&
+      !getClangInstance()->getPreprocessorOpts().AllowPCHWithCompilerErrors)
     return true;
 
   assert(adapter);
@@ -1465,7 +1468,8 @@ bool ClangImporter::Implementation::importHeader(
                       getBufferImporterForDiagnostics());
 
   // FIXME: What do we do if there was already an error?
-  if (!hadError && clangDiags.hasErrorOccurred()) {
+  if (!hadError && clangDiags.hasErrorOccurred() &&
+      !getClangInstance()->getPreprocessorOpts().AllowPCHWithCompilerErrors) {
     diagnose(diagLoc, diag::bridging_header_error, headerName);
     return true;
   }
@@ -1668,7 +1672,8 @@ ClangImporter::emitBridgingPCH(StringRef headerPath,
       FrontendOpts, std::make_unique<clang::GeneratePCHAction>());
   emitInstance->ExecuteAction(*action);
 
-  if (emitInstance->getDiagnostics().hasErrorOccurred()) {
+  if (emitInstance->getDiagnostics().hasErrorOccurred() &&
+      !emitInstance->getPreprocessorOpts().AllowPCHWithCompilerErrors) {
     Impl.diagnose({}, diag::bridging_header_pch_error,
                   outputPCHPath, headerPath);
     return true;
@@ -1728,7 +1733,8 @@ bool ClangImporter::emitPrecompiledModule(StringRef moduleMapPath,
       std::make_unique<clang::GenerateModuleFromModuleMapAction>());
   emitInstance->ExecuteAction(*action);
 
-  if (emitInstance->getDiagnostics().hasErrorOccurred()) {
+  if (emitInstance->getDiagnostics().hasErrorOccurred() &&
+      !FrontendOpts.AllowPCMWithCompilerErrors) {
     Impl.diagnose({}, diag::emit_pcm_error, outputPath, moduleMapPath);
     return true;
   }

--- a/test/ClangImporter/AllowErrors/invalid-pch-bridging-header.swift
+++ b/test/ClangImporter/AllowErrors/invalid-pch-bridging-header.swift
@@ -1,0 +1,29 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/pch %t/pch-dir
+// RUN: split-file %s %t
+
+// Check that the pch is output even though it has errors
+// RUN: %target-swift-frontend -emit-pch -o %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/bridging-header.h
+// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/pch/bridging-header.pch -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: ls %t/pch/*.pch | count 1
+
+// Same but with implicit PCH instead
+// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: ls %t/pch-dir/*.pch | count 1
+
+// Second implicit run since we may go down a different path if the PCH already
+// exists
+// RUN: %target-swift-frontend -typecheck -verify -import-objc-header %t/bridging-header.h -pch-output-dir %t/pch-dir -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/use.swift
+// RUN: ls %t/pch-dir/*.pch | count 1
+
+//--- bridging-header.h
+@import DoesNotExist;
+
+struct SomeTy {
+  int a;
+};
+
+//--- use.swift
+func use(s: SomeTy) {}

--- a/test/ClangImporter/AllowErrors/invalid-pcm.swift
+++ b/test/ClangImporter/AllowErrors/invalid-pcm.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-pcm -module-name m -o %t/m.pcm -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -Xclang -Xcc -fmodule-format=raw %t/mods/module.map
+// RUN: %target-swift-frontend -typecheck -verify -Xcc -Xclang -Xcc -fallow-pcm-with-compiler-errors -Xcc -fmodule-file=%t/m.pcm %t/use.swift
+
+//--- mods/module.map
+module m {
+  header "m.h"
+}
+
+//--- mods/m.h
+@import DoesNotExist;
+
+struct SomeTy {
+  int a;
+};
+
+//--- use.swift
+import m
+func use(s: SomeTy) {}

--- a/test/Frontend/crash.swift
+++ b/test/Frontend/crash.swift
@@ -2,7 +2,7 @@
 // RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -filelist %t.filelist.txt 2>&1 | %FileCheck %s
 
 // Check that we see the contents of the input file list in the crash log.
-// CHECK-NOT: Compiling with {{.*}} while allowing modules with compiler errors enabled
+// CHECK-NOT: while allowing modules with compiler errors
 // CHECK-LABEL: Stack dump
 // CHECK-NEXT: Program arguments: {{.*swift(-frontend)?(c?)(\.exe)?}}
 // CHECK-NEXT: Swift version
@@ -14,12 +14,11 @@
 
 // RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -experimental-allow-module-with-compiler-errors %s 2>&1 | %FileCheck -check-prefix CHECK-ALLOW %s
 // CHECK-ALLOW: Program arguments: {{.*}} -experimental-allow-module-with-compiler-errors
-// CHECK-ALLOW: Compiling with effective version
+// CHECK-ALLOW: Compiling with effective version {{.*}} while allowing modules with compiler errors
 
 // RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -experimental-allow-module-with-compiler-errors -swift-version 5 %s 2>&1 | %FileCheck -check-prefix CHECK-CURRENT %s
 // CHECK-CURRENT: Program arguments: {{.*}} -experimental-allow-module-with-compiler-errors
-// CHECK-CURRENT: Compiling with the current language version
+// CHECK-CURRENT: Compiling with the current language version while allowing modules with compiler errors
 
 func anchor() {}
 anchor()
-


### PR DESCRIPTION
Ignore errors when emitting/reading a PCM/PCH and Clang has
`-fallow-(pcm|pch)-with-compiler-errors` set.

Resolves rdar://85576570.