### PR TITLE
libswift: add support for Android and OpenBSD in the CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ cmake_dependent_option(LIBSWIFT_BUILD_MODE "How to build libswift. Possible valu
     BOOTSTRAPPING: libswift is built with a 2-stage bootstrapping process
     BOOTSTRAPPING-WITH-HOSTLIBS:   libswift is built with a 2-stage bootstrapping process,
                    but the compiler links against the host system swift libs (macOS only)
+    CROSSCOMPILE:  libswift is cross-compiled with a native host compiler, provided in
+                   `SWIFT_NATIVE_SWIFT_TOOLS_PATH` (non-Darwin only)
     CROSSCOMPILE-WITH-HOSTLIBS:    libswift is built with a bootstrapping-with-hostlibs compiled
                                    compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`"
   OFF "NOT CMAKE_GENERATOR STREQUAL \"Xcode\"" OFF)
@@ -616,6 +618,8 @@ elseif(LIBSWIFT_BUILD_MODE MATCHES "BOOTSTRAPPING.*")
   set(SWIFT_EXEC_FOR_LIBSWIFT "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
   if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
     set(LIBSWIFT_BUILD_MODE "CROSSCOMPILE-WITH-HOSTLIBS")
+  elseif(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING")
+    set(LIBSWIFT_BUILD_MODE "CROSSCOMPILE")
   else()
     set(LIBSWIFT_BUILD_MODE "HOSTTOOLS")
   endif()

--- a/libswift/CMakeLists.txt
+++ b/libswift/CMakeLists.txt
@@ -20,7 +20,7 @@ else()
 
   add_subdirectory(Sources)
 
-  if(${LIBSWIFT_BUILD_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE-WITH-HOSTLIBS")
+  if(${LIBSWIFT_BUILD_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
 
     if (NOT SWIFT_EXEC_FOR_LIBSWIFT)
       message(FATAL_ERROR "Need a swift toolchain for building libswift")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -734,7 +734,7 @@ function(_compile_swift_files
       # stdlib in the current stage is not built yet.
       if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
         set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "DYLD_LIBRARY_PATH=${bs_lib_dir}")
-      elseif(SWIFT_HOST_VARIANT_SDK STREQUAL "LINUX")
+      elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD")
         set(set_environment_args "${CMAKE_COMMAND}" "-E" "env" "LD_LIBRARY_PATH=${bs_lib_dir}")
       else()
         message(FATAL_ERROR "TODO: bootstrapping support for ${SWIFT_HOST_VARIANT_SDK}")


### PR DESCRIPTION
Add a new libswift build mode for cross-compilation in the process, that currently only works for non-Darwin hosts.

@3405691582, ~let me know if you'd like me to~ added OpenBSD too.

@eeckstein, this modifies your pull #39461 to add support for Android, which I just built the Nov. 19 source snapshot natively on. When you get back from Thanksgiving, let me know what you think.