### PR TITLE
[cmake] [unittests] remove unnecessary scripts

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -21,24 +21,6 @@ function(add_swift_unittest test_dirname)
     set_property(TARGET "${test_dirname}" APPEND_STRING PROPERTY LINK_FLAGS " ${_lto_flag_out} ")
   endif()
 
-  if(SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
-    # Replace target references with full paths, so that we use LLVM's
-    # build configuration rather than Swift's.
-    get_target_property(libnames ${test_dirname} LINK_LIBRARIES)
-
-    set(new_libnames)
-    foreach(dep ${libnames})
-      if("${dep}" MATCHES "^(LLVM|Clang|gtest)" AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-        list(APPEND new_libnames "${LLVM_LIBRARY_OUTPUT_INTDIR}/lib${dep}.a")
-      else()
-        list(APPEND new_libnames "${dep}")
-      endif()
-    endforeach()
-
-    set_property(TARGET ${test_dirname} PROPERTY LINK_LIBRARIES ${new_libnames})
-    swift_common_llvm_config(${test_dirname} support)
-  endif()
-
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     # Add an @rpath to the swift library directory.
     set_target_properties(${test_dirname} PROPERTIES


### PR DESCRIPTION
from #36971 

"gtest, gtest_main LINK_LIBRARIES dependencies changed by that removed scripts to absolute library file path. as a result losing necessary include path dirs."

this tested and merged for main branch. and is this possible cherry-picking to release/5.5? 

@varungandhi-apple 