### PR TITLE
[build-presets] Support expansion of preset option names

### DIFF
--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -361,11 +361,23 @@ class PresetParser(object):
     def _interpolate_preset_vars(self, preset, vars):
         interpolated_options = []
         for (name, value) in preset.options:
-            try:
-                value = _interpolate_string(value, vars)
-            except KeyError as e:
-                raise InterpolationError(
-                    preset.name, name, value, e.args[0])
+            # If the option is a key-value pair, e.g. 
+            # install-destdir=%(install_dir)s
+            # interpolate the value. If it is a raw option, e.g. 
+            # %(some_flag)s
+            # is a raw option without a value, expand the name.
+            if value:
+                try:
+                    value = _interpolate_string(value, vars)
+                except KeyError as e:
+                    raise InterpolationError(
+                        preset.name, name, value, e.args[0])
+            else:
+                try:
+                    name = _interpolate_string(name, vars)
+                except KeyError as e:
+                    raise InterpolationError(
+                        preset.name, name, name, e.args[0])
 
             interpolated_options.append((name, value))
 

--- a/utils/build_swift/tests/build_swift/test_presets.py
+++ b/utils/build_swift/tests/build_swift/test_presets.py
@@ -113,6 +113,12 @@ ios
 ios
 """
 
+EXPAND_OPTION_NAME = """
+[preset: test]
+
+%(my_option)s
+"""
+
 
 # -----------------------------------------------------------------------------
 
@@ -281,3 +287,12 @@ class TestPresetParser(unittest.TestCase):
 
         self.assertEqual(set(parser.preset_names),
                          set(['foo', 'bar', 'baz']))
+
+    def test_expand_option_name(self):
+        parser = PresetParser()
+        parser.read_string(EXPAND_OPTION_NAME)
+
+        preset = parser.get_preset('test', vars={'my_option': 'macos'})
+        self.assertEqual(preset.options, [
+            ('macos', None),
+        ])


### PR DESCRIPTION
This allows me to selectively enable build features (such as building lldb, building swiftpm reconfiguring etc.) locally from a single preset.