### PR TITLE
WIP: Don't pack bits in CodeCompletionResult

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -418,7 +418,7 @@ public:
 ///
 /// This enum is ordered from the contexts that are "nearest" to the code
 /// completion point to "outside" contexts.
-enum class SemanticContextKind {
+enum class SemanticContextKind : uint8_t {
   /// Used in cases when the concept of semantic context is not applicable.
   None,
 
@@ -482,7 +482,7 @@ enum class CodeCompletionFlairBit: uint8_t {
 using CodeCompletionFlair = OptionSet<CodeCompletionFlairBit>;
 
 /// The declaration kind of a code completion result, if it is a declaration.
-enum class CodeCompletionDeclKind {
+enum class CodeCompletionDeclKind : uint8_t {
   Module,
   Class,
   Struct,
@@ -508,7 +508,7 @@ enum class CodeCompletionDeclKind {
   PrecedenceGroup,
 };
 
-enum class CodeCompletionLiteralKind {
+enum class CodeCompletionLiteralKind : uint8_t {
   ArrayLiteral,
   BooleanLiteral,
   ColorLiteral,
@@ -520,7 +520,7 @@ enum class CodeCompletionLiteralKind {
   Tuple,
 };
 
-enum class CodeCompletionOperatorKind {
+enum class CodeCompletionOperatorKind : uint8_t {
   None,
   Unknown,
   Bang,       // !
@@ -566,14 +566,14 @@ enum class CodeCompletionOperatorKind {
   TildeEq,          // ~=
 };
 
-enum class CodeCompletionKeywordKind {
+enum class CodeCompletionKeywordKind : uint8_t {
   None,
 #define KEYWORD(X) kw_##X,
 #define POUND_KEYWORD(X) pound_##X,
 #include "swift/Syntax/TokenKinds.def"
 };
 
-enum class CompletionKind {
+enum class CompletionKind : uint8_t {
   None,
   Import,
   UnresolvedMember,
@@ -625,7 +625,7 @@ class CodeCompletionResult {
   friend class CodeCompletionResultBuilder;
 
 public:
-  enum class ResultKind {
+  enum class ResultKind : uint8_t {
     Declaration,
     Keyword,
     Pattern,
@@ -635,7 +635,7 @@ public:
 
   /// Describes the relationship between the type of the completion results and
   /// the expected type at the code completion position.
-  enum class ExpectedTypeRelation {
+  enum class ExpectedTypeRelation : uint8_t {
     /// The result does not have a type (e.g. keyword).
     NotApplicable,
 
@@ -656,7 +656,7 @@ public:
     Identical,
   };
 
-  enum class NotRecommendedReason {
+  enum class NotRecommendedReason : uint8_t {
     None = 0,
     RedundantImport,
     RedundantImportIndirect,
@@ -668,13 +668,13 @@ public:
   };
 
 private:
-  unsigned Kind : 3;
+  ResultKind Kind : 3;
   unsigned AssociatedKind : 8;
-  unsigned KnownOperatorKind : 6;
-  unsigned SemanticContext : 3;
-  unsigned Flair: 8;
-  unsigned NotRecommended : 4;
-  unsigned IsSystem : 1;
+  CodeCompletionOperatorKind KnownOperatorKind : 6;
+  SemanticContextKind SemanticContext : 3;
+  unsigned char Flair : 8;
+  NotRecommendedReason NotRecommended : 4;
+  bool IsSystem : 1;
 
   /// The number of bytes to the left of the code completion point that
   /// should be erased first if this completion string is inserted in the
@@ -689,8 +689,8 @@ private:
   StringRef ModuleName;
   StringRef BriefDocComment;
   ArrayRef<StringRef> AssociatedUSRs;
-  unsigned TypeDistance : 3;
-  unsigned DiagnosticSeverity: 3;
+  ExpectedTypeRelation TypeDistance : 3;
+  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
   StringRef DiagnosticMessage;
 
 public:
@@ -704,22 +704,20 @@ public:
                        CodeCompletionOperatorKind KnownOperatorKind =
                            CodeCompletionOperatorKind::None,
                        StringRef BriefDocComment = StringRef())
-      : Kind(unsigned(Kind)), KnownOperatorKind(unsigned(KnownOperatorKind)),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(Kind), KnownOperatorKind(KnownOperatorKind),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(unsigned(TypeDistance)) {
+        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(Kind != ResultKind::Declaration && "use the other constructor");
     assert(CompletionString);
     if (isOperator() && KnownOperatorKind == CodeCompletionOperatorKind::None)
-      this->KnownOperatorKind =
-          (unsigned)getCodeCompletionOperatorKind(CompletionString);
+      this->KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
     assert(!isOperator() ||
            getOperatorKind() != CodeCompletionOperatorKind::None);
     AssociatedKind = 0;
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
   }
 
   /// Constructs a \c Keyword result.
@@ -731,16 +729,16 @@ public:
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance,
                        StringRef BriefDocComment = StringRef())
-      : Kind(unsigned(ResultKind::Keyword)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(ResultKind::Keyword),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(unsigned(TypeDistance)) {
+        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(CompletionString);
     AssociatedKind = static_cast<unsigned>(Kind);
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
   }
 
   /// Constructs a \c Literal result.
@@ -751,15 +749,15 @@ public:
                        CodeCompletionFlair Flair, unsigned NumBytesToErase,
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance)
-      : Kind(unsigned(ResultKind::Literal)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(ResultKind::Literal),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        TypeDistance(unsigned(TypeDistance)) {
+        TypeDistance(TypeDistance) {
     AssociatedKind = static_cast<unsigned>(LiteralKind);
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
     assert(CompletionString);
   }
 
@@ -776,20 +774,20 @@ public:
                        StringRef BriefDocComment,
                        ArrayRef<StringRef> AssociatedUSRs,
                        ExpectedTypeRelation TypeDistance)
-      : Kind(unsigned(ResultKind::Declaration)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())), NotRecommended(unsigned(NotRecReason)),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
-        AssociatedUSRs(AssociatedUSRs), TypeDistance(unsigned(TypeDistance)) {
+      : Kind(ResultKind::Declaration),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecReason), NumBytesToErase(NumBytesToErase),
+        CompletionString(CompletionString), ModuleName(ModuleName),
+        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
+        TypeDistance(TypeDistance) {
     assert(AssociatedDecl && "should have a decl");
     AssociatedKind = unsigned(getCodeCompletionDeclKind(AssociatedDecl));
     IsSystem = getDeclIsSystem(AssociatedDecl);
-    DiagnosticSeverity = 0;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
     assert(CompletionString);
     if (isOperator())
-      KnownOperatorKind =
-          (unsigned)getCodeCompletionOperatorKind(CompletionString);
+      KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
     assert(!isOperator() ||
            getOperatorKind() != CodeCompletionOperatorKind::None);
   }
@@ -806,16 +804,13 @@ public:
                        ArrayRef<StringRef> AssociatedUSRs,
                        ExpectedTypeRelation TypeDistance,
                        CodeCompletionOperatorKind KnownOperatorKind)
-      : Kind(unsigned(ResultKind::Declaration)),
-        KnownOperatorKind(unsigned(KnownOperatorKind)),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())), NotRecommended(unsigned(NotRecReason)),
-        IsSystem(IsSystem), NumBytesToErase(NumBytesToErase),
-        CompletionString(CompletionString), ModuleName(ModuleName),
-        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
-        TypeDistance(unsigned(TypeDistance)),
-        DiagnosticSeverity(unsigned(diagSeverity)),
-        DiagnosticMessage(DiagnosticMessage) {
+      : Kind(ResultKind::Declaration), KnownOperatorKind(KnownOperatorKind),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecReason), IsSystem(IsSystem),
+        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
+        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
+        AssociatedUSRs(AssociatedUSRs), TypeDistance(TypeDistance),
+        DiagnosticSeverity(diagSeverity), DiagnosticMessage(DiagnosticMessage) {
     AssociatedKind = static_cast<unsigned>(DeclKind);
     assert(CompletionString);
     assert(!isOperator() ||
@@ -828,7 +823,7 @@ public:
   CodeCompletionResult *withFlair(CodeCompletionFlair newFlair,
                                   CodeCompletionResultSink &Sink);
 
-  ResultKind getKind() const { return static_cast<ResultKind>(Kind); }
+  ResultKind getKind() const { return Kind; }
 
   CodeCompletionDeclKind getAssociatedDeclKind() const {
     assert(getKind() == ResultKind::Declaration);
@@ -860,33 +855,23 @@ public:
 
   CodeCompletionOperatorKind getOperatorKind() const {
     assert(isOperator());
-    return static_cast<CodeCompletionOperatorKind>(KnownOperatorKind);
+    return KnownOperatorKind;
   }
 
-  bool isSystem() const {
-    return static_cast<bool>(IsSystem);
-  }
+  bool isSystem() const { return IsSystem; }
 
-  ExpectedTypeRelation getExpectedTypeRelation() const {
-    return static_cast<ExpectedTypeRelation>(TypeDistance);
-  }
+  ExpectedTypeRelation getExpectedTypeRelation() const { return TypeDistance; }
 
   NotRecommendedReason getNotRecommendedReason() const {
-    return static_cast<NotRecommendedReason>(NotRecommended);
+    return NotRecommended;
   }
 
-  SemanticContextKind getSemanticContext() const {
-    return static_cast<SemanticContextKind>(SemanticContext);
-  }
+  SemanticContextKind getSemanticContext() const { return SemanticContext; }
 
-  CodeCompletionFlair getFlair() const {
-    return static_cast<CodeCompletionFlair>(Flair);
-  }
+  CodeCompletionFlair getFlair() const { return CodeCompletionFlair(Flair); }
 
   /// Modify "flair" of this result *in place*.
-  void setFlair(CodeCompletionFlair flair) {
-    Flair = unsigned(flair.toRaw());
-  }
+  void setFlair(CodeCompletionFlair flair) { Flair = flair.toRaw(); }
 
   bool isNotRecommended() const {
     return getNotRecommendedReason() != NotRecommendedReason::None;
@@ -911,12 +896,12 @@ public:
   }
 
   void setDiagnostics(CodeCompletionDiagnosticSeverity severity, StringRef message) {
-    DiagnosticSeverity = static_cast<unsigned>(severity);
+    DiagnosticSeverity = severity;
     DiagnosticMessage = message;
   }
 
   CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
-    return static_cast<CodeCompletionDiagnosticSeverity>(DiagnosticSeverity);
+    return DiagnosticSeverity;
   }
 
   StringRef getDiagnosticMessage() const {

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -452,6 +452,8 @@ enum class SemanticContextKind : uint8_t {
 
   /// A declaration imported from other module.
   OtherModule,
+
+  MAX_VALUE = OtherModule
 };
 
 enum class CodeCompletionFlairBit: uint8_t {
@@ -564,6 +566,8 @@ enum class CodeCompletionOperatorKind : uint8_t {
   PipeEq,           // |=
   PipePipe,         // ||
   TildeEq,          // ~=
+
+  MAX_VALUE = TildeEq
 };
 
 enum class CodeCompletionKeywordKind : uint8_t {
@@ -612,12 +616,14 @@ enum class CompletionKind : uint8_t {
   TypeAttrBeginning,
 };
 
-enum class CodeCompletionDiagnosticSeverity: uint8_t {
+enum class CodeCompletionDiagnosticSeverity : uint8_t {
   None,
   Error,
   Warning,
   Remark,
   Note,
+
+  MAX_VALUE = Note
 };
 
 /// A single code completion result.
@@ -631,6 +637,8 @@ public:
     Pattern,
     Literal,
     BuiltinOperator,
+
+    MAX_VALUE = BuiltinOperator
   };
 
   /// Describes the relationship between the type of the completion results and
@@ -654,6 +662,8 @@ public:
 
     /// The result's type is identical to the type of the expected.
     Identical,
+
+    MAX_VALUE = Identical
   };
 
   enum class NotRecommendedReason : uint8_t {
@@ -665,6 +675,8 @@ public:
     InvalidAsyncContext,
     CrossActorReference,
     VariableUsedInOwnDefinition,
+
+    MAX_VALUE = VariableUsedInOwnDefinition
   };
 
 private:
@@ -692,6 +704,14 @@ private:
   ExpectedTypeRelation TypeDistance : 3;
   CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
   StringRef DiagnosticMessage;
+
+  // Assertions for limiting max values of enums.
+  static_assert(int(ResultKind::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(CodeCompletionOperatorKind::MAX_VALUE) < 1 << 6, "");
+  static_assert(int(SemanticContextKind::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(NotRecommendedReason::MAX_VALUE) < 1 << 4, "");
+  static_assert(int(ExpectedTypeRelation::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
 
 public:
   /// Constructs a \c Pattern, \c Keyword or \c BuiltinOperator result.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -313,7 +313,7 @@ private:
 
   /// If true, then this chunk is an annotation that is included only
   /// for exposition and may not be inserted in the editor buffer.
-  unsigned IsAnnotation : 1;
+  bool IsAnnotation;
 
   StringRef Text;
 
@@ -680,18 +680,18 @@ public:
   };
 
 private:
-  ResultKind Kind : 3;
+  ResultKind Kind;
   unsigned AssociatedKind : 8;
-  CodeCompletionOperatorKind KnownOperatorKind : 6;
-  SemanticContextKind SemanticContext : 3;
+  CodeCompletionOperatorKind KnownOperatorKind;
+  SemanticContextKind SemanticContext;
   unsigned char Flair : 8;
-  NotRecommendedReason NotRecommended : 4;
-  bool IsSystem : 1;
+  NotRecommendedReason NotRecommended;
+  bool IsSystem;
 
   /// The number of bytes to the left of the code completion point that
   /// should be erased first if this completion string is inserted in the
   /// editor buffer.
-  unsigned NumBytesToErase : 7;
+  unsigned NumBytesToErase;
 
 public:
   static const unsigned MaxNumBytesToErase = 127;
@@ -701,8 +701,8 @@ private:
   StringRef ModuleName;
   StringRef BriefDocComment;
   ArrayRef<StringRef> AssociatedUSRs;
-  ExpectedTypeRelation TypeDistance : 3;
-  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
+  ExpectedTypeRelation TypeDistance;
+  CodeCompletionDiagnosticSeverity DiagnosticSeverity;
   StringRef DiagnosticMessage;
 
   // Assertions for limiting max values of enums.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -590,7 +590,7 @@ void CodeCompletionResult::printPrefix(raw_ostream &OS) const {
     PRINT_FLAIR(ExpressionAtNonScriptOrMainFileScope, "ExprAtFileScope")
     Prefix.append("]");
   }
-  if (NotRecommended)
+  if (NotRecommended != NotRecommendedReason::None)
     Prefix.append("/NotRecommended");
   if (IsSystem)
     Prefix.append("/IsSystem");

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -24,7 +24,7 @@ class Expr;
 class ValueDecl;
 
 namespace ide {
-enum class SemanticContextKind;
+enum class SemanticContextKind : uint8_t;
 
 /// Type check parent contexts of the given decl context, and the body of the
 /// given context until \c Loc if the context is a function body.

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -57,7 +57,7 @@ namespace ide {
   class CompletionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
-  enum class CodeCompletionDeclKind;
+  enum class CodeCompletionDeclKind : uint8_t;
   enum class SyntaxNodeKind : uint8_t;
   enum class SyntaxStructureKind : uint8_t;
   enum class SyntaxStructureElementKind : uint8_t;


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/40163

---

I saw performance improvements in SwiftSyntax when not packing bitfields. Let’s see if it has a performance impact on code completion as well.