### PR TITLE
tests: fix the immortal-arc-elimination.swift test

### DIFF
--- a/test/SILOptimizer/immortal-arc-elimination.swift
+++ b/test/SILOptimizer/immortal-arc-elimination.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts -module-name=test -O -target %target-cpu-apple-macos10.14 -emit-sil | %FileCheck --check-prefix=CHECK-SWIFT4x %s
-// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts -module-name=test -O -target %target-cpu-apple-macos10.15 -emit-sil | %FileCheck --check-prefix=CHECK-SWIFT50 %s
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts -module-name=test -O -target %target-cpu-apple-macos10.15 -emit-sil | %FileCheck %s
 
 // RUN: %empty-directory(%t) 
 // RUN: %target-build-swift -O -Xllvm -sil-disable-pass=function-signature-opts -module-name=test %s -o %t/a.out
@@ -12,30 +11,20 @@
 // Check that the optimizer can remove "unbalanced" retains for immortal objects.
 // But only with a Swift 5.1 runtime (which supports immortal objects).
 
-// CHECK-SWIFT4x-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
-// CHECK-SWIFT4x:   global_addr
-// CHECK-SWIFT4x:   retain
-// CHECK-SWIFT4x: } // end sil function '$s4test10emptyArraySaySiGyF'
-
-// CHECK-SWIFT50-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
-// CHECK-SWIFT50:       global_addr
-// CHECK-SWIFT50-NOT:   retain
-// CHECK-SWIFT50: } // end sil function '$s4test10emptyArraySaySiGyF'
+// CHECK-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
+// CHECK:       global_addr
+// CHECK-NOT:   retain
+// CHECK: } // end sil function '$s4test10emptyArraySaySiGyF'
 @inline(never)
 func emptyArray() -> [Int] {
   let x = [Int]()
   return x
 }
 
-// CHECK-SWIFT4x-LABEL: sil hidden [noinline] @$s4test13constantArraySaySiGyF
-// CHECK-SWIFT4x:   global_value
-// CHECK-SWIFT4x:   retain
-// CHECK-SWIFT4x: } // end sil function '$s4test13constantArraySaySiGyF'
-
-// CHECK-SWIFT50-LABEL: sil hidden [noinline] @$s4test13constantArraySaySiGyF
-// CHECK-SWIFT50:       global_value
-// CHECK-SWIFT50-NOT:   retain
-// CHECK-SWIFT50: } // end sil function '$s4test13constantArraySaySiGyF'
+// CHECK-LABEL: sil hidden [noinline] @$s4test13constantArraySaySiGyF
+// CHECK:       global_value
+// CHECK-NOT:   retain
+// CHECK: } // end sil function '$s4test13constantArraySaySiGyF'
 @inline(never)
 func constantArray() -> [Int] {
   return [1, 2, 3]

--- a/test/SILOptimizer/no-immortal-arc-elimination.swift
+++ b/test/SILOptimizer/no-immortal-arc-elimination.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=function-signature-opts -module-name=test -O -target %target-cpu-apple-macos10.14 -emit-sil | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: libswift
+
+// Check that the optimizer does not remove "unbalanced" retains for immortal objects
+// prior to a Swift 5.1 runtime (which does not support immortal objects).
+
+// CHECK-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
+// CHECK:   global_addr
+// CHECK:   retain
+// CHECK: } // end sil function '$s4test10emptyArraySaySiGyF'
+@inline(never)
+func emptyArray() -> [Int] {
+  let x = [Int]()
+  return x
+}
+
+// CHECK-LABEL: sil hidden [noinline] @$s4test13constantArraySaySiGyF
+// CHECK:   global_value
+// CHECK:   retain
+// CHECK: } // end sil function '$s4test13constantArraySaySiGyF'
+@inline(never)
+func constantArray() -> [Int] {
+  return [1, 2, 3]
+}
+


### PR DESCRIPTION
The negative test, which requires that the optimization is not done with an old swift runtime, must run on macos/x86_64.
Other platforms don't necessarily have old runtimes.

rdar://85519651
