### PR TITLE
[DO NOT MERGE] Test, workaround for compiler crash

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9735,7 +9735,7 @@ static void loadAllMembersOfRecordDecl(StructDecl *recordDecl) {
       continue;
 
     for (auto found : recordDecl->lookupDirect(name)) {
-      if (addedMembers.insert(found).second)
+      if (addedMembers.insert(found).second && found->getDeclContext() == recordDecl)
         recordDecl->addMember(found);
     }
   }

--- a/test/ClangImporter/struct_extension_same_name.swift
+++ b/test/ClangImporter/struct_extension_same_name.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -c %clang-importer-sdk -enable-objc-interop %s
+
+import CoreGraphics
+
+extension CGSize {
+    public static func width(_ value: CGFloat) -> CGSize {
+        return CGSize(width: value, height: 0)
+    }
+}


### PR DESCRIPTION
When trying to compile https://github.com/roberthein/TinyConstraints
with a recent main checkout, there is crash which seems related to the
changes in #38675 and #39664.

The crash was reduced to a test case (included in this PR) in which
a C struct is extended with static function with the same name as one of
the struct fields. If the name is different, the crash does not
reproduce.

The PR also includes a possible fix derived from a check which was added
in #39664 but removed in #38675. Reintroducing the check removes the
problem, and as far as my testing can check, it doesn't create new
problems in the test suite.

The crash in main is the following:

```
Assertion failed: (prevEnd.isValid() && "Only implicit decls can have invalid source location"), function operator(), file DeclContext.cpp, line 884.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
Stack dump:
0.	Program arguments: /Users/danielrodriguez/code/swift-source/build/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swift-frontend -target x86_64-apple-macosx10.9 -module-cache-path /Users/danielrodriguez/code/swift-source/build/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache -sdk /Applications/Xcode_13.1.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk -swift-version 4 -define-availability "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -define-availability "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2" -define-availability "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0" -define-availability "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4" -define-availability "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0" -define-availability "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5" -define-availability "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0" -define-availability "SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -typo-correction-limit 10 -c -enable-source-import -sdk /Users/danielrodriguez/code/swift-source/swift/test/Inputs/clang-importer-sdk -I /Users/danielrodriguez/code/swift-source/swift/test/Inputs/clang-importer-sdk/swift-modules -enable-objc-interop /Users/danielrodriguez/code/swift-source/swift/test/ClangImporter/struct_extension_same_name.swift
1.	Swift version 5.6-dev (LLVM 27222cde774bd6b, Swift 861da8719217076)
2.	Compiling with effective version 4.1.50
3.	While evaluating request ASTLoweringRequest(Lowering AST to SIL for module struct_extension_same_name)
4.	While evaluating request StoredPropertiesRequest(CoreGraphics.(file).CGSize)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x00000001064d44d7 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 39
1  swift-frontend           0x00000001064d33f8 llvm::sys::RunSignalHandlers() + 248
2  swift-frontend           0x00000001064d4b20 SignalHandler(int) + 288
3  libsystem_platform.dylib 0x00007fff2045ed7d _sigtramp + 29
4  libsystem_platform.dylib 000000000000000000 _sigtramp + 18446603339974709920
5  libsystem_c.dylib        0x00007fff2036e406 abort + 125
6  libsystem_c.dylib        0x00007fff2036d7d8 err + 0
7  swift-frontend           0x0000000106a03bd3 swift::IterableDeclContext::addMemberSilently(swift::Decl*, swift::Decl*, bool) const::$_1::operator()(swift::Decl*, swift::Decl*) const (.cold.3) + 35
8  swift-frontend           0x00000001027cff14 swift::IterableDeclContext::addMemberSilently(swift::Decl*, swift::Decl*, bool) const::$_1::operator()(swift::Decl*, swift::Decl*) const + 372
9  swift-frontend           0x00000001027cfd4d swift::IterableDeclContext::addMemberSilently(swift::Decl*, swift::Decl*, bool) const + 221
10 swift-frontend           0x00000001027cfbf2 swift::IterableDeclContext::addMember(swift::Decl*, swift::Decl*, bool) + 18
11 swift-frontend           0x00000001025a8516 swift::ClangImporter::Implementation::loadAllMembers(swift::Decl*, unsigned long long) + 1254
12 swift-frontend           0x00000001027cf4a2 swift::IterableDeclContext::loadAllMembers() const + 354
13 swift-frontend           0x00000001027cf32e swift::IterableDeclContext::getMembers() const + 14
14 swift-frontend           0x00000001024b252c swift::StoredPropertiesRequest::evaluate(swift::Evaluator&, swift::NominalTypeDecl*) const + 172
15 swift-frontend           0x0000000102748e5e llvm::Expected<swift::StoredPropertiesRequest::OutputType> swift::Evaluator::getResultUncached<swift::StoredPropertiesRequest>(swift::StoredPropertiesRequest const&) + 414
16 swift-frontend           0x0000000102748b3a llvm::Expected<swift::StoredPropertiesRequest::OutputType> swift::Evaluator::getResultCached<swift::StoredPropertiesRequest, (void*)0>(swift::StoredPropertiesRequest const&) + 426
17 swift-frontend           0x0000000102704988 swift::StoredPropertiesRequest::OutputType swift::evaluateOrDefault<swift::StoredPropertiesRequest>(swift::Evaluator&, swift::StoredPropertiesRequest, swift::StoredPropertiesRequest::OutputType) + 40
18 swift-frontend           0x0000000101883258 (anonymous namespace)::LowerType::visitAnyStructType(swift::CanType, swift::Lowering::AbstractionPattern, swift::StructDecl*, swift::Lowering::IsTypeExpansionSensitive_t) + 184
19 swift-frontend           0x0000000101874b67 swift::CanTypeVisitor<(anonymous namespace)::LowerType, swift::Lowering::TypeLowering*, swift::Lowering::AbstractionPattern, swift::Lowering::IsTypeExpansionSensitive_t>::visit(swift::CanType, swift::Lowering::AbstractionPattern, swift::Lowering::IsTypeExpansionSensitive_t) + 2455
20 swift-frontend           0x0000000101873fd4 swift::Lowering::TypeConverter::getTypeLowering(swift::Lowering::AbstractionPattern, swift::Type, swift::TypeExpansionContext) + 820
21 swift-frontend           0x00000001017f6513 (anonymous namespace)::DestructureResults::destructure(swift::Lowering::AbstractionPattern, swift::CanType) + 307
22 swift-frontend           0x00000001017f4eb0 getSILFunctionType(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::SILExtInfoBuilder, (anonymous namespace)::Conventions const&, swift::ForeignInfo const&, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SubstitutionMap>, swift::ProtocolConformanceRef, llvm::Optional<llvm::SmallBitVector>) + 4064
23 swift-frontend           0x00000001017f3e3d getNativeSILFunctionType(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::SILExtInfoBuilder, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SubstitutionMap>, swift::ProtocolConformanceRef, llvm::Optional<llvm::SmallBitVector>)::$_12::operator()((anonymous namespace)::Conventions const&) const + 637
24 swift-frontend           0x00000001017ec53b getNativeSILFunctionType(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::Lowering::AbstractionPattern, swift::CanTypeWrapper<swift::AnyFunctionType>, swift::SILExtInfoBuilder, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SILDeclRef>, llvm::Optional<swift::SubstitutionMap>, swift::ProtocolConformanceRef, llvm::Optional<llvm::SmallBitVector>) + 587
25 swift-frontend           0x00000001017ede8f getUncachedSILFunctionTypeForConstant(swift::Lowering::TypeConverter&, swift::TypeExpansionContext, swift::SILDeclRef, swift::Lowering::TypeConverter::LoweredFormalTypes) + 2623
26 swift-frontend           0x00000001017ee88c swift::Lowering::TypeConverter::getConstantInfo(swift::TypeExpansionContext, swift::SILDeclRef) + 204
27 swift-frontend           0x00000001017e557f swift::SILFunctionBuilder::getOrCreateFunction(swift::SILLocation, swift::SILDeclRef, swift::ForDefinition_t, llvm::function_ref<swift::SILFunction* (swift::SILLocation, swift::SILDeclRef)>, swift::ProfileCounter) + 143
28 swift-frontend           0x0000000101c74a58 swift::Lowering::SILGenModule::getFunction(swift::SILDeclRef, swift::ForDefinition_t) + 360
29 swift-frontend           0x0000000101c78d1c emitOrDelayFunction(swift::Lowering::SILGenModule&, swift::SILDeclRef, bool) + 380
30 swift-frontend           0x0000000101c7526c swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) + 124
31 swift-frontend           0x0000000101d577b7 SILGenExtension::visitFuncDecl(swift::FuncDecl*) + 135
32 swift-frontend           0x0000000101d53c3d SILGenExtension::emitExtension(swift::ExtensionDecl*) + 77
33 swift-frontend           0x0000000101d53be5 swift::Lowering::SILGenModule::visitExtensionDecl(swift::ExtensionDecl*) + 21
34 swift-frontend           0x0000000101c7b2b4 swift::ASTLoweringRequest::evaluate(swift::Evaluator&, swift::ASTLoweringDescriptor) const + 1924
35 swift-frontend           0x0000000101d444a8 swift::SimpleRequest<swift::ASTLoweringRequest, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> > (swift::ASTLoweringDescriptor), (swift::RequestFlags)9>::evaluateRequest(swift::ASTLoweringRequest const&, swift::Evaluator&) + 120
36 swift-frontend           0x0000000101c7f6a9 llvm::Expected<swift::ASTLoweringRequest::OutputType> swift::Evaluator::getResultUncached<swift::ASTLoweringRequest>(swift::ASTLoweringRequest const&) + 393
37 swift-frontend           0x0000000101c7c0da swift::performASTLowering(swift::ModuleDecl*, swift::Lowering::TypeConverter&, swift::SILOptions const&) + 154
38 swift-frontend           0x0000000101629fed performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 2141
39 swift-frontend           0x000000010161f3fb swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3643
40 swift-frontend           0x00000001015e8d77 swift::mainEntry(int, char const**) + 503
41 libdyld.dylib            0x00007fff20434f3d start + 1
42 libdyld.dylib            0x0000000000000023 start + 18446603339974881511
```

In a different internal branch the assert against TinyConstraints was a little bit different, but it was what gave me the initial clue:

```
swift-frontend: …swift/lib/AST/DeclContext.cpp:852: void swift::IterableDeclContext::addMemberSilently(swift::Decl *, swift::Decl *, bool) const: Assertion `!member->NextDecl && "Already added to a container"' failed.
``` 

@zoecarver this might be interesting for you to look at, since you are the author of the original code.

/cc @NuriAmari @rmaz 