### PR TITLE
[gardening] Add "&" to eliminate warning.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -181,7 +181,7 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
       if (fn->isAsync() || fn->isSendable() || fn->hasGlobalActor())
         return true;
 
-      for (const auto param: fn->getParams()) {
+      for (const auto &param : fn->getParams()) {
         if (param.isIsolated())
           return true;
       }


### PR DESCRIPTION
For when the tree opens again.