### PR TITLE
Fix crash when generating IR for a dependent objc generic.

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -788,6 +788,10 @@ clang::QualType ClangTypeConverter::visitArchetypeType(ArchetypeType *type) {
   return getClangIdType(ClangASTContext);
 }
 
+clang::QualType ClangTypeConverter::visitDependentMemberType(DependentMemberType *type) {
+  return convert(type->getBase());
+}
+
 clang::QualType ClangTypeConverter::visitDynamicSelfType(DynamicSelfType *type) {
   // Dynamic Self is equivalent to 'instancetype', which is treated as
   // 'id' within the Objective-C type system.

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -126,6 +126,7 @@ private:
   clang::QualType visitBuiltinIntegerType(BuiltinIntegerType *type);
   clang::QualType visitBuiltinFloatType(BuiltinFloatType *type);
   clang::QualType visitArchetypeType(ArchetypeType *type);
+  clang::QualType visitDependentMemberType(DependentMemberType *type);
   clang::QualType visitSILFunctionType(SILFunctionType *type);
   clang::QualType visitGenericTypeParamType(GenericTypeParamType *type);
   clang::QualType visitDynamicSelfType(DynamicSelfType *type);

--- a/test/IRGen/Inputs/objc_dependent_type_closure_argument.h
+++ b/test/IRGen/Inputs/objc_dependent_type_closure_argument.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjCClass<V> : NSObject
+
+- (void)barWithBlock:(nullable void (^)(V _Nullable))block;
+
+@end

--- a/test/IRGen/objc_dependent_type_closure_argument.swift
+++ b/test/IRGen/objc_dependent_type_closure_argument.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir -primary-file %s -enable-objc-interop -import-objc-header %S/Inputs/objc_dependent_type_closure_argument.h
+
+// Regression test for https://github.com/apple/swift/pull/40295
+public protocol SwiftProtocol {
+  associatedtype T: AnyObject
+}
+
+public class SwiftClass<S: SwiftProtocol> {
+  static func foo(objcClass: ObjCClass<S.T>) {
+    objcClass.bar(block: { _ in })
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a crash bug when:
1) Swift code calls an ObjC method in a generic object.
2) The ObjC method has a block argument with the ObjC generic type as its own argument.
3) The ObjC generic type is constrained to equal an associated type of a protocol.

See this minimal example:
```swift
public protocol SwiftProtocol {
  associatedtype T: AnyObject
}

public class SwiftClass<S: SwiftProtocol> {
  static func foo(objcClass: ObjCClass<S.T>) {
    objcClass.bar(block: { _ in })
  }
}
```

```objc
@interface ObjCClass<V> : NSObject

- (void)barWithBlock:(nullable void (^)(V _Nullable))block;

@end
```

I hope the solution makes sense, if not I'd be happy to adapt the PR.
In addition I'd like to add this example as a test, but I'm really unsure where.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
