### PR TITLE
SIL: support non-clang compilers again

### DIFF
--- a/include/swift/SIL/BridgedSwiftObject.h
+++ b/include/swift/SIL/BridgedSwiftObject.h
@@ -20,6 +20,10 @@
 
 #include <stdint.h>
 
+#if !defined(__has_feature)
+#define __has_feature(feature) 0
+#endif
+
 // TODO: These macro definitions are duplicated in Visibility.h. Move
 // them to a single file if we find a location that both Visibility.h and
 // BridgedSwiftObject.h can import.


### PR DESCRIPTION
The toolchain has traditionally been buildable with clang, cl (MSVC),
and gcc.  `__has_feature` is a clang-specific directive, ensure that we
are portable to other compilers by providing a definition of the macro
incase it is not available (which also includes older clang releases).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
