### PR TITLE
libswift: replace use of `std::string` with `char *`

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -15,7 +15,6 @@
 
 #include "BridgedSwiftObject.h"
 #include <stddef.h>
-#include <string>
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -161,19 +160,19 @@ BridgedSlab PassContext_freeSlab(BridgedPassContext passContext,
                                  BridgedSlab slab);
 
 BridgedStringRef SILFunction_getName(BridgedFunction function);
-std::string SILFunction_debugDescription(BridgedFunction function);
+char * _Nonnull SILFunction_debugDescription(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_lastBlock(BridgedFunction function);
 SwiftInt SILFunction_numIndirectResultArguments(BridgedFunction function);
 SwiftInt SILFunction_getSelfArgumentIndex(BridgedFunction function);
 
 BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global);
-std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global);
+char * _Nonnull SILGlobalVariable_debugDescription(BridgedGlobalVar global);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
 OptionalBridgedBasicBlock SILBasicBlock_previous(BridgedBasicBlock block);
 BridgedFunction SILBasicBlock_getFunction(BridgedBasicBlock block);
-std::string SILBasicBlock_debugDescription(BridgedBasicBlock block);
+char * _Nonnull SILBasicBlock_debugDescription(BridgedBasicBlock block);
 OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block);
 OptionalBridgedInstruction SILBasicBlock_lastInst(BridgedBasicBlock block);
 SwiftInt SILBasicBlock_getNumArguments(BridgedBasicBlock block);
@@ -188,7 +187,7 @@ OptionalBridgedOperand Operand_nextUse(BridgedOperand);
 BridgedInstruction Operand_getUser(BridgedOperand);
 SwiftInt Operand_isTypeDependent(BridgedOperand);
 
-std::string SILNode_debugDescription(BridgedNode node);
+char * _Nonnull SILNode_debugDescription(BridgedNode node);
 OptionalBridgedOperand SILValue_firstUse(BridgedValue value);
 BridgedType SILValue_getType(BridgedValue value);
 

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -165,12 +165,12 @@ BridgedStringRef SILFunction_getName(BridgedFunction function) {
   return getBridgedStringRef(castToFunction(function)->getName());
 }
 
-std::string SILFunction_debugDescription(BridgedFunction function) {
+char *SILFunction_debugDescription(BridgedFunction function) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToFunction(function)->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return strdup(str.c_str());
 }
 
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function) {
@@ -226,12 +226,12 @@ BridgedFunction SILBasicBlock_getFunction(BridgedBasicBlock block) {
   return {castToBasicBlock(block)->getParent()};
 }
 
-std::string SILBasicBlock_debugDescription(BridgedBasicBlock block) {
+char *SILBasicBlock_debugDescription(BridgedBasicBlock block) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToBasicBlock(block)->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return strdup(str.c_str());
 }
 
 OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block) {
@@ -291,12 +291,12 @@ BridgedBasicBlock SILArgument_getParent(BridgedArgument argument) {
 static_assert(BridgedOperandSize == sizeof(Operand),
               "wrong bridged Operand size");
 
-std::string SILNode_debugDescription(BridgedNode node) {
+char *SILNode_debugDescription(BridgedNode node) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToSILNode(node)->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return strdup(str.c_str());
 }
 
 static Operand *castToOperand(BridgedOperand operand) {
@@ -347,12 +347,12 @@ BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global) {
   return getBridgedStringRef(castToGlobal(global)->getName());
 }
 
-std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
+char *SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToGlobal(global)->print(os);
   str.pop_back(); // Remove trailing newline.
-  return str;
+  return strdup(str.c_str());
 }
 
 //===----------------------------------------------------------------------===//

--- a/libswift/Sources/SIL/BasicBlock.swift
+++ b/libswift/Sources/SIL/BasicBlock.swift
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import SILBridging
+#if os(Windows)
+@_implementationOnly import func ucrt.free
+#elseif os(Linux)
+@_implementationOnly import func Glibc.free
+#else
+@_implementationOnly import func Darwin.free
+#endif
 
 final public class BasicBlock : ListNode, CustomStringConvertible {
   public var next: BasicBlock? { SILBasicBlock_next(bridged).block }
@@ -19,8 +26,9 @@ final public class BasicBlock : ListNode, CustomStringConvertible {
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    var s = SILBasicBlock_debugDescription(bridged)
-    return String(cString: s.c_str())
+    let buffer = SILBasicBlock_debugDescription(bridged)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
 
   public var arguments: ArgumentArray { ArgumentArray(block: self) }

--- a/libswift/Sources/SIL/Function.swift
+++ b/libswift/Sources/SIL/Function.swift
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import SILBridging
+#if os(Windows)
+@_implementationOnly import func ucrt.free
+#elseif os(Linux)
+@_implementationOnly import func Glibc.free
+#else
+@_implementationOnly import func Darwin.free
+#endif
 
 final public class Function : CustomStringConvertible {
   public var name: String {
@@ -18,8 +25,9 @@ final public class Function : CustomStringConvertible {
   }
 
   final public var description: String {
-    var s = SILFunction_debugDescription(bridged)
-    return String(cString: s.c_str())
+    let buffer = SILFunction_debugDescription(bridged)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
 
   public var entryBlock: BasicBlock {

--- a/libswift/Sources/SIL/GlobalVariable.swift
+++ b/libswift/Sources/SIL/GlobalVariable.swift
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import SILBridging
+#if os(Windows)
+@_implementationOnly import func ucrt.free
+#elseif os(Linux)
+@_implementationOnly import func Glibc.free
+#else
+@_implementationOnly import func Darwin.free
+#endif
 
 final public class GlobalVariable : CustomStringConvertible {
   public var name: String {
@@ -18,8 +25,9 @@ final public class GlobalVariable : CustomStringConvertible {
   }
 
   public var description: String {
-    var s = SILGlobalVariable_debugDescription(bridged)
-    return String(cString: s.c_str())
+    let buffer = SILGlobalVariable_debugDescription(bridged)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
 
   // TODO: initializer instructions

--- a/libswift/Sources/SIL/Instruction.swift
+++ b/libswift/Sources/SIL/Instruction.swift
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import SILBridging
+#if os(Windows)
+@_implementationOnly import func ucrt.free
+#elseif os(Linux)
+@_implementationOnly import func Glibc.free
+#else
+@_implementationOnly import func Darwin.free
+#endif
 
 //===----------------------------------------------------------------------===//
 //                       Instruction base classes
@@ -30,10 +37,11 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   }
 
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    let buffer = SILNode_debugDescription(bridgedNode)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
-  
+
   final public var operands: OperandArray {
     return OperandArray(opArray: SILInstruction_getOperands(bridged))
   }
@@ -124,8 +132,9 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    let buffer = SILNode_debugDescription(bridgedNode)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
 
   public var instruction: Instruction {

--- a/libswift/Sources/SIL/Value.swift
+++ b/libswift/Sources/SIL/Value.swift
@@ -11,6 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import SILBridging
+#if os(Windows)
+@_implementationOnly import func ucrt.free
+#elseif os(Linux)
+@_implementationOnly import func Glibc.free
+#else
+@_implementationOnly import func Darwin.free
+#endif
 
 public protocol Value : AnyObject, CustomStringConvertible {
   var uses: UseList { get }
@@ -20,8 +27,9 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
 extension Value {
   public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    let buffer = SILNode_debugDescription(bridgedNode)
+    defer { free(buffer) }
+    return String(cString: buffer)
   }
 
   public var uses: UseList {


### PR DESCRIPTION
This replaces the use of C++ interop with C bindings for the string
bridging.  This change ensures that the interop can be used on all
platforms, including those where the ABI concerns with C++ have not yet
been addressed.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
