### PR TITLE
[android] Do not pick a linker when testing anymore, as the NDK only uses lld now

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1527,7 +1527,6 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-sdk', config.variant_sdk, '-Xclang-linker',
         '--target={}{}'.format(config.variant_triple, config.android_api_level),
         '-tools-directory', tools_directory,
-        '-use-ld=%s' % config.android_linker_name,
         config.resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
@@ -1575,7 +1574,6 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '--target={}{}'.format(config.variant_triple, config.android_api_level),
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt,
-        '-use-ld=%s' % config.android_linker_name,
         config.swift_driver_test_options])
     config.target_swift_modulewrap = ' '.join([
         config.swiftc, '-modulewrap',

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -42,7 +42,6 @@ config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
 
 # --- android ---
-config.android_linker_name = "lld"
 config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_api_level = "@SWIFT_ANDROID_API_LEVEL@"
 

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -36,7 +36,6 @@ config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 config.darwin_xcrun_toolchain = "@SWIFT_DARWIN_XCRUN_TOOLCHAIN@"
 
 # --- Android Configuration ---
-config.android_linker_name = "lld"
 config.android_ndk_path = "@SWIFT_ANDROID_NDK_PATH@"
 config.android_api_level = "@SWIFT_ANDROID_API_LEVEL@"
 


### PR DESCRIPTION
@drodriguez, I just noticed that this is superfluous, should have removed these in #39921.