### PR TITLE
gardening: make c++98-compat-extra-semi an error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,12 @@ if(CMAKE_C_COMPILER_ID MATCHES Clang)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
 endif()
 
+# Make some warnings errors as they are commonly occurring and flood the build
+# with unnecessary noise.
+if(CMAKE_C_COMPILER_ID MATCHES Clang)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=c++98-compat-extra-semi>)
+endif()
+
 # Use dispatch as the system scheduler by default.
 # For convenience, we set this to false when concurrency is disabled.
 set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -221,7 +221,7 @@ convertRepresentation(FunctionTypeRepresentation rep) {
     return SILFunctionTypeRepresentation::CFunctionPointer;
   }
   llvm_unreachable("Unhandled FunctionTypeRepresentation!");
-};
+}
 
 inline Optional<FunctionTypeRepresentation>
 convertRepresentation(SILFunctionTypeRepresentation rep) {
@@ -241,7 +241,7 @@ convertRepresentation(SILFunctionTypeRepresentation rep) {
     return None;
   }
   llvm_unreachable("Unhandled SILFunctionTypeRepresentation!");
-};
+}
 
 /// Can this calling convention result in a function being called indirectly
 /// through the runtime.

--- a/include/swift/AST/IRGenRequests.h
+++ b/include/swift/AST/IRGenRequests.h
@@ -35,13 +35,13 @@ class TBDGenDescriptor;
 
 namespace irgen {
   class IRGenModule;
-};
+}
 
 namespace Lowering {
   class TypeConverter;
-};
+}
 
-}; // namespace swift
+} // namespace swift
 
 namespace llvm {
 class GlobalVariable;
@@ -51,9 +51,9 @@ class TargetMachine;
 
 namespace orc {
 class ThreadSafeModule;
-}; // namespace orc
+} // namespace orc
 
-}; // namespace llvm
+} // namespace llvm
 
 namespace swift {
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1396,7 +1396,7 @@ inline void simple_display(llvm::raw_ostream &out, Stmt *S) {
     out << Stmt::getKindName(S->getKind());
   else
     out << "(null)";
-};
+}
 
 } // end namespace swift
 

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -123,7 +123,7 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::SILFunctionType,
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::Stmt, swift::StmtAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::BraceStmt, swift::StmtAlignInBits)
 
-LLVM_DECLARE_TYPE_ALIGNMENT(swift::ASTContext, swift::ASTContextAlignInBits);
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::ASTContext, swift::ASTContextAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::DeclContext, swift::DeclContextAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::FileUnit, swift::DeclContextAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::DifferentiableAttr, swift::PointerAlignInBits)
@@ -152,7 +152,7 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::AttributeBase, swift::AttrAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeRepr, swift::TypeReprAlignInBits)
 
-LLVM_DECLARE_TYPE_ALIGNMENT(swift::CaseLabelItem, swift::PatternAlignInBits);
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::CaseLabelItem, swift::PatternAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1407,7 +1407,7 @@ public:
     return T->getKind() == TypeKind::BuiltinRawPointer;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinRawPointerType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinRawPointerType, BuiltinType)
 
 /// BuiltinRawContinuationType - The builtin raw unsafe continuation type.
 /// In C, this is a non-null AsyncTask*.  This pointer is completely
@@ -1422,7 +1422,7 @@ public:
     return T->getKind() == TypeKind::BuiltinRawUnsafeContinuation;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinRawUnsafeContinuationType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinRawUnsafeContinuationType, BuiltinType)
 
 /// BuiltinExecutorType - The builtin executor-ref type.  In C, this
 /// is the ExecutorRef struct type.
@@ -1435,7 +1435,7 @@ public:
     return T->getKind() == TypeKind::BuiltinExecutor;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinExecutorType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinExecutorType, BuiltinType)
 
 /// BuiltinJobType - The builtin job type.  In C, this is a
 /// non-null Job*.  This pointer is completely unmanaged (the unscheduled
@@ -1449,7 +1449,7 @@ public:
     return T->getKind() == TypeKind::BuiltinJob;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinJobType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinJobType, BuiltinType)
 
 /// BuiltinDefaultActorStorageType - The type of the stored property
 /// that's added implicitly to default actors.  No C equivalent because
@@ -1465,7 +1465,7 @@ public:
     return T->getKind() == TypeKind::BuiltinDefaultActorStorage;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinDefaultActorStorageType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinDefaultActorStorageType, BuiltinType)
 
 /// BuiltinNativeObjectType - The builtin opaque object-pointer type.
 /// Useful for keeping an object alive when it is otherwise being
@@ -1479,7 +1479,7 @@ public:
     return T->getKind() == TypeKind::BuiltinNativeObject;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinNativeObjectType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinNativeObjectType, BuiltinType)
 
 /// A type that contains an owning reference to a heap object packed with
 /// additional bits. The type uses a bit to discriminate native Swift objects
@@ -1493,7 +1493,7 @@ public:
     return T->getKind() == TypeKind::BuiltinBridgeObject;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinBridgeObjectType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinBridgeObjectType, BuiltinType)
 
 /// BuiltinUnsafeValueBufferType - The builtin opaque fixed-size value
 /// buffer type, into which storage for an arbitrary value can be
@@ -1512,7 +1512,7 @@ public:
     return T->getKind() == TypeKind::BuiltinUnsafeValueBuffer;
   }
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinUnsafeValueBufferType, BuiltinType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinUnsafeValueBufferType, BuiltinType)
 
 /// A builtin vector type.
 class BuiltinVectorType : public BuiltinType, public llvm::FoldingSetNode {
@@ -1743,7 +1743,7 @@ public:
 
   BuiltinIntegerWidth getWidth() const = delete;
 };
-DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinIntegerLiteralType, AnyBuiltinIntegerType);
+DEFINE_EMPTY_CAN_TYPE_WRAPPER(BuiltinIntegerLiteralType, AnyBuiltinIntegerType)
 
 inline BuiltinIntegerWidth AnyBuiltinIntegerType::getWidth() const {
   if (auto intTy = dyn_cast<BuiltinIntegerType>(this)) {
@@ -4096,7 +4096,7 @@ substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef ref, Type origType,
                                     TypeExpansionContext context);
 namespace Lowering {
   class TypeConverter;
-};
+}
 
 /// SILFunctionType - The lowered type of a function value, suitable
 /// for use by SIL.

--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -24,7 +24,7 @@ namespace llvm {
 namespace yaml {
 class IO;
 }
-}; // namespace llvm
+} // namespace llvm
 
 namespace swift {
 
@@ -118,7 +118,7 @@ private:
 };
 
 void simple_display(llvm::raw_ostream &out, const Fingerprint &fp);
-}; // namespace swift
+} // namespace swift
 
 namespace swift {
 
@@ -134,11 +134,11 @@ template <> struct StableHasher::Combiner<Fingerprint> {
   }
 };
 
-}; // namespace swift
+} // namespace swift
 
 namespace llvm {
 class raw_ostream;
 raw_ostream &operator<<(raw_ostream &OS, const swift::Fingerprint &fp);
-}; // namespace llvm
+} // namespace llvm
 
 #endif // SWIFT_BASIC_FINGERPRINT_H

--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -60,6 +60,6 @@ size_t _swift_indexToSize(size_t idx);
 SWIFT_RUNTIME_EXPORT
 void _swift_zone_init(void);
 
-};
+}
 
 #endif

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -178,7 +178,7 @@ SDKNodeDeclImport::SDKNodeDeclImport(SDKNodeInitInfo Info):
   SDKNodeDecl(Info, SDKNodeKind::DeclImport) {}
 
 SDKNodeDeclAssociatedType::SDKNodeDeclAssociatedType(SDKNodeInitInfo Info):
-  SDKNodeDecl(Info, SDKNodeKind::DeclAssociatedType) {};
+  SDKNodeDecl(Info, SDKNodeKind::DeclAssociatedType) {}
 
 SDKNodeDeclSubscript::SDKNodeDeclSubscript(SDKNodeInitInfo Info):
   SDKNodeDeclAbstractFunc(Info, SDKNodeKind::DeclSubscript),

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1742,7 +1742,7 @@ namespace {
   static StringRef
   pathStringFromFrameworkSearchPath(const SearchPathOptions::FrameworkSearchPath &next) {
     return next.Path;
-  };
+  }
 }
 
 std::vector<std::string> ASTContext::getDarwinImplicitFrameworkSearchPaths()

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1727,7 +1727,7 @@ static char getParamConvention(ParameterConvention conv) {
     case ParameterConvention::Direct_Guaranteed: return 'g';
   }
   llvm_unreachable("bad parameter convention");
-};
+}
 
 static Optional<char>
 getParamDifferentiability(SILParameterDifferentiability diffKind) {
@@ -1738,7 +1738,7 @@ getParamDifferentiability(SILParameterDifferentiability diffKind) {
     return 'w';
   }
   llvm_unreachable("bad parameter differentiability");
-};
+}
 
 static char getResultConvention(ResultConvention conv) {
   switch (conv) {
@@ -1749,7 +1749,7 @@ static char getResultConvention(ResultConvention conv) {
     case ResultConvention::Autoreleased: return 'a';
   }
   llvm_unreachable("bad result convention");
-};
+}
 
 static Optional<char>
 getResultDifferentiability(SILResultDifferentiability diffKind) {
@@ -1760,7 +1760,7 @@ getResultDifferentiability(SILResultDifferentiability diffKind) {
     return 'w';
   }
   llvm_unreachable("bad result differentiability");
-};
+}
 
 void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
                                         GenericSignature outerGenericSig) {

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -163,8 +163,8 @@ void AccessNote::dump(llvm::raw_ostream &os, int indent) const {
 
 }
 
-LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::AccessNoteDeclName, QuotingType::Single);
-LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::ObjCSelector, QuotingType::Single);
+LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::AccessNoteDeclName, QuotingType::Single)
+LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::ObjCSelector, QuotingType::Single)
 LLVM_YAML_IS_SEQUENCE_VECTOR(swift::AccessNote)
 LLVM_YAML_DECLARE_MAPPING_TRAITS(swift::AccessNotesFile)
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4182,7 +4182,7 @@ static AssociatedTypeDecl *getAssociatedTypeAnchor(
 
   return bestAnchor;
 }
-};
+}
 
 AssociatedTypeDecl *AssociatedTypeDecl::getAssociatedTypeAnchor() const {
   llvm::SmallSet<const AssociatedTypeDecl *, 8> searched;

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -309,7 +309,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
   auto result = allocateArray(ctx, accessPaths);
   ShadowCache[key] = result;
   return result;
-};
+}
 
 ArrayRef<ImportedModule>
 swift::namelookup::getAllImports(const DeclContext *dc) {

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -343,7 +343,7 @@ bool RewriteStep::isInverseOf(const RewriteStep &other) const {
 
   assert(EndOffset == other.EndOffset && "Bad whiskering?");
   return true;
-};
+}
 
 bool RewriteStep::maybeSwapRewriteSteps(RewriteStep &other,
                                         const RewriteSystem &system) {

--- a/lib/Basic/PrefixMap.cpp
+++ b/lib/Basic/PrefixMap.cpp
@@ -118,7 +118,7 @@ void swift::printOpaquePrefixMap(raw_ostream &out, void *_root,
 
 void PrefixMapKeyPrinter<char>::print(raw_ostream &out, ArrayRef<char> key) {
   out << QuotedString(StringRef(key.data(), key.size()));
-};
+}
 
 void PrefixMapKeyPrinter<unsigned char>::print(raw_ostream &out,
                                                ArrayRef<unsigned char> key) {

--- a/lib/Basic/StableHasher.cpp
+++ b/lib/Basic/StableHasher.cpp
@@ -35,7 +35,7 @@ static inline void sip_round(uint64_t &v0, uint64_t &v1, uint64_t &v2,
   v1 ^= v2;
   v2 = ROTATE_LEFT(v2, 32);
 }
-}; // end anonymous namespace
+} // end anonymous namespace
 
 void StableHasher::compress(uint64_t value) {
   state.v3 ^= value;

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2117,7 +2117,7 @@ void SwiftLookupTableWriter::populateTable(SwiftLookupTable &table,
 
   // Finalize the lookup table, which may fail.
   finalizeLookupTable(table, nameImporter, buffersForDiagnostics);
-};
+}
 
 std::unique_ptr<clang::ModuleFileExtensionWriter>
 SwiftNameLookupExtension::createExtensionWriter(clang::ASTWriter &writer) {

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3047,7 +3047,7 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
     PostfixContext = nullptr;
   }
   return PostfixContext;
-};
+}
 
 void NodePrinter::printEntityType(NodePointer Entity, NodePointer type,
                                   NodePointer genericFunctionTypeList,

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -259,7 +259,7 @@ static bool isInSwiftModule(Node *node) {
           context->getText() == STDLIB_NAME &&
           // Check for private declarations in Swift
           node->getChild(1)->getKind() == Node::Kind::Identifier);
-};
+}
 
 bool Remangler::mangleStandardSubstitution(Node *node) {
   // Look for known substitutions.

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -150,7 +150,7 @@ Compilation::Compilation(DiagnosticEngine &Diags,
     EmitFineGrainedDependencyDotFileAfterEveryImport(
       EmitFineGrainedDependencyDotFileAfterEveryImport),
     EnableCrossModuleIncrementalBuild(EnableCrossModuleIncrementalBuild)
-    { };
+    { }
 // clang-format on
 
 static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -550,7 +550,7 @@ SupplementaryOutputPathsComputer::determineSupplementaryOutputFilename(
   llvm::SmallString<128> path(defaultSupplementaryOutputPathExcludingExtension);
   llvm::sys::path::replace_extension(path, file_types::getExtension(type));
   return path.str().str();
-};
+}
 
 void SupplementaryOutputPathsComputer::deriveModulePathParameters(
     StringRef mainOutputFile, options::ID &emitOption, std::string &extension,

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -329,11 +329,11 @@ static APIDiffItemKind parseDiffItemKind(StringRef Content) {
 static StringRef getScalarString(llvm::yaml::Node *N) {
   auto WithQuote = cast<llvm::yaml::ScalarNode>(N)->getRawValue();
   return WithQuote.substr(1, WithQuote.size() - 2);
-};
+}
 
 static int getScalarInt(llvm::yaml::Node *N) {
   return std::stoi(cast<llvm::yaml::ScalarNode>(N)->getRawValue().str());
-};
+}
 
 static APIDiffItem*
 serializeDiffItem(llvm::BumpPtrAllocator &Alloc,

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -1033,7 +1033,7 @@ bool RangeResolver::walkToStmtPre(Stmt *S) {
   Impl->analyze(S);
   Impl->enter(S);
   return true;
-};
+}
 
 bool RangeResolver::walkToDeclPre(Decl *D, CharSourceRange Range) {
   if (D->isImplicit())
@@ -1053,7 +1053,7 @@ bool RangeResolver::walkToExprPost(Expr *E) {
 bool RangeResolver::walkToStmtPost(Stmt *S) {
   Impl->leave(S);
   return !Impl->hasResult();
-};
+}
 
 bool RangeResolver::walkToDeclPost(Decl *D) {
   Impl->leave(D);

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -378,7 +378,7 @@ static bool printModuleInterfaceDecl(Decl *D,
 /// Sorts import declarations for display.
 static bool compareImports(ImportDecl *LHS, ImportDecl *RHS) {
   return LHS->getImportPath() < RHS->getImportPath();
-};
+}
 
 /// Sorts Swift declarations for display.
 static bool compareSwiftDecls(Decl *LHS, Decl *RHS) {
@@ -393,7 +393,7 @@ static bool compareSwiftDecls(Decl *LHS, Decl *RHS) {
     // FIXME: not sufficient to establish a total order for overloaded decls.
   }
   return LHS->getKind() < RHS->getKind();
-};
+}
 
 static std::pair<ArrayRef<Decl*>, ArrayRef<Decl*>>
 getDeclsFromCrossImportOverlay(ModuleDecl *Overlay, ModuleDecl *Declaring,

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2917,7 +2917,7 @@ getUnsatisfiedRequirements(const IterableDeclContext *IDC) {
 bool RefactoringActionFillProtocolStub::
 isApplicable(const ResolvedCursorInfo &Tok, DiagnosticEngine &Diag) {
   return FillProtocolStubContext::getContextFromCursorInfo(Tok).canProceed();
-};
+}
 
 bool RefactoringActionFillProtocolStub::performChange() {
   // Get the filling protocol context from the input token.

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -655,7 +655,7 @@ bool NameMatcher::tryResolve(ASTWalker::ParentTy Node, SourceLoc NameLoc,
     }
   }
   return WasResolved;
-};
+}
 
 void ResolvedRangeInfo::print(llvm::raw_ostream &OS) const {
   OS << "<Kind>";

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2883,7 +2883,7 @@ static void save(const NecessaryBindings &bindings, IRGenFunction &IGF,
           return transform(requirement, metadata);
         }
       });
-};
+}
 
 void NecessaryBindings::save(IRGenFunction &IGF, Address buffer,
                              Explosion &source) const {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -81,14 +81,14 @@ static llvm::StructType *createStructType(IRGenModule &IGM,
                                   ArrayRef<llvm::Type*>(types.begin(),
                                                         types.size()),
                                   name, packed);
-};
+}
 
 /// A helper for creating pointer-to-struct types.
 static llvm::PointerType *createStructPointerType(IRGenModule &IGM,
                                                   StringRef name,
                                   std::initializer_list<llvm::Type*> types) {
   return createStructType(IGM, name, types)->getPointerTo(DefaultAS);
-};
+}
 
 static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
                                                  llvm::LLVMContext &LLVMContext,

--- a/lib/IRGen/LegacyLayoutFormat.h
+++ b/lib/IRGen/LegacyLayoutFormat.h
@@ -99,7 +99,7 @@ template <> struct MappingTraits<swift::irgen::YAMLModuleNode> {
 } // namespace yaml
 } // namespace llvm
 
-LLVM_YAML_IS_SEQUENCE_VECTOR(swift::irgen::YAMLTypeInfoNode);
-LLVM_YAML_IS_DOCUMENT_LIST_VECTOR(swift::irgen::YAMLModuleNode);
+LLVM_YAML_IS_SEQUENCE_VECTOR(swift::irgen::YAMLTypeInfoNode)
+LLVM_YAML_IS_DOCUMENT_LIST_VECTOR(swift::irgen::YAMLModuleNode)
 
 #endif // SWIFT_IRGEN_LEGACY_LAYOUT_FORMAT_H

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1061,7 +1061,7 @@ static bool errorAndSkipUntilConsumeRightParen(Parser &P, StringRef attrName,
     }
   }
   return true;
-};
+}
 
 /// Parse a differentiability parameters 'wrt:' clause, returning true on error.
 /// If `allowNamedParameters` is false, allow only index parameters and 'self'.

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -119,7 +119,7 @@ Type TypeConverter::getLoweredBridgedType(AbstractionPattern pattern,
   }
 
   llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
-};
+}
 
 Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
                                            Type t, Bridgeability bridging,

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2108,7 +2108,7 @@ bool SILParser::parseForwardingOwnershipKind(
            || parseSILOwnership(forwardingKind);
   }
   return false;
-};
+}
 
 ///  (',' sil-loc)? (',' sil-scope-ref)?
 bool SILParser::parseSILDebugLocation(SILLocation &L, SILBuilder &B) {
@@ -2191,7 +2191,7 @@ static bool parseIndexList(Parser &P, StringRef label,
                    "index list"))
     return true;
   return false;
-};
+}
 
 /// Parse a differentiability kind, an autodiff config, and a function name for
 /// a differentiability witness. Returns true on error.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3420,7 +3420,7 @@ lowerKeyPathSubscriptIndexTypes(
                                     ->getCanonicalType(),
                              indexLoweredTy});
   }
-};
+}
 
 static void
 lowerKeyPathSubscriptIndexPatterns(
@@ -3438,7 +3438,7 @@ lowerKeyPathSubscriptIndexPatterns(
 
     indexPatterns.push_back({baseOperand++, formalTy, loweredTy, hashable});
   }
-};
+}
 
 KeyPathPatternComponent
 SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1378,7 +1378,7 @@ void PatternMatchEmission::emitSpecializedDispatch(ClauseMatrix &clauses,
     return emitBoolDispatch(rowsToSpecialize, arg, handler, failure);
   }
   llvm_unreachable("bad pattern kind");
-};
+}
 
 /// Given that we've broken down a source value into this subobject,
 /// and that we were supposed to use the given consumption rules on

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -171,7 +171,7 @@ namespace {
                                    const TypeLowering &expectedTL);
   };
 } // end anonymous namespace
-;
+
 
 static ArrayRef<ProtocolConformanceRef>
 collectExistentialConformances(ModuleDecl *M, CanType fromType, CanType toType) {
@@ -339,7 +339,7 @@ static bool isProtocolClass(Type t) {
   ASTContext &ctx = classDecl->getASTContext();
   return (classDecl->getName() == ctx.Id_Protocol &&
           classDecl->getModuleContext()->getName() == ctx.Id_ObjectiveC);
-};
+}
 
 static ManagedValue emitManagedLoad(SILGenFunction &SGF, SILLocation loc,
                                     ManagedValue addr,

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -335,7 +335,7 @@ static bool isStructurallyIdentical(SILValue LHS, SILValue RHS) {
   return (lResult->ResultIndex == rResult->ResultIndex &&
           lResult->Instruction->isIdenticalTo(rResult->Instruction,
                                               isStructurallyIdentical));
-};
+}
 
 /// Compare two sequences of SIL instructions. They should be structurally
 /// equivalent.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1405,7 +1405,7 @@ hasOnlyRecursiveOwnershipUsers(ApplyInst *ai, SILInstruction *ignoreUser,
     foundUsers.push_back(user);
   }
   return true;
-};
+}
 
 /// We only know how to simulate reference call effects for unary
 /// function calls that take their argument @owned or @guaranteed and return an

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1706,7 +1706,7 @@ void GuaranteedPhiBorrowFixup::insertEndBorrowsAndFindPhis(
     // Otherwise, just plop down an end_borrow after the last use.
     createEndBorrow(phi, std::next(lastUser->getIterator()));
   }
-};
+}
 
 // For each phi that transitively uses an inner guaranteed value, create nested
 // borrow scopes so that it is a well-formed reborrow.

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -169,7 +169,7 @@ bool TreatArrayLiteralAsDictionary::diagnose(const Solution &solution,
                                                     getToType(), getFromType(),
                                                     getLocator());
   return failure.diagnose(asNote);
-};
+}
 
 TreatArrayLiteralAsDictionary *
 TreatArrayLiteralAsDictionary::create(ConstraintSystem &cs,
@@ -178,7 +178,7 @@ TreatArrayLiteralAsDictionary::create(ConstraintSystem &cs,
   assert(getAsExpr<ArrayExpr>(locator->getAnchor())->getNumElements() <= 1);
   return new (cs.getAllocator())
       TreatArrayLiteralAsDictionary(cs, dictionaryTy, arrayTy, locator);
-};
+}
 
 bool MarkExplicitlyEscaping::diagnose(const Solution &solution,
                                       bool asNote) const {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4215,9 +4215,9 @@ struct ResolvedMemberResult::Implementation {
   Optional<unsigned> BestIdx;
 };
 
-ResolvedMemberResult::ResolvedMemberResult(): Impl(new Implementation()) {};
+ResolvedMemberResult::ResolvedMemberResult(): Impl(new Implementation()) {}
 
-ResolvedMemberResult::~ResolvedMemberResult() { delete Impl; };
+ResolvedMemberResult::~ResolvedMemberResult() { delete Impl; }
 
 ResolvedMemberResult::operator bool() const {
   return !Impl->AllDecls.empty();

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -786,7 +786,7 @@ struct TypeBindingsToCompare {
     return !Type1WasLabeled && !Type2WasLabeled && Type1->isEqual(Type2);
   }
 };
-}; // end anonymous namespace
+} // end anonymous namespace
 
 /// Given the bound types of two constructor overloads, returns their parameter
 /// list types as tuples to compare for solution ranking, or \c None if they

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2329,7 +2329,7 @@ static bool fixItOverrideDeclarationTypesImpl(
 
   llvm_unreachable("unknown overridable member");
 }
-};
+}
 
 bool swift::computeFixitsForOverridenDeclaration(
     ValueDecl *decl, const ValueDecl *base,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1548,7 +1548,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
   }
 
   return DisallowedOriginKind::None;
-};
+}
 
 namespace {
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3653,7 +3653,7 @@ static bool conformsToDifferentiable(Type type, ModuleDecl *module,
     return true;
   auto tanType = conf.getTypeWitnessByName(type, ctx.Id_TangentVector);
   return type->isEqual(tanType);
-};
+}
 
 IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     AbstractFunctionDecl *AFD, GenericEnvironment *derivativeGenEnv) {
@@ -4105,7 +4105,7 @@ static bool checkFunctionSignature(
 
   // Required result type is a function. Recurse.
   return checkFunctionSignature(requiredResultFnTy, candidateResultTy);
-};
+}
 
 /// Returns an `AnyFunctionType` from the given parameters, result type, and
 /// generic signature.

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -1092,7 +1092,7 @@ static Type getTypeForCompletion(const constraints::Solution &S, Expr *E) {
   }
 
   return S.getResolvedType(E);
-};
+}
 
 /// Whether the given completion expression is the only expression in its
 /// containing closure or function body and its value is implicitly returned.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -408,7 +408,7 @@ namespace {
       return true;
     }
   };
-};
+}
 
 /// Expose TypeChecker's handling of GenericParamList to SIL parsing.
 GenericEnvironment *

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1158,7 +1158,7 @@ bool diagnoseInvalidFunctionType(FunctionType *fnTy, SourceLoc loc,
 /// type repr. \param inferredType The type inferred by the type checker.
 void notePlaceholderReplacementTypes(Type writtenType, Type inferredType);
 
-}; // namespace TypeChecker
+} // namespace TypeChecker
 
 /// Returns the protocol requirement kind of the given declaration.
 /// Used in diagnostics.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2064,7 +2064,7 @@ namespace identifier_block {
   };
 
   using IdentifierDataLayout = BCRecordLayout<IDENTIFIER_DATA, BCBlob>;
-};
+}
 
 /// The record types within the index block.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5340,7 +5340,7 @@ static void recordDerivativeFunctionConfig(
         {ctx.getIdentifier(attr->getParameterIndices()->getString()),
          AFD->getGenericSignature()});
   }
-};
+}
 
 /// Recursively walks the members and derived global decls of any nominal types
 /// to build up global tables.

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1468,7 +1468,7 @@ SerializedASTFile::getSourceOrderForDecl(const Decl *D) const {
 void SerializedASTFile::collectAllGroups(
     SmallVectorImpl<StringRef> &Names) const {
   File.collectAllGroups(Names);
-};
+}
 
 Optional<StringRef>
 SerializedASTFile::getGroupNameByUSR(StringRef USR) const {

--- a/stdlib/public/Concurrency/AsyncStream.cpp
+++ b/stdlib/public/Concurrency/AsyncStream.cpp
@@ -36,4 +36,4 @@ void _swift_async_stream_lock_unlock(MutexHandle &lock) {
   MutexPlatformHelper::unlock(lock);
 }
 
-};
+}

--- a/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
@@ -472,7 +472,7 @@ static void addImageCallback(const mach_header *mh) {
   Conformances.unsafeGetAlreadyInitialized()
     .SectionsToScan
     .push_back(ConformanceSection{recordsBegin, recordsEnd});
-};
+}
 
 static void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
   addImageCallback(mh);

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -27,7 +27,7 @@ GlobalConfig::update(Optional<unsigned> CompletionMaxASTContextReuseCount,
     State.CompletionOpts.CheckDependencyInterval =
         *CompletionCheckDependencyInterval;
   return State;
-};
+}
 
 GlobalConfig::Settings::CompletionOptions
 GlobalConfig::getCompletionOpts() const {

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -637,7 +637,7 @@ static int compareResultName(Item &a, Item &b) {
 
   // Next, sort by full description text.
   return a.description.compare(b.description);
-};
+}
 
 namespace {
 enum class ResultBucket {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1282,7 +1282,7 @@ RequestRefactoringEditConsumer(CategorizedEditsReceiver Receiver) :
   Impl(*new Implementation(Receiver)) {}
 
 RequestRefactoringEditConsumer::
-~RequestRefactoringEditConsumer() { delete &Impl; };
+~RequestRefactoringEditConsumer() { delete &Impl; }
 
 void RequestRefactoringEditConsumer::
 accept(SourceManager &SM, RegionType RegionType,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -488,7 +488,7 @@ bool SwiftInterfaceGenContext::isModule() const {
 
 ModuleDecl *SwiftInterfaceGenContext::getModuleDecl() const {
   return Impl.Mod;
-};
+}
 
 bool SwiftInterfaceGenContext::matches(StringRef ModuleName,
                                        const swift::CompilerInvocation &Invok) {

--- a/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
+++ b/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
@@ -601,7 +601,7 @@ static bool printResponse(sourcekitd_response_t Resp) {
 
   sourcekitd_response_dispose(Resp);
   return IsError;
-};
+}
 
 static bool handleRequest(StringRef ReqStr, std::string &ErrorMessage) {
   bool UseAsync = false;

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -23,7 +23,7 @@
 
 using namespace swift::dependencies;
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScanningTool, swiftscan_scanner_t);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScanningTool, swiftscan_scanner_t)
 
 //=== Private Cleanup Functions -------------------------------------------===//
 

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -66,4 +66,4 @@ int main(int argc, char **argv) {
   llvm::outs() << '\n';
 
   return 0;
-};
+}

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -42,7 +42,7 @@ void UnitTestSourceFileDepGraphFactory::addAllUsedDecls() {
     if (!isADefinedDecl(s))
       addAUsedDecl(s, kind);
   });
-};
+}
 
 //==============================================================================
 // MARK: UnitTestSourceFileDepGraphFactory - adding individual Decls


### PR DESCRIPTION
This cleans up 90 instances of this warning and reduces the build spew
when building on Linux.  This helps identify actual issues when
building which can get lost in the stream of warning messages.  It also
helps restore the ability to build the compiler with gcc.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
