### PR TITLE
cmake: add some caches for Linux

### DIFF
--- a/cmake/caches/Linux-x86_64.cmake
+++ b/cmake/caches/Linux-x86_64.cmake
@@ -1,0 +1,165 @@
+set(LLVM_ENABLE_PROJECTS
+      clang
+      clang-tools-extra
+      lld
+      lldb
+    CACHE STRING "")
+
+set(LLVM_EXTERNAL_PROJECTS
+      cmark
+      swift
+    CACHE STRING "")
+
+set(LLVM_ENABLE_RUNTIMES
+      compiler-rt
+    CACHE STRING "")
+
+# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
+# context to resolve issues otherwise and may silently generate invalid output.
+set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
+
+set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
+
+# NOTE(compnerd) we can hardcode the default target triple since the cache files
+# are target dependent.
+set(LLVM_DEFAULT_TARGET_TRIPLE x86_64-unknown-linux-gnu CACHE STRING "")
+
+set(LLVM_APPEND_VC_REV NO CACHE BOOL "")
+set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR YES CACHE BOOL "")
+set(LLVM_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLVM_BUILTIN_TARGETS
+      x86_64-unknown-linux-gnu
+    CACHE STRING "")
+foreach(target ${LLVM_RUNTIME_TARGETS})
+  set(BUILTINS_${target}_LLVM_ENABLE_RUNTIMES
+        compiler-rt
+      CACHE STRING "")
+  set(BUILTINS_${target}_CMAKE_SYSTEM_NAME Linux CACHE STRING "")
+  set(BUILTINS_${target}_CMAKE_BUILD_TYPE Release CACHE STRING "")
+  set(BUILTINS_${target}_COMPILER_RT_BUILD_CRT NO CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_BUILD_LIBFUZZER NO CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_BUILD_PROFILE YES CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_BUILD_SANITIZERS NO CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_BUILD_XRAY NO CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_DEFAULT_TARGET_ONLY YES CACHE BOOL "")
+  set(BUILTINS_${target}_COMPILER_RT_INCLUDE_TESTS NO CACHE BOOL "")
+endforeach()
+
+set(LLVM_TARGETS_TO_BUILD AArch64 ARM WebAssembly X86 CACHE STRING "")
+
+# Disable certain targets to reduce the configure time or to avoid configuration
+# differences (and in some cases weird build errors on a complete build).
+set(LLVM_BUILD_LLVM_DYLIB NO CACHE BOOL "")
+set(LLVM_BUILD_LLVM_C_DYLIB NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT NO CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 NO CACHE BOOL "")
+set(LLVM_ENABLE_OCAMLDOC NO CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO NO CACHE BOOL "")
+set(LLVM_ENABLE_Z3_SOLVER NO CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB NO CACHE BOOL "")
+set(LLVM_INCLUDE_BENCHMARKS NO CACHE BOOL "")
+set(LLVM_INCLUDE_DOCS NO CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES NO CACHE BOOL "")
+set(LLVM_INCLUDE_GO_TESTS NO CACHE BOOL "")
+set(LLVM_TOOL_GOLD_BUILD NO CACHE BOOL "")
+set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
+
+# Avoid swig dependency for lldb
+set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+
+# This requires perl which may not be available on Windows
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+set(SWIFT_BUILD_ENABLE_PARSER_LIB YES CACHE BOOL "")
+# static linking is not supported on Windows yet
+set(SWIFT_BUILD_STATIC_STDLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_STATIC_SDK_OVERLAY NO CACHE BOOL "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS YES CACHE BOOL "")
+set(LLVM_INSTALL_TOOLCHAIN_ONLY YES CACHE BOOL "")
+set(LLVM_TOOLCHAIN_TOOLS
+      addr2line
+      ar
+      c++filt
+      dsymutil
+      dwp
+      # lipo
+      llvm-ar
+      llvm-cov
+      llvm-cvtres
+      llvm-cxxfilt
+      llvm-dlltool
+      llvm-dwarfdump
+      llvm-dwp
+      llvm-lib
+      llvm-lipo
+      llvm-mt
+      llvm-nm
+      llvm-objcopy
+      llvm-objdump
+      llvm-pdbutil
+      llvm-profdata
+      llvm-ranlib
+      llvm-rc
+      llvm-readelf
+      llvm-readobj
+      llvm-size
+      llvm-strings
+      llvm-strip
+      llvm-symbolizer
+      llvm-undname
+      nm
+      objcopy
+      objdump
+      ranlib
+      readelf
+      size
+      strings
+    CACHE STRING "")
+
+set(CLANG_TOOLS
+      clang
+      clangd
+      clang-format
+      clang-resource-headers
+      clang-tidy
+    CACHE STRING "")
+
+set(LLD_TOOLS
+      lld
+    CACHE STRING "")
+
+set(LLDB_TOOLS
+      liblldb
+      lldb
+      lldb-argdumper
+      lldb-python-scripts
+      lldb-server
+      lldb-vscode
+      repl_swift
+    CACHE STRING "")
+
+set(SWIFT_INSTALL_COMPONENTS
+      autolink-driver
+      compiler
+      clang-builtin-headers
+      editor-integration
+      tools
+      sourcekit-inproc
+      swift-remote-mirror
+      swift-remote-mirror-headers
+      parser-lib
+    CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+      IndexStore
+      libclang
+      libclang-headers
+      LTO
+      runtimes
+      ${LLVM_TOOLCHAIN_TOOLS}
+      ${CLANG_TOOLS}
+      ${LLD_TOOLS}
+      ${LLDB_TOOLS}
+      ${SWIFT_INSTALL_COMPONENTS}
+    CACHE STRING "")

--- a/cmake/caches/Runtime-Linux-x86_64.cmake
+++ b/cmake/caches/Runtime-Linux-x86_64.cmake
@@ -1,0 +1,20 @@
+
+set(SWIFT_HOST_VARIANT_SDK LINUX CACHE STRING "")
+set(SWIFT_HOST_VARIANT_ARCH x86_64 CACHE STRING "")
+
+# NOTE(compnerd) disable the tools, we are trying to build just the standard
+# library.
+set(SWIFT_INCLUDE_TOOLS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build tests since the tests require the toolchain
+set(SWIFT_INCLUDE_TESTS NO CACHE BOOL "")
+
+# NOTE(compnerd) cannot build docs since that requires perl
+set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+
+# NOTE(compnerd) these are part of the toolchain, not the runtime.
+set(SWIFT_BUILD_SYNTAXPARSERLIB NO CACHE BOOL "")
+set(SWIFT_BUILD_SOURCEKIT NO CACHE BOOL "")
+
+# NOTE(compnerd) build with the compiler specified, not a just built compiler.
+set(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER YES CACHE BOOL "")


### PR DESCRIPTION
This adds a set of cmake caches to build a toolchain and runtime for
Linux x86_64.  It is derived from the Windows configuration, but works
for Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
