### PR TITLE
Update availability diagnostic for macOS major version number changes

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1881,8 +1881,8 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
                                  AvailabilityContext(RunningRange))) {
 
     // Only fix situations that are "nearby" versions, meaning
-    // disagreement on a minor-or-less version for non-macOS,
-    // or disagreement on a subminor-or-less version for macOS.
+    // disagreement on a subminor-or-less version for macOS 10,
+    // or disagreement on a minor-or-less version otherwise.
     auto RunningVers = RunningRange.getLowerEndpoint();
     auto RequiredVers = RequiredRange.getLowerEndpoint();
     auto Platform = targetPlatform(Context.LangOpts);
@@ -1890,10 +1890,10 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
       return false;
     if ((Platform == PlatformKind::macOS ||
          Platform == PlatformKind::macOSApplicationExtension) &&
+        RunningVers.getMajor() == 10 &&
         !(RunningVers.getMinor().has_value() &&
           RequiredVers.getMinor().has_value() &&
-          RunningVers.getMinor().value() ==
-          RequiredVers.getMinor().value()))
+          RunningVers.getMinor().value() == RequiredVers.getMinor().value()))
       return false;
 
     auto FixRange = TRC->getAvailabilityConditionVersionSourceRange(

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -32,19 +32,16 @@ func useFromOtherOn99_51() {
 
   let o10_9 = OtherIntroduced10_9()
   o10_9.extensionMethodOnOtherIntroduced10_9AvailableOn99_51(o99_51)
-  _ = o99_51.returns99_52Introduced99_52() // expected-error {{'returns99_52Introduced99_52()' is only available in macOS 99.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = o99_51.returns99_52Introduced99_52() // expected-error {{'returns99_52Introduced99_52()' is only available in macOS 99.52 or newer}} {{26:29-34=99.52}}
 
   _ = OtherIntroduced99_52()
-      // expected-error@-1 {{'OtherIntroduced99_52' is only available in macOS 99.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}}
+      // expected-error@-1 {{'OtherIntroduced99_52' is only available in macOS 99.52 or newer}} {{26:29-34=99.52}}
 
-  o99_51.extensionMethodOnOtherIntroduced99_51AvailableOn99_52() // expected-error {{'extensionMethodOnOtherIntroduced99_51AvailableOn99_52()' is only available in macOS 99.52 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  o99_51.extensionMethodOnOtherIntroduced99_51AvailableOn99_52() 
+      // expected-error@-1 {{'extensionMethodOnOtherIntroduced99_51AvailableOn99_52()' is only available in macOS 99.52 or newer}} {{26:29-34=99.52}}
 
   _ = OtherIntroduced99_51.NestedIntroduced99_52()
-      // expected-error@-1 {{'NestedIntroduced99_52' is only available in macOS 99.52 or newer}}
-      // expected-note@-2 {{add 'if #available' version check}}
+      // expected-error@-1 {{'NestedIntroduced99_52' is only available in macOS 99.52 or newer}} {{26:29-34=99.52}}
 }
 
 @available(OSX, introduced: 99.52)
@@ -53,8 +50,7 @@ func useFromOtherOn99_52() {
 
   let n99_52 = OtherIntroduced99_51.NestedIntroduced99_52()
   _ = n99_52.returns99_52()
-  _ = n99_52.returns99_53() // expected-error {{'returns99_53()' is only available in macOS 99.53 or newer}}
-      // expected-note@-1 {{add 'if #available' version check}}
+  _ = n99_52.returns99_53() // expected-error {{'returns99_53()' is only available in macOS 99.53 or newer}} {{47:29-34=99.53}}
 
   // This will trigger validation of the global in availability_in_multi_other.swift
   _ = globalFromOtherOn99_52


### PR DESCRIPTION
Resolves: #57419

_From the description of the Swift Report in question:_

>In TypeCheckAvailability.cpp, the function fixAvailabilityByNarrowingNearbyVersionCheck() checks if an availability specifier near the site of an error has a version that's very close to the one needed for that API, and if so, offers a fix-it for it.
"Very close" is defined as having the same major version number on most OSes, but for macOS, the minor version also has to match. This made sense a few years ago when macOS releases all had 10.x versions, but now that Apple is incrementing the major macOS version number regularly, it probably doesn't make sense anymore. So this condition should be tweaked to only apply if the major version number is 10.

So that's what I did 🙂 