### PR TITLE
[update-checkout] Decode stderr from failed update command

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -70,7 +70,7 @@ def check_parallel_results(results, op):
             print("%s failed (ret=%d): %s" % (r.repo_path, r.ret, r))
             fail_count += 1
             if r.stderr:
-                print(r.stderr)
+                print(r.stderr.decode('utf-8'))
     return fail_count
 
 


### PR DESCRIPTION
Otherwise, the error message gets printed as a Python binary string, e.g. you see
```
b'error: Your local changes to the following files would be overwritten by checkout:\n\tinclude/swift/IDE/CodeCompletion.h\n\tutils/update_checkout/update_checkout/update_checkout.py\nPlease commit your changes or stash them before you switch branches.\nAborting\n'
```
instead of
```
error: Your local changes to the following files would be overwritten by checkout:
	include/swift/IDE/CodeCompletion.h
	utils/update_checkout/update_checkout/update_checkout.py
Please commit your changes or stash them before you switch branches.
Aborting
```