### PR TITLE
[Sema] Made $main non-dynamic.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2093,6 +2093,9 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
       /*GenericParams=*/nullptr, ParameterList::createEmpty(context),
       /*FnRetType=*/TupleType::getEmpty(context), declContext);
   func->setSynthesized(true);
+  // It's never useful to provide a dynamic replacement of this function--it is
+  // just a pass-through to MainType.main.
+  func->setIsDynamic(false);
 
   auto *params = context.Allocate<MainTypeAttrParams>();
   params->mainFunction = mainFunction;

--- a/test/attr/ApplicationMain/attr_main_implicitDynamicReplacement.swift
+++ b/test/attr/ApplicationMain/attr_main_implicitDynamicReplacement.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -c -parse-as-library %s -enable-implicit-dynamic
+
+@main
+struct BasicAppApp {
+  static func main() {}
+}


### PR DESCRIPTION
Previously, it was possible for $main to be made dynamic by passing -enable-implicit-dynamic.  That has always been a problem in asserts builds because a direct function_ref to $main is created in the main function.  More recently, it has become a problem in non-asserts builds because the dynamic replacements are now in the IR module but are not in the TBD file.

Here, the function is marked as not dynamic.

rdar://84962693