### PR TITLE
[IRGen] NFC: Remove outdated comment about number of async parameters

### DIFF
--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -164,8 +164,6 @@ void IRGenThunk::prepareArguments() {
 
   // Chop off the async context parameters.
   if (isAsync) {
-    // FIXME: Once we remove async task and executor this should be one not
-    // three.
     unsigned numAsyncContextParams =
         (unsigned)AsyncFunctionArgumentIndex::Context + 1;
     (void)original.claim(numAsyncContextParams);


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
