### PR TITLE
[AST] Prevent memory leak when allocating `ExternalSourceLocs`

### DIFF
--- a/include/swift/Basic/BasicSourceInfo.h
+++ b/include/swift/Basic/BasicSourceInfo.h
@@ -50,7 +50,7 @@ struct ExternalSourceLocs {
 
   unsigned BufferID = 0;
   SourceLoc Loc;
-  SmallVector<CharSourceRange, 4> DocRanges;
+  ArrayRef<CharSourceRange> DocRanges;
 };
 
 class BasicSourceFileInfo {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -652,9 +652,14 @@ const ExternalSourceLocs *Decl::getSerializedLocs() const {
   auto *Result = getASTContext().Allocate<ExternalSourceLocs>();
   Result->BufferID = BufferID;
   Result->Loc = ResolveLoc(RawLocs->Loc);
-  for (auto &Range : RawLocs->DocRanges) {
-    Result->DocRanges.emplace_back(ResolveLoc(Range.first), Range.second);
+
+  auto DocRanges = getASTContext().AllocateUninitialized<CharSourceRange>(RawLocs->DocRanges.size());
+  for (auto I : indices(RawLocs->DocRanges)) {
+    auto &Range = RawLocs->DocRanges[I];
+    DocRanges[I] = CharSourceRange(ResolveLoc(Range.first), Range.second);
   }
+  Result->DocRanges = DocRanges;
+
   Context.setExternalSourceLocs(this, Result);
   return Result;
 }


### PR DESCRIPTION
c763ab5d1ec11f6fa9a46537e795344fc284caac fixed an issue in
`getSerializedLocs` where it never actually cached its result (and thus
always allocated a new `CachedExternalSourceLocs`). Unfortunately it
missed a leak that could occur when `DocRanges` grows beyond its initial
size of 4.

Allocate `DocRanges` upfront in the `ASTContext` as well in order to
prevent this leak.

Resolves rdar://85472403.