### PR TITLE
Revert "[TypeChecker] SE-0326: Enable multi-statement closure inference by default"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -688,7 +688,7 @@ namespace swift {
 
     /// Enable experimental support for type inference through multi-statement
     /// closures.
-    bool EnableMultiStatementClosureInference = true;
+    bool EnableMultiStatementClosureInference = false;
 
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -338,14 +338,6 @@ public:
 
   TypeVariableType *getTypeVariable() const { return Info.TypeVar; }
 
-  /// Check whether this binding set belongs to a type variable
-  /// that represents a result type of a closure.
-  bool forClosureResult() const;
-
-  /// Check whether this binding set belongs to a type variable
-  /// that represents a generic parameter.
-  bool forGenericParameter() const;
-
   bool canBeNil() const;
 
   /// If this type variable doesn't have any viable bindings, or

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2305,10 +2305,6 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
-
   static SpecifyClosureParameterType *create(ConstraintSystem &cs,
                                              ConstraintLocator *locator);
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -442,8 +442,6 @@ class Constraint final : public llvm::ilist_node<Constraint>,
       ASTNode Element;
       /// Contextual information associated with the element (if any).
       ContextualTypeInfo Context;
-      /// Identifies whether result of this node is unused.
-      bool IsDiscarded;
     } ClosureElement;
   };
 
@@ -497,7 +495,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
   /// Construct a closure body element constraint.
-  Constraint(ASTNode node, ContextualTypeInfo context, bool isDiscarded,
+  Constraint(ASTNode node, ContextualTypeInfo context,
              ConstraintLocator *locator,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
@@ -587,14 +585,12 @@ public:
 
   static Constraint *createClosureBodyElement(ConstraintSystem &cs,
                                               ASTNode node,
-                                              ConstraintLocator *locator,
-                                              bool isDiscarded = false);
+                                              ConstraintLocator *locator);
 
   static Constraint *createClosureBodyElement(ConstraintSystem &cs,
                                               ASTNode node,
                                               ContextualTypeInfo context,
-                                              ConstraintLocator *locator,
-                                              bool isDiscarded = false);
+                                              ConstraintLocator *locator);
 
   /// Determine the kind of constraint.
   ConstraintKind getKind() const { return Kind; }
@@ -859,11 +855,6 @@ public:
   ContextualTypeInfo getElementContext() const {
     assert(Kind == ConstraintKind::ClosureBodyElement);
     return ClosureElement.Context;
-  }
-
-  bool isDiscardedElement() const {
-    assert(Kind == ConstraintKind::ClosureBodyElement);
-    return ClosureElement.IsDiscarded;
   }
 
   /// For an applicable function constraint, retrieve the trailing closure

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4854,8 +4854,8 @@ private:
   /// Simplify a closure body element constraint by generating required
   /// constraints to represent the given element in constraint system.
   SolutionKind simplifyClosureBodyElementConstraint(
-      ASTNode element, ContextualTypeInfo context, bool isDiscarded,
-      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
+      ASTNode element, ContextualTypeInfo context, TypeMatchOptions flags,
+      ConstraintLocatorBuilder locator);
 
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
@@ -5014,8 +5014,7 @@ public:
   /// \param replaceInvalidRefsWithErrors Indicates whether it's allowed
   /// to replace any discovered invalid member references with `ErrorExpr`.
   static bool preCheckExpression(Expr *&expr, DeclContext *dc,
-                                 bool replaceInvalidRefsWithErrors,
-                                 bool leaveClosureBodiesUnchecked);
+                                 bool replaceInvalidRefsWithErrors);
 
   /// Solve the system of constraints generated from provided target.
   ///
@@ -5245,16 +5244,6 @@ public:
   /// Determine whether given locator represents an argument to declaration
   /// imported from C/ObjectiveC.
   bool isArgumentOfImportedDecl(ConstraintLocatorBuilder locator);
-
-  /// Check whether given closure should participate in inference e.g.
-  /// if it's a single-expression closure - it always does, but
-  /// multi-statement closures require special flags.
-  bool participatesInInference(ClosureExpr *closure) const;
-
-  /// Visit each subexpression that will be part of the constraint system
-  /// of the given expression, including those in closure bodies that will be
-  /// part of the constraint system.
-  void forEachExpr(Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
 
   SWIFT_DEBUG_DUMP;
   SWIFT_DEBUG_DUMPER(dump(Expr *));
@@ -6079,6 +6068,18 @@ BraceStmt *applyResultBuilderTransform(
         Optional<constraints::SolutionApplicationTarget> (
           constraints::SolutionApplicationTarget)>
             rewriteTarget);
+
+/// Determine whether the given closure expression should be type-checked
+/// within the context of its enclosing expression. Otherwise, it will be
+/// separately type-checked once its enclosing expression has determined all
+/// of the parameter and result types without looking at the body.
+bool shouldTypeCheckInEnclosingExpression(ClosureExpr *expr);
+
+/// Visit each subexpression that will be part of the constraint system
+/// of the given expression, including those in closure bodies that will be
+/// part of the constraint system.
+void forEachExprInConstraintSystem(
+    Expr *expr, llvm::function_ref<Expr *(Expr *)> callback);
 
 /// Whether the given parameter requires an argument.
 bool parameterRequiresArgument(

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -47,8 +47,7 @@ namespace swift {
   struct PrintOptions;
 
   /// Typecheck binding initializer at \p bindingIndex.
-  void typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned bindingIndex,
-                               bool leaveClosureBodiesUnchecked);
+  void typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned bindingIndex);
 
   /// Check if T1 is convertible to T2.
   ///

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -98,8 +98,7 @@ void swift::ide::typeCheckContextAt(DeclContext *DC, SourceLoc Loc) {
             [](VarDecl *VD) { (void)VD->getInterfaceType(); });
         if (PBD->getInit(i)) {
           if (!PBD->isInitializerChecked(i))
-            typeCheckPatternBinding(PBD, i,
-                                    /*LeaveClosureBodyUnchecked=*/true);
+            typeCheckPatternBinding(PBD, i);
         }
       }
     } else if (auto *defaultArg = dyn_cast<DefaultArgumentInitializer>(DC)) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1932,9 +1932,7 @@ public:
       DiagnosticTransaction transaction(diagEngine);
 
       HasError |= ConstraintSystem::preCheckExpression(
-          E, DC, /*replaceInvalidRefsWithErrors=*/true,
-          /*leaveClosureBodiesUnchecked=*/false);
-
+          E, DC, /*replaceInvalidRefsWithErrors=*/true);
       HasError |= transaction.hasErrors();
 
       if (!HasError)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4056,7 +4056,8 @@ namespace {
       if (expr->isLiteralInit()) {
         auto *literalInit = expr->getSubExpr();
         if (auto *call = dyn_cast<CallExpr>(literalInit)) {
-          cs.forEachExpr(call->getFn(), [&](Expr *subExpr) -> Expr * {
+          forEachExprInConstraintSystem(call->getFn(),
+                                        [&](Expr *subExpr) -> Expr * {
             auto *TE = dyn_cast<TypeExpr>(subExpr);
             if (!TE)
               return subExpr;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -25,14 +25,6 @@ using namespace swift;
 using namespace constraints;
 using namespace inference;
 
-bool BindingSet::forClosureResult() const {
-  return Info.TypeVar->getImpl().isClosureResultType();
-}
-
-bool BindingSet::forGenericParameter() const {
-  return bool(Info.TypeVar->getImpl().getGenericParameter());
-}
-
 bool BindingSet::canBeNil() const {
   auto &ctx = CS.getASTContext();
   return Literals.count(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -463,8 +463,7 @@ bool MissingConformanceFailure::diagnoseAsError() {
       }
 
       bool hasFix = false;
-      auto &cs = getConstraintSystem();
-      cs.forEachExpr(caseExpr, [&](Expr *expr) -> Expr * {
+      forEachExprInConstraintSystem(caseExpr, [&](Expr *expr) -> Expr * {
         hasFix |= anchors.count(expr);
         return hasFix ? nullptr : expr;
       });
@@ -3592,8 +3591,7 @@ bool MissingMemberFailure::diagnoseAsError() {
 
     bool hasUnresolvedPattern = false;
     if (auto *E = getAsExpr(anchor)) {
-      auto &cs = getConstraintSystem();
-      cs.forEachExpr(const_cast<Expr *>(E), [&](Expr *expr) {
+      forEachExprInConstraintSystem(const_cast<Expr *>(E), [&](Expr *expr) {
         hasUnresolvedPattern |= isa<UnresolvedPatternExpr>(expr);
         return hasUnresolvedPattern ? nullptr : expr;
       });

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2105,7 +2105,7 @@ namespace {
         // If this is a multi-statement closure, let's mark result
         // as potential hole right away.
         return Type(CS.createTypeVariable(
-            resultLocator, CS.participatesInInference(closure)
+            resultLocator, shouldTypeCheckInEnclosingExpression(closure)
                                ? 0
                                : TVO_CanBindToHole));
       }();
@@ -2627,7 +2627,7 @@ namespace {
       // genreation only if closure is going to participate
       // in the type-check. This allows us to delay validation of
       // multi-statement closures until body is opened.
-      if (CS.participatesInInference(closure) &&
+      if (shouldTypeCheckInEnclosingExpression(closure) &&
           collectVarRefs.hasErrorExprs) {
         return Type();
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2032,7 +2032,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
 
       // Something like `foo { x in }` or `foo { $0 }`
       if (auto *closure = getAsExpr<ClosureExpr>(anchor)) {
-        cs.forEachExpr(closure, [&](Expr *expr) -> Expr * {
+        forEachExprInConstraintSystem(closure, [&](Expr *expr) -> Expr * {
           if (auto *UDE = dyn_cast<UnresolvedDotExpr>(expr)) {
             if (!isParam(UDE->getBase()))
               return expr;
@@ -11637,7 +11637,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
 
   bool found = false;
   if (auto *expr = getAsExpr(anchor)) {
-    forEachExpr(expr, [&](Expr *subExpr) -> Expr * {
+    forEachExprInConstraintSystem(expr, [&](Expr *subExpr) -> Expr * {
       found |= anchors.count(subExpr);
       return subExpr;
     });
@@ -12684,7 +12684,6 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::ClosureBodyElement:
     return simplifyClosureBodyElementConstraint(
         constraint.getClosureElement(), constraint.getElementContext(),
-        constraint.isDiscardedElement(),
         /*flags=*/None, constraint.getLocator());
 
   case ConstraintKind::BindTupleOfFunctionParams:

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -345,19 +345,6 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto *disjunction = CS.selectDisjunction();
   auto bestBindings = CS.determineBestBindings();
 
-  if (CS.shouldAttemptFixes()) {
-    if ((bestBindings &&
-         (bestBindings->forClosureResult() ||
-          bestBindings->forGenericParameter()) &&
-         bestBindings->isHole()) &&
-        !disjunction) {
-      if (auto *conjunction = CS.selectConjunction()) {
-        return suspend(
-            std::make_unique<ConjunctionStep>(CS, conjunction, Solutions));
-      }
-    }
-  }
-
   if (bestBindings &&
       (!disjunction || bestBindings->favoredOverDisjunction(disjunction))) {
     // Produce a type variable step.

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -359,13 +359,10 @@ void swift::diagnoseConstantArgumentRequirement(
     }
     
     std::pair<bool, Expr *> walkToClosureExprPre(ClosureExpr *closure) {
-      auto &ctx = DC->getASTContext();
-
-      if (closure->hasSingleExpressionBody() ||
-          ctx.TypeCheckerOpts.EnableMultiStatementClosureInference) {
-        // Closure bodies are not visited directly by the ASTVisitor,
-        // so we must descend into the body manuall and set the
-        // DeclContext to that of the closure.
+      if (closure->hasSingleExpressionBody()) {
+        // Single expression closure bodies are not visited directly
+        // by the ASTVisitor, so we must descend into the body manually
+        // and set the DeclContext to that of the closure.
         DC = closure;
         return {true, closure};
       }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -258,14 +258,13 @@ Constraint::Constraint(ConstraintKind kind, ConstraintFix *fix, Type first,
 }
 
 Constraint::Constraint(ASTNode node, ContextualTypeInfo context,
-                       bool isDiscarded, ConstraintLocator *locator,
+                       ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
     : Kind(ConstraintKind::ClosureBodyElement), TheFix(nullptr),
       HasRestriction(false), IsActive(false), IsDisabled(false),
       IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
       IsIsolated(false),
-      NumTypeVariables(typeVars.size()), ClosureElement{node, context,
-                                                        isDiscarded},
+      NumTypeVariables(typeVars.size()), ClosureElement{node, context},
       Locator(locator) {
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
 }
@@ -344,8 +343,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
                   getLocator());
 
   case ConstraintKind::ClosureBodyElement:
-    return createClosureBodyElement(cs, getClosureElement(), getLocator(),
-                                    isDiscardedElement());
+    return createClosureBodyElement(cs, getClosureElement(), getLocator());
   }
 
   llvm_unreachable("Unhandled ConstraintKind in switch.");
@@ -1014,21 +1012,18 @@ Constraint *Constraint::createApplicableFunction(
 
 Constraint *Constraint::createClosureBodyElement(ConstraintSystem &cs,
                                                  ASTNode node,
-                                                 ConstraintLocator *locator,
-                                                 bool isDiscarded) {
-  return createClosureBodyElement(cs, node, ContextualTypeInfo(), locator,
-                                  isDiscarded);
+                                                 ConstraintLocator *locator) {
+  return createClosureBodyElement(cs, node, ContextualTypeInfo(), locator);
 }
 
 Constraint *Constraint::createClosureBodyElement(ConstraintSystem &cs,
                                                  ASTNode node,
                                                  ContextualTypeInfo context,
-                                                 ConstraintLocator *locator,
-                                                 bool isDiscarded) {
+                                                 ConstraintLocator *locator) {
   SmallPtrSet<TypeVariableType *, 4> typeVars;
   unsigned size = totalSizeToAlloc<TypeVariableType *>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
-  return new (mem) Constraint(node, context, isDiscarded, locator, typeVars);
+  return new (mem) Constraint(node, context, locator, typeVars);
 }
 
 Optional<TrailingClosureMatching>

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5874,18 +5874,6 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   return false;
 }
 
-bool ConstraintSystem::participatesInInference(ClosureExpr *closure) const {
-  if (closure->hasSingleExpressionBody())
-    return true;
-
-  if (Options.contains(ConstraintSystemFlags::LeaveClosureBodyUnchecked))
-    return false;
-
-  auto &ctx = closure->getASTContext();
-  return !closure->hasEmptyBody() &&
-         ctx.TypeCheckerOpts.EnableMultiStatementClosureInference;
-}
-
 TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
     : BindingProducer(bindings.getConstraintSystem(),
                       bindings.getTypeVariable()->getImpl().getLocator()),

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -208,49 +208,6 @@ private:
     auto *PODeclRef = new (Ctx)
         UnresolvedDeclRefExpr(StringForPrintObjectName,
                               DeclRefKind::Ordinary, DeclNameLoc());
-
-    std::function<DeclRefExpr *(DeclRefExpr *)> cloneDeclRef =
-        [&](DeclRefExpr *DRE) {
-          auto *ref = new (Ctx) DeclRefExpr(
-              DRE->getDeclRef(),
-              /*Loc=*/DeclNameLoc(),
-              /*Implicit=*/true, DRE->getAccessSemantics(), DRE->getType());
-
-          if (auto hopTarget = DRE->isImplicitlyAsync())
-            ref->setImplicitlyAsync(*hopTarget);
-
-          ref->setImplicitlyThrows(DRE->isImplicitlyThrows());
-
-          return ref;
-        };
-
-    std::function<MemberRefExpr *(MemberRefExpr *)> cloneMemberRef =
-        [&](MemberRefExpr *M) {
-          auto *base = M->getBase();
-
-          if (auto *DRE = dyn_cast<DeclRefExpr>(base))
-            base = cloneDeclRef(DRE);
-          else if (auto *M = dyn_cast<MemberRefExpr>(base))
-            base = cloneMemberRef(M);
-
-          auto *ref = new (Ctx)
-              MemberRefExpr(base, /*dotLoc=*/SourceLoc(), M->getDecl(),
-                            /*loc=*/DeclNameLoc(),
-                            /*Implicit=*/true, M->getAccessSemantics());
-          ref->setType(M->getType());
-
-          return ref;
-        };
-
-    // Let's make a copy of either decl or member ref without source
-    // information. It's invalid to have decl reference expressions
-    // reused, each reference should get a fresh expression.
-    if (auto *DRE = dyn_cast<DeclRefExpr>(DstRef)) {
-      DstRef = cloneDeclRef(DRE);
-    } else {
-      DstRef = cloneMemberRef(cast<MemberRefExpr>(DstRef));
-    }
-
     auto *POArgList = ArgumentList::forImplicitUnlabeled(Ctx, {DstRef});
     auto *POCall = CallExpr::createImplicit(Ctx, PODeclRef, POArgList);
     POCall->setThrows(false);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -24,7 +24,6 @@
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/SourceFile.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
@@ -51,37 +50,6 @@ static Expr *isImplicitPromotionToOptional(Expr *E) {
   return nullptr;
 }
 
-bool BaseDiagnosticWalker::walkToDeclPre(Decl *D) {
-  return isa<ClosureExpr>(D->getDeclContext())
-             ? shouldWalkIntoDeclInClosureContext(D)
-             : false;
-}
-
-bool BaseDiagnosticWalker::shouldWalkIntoDeclInClosureContext(Decl *D) {
-  auto *closure = dyn_cast<ClosureExpr>(D->getDeclContext());
-  assert(closure);
-
-  if (closure->isSeparatelyTypeChecked())
-    return false;
-
-  auto &opts = D->getASTContext().TypeCheckerOpts;
-
-  // If multi-statement inference is enabled, let's not walk
-  // into declarations contained in a multi-statement closure
-  // because they'd be handled via `typeCheckDecl` that runs
-  // syntactic diagnostics.
-  if (opts.EnableMultiStatementClosureInference &&
-      !closure->hasSingleExpressionBody()) {
-    // Since pattern bindings get their types through solution application,
-    // `typeCheckDecl` doesn't touch initializers (because they are already
-    // fully type-checked), so pattern bindings have to be allowed to be
-    // walked to diagnose syntactic issues.
-    return isa<PatternBindingDecl>(D);
-  }
-
-  return true;
-}
-
 /// Diagnose syntactic restrictions of expressions.
 ///
 ///   - Module values may only occur as part of qualification.
@@ -104,7 +72,7 @@ bool BaseDiagnosticWalker::shouldWalkIntoDeclInClosureContext(Decl *D) {
 ///
 static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                                          bool isExprStmt) {
-  class DiagnoseWalker : public BaseDiagnosticWalker {
+  class DiagnoseWalker : public ASTWalker {
     SmallPtrSet<Expr*, 4> AlreadyDiagnosedMetatypes;
     SmallPtrSet<DeclRefExpr*, 4> AlreadyDiagnosedBitCasts;
 
@@ -121,7 +89,17 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       return { false, P };
     }
 
+    bool walkToDeclPre(Decl *D) override {
+      if (auto *closure = dyn_cast<ClosureExpr>(D->getDeclContext()))
+        return !closure->isSeparatelyTypeChecked();
+      return false;
+    }
+
     bool walkToTypeReprPre(TypeRepr *T) override { return true; }
+
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
+    }
 
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
@@ -1471,7 +1449,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
 /// confusion, so we force an explicit self.
 static void diagnoseImplicitSelfUseInClosure(const Expr *E,
                                              const DeclContext *DC) {
-  class DiagnoseWalker : public BaseDiagnosticWalker {
+  class DiagnoseWalker : public ASTWalker {
     ASTContext &Ctx;
     SmallVector<AbstractClosureExpr *, 4> Closures;
   public:
@@ -1550,6 +1528,18 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       }
 
       return true;
+    }
+
+
+    // Don't walk into nested decls.
+    bool walkToDeclPre(Decl *D) override {
+      if (auto *closure = dyn_cast<ClosureExpr>(D->getDeclContext()))
+        return !closure->isSeparatelyTypeChecked();
+      return false;
+    }
+
+    bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
+      return false;
     }
 
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
@@ -5149,34 +5139,4 @@ Optional<Identifier> TypeChecker::omitNeedlessWords(VarDecl *var) {
   }
 
   return None;
-}
-
-bool swift::diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
-                                                  ForEachStmt *forEach) {
-  if (!forEach->getAwaitLoc().isValid())
-    return false;
-
-  auto &ctx = dc->getASTContext();
-
-  auto sequenceProto = TypeChecker::getProtocol(
-      ctx, forEach->getForLoc(), KnownProtocolKind::AsyncSequence);
-
-  if (!sequenceProto)
-    return false;
-
-  // fetch the sequence out of the statement
-  // else wise the value is potentially unresolved
-  auto Ty = forEach->getSequence()->getType();
-  auto module = dc->getParentModule();
-  auto conformanceRef = module->lookupConformance(Ty, sequenceProto);
-
-  if (conformanceRef.hasEffect(EffectKind::Throws) &&
-      forEach->getTryLoc().isInvalid()) {
-    ctx.Diags
-        .diagnose(forEach->getAwaitLoc(), diag::throwing_call_unhandled, "call")
-        .fixItInsert(forEach->getAwaitLoc(), "try");
-    return true;
-  }
-
-  return false;
 }

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_SEMA_MISC_DIAGNOSTICS_H
 #define SWIFT_SEMA_MISC_DIAGNOSTICS_H
 
-#include "swift/AST/ASTWalker.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Expr.h"
@@ -27,15 +26,12 @@ namespace swift {
   class AbstractFunctionDecl;
   class ApplyExpr;
   class CallExpr;
-  class ClosureExpr;
   class DeclContext;
-  class Decl;
   class Expr;
   class InFlightDiagnostic;
   class Stmt;
   class TopLevelCodeDecl;
   class ValueDecl;
-  class ForEachStmt;
 
 /// Emit diagnostics for syntactic restrictions on a given expression.
 void performSyntacticExprDiagnostics(
@@ -119,23 +115,6 @@ void fixItEncloseTrailingClosure(ASTContext &ctx,
 /// we emit a diagnostic suggesting the async call.
 void checkFunctionAsyncUsage(AbstractFunctionDecl *decl);
 void checkPatternBindingDeclAsyncUsage(PatternBindingDecl *decl);
-
-/// Detect and diagnose a missing `try` in `for-in` loop sequence
-/// expression in async context (denoted with `await` keyword).
-bool diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
-                                           ForEachStmt *forEach);
-
-class BaseDiagnosticWalker : public ASTWalker {
-  bool walkToDeclPre(Decl *D) override;
-
-  bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
-    return false;
-  }
-
-private:
-  static bool shouldWalkIntoDeclInClosureContext(Decl *D);
-};
-
 } // namespace swift
 
 #endif // SWIFT_SEMA_MISC_DIAGNOSTICS_H

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3302,7 +3302,7 @@ void swift::diagnoseExprAvailability(const Expr *E, DeclContext *DC) {
 
 namespace {
 
-class StmtAvailabilityWalker : public BaseDiagnosticWalker {
+class StmtAvailabilityWalker : public ASTWalker {
   DeclContext *DC;
   bool WalkRecursively;
 
@@ -3338,6 +3338,7 @@ public:
     return std::make_pair(true, P);
   }
 };
+
 }
 
 void swift::diagnoseStmtAvailability(const Stmt *S, DeclContext *DC,

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -206,9 +206,7 @@ public:
       // If this is a closure, only walk into its children if they
       // are type-checked in the context of the enclosing expression.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        // TODO: This has to be deleted once `EnableMultiStatementClosureInference`
-        //       is enabled by default.
-        if (!closure->hasSingleExpressionBody())
+        if (!shouldTypeCheckInEnclosingExpression(closure))
           return { false, expr };
         for (auto &Param : *closure->getParameters()) {
           Param->setSpecifier(swift::ParamSpecifier::Default);
@@ -307,12 +305,8 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
   referencedDecl = nullptr;
 
-  ConstraintSystemOptions options;
-  options |= ConstraintSystemFlags::SuppressDiagnostics;
-  options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
-
   // Construct a constraint system from this expression.
-  ConstraintSystem cs(dc, options);
+  ConstraintSystem cs(dc, ConstraintSystemFlags::SuppressDiagnostics);
 
   // Attempt to solve the constraint system.
   const Type originalType = expr->getType();
@@ -404,7 +398,6 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
   ConstraintSystemOptions options;
   options |= ConstraintSystemFlags::SuppressDiagnostics;
   options |= ConstraintSystemFlags::ReusePrecheckedType;
-  options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
 
   // Construct a constraint system from this expression.
   ConstraintSystem CS(DC, options);
@@ -795,8 +788,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
     // expression and folding sequence expressions.
     auto failedPreCheck = ConstraintSystem::preCheckExpression(
         expr, DC,
-        /*replaceInvalidRefsWithErrors=*/true,
-        /*leaveClosureBodiesUnchecked=*/true);
+        /*replaceInvalidRefsWithErrors=*/true);
 
     target.setExpr(expr);
 
@@ -812,8 +804,6 @@ bool TypeChecker::typeCheckForCodeCompletion(
     options |= ConstraintSystemFlags::AllowFixes;
     options |= ConstraintSystemFlags::SuppressDiagnostics;
     options |= ConstraintSystemFlags::ForCodeCompletion;
-    options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
-
 
     ConstraintSystem cs(DC, options);
 
@@ -902,9 +892,7 @@ static Optional<Type> getTypeOfCompletionContextExpr(
                         Expr *&parsedExpr,
                         ConcreteDeclRef &referencedDecl) {
   if (constraints::ConstraintSystem::preCheckExpression(
-          parsedExpr, DC,
-          /*replaceInvalidRefsWithErrors=*/true,
-          /*leaveClosureBodiesUnchecked=*/true))
+          parsedExpr, DC, /*replaceInvalidRefsWithErrors=*/true))
     return None;
 
   switch (kind) {
@@ -984,9 +972,7 @@ bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   parsedExpr = parsedExpr->walk(SanitizeExpr(ctx, /*shouldReusePrecheckedType=*/false));
 
   DiagnosticSuppression suppression(ctx.Diags);
-  auto resultTy = TypeChecker::typeCheckExpression(
-      parsedExpr, DC,
-      /*contextualInfo=*/{}, TypeCheckExprFlags::LeaveClosureBodyUnchecked);
+  auto resultTy = TypeChecker::typeCheckExpression(parsedExpr, DC);
   return !resultTy;
 }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1670,12 +1670,7 @@ public:
   ASTContext &Ctx;
   SourceFile *SF;
 
-  bool LeaveClosureBodiesUnchecked;
-
-  explicit DeclChecker(ASTContext &ctx, SourceFile *SF,
-                       bool LeaveClosureBodiesUnchecked = false)
-      : Ctx(ctx), SF(SF),
-        LeaveClosureBodiesUnchecked(LeaveClosureBodiesUnchecked) {}
+  explicit DeclChecker(ASTContext &ctx, SourceFile *SF) : Ctx(ctx), SF(SF) {}
 
   ASTContext &getASTContext() const { return Ctx; }
   void addDelayedFunction(AbstractFunctionDecl *AFD) {
@@ -2049,13 +2044,7 @@ public:
         continue;
 
       if (!PBD->isInitializerChecked(i)) {
-        TypeCheckExprOptions options;
-
-        if (LeaveClosureBodiesUnchecked)
-          options |= TypeCheckExprFlags::LeaveClosureBodyUnchecked;
-
-        TypeChecker::typeCheckPatternBinding(PBD, i, /*patternType=*/Type(),
-                                             options);
+        TypeChecker::typeCheckPatternBinding(PBD, i);
       }
 
       if (!PBD->isInvalid()) {
@@ -3175,9 +3164,9 @@ public:
 };
 } // end anonymous namespace
 
-void TypeChecker::typeCheckDecl(Decl *D, bool LeaveClosureBodiesUnchecked) {
+void TypeChecker::typeCheckDecl(Decl *D) {
   auto *SF = D->getDeclContext()->getParentSourceFile();
-  DeclChecker(D->getASTContext(), SF, LeaveClosureBodiesUnchecked).visit(D);
+  DeclChecker(D->getASTContext(), SF).visit(D);
 }
 
 void TypeChecker::checkParameterList(ParameterList *params,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1514,7 +1514,7 @@ void StmtChecker::typeCheckASTNode(ASTNode &node) {
 
   // Type check the declaration.
   if (auto *D = node.dyn_cast<Decl *>()) {
-    TypeChecker::typeCheckDecl(D, LeaveBraceStmtBodyUnchecked);
+    TypeChecker::typeCheckDecl(D);
     return;
   }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -445,20 +445,15 @@ swift::handleSILGenericParams(GenericParamList *genericParams,
 }
 
 void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
-                                    unsigned bindingIndex,
-                                    bool leaveClosureBodiesUnchecked) {
+                                    unsigned bindingIndex) {
   assert(!PBD->isInitializerChecked(bindingIndex) &&
          PBD->getInit(bindingIndex));
 
   auto &Ctx = PBD->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-
-  TypeCheckExprOptions options;
-  if (leaveClosureBodiesUnchecked)
-    options |= TypeCheckExprFlags::LeaveClosureBodyUnchecked;
-
-  TypeChecker::typeCheckPatternBinding(PBD, bindingIndex,
-                                       /*patternType=*/Type(), options);
+  (void)evaluateOrDefault(
+      Ctx.evaluator, PatternBindingEntryRequest{PBD, bindingIndex}, nullptr);
+  TypeChecker::typeCheckPatternBinding(PBD, bindingIndex);
 }
 
 bool swift::typeCheckASTNodeAtLoc(DeclContext *DC, SourceLoc TargetLoc) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -400,7 +400,7 @@ Type typeCheckParameterDefault(Expr *&defaultValue, DeclContext *DC,
 
 void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 
-void typeCheckDecl(Decl *D, bool LeaveClosureBodiesUnchecked = false);
+void typeCheckDecl(Decl *D);
 
 void addImplicitDynamicAttribute(Decl *D);
 void checkDeclAttributes(Decl *D);
@@ -665,11 +665,9 @@ void coerceParameterListToType(ParameterList *P, AnyFunctionType *FN);
 bool typeCheckBinding(Pattern *&P, Expr *&Init, DeclContext *DC,
                       Type patternType,
                       PatternBindingDecl *PBD = nullptr,
-                      unsigned patternNumber = 0,
-                      TypeCheckExprOptions options = {});
+                      unsigned patternNumber = 0);
 bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
-                             Type patternType = Type(),
-                             TypeCheckExprOptions options = {});
+                             Type patternType = Type());
 
 /// Type-check a for-each loop's pattern binding and sequence together.
 ///

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -252,7 +252,7 @@ struct CC {}
 func callCC<U>(_ f: (CC) -> U) -> () {}
 
 func typeCheckMultiStmtClosureCrash() {
-  callCC {
+  callCC { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
     _ = $0
     return 1
   }
@@ -312,8 +312,9 @@ func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
 struct Thing {
   init?() {}
 }
-
-let things = Thing().map { thing in
+// This throws a compiler error
+let things = Thing().map { thing in  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{34-34=-> <#Result#> }}
+  // Commenting out this makes it compile
   _ = thing
   return thing
 }
@@ -321,14 +322,14 @@ let things = Thing().map { thing in
 
 // <rdar://problem/21675896> QoI: [Closure return type inference] Swift cannot find members for the result of inlined lambdas with branches
 func r21675896(file : String) {
-  let x: String = {
+  let x: String = { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{20-20= () -> <#Result#> in }}
     if true {
       return "foo"
     }
     else {
       return file
     }
-  }().pathExtension // expected-error {{value of type 'String' has no member 'pathExtension'}}
+  }().pathExtension
 }
 
 
@@ -359,7 +360,7 @@ func someGeneric19997471<T>(_ x: T) {
 
 
 // <rdar://problem/20921068> Swift fails to compile: [0].map() { _ in let r = (1,2).0; return r }
-let _ = [0].map {
+[0].map {  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{5-5=-> <#Result#> }}
   _ in
   let r =  (1,2).0
   return r
@@ -407,7 +408,7 @@ func r20789423() {
   print(p.f(p)())  // expected-error {{cannot convert value of type 'C' to expected argument type 'Int'}}
   // expected-error@-1:11 {{cannot call value of non-function type '()'}}
   
-  let _f = { (v: Int) in
+  let _f = { (v: Int) in  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{23-23=-> <#Result#> }}
     print("a")
     return "hi"
   }
@@ -1126,7 +1127,7 @@ func rdar76058892() {
   func experiment(arr: [S]?) {
     test { // expected-error {{contextual closure type '() -> String' expects 0 arguments, but 1 was used in closure body}}
       if let arr = arr {
-        arr.map($0.test) // expected-note {{anonymous closure parameter '$0' is used here}} // expected-error {{generic parameter 'T' could not be inferred}}
+        arr.map($0.test) // expected-note {{anonymous closure parameter '$0' is used here}}
       }
     }
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -148,7 +148,7 @@ func ***~(_: Int, _: String) { }
 i ***~ i // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
 
 @available(*, unavailable, message: "call the 'map()' method on the sequence")
-public func myMap<C : Collection, T>( // expected-note {{'myMap' has been explicitly marked unavailable here}}
+public func myMap<C : Collection, T>(
   _ source: C, _ transform: (C.Iterator.Element) -> T
 ) -> [T] {
   fatalError("unavailable function can't be called")
@@ -161,7 +161,7 @@ public func myMap<T, U>(_ x: T?, _ f: (T) -> U) -> U? {
 
 // <rdar://problem/20142523>
 func rdar20142523() {
-  _ = myMap(0..<10, { x in // expected-error {{'myMap' is unavailable: call the 'map()' method on the sequence}}
+  myMap(0..<10, { x in // expected-error{{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{21-21=-> <#Result#> }} {{educational-notes=complex-closure-inference}}
     ()
     return x
   })

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -595,10 +595,10 @@ func rdar50679161() {
 
   func foo() {
     _ = { () -> Void in
-      // Missing `.self` or `init` is not diagnosed here because there are errors in
-      // `if let` statement and `MiscDiagnostics` only run if the body is completely valid.
       var foo = S
-
+      // expected-error@-1 {{expected member name or constructor call after type name}}
+      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+      // expected-note@-3 {{use '.self' to reference the type object}}
       if let v = Int?(1) {
         var _ = Q(
           a: v + foo.w,
@@ -609,14 +609,6 @@ func rdar50679161() {
           // expected-error@-2 {{cannot convert value of type 'Point' to expected argument type 'Int'}}
         )
       }
-    }
-
-    _ = { () -> Void in
-      var foo = S
-      // expected-error@-1 {{expected member name or constructor call after type name}}
-      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-      // expected-note@-3 {{use '.self' to reference the type object}}
-      print(foo)
     }
   }
 }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -230,14 +230,14 @@ func good(_ a: A<EE>) -> Int {
 }
 
 func bad(_ a: A<EE>) {
-  let _ = a.map {
+  a.map { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
     let _: EE = $0
     return 1
   }
 }
 
 func ugly(_ a: A<EE>) {
-  let _ = a.map {
+  a.map { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
     switch $0 {
     case .A:
       return 1

--- a/test/Constraints/rdar46544601.swift
+++ b/test/Constraints/rdar46544601.swift
@@ -26,6 +26,6 @@ func crash(_ p: P, payload: [UInt8]) throws {
     p.foo(arr: arr, data: []).and(result: (id, arr))
   }.then { args0 in
     let (parentID, args1) = args0
-    p.bar(root: parentID, from: p).and(result: args1)
+    p.bar(root: parentID, from: p).and(args1)
   }.whenFailure { _ in }
 }

--- a/test/Constraints/rdar65320500.swift
+++ b/test/Constraints/rdar65320500.swift
@@ -31,13 +31,13 @@ test_builder {
 test_builder {
   test(doesntExist()) // expected-error {{cannot find 'doesntExist' in scope}}
 
-  if let result = doesntExist() { // expected-error {{cannot find 'doesntExist' in scope}}
+  if let result = doesntExist() {
   }
 
-  if bar = test(42) {} // expected-error {{cannot find 'bar' in scope}}
+  if bar = test(42) {}
 
-  let foo = bar() // expected-error {{cannot find 'bar' in scope}}
+  let foo = bar()
 
-  switch (doesntExist()) { // expected-error {{cannot find 'doesntExist' in scope}}
+  switch (doesntExist()) {
   }
 }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -78,7 +78,7 @@ struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf
   static func buildDo<T>(_ value: T) -> T { return value }
 }
 
-func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) { // expected-note {{in call to function 'tuplify(_:body:)'}}
+func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
   print(body(cond))
 }
 
@@ -309,13 +309,12 @@ struct MyTuplifiedStruct {
 
 func test_invalid_return_type_in_body() {
   tuplify(true) { _ -> (Void, Int) in
-    // If there is a `return` in the body result builder attribute is dropped, so nested `tuplify(false)`
-    // is correct (type-check is successful) with multi-statement closure inference enabled.
     tuplify(false) { condition in
       if condition {
-        return 42
+        return 42 // expected-error {{cannot use explicit 'return' statement in the body of result builder 'TupleBuilder'}}
+        // expected-note@-1 {{remove 'return' statements to apply the result builder}} {{9-16=}}
       } else {
-        1 // expected-warning {{integer literal is unused}}
+        1
       }
     }
 
@@ -483,7 +482,7 @@ struct TestConstraintGenerationErrors {
   func buildTupleClosure() {
     tuplify(true) { _ in
       let a = nothing // expected-error {{cannot find 'nothing' in scope}}
-      String(nothing) // expected-error {{cannot find 'nothing' in scope}}
+      String(nothing)
     }
   }
 }
@@ -524,7 +523,7 @@ enum E3 {
 }
 
 func testCaseMutabilityMismatches(e: E3) {
-   tuplify(true) { c in // expected-error {{generic parameter 'T' could not be inferred}}
+    tuplify(true) { c in
     "testSwitch"
     switch e {
     case .a(let x, var y),

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -218,14 +218,14 @@ extension r25271859 {
   func map<U>(f: (T) -> U) -> r25271859<U> {
   }
 
-  func andThen<U>(f: (T) -> r25271859<U>) {
+  func andThen<U>(f: (T) -> r25271859<U>) { // expected-note {{in call to function 'andThen(f:)'}}
   }
 }
 
 func f(a : r25271859<(Float, Int)>) {
-  a.map { $0.0 }
+  a.map { $0.0 } // expected-error {{generic parameter 'U' could not be inferred}} (This is related to how solver is setup with multiple statements)
     .andThen { _ in
-      print("hello")
+      print("hello") // comment this out and it runs, leave any form of print in and it doesn't
       return r25271859<String>()
   }
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1407,17 +1407,9 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   }
 
   f2.forEach { block in
-  // expected-note@-1 {{'block' declared here}}
+  // expected-note@-1 2{{'block' declared here}}
     block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
-  }
-
-  f2.forEach { block in
-  // expected-note@-1 {{'block' declared here}}
     block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
-    block(c, c)
-  }
-
-  f2.forEach { block in
     block(c, c)
   }
 
@@ -1425,21 +1417,13 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> Void' to expected argument type '(@escaping (Bool, Bool) -> ()) throws -> Void'}}
     block(p)
     block((c, c))
-    block(c, c) // expected-error {{parameter 'block' expects a single parameter of type '(Bool, Bool)'}}
-  }
-
-  f2.forEach { (block: (Bool, Bool) -> ()) in
-  // expected-note@-1 {{'block' declared here}}
-    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
-  }
-
-  f2.forEach { (block: (Bool, Bool) -> ()) in
-    // expected-note@-1 {{'block' declared here}}
-    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 
   f2.forEach { (block: (Bool, Bool) -> ()) in
+  // expected-note@-1 2{{'block' declared here}}
+    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
+    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 }

--- a/test/Constraints/without_actually_escaping.swift
+++ b/test/Constraints/without_actually_escaping.swift
@@ -10,7 +10,7 @@ func escapeX(_ xx: (Int) -> Int, _ value: Int) { // expected-note* {{non-escapin
   withoutActuallyEscaping(xx) { escapableXX in
     x = xx // expected-error{{non-escaping parameter}}
     x = escapableXX
-    x = xx
+    x = xx // expected-error{{non-escaping parameter}}
 
     _ = x(value)
     _ = xx(value)

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -132,13 +132,15 @@ func SR12689(_ u: UnsafeBufferPointer<UInt16>) {}
 let array : [UInt16] = [1, 2]
 
 array.withUnsafeBufferPointer {
-  _ = SR12689(UnsafeRawPointer($0).bindMemory(to: UInt16.self, capacity: 1)) // expected-error {{cannot convert value of type 'UnsafePointer<UInt16>' to expected argument type 'UnsafeBufferPointer<UInt16>'}}
-  // expected-error@-1 {{cannot convert value of type 'UnsafeBufferPointer<UInt16>' to expected argument type 'UnsafeMutableRawPointer'}}
-}
+  SR12689(UnsafeRawPointer($0).bindMemory(to: UInt16.self, capacity: 1)) // expected-error {{cannot convert value of type 'UnsafePointer<UInt16>' to expected argument type 'UnsafeBufferPointer<UInt16>'}}
+  // expected-error@-1 {{no exact matches in call to initializer}}
+  // expected-note@-2 {{candidate expects value of type 'UnsafeRawPointer' for parameter #1}}
+  // expected-note@-3 {{candidate expects value of type 'UnsafeMutableRawPointer' for parameter #1}}
 
-array.withUnsafeBufferPointer {
-  _ = UnsafeRawPointer($0) as UnsafeBufferPointer<UInt16> // expected-error {{cannot convert value of type 'UnsafeRawPointer' to type 'UnsafeBufferPointer<UInt16>' in coercion}}
-  // expected-error@-1 {{cannot convert value of type 'UnsafeBufferPointer<UInt16>' to expected argument type 'UnsafeMutableRawPointer'}}
+  UnsafeRawPointer($0) as UnsafeBufferPointer<UInt16> // expected-error {{cannot convert value of type 'UnsafeRawPointer' to type 'UnsafeBufferPointer<UInt16>' in coercion}}
+  // expected-error@-1 {{no exact matches in call to initializer}}
+  // expected-note@-2 {{found candidate with type '(UnsafeRawPointer) -> UnsafeRawPointer'}}
+  // expected-note@-3 {{found candidate with type '(UnsafeMutableRawPointer) -> UnsafeRawPointer'}}
 }
 
 func SR12689_1(_ u: Int) -> String { "" } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -124,6 +124,13 @@ foo(b:
 // CHECK:             |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: [[#LINE+1]] | }
 
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:9
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | let x = { () -> Result in
+// CHECK:             |          +++++++++++++++++
+// CHECK:             |         ^ error: cannot infer return type for closure with multiple statements; add explicit type to disambiguate
+// CHECK: [[#LINE+1]] |   let y = 1
+
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:8
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | struct B: Decodable {
@@ -141,6 +148,12 @@ foo(b:
 // CHECK:             |           ++++++~~~~------
 // CHECK:             |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: [[#LINE+1]] |
+
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:20
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | let 👍👍👍 = {
+// CHECK:    | --> error: cannot infer return type for closure with multiple statements; add explicit type to disambiguate [insert ' () -> <#Result#> in ']
+// CHECK: [[#LINE+1]] |   let y = 1
 
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:5
 // CHECK: [[#LINE-2]] | // Multi-line fix-its

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -29,7 +29,11 @@ func variadic() {
 
   takesVariadicGeneric({takesIntArray($0)})
 
+  // FIXME: Problem here is related to multi-statement closure body not being type-checked together with
+  // enclosing context. We could have inferred `$0` to be `[Int]` if `let` was a part of constraint system.
   takesVariadicGeneric({let _: [Int] = $0})
+  // expected-error@-1 {{unable to infer type of a closure parameter '$0' in the current context}}
+
   takesVariadicIntInt({_ = $0; takesIntArray($1)})
   takesVariadicIntInt({_ = $0; let _: [Int] = $1})
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -120,8 +120,9 @@ var selfRef = { selfRef() }
 // expected-note@-1 2{{through reference here}}
 // expected-error@-2 {{circular reference}}
 
-var nestedSelfRef = { // expected-error {{circular reference}} expected-note 2 {{through reference here}}
+var nestedSelfRef = {
   var recursive = { nestedSelfRef() }
+  // expected-warning@-1 {{variable 'recursive' was never mutated; consider changing to 'let' constant}}
   recursive()
 }
 
@@ -139,11 +140,12 @@ func anonymousClosureArgsInClosureWithArgs() {
   var a3 = { (z: Int) in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{26-28=z}}
   var a4 = { (z: [Int], w: [Int]) in
     f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{7-9=z}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
-    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}}
+    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
   }
   var a5 = { (_: [Int], w: [Int]) in
     f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
     f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
   }
 }
 
@@ -401,7 +403,7 @@ Void(0) // expected-error{{argument passed to call that takes no arguments}}
 _ = {0}
 
 // <rdar://problem/22086634> "multi-statement closures require an explicit return type" should be an error not a note
-let samples = {
+let samples = {   // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{16-16= () -> <#Result#> in }}
           if (i > 10) { return true }
           else { return false }
         }()
@@ -483,8 +485,8 @@ func lvalueCapture<T>(c: GenericClass<T>) {
 }
 
 // Don't expose @lvalue-ness in diagnostics.
-let closure = {
-  var helper = true // expected-warning {{variable 'helper' was never mutated; consider changing to 'let' constant}}
+let closure = { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{16-16= () -> <#Result#> in }}
+  var helper = true
   return helper
 }
 

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -34,9 +34,10 @@ func unnamed() {
 // Regression tests.
 
 var nestedClosuresWithBrokenInference = { f: Int in {} }
-    // expected-error@-1 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
-    // expected-error@-2 {{expected expression}}
-    // expected-error@-3 {{cannot find 'f' in scope}}
+    // expected-error@-1 {{closure expression is unused}} expected-note@-1 {{did you mean to use a 'do' statement?}} {{53-53=do }}
+    // expected-error@-2 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
+    // expected-error@-3 {{expected expression}}
+    // expected-error@-4 {{cannot find 'f' in scope}}
 
 // SR-11540
 

--- a/test/expr/closure/let.swift
+++ b/test/expr/closure/let.swift
@@ -9,7 +9,7 @@ func foo() {
 
   _ = { frob(x: x) }() // expected-error{{'x' is a 'let'}}
   _ = { x = 0 }() // expected-error{{'x' is a 'let'}}
-  _ = { frob(x: x); x = 0 }() // expected-error {{'x' is a 'let'}}
+  _ = { frob(x: x); x = 0 }() // expected-error 2 {{'x' is a 'let'}}
 }
 
 let a: Int 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -246,9 +246,11 @@ func test_as_2() {
 func test_lambda() {
   // A simple closure.
   var a = { (value: Int) -> () in markUsed(value+1) }
+  // expected-warning@-1 {{initialization of variable 'a' was never used; consider replacing with assignment to '_' or removing it}}
 
   // A recursive lambda.
-  var fib = { (n: Int) -> Int in // expected-error {{circular reference}} expected-note 2 {{through reference here}}
+  var fib = { (n: Int) -> Int in
+    // expected-warning@-1 {{variable 'fib' was never mutated; consider changing to 'let' constant}}
     if (n < 2) {
       return n
     }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1093,6 +1093,8 @@ func rdar74711236() {
         // `isSupported` should be an invalid declaration to trigger a crash in `map(\.option)`
         let isSupported = context!.supported().contains(type)
         return (isSupported ? [type] : []).map(\.option)
+        // expected-error@-1 {{value of type 'Any' has no member 'option'}}
+        // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
       }
       return []
     }()

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -400,19 +400,12 @@ func test_is_as_patterns() {
 }
 
 // <rdar://problem/21387308> Fuzzing SourceKit: crash in Parser::parseStmtForEach(...)
-func matching_pattern_recursion(zs: [Int]) { // expected-note {{'zs' declared here}}
+func matching_pattern_recursion() {
   switch 42 {
   case {  // expected-error {{expression pattern of type '() -> ()' cannot match values of type 'Int'}}
       for i in zs {
       }
   }: break
-  }
-
-  switch 42 {
-  case {
-      for i in ws { // expected-error {{cannot find 'ws' in scope; did you mean 'zs'?}}
-      }
-    }: break
   }
 }
 

--- a/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
+++ b/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
@@ -17,7 +17,7 @@ struct M<L : P, R> {
   }
 }
 
-protocol P { // expected-note {{where 'Self' = 'M<WritableKeyPath<X, Int>, Int>'}}
+protocol P { // expected-note {{where 'Self' = 'M<WritableKeyPath<X, Int>, R>'}}
   associatedtype A
   associatedtype B
 
@@ -42,4 +42,5 @@ extension WritableKeyPath : P {
 struct X { var y: Int = 0 }
 var x = X()
 x ~> \X.y ≈> { a in a += 1; return 3 }
-//expected-error@-1 {{referencing operator function '~>' on 'P' requires that 'M<WritableKeyPath<X, Int>, Int>' conform to 'P'}}
+// expected-error@-1 {{referencing operator function '~>' on 'P' requires that 'M<WritableKeyPath<X, Int>, R>' conform to 'P'}}
+// expected-error@-2 {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}}


### PR DESCRIPTION
Reverts apple/swift#39989

Has to be reverted due to performance issues related to operators (because `shrink` is not run for expressions in the multi-statement closure body).