### PR TITLE
[SourceKit] Add structure node for SubscriptExpr

### DIFF
--- a/test/SourceKit/DocumentStructure/access_parse.swift.response
+++ b/test/SourceKit/DocumentStructure/access_parse.swift.response
@@ -543,8 +543,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 911,
           key.length: 9,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -561,8 +559,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 923,
           key.length: 9,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,

--- a/test/SourceKit/DocumentStructure/mark_edit.swift.response
+++ b/test/SourceKit/DocumentStructure/mark_edit.swift.response
@@ -6,9 +6,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment.mark,
       key.offset: 5,
-      key.length: 11,
-      key.nameoffset: 0,
-      key.namelength: 0
+      key.length: 11
     }
   ]
 }
@@ -18,9 +16,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment.mark,
       key.offset: 6,
-      key.length: 11,
-      key.nameoffset: 0,
-      key.namelength: 0
+      key.length: 11
     }
   ]
 }

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -70,8 +70,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 105,
               key.length: 19,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -84,8 +82,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 113,
                   key.length: 11,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 114,
                   key.bodylength: 9
                 }
@@ -311,8 +307,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 529,
               key.length: 63,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -325,8 +319,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 539,
                   key.length: 53,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 540,
                   key.bodylength: 51,
                   key.substructure: [
@@ -344,8 +336,6 @@
                           key.kind: source.lang.swift.expr.argument,
                           key.offset: 564,
                           key.length: 1,
-                          key.nameoffset: 0,
-                          key.namelength: 0,
                           key.bodyoffset: 564,
                           key.bodylength: 1
                         },
@@ -403,9 +393,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment.mark,
       key.offset: 666,
-      key.length: 16,
-      key.nameoffset: 0,
-      key.namelength: 0
+      key.length: 16
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -421,9 +409,7 @@
         {
           key.kind: source.lang.swift.syntaxtype.comment.mark,
           key.offset: 711,
-          key.length: 16,
-          key.nameoffset: 0,
-          key.namelength: 0
+          key.length: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -449,16 +435,12 @@
             {
               key.kind: source.lang.swift.syntaxtype.comment.mark,
               key.offset: 774,
-              key.length: 12,
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.length: 12
             },
             {
               key.kind: source.lang.swift.stmt.if,
               key.offset: 795,
               key.length: 70,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -471,17 +453,13 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 805,
                   key.length: 60,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 806,
                   key.bodylength: 58,
                   key.substructure: [
                     {
                       key.kind: source.lang.swift.syntaxtype.comment.mark,
                       key.offset: 822,
-                      key.length: 12,
-                      key.nameoffset: 0,
-                      key.namelength: 0
+                      key.length: 12
                     }
                   ]
                 }
@@ -515,8 +493,6 @@
           key.kind: source.lang.swift.stmt.if,
           key.offset: 921,
           key.length: 74,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -529,17 +505,13 @@
               key.kind: source.lang.swift.stmt.brace,
               key.offset: 931,
               key.length: 64,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 932,
               key.bodylength: 62,
               key.substructure: [
                 {
                   key.kind: source.lang.swift.syntaxtype.comment.mark,
                   key.offset: 960,
-                  key.length: 29,
-                  key.nameoffset: 0,
-                  key.namelength: 0
+                  key.length: 29
                 }
               ]
             }
@@ -582,8 +554,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -609,8 +579,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1129,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1130,
           key.bodylength: 0
         }
@@ -620,8 +588,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1132,
       key.length: 37,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -642,8 +608,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1167,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1168,
           key.bodylength: 0
         }
@@ -653,8 +617,6 @@
       key.kind: source.lang.swift.stmt.while,
       key.offset: 1170,
       key.length: 36,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -683,8 +645,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1204,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1205,
           key.bodylength: 0
         }
@@ -694,8 +654,6 @@
       key.kind: source.lang.swift.stmt.repeatwhile,
       key.offset: 1207,
       key.length: 22,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -708,8 +666,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1214,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1215,
           key.bodylength: 0
         }
@@ -719,8 +675,6 @@
       key.kind: source.lang.swift.stmt.if,
       key.offset: 1230,
       key.length: 33,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -749,8 +703,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1261,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1262,
           key.bodylength: 0
         }
@@ -760,8 +712,6 @@
       key.kind: source.lang.swift.stmt.switch,
       key.offset: 1264,
       key.length: 67,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -774,8 +724,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1277,
           key.length: 14,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -788,8 +736,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1294,
           key.length: 17,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -807,8 +753,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1314,
           key.length: 15,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -832,8 +776,6 @@
       key.kind: source.lang.swift.expr.array,
       key.offset: 1347,
       key.length: 9,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1348,
       key.bodylength: 7,
       key.elements: [
@@ -867,8 +809,6 @@
       key.kind: source.lang.swift.expr.dictionary,
       key.offset: 1370,
       key.length: 15,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1371,
       key.bodylength: 13,
       key.elements: [
@@ -1102,8 +1042,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 1787,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1787,
           key.bodylength: 2,
           key.substructure: [
@@ -1111,8 +1049,6 @@
               key.kind: source.lang.swift.expr.closure,
               key.offset: 1787,
               key.length: 2,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 1788,
               key.bodylength: 0,
               key.substructure: [
@@ -1120,8 +1056,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 1787,
                   key.length: 2,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 1788,
                   key.bodylength: 0
                 }
@@ -1222,8 +1156,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2006,
           key.length: 18,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1264,8 +1196,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2050,
           key.length: 12,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1370,9 +1300,7 @@
               key.name: "ident",
               key.offset: 2204,
               key.length: 15,
-              key.typename: "String",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "String"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1424,18 +1352,14 @@
               key.name: "lhs",
               key.offset: 2287,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.decl.var.parameter,
               key.name: "rhs",
               key.offset: 2302,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1649,8 +1573,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 2675,
           key.length: 8,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 2675,
           key.bodylength: 8
         }

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -70,8 +70,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 105,
               key.length: 19,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -84,8 +82,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 113,
                   key.length: 11,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 114,
                   key.bodylength: 9
                 }
@@ -311,8 +307,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 529,
               key.length: 63,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -325,8 +319,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 539,
                   key.length: 53,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 540,
                   key.bodylength: 51,
                   key.substructure: [
@@ -344,8 +336,6 @@
                           key.kind: source.lang.swift.expr.argument,
                           key.offset: 564,
                           key.length: 1,
-                          key.nameoffset: 0,
-                          key.namelength: 0,
                           key.bodyoffset: 564,
                           key.bodylength: 1
                         },
@@ -403,9 +393,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment.mark,
       key.offset: 666,
-      key.length: 16,
-      key.nameoffset: 0,
-      key.namelength: 0
+      key.length: 16
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -421,9 +409,7 @@
         {
           key.kind: source.lang.swift.syntaxtype.comment.mark,
           key.offset: 711,
-          key.length: 16,
-          key.nameoffset: 0,
-          key.namelength: 0
+          key.length: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -449,16 +435,12 @@
             {
               key.kind: source.lang.swift.syntaxtype.comment.mark,
               key.offset: 774,
-              key.length: 12,
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.length: 12
             },
             {
               key.kind: source.lang.swift.stmt.if,
               key.offset: 795,
               key.length: 70,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -471,17 +453,13 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 805,
                   key.length: 60,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 806,
                   key.bodylength: 58,
                   key.substructure: [
                     {
                       key.kind: source.lang.swift.syntaxtype.comment.mark,
                       key.offset: 822,
-                      key.length: 12,
-                      key.nameoffset: 0,
-                      key.namelength: 0
+                      key.length: 12
                     }
                   ]
                 }
@@ -515,8 +493,6 @@
           key.kind: source.lang.swift.stmt.if,
           key.offset: 921,
           key.length: 74,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -529,17 +505,13 @@
               key.kind: source.lang.swift.stmt.brace,
               key.offset: 931,
               key.length: 64,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 932,
               key.bodylength: 62,
               key.substructure: [
                 {
                   key.kind: source.lang.swift.syntaxtype.comment.mark,
                   key.offset: 960,
-                  key.length: 29,
-                  key.nameoffset: 0,
-                  key.namelength: 0
+                  key.length: 29
                 }
               ]
             }
@@ -582,8 +554,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -609,8 +579,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1129,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1130,
           key.bodylength: 0
         }
@@ -620,8 +588,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1132,
       key.length: 37,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -642,8 +608,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1167,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1168,
           key.bodylength: 0
         }
@@ -653,8 +617,6 @@
       key.kind: source.lang.swift.stmt.while,
       key.offset: 1170,
       key.length: 36,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -683,8 +645,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1204,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1205,
           key.bodylength: 0
         }
@@ -694,8 +654,6 @@
       key.kind: source.lang.swift.stmt.repeatwhile,
       key.offset: 1207,
       key.length: 22,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -708,8 +666,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1214,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1215,
           key.bodylength: 0
         }
@@ -719,8 +675,6 @@
       key.kind: source.lang.swift.stmt.if,
       key.offset: 1230,
       key.length: 33,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -749,8 +703,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1261,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1262,
           key.bodylength: 0
         }
@@ -760,8 +712,6 @@
       key.kind: source.lang.swift.stmt.switch,
       key.offset: 1264,
       key.length: 67,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -774,8 +724,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1277,
           key.length: 14,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -788,8 +736,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1294,
           key.length: 17,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -807,8 +753,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1314,
           key.length: 15,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -832,8 +776,6 @@
       key.kind: source.lang.swift.expr.array,
       key.offset: 1347,
       key.length: 9,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1348,
       key.bodylength: 7,
       key.elements: [
@@ -867,8 +809,6 @@
       key.kind: source.lang.swift.expr.dictionary,
       key.offset: 1370,
       key.length: 15,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1371,
       key.bodylength: 13,
       key.elements: [
@@ -1102,8 +1042,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 1787,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1787,
           key.bodylength: 2,
           key.substructure: [
@@ -1111,8 +1049,6 @@
               key.kind: source.lang.swift.expr.closure,
               key.offset: 1787,
               key.length: 2,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 1788,
               key.bodylength: 0,
               key.substructure: [
@@ -1120,8 +1056,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 1787,
                   key.length: 2,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 1788,
                   key.bodylength: 0
                 }
@@ -1222,8 +1156,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2006,
           key.length: 18,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1264,8 +1196,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2050,
           key.length: 12,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1370,9 +1300,7 @@
               key.name: "ident",
               key.offset: 2204,
               key.length: 15,
-              key.typename: "String",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "String"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1424,18 +1352,14 @@
               key.name: "lhs",
               key.offset: 2287,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.decl.var.parameter,
               key.name: "rhs",
               key.offset: 2302,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1649,8 +1573,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 2675,
           key.length: 8,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 2675,
           key.bodylength: 8
         }

--- a/test/SourceKit/DocumentStructure/structure.swift.invalid.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.invalid.response
@@ -94,8 +94,6 @@
       key.kind: source.lang.swift.expr.closure,
       key.offset: 141,
       key.length: 24,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 142,
       key.bodylength: 22,
       key.substructure: [
@@ -103,8 +101,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 141,
           key.length: 24,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 142,
           key.bodylength: 22,
           key.substructure: [

--- a/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
@@ -41,8 +41,6 @@
           key.kind: source.lang.swift.stmt.foreach,
           key.offset: 59,
           key.length: 28,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.id,
@@ -68,8 +66,6 @@
               key.kind: source.lang.swift.stmt.brace,
               key.offset: 85,
               key.length: 2,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 86,
               key.bodylength: 0
             }
@@ -90,8 +86,6 @@
       key.kind: source.lang.swift.expr.array,
       key.offset: 239,
       key.length: 22,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 240,
       key.bodylength: 20,
       key.elements: [

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -70,8 +70,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 105,
               key.length: 19,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -84,8 +82,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 113,
                   key.length: 11,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 114,
                   key.bodylength: 9
                 }
@@ -311,8 +307,6 @@
               key.kind: source.lang.swift.stmt.if,
               key.offset: 529,
               key.length: 63,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -325,8 +319,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 539,
                   key.length: 53,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 540,
                   key.bodylength: 51,
                   key.substructure: [
@@ -344,8 +336,6 @@
                           key.kind: source.lang.swift.expr.argument,
                           key.offset: 564,
                           key.length: 1,
-                          key.nameoffset: 0,
-                          key.namelength: 0,
                           key.bodyoffset: 564,
                           key.bodylength: 1
                         },
@@ -403,9 +393,7 @@
     {
       key.kind: source.lang.swift.syntaxtype.comment.mark,
       key.offset: 666,
-      key.length: 16,
-      key.nameoffset: 0,
-      key.namelength: 0
+      key.length: 16
     },
     {
       key.kind: source.lang.swift.decl.class,
@@ -421,9 +409,7 @@
         {
           key.kind: source.lang.swift.syntaxtype.comment.mark,
           key.offset: 711,
-          key.length: 16,
-          key.nameoffset: 0,
-          key.namelength: 0
+          key.length: 16
         },
         {
           key.kind: source.lang.swift.decl.function.method.instance,
@@ -449,16 +435,12 @@
             {
               key.kind: source.lang.swift.syntaxtype.comment.mark,
               key.offset: 774,
-              key.length: 12,
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.length: 12
             },
             {
               key.kind: source.lang.swift.stmt.if,
               key.offset: 795,
               key.length: 70,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.elements: [
                 {
                   key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -471,17 +453,13 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 805,
                   key.length: 60,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 806,
                   key.bodylength: 58,
                   key.substructure: [
                     {
                       key.kind: source.lang.swift.syntaxtype.comment.mark,
                       key.offset: 822,
-                      key.length: 12,
-                      key.nameoffset: 0,
-                      key.namelength: 0
+                      key.length: 12
                     }
                   ]
                 }
@@ -515,8 +493,6 @@
           key.kind: source.lang.swift.stmt.if,
           key.offset: 921,
           key.length: 74,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -529,17 +505,13 @@
               key.kind: source.lang.swift.stmt.brace,
               key.offset: 931,
               key.length: 64,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 932,
               key.bodylength: 62,
               key.substructure: [
                 {
                   key.kind: source.lang.swift.syntaxtype.comment.mark,
                   key.offset: 960,
-                  key.length: 29,
-                  key.nameoffset: 0,
-                  key.namelength: 0
+                  key.length: 29
                 }
               ]
             }
@@ -582,8 +554,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1114,
       key.length: 17,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -609,8 +579,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1129,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1130,
           key.bodylength: 0
         }
@@ -620,8 +588,6 @@
       key.kind: source.lang.swift.stmt.foreach,
       key.offset: 1132,
       key.length: 37,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.id,
@@ -642,8 +608,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1167,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1168,
           key.bodylength: 0
         }
@@ -653,8 +617,6 @@
       key.kind: source.lang.swift.stmt.while,
       key.offset: 1170,
       key.length: 36,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -683,8 +645,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1204,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1205,
           key.bodylength: 0
         }
@@ -694,8 +654,6 @@
       key.kind: source.lang.swift.stmt.repeatwhile,
       key.offset: 1207,
       key.length: 22,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -708,8 +666,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1214,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1215,
           key.bodylength: 0
         }
@@ -719,8 +675,6 @@
       key.kind: source.lang.swift.stmt.if,
       key.offset: 1230,
       key.length: 33,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.condition_expr,
@@ -749,8 +703,6 @@
           key.kind: source.lang.swift.stmt.brace,
           key.offset: 1261,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1262,
           key.bodylength: 0
         }
@@ -760,8 +712,6 @@
       key.kind: source.lang.swift.stmt.switch,
       key.offset: 1264,
       key.length: 67,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.elements: [
         {
           key.kind: source.lang.swift.structure.elem.expr,
@@ -774,8 +724,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1277,
           key.length: 14,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -788,8 +736,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1294,
           key.length: 17,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -807,8 +753,6 @@
           key.kind: source.lang.swift.stmt.case,
           key.offset: 1314,
           key.length: 15,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.elements: [
             {
               key.kind: source.lang.swift.structure.elem.pattern,
@@ -832,8 +776,6 @@
       key.kind: source.lang.swift.expr.array,
       key.offset: 1347,
       key.length: 9,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1348,
       key.bodylength: 7,
       key.elements: [
@@ -867,8 +809,6 @@
       key.kind: source.lang.swift.expr.dictionary,
       key.offset: 1370,
       key.length: 15,
-      key.nameoffset: 0,
-      key.namelength: 0,
       key.bodyoffset: 1371,
       key.bodylength: 13,
       key.elements: [
@@ -1102,8 +1042,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 1787,
           key.length: 2,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 1787,
           key.bodylength: 2,
           key.substructure: [
@@ -1111,8 +1049,6 @@
               key.kind: source.lang.swift.expr.closure,
               key.offset: 1787,
               key.length: 2,
-              key.nameoffset: 0,
-              key.namelength: 0,
               key.bodyoffset: 1788,
               key.bodylength: 0,
               key.substructure: [
@@ -1120,8 +1056,6 @@
                   key.kind: source.lang.swift.stmt.brace,
                   key.offset: 1787,
                   key.length: 2,
-                  key.nameoffset: 0,
-                  key.namelength: 0,
                   key.bodyoffset: 1788,
                   key.bodylength: 0
                 }
@@ -1222,8 +1156,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2006,
           key.length: 18,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1264,8 +1196,6 @@
           key.kind: source.lang.swift.decl.enumcase,
           key.offset: 2050,
           key.length: 12,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.substructure: [
             {
               key.kind: source.lang.swift.decl.enumelement,
@@ -1370,9 +1300,7 @@
               key.name: "ident",
               key.offset: 2204,
               key.length: 15,
-              key.typename: "String",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "String"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1424,18 +1352,14 @@
               key.name: "lhs",
               key.offset: 2287,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.decl.var.parameter,
               key.name: "rhs",
               key.offset: 2302,
               key.length: 13,
-              key.typename: "Chain<A>",
-              key.nameoffset: 0,
-              key.namelength: 0
+              key.typename: "Chain<A>"
             },
             {
               key.kind: source.lang.swift.expr.call,
@@ -1649,8 +1573,6 @@
           key.kind: source.lang.swift.expr.argument,
           key.offset: 2675,
           key.length: 8,
-          key.nameoffset: 0,
-          key.namelength: 0,
           key.bodyoffset: 2675,
           key.bodylength: 8
         }

--- a/test/SourceKit/DocumentStructure/structure_args.swift
+++ b/test/SourceKit/DocumentStructure/structure_args.swift
@@ -1,0 +1,10 @@
+simple.paramNoLabel(0)
+simple.paramsNoLabels(0, 1)
+simple.paramWithLabel(label: 0)
+simple.paramsWithLabel(label1: 0, label2: 1)
+
+subscriptNoLabel[b].paramNoLabel(0)
+subscriptWithLabel[label: b].paramWithLabel(label: 0)
+
+// RUN: %sourcekitd-test -req=structure %s > %t.response
+// RUN: %diff -u %s.response %t.response

--- a/test/SourceKit/DocumentStructure/structure_args.swift.response
+++ b/test/SourceKit/DocumentStructure/structure_args.swift.response
@@ -1,0 +1,188 @@
+{
+  key.offset: 0,
+  key.length: 318,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.substructure: [
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "simple.paramNoLabel",
+      key.offset: 0,
+      key.length: 22,
+      key.nameoffset: 0,
+      key.namelength: 19,
+      key.bodyoffset: 20,
+      key.bodylength: 1,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 20,
+          key.length: 1,
+          key.bodyoffset: 20,
+          key.bodylength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "simple.paramsNoLabels",
+      key.offset: 23,
+      key.length: 27,
+      key.nameoffset: 23,
+      key.namelength: 21,
+      key.bodyoffset: 45,
+      key.bodylength: 4,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 45,
+          key.length: 1,
+          key.bodyoffset: 45,
+          key.bodylength: 1
+        },
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 48,
+          key.length: 1,
+          key.bodyoffset: 48,
+          key.bodylength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "simple.paramWithLabel",
+      key.offset: 51,
+      key.length: 31,
+      key.nameoffset: 51,
+      key.namelength: 21,
+      key.bodyoffset: 73,
+      key.bodylength: 8,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.name: "label",
+          key.offset: 73,
+          key.length: 8,
+          key.nameoffset: 73,
+          key.namelength: 5,
+          key.bodyoffset: 80,
+          key.bodylength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "simple.paramsWithLabel",
+      key.offset: 83,
+      key.length: 44,
+      key.nameoffset: 83,
+      key.namelength: 22,
+      key.bodyoffset: 106,
+      key.bodylength: 20,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.name: "label1",
+          key.offset: 106,
+          key.length: 9,
+          key.nameoffset: 106,
+          key.namelength: 6,
+          key.bodyoffset: 114,
+          key.bodylength: 1
+        },
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.name: "label2",
+          key.offset: 117,
+          key.length: 9,
+          key.nameoffset: 117,
+          key.namelength: 6,
+          key.bodyoffset: 125,
+          key.bodylength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "subscriptNoLabel[b].paramNoLabel",
+      key.offset: 129,
+      key.length: 35,
+      key.nameoffset: 129,
+      key.namelength: 32,
+      key.bodyoffset: 162,
+      key.bodylength: 1,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "subscriptNoLabel",
+          key.offset: 129,
+          key.length: 19,
+          key.nameoffset: 129,
+          key.namelength: 16,
+          key.bodyoffset: 146,
+          key.bodylength: 1,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.expr.argument,
+              key.offset: 146,
+              key.length: 1,
+              key.bodyoffset: 146,
+              key.bodylength: 1
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 162,
+          key.length: 1,
+          key.bodyoffset: 162,
+          key.bodylength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.expr.call,
+      key.name: "subscriptWithLabel[label: b].paramWithLabel",
+      key.offset: 165,
+      key.length: 53,
+      key.nameoffset: 165,
+      key.namelength: 43,
+      key.bodyoffset: 209,
+      key.bodylength: 8,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.call,
+          key.name: "subscriptWithLabel",
+          key.offset: 165,
+          key.length: 28,
+          key.nameoffset: 165,
+          key.namelength: 18,
+          key.bodyoffset: 184,
+          key.bodylength: 8,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.expr.argument,
+              key.name: "label",
+              key.offset: 184,
+              key.length: 8,
+              key.nameoffset: 184,
+              key.namelength: 5,
+              key.bodyoffset: 191,
+              key.bodylength: 1
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.name: "label",
+          key.offset: 209,
+          key.length: 8,
+          key.nameoffset: 209,
+          key.namelength: 5,
+          key.bodyoffset: 216,
+          key.bodylength: 1
+        }
+      ]
+    }
+  ]
+}

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
@@ -75,9 +75,7 @@ public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
         key.name: "a",
         key.offset: 45,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -193,9 +193,7 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
         key.name: "a",
         key.offset: 94,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4281,9 +4281,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "rawValue",
             key.offset: 269,
             key.length: 18,
-            key.typename: "UInt32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "UInt32"
           }
         ]
       },
@@ -4414,9 +4412,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "rawValue",
             key.offset: 499,
             key.length: 18,
-            key.typename: "UInt32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "UInt32"
           }
         ]
       },
@@ -4564,9 +4560,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "rawValue",
             key.offset: 739,
             key.length: 18,
-            key.typename: "UInt32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "UInt32"
           }
         ]
       },
@@ -4691,8 +4685,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 1020,
         key.length: 26,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -4716,8 +4708,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 1052,
         key.length: 20,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -4741,8 +4731,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 1103,
         key.length: 26,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -5281,9 +5269,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "a",
         key.offset: 2135,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },
@@ -5308,9 +5294,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.parameter,
         key.offset: 2192,
         key.length: 8,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },
@@ -5336,36 +5320,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "a",
         key.offset: 2232,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
         key.offset: 2244,
         key.length: 10,
-        key.typename: "Float",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Float"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
         key.offset: 2256,
         key.length: 11,
-        key.typename: "Double",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Double"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
         key.offset: 2269,
         key.length: 33,
-        key.typename: "UnsafeMutablePointer<Int32>!",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "UnsafeMutablePointer<Int32>!"
       }
     ]
   },
@@ -5390,9 +5366,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "blk",
         key.offset: 2390,
         key.length: 26,
-        key.typename: "((Float) -> Int32)!",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "((Float) -> Int32)!"
       }
     ]
   },
@@ -5417,9 +5391,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "fptr",
         key.offset: 2458,
         key.length: 42,
-        key.typename: "(@convention(c) (Float) -> Int32)!",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "(@convention(c) (Float) -> Int32)!"
       }
     ]
   },
@@ -5571,9 +5543,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.name: "a",
         key.offset: 3132,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },
@@ -5765,9 +5735,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "anObject",
             key.offset: 3877,
             key.length: 16,
-            key.typename: "Any!",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "Any!"
           }
         ]
       },
@@ -5985,9 +5953,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "a",
             key.offset: 4426,
             key.length: 10,
-            key.typename: "Int32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "Int32"
           }
         ]
       },
@@ -6012,9 +5978,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.name: "a",
             key.offset: 4470,
             key.length: 10,
-            key.typename: "Int32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "Int32"
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
@@ -7022,8 +6986,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 6777,
         key.length: 22,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -7047,8 +7009,6 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 6859,
         key.length: 19,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -316,9 +316,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "a",
         key.offset: 43,
         key.length: 10,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },
@@ -381,9 +379,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
             key.name: "rawValue",
             key.offset: 140,
             key.length: 18,
-            key.typename: "UInt32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "UInt32"
           }
         ]
       },

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
@@ -202,8 +202,6 @@ extension SKFuelKind {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 45,
         key.length: 11,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -227,8 +225,6 @@ extension SKFuelKind {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 62,
         key.length: 12,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -252,8 +248,6 @@ extension SKFuelKind {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 80,
         key.length: 15,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,

--- a/test/SourceKit/InterfaceGen/gen_header.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.response
@@ -179,9 +179,7 @@ public protocol SameNameProtocol {
         key.name: "arg",
         key.offset: 30,
         key.length: 12,
-        key.typename: "Int32",
-        key.nameoffset: 0,
-        key.namelength: 0
+        key.typename: "Int32"
       }
     ]
   },
@@ -224,9 +222,7 @@ public protocol SameNameProtocol {
             key.name: "arg",
             key.offset: 89,
             key.length: 12,
-            key.typename: "Int32",
-            key.nameoffset: 0,
-            key.namelength: 0
+            key.typename: "Int32"
           }
         ]
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -634,8 +634,6 @@ internal enum Colors {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 615,
         key.length: 8,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
@@ -652,8 +650,6 @@ internal enum Colors {
         key.kind: source.lang.swift.decl.enumcase,
         key.offset: 629,
         key.length: 9,
-        key.nameoffset: 0,
-        key.namelength: 0,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,

--- a/test/SourceKit/Misc/print-response-as-json.swift.response
+++ b/test/SourceKit/Misc/print-response-as-json.swift.response
@@ -19,9 +19,7 @@
           "key.name": "x",
           "key.offset": 14,
           "key.length": 8,
-          "key.typename": "Int",
-          "key.nameoffset": 0,
-          "key.namelength": 0
+          "key.typename": "Int"
         }
       ]
     }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/DocStructureArray.cpp
@@ -482,8 +482,10 @@ struct DocStructureReader {
       APPLY(KeyAccessLevel, UID, node.AccessLevel);
     if (node.SetterAccessLevel)
       APPLY(KeySetterAccessLevel, UID, node.SetterAccessLevel);
-    APPLY(KeyNameOffset, Int, node.NameOffset);
-    APPLY(KeyNameLength, Int, node.NameLength);
+    if (node.NameOffset || node.NameLength) {
+      APPLY(KeyNameOffset, Int, node.NameOffset);
+      APPLY(KeyNameLength, Int, node.NameLength);
+    }
     if (node.BodyOffset || node.BodyLength) {
       APPLY(KeyBodyOffset, Int, node.BodyOffset);
       APPLY(KeyBodyLength, Int, node.BodyLength);


### PR DESCRIPTION
Arguments in `SubscriptExpr` are visited since the recent `ArgumentList`
refactoring, but were being added to the containing `CallExpr`. Add a
node for the `SubscriptExpr` itself so that its argument is added there
instead of the `CallExpr`.

Also remove `key.nameoffset` and `key.namelength` from the response when
both are 0 to match the rest of the offsets and lengths.

Resolves rdar://85412164.