### PR TITLE
build-presets: don't build with "bootstrapping" when check-incremental-compilation is turned on

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -218,10 +218,6 @@ skip-test-tvos-host
 skip-test-watchos-host
 check-incremental-compilation
 
-# Test the full bootstrapping on at least some jobs
-# (the default is bootstrapping-with-hostlibs)
-libswift=bootstrapping
-
 [preset: buildbot,tools=R,stdlib=RD,test=non_executable]
 mixin-preset=
      mixin_buildbot_tools_R_stdlib_RD
@@ -233,6 +229,9 @@ skip-test-ios-simulator
 skip-test-tvos-simulator
 skip-test-watchos-simulator
 
+# Test the full bootstrapping on at least some jobs
+# (the default is bootstrapping-with-hostlibs)
+libswift=bootstrapping
 
 [preset: buildbot,tools=RA,stdlib=RDA]
 mixin-preset=


### PR DESCRIPTION
This does not work, because the check-incremental script is not setting the environment as needed.
Build with "bootstrapping" on another job.

rdar://85828409
