### PR TITLE
Concurrency: report errors on failures on Windows

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1100,13 +1100,13 @@ static void swift_task_asyncMainDrainQueueImpl() {
 
   HMODULE hModule = LoadLibraryW(L"dispatch.dll");
   if (hModule == NULL)
-    abort();
+    swift_reportError(0, "unable to load dispatch.dll");
 
   pfndispatch_main =
       reinterpret_cast<void (FAR *)(void)>(GetProcAddress(hModule,
                                                           "dispatch_main"));
   if (pfndispatch_main == NULL)
-    abort();
+    swift_reportError(0, "unable to locate dispatch_main in dispatch.dll");
 
   pfndispatch_main();
   exit(0);


### PR DESCRIPTION
The usage of libdispatch in Concurrency is dynamic - it does not
explicitly link against libdispatch and thus cannot directly invoke
`dispatch_main`.  While linking against dispatch would be ideal, this
should improve the current path.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
