### PR TITLE
[Runtime] Don't use threading APIs when building single threaded.

### DIFF
--- a/include/swift/Runtime/ThreadLocal.h
+++ b/include/swift/Runtime/ThreadLocal.h
@@ -23,13 +23,13 @@
 
 /// SWIFT_RUNTIME_SUPPORTS_THREAD_LOCAL - Does the current configuration
 /// allow the use of SWIFT_RUNTIME_ATTRIBUTE_THREAD_LOCAL?
-#if defined(__APPLE__)
-// The pthread TLS APIs work better than C++ TLS on Apple platforms.
-#define SWIFT_RUNTIME_SUPPORTS_THREAD_LOCAL 0
-#elif defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+#if SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
 // We define SWIFT_RUNTIME_ATTRIBUTE_THREAD_LOCAL to nothing in this
 // configuration and just use a global variable, so this is okay.
 #define SWIFT_RUNTIME_SUPPORTS_THREAD_LOCAL 1
+#elif defined(__APPLE__)
+// The pthread TLS APIs work better than C++ TLS on Apple platforms.
+#define SWIFT_RUNTIME_SUPPORTS_THREAD_LOCAL 0
 #elif __has_feature(tls)
 // If __has_feature reports that TLS is available, use it.
 #define SWIFT_RUNTIME_SUPPORTS_THREAD_LOCAL 1
@@ -43,7 +43,7 @@
 
 /// SWIFT_RUNTIME_THREAD_LOCAL - Declare that something is a
 /// thread-local variable in the runtime.
-#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+#if SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
 // In a single-threaded runtime, thread-locals are global.
 #define SWIFT_RUNTIME_ATTRIBUTE_THREAD_LOCAL
 #elif defined(__GNUC__)

--- a/include/swift/Runtime/VoucherShims.h
+++ b/include/swift/Runtime/VoucherShims.h
@@ -20,8 +20,10 @@
 #include "Config.h"
 
 // swift-corelibs-libdispatch has os/voucher_private.h but it doesn't work for
-// us yet, so only look for it on Apple platforms.
-#if __APPLE__ && __has_include(<os/voucher_private.h>)
+// us yet, so only look for it on Apple platforms.  We also don't need vouchers
+// in the single threaded concurrency runtime.
+#if __APPLE__ && !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME \
+  && __has_include(<os/voucher_private.h>)
 #define SWIFT_HAS_VOUCHER_HEADER 1
 #include <os/voucher_private.h>
 #endif

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -306,6 +306,10 @@ function(_add_target_variant_swift_compile_flags
     list(APPEND result "-Xcc" "-DSWIFT_STDLIB_HAS_ENVIRON")
   endif()
 
+  if(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+    list(APPEND result "-D" "SWIFT_STDLIB_SINGLE_THREADED_RUNTIME")
+  endif()
+
   set("${result_var_name}" "${result}" PARENT_SCOPE)
 endfunction()
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -288,7 +288,9 @@ static HANDLE __initialPthread = INVALID_HANDLE_VALUE;
 /// Determine whether we are currently executing on the main thread
 /// independently of whether we know that we are on the main actor.
 static bool isExecutingOnMainThread() {
-#if defined(__linux__)
+#if SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+  return true;
+#elif defined(__linux__)
   return syscall(SYS_gettid) == getpid();
 #elif defined(_WIN32)
   if (__initialPthread == INVALID_HANDLE_VALUE) {
@@ -304,7 +306,9 @@ static bool isExecutingOnMainThread() {
 }
 
 JobPriority swift::swift_task_getCurrentThreadPriority() {
-#if defined(__APPLE__)
+#if SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+  return JobPriority::UserInitiated;
+#elif defined(__APPLE__)
   return static_cast<JobPriority>(qos_class_self());
 #else
   if (isExecutingOnMainThread())

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -281,7 +281,13 @@ private:
 
 #if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
   // TODO: move to lockless via the status atomic (make readyQueue an mpsc_queue_t<ReadyQueueItem>)
-  mutable std::mutex mutex;
+  mutable std::mutex mutex_;
+
+  void lock() const { mutex_.lock(); }
+  void unlock() const { mutex_.unlock(); }
+#else
+  void lock() const {}
+  void unlock() const {}
 #endif
 
   /// Used for queue management, counting number of waiting and ready tasks
@@ -561,9 +567,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
   assert(completedTask->groupChildFragment()->getGroup() == asAbstract(this));
   SWIFT_TASK_DEBUG_LOG("offer task %p to group %p", completedTask, this);
 
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-  mutex.lock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+  lock(); // TODO: remove fragment lock, and use status for synchronization
 
   // Immediately increment ready count and acquire the status
   // Examples:
@@ -601,9 +605,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
 
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-        mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+        unlock(); // TODO: remove fragment lock, and use status for synchronization
 
         auto waitingContext =
             static_cast<TaskFutureWaitAsyncContext *>(
@@ -643,9 +645,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
   assert(completedTask == readyItem.getTask());
   assert(readyItem.getTask()->isFuture());
   readyQueue.enqueue(readyItem);
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-  mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+  unlock(); // TODO: remove fragment lock, and use status for synchronization
   return;
 }
 
@@ -730,9 +730,7 @@ static void swift_taskGroup_wait_next_throwingImpl(
 }
 
 PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-  mutex.lock(); // TODO: remove group lock, and use status for synchronization
-#endif
+  lock(); // TODO: remove group lock, and use status for synchronization
   SWIFT_TASK_DEBUG_LOG("poll group = %p", this);
   auto assumed = statusMarkWaitingAssumeAcquire();
 
@@ -750,9 +748,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
     statusRemoveWaiting();
     result.status = PollStatus::Empty;
     result.successType = this->successType;
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-    mutex.unlock(); // TODO: remove group lock, and use status for synchronization
-#endif
+    unlock(); // TODO: remove group lock, and use status for synchronization
     return result;
   }
 
@@ -799,9 +795,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.successType = futureFragment->getResultType();
           assert(result.retainedTask && "polled a task, it must be not null");
           _swift_tsan_acquire(static_cast<Job *>(result.retainedTask));
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-          mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+          unlock(); // TODO: remove fragment lock, and use status for synchronization
           return result;
 
         case ReadyStatus::Error:
@@ -812,9 +806,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.successType = nullptr;
           assert(result.retainedTask && "polled a task, it must be not null");
           _swift_tsan_acquire(static_cast<Job *>(result.retainedTask));
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-          mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+          unlock(); // TODO: remove fragment lock, and use status for synchronization
           return result;
 
         case ReadyStatus::Empty:
@@ -822,9 +814,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.storage = nullptr;
           result.retainedTask = nullptr;
           result.successType = this->successType;
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-          mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+          unlock(); // TODO: remove fragment lock, and use status for synchronization
           return result;
       }
       assert(false && "must return result when status compare-and-swap was successful");
@@ -844,9 +834,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
-#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-      mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
-#endif
+      unlock(); // TODO: remove fragment lock, and use status for synchronization
       // no ready tasks, so we must wait.
       result.status = PollStatus::MustWait;
       _swift_task_clearCurrent();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -279,8 +279,10 @@ public:
 
 private:
 
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
   // TODO: move to lockless via the status atomic (make readyQueue an mpsc_queue_t<ReadyQueueItem>)
   mutable std::mutex mutex;
+#endif
 
   /// Used for queue management, counting number of waiting and ready tasks
   std::atomic <uint64_t> status;
@@ -559,7 +561,9 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
   assert(completedTask->groupChildFragment()->getGroup() == asAbstract(this));
   SWIFT_TASK_DEBUG_LOG("offer task %p to group %p", completedTask, this);
 
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
   mutex.lock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
 
   // Immediately increment ready count and acquire the status
   // Examples:
@@ -597,7 +601,9 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
 
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
         mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
 
         auto waitingContext =
             static_cast<TaskFutureWaitAsyncContext *>(
@@ -637,7 +643,9 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
   assert(completedTask == readyItem.getTask());
   assert(readyItem.getTask()->isFuture());
   readyQueue.enqueue(readyItem);
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
   mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
   return;
 }
 
@@ -722,7 +730,9 @@ static void swift_taskGroup_wait_next_throwingImpl(
 }
 
 PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
   mutex.lock(); // TODO: remove group lock, and use status for synchronization
+#endif
   SWIFT_TASK_DEBUG_LOG("poll group = %p", this);
   auto assumed = statusMarkWaitingAssumeAcquire();
 
@@ -740,7 +750,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
     statusRemoveWaiting();
     result.status = PollStatus::Empty;
     result.successType = this->successType;
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
     mutex.unlock(); // TODO: remove group lock, and use status for synchronization
+#endif
     return result;
   }
 
@@ -787,7 +799,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.successType = futureFragment->getResultType();
           assert(result.retainedTask && "polled a task, it must be not null");
           _swift_tsan_acquire(static_cast<Job *>(result.retainedTask));
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
           mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
           return result;
 
         case ReadyStatus::Error:
@@ -798,7 +812,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.successType = nullptr;
           assert(result.retainedTask && "polled a task, it must be not null");
           _swift_tsan_acquire(static_cast<Job *>(result.retainedTask));
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
           mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
           return result;
 
         case ReadyStatus::Empty:
@@ -806,7 +822,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
           result.storage = nullptr;
           result.retainedTask = nullptr;
           result.successType = this->successType;
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
           mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
           return result;
       }
       assert(false && "must return result when status compare-and-swap was successful");
@@ -826,7 +844,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
       mutex.unlock(); // TODO: remove fragment lock, and use status for synchronization
+#endif
       // no ready tasks, so we must wait.
       result.status = PollStatus::MustWait;
       _swift_task_clearCurrent();

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -977,15 +977,17 @@ if run_vendor == 'apple':
 
     # Auto-linking does not work when stdlib is built with LTO, because linked
     # libraries are discovered too late (after optimizations are applied), and
-    # ld64 hits an assert and crashes. Until ld64 fixes this, let's workaround
-    # it by explicitly -l linking all libraries needed in tests.
+    # ld64 hits an assert and crashes, or worse, deadlocks. Until ld64 fixes
+    # this, let's workaround it by explicitly -l linking all libraries needed in
+    # tests.
+    # rdar://70787171
     if "stdlib_lto" in config.available_features:
         for library in ["swiftCore", "swiftStdlibUnittest",
                         "swiftStdlibUnicodeUnittest",
                         "swiftStdlibCollectionUnittest",
                         "swiftSwiftPrivateLibcExtras", "swiftSwiftPrivate",
                         "swiftDarwin", "swiftSwiftPrivateThreadExtras",
-                        "swiftSwiftOnoneSupport"]:
+                        "swiftSwiftOnoneSupport", "swift_Concurrency"]:
             swift_execution_tests_extra_flags += ' -Xlinker -l%s'% library
 
         swift_native_clang_tools_path = lit_config.params.get('swift_native_clang_tools_path', None)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2501,7 +2501,7 @@ verbose-build
 
 [preset: mixin_stdlib_minimal]
 enable-experimental-differentiable-programming=0
-enable-experimental-concurrency=0
+enable-experimental-concurrency=1
 enable-experimental-distributed=0
 build-swift-dynamic-sdk-overlay=0
 build-swift-dynamic-stdlib=0


### PR DESCRIPTION
Mostly this consists of `#if`-ing out code that we don't need when running single threaded.

rdar://84393438
