### PR TITLE
[TypeChecker] NFC: Scope down per test-case for rdar://74035425

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar74035425.swift
@@ -7,5 +7,5 @@ struct Value {
 }
 
 func test(values: [[Value]]) -> String {
-  "[" + "" + values.map({ "[" + $0.map({ $0.debugDescription }).joined(separator: ", ") + "]" }).joined(separator: ", ") + "]"
+  values.map({ "[" + $0.map({ $0.debugDescription }).joined(separator: ", ") + "]" }).joined(separator: ", ")
 }


### PR DESCRIPTION
Remove some literals from the test-case to prevent it from randomly
failing in some CI configurations.

Resolves: rdar://85267603

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
