### PR TITLE
[nfc][cxx-interop] Mark lazy member loading complete only after members are loaded.

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -825,6 +825,9 @@ public:
   /// Setup the loader for lazily-loaded members.
   void setMemberLoader(LazyMemberLoader *loader, uint64_t contextData);
 
+  /// Externally tell this context that it has no more lazy members, i.e. all lazy member loading is complete.
+  void setHasLazyMembers(bool hasLazyMembers) const;
+
   /// Load all of the members of this context.
   void loadAllMembers() const;
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -966,6 +966,10 @@ bool IterableDeclContext::hasUnparsedMembers() const {
   return true;
 }
 
+void IterableDeclContext::setHasLazyMembers(bool hasLazyMembers) const {
+  FirstDeclAndLazyMembers.setInt(hasLazyMembers);
+}
+
 void IterableDeclContext::loadAllMembers() const {
   ASTContext &ctx = getASTContext();
 
@@ -990,7 +994,7 @@ void IterableDeclContext::loadAllMembers() const {
     return;
 
   // Don't try to load all members re-entrant-ly.
-  FirstDeclAndLazyMembers.setInt(false);
+  setHasLazyMembers(false);
 
   const Decl *container = getDecl();
   auto contextInfo = ctx.getOrCreateLazyIterableContextData(this,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9773,18 +9773,19 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
   }
 
   if (isa_and_nonnull<clang::RecordDecl>(D->getClangDecl())) {
-    // TODO: this is a hack to set member loading as lazy again. It got set to
-    // non-lazy when getMembers was called.
-    cast<StructDecl>(D)->setMemberLoader(this, 0);
+    // We haven't loaded any members yet, so tell our context that it still has
+    // lazy members. Otherwise, we won't be able to look up any individual
+    // members (lazily) in "loadAllMembersOfRecordDecl".
+    cast<StructDecl>(D)->setHasLazyMembers(true);
     loadAllMembersOfRecordDecl(cast<StructDecl>(D));
+    // Now that all members are loaded, mark the context as lazily complete.
+    cast<StructDecl>(D)->setHasLazyMembers(false);
     return;
   }
 
-  // Namespace members will only be loaded lazily.
   if (isa_and_nonnull<clang::NamespaceDecl>(D->getClangDecl())) {
-    // TODO: this is a hack to set member loading as lazy again. It got set to
-    // non-lazy when getMembers was called.
-    cast<EnumDecl>(D)->setMemberLoader(this, 0);
+    // Namespace members will only be loaded lazily.
+    cast<EnumDecl>(D)->setHasLazyMembers(true);
     return;
   }
 


### PR DESCRIPTION
This will be slightly more performant because we don't have to walk through all members multiple times (even though we cache all the member lookups). 