### PR TITLE
[SourceKit] Improvements to stamp handling in SwiftASTManager

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -246,6 +246,10 @@ struct FileContent {
   explicit operator InputFile() const {
     return InputFile(Filename, IsPrimary, Buffer.get());
   }
+
+  size_t getMemoryCost() const {
+    return sizeof(*this) + Filename.size() + Buffer->getBufferSize();
+  }
 };
 
 /// An \c ASTBuildOperations builds an AST. Once the AST is built, it informs
@@ -400,8 +404,12 @@ public:
   }
 
   size_t getMemoryCost() {
-    return sizeof(*this) + getVectorMemoryCost(FileContents) +
-           Result.getMemoryCost();
+    size_t Cost = sizeof(*this) + getVectorMemoryCost(FileContents) +
+                  Result.getMemoryCost();
+    for (const FileContent &File : FileContents) {
+      Cost += File.getMemoryCost();
+    }
+    return Cost;
   }
 
   /// Schedule building this AST on the given \p Queue.

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -248,9 +248,7 @@ public:
   processASTAsync(SwiftInvocationRef Invok, SwiftASTConsumerRef ASTConsumer,
                   const void *OncePerASTToken,
                   SourceKitCancellationToken CancellationToken,
-                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem,
-                  ArrayRef<ImmutableTextSnapshotRef> Snapshots =
-                      ArrayRef<ImmutableTextSnapshotRef>());
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem);
 
   std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(StringRef Filename,
                                                       std::string &Error);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -245,14 +245,18 @@ SwiftEditorDocumentFileMap::getByUnresolvedName(StringRef FilePath) {
 }
 
 SwiftEditorDocumentRef
-SwiftEditorDocumentFileMap::findByPath(StringRef FilePath) {
+SwiftEditorDocumentFileMap::findByPath(StringRef FilePath, bool IsRealpath) {
   SwiftEditorDocumentRef EditorDoc;
 
-  std::string ResolvedPath = SwiftLangSupport::resolvePathSymlinks(FilePath);
+  std::string Scratch;
+  if (!IsRealpath) {
+    Scratch = SwiftLangSupport::resolvePathSymlinks(FilePath);
+    FilePath = Scratch;
+  }
   Queue.dispatchSync([&]{
     for (auto &Entry : Docs) {
       if (Entry.getKey() == FilePath ||
-          Entry.getValue().ResolvedPath == ResolvedPath) {
+          Entry.getValue().ResolvedPath == FilePath) {
         EditorDoc = Entry.getValue().DocRef;
         break;
       }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -156,7 +156,10 @@ public:
   /// Looks up the document only by the path name that was given initially.
   SwiftEditorDocumentRef getByUnresolvedName(StringRef FilePath);
   /// Looks up the document by resolving symlinks in the paths.
-  SwiftEditorDocumentRef findByPath(StringRef FilePath);
+  /// If \p IsRealpath is \c true, then \p FilePath must already be
+  /// canonicalized to a realpath.
+  SwiftEditorDocumentRef findByPath(StringRef FilePath,
+                                    bool IsRealpath = false);
   SwiftEditorDocumentRef remove(StringRef FilePath);
 };
 


### PR DESCRIPTION
Some refactoring of `SwiftASTManager`, motivated by the fact that we were computing an input file’s realpath 3 times from `fileContentsForFilesInCompilerInvocation`.