### PR TITLE
Enable availability-checking on objc_async.swift test

### DIFF
--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,9 +1,11 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -disable-availability-checking  %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
+
+if #available(SwiftStdlib 5.5, *) {
 
 @MainActor func onlyOnMainActor() { }
 
@@ -120,7 +122,7 @@ func testSendableAttrs(
   func takesSendable<T: Sendable>(_: T) {}
 
   takesSendable(sendableClass)        // no-error
-  takesSendable(nonSendableClass)     // expected-FIXME-warning{{something about missing conformance}}
+  takesSendable(nonSendableClass)     // expected-warning{{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
 
   doSomethingConcurrently {
     print(sendableClass)               // no-error
@@ -213,3 +215,5 @@ func testMirrored(instance: ClassWithAsync) async {
     }
   }
 }
+
+} // SwiftStdlib 5.5


### PR DESCRIPTION
I'm re-enabling availability checking in the
test/ClangImporter/objc_async.swift test because I want to perform an
availability check in the future.

In re-enabling it, I came across a warning with a fixme and a test
failure on the line. Given that the expected warning has a fixme and is
currently filled in with "something about missing conformance", I think
this is the warning message that they were looking for. Supplying that
gets the test passing with availability-checking enabled.