### PR TITLE
IRGen: Default to `weak hidden` instead of `internal` linkage for objc metadata

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1341,7 +1341,8 @@ namespace {
       // };
 
       assert(fields.getNextOffsetFromGlobal() == size);
-      return buildGlobalVariable(fields, "_CATEGORY_", /*const*/ true);
+      return buildGlobalVariable(fields, "_CATEGORY_", /*const*/ true,
+                                 llvm::GlobalVariable::InternalLinkage);
     }
     
     llvm::Constant *emitProtocol() {
@@ -1501,7 +1502,8 @@ namespace {
       // statically. Otherwise, the ObjC runtime may slide the InstanceSize
       // based on changing base class layout.
       return buildGlobalVariable(fields, dataSuffix,
-                               /*const*/ forMeta || FieldLayout->isFixedSize());
+                               /*const*/ forMeta || FieldLayout->isFixedSize(),
+                               llvm::GlobalVariable::InternalLinkage);
     }
 
   private:
@@ -1766,12 +1768,8 @@ namespace {
         return null();
       }
 
-      auto *gv_as_const =  buildGlobalVariable(array, "_PROTOCOL_METHOD_TYPES_",
-                               /*const*/ true,
-                               /*likage*/ llvm::GlobalVariable::WeakAnyLinkage);
-      llvm::GlobalValue *gv = (llvm::GlobalValue *)gv_as_const;
-      gv->setVisibility(llvm::GlobalValue::HiddenVisibility);
-      return gv;
+      return buildGlobalVariable(array, "_PROTOCOL_METHOD_TYPES_",
+                                 /*const*/ true);
     }
 
     void buildExtMethodTypes(ConstantArrayBuilder &array,
@@ -2173,7 +2171,7 @@ namespace {
     template <class B>
     llvm::Constant *buildGlobalVariable(B &fields, StringRef nameBase, bool isConst,
                       llvm::GlobalValue::LinkageTypes linkage =
-                          llvm::GlobalVariable::InternalLinkage) {
+                          llvm::GlobalVariable::WeakAnyLinkage) {
       llvm::SmallString<64> nameBuffer;
       auto var =
         fields.finishAndCreateGlobal(Twine(nameBase) 
@@ -2184,6 +2182,9 @@ namespace {
                                      IGM.getPointerAlignment(),
                                      /*constant*/ true,
                                      linkage);
+      if (linkage == llvm::GlobalVariable::WeakAnyLinkage) {
+        var->setVisibility(llvm::GlobalValue::HiddenVisibility);
+      }
 
       switch (IGM.TargetInfo.OutputObjectFormat) {
       case llvm::Triple::MachO:

--- a/test/Concurrency/objc_async_protocol_irgen.swift
+++ b/test/Concurrency/objc_async_protocol_irgen.swift
@@ -9,7 +9,7 @@ let anyObject: AnyObject = (MyAsyncProtocol.self as AnyObject) // or something l
 // Make sure we don't emit 2 copies of methods, due to a completion-handler
 // version and another due to an async based version.
 
-// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS_MyAsyncProtocol = internal constant
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS_MyAsyncProtocol = weak hidden constant
 // CHECK-SAME: selector_data(myAsyncMethod:)
 // CHECK-NOT: selector_data(myAsyncMethod:)
 // CHECK-SAME: align [[ALIGNMENT]]

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -8,22 +8,22 @@ import Foundation
 import gizmo
 
 // -- Protocol records for cast-to ObjC protocols
-// CHECK: @_PROTOCOL__TtP13generic_casts10ObjCProto1_ = internal constant
+// CHECK: @_PROTOCOL__TtP13generic_casts10ObjCProto1_ = weak hidden constant
 // CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*), section {{"__DATA,__objc_protolist,coalesced,no_dead_strip"|"objc_protolist"|".objc_protolist\$B"}}
 // CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP13generic_casts10ObjCProto1_" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL__TtP13generic_casts10ObjCProto1_ to i8*), section {{"__DATA,__objc_protorefs,coalesced,no_dead_strip"|"objc_protorefs"|".objc_protorefs\$B"}}
 
-// CHECK: @_PROTOCOL_NSRuncing = internal constant
+// CHECK: @_PROTOCOL_NSRuncing = weak hidden constant
 // CHECK: @"\01l_OBJC_LABEL_PROTOCOL_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*), section {{"__DATA,__objc_protolist,coalesced,no_dead_strip"|"objc_protolist"|".objc_protolist\$B"}}
 // CHECK: @"\01l_OBJC_PROTOCOL_REFERENCE_$_NSRuncing" = weak hidden global i8* bitcast ({{.*}} @_PROTOCOL_NSRuncing to i8*), section {{"__DATA,__objc_protorefs,coalesced,no_dead_strip"|"objc_protorefs"|".objc_protorefs\$B"}}
 
-// CHECK: @_PROTOCOLS__TtC13generic_casts10ObjCClass2 = internal constant { i64, [1 x i8*] } {
+// CHECK: @_PROTOCOLS__TtC13generic_casts10ObjCClass2 = weak hidden constant { i64, [1 x i8*] } {
 // CHECK:   i64 1, 
 // CHECK:   @_PROTOCOL__TtP13generic_casts10ObjCProto2_
 // CHECK: }
 
 // CHECK: @_DATA__TtC13generic_casts10ObjCClass2 = internal constant {{.*}} @_PROTOCOLS__TtC13generic_casts10ObjCClass2
 
-// CHECK: @_PROTOCOL_PROTOCOLS__TtP13generic_casts10ObjCProto2_ = internal constant { i64, [1 x i8*] } {
+// CHECK: @_PROTOCOL_PROTOCOLS__TtP13generic_casts10ObjCProto2_ = weak hidden constant { i64, [1 x i8*] } {
 // CHECK:   i64 1, 
 // CHECK:   @_PROTOCOL__TtP13generic_casts10ObjCProto1_
 // CHECK: }

--- a/test/IRGen/objc_async_metadata.swift
+++ b/test/IRGen/objc_async_metadata.swift
@@ -12,7 +12,7 @@ import Foundation
 // CHECK: [[ENCODE_ASYNC_STRING:@.*]] = private unnamed_addr constant [28 x i8] c"v24@0:8@?<v@?@\22NSString\22>16\00"
 // CHECK: [[ENCODE_ASYNC_THROWS_STRING:@.*]] = private unnamed_addr constant [38 x i8] c"v24@0:8@?<v@?@\22NSString\22@\22NSError\22>16\00"
 
-// CHECK: @_INSTANCE_METHODS__TtC19objc_async_metadata7MyClass = internal constant
+// CHECK: @_INSTANCE_METHODS__TtC19objc_async_metadata7MyClass = weak hidden constant
 // CHECK-SAME: methodWithCompletionHandler:
 // CHECK-SAME: [[ENCODE_ASYNC_STRING]]
 // CHECK-SAME: throwingMethodWithCompletionHandler:
@@ -23,7 +23,7 @@ class MyClass: NSObject {
 }
 
 // CHECK: [[ENCODE_ASYNC_STRING_PROTO:@.*]] = private unnamed_addr constant [15 x i8] c"v32@0:8@16@?24\00"
-// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS__TtP19objc_async_metadata7MyProto_ = internal constant
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS__TtP19objc_async_metadata7MyProto_ = weak hidden constant
 // CHECK-SAME: _selector_data(myProtoRequirement:completionHandler:)
 // CHECK-SAME: [15 x i8]* [[ENCODE_ASYNC_STRING_PROTO]]
 

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -17,12 +17,12 @@ import Foundation
 sil_vtable X {}
 
 // The getter/setter should not show up in the Objective-C metadata.
-// CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } { i32 24, i32 2, {{.*}} @"\01L_selector_data(initWithBellsOn:)", {{.*}} @"\01L_selector_data(init)",
+// CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = weak hidden constant { i32, i32, [2 x { i8*, i8*, i8* }] } { i32 24, i32 2, {{.*}} @"\01L_selector_data(initWithBellsOn:)", {{.*}} @"\01L_selector_data(init)",
 
 // CHECK: [[X:@[0-9]+]] = private unnamed_addr constant [2 x i8] c"x\00"
 
 // The property 'x' should show up in the Objective-C metadata.
-// CHECK: @_PROPERTIES__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { {{.*}}i32, i32, [1 x { i8*, i8* }] } { i32 16, i32 1, [1 x { i8*, i8* }] [{ i8*, i8* } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[X]], i64 0, i64 0),
+// CHECK: @_PROPERTIES__TtC19objc_attr_NSManaged10SwiftGizmo = weak hidden constant { {{.*}}i32, i32, [1 x { i8*, i8* }] } { i32 16, i32 1, [1 x { i8*, i8* }] [{ i8*, i8* } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[X]], i64 0, i64 0),
 
 // The getter/setter should not show up in the Swift metadata.
 // CHECK: @"$s19objc_attr_NSManaged10SwiftGizmoCMf" = internal global <{ {{.*}} }> <{ void (%T19objc_attr_NSManaged10SwiftGizmoC*)* {{.*}}@"$s19objc_attr_NSManaged10SwiftGizmoCfD{{(\.ptrauth)?}}"{{.*}}, i8** @"$sBOWV", i64 ptrtoint (%objc_class* @"OBJC_METACLASS_$__TtC19objc_attr_NSManaged10SwiftGizmo" to i64), %objc_class* @"OBJC_CLASS_$_Gizmo", %swift.opaque* @_objc_empty_cache, %swift.opaque* null, i64 add (i64 ptrtoint ({ i32, i32, i32, i32, i8*, i8*, { i32, i32, [2 x { i8*, i8*, i8* }] }*, i8*, i8*, i8*, { i32, i32, [1 x { i8*, i8* }] }* }* @_DATA__TtC19objc_attr_NSManaged10SwiftGizmo to i64), i64 {{1|2}}), i32 {{1|0}}, i32 0, i32 8, i16 7, i16 0, i32 96, i32 16, {{.*}}* @"$s19objc_attr_NSManaged10SwiftGizmoCMn{{(\.ptrauth)?}}"{{.*}}, i8* null }>

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -11,7 +11,7 @@ import Foundation
 // CHECK: [[SETTER_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
 // CHECK: [[DEALLOC_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 
-// CHECK: @_INSTANCE_METHODS__TtC11objc_bridge3Bas = internal constant { i32, i32, [17 x { i8*, i8*, i8* }] } {
+// CHECK: @_INSTANCE_METHODS__TtC11objc_bridge3Bas = weak hidden constant { i32, i32, [17 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24,
 // CHECK:   i32 17,
 // CHECK:   [17 x { i8*, i8*, i8* }] [
@@ -114,10 +114,10 @@ import Foundation
 // CHECK:   ]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
-// CHECK: @_PROPERTIES__TtC11objc_bridge3Bas = internal constant { i32, i32, [5 x { i8*, i8* }] } {
+// CHECK: @_PROPERTIES__TtC11objc_bridge3Bas = weak hidden constant { i32, i32, [5 x { i8*, i8* }] } {
 
 // CHECK: [[OBJC_BLOCK_PROPERTY:@.*]] = private unnamed_addr constant [8 x i8] c"T@?,N,C\00"
-// CHECK: @_PROPERTIES__TtC11objc_bridge21OptionalBlockProperty = internal constant {{.*}} [[OBJC_BLOCK_PROPERTY]]
+// CHECK: @_PROPERTIES__TtC11objc_bridge21OptionalBlockProperty = weak hidden constant {{.*}} [[OBJC_BLOCK_PROPERTY]]
 
 func getDescription(_ o: NSObject) -> String {
   return o.description

--- a/test/IRGen/objc_class_property.swift
+++ b/test/IRGen/objc_class_property.swift
@@ -6,10 +6,10 @@
 // class properties, so no ObjC property is reflected.
 
 // CHECK-NOT: @_PROPERTIES__TtC19objc_class_property7Smashed
-// CHECK: @_CLASS_METHODS__TtC19objc_class_property7Smashed = internal constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
+// CHECK: @_CLASS_METHODS__TtC19objc_class_property7Smashed = weak hidden constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
 // CHECK:   i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(sharedSmashed)"
 // CHECK-NOT: @_PROPERTIES__TtC19objc_class_property7Smashed
-// CHECK: @_INSTANCE_METHODS__TtC19objc_class_property7Smashed = internal constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
+// CHECK: @_INSTANCE_METHODS__TtC19objc_class_property7Smashed = weak hidden constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
 // CHECK:   i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)"
 // CHECK-NOT: @_PROPERTIES__TtC19objc_class_property7Smashed
 

--- a/test/IRGen/objc_extensions.swift
+++ b/test/IRGen/objc_extensions.swift
@@ -16,7 +16,7 @@ import objc_extension_base
 // CHECK: [[CATEGORY_NAME:@.*]] = private constant [16 x i8] c"objc_extensions\00"
 // CHECK: [[METHOD_TYPE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 
-// CHECK-LABEL: @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions" = internal constant
+// CHECK-LABEL: @"_CATEGORY_PROTOCOLS_Gizmo_$_objc_extensions" = weak hidden constant
 // CHECK-SAME:   i64 1,
 // CHECK-SAME:   @_PROTOCOL__TtP15objc_extensions11NewProtocol_
 
@@ -84,7 +84,7 @@ extension Gizmo {
 class Hoozit : NSObject {
 }
 
-// CHECK-LABEL: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions" = internal constant
+// CHECK-LABEL: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions" = weak hidden constant
 // CHECK:   i32 24,
 // CHECK:   i32 1,
 // CHECK:   [1 x { i8*, i8*, i8* }] [{ i8*, i8*, i8* } {
@@ -94,7 +94,7 @@ class Hoozit : NSObject {
 // CHECK:   }]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
-// CHECK-LABEL: @"_CATEGORY_CLASS_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions" = internal constant
+// CHECK-LABEL: @"_CATEGORY_CLASS_METHODS__TtC15objc_extensions6Hoozit_$_objc_extensions" = weak hidden constant
 // CHECK:   i32 24,
 // CHECK:   i32 1,
 // CHECK:   [1 x { i8*, i8*, i8* }] [{ i8*, i8*, i8* } {
@@ -120,7 +120,7 @@ extension Hoozit {
 
 class SwiftOnly { }
 
-// CHECK-LABEL: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_extensions9SwiftOnly_$_objc_extensions" = internal constant
+// CHECK-LABEL: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_extensions9SwiftOnly_$_objc_extensions" = weak hidden constant
 // CHECK:   i32 24,
 // CHECK:   i32 1,
 // CHECK:   [1 x { i8*, i8*, i8* }] [{ i8*, i8*, i8* } {
@@ -175,7 +175,7 @@ class NSDogcow : NSObject {}
 
 // CHECK: [[NAME:@.*]] = private unnamed_addr constant [5 x i8] c"woof\00"
 // CHECK: [[ATTR:@.*]] = private unnamed_addr constant [7 x i8] c"Tq,N,D\00"
-// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_extensions8NSDogcow_$_objc_extensions" = internal constant {{.*}} [[NAME]], {{.*}} [[ATTR]], {{.*}}, section "__DATA, {{.*}}", align 8
+// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_extensions8NSDogcow_$_objc_extensions" = weak hidden constant {{.*}} [[NAME]], {{.*}} [[ATTR]], {{.*}}, section "__DATA, {{.*}}", align 8
 extension NSDogcow {
   @NSManaged var woof: Int
 }

--- a/test/IRGen/objc_int_encoding.sil
+++ b/test/IRGen/objc_int_encoding.sil
@@ -5,7 +5,7 @@
 // CHECK-64: [[INT_UINT_METHOD_ENCODING:@.*]] = private unnamed_addr constant {{.*}} c"Q24@0:8q16\00"
 // CHECK-32: [[INT_UINT_METHOD_ENCODING:@.*]] = private unnamed_addr constant {{.*}} c"I12@0:4i8\00"
 
-// CHECK: @_INSTANCE_METHODS__TtC17objc_int_encoding3Foo = internal constant {{.*}} [[SELECTOR]], {{.*}} [[INT_UINT_METHOD_ENCODING]], {{.*}} @"$s17objc_int_encoding3FooC3foo1xSuSi_tFTo{{(\.ptrauth)?}}"
+// CHECK: @_INSTANCE_METHODS__TtC17objc_int_encoding3Foo = weak hidden constant {{.*}} [[SELECTOR]], {{.*}} [[INT_UINT_METHOD_ENCODING]], {{.*}} @"$s17objc_int_encoding3FooC3foo1xSuSi_tFTo{{(\.ptrauth)?}}"
 
 sil_stage canonical
 

--- a/test/IRGen/objc_methods.swift
+++ b/test/IRGen/objc_methods.swift
@@ -54,7 +54,7 @@ class ObjcDestructible: NSObject {
 // CHECK-ios: [[FAIL_SIGNATURE:@.*]] = private unnamed_addr constant [12 x i8] c"B24@0:8^@16\00"
 // CHECK-tvos: [[FAIL_SIGNATURE:@.*]] = private unnamed_addr constant [12 x i8] c"B24@0:8^@16\00"
 // CHECK-watchos: [[FAIL_SIGNATURE:@.*]] = private unnamed_addr constant [12 x i8] c"B24@0:8^@16\00"
-// CHECK: @_INSTANCE_METHODS__TtC12objc_methods3Foo = internal constant { {{.*}}] } {
+// CHECK: @_INSTANCE_METHODS__TtC12objc_methods3Foo = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 24,
 // CHECK:   i32 10,
 // CHECK:   [10 x { i8*, i8*, i8* }] [{
@@ -84,7 +84,7 @@ class ObjcDestructible: NSObject {
 // CHECK-ios:     i8* bitcast (i1 (i8*, i8*, %4**)* @"$s12objc_methods3FooC4failyyKFTo" to i8*)
 // CHECK:   }]
 // CHECK: }, section "__DATA, {{.*}}", align 8
-// CHECK: @_INSTANCE_METHODS__TtC12objc_methods16ObjcDestructible = internal constant { {{.*}}] } {
+// CHECK: @_INSTANCE_METHODS__TtC12objc_methods16ObjcDestructible = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 24,
 // CHECK:   i32 2,
 // CHECK:   [2 x { i8*, i8*, i8* }] [{

--- a/test/IRGen/objc_properties.swift
+++ b/test/IRGen/objc_properties.swift
@@ -105,7 +105,7 @@ class SomeWrapperTests {
 // CHECK-NEW: [[SHARED_NAME:@.*]] = private unnamed_addr constant [11 x i8] c"sharedProp\00"
 // CHECK-NEW: [[SHARED_ATTRS:@.*]] = private unnamed_addr constant [5 x i8] c"Tq,N\00"
 
-// CHECK-NEW: @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject = internal constant { {{.*}}] } {
+// CHECK-NEW: @_CLASS_PROPERTIES__TtC15objc_properties10SomeObject = weak hidden constant { {{.*}}] } {
 // CHECK-NEW:   i32 16,
 // CHECK-NEW:   i32 1,
 // CHECK-NEW:   [1 x { i8*, i8* }] [{
@@ -127,7 +127,7 @@ class SomeWrapperTests {
 // CHECK: [[GETTER_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"@16@0:8\00"
 // CHECK: [[SETTER_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
 
-// CHECK: @_INSTANCE_METHODS__TtC15objc_properties10SomeObject = internal constant { {{.*}}] } {
+// CHECK: @_INSTANCE_METHODS__TtC15objc_properties10SomeObject = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 24,
 // CHECK:   i32 8,
 // CHECK:   [8 x { i8*, i8*, i8* }] [{
@@ -179,7 +179,7 @@ class SomeWrapperTests {
 // CHECK: [[WIBBLE_NAME:@.*]] = private unnamed_addr constant [7 x i8] c"wobble\00"
 // CHECK: [[WIBBLE_ATTRS:@.*]] = private unnamed_addr constant [50 x i8] c"T@\22_TtC15objc_properties10SomeObject\22,N,&,Vwibble\00"
 
-// CHECK: @_PROPERTIES__TtC15objc_properties10SomeObject = internal constant { {{.*}}] } {
+// CHECK: @_PROPERTIES__TtC15objc_properties10SomeObject = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 16,
 // CHECK:   i32 4,
 // CHECK:   [4 x { i8*, i8* }] [{
@@ -208,7 +208,7 @@ class SomeWrapperTests {
 // CHECK:   { {{.+}} }* @_PROPERTIES__TtC15objc_properties10SomeObject
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
-// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_properties10SomeObject_$_objc_properties" = internal constant { {{.*}}] } {
+// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC15objc_properties10SomeObject_$_objc_properties" = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 24,
 // CHECK:   i32 2,
 // CHECK:   [2 x { i8*, i8*, i8* }] [{
@@ -224,7 +224,7 @@ class SomeWrapperTests {
 
 // CHECK: [[EXTENSIONPROPERTY_NAME:@.*]] = private unnamed_addr constant [18 x i8] c"extensionProperty\00"
 
-// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = internal constant { {{.*}}] } {
+// CHECK: @"_CATEGORY_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 16,
 // CHECK:   i32 1,
 // CHECK:   [1 x { i8*, i8* }] [{
@@ -237,7 +237,7 @@ class SomeWrapperTests {
 // CHECK-NEW: [[EXTENSIONCLASSPROPERTY_ATTRS:@.*]] = private unnamed_addr constant [7 x i8] c"T#,N,R\00"
 // CHECK-NEW: [[EXTENSIONSTATICPROPERTY_NAME:@.*]] = private unnamed_addr constant [26 x i8] c"extensionStoredStaticProp\00"
 
-// CHECK-NEW: @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = internal constant { {{.*}}] } {
+// CHECK-NEW: @"_CATEGORY_CLASS_PROPERTIES__TtC15objc_properties10SomeObject_$_objc_properties" = weak hidden constant { {{.*}}] } {
 // CHECK-NEW:   i32 16,
 // CHECK-NEW:   i32 2,
 // CHECK-NEW:   [2 x { i8*, i8* }] [{
@@ -269,7 +269,7 @@ class SomeWrapperTests {
 // CHECK:    i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
 // CHECK:    @"$s15objc_properties4TreeC6parentACSgvsTo{{(.ptrauth)?}}"
 
-// CHECK: @_PROTOCOL__TtP15objc_properties5Proto_ = internal constant { {{.+}} } {
+// CHECK: @_PROTOCOL__TtP15objc_properties5Proto_ = weak hidden constant { {{.+}} } {
 // CHECK:   i8* null,
 // CHECK:   i8* getelementptr inbounds ([{{.+}} x i8], [{{.+}} x i8]* {{@.+}}, i64 0, i64 0),
 // CHECK:   i8* null,
@@ -289,7 +289,7 @@ class SomeWrapperTests {
 // CHECK: [[PROTOCOLPROPERTY_NAME:@.+]] = private unnamed_addr constant [6 x i8] c"value\00"
 // CHECK: [[PROTOCOLPROPERTY_ATTRS:@.+]] = private unnamed_addr constant [7 x i8] c"Tq,N,R\00"
 
-// CHECK: @_PROTOCOL_PROPERTIES__TtP15objc_properties5Proto_ = internal constant { {{.*}}] } {
+// CHECK: @_PROTOCOL_PROPERTIES__TtP15objc_properties5Proto_ = weak hidden constant { {{.*}}] } {
 // CHECK:   i32 16,
 // CHECK:   i32 1,
 // CHECK:   [1 x { i8*, i8* }] [{
@@ -301,7 +301,7 @@ class SomeWrapperTests {
 // CHECK-NEW: [[PROTOCOLCLASSPROPERTY_NAME:@.+]] = private unnamed_addr constant [15 x i8] c"sharedInstance\00"
 // CHECK-NEW: [[PROTOCOLCLASSPROPERTY_ATTRS:@.+]] = private unnamed_addr constant [7 x i8] c"T@,N,&\00"
 
-// CHECK-NEW: @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_ = internal constant { {{.*}}] } {
+// CHECK-NEW: @_PROTOCOL_CLASS_PROPERTIES__TtP15objc_properties5Proto_ = weak hidden constant { {{.*}}] } {
 // CHECK-NEW:   i32 16,
 // CHECK-NEW:   i32 1,
 // CHECK-NEW:   [1 x { i8*, i8* }] [{

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -25,7 +25,7 @@ class Foo : NSRuncing, NSFunging, Ansible {
   @objc func foo() {}
   func anse() {}
 }
-// CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Foo = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
+// CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Foo = weak hidden constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC:@[0-9]+]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
@@ -50,7 +50,7 @@ extension Bar : NSRuncing, NSFunging {
 }
 
 // -- ...but the ObjC protocol conformances on its extension add some
-// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC14objc_protocols3Bar_$_objc_protocols" = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
+// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC14objc_protocols3Bar_$_objc_protocols" = weak hidden constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
@@ -66,7 +66,7 @@ extension Bas : NSRuncing {
   func foo() {}
 }
 
-// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas3Bas_$_objc_protocols" = internal constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
+// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas3Bas_$_objc_protocols" = weak hidden constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 1,
 // CHECK:   [1 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas0C0C0a1_B0E3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
@@ -86,7 +86,7 @@ class Zim : Frungible {
   func frunge() {}
 }
 
-// CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Zim = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
+// CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Zim = weak hidden constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
@@ -106,7 +106,7 @@ extension Zang : Frungible {
   func frunge() {}
 }
 
-// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas4Zang_$_objc_protocols" = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } {
+// CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas4Zang_$_objc_protocols" = weak hidden constant { i32, i32, [2 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 2,
 // CHECK:   [2 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas4ZangC0a1_B0E5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
@@ -120,7 +120,7 @@ protocol InheritingProtocol : BaseProtocol { }
 // CHECK: @_PROTOCOLS__TtC14objc_protocols17ImplementingClass {{.*}} @_PROTOCOL__TtP14objc_protocols12BaseProtocol_
 class ImplementingClass : InheritingProtocol { }
 
-// CHECK: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = internal constant{{.*}}i64 2{{.*}} @_PROTOCOL_NSFungingAndRuncing {{.*}}@_PROTOCOL_NSFunging
+// CHECK: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = weak hidden constant{{.*}}i64 2{{.*}} @_PROTOCOL_NSFungingAndRuncing {{.*}}@_PROTOCOL_NSFunging
 
 // -- Force generation of witness for Zim.
 // CHECK: define hidden swiftcc { %objc_object*, i8** } @"$s14objc_protocols22mixed_heritage_erasure{{[_0-9a-zA-Z]*}}F"

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -62,7 +62,7 @@
 // CHECK-32: [[DEALLOC_ENCODING:@.*]] = private unnamed_addr constant [7 x i8] c"v8@0:4\00"
 // CHECK-64: [[DEALLOC_ENCODING:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
 
-// CHECK-32: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
+// CHECK-32: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = weak hidden constant { {{.*}}] } {
 // CHECK-32:   i32 12,
 // CHECK-32:   i32 11,
 // CHECK-32:   [11 x { i8*, i8*, i8* }] [{ i8*, i8*, i8* } {
@@ -112,7 +112,7 @@
 // CHECK-32:   }]
 // CHECK-32: }, section "__DATA, {{.*}}", align 4
 
-// CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
+// CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = weak hidden constant { {{.*}}] } {
 // CHECK-64:   i32 24,
 // CHECK-64:   i32 11,
 // CHECK-64:   [11 x { i8*, i8*, i8* }] [{
@@ -165,7 +165,7 @@
 // CHECK: [[STRING_X:@.*]] = private unnamed_addr constant [2 x i8] c"x\00"
 // CHECK-64: [[STRING_EMPTY:@.*]] = private unnamed_addr constant [1 x i8] zeroinitializer
 
-// CHECK-32: @_IVARS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
+// CHECK-32: @_IVARS__TtC13objc_subclass10SwiftGizmo = weak hidden constant { {{.*}}] } {
 // CHECK-32:   i32 20,
 // CHECK-32:   i32 1,
 // CHECK-32:   [1 x { i32*, i8*, i8*, i32, i32 }] [{ i32*, i8*, i8*, i32, i32 } {
@@ -176,7 +176,7 @@
 // CHECK-32:     i32 4 }]
 // CHECK-32: }, section "__DATA, {{.*}}", align 4
 
-// CHECK-64: @_IVARS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
+// CHECK-64: @_IVARS__TtC13objc_subclass10SwiftGizmo = weak hidden constant { {{.*}}] } {
 // CHECK-64:   i32 32,
 // CHECK-64:   i32 1,
 // CHECK-64:   [1 x { i64*, i8*, i8*, i32, i32 }] [{ i64*, i8*, i8*, i32, i32 } {
@@ -221,7 +221,7 @@
 // CHECK-32: [[SETTER_ENCODING:@.*]] = private unnamed_addr constant [10 x i8] c"v12@0:4@8\00"
 // CHECK-64: [[SETTER_ENCODING:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
 
-// CHECK-32: @_INSTANCE_METHODS__TtC13objc_subclass11SwiftGizmo2 = internal constant { i32, i32, [5 x { i8*, i8*, i8* }] } {
+// CHECK-32: @_INSTANCE_METHODS__TtC13objc_subclass11SwiftGizmo2 = weak hidden constant { i32, i32, [5 x { i8*, i8*, i8* }] } {
 // CHECK-32:   i32 12,
 // CHECK-32:   i32 5,
 // CHECK-32:   [5 x { i8*, i8*, i8* }] [
@@ -249,7 +249,7 @@
 // CHECK-32:   ]
 // CHECK-32: }, section "__DATA, {{.*}}", align 4
 
-// CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass11SwiftGizmo2 = internal constant { i32, {{.*}}] } {
+// CHECK-64: @_INSTANCE_METHODS__TtC13objc_subclass11SwiftGizmo2 = weak hidden constant { i32, {{.*}}] } {
 // CHECK-64:   i32 24,
 // CHECK-64:   i32 5,
 // CHECK-64:   [5 x { i8*, i8*, i8* }] [

--- a/test/IRGen/objc_subscripts.swift
+++ b/test/IRGen/objc_subscripts.swift
@@ -8,7 +8,7 @@
 // CHECK: [[KEYED_SETTER_ENCODING:@.+]] = private unnamed_addr constant [14 x i8] c"v32@0:8q16@24\00"
 
 // CHECK: @_INSTANCE_METHODS__TtC15objc_subscripts10SomeObject = 
-// CHECK:   internal constant { i32, i32, [5 x { i8*, i8*, i8* }] } 
+// CHECK:   weak hidden constant { i32, i32, [5 x { i8*, i8*, i8* }] } 
 // CHECK:   { i32 24, i32 5, [5 x { i8*, i8*, i8* }] 
 // CHECK:     [
 // CHECK:       { i8*, i8*, i8* } 

--- a/test/IRGen/prespecialized-metadata/class-with-differently-mangled-method-list.swift
+++ b/test/IRGen/prespecialized-metadata/class-with-differently-mangled-method-list.swift
@@ -20,7 +20,7 @@ func consume<T>(_ t: T) {
 }
 
 func doit() {
-  //      CHECK: @"_INSTANCE_METHODS_$s4main5ClazzCyAA1SVGMf" = internal constant
+  //      CHECK: @"_INSTANCE_METHODS_$s4main5ClazzCyAA1SVGMf" = weak hidden constant
   consume(Clazz<S>.self)
 }
 

--- a/test/IRGen/protocol_metadata.swift
+++ b/test/IRGen/protocol_metadata.swift
@@ -52,7 +52,7 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME: }
 
 // -- @objc protocol O uses ObjC symbol mangling and layout
-// CHECK-LABEL: @_PROTOCOL__TtP17protocol_metadata1O_ = internal constant
+// CHECK-LABEL: @_PROTOCOL__TtP17protocol_metadata1O_ = weak hidden constant
 // CHECK-SAME:   @_PROTOCOL_INSTANCE_METHODS__TtP17protocol_metadata1O_,
 // -- size, flags: 1 = Swift
 // CHECK-SAME:   i32 96, i32 1
@@ -60,7 +60,7 @@ protocol ABO : A, B, O { func abo() }
 // CHECK-SAME: }
 
 // -- @objc protocol OPT uses ObjC symbol mangling and layout
-// CHECK: @_PROTOCOL__TtP17protocol_metadata3OPT_ = internal constant { {{.*}} i32, [4 x i8*]*, i8*, i8* } {
+// CHECK: @_PROTOCOL__TtP17protocol_metadata3OPT_ = weak hidden constant { {{.*}} i32, [4 x i8*]*, i8*, i8* } {
 // CHECK-SAME:   @_PROTOCOL_INSTANCE_METHODS_OPT__TtP17protocol_metadata3OPT_,
 // CHECK-SAME:   @_PROTOCOL_CLASS_METHODS_OPT__TtP17protocol_metadata3OPT_,
 // -- size, flags: 1 = Swift

--- a/test/decl/protocol/special/JSExport.swift
+++ b/test/decl/protocol/special/JSExport.swift
@@ -9,13 +9,13 @@ import Foundation
 
 @objc protocol RootJSExport : JSExport { }
 
-// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub1_ = internal constant{{.*}}_PROTOCOL__TtP8JSExport8JSExport_{{.*}}_PROTOCOL__TtP8JSExport12RootJSExport_
+// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub1_ = weak hidden constant{{.*}}_PROTOCOL__TtP8JSExport8JSExport_{{.*}}_PROTOCOL__TtP8JSExport12RootJSExport_
 @objc protocol Sub1 : JSExport, RootJSExport { }
 
 // CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub2_{{.*}}_PROTOCOL__TtP8JSExport4Sub1_{{.*}}_PROTOCOL__TtP8JSExport8JSExport_
 @objc protocol Sub2 : Sub1, JSExport { }
 
-// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub3_ = internal constant{{.*}}@_PROTOCOL__TtP8JSExport4Sub2_
+// CHECK: @_PROTOCOL_PROTOCOLS__TtP8JSExport4Sub3_ = weak hidden constant{{.*}}@_PROTOCOL__TtP8JSExport4Sub2_
 @objc protocol Sub3 : Sub2 { }
 
 protocol ReexportJSExport : RootJSExport, JSExport { }


### PR DESCRIPTION
This extends #39944 to apply to more objc metadata.

rdar://85037490

