### PR TITLE
[test] Fix back deployment for tests looking at exclusivity checking

### DIFF
--- a/validation-test/Runtime/ExclusivityTest.swift
+++ b/validation-test/Runtime/ExclusivityTest.swift
@@ -4,27 +4,52 @@
 import StdlibUnittest
 import RuntimeUnittest
 
+func hasBackdeployedConcurrencyRuntime() -> Bool {
+  // If the stdlib we've loaded predates Swift 5.5, then we're running on a back
+  // deployed concurrency runtime, which has the side effect of disabling
+  // regular runtime exclusivity checks.
+  if #available(SwiftStdlib 5.5, *) { return false } // recent enough production stdlib
+  if #available(SwiftStdlib 9999, *) { return false } // dev stdlib
+  return true
+}
+
 var ExclusivityTestSuite = TestSuite("Exclusivity")
 
-ExclusivityTestSuite.test("testExclusivityNullPC") {
+ExclusivityTestSuite.test("testExclusivityNullPC")
+  .skip(.custom(
+    { hasBackdeployedConcurrencyRuntime() },
+    reason: "the back deployed concurrency runtime doesn't do exclusivity checks"))
+  .code {
   expectCrash(withMessage: "Simultaneous accesses") {
       SwiftRuntimeUnitTest.testExclusivityNullPC()
   }
 }
 
-ExclusivityTestSuite.test("testExclusivityPCOne") {
+ExclusivityTestSuite.test("testExclusivityPCOne")
+  .skip(.custom(
+    { hasBackdeployedConcurrencyRuntime() },
+    reason: "the back deployed concurrency runtime doesn't do exclusivity checks"))
+  .code {
   expectCrash(withMessage: "Simultaneous accesses") {
     SwiftRuntimeUnitTest.testExclusivityPCOne()
   }
 }
 
-ExclusivityTestSuite.test("testExclusivityBogusPC") {
+ExclusivityTestSuite.test("testExclusivityBogusPC")
+  .skip(.custom(
+    { hasBackdeployedConcurrencyRuntime() },
+    reason: "the back deployed concurrency runtime doesn't do exclusivity checks"))
+  .code {
   expectCrash(withMessage: "Simultaneous accesses") {
     SwiftRuntimeUnitTest.testExclusivityBogusPC()
   }
 }
 
-ExclusivityTestSuite.test("testExclusivityNonNestedPC") {
+ExclusivityTestSuite.test("testExclusivityNonNestedPC")
+  .skip(.custom(
+    { hasBackdeployedConcurrencyRuntime() },
+    reason: "the back deployed concurrency runtime doesn't do exclusivity checks"))
+  .code {
   SwiftRuntimeUnitTest.testExclusivityNonNestedPC()
 }
 

--- a/validation-test/stdlib/ArrayTrapsObjC.swift
+++ b/validation-test/stdlib/ArrayTrapsObjC.swift
@@ -124,6 +124,9 @@ class ViolateInoutSafetySwitchToObjcBuffer {
     // loop calls a function that violates inout safety and overrides the array.
     let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
     for i in 0..<A.count {
+      // Note: the compiler is sometimes able to eliminate this
+      // `_checkSubscript` call when optimizations are enabled, skipping the
+      // exclusivity check contained within.
       let t = A._checkSubscript(
         i, wasNativeTypeChecked: isNativeTypeChecked)
       _ = A._getElement(
@@ -141,11 +144,11 @@ class ViolateInoutSafetySwitchToObjcBuffer {
 
 ArraySemanticOptzns.test("inout_rule_violated_isNativeBuffer")
   .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -O or -Ounchecked"))
   .crashOutputMatches(
-    !_isDebugAssertConfiguration() ? ""
-    : hasBackdeployedConcurrencyRuntime() ? "inout rules were violated"
+    hasBackdeployedConcurrencyRuntime()
+    ? "inout rules were violated"
     : "Fatal access conflict detected."
   )
   .code {
@@ -170,6 +173,9 @@ class ViolateInoutSafetyNeedElementTypeCheck {
     // loop calls a function that violates inout safety and overrides the array.
     let isNativeTypeChecked = A._hoistableIsNativeTypeChecked()
     for i in 0..<A.count {
+      // Note: the compiler is sometimes able to eliminate this
+      // `_checkSubscript` call when optimizations are enabled, skipping the
+      // exclusivity check contained within.
       let t = A._checkSubscript(
         i, wasNativeTypeChecked: isNativeTypeChecked)
       _ = A._getElement(
@@ -187,11 +193,11 @@ class ViolateInoutSafetyNeedElementTypeCheck {
 
 ArraySemanticOptzns.test("inout_rule_violated_needsElementTypeCheck")
   .skip(.custom(
-    { _isFastAssertConfiguration() },
-    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+    { !_isDebugAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -O or -Ounchecked"))
   .crashOutputMatches(
-    !_isDebugAssertConfiguration() ? ""
-    : hasBackdeployedConcurrencyRuntime() ? "inout rules were violated"
+    hasBackdeployedConcurrencyRuntime()
+    ? "inout rules were violated"
     : "Fatal access conflict detected."
   )
   .code {


### PR DESCRIPTION
These two have been breaking back deployment tests for a while; https://github.com/apple/swift/pull/40134 attempted to fix the ArrayTraps test, but it proved incomplete.

rdar://85620934