### PR TITLE
Align Sendable diagnostic behavior with incremental-adoption proposal. 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4601,9 +4601,9 @@ WARNING(non_sendable_keypath_access,none,
         "cannot form key path that accesses non-sendable type %0",
         (Type))
 ERROR(non_concurrent_type_member,none,
-      "%select{stored property %1|associated value %1}0 of "
-      "'Sendable'-conforming %2 %3 has non-sendable type %4",
-      (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
+      "%select{stored property %2|associated value %2}1 of "
+      "'Sendable'-conforming %3 %4 has non-sendable type %0",
+      (Type, bool, DeclName, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_class_mutable_property,none,
       "stored property %0 of 'Sendable'-conforming %1 %2 is mutable",
       (DeclName, DescriptiveDeclKind, DeclName))

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3526,9 +3526,9 @@ void swift::diagnoseTypeAvailability(const TypeRepr *TR, Type T, SourceLoc loc,
 }
 
 static void diagnoseMissingConformance(
-    SourceLoc loc, Type type, ProtocolDecl *proto, ModuleDecl *module) {
+    SourceLoc loc, Type type, ProtocolDecl *proto, const DeclContext *fromDC) {
   assert(proto->isSpecificProtocol(KnownProtocolKind::Sendable));
-  diagnoseMissingSendableConformance(loc, type, module);
+  diagnoseMissingSendableConformance(loc, type, fromDC);
 }
 
 bool
@@ -3546,15 +3546,13 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
 
   // Diagnose "missing" conformances where we needed a conformance but
   // didn't have one.
+  auto *DC = where.getDeclContext();
   if (auto builtinConformance = dyn_cast<BuiltinProtocolConformance>(rootConf)){
     if (builtinConformance->isMissing()) {
       diagnoseMissingConformance(loc, builtinConformance->getType(),
-                                 builtinConformance->getProtocol(),
-                                 where.getDeclContext()->getParentModule());
+                                 builtinConformance->getProtocol(), DC);
     }
   }
-
-  auto *DC = where.getDeclContext();
 
   auto maybeEmitAssociatedTypeNote = [&]() {
     if (!depTy && !replacementTy)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -601,46 +601,96 @@ static bool hasUnavailableConformance(ProtocolConformanceRef conformance) {
   return false;
 }
 
+static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
+  if (dc->getParentModule()->isConcurrencyChecked())
+    return true;
+
+  return contextUsesConcurrencyFeatures(dc);
+}
+
+/// Determine the default diagnostic behavior for this language mode.
+static DiagnosticBehavior defaultSendableDiagnosticBehavior(
+    const LangOptions &langOpts) {
+  // Prior to Swift 6, all Sendable-related diagnostics are warnings.
+  if (!langOpts.isSwiftVersionAtLeast(6))
+    return DiagnosticBehavior::Warning;
+
+  return DiagnosticBehavior::Unspecified;
+}
+
+DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
+  // If we're not supposed to diagnose existing data races from this context,
+  // ignore the diagnostic entirely.
+  if (!shouldDiagnoseExistingDataRaces(fromDC))
+    return DiagnosticBehavior::Ignore;
+
+  return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
+}
+
+/// Determine the diagnostic behavior for a Sendable reference to the given
+/// nominal type.
+DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
+    NominalTypeDecl *nominal) const {
+  // Determine whether the type was explicitly non-Sendable.
+  auto nominalModule = nominal->getParentModule();
+  bool isExplicitlyNonSendable = nominalModule->isConcurrencyChecked();
+
+  // If we are performing an explicit conformance check, always consider this
+  // to be an explicitly non-Sendable type.
+  if (conformanceCheck) {
+    switch (*conformanceCheck) {
+    case SendableCheck::Explicit:
+      isExplicitlyNonSendable = true;
+      break;
+
+    case SendableCheck::ImpliedByStandardProtocol:
+    case SendableCheck::Implicit:
+      break;
+    }
+  }
+
+  // Determine whether this nominal type is visible via a @_predatesConcurrency
+  // import.
+  ImportDecl *predatesConcurrencyImport = nullptr;
+
+  // When the type is explicitly non-Sendable...
+  if (isExplicitlyNonSendable) {
+    // @_predatesConcurrency imports downgrade the diagnostic to a warning.
+    if (predatesConcurrencyImport) {
+      // FIXME: Note that this @_predatesConcurrency import was "used".
+      return DiagnosticBehavior::Warning;
+    }
+
+    return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
+  }
+
+  // When the type is implicitly non-Sendable...
+
+  // @_predatesConcurrency always suppresses the diagnostic.
+  if (predatesConcurrencyImport) {
+    // FIXME: Note that this @_predatesConcurrency import was "used".
+    return DiagnosticBehavior::Ignore;
+  }
+
+  return defaultDiagnosticBehavior();
+}
+
 /// Produce a diagnostic for a single instance of a non-Sendable type where
 /// a Sendable type is required.
 static bool diagnoseSingleNonSendableType(
-    Type type, ModuleDecl *module, SourceLoc loc,
+    Type type, SendableCheckContext fromContext, SourceLoc loc,
     llvm::function_ref<
       std::pair<DiagnosticBehavior, bool>(Type, DiagnosticBehavior)> diagnose) {
 
   auto behavior = DiagnosticBehavior::Unspecified;
 
+  auto module = fromContext.fromDC->getParentModule();
   ASTContext &ctx = module->getASTContext();
   auto nominal = type->getAnyNominal();
-  const LangOptions &langOpts = ctx.LangOpts;
   if (nominal) {
-    // A nominal type that has not provided conformance to Sendable will be
-    // diagnosed based on whether its defining module was consistently
-    // checked for concurrency.
-    auto nominalModule = nominal->getParentModule();
-
-    if (langOpts.isSwiftVersionAtLeast(6)) {
-      // In Swift 6, error when the nominal type comes from a module that
-      // had the concurrency checks consistently applied or from this module.
-      // Otherwise, warn.
-      if (nominalModule->isConcurrencyChecked() || nominalModule == module)
-        behavior = DiagnosticBehavior::Unspecified;
-      else
-        behavior = DiagnosticBehavior::Warning;
-    } else {
-      // In Swift 5, warn if either the imported or importing model is
-      // checking for concurrency, or if the nominal type comes from this
-      // module. Otherwise, leave a safety hole.
-      if (nominalModule->isConcurrencyChecked() ||
-          nominalModule == module ||
-          langOpts.WarnConcurrency)
-        behavior = DiagnosticBehavior::Warning;
-      else
-        behavior = DiagnosticBehavior::Ignore;
-    }
-  } else if (!langOpts.isSwiftVersionAtLeast(6)) {
-    // Always warn in Swift 5.
-    behavior = DiagnosticBehavior::Warning;
+    behavior = fromContext.diagnosticBehavior(nominal);
+  } else {
+    behavior = fromContext.defaultDiagnosticBehavior();
   }
 
   DiagnosticBehavior actualBehavior;
@@ -667,9 +717,11 @@ static bool diagnoseSingleNonSendableType(
 }
 
 bool swift::diagnoseNonSendableTypes(
-    Type type, ModuleDecl *module, SourceLoc loc,
+    Type type, SendableCheckContext fromContext, SourceLoc loc,
     llvm::function_ref<
       std::pair<DiagnosticBehavior, bool>(Type, DiagnosticBehavior)> diagnose) {
+  auto module = fromContext.fromDC->getParentModule();
+
   // If the Sendable protocol is missing, do nothing.
   auto proto = module->getASTContext().getProtocol(KnownProtocolKind::Sendable);
   if (!proto)
@@ -678,7 +730,7 @@ bool swift::diagnoseNonSendableTypes(
   // FIXME: More detail for unavailable conformances.
   auto conformance = TypeChecker::conformsToProtocol(type, proto, module);
   if (conformance.isInvalid() || hasUnavailableConformance(conformance)) {
-    return diagnoseSingleNonSendableType(type, module, loc, diagnose);
+    return diagnoseSingleNonSendableType(type, fromContext, loc, diagnose);
   }
 
   // Walk the conformance, diagnosing any missing Sendable conformances.
@@ -686,7 +738,7 @@ bool swift::diagnoseNonSendableTypes(
   conformance.forEachMissingConformance(module,
       [&](BuiltinProtocolConformance *missing) {
         if (diagnoseSingleNonSendableType(
-                missing->getType(), module, loc, diagnose)) {
+                missing->getType(), fromContext, loc, diagnose)) {
           anyMissing = true;
         }
 
@@ -697,7 +749,7 @@ bool swift::diagnoseNonSendableTypes(
 }
 
 bool swift::diagnoseNonSendableTypesInReference(
-    ConcreteDeclRef declRef, ModuleDecl *module, SourceLoc loc,
+    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
     ConcurrentReferenceKind refKind) {
   // For functions, check the parameter and result types.
   SubstitutionMap subs = declRef.getSubstitutions();
@@ -705,7 +757,7 @@ bool swift::diagnoseNonSendableTypesInReference(
     for (auto param : *function->getParameters()) {
       Type paramType = param->getInterfaceType().subst(subs);
       if (diagnoseNonSendableTypes(
-              paramType, module, loc, diag::non_sendable_param_type))
+              paramType, fromDC, loc, diag::non_sendable_param_type))
         return true;
     }
 
@@ -713,7 +765,7 @@ bool swift::diagnoseNonSendableTypesInReference(
     if (auto func = dyn_cast<FuncDecl>(function)) {
       Type resultType = func->getResultInterfaceType().subst(subs);
       if (diagnoseNonSendableTypes(
-              resultType, module, loc, diag::non_sendable_result_type))
+              resultType, fromDC, loc, diag::non_sendable_result_type))
         return true;
     }
 
@@ -725,7 +777,7 @@ bool swift::diagnoseNonSendableTypesInReference(
         ? var->getType()
         : var->getValueInterfaceType().subst(subs);
     if (diagnoseNonSendableTypes(
-            propertyType, module, loc,
+            propertyType, fromDC, loc,
             diag::non_sendable_property_type,
             var->getDescriptiveKind(), var->getName(),
             var->isLocalCapture()))
@@ -736,14 +788,14 @@ bool swift::diagnoseNonSendableTypesInReference(
     for (auto param : *subscript->getIndices()) {
       Type paramType = param->getInterfaceType().subst(subs);
       if (diagnoseNonSendableTypes(
-              paramType, module, loc, diag::non_sendable_param_type))
+              paramType, fromDC, loc, diag::non_sendable_param_type))
         return true;
     }
 
     // Check the element type of a subscript.
     Type resultType = subscript->getElementInterfaceType().subst(subs);
     if (diagnoseNonSendableTypes(
-            resultType, module, loc, diag::non_sendable_result_type))
+            resultType, fromDC, loc, diag::non_sendable_result_type))
       return true;
 
     return false;
@@ -753,9 +805,9 @@ bool swift::diagnoseNonSendableTypesInReference(
 }
 
 void swift::diagnoseMissingSendableConformance(
-    SourceLoc loc, Type type, ModuleDecl *module) {
+    SourceLoc loc, Type type, const DeclContext *fromDC) {
   diagnoseNonSendableTypes(
-      type, module, loc, diag::non_sendable_type);
+      type, fromDC, loc, diag::non_sendable_type);
 }
 
 namespace {
@@ -1893,7 +1945,7 @@ namespace {
         // Check for non-sendable types.
         bool problemFound =
             diagnoseNonSendableTypesInReference(
-              concDeclRef, getDeclContext()->getParentModule(), declLoc,
+              concDeclRef, getDeclContext(), declLoc,
               ConcurrentReferenceKind::SynchronousAsAsyncCall);
         if (problemFound)
           result = AsyncMarkingResult::NotSendable;
@@ -2023,14 +2075,14 @@ namespace {
       for (const auto &param : fnType->getParams()) {
         // FIXME: Dig out the locations of the corresponding arguments.
         if (diagnoseNonSendableTypes(
-                param.getParameterType(), getParentModule(), apply->getLoc(),
+                param.getParameterType(), getDeclContext(), apply->getLoc(),
                 diag::non_sendable_param_type))
           return true;
       }
 
       // Check for sendability of the result type.
       if (diagnoseNonSendableTypes(
-             fnType->getResult(), getParentModule(), apply->getLoc(),
+             fnType->getResult(), getDeclContext(), apply->getLoc(),
              diag::non_sendable_result_type))
         return true;
 
@@ -2056,7 +2108,7 @@ namespace {
       // A cross-actor access requires types to be concurrent-safe.
       if (isCrossActor) {
         return diagnoseNonSendableTypesInReference(
-            valueRef, getParentModule(), loc,
+            valueRef, getDeclContext(), loc,
             ConcurrentReferenceKind::CrossActor);
       }
 
@@ -2174,7 +2226,7 @@ namespace {
             (ctx.LangOpts.EnableExperimentalFlowSensitiveConcurrentCaptures &&
              parent.dyn_cast<LoadExpr *>())) {
           return diagnoseNonSendableTypesInReference(
-              valueRef, getParentModule(), loc,
+              valueRef, getDeclContext(), loc,
               ConcurrentReferenceKind::LocalCapture);
         }
 
@@ -2226,7 +2278,7 @@ namespace {
             auto type = component.getComponentType();
             if (shouldDiagnoseExistingDataRaces(getDeclContext()) &&
                 diagnoseNonSendableTypes(
-                    type, getParentModule(), component.getLoc(),
+                    type, getDeclContext(), component.getLoc(),
                     diag::non_sendable_keypath_access))
               return true;
 
@@ -2293,7 +2345,7 @@ namespace {
             if (type &&
                 shouldDiagnoseExistingDataRaces(getDeclContext()) &&
                 diagnoseNonSendableTypes(
-                    type, getParentModule(), component.getLoc(),
+                    type, getDeclContext(), component.getLoc(),
                     diag::non_sendable_keypath_capture))
               diagnosed = true;
           }
@@ -2399,7 +2451,7 @@ namespace {
         }
 
         return diagnoseNonSendableTypesInReference(
-            memberRef, getDeclContext()->getParentModule(), memberLoc,
+            memberRef, getDeclContext(), memberLoc,
             ConcurrentReferenceKind::CrossActor);
       }
 
@@ -3172,9 +3224,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
         subs = genericEnv->getForwardingSubstitutionMap();
       }
       diagnoseNonSendableTypesInReference(
-          ConcreteDeclRef(value, subs),
-          value->getDeclContext()->getParentModule(), value->getLoc(),
-          ConcurrentReferenceKind::Nonisolated);
+          ConcreteDeclRef(value, subs), value->getDeclContext(),
+          value->getLoc(), ConcurrentReferenceKind::Nonisolated);
     }
 
     // Classes with global actors have additional rules regarding inheritance.
@@ -3589,13 +3640,6 @@ bool swift::contextUsesConcurrencyFeatures(const DeclContext *dc) {
   return false;
 }
 
-static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
-  if (dc->getParentModule()->isConcurrencyChecked())
-    return true;
-
-  return contextUsesConcurrencyFeatures(dc);
-}
-
 /// Limit the diagnostic behavior used when performing checks for the Sendable
 /// instance storage of Sendable types.
 ///
@@ -3718,7 +3762,7 @@ static bool checkSendableInstanceStorage(
 
       // Check that the property type is Sendable.
       bool diagnosedProperty = diagnoseNonSendableTypes(
-          propertyType, dc->getParentModule(), property->getLoc(),
+          propertyType, SendableCheckContext(dc, check), property->getLoc(),
           [&](Type type, DiagnosticBehavior suggestedBehavior) {
             auto action = limitSendableInstanceBehavior(
                 langOpts, check, suggestedBehavior);
@@ -3748,7 +3792,7 @@ static bool checkSendableInstanceStorage(
     /// Handle an enum associated value.
     bool operator()(EnumElementDecl *element, Type elementType) {
       bool diagnosedElement = diagnoseNonSendableTypes(
-          elementType, dc->getParentModule(), element->getLoc(),
+          elementType, SendableCheckContext(dc, check), element->getLoc(),
           [&](Type type, DiagnosticBehavior suggestedBehavior) {
             auto action = limitSendableInstanceBehavior(
                 langOpts, check, suggestedBehavior);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -227,8 +227,7 @@ bool contextUsesConcurrencyFeatures(const DeclContext *dc);
 /// domain, including the substitutions so that (e.g.) we can consider the
 /// specific types at the use site.
 ///
-/// \param module The module from which the reference occurs. This is
-/// used to perform lookup of conformances to the \c Sendable protocol.
+/// \param fromDC The context from which the reference occurs.
 ///
 /// \param loc The location at which the reference occurs, which will be
 /// used when emitting diagnostics.
@@ -238,16 +237,49 @@ bool contextUsesConcurrencyFeatures(const DeclContext *dc);
 ///
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
-    ConcreteDeclRef declRef, ModuleDecl *module, SourceLoc loc,
+    ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
     ConcurrentReferenceKind refKind);
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(
-    SourceLoc loc, Type type, ModuleDecl *module);
+    SourceLoc loc, Type type, const DeclContext *fromDC);
 
 /// If the given nominal type is public and does not explicitly
 /// state whether it conforms to Sendable, provide a diagnostic.
 void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
+
+/// How the Sendable check should be performed.
+enum class SendableCheck {
+  /// Sendable conformance was explicitly stated and should be
+  /// fully checked.
+  Explicit,
+
+  /// Sendable conformance was implied by a protocol that inherits from
+  /// Sendable and also predates concurrency.
+  ImpliedByStandardProtocol,
+
+  /// Implicit conformance to Sendable.
+  Implicit,
+};
+
+/// Describes the context in which a \c Sendable check occurs.
+struct SendableCheckContext {
+  const DeclContext * const fromDC;
+  const Optional<SendableCheck> conformanceCheck;
+
+  SendableCheckContext(
+      const DeclContext * fromDC,
+      Optional<SendableCheck> conformanceCheck = None
+  ) : fromDC(fromDC), conformanceCheck(conformanceCheck) { }
+
+  /// Determine the default diagnostic behavior for a missing/unavailable
+  /// Sendable conformance in this context.
+  DiagnosticBehavior defaultDiagnosticBehavior() const;
+
+  /// Determine the diagnostic behavior when referencing the given nominal
+  /// type in this context.
+  DiagnosticBehavior diagnosticBehavior(NominalTypeDecl *nominal) const;
+};
 
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
@@ -258,7 +290,7 @@ void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
 ///
 /// \returns \c true if any diagnostics were produced, \c false otherwise.
 bool diagnoseNonSendableTypes(
-    Type type, ModuleDecl *module, SourceLoc loc,
+    Type type, SendableCheckContext fromContext, SourceLoc loc,
     llvm::function_ref<
       std::pair<DiagnosticBehavior, bool>(Type, DiagnosticBehavior)> diagnose);
 
@@ -268,37 +300,26 @@ namespace detail {
     typedef T type;
   };
 }
+
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///
 /// \returns \c true if any errors were produced, \c false otherwise.
 template<typename ...DiagArgs>
 bool diagnoseNonSendableTypes(
-    Type type, ModuleDecl *module, SourceLoc loc, Diag<Type, DiagArgs...> diag,
+    Type type, SendableCheckContext fromContext, SourceLoc loc,
+    Diag<Type, DiagArgs...> diag,
     typename detail::Identity<DiagArgs>::type ...diagArgs) {
-  ASTContext &ctx = module->getASTContext();
+  ASTContext &ctx = fromContext.fromDC->getASTContext();
   return diagnoseNonSendableTypes(
-      type, module, loc, [&](Type specificType, DiagnosticBehavior behavior) {
+      type, fromContext, loc, [&](Type specificType,
+      DiagnosticBehavior behavior) {
     ctx.Diags.diagnose(loc, diag, type, diagArgs...)
       .limitBehavior(behavior);
     return std::pair<DiagnosticBehavior, bool>(
         behavior, behavior == DiagnosticBehavior::Unspecified);
   });
 }
-
-/// How the concurrent value check should be performed.
-enum class SendableCheck {
-  /// Sendable conformance was explicitly stated and should be
-  /// fully checked.
-  Explicit,
-
-  /// Sendable conformance was implied by one of the standard library
-  /// protocols that added Sendable after-the-fact.
-  ImpliedByStandardProtocol,
-
-  /// Implicit conformance to Sendable.
-  Implicit,
-};
 
 /// Given a set of custom attributes, pick out the global actor attributes
 /// and perform any necessary resolution and diagnostics, returning the

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -438,7 +438,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
   case ActorIsolationRestriction::CrossActorSelf:
     // FIXME: Substitution map?
     diagnoseNonSendableTypesInReference(
-        const_cast<ValueDecl *>(VD), VD->getDeclContext()->getParentModule(),
+        const_cast<ValueDecl *>(VD), VD->getDeclContext(),
         VD->getLoc(), ConcurrentReferenceKind::CrossActor);
     return false;
   case ActorIsolationRestriction::ActorSelf:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3012,7 +3012,7 @@ bool ConformanceChecker::checkActorIsolation(
 
   case ActorIsolationRestriction::CrossActorSelf: {
     if (diagnoseNonSendableTypesInReference(
-        witness, DC->getParentModule(), witness->getLoc(),
+        witness, DC, witness->getLoc(),
         ConcurrentReferenceKind::CrossActor)) {
       return true;
     }
@@ -3145,7 +3145,7 @@ bool ConformanceChecker::checkActorIsolation(
       return false;
 
     return diagnoseNonSendableTypesInReference(
-      witness, DC->getParentModule(), witness->getLoc(),
+      witness, DC, witness->getLoc(),
       ConcurrentReferenceKind::CrossActor);
   }
 
@@ -3180,7 +3180,7 @@ bool ConformanceChecker::checkActorIsolation(
 
     if (isCrossActor) {
       return diagnoseNonSendableTypesInReference(
-        witness, DC->getParentModule(), witness->getLoc(),
+        witness, DC, witness->getLoc(),
         ConcurrentReferenceKind::CrossActor);
     }
 

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -34,7 +34,7 @@ struct S4_P1: P1 {
 }
 
 @MainActor(unsafe)
-protocol P2 { // expected-note{{protocol 'P2' does not conform to the 'Sendable' protocol}}
+protocol P2 {
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func g()
 }
@@ -44,7 +44,6 @@ struct S5_P2: P2 {
   func g() { }
 }
 
-// expected-warning@+1{{cannot pass argument of non-sendable type 'P2' across actors}}
 nonisolated func testP2(x: S5_P2, p2: P2) {
   p2.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // OKAY

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -231,11 +231,11 @@ func concurrentClosures<T>(_: T) {
 // Sendable checking
 // ----------------------------------------------------------------------
 struct S1: Sendable {
-  var nc: NotConcurrent // expected-error{{stored property 'nc' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NotConcurrent'}}
+  var nc: NotConcurrent // expected-warning{{stored property 'nc' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NotConcurrent'}}
 }
 
 struct S2<T>: Sendable {
-  var nc: T // expected-error{{stored property 'nc' of 'Sendable'-conforming generic struct 'S2' has non-sendable type 'T'}}
+  var nc: T // expected-warning{{stored property 'nc' of 'Sendable'-conforming generic struct 'S2' has non-sendable type 'T'}}
 }
 
 struct S3<T> {
@@ -246,7 +246,7 @@ struct S3<T> {
 extension S3: Sendable where T: Sendable { }
 
 enum E1: Sendable {
-  case payload(NotConcurrent) // expected-error{{associated value 'payload' of 'Sendable'-conforming enum 'E1' has non-sendable type 'NotConcurrent'}}
+  case payload(NotConcurrent) // expected-warning{{associated value 'payload' of 'Sendable'-conforming enum 'E1' has non-sendable type 'NotConcurrent'}}
 }
 
 enum E2<T> {
@@ -256,8 +256,8 @@ enum E2<T> {
 extension E2: Sendable where T: Sendable { }
 
 final class C1: Sendable {
-  let nc: NotConcurrent? = nil // expected-error{{stored property 'nc' of 'Sendable'-conforming class 'C1' has non-sendable type 'NotConcurrent?'}}
-  var x: Int = 0 // expected-error{{stored property 'x' of 'Sendable'-conforming class 'C1' is mutable}}
+  let nc: NotConcurrent? = nil // expected-warning{{stored property 'nc' of 'Sendable'-conforming class 'C1' has non-sendable type 'NotConcurrent?'}}
+  var x: Int = 0 // expected-warning{{stored property 'x' of 'Sendable'-conforming class 'C1' is mutable}}
   let i: Int = 0
 }
 
@@ -281,7 +281,7 @@ class C6: C5 {
 
 final class C7<T>: Sendable { }
 
-class C9: Sendable { } // expected-error{{non-final class 'C9' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+class C9: Sendable { } // expected-warning{{non-final class 'C9' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 
 // ----------------------------------------------------------------------
 // @unchecked Sendable disabling checking

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -10,13 +10,13 @@ final class A: NSObject, Sendable {
 }
 
 final class B: NSObject, Sendable {
-  var x: Int = 5 // expected-error{{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
+  var x: Int = 5 // expected-warning{{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
 }
 
 class C { } // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
 
 final class D: NSObject, Sendable {
-  let c: C = C() // expected-error{{stored property 'c' of 'Sendable'-conforming class 'D' has non-sendable type 'C'}}
+  let c: C = C() // expected-warning{{stored property 'c' of 'Sendable'-conforming class 'D' has non-sendable type 'C'}}
 }
 
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -111,7 +111,7 @@ struct S2: Q {
 }
 
 struct S3: Q, Sendable {
-  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-sendable type 'NS'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-sendable type 'NS'}}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -95,5 +95,5 @@ public struct S10 { // expected-warning{{public struct 'S10' does not specify wh
 }
 
 struct S11: Sendable {
-  var s7: S7 // expected-error{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-sendable type 'S7'}}
+  var s7: S7 // expected-warning{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-sendable type 'S7'}}
 }

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -14,7 +14,6 @@ actor A {
 
 func testA(a: A) async {
   _ = await a.f() // CHECK: warning: cannot call function returning non-sendable type '[StrictStruct : NonStrictClass]' across actors}}
-  // CHECK-NOT: NonStrictClass
   // CHECK: note: struct 'StrictStruct' does not conform to the 'Sendable' protocol
-  // CHECK-NOT: NonStrictClass
+  // CHECK: note: class 'NonStrictClass' does not conform to the 'Sendable' protocol
 }

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -44,7 +44,6 @@ actor A7 {
 @available(SwiftStdlib 5.1, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
@@ -53,7 +52,6 @@ class C1: Actor {
 @available(SwiftStdlib 5.1, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -64,7 +62,6 @@ class C2: Actor {
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
-  // expected-error@-3{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 


### PR DESCRIPTION
Determine whether a particular missing Sendable diagnostic should be
emitted as a warning or error, or even ignored entirely, based on the
emerging rules from the proposal for incremental adoption of Sendable
checking.