### PR TITLE
[AutoDiff] Fix crasher when type-checking mismatched derivative.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4066,9 +4066,15 @@ static bool checkFunctionSignature(
   // Check that generic signatures match.
   auto requiredGenSig = required.getOptGenericSignature();
   auto candidateGenSig = candidateFnTy.getOptGenericSignature();
-  if (!candidateGenSig.requirementsNotSatisfiedBy(requiredGenSig).empty()) {
+  // Check that the candidate signature's generic parameters are a subset of
+  // those of the required signature.
+  if (requiredGenSig && candidateGenSig &&
+      candidateGenSig.getGenericParams().size()
+          > requiredGenSig.getGenericParams().size())
     return false;
-  }
+  // Check that the requirements are satisfied.
+  if (!candidateGenSig.requirementsNotSatisfiedBy(requiredGenSig).empty())
+    return false;
 
   // Check that parameter types match, disregarding labels.
   if (required->getNumParams() != candidateFnTy->getNumParams())

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -573,6 +573,27 @@ extension Struct where T: Differentiable & AdditiveArithmetic {
   }
 }
 
+struct SR15530_Struct<T> {}
+extension SR15530_Struct: Differentiable where T: Differentiable {}
+
+extension SR15530_Struct {
+  // expected-note @+1 {{candidate instance method does not have type equal to or less constrained than '<T where T : Differentiable> (inout SR15530_Struct<T>) -> (Int, @differentiable(reverse) (inout T) -> Void) -> Void'}}
+  mutating func sr15530_update<D>(at index: Int, byCalling closure: (inout T, D) -> Void, withArgument: D) {
+    fatalError("Stop")
+  }
+}
+
+extension SR15530_Struct where T: Differentiable {
+  // expected-error @+1 {{referenced declaration 'sr15530_update' could not be resolved}}
+  @derivative(of: sr15530_update)
+  mutating func vjp_sr15530_update(
+    at index: Int,
+    byCalling closure: @differentiable(reverse) (inout T) -> Void
+  ) -> (value: Void, pullback: (inout Self.TangentVector) -> Void) {
+    fatalError("Stop")
+  }
+}
+
 extension Class {
   subscript() -> Float {
     get { 1 }

--- a/test/AutoDiff/compiler_crashers/sr14223-apply-opened-opened-existential-argument.swift
+++ b/test/AutoDiff/compiler_crashers/sr14223-apply-opened-opened-existential-argument.swift
@@ -1,6 +1,6 @@
 // RUN: not --crash %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
 
-// TF-1181: Differentiation transform crash for `apply` with opened existential arguments.
+// SR-14223: Differentiation transform crash for `apply` with opened existential arguments.
 
 import _Differentiation
 


### PR DESCRIPTION
When checking the viability of an original function candidate as specified in a `@derivative` attribute, a candidate's signautre can have more generic requirements than the required signature. Such cases need to be checked and diagnosed.

Resolves SR-15530 / rdar://85845512.