### PR TITLE
[rebranch] Include C++ std headers where required

### DIFF
--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -24,8 +24,9 @@
 
 #include "llvm/Support/ErrorHandling.h"
 #include "swift/Basic/type_traits.h"
+#include <cassert>
+#include <cstdint>
 #include <utility>
-#include <assert.h>
 
 namespace swift {
 

--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -20,6 +20,7 @@
 
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/Runtime/Portability.h"
+#include <cstring>
 #include <string>
 
 namespace swift {


### PR DESCRIPTION
These appear to be implicitly included somewhere by MacOS but not by
Linux. Add explicitly.

Resolves rdar://85996864.