### PR TITLE
[cxx-interop] import const reference parameters as __shared T

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1289,6 +1289,17 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
 
     return true;
   }
+
+  // Pass C++ const reference types indirectly.
+  if (clangTy->isReferenceType() &&
+      clangTy->getPointeeType().isConstQualified()) {
+    // FIXME: Template substitution references are still mapped as
+    // UnsafePointer.
+    if (isa<clang::SubstTemplateTypeParmType>(
+            clangTy->getPointeeType().getTypePtr()))
+      return false;
+    return true;
+  }
   return false;
 }
 

--- a/test/Interop/Cxx/reference/Inputs/reference.cpp
+++ b/test/Interop/Cxx/reference/Inputs/reference.cpp
@@ -16,3 +16,19 @@ void setConstStaticIntRvalueRef(const int &&i) { staticInt = i; }
 
 auto getFuncRef() -> int (&)() { return getStaticInt; }
 auto getFuncRvalueRef() -> int (&&)() { return getStaticInt; }
+
+void takeConstPODStructRef(const PODStruct &value) {
+  staticInt = value.x;
+}
+
+void takeConstPODStructRvalueRef(const PODStruct &&value) {
+  staticInt = value.x;
+}
+
+void takeConstPODStructPointerConstRef(PODStruct * _Nonnull const &value) {
+  staticInt = value->x;
+}
+
+void takeConstPODStructPointerConstRvalueRef(PODStruct * _Nonnull const &&value) {
+  staticInt = value->x;
+}

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -20,4 +20,14 @@ auto getFuncRvalueRef() -> int (&&)();
 // crashing when we have an "_Atomic" type or a reference to one.
 void dontImportAtomicRef(_Atomic(int)&) { }
 
+struct PODStruct {
+  int x;
+};
+
+void takeConstPODStructRef(const PODStruct &);
+void takeConstPODStructRvalueRef(const PODStruct &&);
+
+void takeConstPODStructPointerConstRef(PODStruct * _Nonnull const &);
+void takeConstPODStructPointerConstRvalueRef(PODStruct * _Nonnull const &&);
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -39,8 +39,8 @@ public func setCxxRef() {
 // CHECK: call void @{{_Z15setStaticIntRefRi|"\?setStaticIntRef@@YAXAEAH@Z"}}(i32* %{{.*}})
 
 public func setCxxConstRef() {
-  var val: CInt = 21
-  setConstStaticIntRef(&val)
+  let val: CInt = 21
+  setConstStaticIntRef(val)
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main14setCxxConstRefyyF"()
@@ -55,8 +55,8 @@ public func setCxxRvalueRef() {
 // CHECK: call void @{{_Z21setStaticIntRvalueRefOi|"\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z"}}(i32* %{{.*}})
 
 public func setCxxConstRvalueRef() {
-  var val: CInt = 21
-  setConstStaticIntRvalueRef(&val)
+  let val: CInt = 21
+  setConstStaticIntRvalueRef(val)
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20setCxxConstRvalueRefyyF"()

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -8,8 +8,8 @@
 // CHECK: func setStaticInt(_: Int32)
 // CHECK: func setStaticIntRef(_: inout Int32)
 // CHECK: func setStaticIntRvalueRef(_: inout Int32)
-// CHECK: func setConstStaticIntRef(_: inout Int32)
-// CHECK: func setConstStaticIntRvalueRef(_: inout Int32)
+// CHECK: func setConstStaticIntRef(_: __shared Int32)
+// CHECK: func setConstStaticIntRvalueRef(_: __shared Int32)
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32
 // CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32
 

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -44,13 +44,13 @@ func setCxxRef() {
 // CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
 
 func setCxxConstRef() {
-  var val: CInt = 21
-  setConstStaticIntRef(&val)
+  let val: CInt = 21
+  setConstStaticIntRef(val)
 }
 
 // CHECK: sil hidden @$s4main14setCxxConstRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z20setConstStaticIntRefRKi|\?setConstStaticIntRef@@YAXAEBH@Z}} : $@convention(c) (@inout Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z20setConstStaticIntRefRKi|\?setConstStaticIntRef@@YAXAEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()
 
 func setCxxRvalueRef() {
   var val: CInt = 21
@@ -62,10 +62,10 @@ func setCxxRvalueRef() {
 // CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
 
 func setCxxConstRvalueRef() {
-  var val: CInt = 21
-  setConstStaticIntRvalueRef(&val)
+  let val: CInt = 21
+  setConstStaticIntRvalueRef(val)
 }
 
 // CHECK: sil hidden @$s4main20setCxxConstRvalueRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z26setConstStaticIntRvalueRefOKi|\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z}} : $@convention(c) (@inout Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z26setConstStaticIntRvalueRefOKi|\?setConstStaticIntRvalueRef@@YAX\$\$QEBH@Z}} : $@convention(c) (@in_guaranteed Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in_guaranteed Int32) -> ()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -46,8 +46,8 @@ ReferenceTestSuite.test("pass-lvalue-reference") {
 
 ReferenceTestSuite.test("pass-const-lvalue-reference") {
   expectNotEqual(22, getStaticInt())
-  var val: CInt = 22
-  setConstStaticIntRef(&val)
+  let val: CInt = 22
+  setConstStaticIntRef(val)
   expectEqual(22, getStaticInt())
 }
 
@@ -60,8 +60,8 @@ ReferenceTestSuite.test("pass-rvalue-reference") {
 
 ReferenceTestSuite.test("pass-const-rvalue-reference") {
   expectNotEqual(53, getStaticInt())
-  var val: CInt = 53
-  setConstStaticIntRvalueRef(&val)
+  let val: CInt = 53
+  setConstStaticIntRvalueRef(val)
   expectEqual(53, getStaticInt())
 }
 
@@ -79,6 +79,42 @@ ReferenceTestSuite.test("func-rvalue-reference") {
   expectNotEqual(61, getStaticInt())
   setStaticInt(61)
   expectEqual(61, cxxF())
+}
+
+ReferenceTestSuite.test("pod-struct-const-lvalue-reference") {
+  let pod = PODStruct(x: 78)
+
+  expectNotEqual(78, getStaticInt())
+  takeConstPODStructRef(pod)
+  expectEqual(78, getStaticInt())
+}
+
+ReferenceTestSuite.test("pod-struct-const-rvalue-reference") {
+  let pod = PODStruct(x: 79)
+
+  expectNotEqual(79, getStaticInt())
+  takeConstPODStructRvalueRef(pod)
+  expectEqual(79, getStaticInt())
+}
+
+ReferenceTestSuite.test("pod-struct-pointer-const-lvalue-reference") {
+  var pod = PODStruct(x: 84)
+
+  expectNotEqual(84, getStaticInt())
+  withUnsafeMutablePointer(to: &pod) { ump in
+    takeConstPODStructPointerConstRef(ump)
+  }
+  expectEqual(84, getStaticInt())
+}
+
+ReferenceTestSuite.test("pod-struct-pointer-const-rvalue-reference") {
+  var pod = PODStruct(x: 85)
+
+  expectNotEqual(85, getStaticInt())
+  withUnsafeMutablePointer(to: &pod) { ump in
+    takeConstPODStructPointerConstRvalueRef(ump)
+  }
+  expectEqual(85, getStaticInt())
 }
 
 runAllTests()


### PR DESCRIPTION
This change allows Swift code to pass immutable values to const references in C++.
Note that const reference parameters in function template instantiations are not yet
supported in this patch, as even non-const refs are mapped as pointers instead of 'inout' parameters
in Swift. The support for reference parameters in function template instantions will be
added in a follow-up patch.
