### PR TITLE
[CodeComplete] Markup default arguments

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -962,6 +962,9 @@ struct CodeCompletionResultSink {
   /// Whether to perform "call pettern heuristics".
   bool enableCallPatternHeuristics = false;
 
+  /// Whether to include an item without any default arguments.
+  bool addCallWithNoDefaultArgs = true;
+
   std::vector<CodeCompletionResult *> Results;
 
   /// A single-element cache for module names stored in Allocator, keyed by a
@@ -1052,6 +1055,13 @@ public:
   }
   bool getCallPatternHeuristics() const {
     return CurrentResults.enableCallPatternHeuristics;
+  }
+
+  void setAddCallWithNoDefaultArgs(bool flag) {
+    CurrentResults.addCallWithNoDefaultArgs = flag;
+  }
+  bool addCallWithNoDefaultArgs() const {
+    return CurrentResults.addCallWithNoDefaultArgs;
   }
 
   /// Allocate a string owned by the code completion context.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -174,6 +174,9 @@ public:
     /// Argument type tag for annotated results.
     CallArgumentTypeBegin,
 
+    /// Added if the argument has a default value.
+    CallArgumentDefaultBegin,
+
     /// System type name.
     TypeIdSystem,
 
@@ -252,6 +255,7 @@ public:
            Kind == ChunkKind::GenericParameterBegin ||
            Kind == ChunkKind::OptionalBegin ||
            Kind == ChunkKind::CallArgumentTypeBegin ||
+           Kind == ChunkKind::CallArgumentDefaultBegin ||
            Kind == ChunkKind::TypeAnnotationBegin ||
            Kind == ChunkKind::ParameterDeclBegin ||
            Kind == ChunkKind::ParameterDeclTypeBegin ||

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -13,8 +13,9 @@
 #ifndef SWIFT_IDE_CODE_COMPLETIONCACHE_H
 #define SWIFT_IDE_CODE_COMPLETIONCACHE_H
 
-#include "swift/IDE/CodeCompletion.h"
 #include "swift/Basic/ThreadSafeRefCounted.h"
+#include "swift/IDE/CodeCompletion.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/Chrono.h"
 #include <system_error>
@@ -43,17 +44,19 @@ public:
     bool ForTestableLookup;
     bool ForPrivateImportLookup;
     bool AddInitsInToplevel;
+    bool AddCallWithNoDefaultArgs;
     bool Annotated;
 
     friend bool operator==(const Key &LHS, const Key &RHS) {
       return LHS.ModuleFilename == RHS.ModuleFilename &&
-        LHS.ModuleName == RHS.ModuleName &&
-        LHS.AccessPath == RHS.AccessPath &&
-        LHS.ResultsHaveLeadingDot == RHS.ResultsHaveLeadingDot &&
-        LHS.ForTestableLookup == RHS.ForTestableLookup &&
-        LHS.ForPrivateImportLookup == RHS.ForPrivateImportLookup &&
-        LHS.AddInitsInToplevel == RHS.AddInitsInToplevel &&
-        LHS.Annotated == RHS.Annotated;
+             LHS.ModuleName == RHS.ModuleName &&
+             LHS.AccessPath == RHS.AccessPath &&
+             LHS.ResultsHaveLeadingDot == RHS.ResultsHaveLeadingDot &&
+             LHS.ForTestableLookup == RHS.ForTestableLookup &&
+             LHS.ForPrivateImportLookup == RHS.ForPrivateImportLookup &&
+             LHS.AddInitsInToplevel == RHS.AddInitsInToplevel &&
+             LHS.AddCallWithNoDefaultArgs == RHS.AddCallWithNoDefaultArgs &&
+             LHS.Annotated == RHS.Annotated;
     }
   };
 
@@ -110,23 +113,18 @@ template<>
 struct DenseMapInfo<swift::ide::CodeCompletionCache::Key> {
   using KeyTy = swift::ide::CodeCompletionCache::Key;
   static inline KeyTy getEmptyKey() {
-    return KeyTy{"", "", {}, false, false, false, false, false};
+    return KeyTy{"", "", {}, false, false, false, false, false, false};
   }
   static inline KeyTy getTombstoneKey() {
-    return KeyTy{"", "", {}, true, false, false, false, false};
+    return KeyTy{"", "", {}, true, false, false, false, false, false};
   }
   static unsigned getHashValue(const KeyTy &Val) {
-    size_t H = 0;
-    H ^= std::hash<std::string>()(Val.ModuleFilename);
-    H ^= std::hash<std::string>()(Val.ModuleName);
-    for (auto Piece : Val.AccessPath)
-      H ^= std::hash<std::string>()(Piece);
-    H ^= std::hash<bool>()(Val.ResultsHaveLeadingDot);
-    H ^= std::hash<bool>()(Val.ForTestableLookup);
-    H ^= std::hash<bool>()(Val.ForPrivateImportLookup);
-    H ^= std::hash<bool>()(Val.AddInitsInToplevel);
-    H ^= std::hash<bool>()(Val.Annotated);
-    return static_cast<unsigned>(H);
+    return llvm::hash_combine(
+        Val.ModuleFilename, Val.ModuleName,
+        llvm::hash_combine_range(Val.AccessPath.begin(), Val.AccessPath.end()),
+        Val.ResultsHaveLeadingDot, Val.ForTestableLookup,
+        Val.ForPrivateImportLookup, Val.AddInitsInToplevel,
+        Val.AddCallWithNoDefaultArgs, Val.Annotated);
   }
   static bool isEqual(const KeyTy &LHS, const KeyTy &RHS) {
     return LHS == RHS;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -218,6 +218,7 @@ void CodeCompletionString::print(raw_ostream &OS) const {
     case ChunkKind::DeclResultTypeClauseBegin:
     case ChunkKind::ParameterDeclTypeBegin:
     case ChunkKind::AttributeAndModifierListBegin:
+    case ChunkKind::CallArgumentDefaultBegin:
       assert(I->getNestingLevel() == PrevNestingLevel + 1);
       closeTags.emplace_back("");
       break;
@@ -293,6 +294,7 @@ void CodeCompletionString::dump() const {
     CASE(DeclAttrParamColon)
     CASE(CallArgumentType)
     CASE(CallArgumentTypeBegin)
+    CASE(CallArgumentDefaultBegin)
     CASE(TypeIdSystem)
     CASE(TypeIdUser)
     CASE(CallArgumentClosureType)
@@ -910,8 +912,8 @@ public:
 
 void CodeCompletionResultBuilder::addCallArgument(
     Identifier Name, Identifier LocalName, Type Ty, Type ContextTy,
-    bool IsVarArg, bool IsInOut, bool IsIUO, bool isAutoClosure,
-    bool useUnderscoreLabel, bool isLabeledTrailingClosure) {
+    bool IsVarArg, bool IsInOut, bool IsIUO, bool IsAutoClosure,
+    bool UseUnderscoreLabel, bool IsLabeledTrailingClosure, bool HasDefault) {
   ++CurrentNestingLevel;
   using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
 
@@ -952,7 +954,7 @@ void CodeCompletionResultBuilder::addCallArgument(
           escapeKeyword(Name.str(), false, EscapedKeyword));
       addChunkWithTextNoCopy(
           CodeCompletionString::Chunk::ChunkKind::CallArgumentColon, ": ");
-    } else if (useUnderscoreLabel) {
+    } else if (UseUnderscoreLabel) {
       addChunkWithTextNoCopy(
           CodeCompletionString::Chunk::ChunkKind::CallArgumentName, "_");
       addChunkWithTextNoCopy(
@@ -978,7 +980,7 @@ void CodeCompletionResultBuilder::addCallArgument(
   // If the parameter is of the type @autoclosure ()->output, then the
   // code completion should show the parameter of the output type
   // instead of the function type ()->output.
-  if (isAutoClosure) {
+  if (IsAutoClosure) {
     // 'Ty' may be ErrorType.
     if (auto funcTy = Ty->getAs<FunctionType>())
       Ty = funcTy->getResult();
@@ -1004,6 +1006,12 @@ void CodeCompletionResultBuilder::addCallArgument(
     addChunkWithText(ChunkKind::CallArgumentType, TypeName);
   }
 
+  if (HasDefault) {
+    withNestedGroup(ChunkKind::CallArgumentDefaultBegin, []() {
+      // Possibly add the actual value in the future
+    });
+  }
+
   // Look through optional types and type aliases to find out if we have
   // function type.
   Ty = Ty->lookThroughAllOptionalTypes();
@@ -1020,7 +1028,7 @@ void CodeCompletionResultBuilder::addCallArgument(
     if (ContextTy)
       PO.setBaseType(ContextTy);
 
-    if (isLabeledTrailingClosure) {
+    if (IsLabeledTrailingClosure) {
       // Expand the closure body.
       SmallString<32> buffer;
       llvm::raw_svector_ostream OS(buffer);
@@ -1062,6 +1070,7 @@ void CodeCompletionResultBuilder::addCallArgument(
 
   if (IsVarArg)
     addEllipsis();
+
   --CurrentNestingLevel;
 }
 
@@ -1414,6 +1423,7 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::CallArgumentColon:
     case ChunkKind::CallArgumentTypeBegin:
     case ChunkKind::CallArgumentType:
+    case ChunkKind::CallArgumentDefaultBegin:
     case ChunkKind::CallArgumentClosureType:
     case ChunkKind::CallArgumentClosureExpr:
     case ChunkKind::ParameterDeclTypeBegin:
@@ -2746,25 +2756,32 @@ public:
       Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
   }
 
+  static bool hasInterestingDefaultValue(const ParamDecl *param) {
+    if (!param)
+      return false;
+
+    switch (param->getDefaultArgumentKind()) {
+    case DefaultArgumentKind::Normal:
+    case DefaultArgumentKind::NilLiteral:
+    case DefaultArgumentKind::EmptyArray:
+    case DefaultArgumentKind::EmptyDictionary:
+    case DefaultArgumentKind::StoredProperty:
+    case DefaultArgumentKind::Inherited:
+      return true;
+
+    case DefaultArgumentKind::None:
+#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
+    case DefaultArgumentKind::NAME:
+#include "swift/AST/MagicIdentifierKinds.def"
+      return false;
+    }
+  }
+
   static bool hasInterestingDefaultValues(const AbstractFunctionDecl *func) {
     if (!func) return false;
-
     for (auto param : *func->getParameters()) {
-      switch (param->getDefaultArgumentKind()) {
-      case DefaultArgumentKind::Normal:
-      case DefaultArgumentKind::NilLiteral:
-      case DefaultArgumentKind::EmptyArray:
-      case DefaultArgumentKind::EmptyDictionary:
-      case DefaultArgumentKind::StoredProperty:
-      case DefaultArgumentKind::Inherited: // FIXME: include this?
+      if (hasInterestingDefaultValue(param))
         return true;
-
-      case DefaultArgumentKind::None:
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
-      case DefaultArgumentKind::NAME:
-#include "swift/AST/MagicIdentifierKinds.def"
-        break;
-      }
     }
     return false;
   }
@@ -2780,52 +2797,27 @@ public:
     assert(declParams.empty() || typeParams.size() == declParams.size());
 
     bool modifiedBuilder = false;
-
-    // Determine whether we should skip this argument because it is defaulted.
-    auto shouldSkipArg = [&](const ParamDecl *PD) -> bool {
-      switch (PD->getDefaultArgumentKind()) {
-      case DefaultArgumentKind::None:
-        return false;
-
-      case DefaultArgumentKind::Normal:
-      case DefaultArgumentKind::StoredProperty:
-      case DefaultArgumentKind::Inherited:
-      case DefaultArgumentKind::NilLiteral:
-      case DefaultArgumentKind::EmptyArray:
-      case DefaultArgumentKind::EmptyDictionary:
-        return !includeDefaultArgs;
-
-#define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
-      case DefaultArgumentKind::NAME:
-#include "swift/AST/MagicIdentifierKinds.def"
-        // Skip parameters that are defaulted to source location or other
-        // caller context information.  Users typically don't want to specify
-        // these parameters.
-        return true;
-      }
-
-      llvm_unreachable("Unhandled DefaultArgumentKind in switch.");
-    };
-
-    bool NeedComma = false;
+    bool needComma = false;
     // Iterate over each parameter.
     for (unsigned i = 0; i != typeParams.size(); ++i) {
       auto &typeParam = typeParams[i];
 
-      Identifier argName;
+      Identifier argName = typeParam.getLabel();
       Identifier bodyName;
       bool isIUO = false;
-
+      bool hasDefault = false;
       if (!declParams.empty()) {
-        auto *PD = declParams[i];
-        if (shouldSkipArg(PD))
+        const ParamDecl *PD = declParams[i];
+        hasDefault = PD->isDefaultArgument();
+        // Skip default arguments if we're either not including them or they
+        // aren't interesting
+        if (hasDefault &&
+            (!includeDefaultArgs || !hasInterestingDefaultValue(PD)))
           continue;
+
         argName = PD->getArgumentName();
         bodyName = PD->getParameterName();
         isIUO = PD->isImplicitlyUnwrappedOptional();
-      } else {
-        isIUO = false;
-        argName = typeParam.getLabel();
       }
 
       bool isVariadic = typeParam.isVariadic();
@@ -2835,21 +2827,22 @@ public:
       if (isVariadic)
         paramTy = ParamDecl::getVarargBaseTy(paramTy);
 
-      if (NeedComma)
-        Builder.addComma();
       Type contextTy;
       if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
         contextTy = typeContext->getDeclaredTypeInContext();
 
+      if (needComma)
+        Builder.addComma();
       Builder.addCallArgument(argName, bodyName,
                               eraseArchetypes(paramTy, genericSig), contextTy,
                               isVariadic, isInOut, isIUO, isAutoclosure,
-                              /*useUnderscoreLabel=*/false,
-                              /*isLabeledTrailingClosure=*/false);
+                              /*UseUnderscoreLabel=*/false,
+                              /*IsLabeledTrailingClosure=*/false, hasDefault);
 
       modifiedBuilder = true;
-      NeedComma = true;
+      needComma = true;
     }
+
     return modifiedBuilder;
   }
 
@@ -4732,9 +4725,9 @@ public:
       Builder.addCallArgument(Arg->getLabel(), Identifier(),
                               Arg->getPlainType(), ContextType,
                               Arg->isVariadic(), Arg->isInOut(),
-                              /*isIUO=*/false, Arg->isAutoClosure(),
-                              /*useUnderscoreLabel=*/true,
-                              isLabeledTrailingClosure);
+                              /*IsIUO=*/false, Arg->isAutoClosure(),
+                              /*UseUnderscoreLabel=*/true,
+                              isLabeledTrailingClosure, /*HasDefault=*/false);
       Builder.addFlair(CodeCompletionFlairBit::ArgumentLabels);
       auto Ty = Arg->getPlainType();
       if (Arg->isInOut()) {

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -293,6 +293,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
     OSSLE.write(K.ForTestableLookup);
     OSSLE.write(K.ForPrivateImportLookup);
     OSSLE.write(K.AddInitsInToplevel);
+    OSSLE.write(K.AddCallWithNoDefaultArgs);
     OSSLE.write(K.Annotated);
     LE.write(static_cast<uint32_t>(OSS.tell()));   // Size of debug info
     out.write(OSS.str().data(), OSS.str().size()); // Debug info blob
@@ -399,11 +400,12 @@ static std::string getName(StringRef cacheDirectory,
   llvm::sys::path::append(name, K.ModuleName);
   llvm::raw_svector_ostream OSS(name);
 
-  // name[-dot][-testable][-inits]
+  // name[-with-enabled-options]
   OSS << (K.ResultsHaveLeadingDot ? "-dot" : "")
       << (K.ForTestableLookup ? "-testable" : "")
       << (K.ForPrivateImportLookup ? "-private" : "")
       << (K.AddInitsInToplevel ? "-inits" : "")
+      << (K.AddCallWithNoDefaultArgs ? "-nodefaults" : "")
       << (K.Annotated ? "-annotated" : "");
 
   // name[-access-path-components]
@@ -469,8 +471,9 @@ OnDiskCodeCompletionCache::getFromFile(StringRef filename) {
     return None;
 
   // Make up a key for readCachedModule.
-  CodeCompletionCache::Key K{filename.str(), "<module-name>", {},   false,
-                             false,          false,           false, false};
+  CodeCompletionCache::Key K{filename.str(), "<module-name>", {},
+                             false,          false,           false,
+                             false,          false,           false};
 
   // Read the cached results.
   auto V = CodeCompletionCache::createValue();

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -415,14 +415,14 @@ public:
 
   void addCallArgument(Identifier Name, Identifier LocalName, Type Ty,
                        Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
-                       bool isAutoClosure, bool useUnderscoreLabel,
-                       bool isLabeledTrailingClosure);
+                       bool IsAutoClosure, bool UseUnderscoreLabel,
+                       bool IsLabeledTrailingClosure, bool HasDefault);
 
   void addCallArgument(Identifier Name, Type Ty, Type ContextTy = Type()) {
     addCallArgument(Name, Identifier(), Ty, ContextTy,
-                    /*IsVarArg=*/false, /*IsInOut=*/false, /*isIUO=*/false,
-                    /*isAutoClosure=*/false, /*useUnderscoreLabel=*/false,
-                    /*isLabeledTrailingClosure=*/false);
+                    /*IsVarArg=*/false, /*IsInOut=*/false, /*IsIUO=*/false,
+                    /*IsAutoClosure=*/false, /*UseUnderscoreLabel=*/false,
+                    /*IsLabeledTrailingClosure=*/false, /*HasDefault=*/false);
   }
 
   void addGenericParameter(StringRef Name) {

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -74,6 +74,7 @@ static std::string toInsertableString(CodeCompletionResult *Result) {
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureType:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentBegin:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentTypeBegin:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentDefaultBegin:
     case CodeCompletionString::Chunk::ChunkKind::ParameterDeclBegin:
     case CodeCompletionString::Chunk::ChunkKind::ParameterDeclExternalName:
     case CodeCompletionString::Chunk::ChunkKind::ParameterDeclLocalName:

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -1,14 +1,4 @@
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=GLOBAL_EXPR | %FileCheck %s --check-prefix=GLOBAL_EXPR
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=GLOBAL_EXPR | %FileCheck %s --check-prefix=GLOBAL_EXPR
-// NOTE: To GLOBAL_EXPR twice to test completion from the cache.
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=GLOBAL_TYPE | %FileCheck %s --check-prefix=GLOBAL_TYPE
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=EXPR_MEMBER | %FileCheck %s --check-prefix=EXPR_MEMBER
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=EXPR_POSTFIX | %FileCheck %s --check-prefix=EXPR_POSTFIX
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=EXPR_IMPLICITMEMBER | %FileCheck %s --check-prefix=EXPR_IMPLICITMEMBER
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=CALLARG | %FileCheck %s --check-prefix=CALLARG
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=GENERIC | %FileCheck %s --check-prefix=GENERIC
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=WHERE | %FileCheck %s --check-prefix=WHERE
-// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=OVERRIDE -code-completion-sourcetext | %FileCheck %s --check-prefix=OVERRIDE
+// RUN: %target-swift-ide-test -batch-code-completion -code-completion-annotate-results -code-completion-sourcetext -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 struct MyStruct {
   init(x: Int) {}
@@ -151,12 +141,33 @@ class BaseC {
 }
 class DerivedC: BaseC, BaseP {
   #^OVERRIDE^#
+// OVERRIDE: Begin completions
 // OVERRIDE-DAG: Keyword[func]/None:                 <keyword>func</keyword>; typename=; name=func; sourcetext=func
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>protoMethod</name>() -&gt; (<typeid.sys>UInt8</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>; typename=; name=protoMethod(); sourcetext=func protoMethod() -> (UInt8) -> Void {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[InstanceVar]/Super:            <name>value</name>: <typeid.user>MyStruct</typeid.user>; typename=; name=value; sourcetext=var value: MyStruct
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethodAsync</name>(<param><param.label>x</param.label>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) <keyword>async</keyword> -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethodAsync(x:); sourcetext=override func baseMethodAsync(x: Int) async -> Int {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>genericAsyncThrowsConstraint</name>&lt;T, U&gt;(<param><param.label>x</param.label>: <param.type><typeid.user>T</typeid.user></param.type></param>) <keyword>async</keyword> <keyword>throws</keyword> -&gt; <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> <keyword>where</keyword> <typeid.user>U</typeid.user> : <typeid.sys>Collection</typeid.sys>, <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> == <typeid.sys>Int</typeid.sys>; typename=; name=genericAsyncThrowsConstraint(x:); sourcetext=override func genericAsyncThrowsConstraint<T, U>(x: T) async throws -> U.Element where U : Collection, U.Element == Int {\n<#code#>\n}
-
 // OVERRIDE-DAG: Decl[Subscript]/Super:              <name>subscript</name>(<param><param.param>index</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; (<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=subscript(:); sourcetext=override subscript(index: Int) -> (Int) -> Int {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[Constructor]/Super:            <name>init</name>(); typename=; name=init(); sourcetext=override init() {\n<#code#>\n}
+// OVERRIDE: End completions
 }
+
+struct Defaults {
+  func noDefault(a: Int) { }
+  func singleDefault(a: Int = 0) { }
+  func mixedDefaults(a: Int, b: Int = 0, c: Int) { }
+  func closureDefault(a: (Int) -> Void = {_ in }) { }
+}
+func defaults(def: Defaults) {
+  def.#^DEFAULTS^#
+}
+// DEFAULTS: Begin completions
+// DEFAULTS-DAG: Keyword[self]/CurrNominal:          <keyword>self</keyword>; typename=<typeid.user>Defaults</typeid.user>; name=self; sourcetext=self
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>noDefault</name>(<callarg><callarg.label>a</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=noDefault(a:); sourcetext=noDefault(a: <#T##Int#>)
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>singleDefault</name>(); typename=<typeid.sys>Void</typeid.sys>; name=singleDefault(); sourcetext=singleDefault()
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>singleDefault</name>(<callarg><callarg.label>a</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=singleDefault(a:); sourcetext=singleDefault(a: <#T##Int#>)
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>mixedDefaults</name>(<callarg><callarg.label>a</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>, <callarg><callarg.label>c</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=mixedDefaults(a:c:); sourcetext=mixedDefaults(a: <#T##Int#>, c: <#T##Int#>)
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>mixedDefaults</name>(<callarg><callarg.label>a</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>, <callarg><callarg.label>b</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type><callarg.default/></callarg>, <callarg><callarg.label>c</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=mixedDefaults(a:b:c:); sourcetext=mixedDefaults(a: <#T##Int#>, b: <#T##Int#>, c: <#T##Int#>)
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>closureDefault</name>(); typename=<typeid.sys>Void</typeid.sys>; name=closureDefault(); sourcetext=closureDefault()
+// DEFAULTS-DAG: Decl[InstanceMethod]/CurrNominal:   <name>closureDefault</name>(<callarg><callarg.label>a</callarg.label>: <callarg.type>(<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys></callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=closureDefault(a:); sourcetext=closureDefault(a: <#T##(Int) -> Void#>)
+// DEFAULTS: End completions

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_1 | %FileCheck %s -check-prefix=DEFAULT_ARGS_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_2 | %FileCheck %s -check-prefix=DEFAULT_ARGS_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-complete-add-call-with-no-default-args=false -code-completion-token=DEFAULT_ARGS_2 | %FileCheck %s --check-prefix=ONLY_DEFAULTS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_3 | %FileCheck %s -check-prefix=DEFAULT_ARGS_3
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_4 | %FileCheck %s -check-prefix=DEFAULT_ARGS_4
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=DEFAULT_ARGS_5 | %FileCheck %s -check-prefix=DEFAULT_ARGS_5
@@ -80,6 +81,10 @@ func testDefaultArgs2() {
 // DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#(a): Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#(a): Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_2: End completions
+
+// ONLY_DEFAULTS: Begin completions
+// ONLY_DEFAULTS-NEXT: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#(a): Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
+// ONLY_DEFAULTS: End completions
 
 func testDefaultArgs3() {
   freeFuncWithDefaultArgs3#^DEFAULT_ARGS_3^#

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -45,6 +45,7 @@ struct Options {
   bool fuzzyMatching = true;
   bool annotatedDescription = false;
   bool includeObjectLiterals = true;
+  bool addCallWithNoDefaultArgs = true;
   unsigned minFuzzyLength = 2;
   unsigned showTopNonLiteralResults = 3;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -107,6 +107,7 @@ static void swiftCodeCompleteImpl(
   CompletionContext.setIncludeObjectLiterals(opts.includeObjectLiterals);
   CompletionContext.setAddInitsToTopLevel(opts.addInitsToTopLevel);
   CompletionContext.setCallPatternHeuristics(opts.callPatternHeuristics);
+  CompletionContext.setAddCallWithNoDefaultArgs(opts.addCallWithNoDefaultArgs);
 
   Lang.performWithParamsToCompletionLikeOperation(
       UnresolvedInputFile, Offset, Args, FileSystem, CancellationToken,


### PR DESCRIPTION
Add `<callarg.default />` nodes to the annotated description of a
completion result for all arguments that have defaults.

Also add a new option to control whether or not an extra item is added
for calls with no default arguments or not (since clients can now use
the marked up argument to check this themselves).