### PR TITLE
[SwiftSyntax] Add convenience initializer for `BinaryOperatorExpr`

### DIFF
--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -22,5 +22,8 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'StmtBuildable': [
         'CodeBlockItem',
         'SyntaxBuildable'
+    ],
+    'TokenSyntax': [
+        'BinaryOperatorExpr'
     ]
 }


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/344