### PR TITLE
Reapply "Teach TypeLayout the Different Types of References" with fixes

### DIFF
--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -19,6 +19,7 @@
 
 #include "ClassLayout.h"
 #include "HeapTypeInfo.h"
+#include "TypeLayout.h"
 
 namespace swift {
 namespace irgen {
@@ -46,7 +47,7 @@ public:
   ClassTypeInfo(llvm::PointerType *irType, Size size, SpareBitVector spareBits,
                 Alignment align, ClassDecl *theClass,
                 ReferenceCounting refcount)
-      : HeapTypeInfo(irType, size, std::move(spareBits), align),
+      : HeapTypeInfo(refcount, irType, size, std::move(spareBits), align),
         TheClass(theClass), Refcount(refcount) {}
 
   ReferenceCounting getReferenceCounting() const { return Refcount; }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -16,6 +16,7 @@
 
 #include "GenArchetype.h"
 
+#include "TypeLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -126,13 +127,11 @@ class ClassArchetypeTypeInfo
 {
   ReferenceCounting RefCount;
 
-  ClassArchetypeTypeInfo(llvm::PointerType *storageType,
-                         Size size, const SpareBitVector &spareBits,
-                         Alignment align,
+  ClassArchetypeTypeInfo(llvm::PointerType *storageType, Size size,
+                         const SpareBitVector &spareBits, Alignment align,
                          ReferenceCounting refCount)
-    : HeapTypeInfo(storageType, size, spareBits, align),
-      RefCount(refCount)
-  {}
+      : HeapTypeInfo(refCount, storageType, size, spareBits, align),
+        RefCount(refCount) {}
 
 public:
   static const ClassArchetypeTypeInfo *create(llvm::PointerType *storageType,

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -53,7 +53,8 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                      ScalarKind::POD);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -120,7 +120,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
     }
 
     if (getFields().empty()) {
@@ -292,7 +292,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
     }
 
     if (getFields().empty()) {

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -16,7 +16,6 @@
 
 #include "GenExistential.h"
 
-#include "TypeLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -29,7 +28,6 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include "BitPatternBuilder.h"
@@ -663,60 +661,52 @@ namespace {
         return Super::getFixedExtraInhabitantMask(IGM); \
       } \
     }
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
-  class AddressOnly##Name##ClassExistentialTypeInfo final : \
-      public AddressOnlyClassExistentialTypeInfoBase< \
-                                  AddressOnly##Name##ClassExistentialTypeInfo, \
-                                  FixedTypeInfo> { \
-    bool IsOptional; \
-  public: \
-    AddressOnly##Name##ClassExistentialTypeInfo( \
-        ArrayRef<const ProtocolDecl *> protocols, \
-        llvm::Type *ty, \
-        SpareBitVector &&spareBits, \
-        Size size, Alignment align, \
-        ReferenceCounting refcounting, \
-        bool isOptional) \
-      : AddressOnlyClassExistentialTypeInfoBase(protocols, refcounting, \
-                                                ty, size, std::move(spareBits), \
-                                                align, IsNotPOD, \
-                                                IsNotBitwiseTakable, \
-                                                IsFixedSize), \
-        IsOptional(isOptional) {} \
-    TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
-                                          SILType T) const override { \
-      ScalarKind kind; \
-      switch (Refcounting) { \
-        case ReferenceCounting::Native:  kind = ScalarKind::NativeStrongReference; break; \
-        case ReferenceCounting::ObjC:    kind = ScalarKind::ObjCReference; break; \
-        case ReferenceCounting::Block:   kind = ScalarKind::BlockReference; break; \
-        case ReferenceCounting::Unknown: kind = ScalarKind::UnknownReference; break; \
-        case ReferenceCounting::Bridge:  kind = ScalarKind::BridgeReference; break; \
-        case ReferenceCounting::Error:   kind = ScalarKind::ErrorReference; break; \
-      } \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind); \
-    } \
-    void emitValueAssignWithCopy(IRGenFunction &IGF, \
-                                 Address dest, Address src) const { \
-      IGF.emit##Name##CopyAssign(dest, src, Refcounting); \
-    } \
-    void emitValueInitializeWithCopy(IRGenFunction &IGF, \
-                                     Address dest, Address src) const { \
-      IGF.emit##Name##CopyInit(dest, src, Refcounting); \
-    } \
-    void emitValueAssignWithTake(IRGenFunction &IGF, \
-                                Address dest, Address src) const { \
-      IGF.emit##Name##TakeAssign(dest, src, Refcounting); \
-    } \
-    void emitValueInitializeWithTake(IRGenFunction &IGF, \
-                                    Address dest, Address src) const { \
-      IGF.emit##Name##TakeInit(dest, src, Refcounting); \
-    } \
-    void emitValueDestroy(IRGenFunction &IGF, Address addr) const { \
-      IGF.emit##Name##Destroy(addr, Refcounting); \
-    } \
-    StringRef getStructNameSuffix() const { return "." #name "ref"; } \
-    REF_STORAGE_HELPER(Name, FixedTypeInfo) \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                    \
+  class AddressOnly##Name##ClassExistentialTypeInfo final                      \
+      : public AddressOnlyClassExistentialTypeInfoBase<                        \
+            AddressOnly##Name##ClassExistentialTypeInfo, FixedTypeInfo> {      \
+    bool IsOptional;                                                           \
+                                                                               \
+  public:                                                                      \
+    AddressOnly##Name##ClassExistentialTypeInfo(                               \
+        ArrayRef<const ProtocolDecl *> protocols, llvm::Type *ty,              \
+        SpareBitVector &&spareBits, Size size, Alignment align,                \
+        ReferenceCounting refcounting, bool isOptional)                        \
+        : AddressOnlyClassExistentialTypeInfoBase(                             \
+              protocols, refcounting, ty, size, std::move(spareBits), align,   \
+              IsNotPOD, IsNotBitwiseTakable, IsFixedSize),                     \
+          IsOptional(isOptional) {}                                            \
+    TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,                    \
+                                          SILType T) const override {          \
+      if (Refcounting == ReferenceCounting::Native) {                          \
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(                     \
+            *this, T, ScalarKind::Native##Name##Reference);                    \
+      } else {                                                                 \
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(                     \
+            *this, T, ScalarKind::Unknown##Name##Reference);                   \
+      }                                                                        \
+    }                                                                          \
+    void emitValueAssignWithCopy(IRGenFunction &IGF, Address dest,             \
+                                 Address src) const {                          \
+      IGF.emit##Name##CopyAssign(dest, src, Refcounting);                      \
+    }                                                                          \
+    void emitValueInitializeWithCopy(IRGenFunction &IGF, Address dest,         \
+                                     Address src) const {                      \
+      IGF.emit##Name##CopyInit(dest, src, Refcounting);                        \
+    }                                                                          \
+    void emitValueAssignWithTake(IRGenFunction &IGF, Address dest,             \
+                                 Address src) const {                          \
+      IGF.emit##Name##TakeAssign(dest, src, Refcounting);                      \
+    }                                                                          \
+    void emitValueInitializeWithTake(IRGenFunction &IGF, Address dest,         \
+                                     Address src) const {                      \
+      IGF.emit##Name##TakeInit(dest, src, Refcounting);                        \
+    }                                                                          \
+    void emitValueDestroy(IRGenFunction &IGF, Address addr) const {            \
+      IGF.emit##Name##Destroy(addr, Refcounting);                              \
+    }                                                                          \
+    StringRef getStructNameSuffix() const { return "." #name "ref"; }          \
+    REF_STORAGE_HELPER(Name, FixedTypeInfo)                                    \
   };
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
   class Loadable##Name##ClassExistentialTypeInfo final \
@@ -1016,21 +1006,31 @@ class ClassExistentialTypeInfo final
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    ScalarKind kind;
-    switch (Refcounting) {
-    case ReferenceCounting::Native:
-      kind = ScalarKind::NativeStrongReference;
-      break;
-    case ReferenceCounting::ObjC:
-      kind = ScalarKind::ObjCReference;
-      break;
-    case ReferenceCounting::Unknown:
-      kind = ScalarKind::UnknownReference;
-      break;
-    default:
-      llvm_unreachable("Unsupported refcounting style");
+    // We can't create an objc typeinfo by itself, so don't destructure if we
+    // have one
+    if (Refcounting == ReferenceCounting::ObjC) {
+      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
     }
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T, kind);
+
+    /// The storage type of a class existential is a struct containing
+    /// a refcounted pointer to the class instance value followed by
+    /// witness table pointers for each conformed-to protocol.
+    std::vector<TypeLayoutEntry *> alignedGroup;
+    const TypeInfo &typeinfo = Refcounting == ReferenceCounting::Native
+                                   ? IGM.getNativeObjectTypeInfo()
+                                   : IGM.getUnknownObjectTypeInfo();
+
+    alignedGroup.push_back(IGM.typeLayoutCache.getOrCreateScalarEntry(
+        typeinfo, T, refcountingToScalarKind(Refcounting)));
+    for (unsigned i = 0; i < getNumStoredProtocols(); i++) {
+      alignedGroup.push_back(IGM.typeLayoutCache.getOrCreateScalarEntry(
+          IGM.getWitnessTablePtrTypeInfo(),
+          SILType::getBuiltinIntegerType(IGM.getPointerSize().getValue(),
+                                         IGM.Context),
+          ScalarKind::POD));
+    }
+
+    return IGM.typeLayoutCache.getOrCreateAlignedGroupEntry(alignedGroup, 0);
   }
 
   /// Given an explosion with multiple pointer elements in them, pack them

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -95,6 +95,14 @@ namespace irgen {
   void emitDeallocateBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
                                                   SILType existentialType,
                                                   Address existentialContainer);
+
+  /// Free the storage for an opaque existential in the existential
+  /// container.
+  /// If the value is not stored inline, this will free the box for the
+  /// value.
+  void emitDestroyBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
+                                               SILType existentialType,
+                                               Address existentialContainer);
   Address emitOpaqueBoxedExistentialProjection(
       IRGenFunction &IGF, OpenedExistentialAccess accessKind, Address base,
       SILType existentialType, CanArchetypeType openedArchetype);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -156,7 +156,8 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::POD);
     }
 
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
@@ -223,7 +224,13 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      if (isPOD(ResilienceExpansion::Maximal)) {
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                          ScalarKind::POD);
+      } else {
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(
+            *this, T, ScalarKind::ThickFunc);
+      }
     }
 
     static Size getFirstElementSize(IRGenModule &IGM) {
@@ -385,20 +392,19 @@ namespace {
                         public FuncSignatureInfo
   {
   public:
-    BlockTypeInfo(CanSILFunctionType ty,
-                  llvm::PointerType *storageType,
+    BlockTypeInfo(CanSILFunctionType ty, llvm::PointerType *storageType,
                   Size size, SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align),
-        FuncSignatureInfo(ty)
-    {
-    }
+        : HeapTypeInfo(ReferenceCounting::Block, storageType, size, spareBits,
+                       align),
+          FuncSignatureInfo(ty) {}
 
     ReferenceCounting getReferenceCounting() const {
       return ReferenceCounting::Block;
     }
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(
+          *this, T, ScalarKind::BlockReference);
     }
   };
   
@@ -420,7 +426,8 @@ namespace {
     
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(
+          *this, T, ScalarKind::BlockStorage);
     }
     // The lowered type should be an LLVM struct comprising the block header
     // (IGM.ObjCBlockStructTy) as its first element and the capture as its

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -54,7 +54,8 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                      ScalarKind::POD);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -190,9 +190,9 @@ namespace {
   class UnknownTypeInfo : public HeapTypeInfo<UnknownTypeInfo> {
   public:
     UnknownTypeInfo(llvm::PointerType *storageType, Size size,
-                 SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align) {
-    }
+                    SpareBitVector spareBits, Alignment align)
+        : HeapTypeInfo(ReferenceCounting::Unknown, storageType, size, spareBits,
+                       align) {}
 
     /// AnyObject requires ObjC reference-counting.
     ReferenceCounting getReferenceCounting() const {
@@ -219,9 +219,9 @@ namespace {
   class BridgeObjectTypeInfo : public HeapTypeInfo<BridgeObjectTypeInfo> {
   public:
     BridgeObjectTypeInfo(llvm::PointerType *storageType, Size size,
-                 SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align) {
-    }
+                         SpareBitVector spareBits, Alignment align)
+        : HeapTypeInfo(ReferenceCounting::Bridge, storageType, size, spareBits,
+                       align) {}
 
     /// Builtin.BridgeObject uses its own specialized refcounting implementation.
     ReferenceCounting getReferenceCounting() const {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -358,7 +358,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (!areFieldsABIAccessible()) {
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
@@ -545,7 +545,7 @@ namespace {
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts || getCXXDestructor(T) ||
           !areFieldsABIAccessible()) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       std::vector<TypeLayoutEntry *> fields;
@@ -625,7 +625,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {
@@ -687,7 +687,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -235,7 +235,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();
@@ -280,7 +280,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1135,7 +1135,8 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::POD);
     }
 
     unsigned getExplosionSize() const override {
@@ -1256,7 +1257,8 @@ namespace {
                          IsNotPOD, IsNotBitwiseTakable, IsFixedSize) {}
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::Immovable);
     }
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
@@ -2350,7 +2352,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    llvm_unreachable("Cannot construct type layout for legacy types");
   }
 
   virtual unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -64,9 +64,10 @@ class HeapTypeInfo
 protected:
   using super::asDerived;
 public:
-  HeapTypeInfo(llvm::PointerType *storage, Size size, SpareBitVector spareBits,
-               Alignment align)
-    : super(storage, size, spareBits, align) {}
+  HeapTypeInfo(ReferenceCounting refcounting, llvm::PointerType *storage,
+               Size size, SpareBitVector spareBits, Alignment align)
+      : super(swift::irgen::refcountingToScalarKind(refcounting), storage, size, spareBits,
+              align) {}
 
   bool isSingleRetainablePointer(ResilienceExpansion expansion,
                                  ReferenceCounting *refcounting) const override {

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -240,8 +240,9 @@ class SingleScalarTypeInfoWithTypeLayout
     : public SingleScalarTypeInfo<Derived, Base> {
 protected:
   template <class... T>
-  SingleScalarTypeInfoWithTypeLayout(T &&... args)
-      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...) {}
+  SingleScalarTypeInfoWithTypeLayout(ScalarKind kind, T &&...args)
+      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...),
+        kind(kind) {}
 
   const Derived &asDerived() const {
     return static_cast<const Derived &>(*this);
@@ -252,8 +253,11 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T, kind);
   }
+
+private:
+  ScalarKind kind;
 };
 
 /// PODSingleScalarTypeInfo - A further specialization of
@@ -289,7 +293,8 @@ private:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T,
+                                                      ScalarKind::POD);
   }
 
 };

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -12,16 +12,54 @@
 #include "TypeLayout.h"
 #include "EnumPayload.h"
 #include "FixedTypeInfo.h"
+#include "GenExistential.h"
 #include "GenOpaque.h"
+#include "GenType.h"
 #include "IRGen.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "SwitchBuilder.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/SIL/TypeLowering.h"
 #include "llvm/IR/DerivedTypes.h"
 
 using namespace swift;
 using namespace irgen;
+
+ScalarKind swift::irgen::refcountingToScalarKind(ReferenceCounting refCounting) {
+  switch (refCounting) {
+  case ReferenceCounting::Native:
+    return ScalarKind::NativeStrongReference;
+  case ReferenceCounting::Bridge:
+    return ScalarKind::BridgeReference;
+  case ReferenceCounting::Block:
+    return ScalarKind::BlockReference;
+  case ReferenceCounting::Error:
+    return ScalarKind::ErrorReference;
+  case ReferenceCounting::Unknown:
+    return ScalarKind::UnknownReference; 
+  case ReferenceCounting::ObjC:
+    return ScalarKind::ObjCReference;
+  }
+}
+
+static bool isNullableRefCounted(ScalarKind kind) {
+  switch (kind) {
+  case ScalarKind::ErrorReference:
+  case ScalarKind::NativeStrongReference:
+  case ScalarKind::NativeUnownedReference:
+  case ScalarKind::NativeWeakReference:
+  case ScalarKind::UnknownUnownedReference:
+  case ScalarKind::UnknownWeakReference:
+  case ScalarKind::UnknownReference:
+  case ScalarKind::BlockReference:
+  case ScalarKind::BridgeReference:
+  case ScalarKind::ObjCReference:
+    return true;
+  default:
+    return false;
+  }
+}
 
 TypeLayoutEntry::~TypeLayoutEntry() {}
 
@@ -694,7 +732,7 @@ llvm::Value *ScalarTypeLayoutEntry::size(IRGenFunction &IGF) const {
 bool ScalarTypeLayoutEntry::isFixedSize(IRGenModule &IGM) const { return true; }
 
 bool ScalarTypeLayoutEntry::isPOD() const {
-  return typeInfo.isPOD(ResilienceExpansion::Maximal);
+  return scalarKind == ScalarKind::POD;
 }
 
 bool ScalarTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
@@ -703,7 +741,7 @@ bool ScalarTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
 }
 
 bool ScalarTypeLayoutEntry::isSingleRetainablePointer() const {
-  return typeInfo.isSingleRetainablePointer(ResilienceExpansion::Maximal);
+  return isNullableRefCounted(scalarKind);
 }
 
 llvm::Optional<Size> ScalarTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
@@ -733,12 +771,99 @@ llvm::Value *ScalarTypeLayoutEntry::isBitwiseTakable(IRGenFunction &IGF) const {
 }
 
 void ScalarTypeLayoutEntry::destroy(IRGenFunction &IGF, Address addr) const {
-  auto alignment = typeInfo.getFixedAlignment();
-  auto addressType = typeInfo.getStorageType()->getPointerTo();
-  auto &Builder = IGF.Builder;
-  addr =
-      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
-  typeInfo.destroy(IGF, addr, representative, true);
+  switch (scalarKind) {
+  case ScalarKind::POD:
+    return;
+  case ScalarKind::Immovable:
+    llvm_unreachable("cannot opaquely manipulate immovable types!");
+  case ScalarKind::NativeStrongReference: {
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
+    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
+    IGF.emitNativeStrongRelease(val, IGF.getDefaultAtomicity());
+    return;
+  }
+  case ScalarKind::ErrorReference: {
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
+    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
+    IGF.emitErrorStrongRelease(val);
+    return;
+  }
+  case ScalarKind::NativeWeakReference: {
+    IGF.emitNativeWeakDestroy(addr);
+    return;
+  }
+  case ScalarKind::NativeUnownedReference: {
+    IGF.emitNativeUnownedDestroy(addr);
+    return;
+  }
+  case ScalarKind::BlockReference: {
+    IGF.emitBlockRelease(addr.getAddress());
+    return;
+  }
+  case ScalarKind::UnknownReference: {
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
+    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
+    IGF.emitUnknownStrongRelease(val, IGF.getDefaultAtomicity());
+    return;
+  }
+  case ScalarKind::UnknownUnownedReference: {
+    IGF.emitUnknownUnownedDestroy(addr);
+    return;
+  }
+  case ScalarKind::UnknownWeakReference: {
+    IGF.emitUnknownWeakDestroy(addr);
+    return;
+  }
+  case ScalarKind::BridgeReference: {
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
+    llvm::Value *val = IGF.Builder.CreateLoad(castAddr, alignment, "toDestroy");
+    IGF.emitBridgeStrongRelease(val, IGF.getDefaultAtomicity());
+    return;
+  }
+  case ScalarKind::ObjCReference: {
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto &Builder = IGF.Builder;
+    addr = Address(Builder.CreateBitCast(addr.getAddress(), addressType),
+                   alignment);
+    llvm::Value *val =
+        IGF.Builder.CreateLoad(addr.getAddress(), alignment, "toDestroy");
+    IGF.emitObjCStrongRelease(val);
+    break;
+  }
+  case ScalarKind::BlockStorage: {
+    // The frontend will currently never emit copy_addr or destroy_addr for
+    // block storage.
+    IGF.unimplemented(SourceLoc(), "destroying @block_storage");
+    return;
+  }
+  case ScalarKind::ThickFunc: {
+    // A thick function is a pair of a function pointer and an optional
+    // ref counted opaque pointer. We don't need to do anything for the
+    // function pointer, but we need to release the opaque pointer.
+    auto alignment = typeInfo.getFixedAlignment();
+    auto addressType = typeInfo.getStorageType()->getPointerTo();
+    auto castAddr = IGF.Builder.CreateBitCast(addr.getAddress(), addressType);
+    auto secondElement = IGF.Builder.CreateStructGEP(
+        Address(castAddr, alignment), 1, IGF.IGM.getPointerSize(),
+        addr->getName() + ".data");
+    auto pointer = IGF.Builder.CreateLoad(secondElement, "toDestroy");
+    IGF.emitNativeStrongRelease(pointer, IGF.getDefaultAtomicity());
+    return;
+  }
+  case ScalarKind::ExistentialReference: {
+    emitDestroyBoxedOpaqueExistentialBuffer(IGF, representative, addr);
+    return;
+  }
+  }
 }
 
 void ScalarTypeLayoutEntry::assignWithCopy(IRGenFunction &IGF, Address dest,
@@ -811,6 +936,10 @@ void ScalarTypeLayoutEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
       Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
   typeInfo.storeEnumTagSinglePayload(IGF, tag, numEmptyCases, addr,
                                      representative, true);
+}
+
+bool ScalarTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
+  return entry->kind == TypeLayoutEntryKind::Scalar;
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -1263,6 +1392,10 @@ void AlignedGroupEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
       });
 }
 
+bool AlignedGroupEntry::classof(const TypeLayoutEntry *entry) {
+  return entry->kind == TypeLayoutEntryKind::AlignedGroup;
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void AlignedGroupEntry::dump() const {
     llvm::dbgs() << "{ aligned group:\n";
@@ -1372,6 +1505,10 @@ void ArchetypeLayoutEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
               addr.getAlignment());
 
   emitStoreEnumTagSinglePayloadCall(IGF, archetype, tag, numEmptyCases, addr);
+}
+
+bool ArchetypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
+  return entry->kind == TypeLayoutEntryKind::Archetype;
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
@@ -2473,6 +2610,10 @@ void EnumTypeLayoutEntry::destructiveInjectEnumTag(IRGenFunction &IGF,
   storeEnumTagMultipayload(IGF, tag, enumAddr);
 }
 
+bool EnumTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
+  return entry->kind == TypeLayoutEntryKind::Enum;
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void EnumTypeLayoutEntry::dump() const {
     llvm::dbgs() << "{ enum emptycases: " << numEmptyCases << "\n";
@@ -2591,15 +2732,192 @@ void ResilientTypeLayoutEntry::storeEnumTagSinglePayload(
   emitStoreEnumTagSinglePayloadCall(IGF, ty, tag, numEmptyCases, addr);
 }
 
+bool ResilientTypeLayoutEntry::classof(const TypeLayoutEntry *entry) {
+  return entry->kind == TypeLayoutEntryKind::Resilient;
+}
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void ResilientTypeLayoutEntry::dump() const {
   llvm::dbgs() << "{ resilient type: " << ty << " id: " << this << " }\n";
 }
 #endif
 
-ScalarTypeLayoutEntry *
-TypeLayoutCache::getOrCreateScalarEntry(const TypeInfo &ti,
-                                        SILType representative) {
+void TypeInfoBasedTypeLayoutEntry::computeProperties() {
+  // does not add anything.
+}
+
+void TypeInfoBasedTypeLayoutEntry::Profile(llvm::FoldingSetNodeID &id) const {
+  ScalarTypeLayoutEntry::Profile(id, typeInfo, representative);
+}
+
+void TypeInfoBasedTypeLayoutEntry::Profile(llvm::FoldingSetNodeID &id,
+                                           const TypeInfo &ti, SILType ty) {
+  id.AddPointer(&ti);
+  id.AddPointer(ty.getASTType().getPointer());
+}
+
+TypeInfoBasedTypeLayoutEntry::~TypeInfoBasedTypeLayoutEntry() {}
+
+llvm::Value *
+TypeInfoBasedTypeLayoutEntry::alignmentMask(IRGenFunction &IGF) const {
+  return typeInfo.getAlignmentMask(IGF, representative);
+}
+
+llvm::Value *TypeInfoBasedTypeLayoutEntry::size(IRGenFunction &IGF) const {
+  return typeInfo.getSize(IGF, representative);
+}
+
+bool TypeInfoBasedTypeLayoutEntry::isFixedSize(IRGenModule &IGM) const {
+  return true;
+}
+
+llvm::Optional<Size>
+TypeInfoBasedTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
+  return typeInfo.getFixedSize();
+}
+
+llvm::Optional<Alignment>
+TypeInfoBasedTypeLayoutEntry::fixedAlignment(IRGenModule &IGM) const {
+  return typeInfo.getFixedAlignment();
+}
+
+llvm::Optional<uint32_t>
+TypeInfoBasedTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
+  return typeInfo.getFixedExtraInhabitantCount(IGM);
+}
+
+bool TypeInfoBasedTypeLayoutEntry::isPOD() const {
+  return typeInfo.isPOD(ResilienceExpansion::Maximal);
+}
+
+bool TypeInfoBasedTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
+    IRGenModule &IGM, unsigned index) const {
+  return typeInfo.canValueWitnessExtraInhabitantsUpTo(IGM, index);
+}
+
+bool TypeInfoBasedTypeLayoutEntry::isSingleRetainablePointer() const {
+  return typeInfo.isSingleRetainablePointer(ResilienceExpansion::Maximal);
+}
+
+llvm::Value *
+TypeInfoBasedTypeLayoutEntry::extraInhabitantCount(IRGenFunction &IGF) const {
+  auto &IGM = IGF.IGM;
+  auto fixedXICount =
+      cast<FixedTypeInfo>(typeInfo).getFixedExtraInhabitantCount(IGM);
+  return llvm::ConstantInt::get(IGM.Int32Ty, fixedXICount);
+}
+
+llvm::Value *
+TypeInfoBasedTypeLayoutEntry::isBitwiseTakable(IRGenFunction &IGF) const {
+  return llvm::ConstantInt::get(IGF.IGM.Int1Ty,
+                                cast<FixedTypeInfo>(typeInfo).isBitwiseTakable(
+                                    ResilienceExpansion::Maximal));
+}
+
+void TypeInfoBasedTypeLayoutEntry::destroy(IRGenFunction &IGF,
+                                           Address addr) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  addr =
+      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
+  typeInfo.destroy(IGF, addr, representative, true);
+}
+
+void TypeInfoBasedTypeLayoutEntry::assignWithCopy(IRGenFunction &IGF,
+                                                  Address dest,
+                                                  Address src) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  dest =
+      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
+  src =
+      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
+  typeInfo.assignWithCopy(IGF, dest, src, representative, true);
+}
+
+void TypeInfoBasedTypeLayoutEntry::assignWithTake(IRGenFunction &IGF,
+                                                  Address dest,
+                                                  Address src) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  dest =
+      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
+  src =
+      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
+  typeInfo.assignWithTake(IGF, dest, src, representative, true);
+}
+
+void TypeInfoBasedTypeLayoutEntry::initWithCopy(IRGenFunction &IGF,
+                                                Address dest,
+                                                Address src) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  dest =
+      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
+  src =
+      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
+  typeInfo.initializeWithCopy(IGF, dest, src, representative, true);
+}
+
+void TypeInfoBasedTypeLayoutEntry::initWithTake(IRGenFunction &IGF,
+                                                Address dest,
+                                                Address src) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  dest =
+      Address(Builder.CreateBitCast(dest.getAddress(), addressType), alignment);
+  src =
+      Address(Builder.CreateBitCast(src.getAddress(), addressType), alignment);
+  typeInfo.initializeWithTake(IGF, dest, src, representative, true);
+}
+
+llvm::Value *TypeInfoBasedTypeLayoutEntry::getEnumTagSinglePayload(
+    IRGenFunction &IGF, llvm::Value *numEmptyCases, Address value) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  value = Address(Builder.CreateBitCast(value.getAddress(), addressType),
+                  alignment);
+  ;
+  return typeInfo.getEnumTagSinglePayload(IGF, numEmptyCases, value,
+                                          representative, true);
+}
+
+void TypeInfoBasedTypeLayoutEntry::storeEnumTagSinglePayload(
+    IRGenFunction &IGF, llvm::Value *tag, llvm::Value *numEmptyCases,
+    Address addr) const {
+  auto alignment = typeInfo.getFixedAlignment();
+  auto addressType = typeInfo.getStorageType()->getPointerTo();
+  auto &Builder = IGF.Builder;
+  addr =
+      Address(Builder.CreateBitCast(addr.getAddress(), addressType), alignment);
+  typeInfo.storeEnumTagSinglePayload(IGF, tag, numEmptyCases, addr,
+                                     representative, true);
+}
+
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+LLVM_DUMP_METHOD void TypeInfoBasedTypeLayoutEntry::dump() const {
+  if (typeInfo.isFixedSize())
+    llvm::dbgs() << "{ scalar isFixedSize:" << (bool)typeInfo.isFixedSize()
+                 << " isLoadable: " << (bool)typeInfo.isLoadable() << " size: "
+                 << cast<FixedTypeInfo>(typeInfo).getFixedSize().getValue()
+                 << " alignment: "
+                 << cast<FixedTypeInfo>(typeInfo).getFixedAlignment().getValue()
+                 << " rep: " << representative << " id: " << this << " }\n";
+  if (!typeInfo.isFixedSize()) {
+    llvm::dbgs() << "{ scalar non-fixed rep: " << representative
+                 << " id: " << this << " }\n";
+  }
+}
+#endif
+
+ScalarTypeLayoutEntry *TypeLayoutCache::getOrCreateScalarEntry(
+    const TypeInfo &ti, SILType representative, ScalarKind kind) {
   assert(ti.isFixedSize());
   llvm::FoldingSetNodeID id;
   ScalarTypeLayoutEntry::Profile(id, cast<FixedTypeInfo>(ti), representative);
@@ -2611,8 +2929,8 @@ TypeLayoutCache::getOrCreateScalarEntry(const TypeInfo &ti,
   // Otherwise, create a new one.
   auto bytes = sizeof(ScalarTypeLayoutEntry);
   auto mem = bumpAllocator.Allocate(bytes, alignof(ScalarTypeLayoutEntry));
-  auto newEntry =
-      new (mem) ScalarTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative);
+  auto newEntry = new (mem)
+      ScalarTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative, kind);
   scalarEntries.InsertNode(newEntry, insertPos);
   newEntry->computeProperties();
   return newEntry;
@@ -2635,7 +2953,7 @@ TypeLayoutCache::getOrCreateArchetypeEntry(SILType archetype) {
 }
 
 AlignedGroupEntry *TypeLayoutCache::getOrCreateAlignedGroupEntry(
-    std::vector<TypeLayoutEntry *> &entries,
+    const std::vector<TypeLayoutEntry *> &entries,
     Alignment::int_type minimumAlignment) {
   llvm::FoldingSetNodeID id;
   AlignedGroupEntry::Profile(id, entries, minimumAlignment);
@@ -2687,6 +3005,27 @@ TypeLayoutCache::getOrCreateResilientEntry(SILType ty) {
   return newEntry;
 }
 
+TypeInfoBasedTypeLayoutEntry *
+TypeLayoutCache::getOrCreateTypeInfoBasedEntry(const TypeInfo &ti,
+                                               SILType representative) {
+  assert(ti.isFixedSize());
+  llvm::FoldingSetNodeID id;
+  TypeInfoBasedTypeLayoutEntry::Profile(id, ti, representative);
+  // Grab the entry from the cache if we have one
+  void *insertPos;
+  if (auto *entry = typeInfoBasedEntries.FindNodeOrInsertPos(id, insertPos)) {
+    return entry;
+  }
+  // Otherwise, create a new one.
+  const auto bytes = sizeof(ScalarTypeLayoutEntry);
+  auto mem = bumpAllocator.Allocate(bytes, alignof(ScalarTypeLayoutEntry));
+  auto newEntry = new (mem)
+      TypeInfoBasedTypeLayoutEntry(cast<FixedTypeInfo>(ti), representative);
+  typeInfoBasedEntries.InsertNode(newEntry, insertPos);
+  newEntry->computeProperties();
+  return newEntry;
+}
+
 TypeLayoutCache::~TypeLayoutCache() {
   for (auto &entry : scalarEntries) {
     entry.~ScalarTypeLayoutEntry();
@@ -2702,5 +3041,8 @@ TypeLayoutCache::~TypeLayoutCache() {
   }
   for (auto &entry : resilientEntries) {
     entry.~ResilientTypeLayoutEntry();
+  }
+  for (auto &entry : typeInfoBasedEntries) {
+    entry.~TypeInfoBasedTypeLayoutEntry();
   }
 }

--- a/test/IRGen/type_layout_protocol_composition.swift
+++ b/test/IRGen/type_layout_protocol_composition.swift
@@ -1,0 +1,105 @@
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Onone -Xfrontend -enable-type-layout %s -o %t/main_type_layouts
+// RUN: %target-build-swift -Onone -Xfrontend -disable-type-layout %s -o %t/main_no_type_layouts
+// RUN: %target-codesign %t/main_type_layouts
+// RUN: %target-codesign %t/main_no_type_layouts
+// RUN: %target-run %t/main_type_layouts
+// RUN: %target-run %t/main_no_type_layouts
+
+import Swift
+import Foundation
+import StdlibUnittest
+
+public class SomeObject {
+    init() {
+        a = LifetimeTracked(0)
+    }
+    let a: LifetimeTracked
+}
+public class SomeNSObject : NSObject {
+    override init() {
+        a = LifetimeTracked(0)
+    }
+    let a: LifetimeTracked
+}
+
+public protocol ProtoA{}
+
+public protocol SomeProtoType { }
+public typealias ObjcComposition = SomeNSObject & SomeProtoType
+public typealias NativeComposition = SomeObject & SomeProtoType
+
+public struct Thing1<T: ProtoA> {
+    let a: ObjcComposition
+    let b: T
+
+    init(
+         a: ObjcComposition,
+         b: T
+    ) {
+        self.a = a
+        self.b = b
+    }
+}
+
+public struct Thing2<T: ProtoA> {
+    let a: NativeComposition
+    let b: T
+
+    init(a: NativeComposition,
+         b: T
+    ) {
+        self.a = a
+        self.b = b
+    }
+}
+
+
+public class Comp1 : SomeNSObject, SomeProtoType {
+    override init() {
+        b = LifetimeTracked(0)
+    }
+    let b: LifetimeTracked
+
+}
+public class Comp2 : SomeObject, SomeProtoType {
+    override init() {
+        b = LifetimeTracked(0)
+    }
+    let b: LifetimeTracked
+}
+public struct Proto1 : ProtoA {
+    init() {
+        a = LifetimeTracked(0)
+    }
+    let a: LifetimeTracked
+}
+
+let ProtocolComp = TestSuite("ProtocolComposition")
+
+func forceVWUsage<T>(_ value1: T, _ value2: T) -> T {
+    var a = value1
+    var b = value2
+    var c = a
+    a = b
+    b = c
+    c = a
+    return c;
+}
+ProtocolComp.test("Objc Class Compositions should destroy properly") {
+    var thing1 = Thing1<Proto1>(a: Comp1(), b: Proto1())
+    expectTrue((thing1.a as! Comp1).b.value == 0)
+    thing1 = forceVWUsage(thing1, thing1)
+    expectTrue((thing1.a as! Comp1).b.value == 0)
+}
+
+ProtocolComp.test("NativeClassCompositions") {
+    var thing2 = Thing2<Proto1>(a: Comp2(), b: Proto1())
+    expectTrue((thing2.a as! Comp2).b.value == 0)
+    thing2 = forceVWUsage(thing2, thing2)
+}
+
+runAllTests()


### PR DESCRIPTION
This reapplies https://github.com/apple/swift/pull/37116 (reverted here: https://github.com/apple/swift/pull/40142) and fixes several issues with the original Scalar Type Layouts patch:

- AddressOnly types need to be lowered to ScalarKinds that do not load when releasing.
- ClassExistentials now handle the case when the existential is an inline
  aggregation of the class pointer and witness table pointers

The first commit contains the original changes, and the second contains fixes for them.