### PR TITLE
[SwiftSyntax] Remove default empty string in `Token`'s `text`

### DIFF
--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -18,7 +18,7 @@ class Token(object):
         else:
             self.unprefixed_kind = unprefixed_kind
         self.serialization_code = serialization_code
-        self.text = text or ""
+        self.text = text
         self.classification = classification_by_name(classification)
         self.is_keyword = is_keyword
         self.requires_leading_space = requires_leading_space


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/341
