### PR TITLE
[SE-0328] Enable structural opaque result types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1874,9 +1874,6 @@ WARNING(spi_attribute_on_import_of_public_module,none,
         (DeclName, StringRef))
 
 // Opaque return types
-ERROR(structural_opaque_types_are_experimental,none,
-      "'opaque' types cannot be nested inside other types; "
-      "structural 'opaque' types are an experimental feature", ())
 ERROR(opaque_type_invalid_constraint,none,
       "an 'opaque' type must specify only 'Any', 'AnyObject', protocols, "
       "and/or a base class", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4865,6 +4865,10 @@ ERROR(opaque_type_unsupported_pattern,none,
 ERROR(opaque_type_in_protocol_requirement,none,
       "'some' type cannot be the return type of a protocol requirement; did you mean to add an associated type?",
       ())
+ERROR(opaque_type_in_parameter,none,
+      "'some' cannot appear in parameter position in result "
+      "type %0",
+      (Type))
 
 // Function differentiability
 ERROR(attr_only_on_parameters_of_differentiable,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -310,10 +310,6 @@ namespace swift {
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;
 
-    /// Enable experimental support for structural opaque result types, e.g.
-    /// `func f() -> (some P)?`.
-    bool EnableExperimentalStructuralOpaqueTypes = false;
-
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -438,9 +438,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 
-  Opts.EnableExperimentalStructuralOpaqueTypes |=
-      Args.hasArg(OPT_enable_experimental_structural_opaque_types);
-
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -115,14 +115,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   auto *dc = originatingDecl->getInnermostDeclContext();
   auto &ctx = dc->getASTContext();
 
-  // Support for structural opaque result types is hidden behind a compiler flag
-  // until the proposal gets approved.
-  if (!ctx.LangOpts.EnableExperimentalStructuralOpaqueTypes &&
-      !isa<OpaqueReturnTypeRepr>(repr)) {
-    ctx.Diags.diagnose(repr->getLoc(), diag::structural_opaque_types_are_experimental);
-    return nullptr;
-  }
-
   // Protocol requirements can't have opaque return types.
   //
   // TODO: Maybe one day we could treat this as sugar for an associated type.

--- a/test/Constraints/result_builder_opaque_result_structural.swift
+++ b/test/Constraints/result_builder_opaque_result_structural.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-structural-opaque-types -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 @resultBuilder
 struct TupleBuilder {

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -76,10 +76,8 @@ struct Test {
 let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
 
 
-// Support for structural opaque result types is hidden behind a compiler flag
-// until the proposal gets approved.
-func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{'opaque' types cannot be nested inside other types}}
-func asArrayElem() -> (some P)! { return [1] } // expected-error{{'opaque' types cannot be nested inside other types}}
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{'(some P, some P)' contains multiple 'opaque' types, but only one 'opaque' type is supported}}
+func asArrayElem() -> [some P] { return [1] }
 
 // Invalid positions
 

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-structural-opaque-types -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 // Tests for experimental extensions to opaque return type support.
 

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -85,3 +85,14 @@ func structuralMemberLookupBad() {
   tup.0.paul();
   tup.0.d(); // expected-error{{value of type 'some P' has no member 'd'}}
 }
+
+// expected-error@+1 {{'some' cannot appear in parameter position in result type '(some P) -> Void'}}
+func opaqueParameter() -> (some P) -> Void {}
+
+// expected-error@+1 {{'some' cannot appear in parameter position in result type '((some P) -> Void) -> Void'}}
+func opaqueParameter() -> ((some P) -> Void) -> Void {}
+
+typealias Takes<T> = (T) -> Void
+
+// expected-error@+1 {{'some' cannot appear in parameter position in result type 'Takes<some P>' (aka '(some P) -> ()')}}
+func indirectOpaqueParameter() -> Takes<some P> {}


### PR DESCRIPTION
* Enable structural opaque types by default
* Remove the `-enable-experimental-structural-opaque-types` frontend flag
* Ban opaque types in parameter position, per the [acceptance decision](https://forums.swift.org/t/accepted-with-modifications-se-0328-structural-opaque-result-type/53789) of SE-0328. Note that this restriction applies to `some` appearing anywhere in the parameter type, including positions that do not consume values from the caller, e.g. `func test() -> ((some P) -> Void) -> Void { ... }`

Resolves: rdar://85275081