### PR TITLE
build: disable building the test binaries when cross-compiling the host tools

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1943,6 +1943,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DLLVM_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-tblgen
+                        -DSWIFT_INCLUDE_TEST_BINARIES:BOOL=FALSE
                     )
                 fi
 


### PR DESCRIPTION
Building the tests [has been disabled when cross-compiling the toolchain almost from the beginning](https://github.com/apple/swift/commit/4ac9c8080945#diff-1a5a064af373f742294e3b312a5c8d0ab52f5aef78052490e6005165472cda48R1480), but #39130 enabled building the test binaries by default again, so [I had to locally disable building those tests when cross-compiling a standalone stdlib for Android](https://github.com/buttaface/swift-android-sdk/commit/bd7e6746cff3f9cc25b836ba481dc11e7ee62840#diff-da0fe2cdefcdd4cf0a111bf62ca0a5170468e47e86875fbcb936e3217b122595R10).

@gottesmm, let me know if we should do more here, like tying `SWIFT_INCLUDE_TEST_BINARIES` to the `build-script-impl` flag `--swift-include-tests` in some way when natively compiling for the host, or if this is enough.