### PR TITLE
sema: always record fix for mismatched constness.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1505,19 +1505,17 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
         }
       }
       if (!argument.isCompileTimeConst() && param.isCompileTimeConst()) {
-        if (cs.shouldAttemptFixes()) {
-          auto *locator = cs.getConstraintLocator(loc);
-          SourceRange range;
-          // simplify locator so the anchor is the exact argument.
-          locator = simplifyLocator(cs, locator, range);
-          if (locator->getPath().empty() &&
-              locator->getAnchor().isExpr(ExprKind::UnresolvedMemberChainResult)) {
-            locator =
-              cs.getConstraintLocator(cast<UnresolvedMemberChainResultExpr>(
-                locator->getAnchor().get<Expr*>())->getChainBase());
-          }
-          cs.recordFix(NotCompileTimeConst::create(cs, paramTy, locator));
+        auto *locator = cs.getConstraintLocator(loc);
+        SourceRange range;
+        // simplify locator so the anchor is the exact argument.
+        locator = simplifyLocator(cs, locator, range);
+        if (locator->getPath().empty() &&
+            locator->getAnchor().isExpr(ExprKind::UnresolvedMemberChainResult)) {
+          locator =
+            cs.getConstraintLocator(cast<UnresolvedMemberChainResultExpr>(
+              locator->getAnchor().get<Expr*>())->getChainBase());
         }
+        cs.recordFix(NotCompileTimeConst::create(cs, paramTy, locator));
       }
 
       cs.addConstraint(

--- a/test/Sema/const_in_property_wrapper.swift
+++ b/test/Sema/const_in_property_wrapper.swift
@@ -1,0 +1,50 @@
+// RUN: %target-typecheck-verify-swift
+
+enum  Colors {
+	case blue
+	case red
+}
+
+let globalString = ""
+let globalInt = 2
+let globalColor = Colors.blue
+
+func giveMeBlue() -> Colors {
+	return .blue
+}
+
+@propertyWrapper struct Wrapper<Value> {
+  let key: String
+  var wrappedValue: Value? { get { return nil } set { } }
+  init(_ key: _const String) {self.key = key }
+  init(_ key: _const Int) {self.key = "" }
+  init(_ key: _const Colors) { self.key = ""}
+}
+
+struct WrapperAdopters {
+    @Wrapper<Bool>(3)
+    var wrappedVar_correct_1
+
+    @Wrapper<Bool>("")
+    var wrappedVar_correct_2
+
+    @Wrapper<Bool>(.blue)
+    var wrappedVar_correct_3
+
+    @Wrapper<Bool>(Colors.blue)
+    var wrappedVar_correct_4
+}
+
+struct WrapperAdopters_incorrect {
+    @Wrapper<Bool>(globalInt) // expected-error{{expect a compile-time constant literal}}
+    var wrappedVar_incorrect_1
+
+    @Wrapper<Bool>(globalString) // expected-error{{expect a compile-time constant literal}}
+    var wrappedVar_incorrect_2
+
+    @Wrapper<Bool>(globalColor) // expected-error{{expect a compile-time constant literal}}
+    var wrappedVar_incorrect_3
+
+    @Wrapper<Bool>(giveMeBlue()) // expected-error{{expect a compile-time constant literal}}
+    var wrappedVar_incorrect_4
+}


### PR DESCRIPTION
Also, this commit has added a test for using _const values in property wrappers.
