### PR TITLE
[Sema] Use the most precise TRC to extend when building them lazily

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -931,7 +931,8 @@ void TypeChecker::buildTypeRefinementContextHierarchyDelayed(SourceFile &SF, Abs
 
   // Build the refinement context for the function body.
   ASTContext &Context = SF.getASTContext();
-  TypeRefinementContextBuilder Builder(RootTRC, Context);
+  auto LocalTRC = RootTRC->findMostRefinedSubContext(AFD->getLoc(), Context.SourceMgr);
+  TypeRefinementContextBuilder Builder(LocalTRC, Context);
   Builder.build(AFD);
 }
 

--- a/test/Sema/availability_and_delayed_parsing.swift
+++ b/test/Sema/availability_and_delayed_parsing.swift
@@ -1,12 +1,19 @@
 /// Check for reliable availability checking in inlinable code even when
 /// skipping some function bodies. rdar://82269657
 
+/// Default build mode reading everything
 // RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s -target %target-cpu-apple-macos10.10 2>&1 \
 // RUN:    | %FileCheck %s --check-prefixes TRC-API,TRC-INLINABLE,TRC-WITHTYPES,TRC-FULL
+
+/// Emit-module-separately mode / for LLDB
 // RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s -target %target-cpu-apple-macos10.10 -experimental-skip-non-inlinable-function-bodies-without-types 2>&1 \
 // RUN:    | %FileCheck %s --check-prefixes TRC-API,TRC-INLINABLE,TRC-WITHTYPES,TRC-FULL-NOT
+
+/// InstallAPI mode
 // RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s -target %target-cpu-apple-macos10.10 -experimental-skip-non-inlinable-function-bodies 2>&1 \
 // RUN:    | %FileCheck %s --check-prefixes TRC-API,TRC-INLINABLE,TRC-WITHTYPES-NOT,TRC-FULL-NOT
+
+/// Index build mode
 // RUN: %target-swift-frontend -typecheck -dump-type-refinement-contexts %s -target %target-cpu-apple-macos10.10 -experimental-skip-all-function-bodies 2>&1 \
 // RUN:    | %FileCheck %s --check-prefixes TRC-API,TRC-INLINABLE-NOT,TRC-WITHTYPES-NOT,TRC-FULL-NOT
 
@@ -16,6 +23,26 @@
 public func foo() { }
 // TRC-API: (root versions=[10.10.0,+Inf)
 // TRC-API:   (decl versions=[10.12,+Inf) decl=foo()
+
+#if canImport(Swift)
+  @available(macOS 10.10, *)
+  extension String {
+    public var computedVariable: String {
+      struct SomeTypeToForceCheckingThis {}
+
+      if #available(macOS 10.12, *) {
+        foo()
+      }
+
+      fatalError()
+    }
+  }
+#endif
+// TRC-FULL:  (decl versions=[10.10,+Inf) decl=extension.String
+// TRC-WITHTYPES:    (condition_following_availability versions=[10.12,+Inf)
+// TRC-WITHTYPES:    (if_then versions=[10.12,+Inf)
+// TRC-WITHTYPES-NOT-NOT:    (condition_following_availability versions=[10.12,+Inf)
+// TRC-WITHTYPES-NOT-NOT:    (if_then versions=[10.12,+Inf)
 
 struct S {
   fileprivate var actual: [String] = [] {


### PR DESCRIPTION
Fix an issue reported with emit-module-separately where the compiler reports false-errors on availability.

rdar://85472278