### PR TITLE
Sema: Narrow down the derivation of == for RawRepresentable enums to non-resilient modules

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4123,6 +4123,11 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   }
 }
 
+static bool isSwiftRawRepresentableEnum(Type adoptee) {
+  auto *enumDecl = dyn_cast<EnumDecl>(adoptee->getAnyNominal());
+  return (enumDecl && enumDecl->hasRawType() && !enumDecl->isObjC());
+}
+
 // If the given witness matches a generic RawRepresentable function conforming
 // with a given protocol e.g. `func == <T : RawRepresentable>(lhs: T, rhs: T) ->
 // Bool where T.RawValue : Equatable`
@@ -4201,13 +4206,8 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       !requirement->getAttrs().isUnavailable(getASTContext());
 
   auto &ctx = getASTContext();
-  bool isEquatableConformance = Conformance->getProtocol() ==
-                                ctx.getProtocol(KnownProtocolKind::Equatable);
-
-  auto decl = Conformance->getDeclContext()->getSelfNominalTypeDecl();
-  auto *enumDecl = dyn_cast_or_null<EnumDecl>(decl);
-  bool isSwiftRawRepresentableEnum =
-      enumDecl && enumDecl->hasRawType() && !enumDecl->isObjC();
+  bool isEquatableConformance = (Conformance->getProtocol() ==
+                                 ctx.getProtocol(KnownProtocolKind::Equatable));
 
   if (findBestWitness(requirement,
                       considerRenames ? &ignoringNames : nullptr,
@@ -4217,12 +4217,23 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     const auto &best = matches[bestIdx];
     auto witness = best.Witness;
 
-    if (canDerive && isSwiftRawRepresentableEnum && isEquatableConformance) {
-      // For swift enum types that can derive equatable conformance,
-      // if the best witness is default generic conditional conforming
-      // `func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool where
-      // T.RawValue : Equatable` let's return as missing and derive
-      // the conformance since it is possible.
+    if (canDerive &&
+        isEquatableConformance &&
+        isSwiftRawRepresentableEnum(Adoptee) &&
+        !Conformance->getDeclContext()->getParentModule()->isResilient()) {
+      // For swift enum types that can derive an Equatable conformance,
+      // if the best witness is the default implementation
+      //
+      //   func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
+      //     where T.RawValue : Equatable
+      //
+      // let's return as missing and derive the conformance, since it will be
+      // more efficient than comparing rawValues.
+      //
+      // However, we only do this if the module is non-resilient. If it is
+      // resilient, this change can break ABI by publishing a synthesized ==
+      // declaration that may not exist in versions of the framework built
+      // with an older compiler.
       if (isRawRepresentableGenericFunction(ctx, witness, Conformance)) {
         return ResolveWitnessResult::Missing;
       }

--- a/test/SILGen/enum_equatable_witness.swift
+++ b/test/SILGen/enum_equatable_witness.swift
@@ -1,70 +1,79 @@
-// RUN: %target-swift-emit-silgen -module-name main %s -verify | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name main %s -verify | %FileCheck %s --check-prefix=FRAGILE
+// RUN: %target-swift-emit-silgen -module-name main %s -verify -enable-library-evolution | %FileCheck %s --check-prefix=RESILIENT
+
 // SR-9425
-enum MyState : String {
+public enum MyState : String {
     case closed = "closed"
     case opened = "opened"
 }
 
-@inline(never)
-func check_state(_ state : MyState) -> Int {
-  // CHECK: function_ref @$s4main7MyStateO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main11check_stateySiAA7MyStateOF : $@convention(thin) (MyState) -> Int {
+public func check_state(_ state : MyState) -> Int {
+  // FRAGILE: function_ref @$s4main7MyStateO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .opened ? 1 : 0
 }
 
 // generic-enum.swift
-enum GenericMyState<T> : String {
+public enum GenericMyState<T> : String {
   case closed
   case opened
 }
 
-@inline(never)
-func check_generic_state(_ state : GenericMyState<Int>) -> Int {
-  // CHECK: function_ref @$s4main14GenericMyStateO21__derived_enum_equalsySbACyxG_AEtFZ
+// CHECK-LABEL: sil [ossa] @$s4main19check_generic_stateySiAA14GenericMyStateOySiGF : $@convention(thin) (GenericMyState<Int>) -> Int {
+public func check_generic_state(_ state : GenericMyState<Int>) -> Int {
+  // FRAGILE: function_ref @$s4main14GenericMyStateO21__derived_enum_equalsySbACyxG_AEtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .opened ? 1 : 0
 }
 
 // regular-enum.swift
-enum Regular {
+public enum Regular {
   case closed
   case opened
 }
 
-@inline(never)
-func check_regular(_ state : Regular) -> Int {
-  // CHECK: function_ref @$s4main7RegularO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main13check_regularySiAA7RegularOF : $@convention(thin) (Regular) -> Int {
+public func check_regular(_ state : Regular) -> Int {
+  // FRAGILE: function_ref @$s4main7RegularO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .closed ? 1 : 0
 }
 
 // string-enum.swift
-enum Alphabet : String {
+public enum Alphabet : String {
   case A = "A", B = "B", C = "C", D = "D", E = "E", F = "F", G = "G", H = "H", I = "I", J = "J"
 }
 
-@inline(never)
-func check_alphabet(_ state : Alphabet) -> Int {
-  // CHECK: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main14check_alphabetySiAA8AlphabetOF : $@convention(thin) (Alphabet) -> Int {
+public func check_alphabet(_ state : Alphabet) -> Int {
+  // FRAGILE: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .E ? 1 : 0
 }
 
-@inline(never)
-func compareIt(_ state : Alphabet, _ rhs: Alphabet) -> Bool {
-  // CHECK: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main9compareItySbAA8AlphabetO_ADtF : $@convention(thin) (Alphabet, Alphabet) -> Bool {
+public func compareIt(_ state : Alphabet, _ rhs: Alphabet) -> Bool {
+  // FRAGILE: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == rhs
 }
 
 // int-enum.swift
-enum AlphabetInt : Int {
+public enum AlphabetInt : Int {
   case A = 10, B = 100, C = 12, D = 456, E = 1, F = 3, G = 77, H = 2, I = 27, J = 42
 }
 
-@inline(never)
-func check_alphabet_int(_ state : AlphabetInt) -> Int {
-  // CHECK: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main18check_alphabet_intySiAA11AlphabetIntOF : $@convention(thin) (AlphabetInt) -> Int {
+public func check_alphabet_int(_ state : AlphabetInt) -> Int {
+  // FRAGILE: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .E ? 1 : 0
 }
 
-@inline(never)
-func compareIt(_ state : AlphabetInt, _ rhs: AlphabetInt) -> Bool {
-  // CHECK: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+// CHECK-LABEL: sil [ossa] @$s4main9compareItySbAA11AlphabetIntO_ADtF : $@convention(thin) (AlphabetInt, AlphabetInt) -> Bool {
+public func compareIt(_ state : AlphabetInt, _ rhs: AlphabetInt) -> Bool {
+  // FRAGILE: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == rhs
 }


### PR DESCRIPTION
This change was originally introduced in https://github.com/apple/swift/pull/36752.

The problem occurs in the following scenario:

- New compiler with this change is used to build a dylib and swiftinterface
  file for module A, which defines a RawRepresentable enum type E.

- Module B imports module A and references == on two E instances.

- The module B is run against a dylib of module A built with the old compiler.

At this point, module B will not link (or run) because the symbol for E.==
is not present in the old dylib for A.

The only real solution here is to disable this new optimization when
building a module for -enable-library-evolution, unfortunately.

In the future, we could make the derived E.== symbol @_alwaysEmitIntoClient.
However today, synthesized declarations cannot be @_alwaysEmitIntoClient
because they do not have source text that can be emitted into the
swiftinterface file. One day, we might gain the ability to print Exprs as
source text that parses back in, at which point we could allow synthesized
declarations to be @_alwaysEmitIntoClient.

Fixes rdar://problem/84912735 and rdar://problem/82919247.