### PR TITLE
[cxx-interop] Implement foreign reference types with support for metadata + generics.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1518,6 +1518,11 @@ struct TargetStructMetadata : public TargetValueMetadata<Runtime> {
   }
 
   bool isCanonicalStaticallySpecializedGenericMetadata() const {
+    // Struct metadata is used for foreign reference types, in which case the
+    // descriptor is not a struct descriptor.
+    if (!llvm::isa<TargetStructDescriptor<Runtime>>(this->Description))
+      return false;
+
     auto *description = getDescription();
     if (!description->isGeneric())
       return false;

--- a/include/swift/AST/ReferenceCounting.h
+++ b/include/swift/AST/ReferenceCounting.h
@@ -29,6 +29,10 @@ enum class ReferenceCounting : uint8_t {
   /// Blocks are always ObjC reference counting compatible.
   ObjC,
 
+  /// The object has no reference counting. This is used by foreign reference
+  /// types.
+  None,
+
   /// The object uses _Block_copy/_Block_release reference counting.
   ///
   /// This is a strict subset of ObjC; all blocks are also ObjC reference

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -488,6 +488,8 @@ public:
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
 
+  bool isForeignReferenceType(); // in Types.h
+
   CanType getOptionalObjectType() const {
     return getOptionalObjectTypeImpl(*this);
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -811,8 +811,8 @@ public:
 
   /// If this is a class type or a bound generic class type, returns the
   /// (possibly generic) class.
-  ClassDecl *getClassOrBoundGenericClass();
-  
+  ClassDecl *getClassOrBoundGenericClass() const;
+
   /// If this is a struct type or a bound generic struct type, returns
   /// the (possibly generic) class.
   StructDecl *getStructOrBoundGenericStruct();
@@ -820,7 +820,10 @@ public:
   /// If this is an enum or a bound generic enum type, returns the
   /// (possibly generic) enum.
   EnumDecl *getEnumOrBoundGenericEnum();
-  
+
+  /// If this is a class, check if this class is a foreign reference type.
+  bool isForeignReferenceType();
+
   /// Determine whether this type may have a superclass, which holds for
   /// classes, bound generic classes, and archetypes that are only instantiable
   /// with a class type.
@@ -6175,7 +6178,7 @@ inline bool TypeBase::canDynamicallyBeOptionalType(bool includeExistential) {
   return isArchetypeOrExistential && !T.isAnyClassReferenceType();
 }
 
-inline ClassDecl *TypeBase::getClassOrBoundGenericClass() {
+inline ClassDecl *TypeBase::getClassOrBoundGenericClass() const {
   return getCanonicalType().getClassOrBoundGenericClass();
 }
 
@@ -6239,8 +6242,6 @@ inline GenericTypeDecl *TypeBase::getAnyGeneric() {
   return getCanonicalType().getAnyGeneric();
 }
 
-  
-  
 inline bool TypeBase::isBuiltinIntegerType(unsigned n) {
   if (auto intTy = dyn_cast<BuiltinIntegerType>(getCanonicalType()))
     return intTy->getWidth().isFixedWidth()

--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -132,10 +132,10 @@ private:
 
 /// The input type for a record member lookup request.
 struct ClangRecordMemberLookupDescriptor final {
-  StructDecl *recordDecl;
+  NominalTypeDecl *recordDecl;
   DeclName name;
 
-  ClangRecordMemberLookupDescriptor(StructDecl *recordDecl, DeclName name)
+  ClangRecordMemberLookupDescriptor(NominalTypeDecl *recordDecl, DeclName name)
       : recordDecl(recordDecl), name(name) {
     assert(isa<clang::RecordDecl>(recordDecl->getClangDecl()));
   }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -236,7 +236,13 @@ public:
   NominalTypeDecl *getNominalOrBoundGenericNominal() const {
     return getASTType().getNominalOrBoundGenericNominal();
   }
-  
+
+  /// If this type maps to a Swift class, check if that class is a foreign
+  /// reference type.
+  bool isForeignReferenceType() const {
+    return getASTType().isForeignReferenceType();
+  }
+
   /// True if the type is an address type.
   bool isAddress() const { return getCategory() == SILValueCategory::Address; }
 

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -545,7 +545,8 @@ ClangTypeConverter::visitBoundGenericType(BoundGenericType *type) {
     auto args = type->getGenericArgs();
     assert((args.size() == 1) && "Optional should have 1 generic argument.");
     clang::QualType innerTy = convert(args[0]);
-    if (swift::canImportAsOptional(innerTy.getTypePtrOrNull()))
+    if (swift::canImportAsOptional(innerTy.getTypePtrOrNull()) ||
+        args[0]->isForeignReferenceType())
       return innerTy;
     return clang::QualType();
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1940,7 +1940,11 @@ static bool isPolymorphic(const AbstractStorageDecl *storage) {
     return true;
 
   if (auto *classDecl = dyn_cast<ClassDecl>(storage->getDeclContext())) {
-    if (storage->isFinal() || classDecl->isFinal())
+    // Accesses to members of foreign reference types should be made directly
+    // to storage as these are references to clang records which are not allowed
+    // to have dynamic dispatch.
+    if (storage->isFinal() || classDecl->isFinal() ||
+        classDecl->isForeignReferenceType())
       return false;
 
     return true;
@@ -4718,6 +4722,10 @@ bool ClassDecl::walkSuperclasses(
   }
 
   return false;
+}
+
+bool ClassDecl::isForeignReferenceType() {
+  return getClangDecl() && isa<clang::RecordDecl>(getClangDecl());
 }
 
 EnumCaseDecl *EnumCaseDecl::create(SourceLoc CaseLoc,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4443,11 +4443,8 @@ bool GenericSignatureBuilder::updateSuperclass(
     auto layoutReqSource =
       source.getSource(*this, type)->viaLayout(*this, superclass);
 
-    auto layout =
-      LayoutConstraint::getLayoutConstraint(
-        superclass->getClassOrBoundGenericClass()->usesObjCObjectModel()
-          ? LayoutConstraintKind::Class
-          : LayoutConstraintKind::NativeClass,
+    auto layout = LayoutConstraint::getLayoutConstraint(
+        superclass->getClassOrBoundGenericClass()->getLayoutConstraintKind(),
         getASTContext());
     addLayoutRequirementDirect(type, layout, layoutReqSource);
     return true;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1478,7 +1478,7 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
     } else if (isa_and_nonnull<clang::RecordDecl>(decl->getClangDecl())) {
       auto allFound = evaluateOrDefault(
           ctx.evaluator,
-          ClangRecordMemberLookup({cast<StructDecl>(decl), name}), {});
+          ClangRecordMemberLookup({cast<NominalTypeDecl>(decl), name}), {});
       // Add all the members we found, later we'll combine these with the
       // existing members.
       for (auto found : allFound)

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -523,9 +523,7 @@ void RuleBuilder::addRequirement(const Requirement &req,
       // Build the symbol [layout: L].
       auto layout =
         LayoutConstraint::getLayoutConstraint(
-          otherType->getClassOrBoundGenericClass()->usesObjCObjectModel()
-            ? LayoutConstraintKind::Class
-            : LayoutConstraintKind::NativeClass,
+          otherType->getClassOrBoundGenericClass()->getLayoutConstraintKind(),
           Context.getASTContext());
       auto layoutSymbol = Symbol::forLayout(layout, Context);
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4121,7 +4121,7 @@ TinyPtrVector<ValueDecl *> CXXNamespaceMemberLookup::evaluate(
 
 TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     Evaluator &evaluator, ClangRecordMemberLookupDescriptor desc) const {
-  StructDecl *recordDecl = desc.recordDecl;
+  NominalTypeDecl *recordDecl = desc.recordDecl;
   DeclName name = desc.name;
 
   auto &ctx = recordDecl->getASTContext();

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -452,6 +452,10 @@ namespace {
           pointeeQualType, ImportTypeKind::Value, AllowNSUIntegerAsInt,
           Bridgeability::None);
 
+      // If this is imported as a reference type, ignore the pointer.
+      if (pointeeType && pointeeType->isForeignReferenceType())
+         return {pointeeType, ImportHint::OtherPointer};
+
       // If the pointed-to type is unrepresentable in Swift, or its C
       // alignment is greater than the maximum Swift alignment, import as
       // OpaquePointer.
@@ -523,6 +527,9 @@ namespace {
                                    AllowNSUIntegerAsInt, Bridgeability::None);
       if (!pointeeType)
         return Type();
+
+      if (pointeeType->isForeignReferenceType())
+        return {pointeeType, ImportHint::None};
 
       if (pointeeQualType->isFunctionType()) {
         return importFunctionPointerLikeType(*type, pointeeType);
@@ -1516,7 +1523,8 @@ static ImportedType adjustTypeForConcreteImport(
   assert(importedType);
 
   if (importKind == ImportTypeKind::RecordField &&
-      importedType->isAnyClassReferenceType()) {
+      importedType->isAnyClassReferenceType() &&
+      !importedType->isForeignReferenceType()) {
     // Wrap retainable struct fields in Unmanaged.
     // FIXME: Eventually we might get C++-like support for strong pointers in
     // structs, at which point we should really be checking the lifetime
@@ -1959,8 +1967,11 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
         param, AccessLevel::Private, SourceLoc(), SourceLoc(), name,
         importSourceLoc(param->getLocation()), bodyName,
         ImportedHeaderUnit);
-    paramInfo->setSpecifier(isInOut ? ParamSpecifier::InOut
-                                    : ParamSpecifier::Default);
+    // Foreign references are already references so they don't need to be passed
+    // as inout.
+    paramInfo->setSpecifier(isInOut && !swiftParamTy->isForeignReferenceType()
+                                ? ParamSpecifier::InOut
+                                : ParamSpecifier::Default);
     paramInfo->setInterfaceType(swiftParamTy);
     recordImplicitUnwrapForDecl(paramInfo, isParamTypeImplicitlyUnwrapped);
     parameters.push_back(paramInfo);

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1448,7 +1448,7 @@ void SignatureExpansion::expandExternalSignatureTypes() {
       auto paramTy = getSILFuncConventions().getSILType(
           param, IGM.getMaximalTypeExpansionContext());
       auto &paramTI = cast<FixedTypeInfo>(IGM.getTypeInfo(paramTy));
-      if (AI.getIndirectByVal()) {
+      if (AI.getIndirectByVal() && !paramTy.isForeignReferenceType()) {
         addByvalArgumentAttributes(
             IGM, Attrs, getCurParamIndex(),
             Alignment(AI.getIndirectAlign().getQuantity()),
@@ -3531,6 +3531,20 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
 
     SILType paramType = silConv.getSILType(
         params[i - firstParam], IGF.IGM.getMaximalTypeExpansionContext());
+
+    // In Swift, values that are foreign references types will always be
+    // pointers. Additionally, we only import functions which use foreign
+    // reference types indirectly (as pointers), so we know in every case, if
+    // the argument type is a foreign reference type, the types will match up
+    // and we can simply use the input directly.
+    if (paramType.isForeignReferenceType()) {
+      auto *arg = in.claimNext();
+      if (isIndirectFormalParameter(params[i - firstParam].getConvention()))
+        arg = IGF.Builder.CreateLoad(arg, IGF.IGM.getPointerAlignment());
+      out.add(arg);
+      continue;
+    }
+
     switch (AI.getKind()) {
     case clang::CodeGen::ABIArgInfo::Extend: {
       bool signExt = clangParamTy->hasSignedIntegerRepresentation();

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -147,6 +147,8 @@ namespace {
         addNSObjectHeader();
         HeaderSize = CurSize;
         break;
+      case ReferenceCounting::None:
+        break;
       case ReferenceCounting::Block:
       case ReferenceCounting::Unknown:
       case ReferenceCounting::Bridge:
@@ -215,7 +217,7 @@ namespace {
     void addFieldsForClassImpl(ClassDecl *rootClass, SILType rootClassType,
                                ClassDecl *theClass, SILType classType,
                                bool superclass) {
-      if (theClass->hasClangNode()) {
+      if (theClass->hasClangNode() && !theClass->isForeignReferenceType()) {
         Options |= ClassMetadataFlags::ClassHasObjCAncestry;
         return;
       }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3663,7 +3663,7 @@ IRGenModule::getTypeEntityReference(GenericTypeDecl *decl) {
 
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     auto clas = dyn_cast<ClassDecl>(decl);
-    if (!clas) {
+    if (!clas || clas->isForeignReferenceType()) {
       return getTypeContextDescriptorEntityReference(*this, nominal);
     }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1563,6 +1563,7 @@ IRGenModule::getReferenceObjectTypeInfo(ReferenceCounting refcounting) {
   case ReferenceCounting::Block:
   case ReferenceCounting::Error:
   case ReferenceCounting::ObjC:
+  case ReferenceCounting::None:
     llvm_unreachable("not implemented");
   }
 

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1162,6 +1162,7 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type,
       witnessSurrogate = C.TheBridgeObjectType;
       break;
     case ReferenceCounting::Error:
+    case ReferenceCounting::None:
       break;
     }
   }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -122,7 +122,8 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
           return true;
 
         // Foreign class types can be symbolically referenced.
-        if (clas->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
+        if (clas->getForeignClassKind() == ClassDecl::ForeignKind::CFType ||
+            const_cast<ClassDecl *>(clas)->isForeignReferenceType())
           return true;
 
         // Otherwise no.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -823,6 +823,7 @@ public:
     case ReferenceCounting::Unknown:
     case ReferenceCounting::ObjC:
     case ReferenceCounting::Block:
+    case ReferenceCounting::None:
       return true;
 
     case ReferenceCounting::Bridge:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2135,7 +2135,10 @@ static void emitDynamicSelfMetadata(IRGenSILFunction &IGF) {
     selfTy = metaTy.getInstanceType();
     switch (metaTy->getRepresentation()) {
     case MetatypeRepresentation::Thin:
-      llvm_unreachable("class metatypes are never thin");
+      assert(selfTy.isForeignReferenceType() &&
+             "Only foreign reference metatypes are allowed to be thin");
+      selfKind = IRGenFunction::ObjectReference;
+      break;
     case MetatypeRepresentation::Thick:
       selfKind = IRGenFunction::SwiftMetatype;
       break;

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -112,7 +112,8 @@ MetadataLayout &IRGenModule::getMetadataLayout(NominalTypeDecl *decl) {
   auto &entry = MetadataLayouts[decl];
   if (!entry) {
     if (auto theClass = dyn_cast<ClassDecl>(decl)) {
-      if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
+      if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType ||
+          theClass->isForeignReferenceType())
         entry = new ForeignClassMetadataLayout(*this, theClass);
       else
         entry = new ClassMetadataLayout(*this, theClass);
@@ -480,7 +481,8 @@ ClassMetadataLayout::getFieldOffsetVectorOffset(IRGenFunction &IGF) const {
 
 Size irgen::getClassFieldOffsetOffset(IRGenModule &IGM, ClassDecl *theClass,
                                       VarDecl *field) {
-  if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
+  if (theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType ||
+      theClass->isForeignReferenceType())
     return Size();
 
   return IGM.getClassMetadataLayout(theClass).getStaticFieldOffset(field);
@@ -679,7 +681,8 @@ StructMetadataLayout::getTrailingFlagsOffset() const {
 ForeignClassMetadataLayout::ForeignClassMetadataLayout(IRGenModule &IGM,
                                                        ClassDecl *theClass)
     : MetadataLayout(Kind::ForeignClass), Class(theClass) {
-  assert(theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType &&
+  assert(theClass->getForeignClassKind() == ClassDecl::ForeignKind::CFType ||
+         theClass->isForeignReferenceType() &&
          "Not a foreign class");
 
   struct Scanner : LayoutScanner<Scanner, ForeignClassMetadataScanner> {

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3249,6 +3249,9 @@ namespace {
       case ReferenceCounting::Bridge:
       case ReferenceCounting::Error:
         llvm_unreachable("classes shouldn't have this kind of refcounting");
+      case ReferenceCounting::None:
+        llvm_unreachable(
+            "Foreign reference types don't conform to 'AnyClass'.");
       }
 
       llvm_unreachable("Not a valid ReferenceCounting.");

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -1028,6 +1028,9 @@ private:
   /// annotations like \c strong and \c weak.
   bool isObjCReferenceCountableObjectType(Type ty) {
     if (auto classDecl = ty->getClassOrBoundGenericClass()) {
+      if (classDecl->isForeignReferenceType())
+        return false;
+
       switch (classDecl->getForeignClassKind()) {
       case ClassDecl::ForeignKind::Normal:
       case ClassDecl::ForeignKind::RuntimeOnly:

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -51,6 +51,8 @@ namespace {
     /// Class metatypes have non-trivial representation due to the
     /// possibility of subclassing.
     bool visitClassType(CanClassType type) {
+      if (type->isForeignReferenceType())
+        return true;
       return false;
     }
     bool visitBoundGenericClassType(CanBoundGenericClassType type) {
@@ -1651,6 +1653,10 @@ namespace {
     TypeLowering *handleReference(CanType type,
                                   RecursiveProperties properties) {
       auto silType = SILType::getPrimitiveObjectType(type);
+      if (type.isForeignReferenceType())
+        return new (TC) TrivialTypeLowering(
+            silType, RecursiveProperties::forTrivial(), Expansion);
+
       return new (TC) ReferenceTypeLowering(silType, properties, Expansion);
     }
 

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -672,8 +672,10 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       if (auto selfType = instTy->getAs<DynamicSelfType>())
         instTy = selfType->getSelfType();
       auto *cl = instTy->getClassOrBoundGenericClass();
-      if ((cl && (cl->usesObjCObjectModel() || cl->isForeign())) ||
-          instTy->isAnyObject())
+      bool isForeign =
+          cl->getObjectModel() == ReferenceCounting::ObjC ||
+          cl->isForeign();
+      if ((cl && isForeign) || instTy->isAnyObject())
         return RuntimeEffect::MetaData | RuntimeEffect::ObjectiveC;
       return RuntimeEffect::MetaData;
     }
@@ -690,7 +692,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       return RuntimeEffect::MetaData;
     case ExistentialRepresentation::Class: {
       auto *cl = opType.getClassOrBoundGenericClass();
-      if ((cl && cl->usesObjCObjectModel()) || opType.isAnyObject())
+      bool usesObjCModel = cl->getObjectModel() == ReferenceCounting::ObjC;
+      if ((cl && usesObjCModel) || opType.isAnyObject())
         return RuntimeEffect::MetaData | RuntimeEffect::ObjectiveC;
       return RuntimeEffect::MetaData | RuntimeEffect::ObjectiveC;
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -821,8 +821,10 @@ public:
   // Require that the operand is a non-optional, non-unowned reference-counted
   // type.
   void requireReferenceValue(SILValue value, const Twine &valueDescription) {
-    require(value->getType().isObject(), valueDescription +" must be an object");
-    require(value->getType().isReferenceCounted(F.getModule()),
+    require(value->getType().isObject(),
+            valueDescription + " must be an object");
+    require(value->getType().isReferenceCounted(F.getModule()) ||
+                value->getType().isForeignReferenceType(),
             valueDescription + " must have reference semantics");
     forbidObjectType(UnownedStorageType, value, valueDescription);
   }
@@ -3430,9 +3432,11 @@ public:
             "foreign method cannot be dispatched natively");
     require(!isa<ExtensionDecl>(member.getDecl()->getDeclContext()),
             "extension method cannot be dispatched natively");
-    
-    // The method ought to appear in the class vtable.
-    require(VerifyClassMethodVisitor(member).Seen,
+
+    // The method ought to appear in the class vtable unless it's a foreign
+    // reference type.
+    require(VerifyClassMethodVisitor(member).Seen ||
+            operandType.isForeignReferenceType(),
             "method does not appear in the class's vtable");
   }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -570,7 +570,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
 bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
   // If the root class was implemented in Objective-C, use Objective-C's
   // allocation methods because they may have been overridden.
-  return theClass->usesObjCObjectModel();
+  return theClass->getObjectModel() == ReferenceCounting::ObjC;
 }
 
 void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5828,6 +5828,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                                   type1, type2, locator);
           return getTypeMatchSuccess();
         };
+
+      // Foreign reference types do *not* conform to AnyObject.
+      if (type1->isForeignReferenceType() && type2->isAnyObject())
+        return getTypeMatchFailure(locator);
       
       if (auto meta1 = type1->getAs<MetatypeType>()) {
         if (meta1->getInstanceType()->mayHaveSuperclass()

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -97,8 +97,12 @@ static bool contextAllowsPatternBindingWithoutVariables(DeclContext *dc) {
 }
 
 static bool hasStoredProperties(NominalTypeDecl *decl) {
+  bool isForeignReferenceTy =
+      isa<ClassDecl>(decl) && cast<ClassDecl>(decl)->isForeignReferenceType();
+
   return (isa<StructDecl>(decl) ||
-          (isa<ClassDecl>(decl) && !decl->hasClangNode()));
+          (isa<ClassDecl>(decl) &&
+           (!decl->hasClangNode() || isForeignReferenceTy)));
 }
 
 static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
@@ -2226,6 +2230,9 @@ RequiresOpaqueAccessorsRequest::evaluate(Evaluator &evaluator,
   } else if (auto *structDecl = dyn_cast<StructDecl>(dc)) {
     if (structDecl->hasClangNode())
       return false;
+  } else if (isa<ClassDecl>(dc) &&
+             cast<ClassDecl>(dc)->isForeignReferenceType()) {
+    return false;
   }
 
   // Stored properties in SIL mode don't get accessors.

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -1,0 +1,24 @@
+module POD {
+  header "pod.h"
+  requires cplusplus
+}
+
+module MoveOnly {
+  header "move-only.h"
+  requires cplusplus
+}
+
+module Singleton {
+  header "singleton.h"
+  requires cplusplus
+}
+
+module Nullable {
+  header "nullable.h"
+  requires cplusplus
+}
+
+module WitnessTable {
+  header "witness-table.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
@@ -1,0 +1,71 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_MOVE_ONLY_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_MOVE_ONLY_H
+
+#include <new>
+#include <stdlib.h>
+#include <utility>
+
+#include "visibility.h"
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+struct __attribute__((swift_attr("import_as_ref"))) MoveOnly {
+  MoveOnly() = default;
+  MoveOnly(const MoveOnly &) = delete;
+  MoveOnly(MoveOnly &&) = default;
+
+  int test() const { return 42; }
+  int testMutable() { return 42; }
+
+  static MoveOnly *create() {
+    return new (malloc(sizeof(MoveOnly))) MoveOnly();
+  }
+};
+
+MoveOnly moveIntoResult(MoveOnly &x) { return std::move(x); }
+
+struct __attribute__((swift_attr("import_as_ref"))) HasMoveOnlyChild {
+  MoveOnly child;
+
+  static HasMoveOnlyChild *create() {
+    return new (malloc(sizeof(HasMoveOnlyChild))) HasMoveOnlyChild();
+  }
+};
+
+HasMoveOnlyChild moveIntoResult(HasMoveOnlyChild &x) { return std::move(x); }
+
+struct __attribute__((swift_attr("import_as_ref"))) PrivateCopyCtor {
+  PrivateCopyCtor() = default;
+  PrivateCopyCtor(PrivateCopyCtor &&) = default;
+
+  int test() const { return 42; }
+  int testMutable() { return 42; }
+
+  static PrivateCopyCtor *create() {
+    return new (malloc(sizeof(PrivateCopyCtor))) PrivateCopyCtor();
+  }
+
+private:
+  PrivateCopyCtor(const PrivateCopyCtor &) {}
+};
+
+PrivateCopyCtor moveIntoResult(PrivateCopyCtor &x) { return std::move(x); }
+
+struct __attribute__((swift_attr("import_as_ref"))) BadCopyCtor {
+  BadCopyCtor() = default;
+  BadCopyCtor(BadCopyCtor &&) = default;
+  BadCopyCtor(const BadCopyCtor &) { __builtin_trap(); }
+
+  int test() const { return 42; }
+  int testMutable() { return 42; }
+
+  static BadCopyCtor *create() {
+    return new (malloc(sizeof(BadCopyCtor))) BadCopyCtor();
+  }
+};
+
+BadCopyCtor moveIntoResult(BadCopyCtor &x) { return std::move(x); }
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_MOVE_ONLY_H

--- a/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
@@ -1,0 +1,29 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_NULLABLE_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_NULLABLE_H
+
+#include <new>
+#include <stdlib.h>
+
+struct __attribute__((swift_attr("import_as_ref"))) Empty {
+  int test() const { return 42; }
+
+  static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
+};
+
+void mutateIt(Empty &) {}
+
+struct __attribute__((swift_attr("import_as_ref"))) IntPair {
+  int a = 1;
+  int b = 2;
+
+  int test() const { return b - a; }
+
+  static IntPair *create() { return new (malloc(sizeof(IntPair))) IntPair(); }
+};
+
+void mutateIt(IntPair *x) {
+  x->a = 2;
+  x->b = 4;
+}
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_NULLABLE_H

--- a/test/Interop/Cxx/foreign-reference/Inputs/pod.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/pod.h
@@ -1,0 +1,121 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_POD_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_POD_H
+
+#include <new>
+#include <stdlib.h>
+
+#include "visibility.h"
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+struct __attribute__((swift_attr("import_as_ref"))) Empty {
+  int test() const { return 42; }
+  int testMutable() { return 42; }
+
+  static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
+};
+
+void mutateIt(Empty &) {}
+Empty passThroughByValue(Empty x) { return x; }
+
+struct __attribute__((swift_attr("@actor")))
+__attribute__((swift_attr("import_as_ref"))) MultipleAttrs {
+  int test() const { return 42; }
+  int testMutable() { return 42; }
+
+  static MultipleAttrs *create() {
+    return new (malloc(sizeof(MultipleAttrs))) MultipleAttrs();
+  }
+};
+
+struct __attribute__((swift_attr("import_as_ref"))) IntPair {
+  int a = 1;
+  int b = 2;
+
+  int test() const { return b - a; }
+  int testMutable() { return b - a; }
+
+  static IntPair *create() { return new (malloc(sizeof(IntPair))) IntPair(); }
+};
+
+void mutateIt(IntPair &x) {
+  x.a = 2;
+  x.b = 4;
+}
+IntPair passThroughByValue(IntPair x) { return x; }
+
+struct __attribute__((swift_attr("import_as_ref"))) RefHoldingPair {
+  // REVIEW-NOTE: I added support for this but then removed it, as this sort of
+  // indicates incorrect usage of a "reference type" and has weird semantics.
+  IntPair pair;
+  int otherValue = 3;
+
+  int test() const { return otherValue - pair.test(); }
+  int testMutable() { return otherValue - pair.test(); }
+
+  static RefHoldingPair *create() {
+    return new (malloc(sizeof(RefHoldingPair))) RefHoldingPair();
+  }
+};
+
+struct __attribute__((swift_attr("import_as_ref"))) RefHoldingPairRef {
+  IntPair &pair;
+  int otherValue;
+  RefHoldingPairRef(IntPair &pair) : pair(pair), otherValue(42) {}
+
+  int test() const { return otherValue - pair.test(); }
+  int testMutable() { return otherValue - pair.test(); }
+
+  static RefHoldingPairRef *create() {
+    IntPair *pair = new (malloc(sizeof(IntPair))) IntPair();
+    return new (malloc(sizeof(RefHoldingPairRef))) RefHoldingPairRef(*pair);
+  }
+};
+
+struct __attribute__((swift_attr("import_as_ref"))) RefHoldingPairPtr {
+  IntPair *pair;
+  int otherValue = 42;
+
+  int test() const { return otherValue - pair->test(); }
+  int testMutable() { return otherValue - pair->test(); }
+
+  static RefHoldingPairPtr *create() {
+    RefHoldingPairPtr *out =
+        new (malloc(sizeof(RefHoldingPairPtr))) RefHoldingPairPtr();
+    out->pair = new (malloc(sizeof(IntPair))) IntPair();
+    return out;
+  }
+};
+
+struct ValueHoldingPair {
+  IntPair pair;
+  int otherValue = 3;
+
+  int test() const { return otherValue - pair.test(); }
+  int testMutable() { return otherValue - pair.test(); }
+
+  static ValueHoldingPair *create() {
+    return new (malloc(sizeof(ValueHoldingPair))) ValueHoldingPair();
+  }
+};
+
+struct __attribute__((swift_attr("import_as_ref"))) BigType {
+  int a = 1;
+  int b = 2;
+  char buffer[32];
+
+  int test() const { return b - a; }
+  int testMutable() { return b - a; }
+
+  static BigType *create() { return new (malloc(sizeof(BigType))) BigType(); }
+};
+
+void mutateIt(BigType &x) {
+  x.a = 2;
+  x.b = 4;
+}
+BigType passThroughByValue(BigType x) { return x; }
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_POD_H

--- a/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
@@ -1,0 +1,89 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_SINGLETON_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_SINGLETON_H
+
+#include <new>
+#include <stdlib.h>
+
+#include "visibility.h"
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+struct __attribute__((swift_attr("import_as_ref"))) DeletedDtor {
+  int value = 42;
+
+  DeletedDtor() = default;
+  DeletedDtor(const DeletedDtor &) = default;
+  DeletedDtor(DeletedDtor &&) = default;
+  ~DeletedDtor() = delete;
+
+  int test() const { return value; }
+  int testMutable() { return value; }
+
+  static DeletedDtor *create() {
+    return new (malloc(sizeof(DeletedDtor))) DeletedDtor();
+  }
+};
+
+void mutateIt(DeletedDtor &x) { x.value = 32; }
+
+struct __attribute__((swift_attr("import_as_ref"))) PrivateDtor {
+  int value = 42;
+
+  PrivateDtor() = default;
+  PrivateDtor(const PrivateDtor &) = default;
+  PrivateDtor(PrivateDtor &&) = default;
+
+  int test() const { return value; }
+  int testMutable() { return value; }
+
+  static PrivateDtor *create() {
+    return new (malloc(sizeof(PrivateDtor))) PrivateDtor();
+  }
+
+private:
+  ~PrivateDtor() {}
+};
+
+void mutateIt(PrivateDtor &x) { x.value = 32; }
+
+struct __attribute__((swift_attr("import_as_ref"))) DeletedSpecialMembers {
+  int value = 42;
+
+  DeletedSpecialMembers() = default;
+  DeletedSpecialMembers(const DeletedSpecialMembers &) = delete;
+  DeletedSpecialMembers(DeletedSpecialMembers &&) = delete;
+  ~DeletedSpecialMembers() = delete;
+
+  int test() const { return value; }
+  int testMutable() { return value; }
+
+  static DeletedSpecialMembers *create() {
+    return new (malloc(sizeof(DeletedSpecialMembers))) DeletedSpecialMembers();
+  }
+};
+
+void mutateIt(DeletedSpecialMembers &x) { x.value = 32; }
+
+struct __attribute__((swift_attr("import_as_ref"))) PrivateSpecialMembers {
+  int value = 42;
+
+  PrivateSpecialMembers() = default;
+
+  int test() const { return value; }
+  int testMutable() { return value; }
+
+  static PrivateSpecialMembers *create() {
+    return new (malloc(sizeof(PrivateSpecialMembers))) PrivateSpecialMembers();
+  }
+
+private:
+  PrivateSpecialMembers(const PrivateSpecialMembers &) = default;
+  PrivateSpecialMembers(PrivateSpecialMembers &&) = default;
+  ~PrivateSpecialMembers() = default;
+};
+
+void mutateIt(PrivateSpecialMembers &x) { x.value = 32; }
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_SINGLETON_H

--- a/test/Interop/Cxx/foreign-reference/Inputs/visibility.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/visibility.h
@@ -1,0 +1,25 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_VISIBILITY_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_VISIBILITY_H
+
+#if __has_feature(nullability)
+// Provide macros to temporarily suppress warning about the use of
+// _Nullable and _Nonnull.
+# define SWIFT_BEGIN_NULLABILITY_ANNOTATIONS                                   \
+  _Pragma("clang diagnostic push")                                             \
+  _Pragma("clang diagnostic ignored \"-Wnullability-extension\"")              \
+  _Pragma("clang assume_nonnull begin")
+# define SWIFT_END_NULLABILITY_ANNOTATIONS                                     \
+  _Pragma("clang diagnostic pop")                                              \
+  _Pragma("clang assume_nonnull end")
+
+#else
+// #define _Nullable and _Nonnull to nothing if we're not being built
+// with a compiler that supports them.
+# define _Nullable
+# define _Nonnull
+# define _Null_unspecified
+# define SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+# define SWIFT_END_NULLABILITY_ANNOTATIONS
+#endif
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_VISIBILITY_H

--- a/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
@@ -1,0 +1,53 @@
+#ifndef TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_WITNESS_TABLE_H
+#define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_WITNESS_TABLE_H
+
+#include <new>
+#include <stdlib.h>
+#include <utility>
+
+struct __attribute__((swift_attr("import_as_ref"))) CxxLinkedList {
+  int value = 3;
+
+  CxxLinkedList * _Nullable next() {
+    if (value == 3)
+      return nullptr;
+
+    return this + 1;
+  }
+};
+
+CxxLinkedList * _Nonnull makeLinkedList() {
+  CxxLinkedList *buff = (CxxLinkedList *)malloc(sizeof(CxxLinkedList) * 4);
+  buff[0].value = 0;
+  buff[1].value = 1;
+  buff[2].value = 2;
+  buff[3].value = 3;
+  return buff;
+}
+
+struct __attribute__((swift_attr("import_as_ref"))) CxxSequence {
+  CxxLinkedList * _Nullable list = nullptr;
+
+  CxxLinkedList * _Nullable next() {
+    if (list->value == 3)
+      return nullptr;
+
+    auto * _Nullable tmp = list;
+    list = tmp + 1;
+    return tmp;
+  }
+};
+
+CxxSequence * _Nonnull makeSequence() {
+  CxxLinkedList *buff = (CxxLinkedList *)malloc(sizeof(CxxLinkedList) * 4);
+  buff[0].value = 0;
+  buff[1].value = 1;
+  buff[2].value = 2;
+  buff[3].value = 3;
+
+  CxxSequence *seq = (CxxSequence *)malloc(sizeof(CxxSequence));
+  seq->list = buff;
+  return seq;
+}
+
+#endif // TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_WITNESS_TABLE_H

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+
+import MoveOnly
+
+// TODO: this should not be opaque.
+// CHECK: %TSo8MoveOnlyV = type opaque
+// CHECK: %struct.MoveOnly = type { i8 }
+
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
+
+// CHECK: [[X:%.*]] = alloca %TSo8MoveOnlyV*
+// CHECK: [[TMP:%.*]] = alloca %TSo8MoveOnlyV*
+
+// CHECK: [[CREATED:%.*]] = call %struct.MoveOnly* @{{_ZN8MoveOnly6createEv|"\?create\@MoveOnly\@\@SAPEAU1\@XZ"}}()
+// CHECK: [[SWIFT_CREATED:%.*]] = bitcast %struct.MoveOnly* [[CREATED]] to %TSo8MoveOnlyV*
+// CHECK: store %TSo8MoveOnlyV* [[SWIFT_CREATED]], %TSo8MoveOnlyV** [[X]]
+// CHECK: store %TSo8MoveOnlyV* [[SWIFT_CREATED]], %TSo8MoveOnlyV** [[TMP]]
+
+// CHECK: [[TMP_LOAD:%.*]] = load %TSo8MoveOnlyV*, %TSo8MoveOnlyV** [[TMP]]
+// CHECK: [[CLANG_CREATED:%.*]] = bitcast %TSo8MoveOnlyV* [[TMP_LOAD]] to %struct.MoveOnly*
+// CHECK: call i32 @{{_ZNK8MoveOnly4testEv|"\?test\@MoveOnly\@\@QEBAHXZ"}}(%struct.MoveOnly* [[CLANG_CREATED]])
+
+// CHECK: ret void
+
+public func test() {
+  var x = MoveOnly.create()
+  _ = x.test()
+}

--- a/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnly -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK-NOT: init
+// CHECK: class MoveOnly {
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> MoveOnly
+// CHECK: }
+// CHECK-NOT: func moveIntoResult(_ x: MoveOnly) -> MoveOnly
+
+// CHECK: class HasMoveOnlyChild {
+// CHECK-NOT:   var child: MoveOnly
+// CHECK:   class func create() -> HasMoveOnlyChild
+// CHECK: }
+// CHECK-NOT: func moveIntoResult(_ x: HasMoveOnlyChild) -> HasMoveOnlyChild
+
+// CHECK: class PrivateCopyCtor {
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> PrivateCopyCtor
+// CHECK: }
+// CHECK-NOT: func moveIntoResult(_ x: PrivateCopyCtor) -> PrivateCopyCtor
+
+// CHECK: class BadCopyCtor {
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> BadCopyCtor
+// CHECK: }
+// CHECK-NOT: func moveIntoResult(_ x: BadCopyCtor) -> BadCopyCtor

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import MoveOnly
+
+// CHECK-NOT: borrow
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK-LABEL: sil [ossa] @$s4main4testyyF : $@convention(thin) () -> ()
+
+// CHECK: [[BOX:%.*]] = project_box {{.*}} : ${ var MoveOnly }, 0
+
+// CHECK: [[CREATE_FN:%.*]] = function_ref @{{_ZN8MoveOnly6createEv|\?create\@MoveOnly\@\@SAPEAU1\@XZ}} : $@convention(c) () -> MoveOnly
+// CHECK: [[CREATED_PTR:%.*]] = apply [[CREATE_FN]]() : $@convention(c) () -> MoveOnly
+// CHECK: store [[CREATED_PTR]] to [trivial] [[BOX]] : $*MoveOnly
+// CHECK: [[ACCESS_1:%.*]] = begin_access [read] [unknown] [[BOX]] : $*MoveOnly
+// CHECK: [[X_1:%.*]] = load [trivial] [[ACCESS_1]] : $*MoveOnly
+
+// CHECK: [[TMP:%.*]] = alloc_stack $MoveOnly
+// CHECK: store [[X_1]] to [trivial] [[TMP]]
+
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed MoveOnly) -> Int32
+// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(c) (@in_guaranteed MoveOnly) -> Int32
+
+// CHECK: return
+// CHECK-LABEL: end sil function '$s4main4testyyF'
+public func test() {
+  var x = MoveOnly.create()
+  _ = x.test()
+}
+
+// CHECK-LABEL: sil [clang MoveOnly.create] @{{_ZN8MoveOnly6createEv|\?create\@MoveOnly\@\@SAPEAU1\@XZ}} : $@convention(c) () -> MoveOnly
+
+// CHECK-LABEL: sil [clang MoveOnly.test] @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed MoveOnly) -> Int32

--- a/test/Interop/Cxx/foreign-reference/move-only.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import MoveOnly
+
+@inline(never)
+func blackHole<T>(_ t: T) { }
+
+var MoveOnlyTestSuite = TestSuite("Move only types that are marked as foreign references")
+
+MoveOnlyTestSuite.test("MoveOnly") {
+  var x = MoveOnly.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  x = MoveOnly.create()
+  expectEqual(x.test(), 42)
+}
+
+MoveOnlyTestSuite.test("PrivateCopyCtor") {
+  var x = PrivateCopyCtor.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  x = PrivateCopyCtor.create()
+  expectEqual(x.test(), 42)
+}
+
+MoveOnlyTestSuite.test("BadCopyCtor") {
+  var x = BadCopyCtor.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  x = BadCopyCtor.create()
+  expectEqual(x.test(), 42)
+
+  let t = (x, x) // Copy this around just to make sure we don't call the copy ctor.
+  blackHole(t)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/not-any-object.swift
+++ b/test/Interop/Cxx/foreign-reference/not-any-object.swift
@@ -1,0 +1,26 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-cxx-interop
+
+//--- Inputs/module.modulemap
+module Test {
+  header "test.h"
+  requires cplusplus
+}
+
+//--- Inputs/test.h
+#include <new>
+#include <stdlib.h>
+
+struct __attribute__((swift_attr("import_as_ref"))) Empty {
+  static Empty *create() { return new (malloc(sizeof(Empty))) Empty(); }
+};
+
+//--- test.swift
+
+import Test;
+
+public func test(_ _: AnyObject) {}
+
+// TODO: make this a better error.
+test(Empty.create()) // expected-error {{type of expression is ambiguous without more context}}

--- a/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Nullable -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: class Empty {
+// CHECK:   func test() -> Int32
+// CHECK:   class func create() -> Empty!
+// CHECK:   init()
+// CHECK: }
+// CHECK: func mutateIt(_: Empty)
+
+// CHECK: class IntPair {
+// CHECK:   var a: Int32
+// CHECK:   var b: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   class func create() -> IntPair!
+// CHECK:   init()
+// CHECK: }
+// CHECK: func mutateIt(_ x: IntPair!)

--- a/test/Interop/Cxx/foreign-reference/nullable.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable.swift
@@ -1,0 +1,34 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Nullable
+
+var NullableTestSuite = TestSuite("Foreign references that are nullable")
+
+NullableTestSuite.test("Empty") {
+  var x = Empty.create()
+  expectEqual(x!.test(), 42)
+
+  mutateIt(x!)
+
+  x = Empty.create() ?? Empty.create()!
+  expectEqual(x!.test(), 42)
+}
+
+NullableTestSuite.test("IntPair") {
+  var x = IntPair.create()
+  expectEqual(x!.test(), 1)
+
+  mutateIt(x)
+  expectEqual(x!.test(), 2)
+
+  x!.b = 42
+  expectEqual(x!.test(), 40)
+
+  x = IntPair.create() ?? IntPair.create()!
+  expectEqual(x!.test(), 1)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+
+import POD
+
+// TODO: this should not be opaque.
+// CHECK: %TSo7IntPairV = type opaque
+// CHECK: %struct.IntPair = type { i32, i32 }
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
+
+// CHECK: [[X:%.*]] = alloca %TSo7IntPairV*
+// CHECK: [[TMP:%.*]] = alloca %TSo7IntPairV*
+
+// CHECK: [[CREATED:%.*]] = call %struct.IntPair* @{{_ZN7IntPair6createEv|"\?create\@IntPair\@\@SAPEAU1\@XZ"}}()
+// CHECK: [[SWIFT_CREATED:%.*]] = bitcast %struct.IntPair* [[CREATED]] to %TSo7IntPairV*
+// CHECK: store %TSo7IntPairV* [[SWIFT_CREATED]], %TSo7IntPairV** [[X]]
+// CHECK: store %TSo7IntPairV* [[SWIFT_CREATED]], %TSo7IntPairV** [[TMP]]
+
+// CHECK: [[TMP_LOAD:%.*]] = load %TSo7IntPairV*, %TSo7IntPairV** [[TMP]]
+// CHECK: [[CLANG_CREATED:%.*]] = bitcast %TSo7IntPairV* [[TMP_LOAD]] to %struct.IntPair*
+// CHECK: call i32 @{{_ZNK7IntPair4testEv|"\?test\@IntPair\@\@QEBAHXZ"}}(%struct.IntPair* [[CLANG_CREATED]])
+
+// CHECK: ret void
+
+public func test() {
+  var x = IntPair.create()
+  _ = x.test()
+}

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK-NOT: init
+// CHECK: class Empty {
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> Empty
+// CHECK: }
+// CHECK: func mutateIt(_: Empty)
+// CHECK-NOT: func passThroughByValue(_ x: Empty) -> Empty
+
+// CHECK: class MultipleAttrs {
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> MultipleAttrs
+// CHECK: }
+
+// CHECK: class IntPair {
+// CHECK:   var a: Int32
+// CHECK:   var b: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> IntPair
+// CHECK: }
+// CHECK: func mutateIt(_ x: IntPair)
+// CHECK-NOT: func passThroughByValue(_ x: IntPair) -> IntPair
+
+// CHECK: class RefHoldingPair {
+// CHECK-NOT: pair
+// CHECK:   var otherValue: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> RefHoldingPair
+// CHECK: }
+
+// CHECK: class RefHoldingPairRef {
+// CHECK:   var pair: IntPair
+// CHECK:   var otherValue: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> RefHoldingPairRef
+// CHECK: }
+
+// CHECK: class RefHoldingPairPtr {
+// CHECK:   var pair: IntPair
+// CHECK:   var otherValue: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> RefHoldingPairPtr
+// CHECK: }
+
+// CHECK: struct ValueHoldingPair {
+// CHECK-NOT: pair
+// CHECK:   init()
+// CHECK:   var otherValue: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   mutating func testMutable() -> Int32
+// CHECK:   static func create() -> UnsafeMutablePointer<ValueHoldingPair>
+// CHECK: }
+
+// CHECK: class BigType {
+// CHECK:   var a: Int32
+// CHECK:   var b: Int32
+// CHECK:   var buffer:
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> BigType
+// CHECK: }
+// CHECK: func mutateIt(_ x: BigType)
+// CHECK-NOT: func passThroughByValue(_ x: BigType) -> BigType

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import POD
+
+// CHECK-NOT: borrow
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK-LABEL: sil [ossa] @$s4main4testyyF : $@convention(thin) () -> ()
+
+// CHECK: [[BOX:%.*]] = project_box {{.*}} : ${ var IntPair }, 0
+
+// CHECK: [[CREATE_FN:%.*]] = function_ref @{{_ZN7IntPair6createEv|\?create\@IntPair\@\@SAPEAU1\@XZ}} : $@convention(c) () -> IntPair
+// CHECK: [[CREATED_PTR:%.*]] = apply [[CREATE_FN]]() : $@convention(c) () -> IntPair
+// CHECK: store [[CREATED_PTR]] to [trivial] [[BOX]] : $*IntPair
+// CHECK: [[ACCESS_1:%.*]] = begin_access [read] [unknown] [[BOX]] : $*IntPair
+// CHECK: [[X_1:%.*]] = load [trivial] [[ACCESS_1]] : $*IntPair
+
+// CHECK: [[TMP:%.*]] = alloc_stack $IntPair
+// CHECK: store [[X_1]] to [trivial] [[TMP]]
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed IntPair) -> Int32
+// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(c) (@in_guaranteed IntPair) -> Int32
+
+// CHECK: return
+// CHECK-LABEL: end sil function '$s4main4testyyF'
+public func test() {
+  var x = IntPair.create()
+  _ = x.test()
+}
+
+// CHECK-LABEL: sil [clang IntPair.create] @{{_ZN7IntPair6createEv|\?create\@IntPair\@\@SAPEAU1\@XZ}} : $@convention(c) () -> IntPair
+
+// CHECK-LABEL: sil [clang IntPair.test] @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed IntPair) -> Int32

--- a/test/Interop/Cxx/foreign-reference/pod.swift
+++ b/test/Interop/Cxx/foreign-reference/pod.swift
@@ -1,0 +1,150 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import POD
+
+struct StructHoldingPair {
+  var pair: IntPair
+};
+
+class ClassHoldingPair {
+  var pair: IntPair
+
+  init(pair: IntPair) { self.pair = pair }
+};
+
+var globalPair: IntPair? = nil
+
+var PODTestSuite = TestSuite("Plain old data types that are marked as foreign references")
+
+PODTestSuite.test("Empty") {
+  var x = Empty.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  mutateIt(x)
+
+  x = Empty.create()
+  expectEqual(x.test(), 42)
+}
+
+PODTestSuite.test("var IntPair") {
+  var x = IntPair.create()
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
+
+  mutateIt(x)
+  expectEqual(x.test(), 2)
+  expectEqual(x.testMutable(), 2)
+
+  x.b = 42
+  expectEqual(x.test(), 40)
+  expectEqual(x.testMutable(), 40)
+
+  x = IntPair.create()
+  expectEqual(x.test(), 1)
+}
+
+PODTestSuite.test("let IntPair") {
+  let x = IntPair.create()
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
+
+  mutateIt(x)
+  expectEqual(x.test(), 2)
+  expectEqual(x.testMutable(), 2)
+
+  x.b = 42
+  expectEqual(x.test(), 40)
+  expectEqual(x.testMutable(), 40)
+}
+
+PODTestSuite.test("global") {
+  globalPair = IntPair.create()
+  expectEqual(globalPair!.test(), 1)
+  expectEqual(globalPair!.testMutable(), 1)
+
+  mutateIt(globalPair!)
+  expectEqual(globalPair!.test(), 2)
+  expectEqual(globalPair!.testMutable(), 2)
+
+  globalPair!.b = 42
+  expectEqual(globalPair!.test(), 40)
+  expectEqual(globalPair!.testMutable(), 40)
+
+  globalPair = IntPair.create()
+  expectEqual(globalPair!.test(), 1)
+}
+
+PODTestSuite.test("RefHoldingPairRef") {
+  var x = RefHoldingPairRef.create()
+  expectEqual(x.test(), 41)
+  expectEqual(x.testMutable(), 41)
+
+  x.pair.b = 42
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
+
+  x = RefHoldingPairRef.create()
+  expectEqual(x.test(), 41)
+}
+
+PODTestSuite.test("RefHoldingPairPtr") {
+  var x = RefHoldingPairPtr.create()
+  expectEqual(x.test(), 41)
+  expectEqual(x.testMutable(), 41)
+
+  x.pair.b = 42
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
+
+  x = RefHoldingPairPtr.create()
+  expectEqual(x.test(), 41)
+}
+
+PODTestSuite.test("StructHoldingPair") {
+  var x = StructHoldingPair(pair: IntPair.create())
+  expectEqual(x.pair.test(), 1)
+  expectEqual(x.pair.testMutable(), 1)
+
+  mutateIt(x.pair)
+  expectEqual(x.pair.test(), 2)
+  expectEqual(x.pair.testMutable(), 2)
+
+  x.pair = IntPair.create()
+  expectEqual(x.pair.test(), 1)
+}
+
+PODTestSuite.test("ClassHoldingPair") {
+  var x = ClassHoldingPair(pair: IntPair.create())
+  expectEqual(x.pair.test(), 1)
+  expectEqual(x.pair.testMutable(), 1)
+
+  mutateIt(x.pair)
+  expectEqual(x.pair.test(), 2)
+  expectEqual(x.pair.testMutable(), 2)
+
+  x.pair = IntPair.create()
+  expectEqual(x.pair.test(), 1)
+}
+
+PODTestSuite.test("BigType") {
+  var x = BigType.create()
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
+
+  mutateIt(x)
+  expectEqual(x.test(), 2)
+  expectEqual(x.testMutable(), 2)
+
+  x.b = 42
+  expectEqual(x.test(), 40)
+  expectEqual(x.testMutable(), 40)
+
+  x = BigType.create()
+  expectEqual(x.test(), 1)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+
+import Singleton
+
+// TODO: this should not be opaque.
+// CHECK: %TSo21DeletedSpecialMembersV = type opaque
+// CHECK: %struct.DeletedSpecialMembers = type { i32 }
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
+
+// CHECK: [[X:%.*]] = alloca %TSo21DeletedSpecialMembersV*
+// CHECK: [[TMP:%.*]] = alloca %TSo21DeletedSpecialMembersV*
+
+// CHECK: [[CREATED:%.*]] = call %struct.DeletedSpecialMembers* @{{_ZN21DeletedSpecialMembers6createEv|"\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ"}}()
+// CHECK: [[SWIFT_CREATED:%.*]] = bitcast %struct.DeletedSpecialMembers* [[CREATED]] to %TSo21DeletedSpecialMembersV*
+// CHECK: store %TSo21DeletedSpecialMembersV* [[SWIFT_CREATED]], %TSo21DeletedSpecialMembersV** [[X]]
+// CHECK: store %TSo21DeletedSpecialMembersV* [[SWIFT_CREATED]], %TSo21DeletedSpecialMembersV** [[TMP]]
+
+// CHECK: [[TMP_LOAD:%.*]] = load %TSo21DeletedSpecialMembersV*, %TSo21DeletedSpecialMembersV** [[TMP]]
+// CHECK: [[CLANG_CREATED:%.*]] = bitcast %TSo21DeletedSpecialMembersV* [[TMP_LOAD]] to %struct.DeletedSpecialMembers*
+// CHECK: call i32 @{{_ZNK21DeletedSpecialMembers4testEv|"\?test\@DeletedSpecialMembers\@\@QEBAHXZ"}}(%struct.DeletedSpecialMembers* [[CLANG_CREATED]])
+
+// CHECK: [[FROM:%.*]] = bitcast %TSo21DeletedSpecialMembersV* [[SWIFT_CREATED]] to %struct.DeletedSpecialMembers*
+// CHECK: call void @{{_Z8mutateItR21DeletedSpecialMembers|"\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z"}}(%struct.DeletedSpecialMembers* [[FROM]])
+
+// CHECK: ret void
+
+public func test() {
+  var x = DeletedSpecialMembers.create()
+  _ = x.test()
+  mutateIt(x)
+}

--- a/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Singleton -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK-NOT: init
+// CHECK: class DeletedDtor {
+// CHECK:   var value: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> DeletedDtor
+// CHECK: }
+// CHECK: func mutateIt(_ x: DeletedDtor)
+
+// CHECK: class PrivateDtor {
+// CHECK:   var value: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> PrivateDtor
+// CHECK: }
+// CHECK: func mutateIt(_ x: PrivateDtor)
+
+// CHECK: class DeletedSpecialMembers {
+// CHECK:   var value: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> DeletedSpecialMembers
+// CHECK: }
+// CHECK: func mutateIt(_ x: DeletedSpecialMembers)
+
+// CHECK: class PrivateSpecialMembers {
+// CHECK:   var value: Int32
+// CHECK:   func test() -> Int32
+// CHECK:   func testMutable() -> Int32
+// CHECK:   class func create() -> PrivateSpecialMembers
+// CHECK: }
+// CHECK: func mutateIt(_ x: PrivateSpecialMembers)

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import Singleton
+
+// CHECK-NOT: borrow
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK-LABEL: sil [ossa] @$s4main4testyyF : $@convention(thin) () -> ()
+
+// CHECK: [[BOX:%.*]] = project_box {{.*}} : ${ var DeletedSpecialMembers }, 0
+
+// CHECK: [[CREATE_FN:%.*]] = function_ref @{{_ZN21DeletedSpecialMembers6createEv|\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ}} : $@convention(c) () -> DeletedSpecialMembers
+// CHECK: [[CREATED_PTR:%.*]] = apply [[CREATE_FN]]() : $@convention(c) () -> DeletedSpecialMembers
+// CHECK: store [[CREATED_PTR]] to [trivial] [[BOX]] : $*DeletedSpecialMembers
+// CHECK: [[ACCESS_1:%.*]] = begin_access [read] [unknown] [[BOX]] : $*DeletedSpecialMembers
+// CHECK: [[X_1:%.*]] = load [trivial] [[ACCESS_1]] : $*DeletedSpecialMembers
+
+// CHECK: [[TMP:%.*]] = alloc_stack $DeletedSpecialMembers
+// CHECK: store [[X_1]] to [trivial] [[TMP]]
+
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed DeletedSpecialMembers) -> Int32
+// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(c) (@in_guaranteed DeletedSpecialMembers) -> Int32
+// CHECK: [[ACCESS_2:%.*]] = begin_access [read] [unknown] [[BOX]] : $*DeletedSpecialMembers
+// CHECK: [[X_2:%.*]] = load [trivial] [[ACCESS_2]] : $*DeletedSpecialMembers
+
+// CHECK: [[MOVE_IN_RES_FN:%.*]] = function_ref @{{_Z8mutateItR21DeletedSpecialMembers|\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z}} : $@convention(c) (DeletedSpecialMembers) -> ()
+// CHECK: apply [[MOVE_IN_RES_FN]]([[X_2]]) : $@convention(c) (DeletedSpecialMembers) -> ()
+
+// CHECK: return
+// CHECK-LABEL: end sil function '$s4main4testyyF'
+public func test() {
+  var x = DeletedSpecialMembers.create()
+  _ = x.test()
+  mutateIt(x)
+}
+
+// CHECK-LABEL: sil [clang DeletedSpecialMembers.create] @{{_ZN21DeletedSpecialMembers6createEv|\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ}} : $@convention(c) () -> DeletedSpecialMembers
+
+// CHECK-LABEL: sil [clang DeletedSpecialMembers.test] @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(c) (@in_guaranteed DeletedSpecialMembers) -> Int32
+
+// CHECK-LABEL: sil [serializable] [clang mutateIt] @{{_Z8mutateItR21DeletedSpecialMembers|\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z}} : $@convention(c) (DeletedSpecialMembers) -> ()

--- a/test/Interop/Cxx/foreign-reference/singleton.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton.swift
@@ -1,0 +1,74 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Singleton
+
+var SingletonTestSuite = TestSuite("Singleton types that are marked as foreign references")
+
+SingletonTestSuite.test("DeletedDtor") {
+  var x = DeletedDtor.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  mutateIt(x)
+  expectEqual(x.test(), 32)
+
+  x = DeletedDtor.create()
+  expectEqual(x.test(), 42)
+
+  x.value = 22
+  expectEqual(x.value, 22)
+  expectEqual(x.test(), 22)
+}
+
+SingletonTestSuite.test("PrivateDtor") {
+  var x = PrivateDtor.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  mutateIt(x)
+  expectEqual(x.test(), 32)
+
+  x = PrivateDtor.create()
+  expectEqual(x.test(), 42)
+
+  x.value = 22
+  expectEqual(x.value, 22)
+  expectEqual(x.test(), 22)
+}
+
+SingletonTestSuite.test("DeletedSpecialMembers") {
+  var x = DeletedSpecialMembers.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  mutateIt(x)
+  expectEqual(x.test(), 32)
+
+  x = DeletedSpecialMembers.create()
+  expectEqual(x.test(), 42)
+
+  x.value = 22
+  expectEqual(x.value, 22)
+  expectEqual(x.test(), 22)
+}
+
+SingletonTestSuite.test("PrivateSpecialMembers") {
+  var x = PrivateSpecialMembers.create()
+  expectEqual(x.test(), 42)
+  expectEqual(x.testMutable(), 42)
+
+  mutateIt(x)
+  expectEqual(x.test(), 32)
+
+  x = PrivateSpecialMembers.create()
+  expectEqual(x.test(), 42)
+
+  x.value = 22
+  expectEqual(x.value, 22)
+  expectEqual(x.test(), 22)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -1,0 +1,56 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import WitnessTable
+
+public protocol ListNode {
+  associatedtype Element
+  func next() -> Element?
+}
+
+public struct List<NodeType: ListNode> : Sequence, IteratorProtocol
+      where NodeType.Element == NodeType {
+  private var currentNode: NodeType?
+
+  public init(startingAt start: NodeType?) { currentNode = start }
+
+  public mutating func next() -> NodeType? {
+    if let node = currentNode {
+      currentNode = node.next()
+      return node
+    }
+    return nil
+  }
+}
+
+extension CxxLinkedList : ListNode { }
+
+var WitnessTableTestSuite = TestSuite("Use foreign reference in a generic context")
+
+WitnessTableTestSuite.test("As generic argument to List") {
+  let first = makeLinkedList()
+  let list = List(startingAt: first)
+  var count = 0
+  for e in list {
+    expectEqual(count, Int(e.value))
+    count += 1
+  }
+  expectEqual(count, 4)
+}
+
+extension CxxSequence : Sequence, IteratorProtocol { }
+
+WitnessTableTestSuite.test("As a Sequence") {
+  let list = makeSequence()
+  var count = 0
+  for e in list {
+    expectEqual(count, Int(e.value))
+    count += 1
+  }
+  expectEqual(count, 3)
+}
+
+runAllTests()
+


### PR DESCRIPTION
This is an expiremental feature to allow an attribute, `import_as_ref`, to import a C++ record as a non-reference-counted reference type in Swift.

This includes a poor implementation of struct metadata for foreign reference types.