### PR TITLE
Module aliasing: Resolve deps graph with real module names when scanning dependencies

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -100,7 +100,9 @@ void ModuleDependencies::addModuleDependencies(
     if (!importDecl)
       continue;
 
-    addModuleDependency(importDecl->getModulePath(), &alreadyAddedModules);
+    ImportPath::Builder scratch;
+    auto realPath = importDecl->getRealModulePath(scratch);
+    addModuleDependency(realPath, &alreadyAddedModules);
   }
 
   auto fileName = sf.getFilename();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1685,6 +1685,7 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   if (subInstance.setup(subInvocation)) {
     return std::make_error_code(std::errc::not_supported);
   }
+
   info.BuildArguments = BuildArgs;
   info.Hash = CacheHash;
   auto target = *(std::find(BuildArgs.rbegin(), BuildArgs.rend(), "-target") - 1);
@@ -1826,7 +1827,12 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 
 bool ExplicitSwiftModuleLoader::canImportModule(
     ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
-  StringRef moduleName = mID.Item.str();
+  // Look up the module with the real name (physical name on disk);
+  // in case `-module-alias` is used, the name appearing in source files
+  // and the real module name are different. For example, '-module-alias Foo=Bar'
+  // maps Foo appearing in source files, e.g. 'import Foo', to the real module
+  // name Bar (on-disk name), which should be searched for loading.
+  StringRef moduleName = Ctx.getRealModuleName(mID.Item).str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no provided explicit module matches the name, then it cannot be imported.
   if (it == Impl.ExplicitModuleMap.end()) {

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -1,0 +1,50 @@
+/// Test -scan-dependencies module aliasing.
+///
+/// Module 'Lib' imports module 'XLogging' via module aliasing and with various import attributes.
+/// Module 'User' imports 'Lib'.
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+/// Create AppleLogging.swiftmodule by aliasing XLogging
+// RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
+// RUN: test -f %t/AppleLogging.swiftmodule
+
+/// Scaned dependencies should contain real name AppleLogging
+// RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
+// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
+// CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
+// CHECK-REAL-NAME-NOT: "compiledModulePath":{{.*}}XLogging.swiftmodule",
+// CHECK-REAL-NAME: "swiftPrebuiltExternal": "AppleLogging"
+// CHECK-REAL-NAME: "compiledModulePath":{{.*}}AppleLogging.swiftmodule",
+
+/// Create AppleLoggingIF.swiftinterface by aliasing XLogging
+///
+// RUN: %target-swift-frontend -module-name AppleLoggingIF %t/FileLogging.swift -module-alias XLogging=AppleLoggingIF -I %t -emit-module -emit-module-interface-path %t/AppleLoggingIF.swiftinterface -swift-version 5 -enable-library-evolution -I %t
+// RUN: test -f %t/AppleLoggingIF.swiftinterface
+
+/// Scaned dependencies should contain real name AppleLoggingIF
+// RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
+// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
+// CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"
+// CHECK-REAL-NAME-IF-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
+// CHECK-REAL-NAME-IF: "swift": "AppleLoggingIF"
+// CHECK-REAL-NAME-IF: "moduleInterfacePath":{{.*}}AppleLoggingIF.swiftinterface
+
+// BEGIN FileLogging.swift
+public struct Logger {
+  public init() {}
+  public func startLogging() {}
+}
+public func setup() -> XLogging.Logger? {
+  return Logger()
+}
+
+// BEGIN FileLib.swift
+import XLogging
+
+public func start() {
+  let it = Logger()
+  it.startLogging()
+}
+

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
 // RUN: test -f %t/AppleLogging.swiftmodule
 
-/// Scaned dependencies with implicit builds should contain real name AppleLogging
+/// Scaned dependencies should contain real name AppleLogging
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
 // CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
@@ -18,35 +18,18 @@
 // CHECK-REAL-NAME: "swiftPrebuiltExternal": "AppleLogging"
 // CHECK-REAL-NAME: "compiledModulePath":{{.*}}AppleLogging.swiftmodule",
 
-/// Scaned dependencies with explicit builds should contain real name AppleLogging
-// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-swift-modules %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandumpExplicit.output
-// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-EXP -input-file  %t/scandumpExplicit.output
-// CHECK-REAL-NAME-EXP-NOT: "swiftPrebuiltExternal": "XLogging"
-// CHECK-REAL-NAME-EXP-NOT: "compiledModulePath":{{.*}}XLogging.swiftmodule",
-// CHECK-REAL-NAME-EXP: "swiftPrebuiltExternal": "AppleLogging"
-// CHECK-REAL-NAME-EXP: "compiledModulePath":{{.*}}AppleLogging.swiftmodule",
-
 /// Create AppleLoggingIF.swiftinterface by aliasing XLogging
 ///
 // RUN: %target-swift-frontend -module-name AppleLoggingIF %t/FileLogging.swift -module-alias XLogging=AppleLoggingIF -I %t -emit-module -emit-module-interface-path %t/AppleLoggingIF.swiftinterface -swift-version 5 -enable-library-evolution -I %t
 // RUN: test -f %t/AppleLoggingIF.swiftinterface
 
-/// Scaned dependencies with implicit builds should contain real name AppleLoggingIF
+/// Scaned dependencies should contain real name AppleLoggingIF
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
 // CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"
 // CHECK-REAL-NAME-IF-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
 // CHECK-REAL-NAME-IF: "swift": "AppleLoggingIF"
 // CHECK-REAL-NAME-IF: "moduleInterfacePath":{{.*}}AppleLoggingIF.swiftinterface
-
-/// Scaned dependencies with explicit builds should contain real name AppleLoggingIF
-// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-swift-modules %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
-// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF-EXP -input-file  %t/scandumpIF.output
-// CHECK-REAL-NAME-IF-EXP-NOT: "swift": "XLogging"
-// CHECK-REAL-NAME-IF-EXP-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
-// CHECK-REAL-NAME-IF-EXP: "swift": "AppleLoggingIF"
-// CHECK-REAL-NAME-IF-EXP: "moduleInterfacePath":{{.*}}AppleLoggingIF.swiftinterface
-
 
 // BEGIN FileLogging.swift
 public struct Logger {

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
 // RUN: test -f %t/AppleLogging.swiftmodule
 
-/// Scaned dependencies should contain real name AppleLogging
+/// Scaned dependencies with implicit builds should contain real name AppleLogging
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
 // CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
@@ -18,18 +18,35 @@
 // CHECK-REAL-NAME: "swiftPrebuiltExternal": "AppleLogging"
 // CHECK-REAL-NAME: "compiledModulePath":{{.*}}AppleLogging.swiftmodule",
 
+/// Scaned dependencies with explicit builds should contain real name AppleLogging
+// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-swift-modules %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandumpExplicit.output
+// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-EXP -input-file  %t/scandumpExplicit.output
+// CHECK-REAL-NAME-EXP-NOT: "swiftPrebuiltExternal": "XLogging"
+// CHECK-REAL-NAME-EXP-NOT: "compiledModulePath":{{.*}}XLogging.swiftmodule",
+// CHECK-REAL-NAME-EXP: "swiftPrebuiltExternal": "AppleLogging"
+// CHECK-REAL-NAME-EXP: "compiledModulePath":{{.*}}AppleLogging.swiftmodule",
+
 /// Create AppleLoggingIF.swiftinterface by aliasing XLogging
 ///
 // RUN: %target-swift-frontend -module-name AppleLoggingIF %t/FileLogging.swift -module-alias XLogging=AppleLoggingIF -I %t -emit-module -emit-module-interface-path %t/AppleLoggingIF.swiftinterface -swift-version 5 -enable-library-evolution -I %t
 // RUN: test -f %t/AppleLoggingIF.swiftinterface
 
-/// Scaned dependencies should contain real name AppleLoggingIF
+/// Scaned dependencies with implicit builds should contain real name AppleLoggingIF
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
 // CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"
 // CHECK-REAL-NAME-IF-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
 // CHECK-REAL-NAME-IF: "swift": "AppleLoggingIF"
 // CHECK-REAL-NAME-IF: "moduleInterfacePath":{{.*}}AppleLoggingIF.swiftinterface
+
+/// Scaned dependencies with explicit builds should contain real name AppleLoggingIF
+// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-swift-modules %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
+// RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF-EXP -input-file  %t/scandumpIF.output
+// CHECK-REAL-NAME-IF-EXP-NOT: "swift": "XLogging"
+// CHECK-REAL-NAME-IF-EXP-NOT: "moduleInterfacePath":{{.*}}XLogging.swiftinterface
+// CHECK-REAL-NAME-IF-EXP: "swift": "AppleLoggingIF"
+// CHECK-REAL-NAME-IF-EXP: "moduleInterfacePath":{{.*}}AppleLoggingIF.swiftinterface
+
 
 // BEGIN FileLogging.swift
 public struct Logger {


### PR DESCRIPTION
Resolved dependencies should contain the real module name if module aliasing is used. 
Resolves rdar://85991587.
