### PR TITLE
[Sema] Don't insert an @_spi on imports for clang SPIs

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -28,7 +28,6 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
-#include "swift/Strings.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -318,23 +317,6 @@ void ImportResolver::bindImport(UnboundImport &&I) {
       ID.get()->setModule(nullptr);
     return;
   }
-  // If the imported module is a clang module, add an implicit import statement
-  // to request the SPIs from the module.
-  if (M->isNonSwiftModule() && ID &&
-      !ID.get()->getAttrs().hasAttribute<SPIAccessControlAttr>()) {
-    ImportDecl *id = ID.get();
-    auto *newId = ImportDecl::create(id->getASTContext(), id->getDeclContext(),
-      SourceLoc(), id->getImportKind(), SourceLoc(), id->getImportPath());
-    // Copy all the existing attribute from the actual import statement.
-    llvm::for_each(id->getAttrs(),
-                  [&](DeclAttribute *attr) {newId->getAttrs().add(attr);});
-    // Add SPI attribute with the default group name.
-    newId->getAttrs().add(SPIAccessControlAttr::create(id->getASTContext(),
-      SourceLoc(), SourceRange(),
-      { ctx.getIdentifier(CLANG_MODULE_DEFUALT_SPI_GROUP_NAME) }));
-    // So we'll resolve the new import.
-    unboundImports.push_back(UnboundImport(newId));
-  }
 
   auto topLevelModule = I.getTopLevelModule(M, SF);
 
@@ -492,8 +474,6 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
   auto *clangImporter =
       static_cast<ClangImporter *>(ctx.getClangModuleLoader());
 
-  SmallVector<Identifier, 4> clangSpiGroups;
-  clangSpiGroups.push_back(ctx.getIdentifier(CLANG_MODULE_DEFUALT_SPI_GROUP_NAME));
   // Implicitly import the bridging header module if needed.
   auto bridgingHeaderPath = importInfo.BridgingHeaderPath;
   if (!bridgingHeaderPath.empty() &&
@@ -501,8 +481,6 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
     auto *headerModule = clangImporter->getImportedHeaderModule();
     assert(headerModule && "Didn't load bridging header?");
     imports.emplace_back(ImportedModule(headerModule), ImportFlags::Exported);
-    imports.back().options |= ImportFlags::SPIAccessControl;
-    imports.back().spiGroups = ctx.AllocateCopy(clangSpiGroups);
   }
 
   // Implicitly import the underlying Clang half of this module if needed.
@@ -513,8 +491,6 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
     unloadedImports.emplace_back(UnloadedImportedModule(importPath.copyTo(ctx),
                                                         /*isScoped=*/false),
                                  ImportFlags::Exported);
-    unloadedImports.back().options |= ImportFlags::SPIAccessControl;
-    unloadedImports.back().spiGroups = ctx.AllocateCopy(clangSpiGroups);
   }
 
   return { ctx.AllocateCopy(imports), ctx.AllocateCopy(unloadedImports) };


### PR DESCRIPTION
This attribute is no more needed as we now fast-track accepting all Objective-C SPIs at access control since #39586.

rdar://85617355