### PR TITLE
tests: disable StringMemoryTest.swift, which fails with ASAN

### DIFF
--- a/validation-test/stdlib/StringMemoryTest.swift
+++ b/validation-test/stdlib/StringMemoryTest.swift
@@ -7,6 +7,8 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar85913190
+
 import Foundation
 
 let str = "abcdefg\u{A758}hijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\u{A759}"


### PR DESCRIPTION
rdar://85913190
