### PR TITLE
Revert "Emit Debug Variables for Errors Bound in Catch Clauses"

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3007,10 +3007,6 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
     // If we don't have a multi-pattern 'catch', we can emit the
     // body inline. Emit the statement here and bail early.
     if (clause->getCaseLabelItems().size() == 1) {
-      // Debug values for catch clause variables must be nested within a scope for
-      // the catch block to avoid name conflicts.
-      DebugScope scope(*this, CleanupLocation(clause));
-
       // If we have case body vars, set them up to point at the matching var
       // decls.
       if (clause->hasCaseBodyVariables()) {
@@ -3031,11 +3027,6 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
             // Ok, we found a match. Update the VarLocs for the case block.
             auto v = VarLocs[vd];
             VarLocs[expected] = v;
-
-            // Emit a debug description of the incoming arg, nested within the scope
-            // for the pattern match.
-            SILDebugVariable dbgVar(vd->isLet(), /*ArgNo=*/0);
-            B.emitDebugDescription(vd, v.value, dbgVar);
           }
         }
       }

--- a/test/DebugInfo/catch_let.swift
+++ b/test/DebugInfo/catch_let.swift
@@ -9,45 +9,14 @@ func throwing() throws -> () {
 
 func use<T>(_ t: T) {}
 
-// CHECK-LABEL: define {{.*}}explicitBinding{{.*}}
-public func explicitBinding() {
+public func foo() {
   do {
     try throwing()
   }
   catch let error {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[EXPLICIT_ERROR:[0-9]+]],
+    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[ERROR:[0-9]+]],
+    // CHECK: ![[ERROR]] = !DILocalVariable(name: "error"
     use(error)
   }
 }
-explicitBinding()
-
-// CHECK-LABEL: define {{.*}}implicitBinding{{.*}}
-public func implicitBinding() {
-  do {
-    try throwing()
-  }
-  catch {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[IMPLICIT_ERROR:[0-9]+]],
-    use(error)
-  }
-}
-implicitBinding()
-
-// CHECK-LABEL: define {{.*}}multiBinding{{.*}}
-public func multiBinding() {
-  do {
-    try throwing()
-  }
-  catch let error as MyError, let error as MyError {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[MULTI_BINDING_ERROR:[0-9]+]],
-    // CHECK-NOT: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}
-    use(error)
-  } catch {
-    use(error)
-  }
-}
-multiBinding()
-
-// CHECK: ![[EXPLICIT_ERROR]] = !DILocalVariable(name: "error"
-// CHECK: ![[IMPLICIT_ERROR]] = !DILocalVariable(name: "error"
-// CHECK: ![[MULTI_BINDING_ERROR]] = !DILocalVariable(name: "error"
+foo();

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -108,7 +108,6 @@ func dont_return<T>(_ argument: T) throws -> T {
 //   Catch HomeworkError.CatAteIt.
 // CHECK:    [[MATCH]]([[T0:%.*]] : @owned $Cat):
 // CHECK-NEXT: [[BORROWED_T0:%.*]] = begin_borrow [lexical] [[T0]]
-// CHECK-NEXT: debug_value [[BORROWED_T0]] : $Cat
 // CHECK-NEXT: [[T0_COPY:%.*]] = copy_value [[BORROWED_T0]]
 // CHECK-NEXT: end_borrow [[BORROWED_T0]]
 // CHECK-NEXT: destroy_value [[T0]]


### PR DESCRIPTION
Reverts apple/swift#40372

This regressed the windows CI: https://ci-external.swift.org/job/swift-PR-windows/18932/consoleText