### PR TITLE
build_swift: Drop support for Python 2

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -8,13 +8,9 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
 """
 The ultimate tool for building Swift.
 """
-
-
-from __future__ import absolute_import, print_function, unicode_literals
 
 import json
 import os
@@ -31,8 +27,6 @@ from build_swift.build_swift.constants import BUILD_SCRIPT_IMPL_PATH
 from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
-
-import six
 
 from swift_build_support.swift_build_support import build_script_invocation
 from swift_build_support.swift_build_support import shell
@@ -120,7 +114,7 @@ class JSONDumper(json.JSONEncoder):
     def default(self, o):
         if hasattr(o, '__dict__'):
             return vars(o)
-        return six.text_type(o)
+        return str(o)
 
 
 def print_xcodebuild_versions(file=sys.stdout):
@@ -499,7 +493,7 @@ def main_preset():
     try:
         preset_parser.read_files(args.preset_file_names)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     if args.show_presets:
         for name in sorted(preset_parser.preset_names,
@@ -520,7 +514,7 @@ def main_preset():
             args.preset,
             vars=args.preset_substitutions)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     preset_args = migration.migrate_swift_sdks(preset.args)
 

--- a/utils/build_swift/README.md
+++ b/utils/build_swift/README.md
@@ -8,5 +8,5 @@ the Swift build-script.
 You may run the unit test suite using the command:
 
 ```sh
-$ python utils/build_swift/run_tests.py
+$ python3 utils/build_swift/run_tests.py
 ```

--- a/utils/build_swift/build_swift/argparse/__init__.py
+++ b/utils/build_swift/build_swift/argparse/__init__.py
@@ -14,8 +14,6 @@ constructing parsers and more argument types. This module exposes a strict
 super-set of the argparse API and is meant to be used as a drop-in replacement.
 """
 
-from __future__ import absolute_import, unicode_literals
-
 from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
                       ArgumentTypeError, FileType, HelpFormatter,
                       Namespace, RawDescriptionHelpFormatter,

--- a/utils/build_swift/build_swift/argparse/actions.py
+++ b/utils/build_swift/build_swift/argparse/actions.py
@@ -12,13 +12,8 @@ Hierarchy of action classes which support multiple destinations, similar to the
 default actions provided by the standard argparse.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import argparse
 import copy
-
-import six
 
 from .types import BoolType, PathType
 
@@ -81,7 +76,7 @@ class Action(argparse.Action):
         if dests == argparse.SUPPRESS:
             dests = []
             metavar = metavar or ''
-        elif isinstance(dests, six.string_types):
+        elif isinstance(dests, str):
             dests = [dests]
             metavar = metavar or dests[0].upper()
 
@@ -138,7 +133,7 @@ class AppendAction(Action):
             **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = [values]
 
         for dest in self.dests:
@@ -343,5 +338,5 @@ class UnsupportedAction(Action):
         if self.message is not None:
             parser.error(self.message)
 
-        arg = option_string or six.text_type(values)
+        arg = option_string or str(values)
         parser.error('unsupported argument: {}'.format(arg))

--- a/utils/build_swift/build_swift/argparse/parser.py
+++ b/utils/build_swift/build_swift/argparse/parser.py
@@ -13,13 +13,8 @@ destination actions as well as a new builder DSL for declaratively
 constructing complex parsers.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import argparse
 from contextlib import contextmanager
-
-import six
 
 from . import Namespace, SUPPRESS, actions
 from .actions import Action
@@ -133,7 +128,7 @@ class _Builder(object):
             *names, action=action, **kwargs)
 
     def add_positional(self, dests, action=None, **kwargs):
-        if isinstance(dests, six.string_types):
+        if isinstance(dests, str):
             dests = [dests]
 
         if any(dest.startswith('-') for dest in dests):
@@ -145,7 +140,7 @@ class _Builder(object):
         return self._add_argument(dests, action, **kwargs)
 
     def add_option(self, option_strings, *actions, **kwargs):
-        if isinstance(option_strings, six.string_types):
+        if isinstance(option_strings, str):
             option_strings = [option_strings]
 
         if not all(opt.startswith('-') for opt in option_strings):

--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -12,14 +12,9 @@ Argument types useful for enforcing data-integrity and form when parsing
 arguments.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import re
 import shlex
-
-import six
 
 from . import ArgumentTypeError
 from ..versions import Version
@@ -42,7 +37,7 @@ def _repr(cls, args):
     """
 
     _args = []
-    for key, value in six.iteritems(args):
+    for key, value in args.items():
         _args.append('{}={}'.format(key, repr(value)))
 
     return '{}({})'.format(type(cls).__name__, ', '.join(_args))

--- a/utils/build_swift/build_swift/cache_utils.py
+++ b/utils/build_swift/build_swift/cache_utils.py
@@ -11,9 +11,6 @@
 Cache related utitlity functions and decorators.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 
 

--- a/utils/build_swift/build_swift/class_utils.py
+++ b/utils/build_swift/build_swift/class_utils.py
@@ -12,9 +12,6 @@ Class utility functions and decorators.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
-
 __all__ = [
     'generate_repr',
 ]

--- a/utils/build_swift/build_swift/constants.py
+++ b/utils/build_swift/build_swift/constants.py
@@ -6,11 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os.path
 
 

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -11,9 +11,6 @@
 Default option value definitions.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import multiprocessing
 import os
 

--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -11,14 +11,8 @@
 Temporary module with functionality used to migrate away from build-script-impl.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import itertools
 import subprocess
-
-import six
-from six.moves import map
 
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
@@ -137,4 +131,4 @@ def check_impl_args(build_script_impl, args):
     _, err = pipe.communicate()
 
     if pipe.returncode != 0:
-        raise ValueError(six.text_type(err.splitlines()[0].decode()))
+        raise ValueError(err.splitlines()[0].decode())

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -11,9 +11,6 @@
 Swift preset parsing and handling functionality.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import io
 from collections import OrderedDict, namedtuple

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -15,8 +15,8 @@ import functools
 import io
 from collections import OrderedDict, namedtuple
 
-from six import StringIO
-from six.moves import configparser
+from io import StringIO
+import configparser
 
 from . import class_utils
 

--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -11,13 +11,7 @@
 Version parsing classes.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
-
-import six
-
 
 __all__ = [
     'InvalidVersionError',
@@ -175,7 +169,7 @@ class Version(object):
     __slots__ = ('components', '_str')
 
     def __init__(self, version):
-        version = six.text_type(version)
+        version = str(version)
 
         # Save the version string since it's impossible to reconstruct it from
         # just the parsed components

--- a/utils/build_swift/build_swift/wrappers/__init__.py
+++ b/utils/build_swift/build_swift/wrappers/__init__.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 from . import xcrun as _xcrun
 
 

--- a/utils/build_swift/build_swift/wrappers/xcrun.py
+++ b/utils/build_swift/build_swift/wrappers/xcrun.py
@@ -11,14 +11,9 @@
 Wrapper module around the 'xcrun' command-line utility.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import re
 import shlex
-
-import six
 
 from .. import shell
 from ..versions import Version
@@ -61,7 +56,7 @@ def _prepend_sdk_and_toolchain(func):
 
     @functools.wraps(func)
     def wrapper(self, args, sdk=None, toolchain=None, **kwargs):
-        if isinstance(args, six.string_types):
+        if isinstance(args, str):
             args = shlex.split(args)
         if toolchain:
             args = ['--toolchain', toolchain] + args

--- a/utils/build_swift/run_tests.py
+++ b/utils/build_swift/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -12,9 +12,6 @@
 """
 Utility script used to easily run the build_swift module unit tests.
 """
-
-
-from __future__ import absolute_import, unicode_literals
 
 import argparse
 import os

--- a/utils/build_swift/tests/build_swift/argparse/test_actions.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_actions.py
@@ -6,15 +6,10 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift.argparse import (
     ArgumentParser, BoolType, Nargs, PathType, SUPPRESS, actions)
-
-import six
 
 from ... import utils
 
@@ -186,7 +181,7 @@ class TestStoreIntAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.StoreIntAction)
 
         for i in [0, 1, 42, -64]:
-            args = parser.parse_args(['--foo', six.text_type(i)])
+            args = parser.parse_args(['--foo', str(i)])
             self.assertEqual(args.foo, i)
 
     def test_invalid_int(self):
@@ -195,7 +190,7 @@ class TestStoreIntAction(unittest.TestCase):
 
         for i in [0.0, True, 'bar']:
             with utils.quiet_output(), self.assertRaises(SystemExit):
-                parser.parse_args(['--foo', six.text_type(i)])
+                parser.parse_args(['--foo', str(i)])
 
 
 class TestStoreTrueAction(unittest.TestCase):
@@ -301,7 +296,7 @@ class TestToggleTrueAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
         for value in BoolType.TRUE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -312,7 +307,7 @@ class TestToggleTrueAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
         for value in BoolType.FALSE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -363,7 +358,7 @@ class TestToggleFalseAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
         for value in BoolType.TRUE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -374,7 +369,7 @@ class TestToggleFalseAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
         for value in BoolType.FALSE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])

--- a/utils/build_swift/tests/build_swift/argparse/test_parser.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_parser.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 from argparse import _ArgumentGroup, _MutuallyExclusiveGroup
 

--- a/utils/build_swift/tests/build_swift/argparse/test_types.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_types.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import platform
 import unittest

--- a/utils/build_swift/tests/build_swift/test_cache_utils.py
+++ b/utils/build_swift/tests/build_swift/test_cache_utils.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift import cache_utils

--- a/utils/build_swift/tests/build_swift/test_constants.py
+++ b/utils/build_swift/tests/build_swift/test_constants.py
@@ -6,10 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import os.path
 import unittest
 

--- a/utils/build_swift/tests/build_swift/test_defaults.py
+++ b/utils/build_swift/tests/build_swift/test_defaults.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift import defaults

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import sys
@@ -19,8 +16,6 @@ from build_swift import constants
 from build_swift import driver_arguments
 from build_swift import migration
 from build_swift.presets import PresetParser
-
-import six
 
 from .test_presets import PRESET_DEFAULTS
 from .. import expected_options as eo
@@ -80,9 +75,6 @@ class TestDriverArgumentParserMeta(type):
             test_name = 'test_preset_{}'.format(name)
             attrs[test_name] = cls.generate_preset_test(name, args)
 
-        if six.PY2:
-            name = str(name)
-
         return super(TestDriverArgumentParserMeta, cls).__new__(
             cls, name, bases, attrs)
 
@@ -92,8 +84,6 @@ class TestDriverArgumentParserMeta(type):
             parsed_values = self.parse_default_args([])
 
             parsed_value = getattr(parsed_values, dest)
-            if default_value.__class__ in six.string_types:
-                parsed_value = six.text_type(parsed_value)
 
             self.assertEqual(default_value, parsed_value,
                              'Invalid default value for "{}": {} != {}'
@@ -215,7 +205,7 @@ class TestDriverArgumentParserMeta(type):
         def test(self):
             for choice in option.choices:
                 namespace = self.parse_args(
-                    [option.option_string, six.text_type(choice)])
+                    [option.option_string, str(choice)])
                 self.assertEqual(getattr(namespace, option.dest), choice)
 
             with self.assertRaises(ParserError):
@@ -228,13 +218,13 @@ class TestDriverArgumentParserMeta(type):
         def test(self):
             for i in [0, 1, 42]:
                 namespace = self.parse_args(
-                    [option.option_string, six.text_type(i)])
+                    [option.option_string, str(i)])
                 self.assertEqual(int(getattr(namespace, option.dest)), i)
 
             # FIXME: int-type options should not accept non-int strings
-            # self.parse_args([option.option_string, six.text_type(0.0)])
-            # self.parse_args([option.option_string, six.text_type(1.0)])
-            # self.parse_args([option.option_string, six.text_type(3.14)])
+            # self.parse_args([option.option_string, str(0.0)])
+            # self.parse_args([option.option_string, str(1.0)])
+            # self.parse_args([option.option_string, str(3.14)])
             # self.parse_args([option.option_string, 'NaN'])
 
         return test
@@ -335,15 +325,15 @@ class TestDriverArgumentParserMeta(type):
         return test
 
 
-@six.add_metaclass(TestDriverArgumentParserMeta)
-class TestDriverArgumentParser(unittest.TestCase):
+class TestDriverArgumentParser(unittest.TestCase,
+                               metaclass=TestDriverArgumentParserMeta):
 
     def _parse_args(self, args):
         try:
             return migration.parse_args(self.parser, args)
         except (SystemExit, ValueError) as e:
             raise ParserError('failed to parse arguments: {} {}'.format(
-                six.text_type(args), e))
+                str(args), e))
 
     def _check_impl_args(self, namespace):
         assert hasattr(namespace, 'build_script_impl_args')
@@ -354,7 +344,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                 namespace.build_script_impl_args)
         except (SystemExit, ValueError) as e:
             raise ParserError('failed to parse impl arguments: {} {}'.format(
-                six.text_type(namespace.build_script_impl_args), e))
+                str(namespace.build_script_impl_args), e))
 
     def parse_args_and_unknown_args(self, args, namespace=None):
         if namespace is None:
@@ -370,7 +360,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                         namespace, unknown_args))
             except (SystemExit, argparse.ArgumentError) as e:
                 raise ParserError('failed to parse arguments: {} {}'.format(
-                    six.text_type(args), e))
+                    str(args), e))
 
         return namespace, unknown_args
 
@@ -380,7 +370,7 @@ class TestDriverArgumentParser(unittest.TestCase):
 
         if unknown_args:
             raise ParserError('unknown arguments: {}'.format(
-                six.text_type(unknown_args)))
+                str(unknown_args)))
 
         return namespace
 

--- a/utils/build_swift/tests/build_swift/test_migration.py
+++ b/utils/build_swift/tests/build_swift/test_migration.py
@@ -6,17 +6,12 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import platform
 import unittest
 
 from build_swift import argparse
 from build_swift import migration
 from build_swift.constants import BUILD_SCRIPT_IMPL_PATH
-
-import six
 
 from swift_build_support.swift_build_support.targets import StdlibDeploymentTarget
 
@@ -66,8 +61,7 @@ class TestMigrateSwiftSDKsMeta(type):
         return test
 
 
-@six.add_metaclass(TestMigrateSwiftSDKsMeta)
-class TestMigrateSwiftSDKs(unittest.TestCase):
+class TestMigrateSwiftSDKs(unittest.TestCase, metaclass=TestMigrateSwiftSDKsMeta):
 
     def test_empty_swift_sdks(self):
         args = migration.migrate_swift_sdks(['--swift-sdks='])

--- a/utils/build_swift/tests/build_swift/test_presets.py
+++ b/utils/build_swift/tests/build_swift/test_presets.py
@@ -6,9 +6,7 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import unicode_literals
-
+import configparser
 import os
 import unittest
 
@@ -16,8 +14,6 @@ from build_swift import constants
 from build_swift import presets
 from build_swift.presets import Preset, PresetParser
 
-import six
-from six.moves import configparser
 
 from .. import utils
 
@@ -158,8 +154,7 @@ class TestPresetParserMeta(type):
         return test
 
 
-@six.add_metaclass(TestPresetParserMeta)
-class TestPresetParser(unittest.TestCase):
+class TestPresetParser(unittest.TestCase, metaclass=TestPresetParserMeta):
 
     def test_read_files(self):
         parser = PresetParser()

--- a/utils/build_swift/tests/build_swift/test_versions.py
+++ b/utils/build_swift/tests/build_swift/test_versions.py
@@ -6,14 +6,9 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift.versions import Version
-
-import six
 
 
 class TestVersion(unittest.TestCase):
@@ -59,7 +54,7 @@ class TestVersion(unittest.TestCase):
     # -------------------------------------------------------------------------
 
     def test_parse(self):
-        for string, components in six.iteritems(self.VERSION_COMPONENTS):
+        for string, components in self.VERSION_COMPONENTS.items():
             # Version parses
             version = Version(string)
 
@@ -90,7 +85,7 @@ class TestVersion(unittest.TestCase):
         self.assertVersionLess('a0b', 'a1')
 
     def test_str(self):
-        for string in six.iterkeys(self.VERSION_COMPONENTS):
+        for string in self.VERSION_COMPONENTS.keys():
             version = Version(string)
 
-            self.assertEqual(six.text_type(version), string)
+            self.assertEqual(str(version), string)

--- a/utils/build_swift/tests/build_swift/wrappers/test_xcrun.py
+++ b/utils/build_swift/tests/build_swift/wrappers/test_xcrun.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import unittest
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import multiprocessing
 
 from build_swift import argparse

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -6,21 +6,15 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import os
 import platform
 import sys
 import unittest
+from io import StringIO
 
 from build_swift import cache_utils
 from build_swift.versions import Version
-
-import six
-from six import StringIO
-
 
 __all__ = [
     'quiet_output',
@@ -161,7 +155,7 @@ def requires_python(version):
     greater or equal to the required version.
     """
 
-    if isinstance(version, six.string_types):
+    if isinstance(version, str):
         version = Version(version)
 
     if _PYTHON_VERSION >= version:


### PR DESCRIPTION
This converts the `build_swift` module to support Python 3 (only). It removes all `from __future__` imports, conditional python2 imports, and any use of the `six` module.

It also removes the subprocess workaround for getting output as a string, instead using the `encoding` parameter to decode the output as UTF-8.
