### PR TITLE
[SourceKit] Compute type relations for global code completion items from the cache

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -1400,7 +1400,8 @@ public:
   virtual void
   handleResultsAndModules(CodeCompletionContext &context,
                           ArrayRef<RequestedCachedModule> requestedModules,
-                          DeclContext *DC) = 0;
+                          DeclContext *DC,
+                          const ExpectedTypeContext &TypeContext) = 0;
 };
 
 /// A simplified code completion consumer interface that clients can use to get
@@ -1411,7 +1412,8 @@ struct SimpleCachingCodeCompletionConsumer : public CodeCompletionConsumer {
   // Implement the CodeCompletionConsumer interface.
   void handleResultsAndModules(CodeCompletionContext &context,
                                ArrayRef<RequestedCachedModule> requestedModules,
-                               DeclContext *DCForModules) override;
+                               DeclContext *DCForModules,
+                               const ExpectedTypeContext &TypeContext) override;
 
   /// Clients should override this method to receive \p Results.
   virtual void handleResults(CodeCompletionContext &context) = 0;

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -418,7 +418,7 @@ public:
 ///
 /// This enum is ordered from the contexts that are "nearest" to the code
 /// completion point to "outside" contexts.
-enum class SemanticContextKind {
+enum class SemanticContextKind : uint8_t {
   /// Used in cases when the concept of semantic context is not applicable.
   None,
 
@@ -482,7 +482,7 @@ enum class CodeCompletionFlairBit: uint8_t {
 using CodeCompletionFlair = OptionSet<CodeCompletionFlairBit>;
 
 /// The declaration kind of a code completion result, if it is a declaration.
-enum class CodeCompletionDeclKind {
+enum class CodeCompletionDeclKind : uint8_t {
   Module,
   Class,
   Struct,
@@ -508,7 +508,7 @@ enum class CodeCompletionDeclKind {
   PrecedenceGroup,
 };
 
-enum class CodeCompletionLiteralKind {
+enum class CodeCompletionLiteralKind : uint8_t {
   ArrayLiteral,
   BooleanLiteral,
   ColorLiteral,
@@ -520,7 +520,7 @@ enum class CodeCompletionLiteralKind {
   Tuple,
 };
 
-enum class CodeCompletionOperatorKind {
+enum class CodeCompletionOperatorKind : uint8_t {
   None,
   Unknown,
   Bang,       // !
@@ -566,14 +566,14 @@ enum class CodeCompletionOperatorKind {
   TildeEq,          // ~=
 };
 
-enum class CodeCompletionKeywordKind {
+enum class CodeCompletionKeywordKind : uint8_t {
   None,
 #define KEYWORD(X) kw_##X,
 #define POUND_KEYWORD(X) pound_##X,
 #include "swift/Syntax/TokenKinds.def"
 };
 
-enum class CompletionKind {
+enum class CompletionKind : uint8_t {
   None,
   Import,
   UnresolvedMember,
@@ -625,7 +625,7 @@ class CodeCompletionResult {
   friend class CodeCompletionResultBuilder;
 
 public:
-  enum class ResultKind {
+  enum class ResultKind : uint8_t {
     Declaration,
     Keyword,
     Pattern,
@@ -635,7 +635,7 @@ public:
 
   /// Describes the relationship between the type of the completion results and
   /// the expected type at the code completion position.
-  enum class ExpectedTypeRelation {
+  enum class ExpectedTypeRelation : uint8_t {
     /// The result does not have a type (e.g. keyword).
     NotApplicable,
 
@@ -656,7 +656,7 @@ public:
     Identical,
   };
 
-  enum class NotRecommendedReason {
+  enum class NotRecommendedReason : uint8_t {
     None = 0,
     RedundantImport,
     RedundantImportIndirect,
@@ -668,13 +668,13 @@ public:
   };
 
 private:
-  unsigned Kind : 3;
+  ResultKind Kind : 3;
   unsigned AssociatedKind : 8;
-  unsigned KnownOperatorKind : 6;
-  unsigned SemanticContext : 3;
-  unsigned Flair: 8;
-  unsigned NotRecommended : 4;
-  unsigned IsSystem : 1;
+  CodeCompletionOperatorKind KnownOperatorKind : 6;
+  SemanticContextKind SemanticContext : 3;
+  unsigned char Flair : 8;
+  NotRecommendedReason NotRecommended : 4;
+  bool IsSystem : 1;
 
   /// The number of bytes to the left of the code completion point that
   /// should be erased first if this completion string is inserted in the
@@ -689,8 +689,8 @@ private:
   StringRef ModuleName;
   StringRef BriefDocComment;
   ArrayRef<StringRef> AssociatedUSRs;
-  unsigned TypeDistance : 3;
-  unsigned DiagnosticSeverity: 3;
+  ExpectedTypeRelation TypeDistance : 3;
+  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
   StringRef DiagnosticMessage;
 
 public:
@@ -704,22 +704,20 @@ public:
                        CodeCompletionOperatorKind KnownOperatorKind =
                            CodeCompletionOperatorKind::None,
                        StringRef BriefDocComment = StringRef())
-      : Kind(unsigned(Kind)), KnownOperatorKind(unsigned(KnownOperatorKind)),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(Kind), KnownOperatorKind(KnownOperatorKind),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(unsigned(TypeDistance)) {
+        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(Kind != ResultKind::Declaration && "use the other constructor");
     assert(CompletionString);
     if (isOperator() && KnownOperatorKind == CodeCompletionOperatorKind::None)
-      this->KnownOperatorKind =
-          (unsigned)getCodeCompletionOperatorKind(CompletionString);
+      this->KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
     assert(!isOperator() ||
            getOperatorKind() != CodeCompletionOperatorKind::None);
     AssociatedKind = 0;
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
   }
 
   /// Constructs a \c Keyword result.
@@ -731,16 +729,16 @@ public:
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance,
                        StringRef BriefDocComment = StringRef())
-      : Kind(unsigned(ResultKind::Keyword)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(ResultKind::Keyword),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(unsigned(TypeDistance)) {
+        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(CompletionString);
     AssociatedKind = static_cast<unsigned>(Kind);
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
   }
 
   /// Constructs a \c Literal result.
@@ -751,15 +749,15 @@ public:
                        CodeCompletionFlair Flair, unsigned NumBytesToErase,
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance)
-      : Kind(unsigned(ResultKind::Literal)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())),
-        NotRecommended(unsigned(NotRecommendedReason::None)),
+      : Kind(ResultKind::Literal),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecommendedReason::None),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        TypeDistance(unsigned(TypeDistance)) {
+        TypeDistance(TypeDistance) {
     AssociatedKind = static_cast<unsigned>(LiteralKind);
-    IsSystem = 0;
-    DiagnosticSeverity = 0;
+    IsSystem = false;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
     assert(CompletionString);
   }
 
@@ -776,20 +774,20 @@ public:
                        StringRef BriefDocComment,
                        ArrayRef<StringRef> AssociatedUSRs,
                        ExpectedTypeRelation TypeDistance)
-      : Kind(unsigned(ResultKind::Declaration)), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())), NotRecommended(unsigned(NotRecReason)),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
-        AssociatedUSRs(AssociatedUSRs), TypeDistance(unsigned(TypeDistance)) {
+      : Kind(ResultKind::Declaration),
+        KnownOperatorKind(CodeCompletionOperatorKind::None),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecReason), NumBytesToErase(NumBytesToErase),
+        CompletionString(CompletionString), ModuleName(ModuleName),
+        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
+        TypeDistance(TypeDistance) {
     assert(AssociatedDecl && "should have a decl");
     AssociatedKind = unsigned(getCodeCompletionDeclKind(AssociatedDecl));
     IsSystem = getDeclIsSystem(AssociatedDecl);
-    DiagnosticSeverity = 0;
+    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
     assert(CompletionString);
     if (isOperator())
-      KnownOperatorKind =
-          (unsigned)getCodeCompletionOperatorKind(CompletionString);
+      KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
     assert(!isOperator() ||
            getOperatorKind() != CodeCompletionOperatorKind::None);
   }
@@ -806,16 +804,13 @@ public:
                        ArrayRef<StringRef> AssociatedUSRs,
                        ExpectedTypeRelation TypeDistance,
                        CodeCompletionOperatorKind KnownOperatorKind)
-      : Kind(unsigned(ResultKind::Declaration)),
-        KnownOperatorKind(unsigned(KnownOperatorKind)),
-        SemanticContext(unsigned(SemanticContext)),
-        Flair(unsigned(Flair.toRaw())), NotRecommended(unsigned(NotRecReason)),
-        IsSystem(IsSystem), NumBytesToErase(NumBytesToErase),
-        CompletionString(CompletionString), ModuleName(ModuleName),
-        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
-        TypeDistance(unsigned(TypeDistance)),
-        DiagnosticSeverity(unsigned(diagSeverity)),
-        DiagnosticMessage(DiagnosticMessage) {
+      : Kind(ResultKind::Declaration), KnownOperatorKind(KnownOperatorKind),
+        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
+        NotRecommended(NotRecReason), IsSystem(IsSystem),
+        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
+        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
+        AssociatedUSRs(AssociatedUSRs), TypeDistance(TypeDistance),
+        DiagnosticSeverity(diagSeverity), DiagnosticMessage(DiagnosticMessage) {
     AssociatedKind = static_cast<unsigned>(DeclKind);
     assert(CompletionString);
     assert(!isOperator() ||
@@ -828,7 +823,7 @@ public:
   CodeCompletionResult *withFlair(CodeCompletionFlair newFlair,
                                   CodeCompletionResultSink &Sink);
 
-  ResultKind getKind() const { return static_cast<ResultKind>(Kind); }
+  ResultKind getKind() const { return Kind; }
 
   CodeCompletionDeclKind getAssociatedDeclKind() const {
     assert(getKind() == ResultKind::Declaration);
@@ -860,33 +855,23 @@ public:
 
   CodeCompletionOperatorKind getOperatorKind() const {
     assert(isOperator());
-    return static_cast<CodeCompletionOperatorKind>(KnownOperatorKind);
+    return KnownOperatorKind;
   }
 
-  bool isSystem() const {
-    return static_cast<bool>(IsSystem);
-  }
+  bool isSystem() const { return IsSystem; }
 
-  ExpectedTypeRelation getExpectedTypeRelation() const {
-    return static_cast<ExpectedTypeRelation>(TypeDistance);
-  }
+  ExpectedTypeRelation getExpectedTypeRelation() const { return TypeDistance; }
 
   NotRecommendedReason getNotRecommendedReason() const {
-    return static_cast<NotRecommendedReason>(NotRecommended);
+    return NotRecommended;
   }
 
-  SemanticContextKind getSemanticContext() const {
-    return static_cast<SemanticContextKind>(SemanticContext);
-  }
+  SemanticContextKind getSemanticContext() const { return SemanticContext; }
 
-  CodeCompletionFlair getFlair() const {
-    return static_cast<CodeCompletionFlair>(Flair);
-  }
+  CodeCompletionFlair getFlair() const { return CodeCompletionFlair(Flair); }
 
   /// Modify "flair" of this result *in place*.
-  void setFlair(CodeCompletionFlair flair) {
-    Flair = unsigned(flair.toRaw());
-  }
+  void setFlair(CodeCompletionFlair flair) { Flair = flair.toRaw(); }
 
   bool isNotRecommended() const {
     return getNotRecommendedReason() != NotRecommendedReason::None;
@@ -911,12 +896,12 @@ public:
   }
 
   void setDiagnostics(CodeCompletionDiagnosticSeverity severity, StringRef message) {
-    DiagnosticSeverity = static_cast<unsigned>(severity);
+    DiagnosticSeverity = severity;
     DiagnosticMessage = message;
   }
 
   CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
-    return static_cast<CodeCompletionDiagnosticSeverity>(DiagnosticSeverity);
+    return DiagnosticSeverity;
   }
 
   StringRef getDiagnosticMessage() const {

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -452,6 +452,8 @@ enum class SemanticContextKind : uint8_t {
 
   /// A declaration imported from other module.
   OtherModule,
+
+  MAX_VALUE = OtherModule
 };
 
 enum class CodeCompletionFlairBit: uint8_t {
@@ -564,6 +566,8 @@ enum class CodeCompletionOperatorKind : uint8_t {
   PipeEq,           // |=
   PipePipe,         // ||
   TildeEq,          // ~=
+
+  MAX_VALUE = TildeEq
 };
 
 enum class CodeCompletionKeywordKind : uint8_t {
@@ -612,12 +616,14 @@ enum class CompletionKind : uint8_t {
   TypeAttrBeginning,
 };
 
-enum class CodeCompletionDiagnosticSeverity: uint8_t {
+enum class CodeCompletionDiagnosticSeverity : uint8_t {
   None,
   Error,
   Warning,
   Remark,
   Note,
+
+  MAX_VALUE = Note
 };
 
 /// A single code completion result.
@@ -631,6 +637,8 @@ public:
     Pattern,
     Literal,
     BuiltinOperator,
+
+    MAX_VALUE = BuiltinOperator
   };
 
   /// Describes the relationship between the type of the completion results and
@@ -654,6 +662,8 @@ public:
 
     /// The result's type is identical to the type of the expected.
     Identical,
+
+    MAX_VALUE = Identical
   };
 
   enum class NotRecommendedReason : uint8_t {
@@ -665,6 +675,8 @@ public:
     InvalidAsyncContext,
     CrossActorReference,
     VariableUsedInOwnDefinition,
+
+    MAX_VALUE = VariableUsedInOwnDefinition
   };
 
 private:
@@ -692,6 +704,14 @@ private:
   ExpectedTypeRelation TypeDistance : 3;
   CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
   StringRef DiagnosticMessage;
+
+  // Assertions for limiting max values of enums.
+  static_assert(int(ResultKind::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(CodeCompletionOperatorKind::MAX_VALUE) < 1 << 6, "");
+  static_assert(int(SemanticContextKind::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(NotRecommendedReason::MAX_VALUE) < 1 << 4, "");
+  static_assert(int(ExpectedTypeRelation::MAX_VALUE) < 1 << 3, "");
+  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
 
 public:
   /// Constructs a \c Pattern, \c Keyword or \c BuiltinOperator result.

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -58,8 +58,16 @@ public:
   };
 
   struct Value : public llvm::ThreadSafeRefCountedBase<Value> {
+    using AllocatorPtr = std::shared_ptr<llvm::BumpPtrAllocator>;
+
+    /// The allocator used to allocate the results stored in this cache.
+    AllocatorPtr Allocator;
+
     llvm::sys::TimePoint<> ModuleModificationTime;
-    CodeCompletionResultSink Sink;
+
+    std::vector<ContextFreeCodeCompletionResult *> Results;
+
+    Value() : Allocator(std::make_shared<llvm::BumpPtrAllocator>()) {}
   };
   using ValueRefCntPtr = llvm::IntrusiveRefCntPtr<Value>;
 

--- a/include/swift/IDE/REPLCodeCompletion.h
+++ b/include/swift/IDE/REPLCodeCompletion.h
@@ -74,7 +74,7 @@ private:
 
 public:
   /// Create an invalid completion set.
-  REPLCompletions();
+  REPLCompletions(const ide::CodeCompletionResultTypeArenaRef &ResultTypeArena);
 
   /// Create completion results for the given string.
   void populate(SourceFile &SF, StringRef EnteredCode);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -590,7 +590,7 @@ void CodeCompletionResult::printPrefix(raw_ostream &OS) const {
     PRINT_FLAIR(ExpressionAtNonScriptOrMainFileScope, "ExprAtFileScope")
     Prefix.append("]");
   }
-  if (NotRecommended)
+  if (NotRecommended != NotRecommendedReason::None)
     Prefix.append("/NotRecommended");
   if (IsSystem)
     Prefix.append("/IsSystem");

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -144,37 +144,44 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 
 } // namespace
 
-bool swift::ide::getCompletionDiagnostics(
-    CodeCompletionResult::NotRecommendedReason reason, const ValueDecl *D,
-    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out) {
-  using NotRecommendedReason = CodeCompletionResult::NotRecommendedReason;
-
-  ASTContext &ctx = D->getASTContext();
-
-  CodeCompletionDiagnostics Diag(ctx);
-  switch (reason) {
-  case NotRecommendedReason::Deprecated:
-  case NotRecommendedReason::SoftDeprecated:
-    return Diag.getDiagnosticForDeprecated(D, severity, Out);
-  case NotRecommendedReason::InvalidAsyncContext:
-    // FIXME: Could we use 'diag::async_in_nonasync_function'?
-    return Diag.getDiagnostics(severity, Out, diag::ide_async_in_nonasync_context,
-                        D->getName());
-  case NotRecommendedReason::CrossActorReference:
-    return Diag.getDiagnostics(severity, Out, diag::ide_cross_actor_reference_swift5,
-                        D->getName());
-  case NotRecommendedReason::RedundantImport:
-    return Diag.getDiagnostics(severity, Out, diag::ide_redundant_import,
-                        D->getName());
-  case NotRecommendedReason::RedundantImportIndirect:
-    return Diag.getDiagnostics(severity, Out, diag::ide_redundant_import_indirect,
-                        D->getName());
-  case NotRecommendedReason::VariableUsedInOwnDefinition:
-    return Diag.getDiagnostics(severity, Out, diag::recursive_accessor_reference,
-                        D->getName().getBaseIdentifier(), /*"getter"*/ 0);
-  case NotRecommendedReason::None:
+bool swift::ide::getContextFreeCompletionDiagnostics(
+    ContextFreeNotRecommendedReason Reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &Severity, llvm::raw_ostream &Out) {
+  CodeCompletionDiagnostics Diag(D->getASTContext());
+  switch (Reason) {
+  case ContextFreeNotRecommendedReason::Deprecated:
+  case ContextFreeNotRecommendedReason::SoftDeprecated:
+    return Diag.getDiagnosticForDeprecated(D, Severity, Out);
+  case ContextFreeNotRecommendedReason::None:
     llvm_unreachable("invalid not recommended reason");
   }
   return true;
 }
 
+bool swift::ide::getContextualCompletionDiagnostics(
+    ContextualNotRecommendedReason Reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &Severity, llvm::raw_ostream &Out) {
+  CodeCompletionDiagnostics Diag(D->getASTContext());
+  switch (Reason) {
+  case ContextualNotRecommendedReason::InvalidAsyncContext:
+    // FIXME: Could we use 'diag::async_in_nonasync_function'?
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_async_in_nonasync_context, D->getName());
+  case ContextualNotRecommendedReason::CrossActorReference:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_cross_actor_reference_swift5, D->getName());
+  case ContextualNotRecommendedReason::RedundantImport:
+    return Diag.getDiagnostics(Severity, Out, diag::ide_redundant_import,
+                               D->getName());
+  case ContextualNotRecommendedReason::RedundantImportIndirect:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_redundant_import_indirect, D->getName());
+  case ContextualNotRecommendedReason::VariableUsedInOwnDefinition:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::recursive_accessor_reference,
+        D->getName().getBaseIdentifier(), /*"getter"*/ 0);
+  case ContextualNotRecommendedReason::None:
+    llvm_unreachable("invalid not recommended reason");
+  }
+  return true;
+}

--- a/lib/IDE/CodeCompletionDiagnostics.h
+++ b/lib/IDE/CodeCompletionDiagnostics.h
@@ -21,12 +21,21 @@ class ValueDecl;
 
 namespace ide {
 
-/// Populate \p severity and \p Out with the diagnostics for \p D.
+/// Populate \p severity and \p Out with the context-free diagnostics for \p D.
+/// See \c NotRecommendedReason for an explaination of context-free vs.
+/// contextual diagnostics.
 /// Returns \c true if it fails to generate the diagnostics.
-bool getCompletionDiagnostics(CodeCompletionResult::NotRecommendedReason reason,
-                              const ValueDecl *D,
-                              CodeCompletionDiagnosticSeverity &severity,
-                              llvm::raw_ostream &Out);
+bool getContextFreeCompletionDiagnostics(
+    ContextFreeNotRecommendedReason reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
+
+/// Populate \p severity and \p Out with the contextual diagnostics for \p D.
+/// See \c NotRecommendedReason for an explaination of context-free vs.
+/// contextual diagnostics.
+/// Returns \c true if it fails to generate the diagnostics.
+bool getContextualCompletionDiagnostics(
+    ContextualNotRecommendedReason reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
 
 } // namespace ide
 } // namespace swift

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -74,7 +74,7 @@ class CodeCompletionResultBuilder {
   friend CodeCompletionStringPrinter;
   
   CodeCompletionResultSink &Sink;
-  CodeCompletionResult::ResultKind Kind;
+  CodeCompletionResultKind Kind;
   SemanticContextKind SemanticContext;
   CodeCompletionFlair Flair;
   unsigned NumBytesToErase = 0;
@@ -89,8 +89,10 @@ class CodeCompletionResultBuilder {
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
       CodeCompletionResult::ExpectedTypeRelation::Unknown;
   bool Cancelled = false;
-  CodeCompletionResult::NotRecommendedReason NotRecReason =
-      CodeCompletionResult::NotRecommendedReason::None;
+  ContextFreeNotRecommendedReason ContextFreeNotRecReason =
+      ContextFreeNotRecommendedReason::None;
+  ContextualNotRecommendedReason ContextualNotRecReason =
+      ContextualNotRecommendedReason::None;
   StringRef BriefDocComment;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
@@ -117,7 +119,7 @@ class CodeCompletionResultBuilder {
 
 public:
   CodeCompletionResultBuilder(CodeCompletionResultSink &Sink,
-                              CodeCompletionResult::ResultKind Kind,
+                              CodeCompletionResultKind Kind,
                               SemanticContextKind SemanticContext,
                               const ExpectedTypeContext &declTypeContext)
       : Sink(Sink), Kind(Kind), SemanticContext(SemanticContext),
@@ -146,12 +148,11 @@ public:
 
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }
-  void setNotRecommended(CodeCompletionResult::NotRecommendedReason Reason) {
-    NotRecReason = Reason;
+  void setContextFreeNotRecommended(ContextFreeNotRecommendedReason Reason) {
+    ContextFreeNotRecReason = Reason;
   }
-
-  void setSemanticContext(SemanticContextKind Kind) {
-    SemanticContext = Kind;
+  void setContextualNotRecommended(ContextualNotRecommendedReason Reason) {
+    ContextualNotRecReason = Reason;
   }
 
   void addFlair(CodeCompletionFlair Options) {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -59,14 +59,14 @@ class CodeCompletionResultBuilder {
   StringRef BriefDocComment;
 
   /// The result type that this completion item produces.
-  ///  - None: The item doesn't have a sensible result type, like a keyword
-  ///  - Null type: The result type of the item is not known
-  ///  - Proper type: The completion item produces an expression of the
+  ///  - Empty: The item doesn't have a sensible result type, like a keyword
+  ///  - Contains null type: The result type of the item is not known
+  ///  - Contains proper type: The completion item produces an expression of the
   ///    specified type.
   ///
   /// We assume that a completion item produces an expression of unknown type
   /// by default.
-  Optional<Type> ResultType = Type();
+  SmallVector<Type, 2> ResultTypes = {Type()};
 
   /// The context in which this completion item is used. Used to compute the
   /// type relation to \c ResultType.
@@ -139,13 +139,17 @@ public:
 
   /// Indicate that the code completion item does not produce something with a
   /// sensible result type, like a keyword or a method override suggestion.
-  void setDoesNotProduceResultType() { ResultType = None; }
+  void setDoesNotProduceResultType() { ResultTypes = {}; }
 
-  /// Set the result type of this code completion item and the context that the
+  /// Set the result types of this code completion item and the context that the
   /// item may be used in.
-  void setResultType(Type ResultType, const ExpectedTypeContext &TypeContext,
-                     const DeclContext *DC) {
-    this->ResultType = ResultType;
+  /// An item might have multiple result types because we consider e.g. \c Int
+  /// as producing both an \c Int metatype and an \c Int instance type.
+  void setResultTypes(ArrayRef<Type> ResultTypes,
+                      const ExpectedTypeContext &TypeContext,
+                      const DeclContext *DC) {
+    this->ResultTypes =
+        SmallVector<Type, 2>(ResultTypes.begin(), ResultTypes.end());
     this->TypeContext = TypeContext;
     this->DC = DC;
   }

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -24,7 +24,7 @@ class Expr;
 class ValueDecl;
 
 namespace ide {
-enum class SemanticContextKind;
+enum class SemanticContextKind : uint8_t;
 
 /// Type check parent contexts of the given decl context, and the body of the
 /// given context until \c Loc if the context is a function body.

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -121,7 +121,7 @@ static void toDisplayString(CodeCompletionResult *Result,
     }
     if (C.is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotation) ||
         C.is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin)) {
-      if (Result->getKind() == CodeCompletionResult::ResultKind::Declaration) {
+      if (Result->getKind() == CodeCompletionResultKind::Declaration) {
         switch (Result->getAssociatedDeclKind()) {
         case CodeCompletionDeclKind::Module:
         case CodeCompletionDeclKind::PrecedenceGroup:

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -201,8 +201,10 @@ public:
 };
 } // namespace swift
 
-REPLCompletions::REPLCompletions()
-    : State(CompletionState::Invalid), CompletionContext(CompletionCache) {
+REPLCompletions::REPLCompletions(
+    const CodeCompletionResultTypeArenaRef &ResultTypeArena)
+    : State(CompletionState::Invalid), CompletionCache(ResultTypeArena),
+      CompletionContext(CompletionCache) {
   // Create a CodeCompletionConsumer.
   Consumer.reset(new REPLCodeCompletionConsumer(*this));
 

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -25,7 +25,7 @@ func testSync() -> Int{
 // 'async'-ness in the cache. (rdar://78317170)
 
 // GLOBAL_IN_SYNC: Begin completions
-// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_SYNC-DAG: Decl[Class]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_SYNC: End completions
@@ -33,7 +33,7 @@ func testSync() -> Int{
 func testAsync() async -> Int {
     #^GLOBAL_IN_ASYNC^#
 // GLOBAL_IN_ASYNC: Begin completions
-// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_ASYNC-DAG: Decl[Class]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_ASYNC: End completions

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -78,7 +78,7 @@ func test001() {
 // CATCH1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error1[#Error1#]; name=Error1{{$}}
 // CATCH1-DAG:  Keyword[let]/None:                  let{{; name=.+$}}
 // CATCH1-DAG:  Decl[Class]/CurrModule:             NoneError1[#NoneError1#]; name=NoneError1{{$}}
-// CATCH1-DAG:  Decl[Class]/OtherModule[Foundation]/IsSystem: NSError[#NSError#]{{; name=.+$}}
+// CATCH1-DAG:  Decl[Class]/OtherModule[Foundation]/IsSystem/TypeRelation[Convertible]: NSError[#NSError#]{{; name=.+$}}
 }
 
 func test002() {

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -3,9 +3,6 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
-// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath
-// Perform the same completion again, this time using the code completion cache that implicitly gets added to swift-ide-test
-// RUN2: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath | %FileCheck %s
 
 //--- Lib.swift
 
@@ -24,18 +21,125 @@ public func makeFoo() -> Foo {
 
 public let GLOBAL_FOO = Foo()
 
+public class MyClass {}
+public class MySubclass: MyClass {}
+
 //--- test.swift
 
 import Lib
 
-func test() -> MyProto {
-	return #^COMPLETE^#
-}
+// This extension should not make Bar convertible to MyProto because Bar's conformance to MyProto can't be cached since that cache might also be used by other modules.
+extension Bar: MyProto {}
 
-// CHECK: Begin completions
-// CHECK-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
-// CHECK-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
-// CHECK-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
-// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
-// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
-// CHECK: End completions
+func testWithProtocolContext() -> MyProto {
+	return #^COMPLETE_PROTOCOL_CONTEXT^#
+}
+// RUN: %empty-directory(%t/protocol_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/protocol_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_PROTOCOL_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_PROTOCOL_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/protocol_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_PROTOCOL_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_PROTOCOL_CONTEXT
+
+// COMPLETE_PROTOCOL_CONTEXT: Begin completions
+// COMPLETE_PROTOCOL_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]:      Bar[#Bar#];
+// COMPLETE_PROTOCOL_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// COMPLETE_PROTOCOL_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT: End completions
+
+func testWithOpaqueResultTypeContext() -> some MyProto {
+	return #^COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT^#
+}
+// RUN: %empty-directory(%t/opaque_result_type_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/opaque_result_type_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_PROTOCOL_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/opaque_result_type_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_PROTOCOL_CONTEXT
+
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT: Begin completions
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]:      Bar[#Bar#];
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// COMPLETE_OPAQUE_RESULT_TYPE_CONTEXT: End completions
+
+func testWithOptionalProtocolContext() -> MyProto? {
+	return #^COMPLETE_OPTIONAL_PROTOCOL_CONTEXT^#
+}
+// RUN: %empty-directory(%t/optional_protocol_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/optional_protocol_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPTIONAL_PROTOCOL_CONTEXT -I %t/ImportPath  | %FileCheck %s --check-prefix=COMPLETE_OPTIONAL_PROTOCOL_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/optional_protocol_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPTIONAL_PROTOCOL_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_OPTIONAL_PROTOCOL_CONTEXT
+
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT: Begin completions
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]:      Bar[#Bar#];
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// COMPLETE_OPTIONAL_PROTOCOL_CONTEXT: End completions
+
+func testWithStructContext() -> Foo {
+	return #^COMPLETE_STRUCT_CONTEXT^#
+}
+// RUN: %empty-directory(%t/struct_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/struct_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_STRUCT_CONTEXT -I %t/ImportPath  | %FileCheck %s --check-prefix=COMPLETE_STRUCT_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/struct_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_STRUCT_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_STRUCT_CONTEXT
+
+// COMPLETE_STRUCT_CONTEXT: Begin completions
+// COMPLETE_STRUCT_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Identical]: Foo[#Foo#];
+// COMPLETE_STRUCT_CONTEXT-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Identical]: GLOBAL_FOO[#Foo#];
+// COMPLETE_STRUCT_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// COMPLETE_STRUCT_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// COMPLETE_STRUCT_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Identical]: makeFoo()[#Foo#];
+// COMPLETE_STRUCT_CONTEXT: End completions
+
+func testWithOptionalStructContext() -> Foo? {
+	return #^COMPLETE_OPTIONAL_STRUCT_CONTEXT^#
+}
+// RUN: %empty-directory(%t/optional_struct_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/optional_struct_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPTIONAL_STRUCT_CONTEXT -I %t/ImportPath  | %FileCheck %s --check-prefix=COMPLETE_OPTIONAL_STRUCT_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/optional_struct_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_OPTIONAL_STRUCT_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_OPTIONAL_STRUCT_CONTEXT
+
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT: Begin completions
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// COMPLETE_OPTIONAL_STRUCT_CONTEXT: End completions
+
+func testWithSuperclassContext() -> MyClass? {
+	return #^COMPLETE_SUPERCLASS_CONTEXT^#
+}
+// RUN: %empty-directory(%t/superclass_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/superclass_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_SUPERCLASS_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_SUPERCLASS_CONTEXT
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/superclass_context_cache -source-filename %t/test.swift -code-completion-token COMPLETE_SUPERCLASS_CONTEXT -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_SUPERCLASS_CONTEXT
+
+// COMPLETE_SUPERCLASS_CONTEXT: Begin completions
+// COMPLETE_SUPERCLASS_CONTEXT-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclass[#MySubclass#];
+// COMPLETE_SUPERCLASS_CONTEXT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: testWithSuperclassContext()[#MyClass?#];
+// COMPLETE_SUPERCLASS_CONTEXT: End completions
+
+//--- test2.swift
+
+// Make sure that we don't cache the conformance Bar: MyProto because it's not declared inside Lib and thus doesn't apply to test2.swift
+
+import Lib
+
+func testWithProtocolContextWithoutExtension() -> MyProto {
+	return #^COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION^#
+}
+// RUN: %empty-directory(%t/protocol_context_cache)
+// RUN: %swift-ide-test_plain -code-completion -completion-cache-path %t/protocol_context_cache -source-filename %t/test2.swift -code-completion-token COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION
+
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION: Begin completions
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// COMPLETE_PROTOCOL_CONTEXT_WITHOUT_PROTOCOL_EXTENSION: End completions

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ImportPath)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath
+// Perform the same completion again, this time using the code completion cache that implicitly gets added to swift-ide-test
+// RUN2: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath | %FileCheck %s
+
+//--- Lib.swift
+
+public protocol MyProto {}
+
+public struct Foo: MyProto {
+	public init() {}
+}
+public struct Bar {
+	public init() {}
+}
+
+public func makeFoo() -> Foo {
+	return Foo()
+}
+
+public let GLOBAL_FOO = Foo()
+
+//--- test.swift
+
+import Lib
+
+func test() -> MyProto {
+	return #^COMPLETE^#
+}
+
+// CHECK: Begin completions
+// CHECK-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// CHECK-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// CHECK-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// CHECK: End completions

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -94,7 +94,7 @@
 // CHECK-FOUNDATION: var uppercased: String
 
 // Note: ok to map base name down to a keyword.
-// CHECK-FOUNDATION: func `do`(_: Selector!)
+// CHECK-FOUNDATION: func `do`(_: Selector)
 
 // Note: Strip names preceded by a gerund.
 // CHECK-FOUNDATION: func startSquashing(_: Bee)

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -947,7 +947,7 @@ __attribute__((availability(macosx, introduced = 10.52)))
 @end
 
 @interface NSObject (Silly)
--(void)doSelector:(SEL)selector;
+- (void)doSelector:(nonnull SEL)selector;
 @end
 
 @interface Bee (Gerunds)
@@ -1071,7 +1071,7 @@ extern NSString *NSHTTPRequestKey;
 @end
 
 @interface NSObject (Selectors)
--(void)messageSomeObject:(nonnull id)object selector:(SEL)selector;
+- (void)messageSomeObject:(nonnull id)object selector:(nonnull SEL)selector;
 @end
 
 @interface NSOperation : NSObject

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -51,7 +51,7 @@ func testUnknown() {
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "Int",
 // BOOLCONTEXT:       key.typename: "Int",
-// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "nil",
 // BOOLCONTEXT:       key.typename: "",
@@ -68,7 +68,7 @@ func testUnknown() {
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "Int",
 // OPTIONALCONTEXT:       key.typename: "Int",
-// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "nil",
 // OPTIONALCONTEXT:       key.typename: "Int?",
@@ -84,7 +84,7 @@ func testUnknown() {
 // VOIDCONTEXT-LABEL: }
 // VOIDCONTEXT-LABEL: key.name: "Int",
 // VOIDCONTEXT:       key.typename: "Int",
-// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
 // VOIDCONTEXT-LABEL: }
 // VOIDCONTEXT-LABEL: key.name: "nil",
 // VOIDCONTEXT:       key.typename: "",

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -51,7 +51,7 @@ func testUnknown() {
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "Int",
 // BOOLCONTEXT:       key.typename: "Int",
-// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "nil",
 // BOOLCONTEXT:       key.typename: "",
@@ -84,7 +84,7 @@ func testUnknown() {
 // VOIDCONTEXT-LABEL: }
 // VOIDCONTEXT-LABEL: key.name: "Int",
 // VOIDCONTEXT:       key.typename: "Int",
-// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unrelated,
+// VOIDCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // VOIDCONTEXT-LABEL: }
 // VOIDCONTEXT-LABEL: key.name: "nil",
 // VOIDCONTEXT:       key.typename: "",

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -112,8 +112,14 @@ struct CompletionSink {
   swift::ide::CodeCompletionResultSink swiftSink;
   llvm::BumpPtrAllocator allocator;
 
+  CompletionSink(
+      const swift::ide::CodeCompletionResultTypeArenaRef &ResultTypeArena)
+      : swiftSink(ResultTypeArena) {}
+
   /// Adds references to a swift sink's allocators to keep its storage alive.
   void adoptSwiftSink(swift::ide::CodeCompletionResultSink &sink) {
+    assert(sink.ResultTypeArena == swiftSink.ResultTypeArena &&
+           "Cannot combine sinks with different ResultTypeArenas.");
     swiftSink.ForeignAllocators.insert(swiftSink.ForeignAllocators.end(),
                                        sink.ForeignAllocators.begin(),
                                        sink.ForeignAllocators.end());

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -125,7 +125,6 @@ class CompletionBuilder {
   CompletionSink &sink;
   SwiftResult &current;
   bool modified = false;
-  Completion::ExpectedTypeRelation typeRelation;
   SemanticContextKind semanticContext;
   CodeCompletionFlair flair;
   CodeCompletionString *completionString;
@@ -142,11 +141,6 @@ public:
   void setModuleImportDepth(Optional<uint8_t> value) {
     assert(!value || *value <= Completion::maxModuleImportDepth);
     moduleImportDepth = value;
-  }
-
-  void setExpectedTypeRelation(Completion::ExpectedTypeRelation Relation) {
-    modified = true;
-    typeRelation = Relation;
   }
 
   void setSemanticContext(SemanticContextKind kind) {

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -1166,7 +1166,7 @@ Completion *CompletionBuilder::finish() {
           currentContextFree.getModuleName(),
           currentContextFree.getBriefDocComment(),
           currentContextFree.getAssociatedUSRs(),
-          currentContextFree.getResultType(),
+          currentContextFree.getResultTypes(),
           currentContextFree.getNotRecommendedReason(),
           currentContextFree.getDiagnosticSeverity(),
           currentContextFree.getDiagnosticMessage());
@@ -1180,7 +1180,7 @@ Completion *CompletionBuilder::finish() {
       ContextFreeCodeCompletionResult ContextFreeResult(
           currentContextFree.getKind(), completionString, opKind,
           currentContextFree.getBriefDocComment(),
-          currentContextFree.getResultType(),
+          currentContextFree.getResultTypes(),
           currentContextFree.getNotRecommendedReason(),
           currentContextFree.getDiagnosticSeverity(),
           currentContextFree.getDiagnosticMessage());

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -910,7 +910,8 @@ static void transformAndForwardResults(
     ContextFreeCodeCompletionResult contextFreeResult(
         CodeCompletionResultKind::BuiltinOperator, completionString,
         CodeCompletionOperatorKind::None,
-        /*BriefDocComment=*/"", ContextFreeNotRecommendedReason::None,
+        /*BriefDocComment=*/"", /*ResultType=*/nullptr,
+        ContextFreeNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None,
         /*DiagnosticMessage=*/"");
     CodeCompletion::SwiftResult paren(

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -973,7 +973,7 @@ public:
 
     unsigned ByteOffset = SM.getLocOffsetInBuffer(Range.getStart(), BufferID);
     unsigned Length = Range.getByteLength();
-    auto Kind = CodeCompletionResult::getCodeCompletionDeclKind(D);
+    auto Kind = ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(D);
     bool IsSystem = D->getModuleContext()->isSystemModule();
     SemaToks.emplace_back(Kind, ByteOffset, Length, IsRef, IsSystem);
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -289,7 +289,10 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   configureCompletionInstance(CompletionInst, SKCtx.getGlobalConfiguration());
 
   // By default, just use the in-memory cache.
-  CCCache->inMemory = std::make_unique<ide::CodeCompletionCache>();
+  CodeCompletionResultTypeArenaRef ResultTypeArena =
+      new CodeCompletionResultTypeArena();
+  CCCache->inMemory =
+      std::make_unique<ide::CodeCompletionCache>(ResultTypeArena);
 
   // Provide a default file system provider.
   setFileSystemProvider("in-memory-vfs", std::make_unique<InMemoryFileSystemProvider>());

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -57,7 +57,7 @@ namespace ide {
   class CompletionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
-  enum class CodeCompletionDeclKind;
+  enum class CodeCompletionDeclKind : uint8_t;
   enum class SyntaxNodeKind : uint8_t;
   enum class SyntaxStructureKind : uint8_t;
   enum class SyntaxStructureElementKind : uint8_t;


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/40163.

---

First, split code completion results into context free part that can be cached and contextual part displayed to the user.
This allows makes the distinction between cachable and non-cachable properties cleaner and allows us to more easily compute contextual information (like type relations) for cached items.

Then, compute type relations for cached items. Computing the type relation for every item in the code completion cache is way too expensive (~4x slowdown for global completion that imports `SwiftUI`). Instead, compute a type’s supertypes (protocol conformances and superclasses) once and write their USRs to the cache. To compute a type relation we can then check if the contextual type is in the completion item’s supertypes.

This reduces the overhead of computing the type relations (again global completion that imports `SwiftUI`) to ~6% – measured by instructions executed.

Technically, we might miss some conversions like
- retroactive conformances inside another module (because we can’t cache them if that other module isn’t imported)
- complex generic conversions (just too complicated to model using USRs)

Because of this, we never report an `unkown` type relation for global items but always default to `unknown`.

But I believe this PR covers the most common cases and is a good tradeoff between accuracy and performance.

rdar://83846531