### PR TITLE
Change instance of JVP to VJP

### DIFF
--- a/docs/DifferentiableProgramming.md
+++ b/docs/DifferentiableProgramming.md
@@ -936,7 +936,7 @@ derivative values.
 ```swift
 // In the standard library:
 //
-//     func derivative<T: FloatingPoint, R>(
+//     func gradient<T: FloatingPoint, R>(
 //         of body: @escaping @differentiable (T) -> R
 //     ) -> (T) -> R where T.TangentVector: FloatingPoint
 
@@ -944,7 +944,7 @@ derivative values.
 func f(_ x: Float) -> Float {
     x * x
 }
-let dfdx = derivative(of: f)
+let dfdx = gradient(of: f)
 dfdx(3) // 6
 ```
 


### PR DESCRIPTION
Swift throws a runtime error when I execute the code sample currently shown. However, changing to `gradient(of:)` produces the same result and works. Changing this could help other developers reading the manifesto overcome difficulties with experimenting with differentiation.

To reproduce this, do the following:
1) In Xcode, make a new macOS project with the "command-line tool" template.
2) In "Add Packages", import https://github.com/philipturner/Differentiation if you are using a Swift release toolchain. This is a temporary workaround sourced from a comment in Swift Forums, and not officially supported.
3) Copy the code sample from before my change into "main.swift", but add `import Differentiation` before it.
4) Change `dfdx(3)` to `print(dfdx(3))`
4) Run the program, and there is a fatal error saying JVP is not supported.
5) Replace `derivative(of:)` with `gradient(of:)`.
6) Run again and no error occurs. The program logs "6", which is the expected derivative.

The reason this happens is that there are two types of automatic differentiation: JVP and VJP. JVP comes from `derivative(of:)`, while VJP comes from `gradient(of:)`. Although they produce the same result in the demonstration, they work in vastly different ways under the hood. The old S4TF team prioritized VJP for Swift for TensorFlow, so JVP isn't supported right now.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
