### PR TITLE
Renamed flag to -enable-lexical-lifetimes.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -262,12 +262,12 @@ def enable_experimental_concurrency :
 def disable_lexical_lifetimes :
   Flag<["-"], "disable-lexical-lifetimes">,
   HelpText<"Disables early lexical lifetimes. Mutually exclusive with "
-           "-enable-experimental-lexical-lifetimes">;
+           "-enable-lexical-lifetimes">;
 
-def enable_experimental_lexical_lifetimes :
-  Flag<["-"], "enable-experimental-lexical-lifetimes">,
-  HelpText<"Enable experimental lexical lifetimes. Mutually exclusive with "
-           "-disable-early-lexical-lifetimes">;
+def enable_lexical_lifetimes :
+  Flag<["-"], "enable-lexical-lifetimes">,
+  HelpText<"Enable lexical lifetimes. Mutually exclusive with "
+           "-disable-lexical-lifetimes">;
 
 def enable_experimental_move_only :
   Flag<["-"], "enable-experimental-move-only">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1452,7 +1452,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // If experimental move only is enabled, always enable lexical lifetime as
   // well. Move only depends on lexical lifetimes.
   bool enableExperimentalLexicalLifetimes =
-      Args.hasArg(OPT_enable_experimental_lexical_lifetimes) ||
+      Args.hasArg(OPT_enable_lexical_lifetimes) ||
       Args.hasArg(OPT_enable_experimental_move_only);
   // Error if both experimental lexical lifetimes and disable lexical lifetimes
   // are both set.

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-lexical-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-lexical-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
 
 import Swift
 

--- a/test/SILOptimizer/allocbox_to_stack_lifetime.sil
+++ b/test/SILOptimizer/allocbox_to_stack_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-experimental-lexical-lifetimes | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-lexical-lifetimes | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -enable-experimental-lexical-lifetimes | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -enable-lexical-lifetimes | %FileCheck %s
 
 import Swift
 

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
 // =============================================================================
 // Copied from mem2reg_ossa.sil                                               {{

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_liveness_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_liveness_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_resilient_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_resilient_lifetime.sil
@@ -1,5 +1,5 @@
 
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg -enable-library-evolution | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg -enable-library-evolution | %FileCheck %s
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_simple_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_simple_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/mem2reg_unreachable_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_unreachable_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg
 
 // Make sure we are not crashing on blocks that are not dominated by the entry block.
 

--- a/test/SILOptimizer/sroa_lifetime.sil
+++ b/test/SILOptimizer/sroa_lifetime.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -sroa %s -enable-experimental-lexical-lifetimes | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all -sroa %s -enable-lexical-lifetimes | %FileCheck %s
 
 sil_stage canonical
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -106,14 +106,14 @@ EnableExperimentalConcurrency("enable-experimental-concurrency",
                    llvm::cl::desc("Enable experimental concurrency model."));
 
 static llvm::cl::opt<bool> EnableExperimentalLexicalLifetimes(
-    "enable-experimental-lexical-lifetimes",
+    "enable-lexical-lifetimes",
     llvm::cl::desc("Enable experimental lexical lifetimes. Mutually exclusive "
                    "with disable-lexical-lifetimes."));
 
 static llvm::cl::opt<bool> DisableLexicalLifetimes(
     "disable-lexical-lifetimes",
     llvm::cl::desc("Disable the default early lexical lifetimes. Mutually "
-                   "exclusive with enable-experimental-lexical-lifetimes"));
+                   "exclusive with enable-lexical-lifetimes"));
 
 static llvm::cl::opt<bool>
 EnableExperimentalMoveOnly("enable-experimental-move-only",
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
   if (enableExperimentalLexicalLifetimes && DisableLexicalLifetimes) {
     fprintf(
         stderr,
-        "Error! Can not specify both -enable-experimental-lexical-lifetimes "
+        "Error! Can not specify both -enable-lexical-lifetimes "
         "and -disable-lexical-lifetimes!\n");
     exit(-1);
   }

--- a/validation-test/SILOptimizer/lexical-lifetimes.swift
+++ b/validation-test/SILOptimizer/lexical-lifetimes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-lexical-lifetimes -Xfrontend -enable-copy-propagation) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-lexical-lifetimes -Xfrontend -enable-copy-propagation) | %FileCheck %s
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Previously, both swift-frontend and sil-opt put lexical lifetimes behind a flag named -enable-experimental-lexical-lifetimes.  That's redundant.  Here, the experimental portion of the name is dropped.
