### PR TITLE
Fix typo UnsafeContination -> UnsafeContinuation

### DIFF
--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -295,7 +295,7 @@ extension ThrowingTaskGroup {
 }
 
 @available(SwiftStdlib 5.1, *)
-@available(*, deprecated, message: "please use UnsafeContination<..., Error>")
+@available(*, deprecated, message: "please use UnsafeContinuation<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
Fix a typo in the deprecation suggestion for `UnsafeThrowingContinuation` from `UnsafeContination` to `UnsafeContinuation`.

Resolves https://bugs.swift.org/browse/SR-15511
