### PR TITLE
Fix JSON formatting for capturedPCMArgs in clang dependency graph

### DIFF
--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -137,8 +137,10 @@ import SubE
 // CHECK-NEXT: "C"
 
 // CHECK: "capturedPCMArgs": [
-// CHECK-NEXT:   "-Xcc",
-// CHECK-NEXT:   "-fapinotes-swift-version=4"
+// CHECK-NEXT:   [,
+// CHECK-NEXT:     "-Xcc",
+// CHECK-NEXT:     "-fapinotes-swift-version=4"
+// CHECK-NEXT:   ]
 // CHECK-NEXT: ]
 
 /// --------Swift module E


### PR DESCRIPTION
Deserialization of clang module dependency graph fails as it expects capturedPCMArgs to be a nested set of strings, but the returned value in JSON has a flat list format. This adds outer brackets to accommodate the nesting.  