### PR TITLE
[frontend] Fix TBD validation almost always done for modules

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1390,10 +1390,14 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
     // may have serialized hand-crafted SIL definitions that are invisible to
     // TBDGen as it is an AST-only traversal.
     if (auto *mod = MSF.dyn_cast<ModuleDecl *>()) {
-      return llvm::none_of(mod->getFiles(), [](const FileUnit *File) -> bool {
+      bool hasSIB = llvm::any_of(mod->getFiles(), [](const FileUnit *File) -> bool {
         auto SASTF = dyn_cast<SerializedASTFile>(File);
         return SASTF && SASTF->isSIB();
       });
+
+      if (hasSIB) {
+        return false;
+      }
     }
 
     // "Default" mode's behavior varies if using a debug compiler.

--- a/test/TBD/sib-module.swift
+++ b/test/TBD/sib-module.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swiftc_driver -emit-sib -module-name mysibmodule %s -o - | %target-swiftc_driver -emit-module -module-name mysibmodule -o %t/mysibmodule.swiftmodule -
+
+/// Since -validate-tbd-against-ir=default, TBD validation is not done since the module has a SIB file
+// RUN: %target-swift-frontend -emit-sil %t/mysibmodule.swiftmodule | %FileCheck %s
+
+// RUN: %target-swiftc_driver -emit-module -module-name mynonsibmodule -o %t/mynonsibmodule.swiftmodule %s
+
+/// Since -validate-tbd-against-ir=default, TBD validation is done or not depending on the build configuration
+// RUN: %target-swift-frontend -emit-sil %t/mynonsibmodule.swiftmodule | %FileCheck %s
+
+public class MyClass {
+  var x : Int
+
+  public init(input : Int) {
+    x = 2 * input
+  }
+
+  public func do_something(input : Int) -> Int {
+    return x * input
+  }
+}
+
+// CHECK: class MyClass


### PR DESCRIPTION
The logic to do or not the validation of TBD against IR was incorrect.
In the case of modules, the comment described what was supposed to
happen (skipping the validation if the module had SIB files), but the
code was returning if the module had or not SIB files, which would have
returned true for any module without SIB files without checking if the
compiler was build in a debug configuration or not.

This was only visible in the case of non-debug builds, and it only
appeared for us in a convoluted mix of optimized builds with
-enable-testing on some modules.
