### PR TITLE
[cxx-interop] Fixing usage of ObjC Categories in C++-Interop mode.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9331,6 +9331,13 @@ ClangImporter::Implementation::importDeclContextOf(
   switch (context.getKind()) {
   case EffectiveClangContext::DeclContext: {
     auto dc = context.getAsDeclContext();
+
+    // For C++-Interop in cases where #ifdef __cplusplus surround an extern "C"
+    // you want to first check if the TU decl is the parent of this extern "C"
+    // decl (aka LinkageSpecDecl) and then proceed.
+    if (dc->getDeclKind() == clang::Decl::LinkageSpec)
+      dc = dc->getParent();
+
     if (dc->isTranslationUnit()) {
       if (auto *module = getClangModuleForDecl(decl))
         return module;

--- a/test/Interop/Cxx/extern-c/Inputs/extern-c.h
+++ b/test/Interop/Cxx/extern-c/Inputs/extern-c.h
@@ -1,0 +1,11 @@
+@interface A
+@end
+
+extern "C"
+@interface A (CAT1)
+- (int)foo;
+@end
+
+@interface A (CAT2)
+- (int)bar;
+@end

--- a/test/Interop/Cxx/extern-c/Inputs/module.modulemap
+++ b/test/Interop/Cxx/extern-c/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module ExternC {
+  header "extern-c.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/extern-c/extern-c-objcxx-category.swift
+++ b/test/Interop/Cxx/extern-c/extern-c-objcxx-category.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ExternC -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck %s
+
+// CHECK: class A {
+// CHECK-NEXT: }
+
+// CHECK: extension A {
+// CHECK-NEXT:   class func foo() -> Int32
+// CHECK-NEXT:   func foo() -> Int32
+// CHECK-NEXT: }
+
+// CHECK: extension A {
+// CHECK-NEXT:   class func bar() -> Int32
+// CHECK-NEXT:   func bar() -> Int32
+// CHECK-NEXT: }


### PR DESCRIPTION
In C/ObjC interop mode a Clang AST with an ObjC Category resembles:

TranslationUnitDecl
`-ObjCCategoryDecl

However in C++-Interop mode the same Category could potentially have an
extern "C" linkage specifier (guarded with #ifdef __cplusplus) and
resembles:

TranslationUnitDecl
|-LinkageSpecDecl
  `-ObjCCategoryDecl

In the latter case when the ClangImporter attempts to import the
category in swift::ClangImporter::Implementation::importDeclContextOr,
prior to this patch, would bail because it is expecting the DeclContext
above the ObjCCategoryDecl to be a TranslationUnitDecl and when it isn't
it returns nullptr.

Because of this, of course the category does not get imported as a swift
extension and therefore any fields or methods are also not imported.

In the case of UIKit, UIView has one of these categories that are
extern-"C"'ed due to UIKIT_EXTERN containing the linkage specifier in
-enable-cxx-interop mode. Since UIView is inherited by lots of other
UIKit types (UILabel etc), many of these types also have lots of missing fields
as well.

This patch checks to see if the decl about to be imported in
importDeclContextOr has a linkage specifier as it's context and makes
sure to materialize the TU from the parent of the declcontext instead of
just immediately bailing. Because of this, this patch enables
c++-interop mode to compile code that uses UIKit without hitting this
mis-compile.

