### PR TITLE
RequirementMachine: Improved modeling of concrete conformances

### DIFF
--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -64,6 +64,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
+#include "RewriteContext.h"
 #include "RewriteSystem.h"
 
 using namespace swift;
@@ -681,7 +682,14 @@ void RewriteSystem::computeGeneratingConformances(
     }
   }
 
+  Context.ConformanceRulesHistogram.add(conformanceRules.size());
+
   computeCandidateConformancePaths(conformancePaths);
+
+  for (const auto &pair : conformancePaths) {
+    if (pair.second.size() > 1)
+      Context.GeneratingConformancesHistogram.add(pair.second.size());
+  }
 
   if (Debug.contains(DebugFlags::GeneratingConformances)) {
     llvm::dbgs() << "Initial set of equations:\n";

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -138,7 +138,7 @@ void RewriteLoop::findProtocolConformanceRules(
       }
     }
 
-    step.apply(evaluator, system);
+    evaluator.apply(step, system);
   }
 }
 

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -134,6 +134,8 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::AdjustConcreteType:
       case RewriteStep::Shift:
       case RewriteStep::Decompose:
+      case RewriteStep::ConcreteConformance:
+      case RewriteStep::SuperclassConformance:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -596,6 +596,7 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
   case Symbol::Kind::Layout:
   case Symbol::Kind::Superclass:
   case Symbol::Kind::ConcreteType:
+  case Symbol::Kind::ConcreteConformance:
     break;
   }
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -240,6 +240,7 @@ RequirementMachine::getLongestValidPrefix(const MutableTerm &term) const {
     case Symbol::Kind::Layout:
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
+    case Symbol::Kind::ConcreteConformance:
       llvm_unreachable("Property symbol cannot appear in a type term");
     }
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -664,3 +664,85 @@ RequirementMachine::lookupNestedType(Type depType, Identifier name) const {
 
   return nullptr;
 }
+
+void RequirementMachine::verify(const MutableTerm &term) const {
+#ifndef NDEBUG
+  // If the term is in the generic parameter domain, ensure we have a valid
+  // generic parameter.
+  if (term.begin()->getKind() == Symbol::Kind::GenericParam) {
+    auto *genericParam = term.begin()->getGenericParam();
+    TypeArrayView<GenericTypeParamType> genericParams = getGenericParams();
+    auto found = std::find(genericParams.begin(),
+                           genericParams.end(),
+                           genericParam);
+    if (found == genericParams.end()) {
+      llvm::errs() << "Bad generic parameter in " << term << "\n";
+      dump(llvm::errs());
+      abort();
+    }
+  }
+
+  MutableTerm erased;
+
+  // First, "erase" resolved associated types from the term, and try
+  // to simplify it again.
+  for (auto symbol : term) {
+    if (erased.empty()) {
+      switch (symbol.getKind()) {
+      case Symbol::Kind::Protocol:
+      case Symbol::Kind::GenericParam:
+        erased.add(symbol);
+        continue;
+
+      case Symbol::Kind::AssociatedType:
+        erased.add(Symbol::forProtocol(symbol.getProtocols()[0], Context));
+        break;
+
+      case Symbol::Kind::Name:
+      case Symbol::Kind::Layout:
+      case Symbol::Kind::Superclass:
+      case Symbol::Kind::ConcreteType:
+      case Symbol::Kind::ConcreteConformance:
+        llvm::errs() << "Bad initial symbol in " << term << "\n";
+        abort();
+        break;
+      }
+    }
+
+    switch (symbol.getKind()) {
+    case Symbol::Kind::Name:
+      assert(!erased.empty());
+      erased.add(symbol);
+      break;
+
+    case Symbol::Kind::AssociatedType:
+      erased.add(Symbol::forName(symbol.getName(), Context));
+      break;
+
+    case Symbol::Kind::Protocol:
+    case Symbol::Kind::GenericParam:
+    case Symbol::Kind::Layout:
+    case Symbol::Kind::Superclass:
+    case Symbol::Kind::ConcreteType:
+    case Symbol::Kind::ConcreteConformance:
+      llvm::errs() << "Bad interior symbol " << symbol << " in " << term << "\n";
+      abort();
+      break;
+    }
+  }
+
+  MutableTerm simplified = erased;
+  System.simplify(simplified);
+
+  // We should end up with the same term.
+  if (simplified != term) {
+    llvm::errs() << "Term verification failed\n";
+    llvm::errs() << "Initial term:    " << term << "\n";
+    llvm::errs() << "Erased term:     " << erased << "\n";
+    llvm::errs() << "Simplified term: " << simplified << "\n";
+    llvm::errs() << "\n";
+    dump(llvm::errs());
+    abort();
+  }
+#endif
+}

--- a/lib/AST/RequirementMachine/Histogram.h
+++ b/lib/AST/RequirementMachine/Histogram.h
@@ -35,6 +35,7 @@ class Histogram {
   unsigned Start;
   std::vector<unsigned> Buckets;
   unsigned OverflowBucket;
+  unsigned MaxValue = 0;
 
   const unsigned MaxWidth = 40;
 
@@ -73,6 +74,9 @@ public:
       ++OverflowBucket;
     else
       ++Buckets[value];
+
+    if (value > MaxValue)
+      MaxValue = value;
   }
 
   /// Print a nice-looking graphical representation of the histogram.
@@ -140,6 +144,8 @@ public:
 
     out << std::string(maxLabelWidth, ' ') << " | ";
     out << "Total: " << sumValues << "\n";
+    out << std::string(maxLabelWidth, ' ') << " | ";
+    out << "Max:   " << MaxValue << "\n";
   }
 };
 

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -99,7 +99,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
       break;
     }
 
-    step.apply(evaluator, system);
+    evaluator.apply(step, system);
   }
 
   // Collect all rules that we saw exactly once in empty context.
@@ -844,7 +844,7 @@ void RewriteSystem::verifyRewriteLoops() const {
     RewritePathEvaluator evaluator(loop.Basepoint);
 
     for (const auto &step : loop.Path) {
-      step.apply(evaluator, *this);
+      evaluator.apply(step, *this);
     }
 
     if (evaluator.getCurrentTerm() != loop.Basepoint) {

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -96,6 +96,8 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::ConcreteConformance:
+    case RewriteStep::SuperclassConformance:
       break;
     }
 
@@ -210,6 +212,8 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::ConcreteConformance:
+    case RewriteStep::SuperclassConformance:
       break;
     }
 
@@ -306,6 +310,8 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::ConcreteConformance:
+    case RewriteStep::SuperclassConformance:
       newSteps.push_back(step);
       break;
     }
@@ -339,6 +345,10 @@ bool RewriteStep::isInverseOf(const RewriteStep &other) const {
 
   case RewriteStep::Decompose:
     return RuleID == other.RuleID;
+
+  case RewriteStep::ConcreteConformance:
+  case RewriteStep::SuperclassConformance:
+    return true;
   }
 
   assert(EndOffset == other.EndOffset && "Bad whiskering?");
@@ -465,7 +475,7 @@ bool RewritePath::computeCyclicallyReducedLoop(MutableTerm &basepoint,
       break;
 
     // Update the basepoint by applying the first step in the path.
-    left.apply(evaluator, system);
+    evaluator.apply(left, system);
 
     ++count;
   }
@@ -522,6 +532,8 @@ bool RewriteLoop::isInContext(const RewriteSystem &system) const {
       case RewriteStep::AdjustConcreteType:
       case RewriteStep::Shift:
       case RewriteStep::Decompose:
+      case RewriteStep::ConcreteConformance:
+      case RewriteStep::SuperclassConformance:
         break;
       }
 
@@ -529,7 +541,7 @@ bool RewriteLoop::isInContext(const RewriteSystem &system) const {
         break;
     }
 
-    step.apply(evaluator, system);
+    evaluator.apply(step, system);
   }
 
   return (minStartOffset > 0 || minEndOffset > 0);

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -451,7 +451,7 @@ RewriteSystem::computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
     // perform the concrete type adjustment:
     //
     //     (σ - T)
-    if (xv.back().isSuperclassOrConcreteType() &&
+    if (xv.back().hasSubstitutions() &&
         !xv.back().getSubstitutions().empty() &&
         t.size() > 0) {
       path.add(RewriteStep::forAdjustment(t.size(), /*inverse=*/true));

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -388,6 +388,10 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
   // the concrete type witnesses in the concrete type's conformance.
   concretizeNestedTypesFromConcreteParents(inducedRules);
 
+  // Finally, introduce concrete conformance rules, relating conformance rules
+  // to concrete type and superclass rules.
+  recordConcreteConformanceRules(inducedRules);
+
   // Some of the induced rules might be trivial; only count the induced rules
   // where the left hand side is not already equivalent to the right hand side.
   unsigned addedNewRules = 0;

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -172,6 +172,8 @@ class PropertyMap {
   using ConcreteTypeInDomain = std::pair<CanType, ArrayRef<const ProtocolDecl *>>;
   llvm::DenseMap<ConcreteTypeInDomain, Term> ConcreteTypeInDomainMap;
 
+  llvm::DenseSet<std::pair<unsigned, unsigned>> ConcreteConformanceRules;
+
   DebugOptions Debug;
 
   PropertyBag *getOrCreateProperties(Term key);
@@ -217,6 +219,15 @@ private:
   MutableTerm computeConstraintTermForTypeWitness(
       Term key, CanType concreteType, CanType typeWitness,
       const MutableTerm &subjectType, ArrayRef<Term> substitutions) const;
+
+  void recordConcreteConformanceRules(
+      SmallVectorImpl<InducedRule> &inducedRules);
+
+  void recordConcreteConformanceRule(
+    unsigned concreteRuleID,
+    unsigned conformanceRuleID,
+    const ProtocolDecl *proto,
+    SmallVectorImpl<InducedRule> &inducedRules);
 
   void verify() const;
 };

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -43,6 +43,21 @@ namespace rewriting {
 class MutableTerm;
 class Term;
 
+/// A new rule introduced during property map construction, as a result of
+/// unifying two property symbols that apply to the same common suffix term.
+struct InducedRule {
+  MutableTerm LHS;
+  MutableTerm RHS;
+  RewritePath Path;
+
+  InducedRule(MutableTerm LHS, MutableTerm RHS, RewritePath Path)
+    : LHS(LHS), RHS(RHS), Path(Path) {}
+
+  // FIXME: Eventually all induced rules will have a rewrite path.
+  InducedRule(MutableTerm LHS, MutableTerm RHS)
+    : LHS(LHS), RHS(RHS) {}
+};
+
 /// Stores a convenient representation of all "property-like" rewrite rules of
 /// the form T.[p] => T, where [p] is a property symbol, for some term 'T'.
 class PropertyBag {
@@ -88,7 +103,7 @@ class PropertyBag {
   void addProperty(Symbol property,
                    unsigned ruleID,
                    RewriteContext &ctx,
-                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+                   SmallVectorImpl<InducedRule> &inducedRules,
                    bool debug);
   void copyPropertiesFrom(const PropertyBag *next,
                           RewriteContext &ctx);
@@ -186,18 +201,18 @@ public:
 private:
   void clear();
   void addProperty(Term key, Symbol property, unsigned ruleID,
-                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules);
+                   SmallVectorImpl<InducedRule> &inducedRules);
 
   void computeConcreteTypeInDomainMap();
   void concretizeNestedTypesFromConcreteParents(
-                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const;
+                   SmallVectorImpl<InducedRule> &inducedRules) const;
 
   void concretizeNestedTypesFromConcreteParent(
                    Term key, RequirementKind requirementKind,
                    CanType concreteType, ArrayRef<Term> substitutions,
                    ArrayRef<const ProtocolDecl *> conformsTo,
                    llvm::TinyPtrVector<ProtocolConformance *> &conformances,
-                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const;
+                   SmallVectorImpl<InducedRule> &inducedRules) const;
 
   MutableTerm computeConstraintTermForTypeWitness(
       Term key, CanType concreteType, CanType typeWitness,

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -90,15 +90,14 @@ namespace {
     ArrayRef<Term> lhsSubstitutions;
     ArrayRef<Term> rhsSubstitutions;
     RewriteContext &ctx;
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules;
+    SmallVectorImpl<InducedRule> &inducedRules;
     bool debug;
 
   public:
     ConcreteTypeMatcher(ArrayRef<Term> lhsSubstitutions,
                         ArrayRef<Term> rhsSubstitutions,
                         RewriteContext &ctx,
-                        SmallVectorImpl<std::pair<MutableTerm,
-                                                  MutableTerm>> &inducedRules,
+                        SmallVectorImpl<InducedRule> &inducedRules,
                         bool debug)
         : lhsSubstitutions(lhsSubstitutions),
           rhsSubstitutions(rhsSubstitutions),
@@ -205,7 +204,7 @@ namespace {
 /// Returns true if a conflict was detected.
 static bool unifyConcreteTypes(
     Symbol lhs, Symbol rhs, RewriteContext &ctx,
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+    SmallVectorImpl<InducedRule> &inducedRules,
     bool debug) {
   auto lhsType = lhs.getConcreteType();
   auto rhsType = rhs.getConcreteType();
@@ -253,7 +252,7 @@ static bool unifyConcreteTypes(
 /// that gets recorded in the property map.
 static Symbol unifySuperclasses(
     Symbol lhs, Symbol rhs, RewriteContext &ctx,
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+    SmallVectorImpl<InducedRule> &inducedRules,
     bool debug) {
   if (debug) {
     llvm::dbgs() << "% Unifying " << lhs << " with " << rhs << "\n";
@@ -310,7 +309,7 @@ static Symbol unifySuperclasses(
 
 void PropertyBag::addProperty(
     Symbol property, unsigned ruleID, RewriteContext &ctx,
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+    SmallVectorImpl<InducedRule> &inducedRules,
     bool debug) {
 
   switch (property.getKind()) {
@@ -395,7 +394,7 @@ void PropertyMap::computeConcreteTypeInDomainMap() {
 }
 
 void PropertyMap::concretizeNestedTypesFromConcreteParents(
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const {
+    SmallVectorImpl<InducedRule> &inducedRules) const {
   for (const auto &props : Entries) {
     if (props->getConformsTo().empty())
       continue;
@@ -478,7 +477,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     CanType concreteType, ArrayRef<Term> substitutions,
     ArrayRef<const ProtocolDecl *> conformsTo,
     llvm::TinyPtrVector<ProtocolConformance *> &conformances,
-    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const {
+    SmallVectorImpl<InducedRule> &inducedRules) const {
   assert(requirementKind == RequirementKind::SameType ||
          requirementKind == RequirementKind::Superclass);
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -309,19 +309,21 @@ static Symbol unifySuperclasses(
 }
 
 void PropertyBag::addProperty(
-    Symbol property, RewriteContext &ctx,
+    Symbol property, unsigned ruleID, RewriteContext &ctx,
     SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
     bool debug) {
 
   switch (property.getKind()) {
   case Symbol::Kind::Protocol:
     ConformsTo.push_back(property.getProtocol());
+    ConformsToRules.push_back(ruleID);
     return;
 
   case Symbol::Kind::Layout:
-    if (!Layout)
+    if (!Layout) {
       Layout = property.getLayoutConstraint();
-    else
+      LayoutRule = ruleID;
+    } else
       Layout = Layout.merge(property.getLayoutConstraint());
 
     return;
@@ -334,6 +336,7 @@ void PropertyBag::addProperty(
                                      ctx, inducedRules, debug);
     } else {
       Superclass = property;
+      SuperclassRule = ruleID;
     }
 
     return;
@@ -345,6 +348,7 @@ void PropertyBag::addProperty(
                                 ctx, inducedRules, debug);
     } else {
       ConcreteType = property;
+      ConcreteTypeRule = ruleID;
     }
 
     return;

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -648,3 +648,152 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
 
   return constraintType;
 }
+
+void PropertyMap::recordConcreteConformanceRules(
+    SmallVectorImpl<InducedRule> &inducedRules) {
+  for (const auto &props : Entries) {
+    if (props->getConformsTo().empty())
+      continue;
+
+    if (props->ConcreteType) {
+      unsigned concreteRuleID = *props->ConcreteTypeRule;
+
+      // The GSB drops all conformance requirements on a type parameter equated
+      // to a concrete type, even if the concrete type doesn't conform. That is,
+      //
+      // protocol P {}
+      // <T where T : P, T == Int>
+      //
+      // minimizes as
+      //
+      // <T where T == Int>.
+      for (unsigned i : indices(props->ConformsTo)) {
+        auto *proto = props->ConformsTo[i];
+        auto conformanceRuleID = props->ConformsToRules[i];
+        recordConcreteConformanceRule(concreteRuleID, conformanceRuleID, proto,
+                                      inducedRules);
+      }
+    }
+
+    if (props->Superclass) {
+      unsigned superclassRuleID = *props->SuperclassRule;
+
+      // For superclass rules, we only introduce a concrete conformance if the
+      // superclass actually conforms. Otherwise, it is totally fine to have a
+      // signature like
+      //
+      // protocol P {}
+      // class C {}
+      // <T  where T : P, T : C>
+      //
+      // There is no relation between P and C here.
+
+      // The conformances in SuperclassConformances should appear in the same
+      // order as the protocols in ConformsTo.
+      auto conformanceIter = props->SuperclassConformances.begin();
+
+      for (unsigned i : indices(props->ConformsTo)) {
+        if (conformanceIter == props->SuperclassConformances.end())
+          break;
+
+        auto *proto = props->ConformsTo[i];
+        if (proto != (*conformanceIter)->getProtocol())
+          continue;
+
+        unsigned conformanceRuleID = props->ConformsToRules[i];
+        recordConcreteConformanceRule(superclassRuleID, conformanceRuleID, proto,
+                                      inducedRules);
+        ++conformanceIter;
+      }
+
+      assert(conformanceIter == props->SuperclassConformances.end());
+    }
+  }
+}
+
+void PropertyMap::recordConcreteConformanceRule(
+    unsigned concreteRuleID,
+    unsigned conformanceRuleID,
+    const ProtocolDecl *proto,
+    SmallVectorImpl<InducedRule> &inducedRules) {
+  if (!ConcreteConformanceRules.insert(
+        std::make_pair(concreteRuleID, conformanceRuleID)).second) {
+    // We've already emitted this rule.
+    return;
+  }
+
+  const auto &concreteRule = System.getRule(concreteRuleID);
+  const auto &conformanceRule = System.getRule(conformanceRuleID);
+
+  auto conformanceSymbol = *conformanceRule.isPropertyRule();
+  assert(conformanceSymbol.getKind() == Symbol::Kind::Protocol);
+  assert(conformanceSymbol.getProtocol() == proto);
+
+  auto concreteSymbol = *concreteRule.isPropertyRule();
+  assert(concreteSymbol.getKind() == Symbol::Kind::ConcreteType ||
+         concreteSymbol.getKind() == Symbol::Kind::Superclass);
+
+  RewritePath path;
+
+  // We have a pair of rules T.[P] and T'.[concrete: C].
+  // Either T == T', or T is a prefix of T', or T' is a prefix of T.
+  //
+  // Let T'' be the longest of T and T'.
+  MutableTerm rhs(concreteRule.getRHS().size() > conformanceRule.getRHS().size()
+                  ? concreteRule.getRHS()
+                  : conformanceRule.getRHS());
+
+  // First, apply the conformance rule in reverse to obtain T''.[P].
+  path.add(RewriteStep::forRewriteRule(
+      /*startOffset=*/rhs.size() - conformanceRule.getRHS().size(),
+      /*endOffset=*/0,
+      /*ruleID=*/conformanceRuleID,
+      /*inverse=*/true));
+
+  // Now, apply the concrete type rule in reverse to obtain T''.[concrete: C].[P].
+  path.add(RewriteStep::forRewriteRule(
+      /*startOffset=*/rhs.size() - concreteRule.getRHS().size(),
+      /*endOffset=*/1,
+      /*ruleID=*/concreteRuleID,
+      /*inverse=*/true));
+
+  // Apply a concrete type adjustment to the concrete symbol if T' is shorter
+  // than T.
+  unsigned adjustment = rhs.size() - concreteRule.getRHS().size();
+  if (adjustment > 0 &&
+      !concreteSymbol.getSubstitutions().empty()) {
+    // FIXME: This needs an endOffset!
+    path.add(RewriteStep::forAdjustment(adjustment, /*inverse=*/false));
+
+    concreteSymbol = concreteSymbol.prependPrefixToConcreteSubstitutions(
+        MutableTerm(rhs.begin(), rhs.begin() + adjustment),
+        Context);
+  }
+
+  // Now, transform T''.[concrete: C].[P] into T''.[concrete: C : P].
+  Symbol concreteConformanceSymbol = [&]() {
+    if (concreteSymbol.getKind() == Symbol::Kind::ConcreteType) {
+      path.add(RewriteStep::forConcreteConformance(/*inverse=*/false));
+      return Symbol::forConcreteConformance(
+          concreteSymbol.getConcreteType(),
+          concreteSymbol.getSubstitutions(),
+          proto, Context);
+    } else {
+      assert(concreteSymbol.getKind() == Symbol::Kind::Superclass);
+      path.add(RewriteStep::forSuperclassConformance(/*inverse=*/false));
+      return Symbol::forConcreteConformance(
+          concreteSymbol.getSuperclass(),
+          concreteSymbol.getSubstitutions(),
+          proto, Context);
+    }
+  }();
+
+  MutableTerm lhs(rhs);
+  lhs.add(concreteConformanceSymbol);
+
+  // The path turns T'' (RHS) into T''.[concrete: C : P] (LHS), but we need
+  // it to go in the other direction.
+  path.invert();
+
+  inducedRules.emplace_back(std::move(lhs), std::move(rhs), std::move(path));
+}

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -350,6 +350,10 @@ void PropertyBag::addProperty(
     return;
   }
 
+  case Symbol::Kind::ConcreteConformance:
+    // FIXME
+    return;
+
   case Symbol::Kind::Name:
   case Symbol::Kind::GenericParam:
   case Symbol::Kind::AssociatedType:

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -21,119 +21,6 @@
 using namespace swift;
 using namespace rewriting;
 
-void RequirementMachine::verify(const MutableTerm &term) const {
-#ifndef NDEBUG
-  // If the term is in the generic parameter domain, ensure we have a valid
-  // generic parameter.
-  if (term.begin()->getKind() == Symbol::Kind::GenericParam) {
-    auto *genericParam = term.begin()->getGenericParam();
-    TypeArrayView<GenericTypeParamType> genericParams = getGenericParams();
-    auto found = std::find(genericParams.begin(),
-                           genericParams.end(),
-                           genericParam);
-    if (found == genericParams.end()) {
-      llvm::errs() << "Bad generic parameter in " << term << "\n";
-      dump(llvm::errs());
-      abort();
-    }
-  }
-
-  MutableTerm erased;
-
-  // First, "erase" resolved associated types from the term, and try
-  // to simplify it again.
-  for (auto symbol : term) {
-    if (erased.empty()) {
-      switch (symbol.getKind()) {
-      case Symbol::Kind::Protocol:
-      case Symbol::Kind::GenericParam:
-        erased.add(symbol);
-        continue;
-
-      case Symbol::Kind::AssociatedType:
-        erased.add(Symbol::forProtocol(symbol.getProtocols()[0], Context));
-        break;
-
-      case Symbol::Kind::Name:
-      case Symbol::Kind::Layout:
-      case Symbol::Kind::Superclass:
-      case Symbol::Kind::ConcreteType:
-      case Symbol::Kind::ConcreteConformance:
-        llvm::errs() << "Bad initial symbol in " << term << "\n";
-        abort();
-        break;
-      }
-    }
-
-    switch (symbol.getKind()) {
-    case Symbol::Kind::Name:
-      assert(!erased.empty());
-      erased.add(symbol);
-      break;
-
-    case Symbol::Kind::AssociatedType:
-      erased.add(Symbol::forName(symbol.getName(), Context));
-      break;
-
-    case Symbol::Kind::Protocol:
-    case Symbol::Kind::GenericParam:
-    case Symbol::Kind::Layout:
-    case Symbol::Kind::Superclass:
-    case Symbol::Kind::ConcreteType:
-    case Symbol::Kind::ConcreteConformance:
-      llvm::errs() << "Bad interior symbol " << symbol << " in " << term << "\n";
-      abort();
-      break;
-    }
-  }
-
-  MutableTerm simplified = erased;
-  System.simplify(simplified);
-
-  // We should end up with the same term.
-  if (simplified != term) {
-    llvm::errs() << "Term verification failed\n";
-    llvm::errs() << "Initial term:    " << term << "\n";
-    llvm::errs() << "Erased term:     " << erased << "\n";
-    llvm::errs() << "Simplified term: " << simplified << "\n";
-    llvm::errs() << "\n";
-    dump(llvm::errs());
-    abort();
-  }
-#endif
-}
-
-void RequirementMachine::dump(llvm::raw_ostream &out) const {
-  out << "Requirement machine for ";
-  if (Sig)
-    out << Sig;
-  else if (!Params.empty()) {
-    out << "fresh signature ";
-    for (auto paramTy : Params)
-      out << " " << Type(paramTy);
-  } else {
-    assert(!Protos.empty());
-    out << "protocols [";
-    for (auto *proto : Protos) {
-      out << " " << proto->getName();
-    }
-    out << " ]";
-  }
-  out << "\n";
-
-  System.dump(out);
-  Map.dump(out);
-
-  out << "Conformance access paths: {\n";
-  for (auto pair : ConformanceAccessPaths) {
-    out << "- " << pair.first.first << " : ";
-    out << pair.first.second->getName() << " => ";
-    pair.second.print(out);
-    out << "\n";
-  }
-  out << "}\n";
-}
-
 RequirementMachine::RequirementMachine(RewriteContext &ctx)
     : Context(ctx), System(ctx), Map(System) {
   auto &langOpts = ctx.getASTContext().LangOpts;
@@ -367,4 +254,35 @@ void RequirementMachine::computeCompletion(RewriteSystem::ValidityPolicy policy)
 
 bool RequirementMachine::isComplete() const {
   return Complete;
+}
+
+void RequirementMachine::dump(llvm::raw_ostream &out) const {
+  out << "Requirement machine for ";
+  if (Sig)
+    out << Sig;
+  else if (!Params.empty()) {
+    out << "fresh signature ";
+    for (auto paramTy : Params)
+      out << " " << Type(paramTy);
+  } else {
+    assert(!Protos.empty());
+    out << "protocols [";
+    for (auto *proto : Protos) {
+      out << " " << proto->getName();
+    }
+    out << " ]";
+  }
+  out << "\n";
+
+  System.dump(out);
+  Map.dump(out);
+
+  out << "Conformance access paths: {\n";
+  for (auto pair : ConformanceAccessPaths) {
+    out << "- " << pair.first.first << " : ";
+    out << pair.first.second->getName() << " => ";
+    pair.second.print(out);
+    out << "\n";
+  }
+  out << "}\n";
 }

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -58,6 +58,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
       case Symbol::Kind::Layout:
       case Symbol::Kind::Superclass:
       case Symbol::Kind::ConcreteType:
+      case Symbol::Kind::ConcreteConformance:
         llvm::errs() << "Bad initial symbol in " << term << "\n";
         abort();
         break;
@@ -79,6 +80,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
     case Symbol::Kind::Layout:
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
+    case Symbol::Kind::ConcreteConformance:
       llvm::errs() << "Bad interior symbol " << symbol << " in " << term << "\n";
       abort();
       break;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -140,6 +140,11 @@ RequirementMachine::buildRequirementsFromRules(
         return;
       }
 
+      case Symbol::Kind::ConcreteConformance:
+        // FIXME
+        llvm::errs() << "Concrete conformance: " << rule << "\n";
+        break;
+
       case Symbol::Kind::Name:
       case Symbol::Kind::AssociatedType:
       case Symbol::Kind::GenericParam:

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -349,6 +349,7 @@ Type getTypeForSymbolRange(Iter begin, Iter end, Type root,
       case Symbol::Kind::Layout:
       case Symbol::Kind::Superclass:
       case Symbol::Kind::ConcreteType:
+      case Symbol::Kind::ConcreteConformance:
         llvm_unreachable("Term has invalid root symbol");
       }
     }

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -671,6 +671,16 @@ RequirementMachine *RewriteContext::getRequirementMachine(
 /// We print stats in the destructor, which should get executed at the end of
 /// a compilation job.
 RewriteContext::~RewriteContext() {
+  for (const auto &pair : Machines)
+    delete pair.second;
+
+  Machines.clear();
+
+  for (const auto &pair : Components)
+    delete pair.second.Machine;
+
+  Components.clear();
+
   if (Context.LangOpts.AnalyzeRequirementMachine) {
     llvm::dbgs() << "--- Requirement Machine Statistics ---\n";
     llvm::dbgs() << "\n* Symbol kind:\n";
@@ -690,14 +700,4 @@ RewriteContext::~RewriteContext() {
     llvm::dbgs() << "\n* Generating conformance equations:\n";
     GeneratingConformancesHistogram.dump(llvm::dbgs());
   }
-
-  for (const auto &pair : Machines)
-    delete pair.second;
-
-  Machines.clear();
-
-  for (const auto &pair : Components)
-    delete pair.second.Machine;
-
-  Components.clear();
 }

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -59,7 +59,9 @@ RewriteContext::RewriteContext(ASTContext &ctx)
       RuleTrieHistogram(16, /*Start=*/1),
       RuleTrieRootHistogram(16),
       PropertyTrieHistogram(16, /*Start=*/1),
-      PropertyTrieRootHistogram(16) {
+      PropertyTrieRootHistogram(16),
+      ConformanceRulesHistogram(16),
+      GeneratingConformancesHistogram(8, /*Start=*/2) {
   auto debugFlags = StringRef(ctx.LangOpts.DebugRequirementMachine);
   if (!debugFlags.empty())
     Debug = parseDebugFlags(debugFlags);
@@ -683,6 +685,10 @@ RewriteContext::~RewriteContext() {
     PropertyTrieHistogram.dump(llvm::dbgs());
     llvm::dbgs() << "\n* Property trie root fanout:\n";
     PropertyTrieRootHistogram.dump(llvm::dbgs());
+    llvm::dbgs() << "\n* Conformance rules:\n";
+    ConformanceRulesHistogram.dump(llvm::dbgs());
+    llvm::dbgs() << "\n* Generating conformance equations:\n";
+    GeneratingConformancesHistogram.dump(llvm::dbgs());
   }
 
   for (const auto &pair : Machines)

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -130,6 +130,8 @@ public:
   Histogram RuleTrieRootHistogram;
   Histogram PropertyTrieHistogram;
   Histogram PropertyTrieRootHistogram;
+  Histogram ConformanceRulesHistogram;
+  Histogram GeneratingConformancesHistogram;
 
   explicit RewriteContext(ASTContext &ctx);
 

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -170,7 +170,7 @@ void RewriteStep::applyDecompose(RewritePathEvaluator &evaluator,
     // concrete type symbol.
     const auto &term = evaluator.getCurrentTerm();
     auto symbol = term.back();
-    if (!symbol.isSuperclassOrConcreteType()) {
+    if (!symbol.hasSubstitutions()) {
       llvm::errs() << "Expected term with superclass or concrete type symbol"
                    << " on A stack\n";
       evaluator.dump(llvm::errs());
@@ -201,7 +201,7 @@ void RewriteStep::applyDecompose(RewritePathEvaluator &evaluator,
     // updating with new substitutions.
     auto &term = *(evaluator.A.end() - numSubstitutions - 1);
     auto symbol = term.back();
-    if (!symbol.isSuperclassOrConcreteType()) {
+    if (!symbol.hasSubstitutions()) {
       llvm::errs() << "Expected term with superclass or concrete type symbol"
                    << " on A stack\n";
       evaluator.dump(llvm::errs());

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -312,14 +312,7 @@ void RewritePathEvaluator::applyDecompose(const RewriteStep &step,
     }
 
     // Build the new symbol with the new substitutions.
-    auto newSymbol = (symbol.getKind() == Symbol::Kind::Superclass
-                      ? Symbol::forSuperclass(symbol.getSuperclass(),
-                                              substitutions, ctx)
-                      : Symbol::forConcreteType(symbol.getConcreteType(),
-                                                substitutions, ctx));
-
-    // Update the term with the new symbol.
-    term.back() = newSymbol;
+    term.back() = symbol.withConcreteSubstitutions(substitutions, ctx);
 
     // Pop the substitutions from the A stack.
     A.resize(A.size() - numSubstitutions);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -285,33 +285,7 @@ void RewriteSystem::simplifySubstitutions(MutableTerm &term,
   }
 
   // Build the new symbol with simplified substitutions.
-  switch (symbol.getKind()) {
-  case Symbol::Kind::Superclass:
-    term.back() = Symbol::forSuperclass(symbol.getSuperclass(),
-                                        newSubstitutions, Context);
-    return;
-
-  case Symbol::Kind::ConcreteType:
-    term.back() = Symbol::forConcreteType(symbol.getConcreteType(),
-                                          newSubstitutions, Context);
-    return;
-
-  case Symbol::Kind::ConcreteConformance:
-    term.back() = Symbol::forConcreteConformance(symbol.getConcreteType(),
-                                                 newSubstitutions,
-                                                 symbol.getProtocol(),
-                                                 Context);
-    return;
-
-  case Symbol::Kind::Protocol:
-  case Symbol::Kind::Name:
-  case Symbol::Kind::AssociatedType:
-  case Symbol::Kind::GenericParam:
-  case Symbol::Kind::Layout:
-    break;
-  }
-
-  llvm_unreachable("Bad symbol kind");
+  term.back() = symbol.withConcreteSubstitutions(newSubstitutions, Context);
 }
 
 /// Adds a rewrite rule, returning true if the new rule was non-trivial.

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -24,6 +24,7 @@ using namespace swift;
 using namespace rewriting;
 
 const StringRef Symbol::Kinds[] = {
+  "conformance",
   "protocol",
   "assocty",
   "generic",
@@ -108,6 +109,21 @@ struct Symbol::Storage final
       getSubstitutions()[i] = substitutions[i];
   }
 
+  Storage(CanType type, ArrayRef<Term> substitutions, const ProtocolDecl *proto) {
+    assert(!type->hasTypeVariable());
+    assert(type->hasTypeParameter() != substitutions.empty());
+
+    Kind = unsigned(Symbol::Kind::ConcreteConformance);
+    NumProtocols = 1;
+    NumSubstitutions = substitutions.size();
+    ConcreteType = type;
+
+    for (unsigned i : indices(substitutions))
+      getSubstitutions()[i] = substitutions[i];
+
+    getProtocols()[0] = proto;
+  }
+
   size_t numTrailingObjects(OverloadToken<const ProtocolDecl *>) const {
     return NumProtocols;
   }
@@ -149,8 +165,12 @@ Identifier Symbol::getName() const {
 
 /// Get the single protocol declaration associated with a protocol symbol.
 const ProtocolDecl *Symbol::getProtocol() const {
-  assert(getKind() == Kind::Protocol);
-  return Ptr->Proto;
+  if (getKind() == Kind::Protocol)
+    return Ptr->Proto;
+
+  assert(getKind() == Kind::ConcreteConformance);
+  assert(Ptr->getProtocols().size() == 1);
+  return Ptr->getProtocols()[0];
 }
 
 /// Get the list of protocols associated with a protocol or associated type
@@ -186,19 +206,21 @@ CanType Symbol::getSuperclass() const {
 
 /// Get the concrete type associated with a concrete type symbol.
 CanType Symbol::getConcreteType() const {
-  assert(getKind() == Kind::ConcreteType);
+  assert(getKind() == Kind::ConcreteType ||
+         getKind() == Kind::ConcreteConformance);
   return Ptr->ConcreteType;
 }
 
 ArrayRef<Term> Symbol::getSubstitutions() const {
   assert(getKind() == Kind::Superclass ||
-         getKind() == Kind::ConcreteType);
+         getKind() == Kind::ConcreteType ||
+         getKind() == Kind::ConcreteConformance);
   return Ptr->getSubstitutions();
 }
 
 /// Creates a new name symbol.
 Symbol Symbol::forName(Identifier name,
-                   RewriteContext &ctx) {
+                       RewriteContext &ctx) {
   llvm::FoldingSetNodeID id;
   id.AddInteger(unsigned(Kind::Name));
   id.AddPointer(name.get());
@@ -417,6 +439,40 @@ Symbol Symbol::forConcreteType(CanType type, ArrayRef<Term> substitutions,
   return symbol;
 }
 
+/// Creates a concrete type symbol, representing a superclass constraint.
+Symbol Symbol::forConcreteConformance(CanType type,
+                                      ArrayRef<Term> substitutions,
+                                      const ProtocolDecl *proto,
+                                      RewriteContext &ctx) {
+  llvm::FoldingSetNodeID id;
+  id.AddInteger(unsigned(Kind::ConcreteConformance));
+  id.AddPointer(type.getPointer());
+  id.AddInteger(unsigned(substitutions.size()));
+  for (auto substitution : substitutions)
+    id.AddPointer(substitution.getOpaquePointer());
+  id.AddPointer(proto);
+
+  void *insertPos = nullptr;
+  if (auto *symbol = ctx.Symbols.FindNodeOrInsertPos(id, insertPos))
+    return symbol;
+
+  unsigned size = Storage::totalSizeToAlloc<const ProtocolDecl *, Term>(
+      /*protos=*/1, substitutions.size());
+  void *mem = ctx.Allocator.Allocate(size, alignof(Storage));
+  auto *symbol = new (mem) Storage(type, substitutions, proto);
+
+#ifndef NDEBUG
+  llvm::FoldingSetNodeID newID;
+  symbol->Profile(newID);
+  assert(id == newID);
+#endif
+
+  ctx.Symbols.InsertNode(symbol, insertPos);
+  ctx.SymbolHistogram.add(unsigned(Kind::ConcreteConformance));
+
+  return symbol;
+}
+
 /// Given that this symbol is the first symbol of a term, return the
 /// "domain" of the term.
 ///
@@ -439,6 +495,7 @@ ArrayRef<const ProtocolDecl *> Symbol::getRootProtocols() const {
   case Symbol::Kind::Layout:
   case Symbol::Kind::Superclass:
   case Symbol::Kind::ConcreteType:
+  case Symbol::Kind::ConcreteConformance:
     break;
   }
 
@@ -449,6 +506,7 @@ ArrayRef<const ProtocolDecl *> Symbol::getRootProtocols() const {
 ///
 /// First, we order different kinds as follows, from smallest to largest:
 ///
+/// - ConcreteConformance
 /// - Protocol
 /// - AssociatedType
 /// - GenericParam
@@ -490,6 +548,11 @@ ArrayRef<const ProtocolDecl *> Symbol::getRootProtocols() const {
 ///   is used to break ties; based on the protocol name and parent module.
 ///
 /// * For layout symbols, we use LayoutConstraint::compare().
+///
+/// * For concrete conformance symbols with distinct protocols, we compare
+///   the protocols.
+///
+/// All other symbol kinds are incomparable.
 int Symbol::compare(Symbol other, RewriteContext &ctx) const {
   // Exit early if the symbols are equal.
   if (Ptr == other.Ptr)
@@ -556,14 +619,30 @@ int Symbol::compare(Symbol other, RewriteContext &ctx) const {
     result = getLayoutConstraint().compare(other.getLayoutConstraint());
     break;
 
-  case Kind::Superclass:
-  case Kind::ConcreteType: {
-    assert(false && "Cannot compare concrete types yet");
+  case Kind::ConcreteConformance: {
+    auto *proto = getProtocol();
+    auto *otherProto = other.getProtocol();
+
+    result = ctx.compareProtocols(proto, otherProto);
     break;
   }
+
+  case Kind::Superclass:
+  case Kind::ConcreteType:
+    llvm::errs() << "Cannot compare concrete types yet\n";
+    llvm::errs() << "LHS: " << *this << "\n";
+    llvm::errs() << "RHS: " << other << "\n";
+    abort();
+
   }
 
-  assert(result != 0 && "Two distinct symbols should not compare equal");
+  if (result == 0) {
+    llvm::errs() << "Two distinct symbols should not compare equal\n";
+    llvm::errs() << "LHS: " << *this << "\n";
+    llvm::errs() << "RHS: " << other << "\n";
+    abort();
+  }
+
   return result;
 }
 
@@ -582,7 +661,7 @@ int Symbol::compare(Symbol other, RewriteContext &ctx) const {
 Symbol Symbol::transformConcreteSubstitutions(
     llvm::function_ref<Term(Term)> fn,
     RewriteContext &ctx) const {
-  assert(isSuperclassOrConcreteType());
+  assert(hasSubstitutions());
 
   if (getSubstitutions().empty())
     return *this;
@@ -603,8 +682,13 @@ Symbol Symbol::transformConcreteSubstitutions(
   switch (getKind()) {
   case Kind::Superclass:
     return Symbol::forSuperclass(getSuperclass(), substitutions, ctx);
+
   case Kind::ConcreteType:
     return Symbol::forConcreteType(getConcreteType(), substitutions, ctx);
+
+  case Kind::ConcreteConformance:
+    return Symbol::forConcreteConformance(getConcreteType(), substitutions,
+                                          getProtocol(), ctx);
 
   case Kind::GenericParam:
   case Kind::Name:
@@ -682,6 +766,14 @@ void Symbol::dump(llvm::raw_ostream &out) const {
     dumpSubstitutions();
     out << "]";
     return;
+
+  case Kind::ConcreteConformance:
+    out << "[concrete: " << getConcreteType();
+    dumpSubstitutions();
+    out << " : ";
+    out << getProtocol()->getName();
+    out << "]";
+    return;
   }
 
   llvm_unreachable("Bad symbol kind");
@@ -726,6 +818,17 @@ void Symbol::Storage::Profile(llvm::FoldingSetNodeID &id) const {
     for (auto term : getSubstitutions())
       id.AddPointer(term.getOpaquePointer());
 
+    return;
+  }
+
+  case Symbol::Kind::ConcreteConformance: {
+    id.AddPointer(ConcreteType.getPointer());
+
+    id.AddInteger(NumSubstitutions);
+    for (auto term : getSubstitutions())
+      id.AddPointer(term.getOpaquePointer());
+
+    id.AddPointer(getProtocols()[0]);
     return;
   }
   }

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -646,6 +646,31 @@ int Symbol::compare(Symbol other, RewriteContext &ctx) const {
   return result;
 }
 
+Symbol Symbol::withConcreteSubstitutions(
+    ArrayRef<Term> substitutions,
+    RewriteContext &ctx) const {
+  switch (getKind()) {
+  case Kind::Superclass:
+    return Symbol::forSuperclass(getSuperclass(), substitutions, ctx);
+
+  case Kind::ConcreteType:
+    return Symbol::forConcreteType(getConcreteType(), substitutions, ctx);
+
+  case Kind::ConcreteConformance:
+    return Symbol::forConcreteConformance(getConcreteType(), substitutions,
+                                          getProtocol(), ctx);
+
+  case Kind::GenericParam:
+  case Kind::Name:
+  case Kind::Protocol:
+  case Kind::AssociatedType:
+  case Kind::Layout:
+    break;
+  }
+
+  llvm_unreachable("Bad symbol kind");
+}
+
 /// For a superclass or concrete type symbol
 ///
 ///   [concrete: Foo<X1, ..., Xn>]
@@ -679,26 +704,7 @@ Symbol Symbol::transformConcreteSubstitutions(
   if (!anyChanged)
     return *this;
 
-  switch (getKind()) {
-  case Kind::Superclass:
-    return Symbol::forSuperclass(getSuperclass(), substitutions, ctx);
-
-  case Kind::ConcreteType:
-    return Symbol::forConcreteType(getConcreteType(), substitutions, ctx);
-
-  case Kind::ConcreteConformance:
-    return Symbol::forConcreteConformance(getConcreteType(), substitutions,
-                                          getProtocol(), ctx);
-
-  case Kind::GenericParam:
-  case Kind::Name:
-  case Kind::Protocol:
-  case Kind::AssociatedType:
-  case Kind::Layout:
-    break;
-  }
-
-  llvm_unreachable("Bad symbol kind");
+  return withConcreteSubstitutions(substitutions, ctx);
 }
 
 /// Print the symbol using our mnemonic representation.

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -227,6 +227,10 @@ public:
 
   int compare(Symbol other, RewriteContext &ctx) const;
 
+  Symbol withConcreteSubstitutions(
+      ArrayRef<Term> substitutions,
+      RewriteContext &ctx) const;
+
   Symbol transformConcreteSubstitutions(
       llvm::function_ref<Term(Term)> fn,
       RewriteContext &ctx) const;


### PR DESCRIPTION
Introduces a new symbol kind, the "concrete conformance symbol". This combines a concrete type with a protocol, and can appear in property rules, like so:

    T.[concrete: C : P] => T

These rules are introduced by property map construction when the same key is known to have a concrete type requirement together with a conformance requirement. Together with the new rule, property map construction also adds a rewrite loop that relates the concrete type rule, the protocol conformance rule and the concrete conformance rule together:

    (T => T.[P]) * (T => T.[concrete: C]).[P] * T.([concrete: C].[P] => [concrete: C : P]) * (T.[concrete: C : P] => T)

The rewrite step `([concrete: C].[P] => [concrete: C : P])` does not correspond to a rewrite rule, but is rather a special new kind `RewriteStep::ConcreteConformance`. It converts a pair of symbols, a concrete type symbol and a protocol symbol, into a concrete conformance symbol (or vice versa, when the step is inverted).

Similarly for superclasses, there is a new `RewriteStep::SuperclassConformance` which converts `([superclass: C].[P])` into `[concrete: C : P]`.

Note that in the new rewrite loop, the protocol conformance and concrete conformance rules appear in empty context, and the concrete type rule appears in context. This means the loop can be used to eliminate either the protocol conformance or the concrete conformance rules.

Concrete conformance symbols order before protocol conformance symbols, so a rule `T.[concrete: C : P] => T` orders before `T.[P] => T`. This means generating conformances will prefer to mark the latter as redundant, if possible.

Putting everything together, this means that given a signature like

    <T where T : Sequence, T : Array<Int>>

The `T : Sequence` requirement will become redundant. The minimized rewrite system will also have the concrete conformance rule. Since there is no such thing as a "concrete conformance requirement" in generic signatures, these rules are just dropped for now.