### PR TITLE
[build-presets] Verify SwiftSyntax generated files in Linux buildbot

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1119,6 +1119,7 @@ xctest
 foundation
 libdispatch
 swiftsyntax
+swiftsyntax-verify-generated-files
 indexstore-db
 sourcekit-lsp
 install-llvm


### PR DESCRIPTION
We never want to re-generate SwiftSyntax files in CI. If the generated files don’t match, we should fail early instead of regenerating files and failing later on with a harder to diagnose compilation error.