### PR TITLE
Make caching the typeref builder cache lazier

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -643,6 +643,10 @@ public:
 
 private:
   std::vector<ReflectionInfo> ReflectionInfos;
+
+  /// Index of the next Reflection Info that should be processed.
+  /// This assumes that Reflection Infos are never removed from the vector.
+  size_t FirstUnprocessedReflectionInfoIndex = 0;
     
   llvm::Optional<std::string> normalizeReflectionName(RemoteRef<char> name);
   bool reflectionNameMatches(RemoteRef<char> reflectionName,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently, when we have a cache miss on the typeref cache, we parse all the metadata that we know of, before querying the cache again. Change this to query for the typeref after parsing every reflection info. This will be especially useful for LLDB, as it uses a client server model, and parsing metadata may involve going through a (potentially slow network). 

This PR also has an added benefit of not re-parsing metadata that was already parsed before, if, for example, a new image is loaded in between different typeref queries.
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
