### PR TITLE
build-script: Explicitly use python3

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -8,13 +8,9 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
 """
 The ultimate tool for building Swift.
 """
-
-
-from __future__ import absolute_import, print_function, unicode_literals
 
 import json
 import os
@@ -31,8 +27,6 @@ from build_swift.build_swift.constants import BUILD_SCRIPT_IMPL_PATH
 from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
-
-import six
 
 from swift_build_support.swift_build_support import build_script_invocation
 from swift_build_support.swift_build_support import shell
@@ -120,7 +114,7 @@ class JSONDumper(json.JSONEncoder):
     def default(self, o):
         if hasattr(o, '__dict__'):
             return vars(o)
-        return six.text_type(o)
+        return str(o)
 
 
 def print_xcodebuild_versions(file=sys.stdout):
@@ -499,7 +493,7 @@ def main_preset():
     try:
         preset_parser.read_files(args.preset_file_names)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     if args.show_presets:
         for name in sorted(preset_parser.preset_names,
@@ -520,7 +514,7 @@ def main_preset():
             args.preset,
             vars=args.preset_substitutions)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     preset_args = migration.migrate_swift_sdks(preset.args)
 


### PR DESCRIPTION
This changes `build-script` shebang to use Python 3 explicitly. The code is already compatible and functional with python3, so this removes any implied backward compatibility, and removes any ambiguity based on the user's current environment, especially since some systems, like macOS, still link `python` to Python 2.

This also removes the now unnecessary `from __future__` imports, and the use of the `six` module, which is only necessary for python2 compatibility.

This is part of an ongoing effort to explicitly move to Python 3 and remove any implied support for Python 2.

Marking as a draft for now. Will test the with the full toolchain, hopefully to determine what went wrong last time.