### PR TITLE
[SwiftSyntax] Use default implementation of ExpressibleAs protocol

### DIFF
--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -211,6 +211,9 @@ def syntax_collection_element_to_collection_mapping():
                 node.collection_element_type, 
                 node.collection_element, 
                 node.is_token())
+            
+            if syntax_child_type == 'SyntaxBuildable':
+                continue
 
             if syntax_child_type not in collection_map:
                 collection_map[syntax_child_type] = []

--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -10,28 +10,20 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
         'MemberDeclListItem',
         'SyntaxBuildable'
     ],
+    'ExprBuildable': [
+        'CodeBlockItem'
+    ],
     'ExprList': [
         'ConditionElement',
-        'SyntaxBuildable'
-    ],
-    'IdentifierPattern': [
-        'PatternBuildable'
     ],
     'MemberDeclList': [
         'MemberDeclBlock'
     ],
-    'FunctionCallExpr': [
-        'CodeBlockItem',
-        'ExprBuildable'
-    ],
     'SequenceExpr': [
-        'CodeBlockItem',
-        'ExprBuildable',
         'TupleExprElement'
     ],
     'SimpleTypeIdentifier': [
         'TypeAnnotation',
-        'TypeBuildable',
         'TypeExpr'
     ],
     'StmtBuildable': [


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/349