### PR TITLE
[PreCheck] Don't use value declared in closure as outer candidate if …

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar85843677.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar85843677.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures
 
 func callClosure(closure: () -> ()) {  
   closure()


### PR DESCRIPTION
…it's validated

With multi-statement closure inference enabled "outer candidates"
hack needs to be careful with its use of `isInvalid()` because some
of the declarations lookup finds might be coming from a multi-statement
closure that being type-checked, such declarations have to be avoided
as candidates, otherwise calling `isInvalid` on them results in a circular
type-checking.

Resolves: rdar://85843677

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
