### PR TITLE
Improve `-require-explicit-sendable` check to account for `@_nonSendable`

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -929,8 +929,13 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
   if (!proto)
     return;
 
-  SmallVector<ProtocolConformance *, 2> conformances;
-  if (nominal->lookupConformance(proto, conformances))
+  // Look for a conformance. If it's present and not (directly) missing,
+  // we're done.
+  auto conformance = nominal->getParentModule()->lookupConformance(
+      nominal->getDeclaredInterfaceType(), proto, /*allowMissing=*/true);
+  if (conformance &&
+      !(isa<BuiltinProtocolConformance>(conformance.getConcrete()) &&
+        cast<BuiltinProtocolConformance>(conformance.getConcrete())->isMissing()))
     return;
 
   // Diagnose it.

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -97,3 +97,5 @@ public struct S10 { // expected-warning{{public struct 'S10' does not specify wh
 struct S11: Sendable {
   var s7: S7 // expected-warning{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-sendable type 'S7'}}
 }
+
+@_nonSendable public struct S12 { }


### PR DESCRIPTION
We were doing the conformance check through a lower-level interface that
didn't deal with the unavailable Sendable synthesis.
Fixes a spurious diagnostic reported via rdar://85894346.
