### PR TITLE
IRGen: Fix OpaqueStorageTypeInfo lowering

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1199,11 +1199,17 @@ namespace {
 
     void consume(IRGenFunction &IGF, Explosion &explosion,
                  Atomicity atomicity) const override {
-      (void)explosion.claimAll();
+      for (auto scalarTy: ScalarTypes) {
+        (void)scalarTy;
+        (void)explosion.claimNext();
+      }
     }
     
     void fixLifetime(IRGenFunction &IGF, Explosion &explosion) const override {
-      (void)explosion.claimAll();
+      for (auto scalarTy: ScalarTypes) {
+        (void)scalarTy;
+        (void)explosion.claimNext();
+      }
     }
 
     void destroy(IRGenFunction &IGF, Address address, SILType T,

--- a/test/IRGen/opaque_storage_type_info.swift
+++ b/test/IRGen/opaque_storage_type_info.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend -O -emit-ir -primary-file %s -module-name A
+// REQUIRES: VENDOR=apple
+import Foundation
+
+public struct Fooz {
+    var str = ""
+    var dec = Decimal()
+}


### PR DESCRIPTION
Can't call claimAll, rather need to call claimNext() according to the
number of expected explosions.

rdar://86069782