### PR TITLE
Align "explicitly non-Sendable" definition with proposal.

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1787,10 +1787,13 @@ behaviorLimitForExplicitUnavailability(
   auto protoDecl = rootConf->getProtocol();
 
   // Soften errors about unavailable `Sendable` conformances depending on the
-  // concurrency checking mode
-  if (protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable) ||
-      protoDecl->isSpecificProtocol(KnownProtocolKind::UnsafeSendable)) {
-    return SendableCheckContext(fromDC).defaultDiagnosticBehavior();
+  // concurrency checking mode.
+  if (protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+    SendableCheckContext checkContext(fromDC);
+    if (auto nominal = rootConf->getType()->getAnyNominal())
+      return checkContext.diagnosticBehavior(nominal);
+
+    return checkContext.defaultDiagnosticBehavior();
   }
 
   return DiagnosticBehavior::Unspecified;

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -8,7 +8,7 @@ struct NS1 { }
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable)
 extension NS1: Sendable { }
-// expected-note@-1 2{{conformance of 'NS1' to 'Sendable' has been explicitly marked unavailable here}}
+// expected-note@-1 4{{conformance of 'NS1' to 'Sendable' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
 struct NS2 { // expected-note{{consider making struct 'NS2' conform to the 'Sendable' protocol}}
@@ -22,26 +22,33 @@ struct NS3 { }
 extension NS3: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
+class NS4 { } // expected-note{{class 'NS4' does not conform to the 'Sendable' protocol}}
+
+@available(SwiftStdlib 5.1, *)
 func acceptCV<T: Sendable>(_: T) { }
 
 func acceptSendableFn(_: @Sendable @escaping () -> Void) { }
 
 @available(SwiftStdlib 5.1, *)
 func testCV(
-  ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, fn: @escaping () -> Void
+  ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
+  fn: @escaping () -> Void
   // expected-note@-1{{parameter 'fn' is implicitly non-sendable}}
 ) {
-  acceptCV(ns1)
-  acceptCV(ns1array)
+  acceptCV(ns1) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
+  acceptCV(ns1array) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
   acceptCV(ns2)
-  acceptCV(ns3)
+  acceptCV(ns3) // expected-warning{{conformance of 'NS3' to 'Sendable' is only available in macOS 11.0 or newer}}
+  // expected-note@-1{{add 'if #available' version check}}
+  acceptCV(ns4)
   acceptCV(fn)
   acceptSendableFn(fn) // expected-warning{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
 }
 
 @available(SwiftStdlib 5.1, *)
 func testCV(
-  ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, fn: @escaping () -> Void
+  ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
+  fn: @escaping () -> Void
   // expected-note@-1{{parameter 'fn' is implicitly non-sendable}}
 ) async {
   acceptCV(ns1) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
@@ -49,6 +56,7 @@ func testCV(
   acceptCV(ns2) // expected-warning{{type 'NS2' does not conform to the 'Sendable' protocol}}
   acceptCV(ns3) // expected-warning{{conformance of 'NS3' to 'Sendable' is only available in macOS 11.0 or newer}}
   // expected-note@-1{{add 'if #available' version check}}
+  acceptCV(ns4) // expected-warning{{type 'NS4' does not conform to the 'Sendable' protocol}}
   acceptCV(fn) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
   // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   acceptSendableFn(fn) // expected-error{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}


### PR DESCRIPTION
Use the explicit check for a Sendable conformance (even an unavailable
one) as the mechanism for determining whether to diagnose a
missing/unavailable Sendable conformance in a particular context.