### PR TITLE
test: repair the IRGen tests after #39680

### DIFF
--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -1,6 +1,10 @@
-// RUN: %target-swift-frontend  -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s
+// RUN: %target-swift-frontend  -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s -check-prefix CHECK-%target-abi
 
 // REQUIRES: concurrency
+
+// WASI does not support the mandatory tail call, and needs to take the same
+// path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
+// XFAIL: OS=wasi
 
 sil_stage canonical
 
@@ -10,13 +14,14 @@ import _Concurrency
 
 // CHECK-LABEL: define{{.*}} void @test_simple(
 // CHECK-SAME: %swift.context* swiftasync %0, [[INT]] %1, [[INT]] %2)
-// CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
-// CHECK: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
+// CHECK-DAG: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
+// CHECK-DAG: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
 // CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
 // CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
-// CHECK: unreachable
+// CHECK-WIN: ret void
+// CHECK-SYSV: unreachable
 
 sil @test_simple : $@async (@guaranteed Optional<Builtin.Executor>) -> () {
 bb0(%0 : $Optional<Builtin.Executor>):

--- a/test/IRGen/async/non_musttail_target.sil
+++ b/test/IRGen/async/non_musttail_target.sil
@@ -1,7 +1,8 @@
 // Ensure that IRGen don't emit unreachable after coro.end.async for targets that don't support musttail call.
-// RUN: %swift -disable-legacy-type-info -parse-stdlib -target wasm32-unknown-wasi %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -disable-legacy-type-info -parse-stdlib %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+
 // REQUIRES: concurrency
-// REQUIRES: CODEGENERATOR=WebAssembly
+// REQUIRES: OS=wasi || OS=windows-msvc
 
 sil_stage canonical
 


### PR DESCRIPTION
The change in 39680 impacts more than WebAssembly, but it did not update
the tests for impacted targets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
