### PR TITLE
[5.5] Cherry-pick a change from main to handle missing mandatory tail call optimizations

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4949,7 +4949,15 @@ void irgen::emitAsyncReturn(
     arguments.push_back(arg);
 
   Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_end_async, arguments);
-  Builder.CreateUnreachable();
+
+  if (IGF.IGM.AsyncTailCallKind == llvm::CallInst::TCK_MustTail) {
+    Builder.CreateUnreachable();
+  } else {
+    // If target doesn't support musttail (e.g. WebAssembly), the function
+    // passed to coro.end.async can return control back to the caller.
+    // So use ret void instead of unreachable to allow it.
+    Builder.CreateRetVoid();
+  }
 }
 
 void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -1,6 +1,10 @@
-// RUN: %target-swift-frontend -enable-experimental-concurrency -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-concurrency -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s -check-prefix CHECK-%target-abi
 
 // REQUIRES: concurrency
+
+// WASI does not support the mandatory tail call, and needs to take the same
+// path as CHECK-WIN, but will currently go down CHECK-SYSV, failing the test.
+// XFAIL: OS=wasi
 
 sil_stage canonical
 
@@ -10,13 +14,14 @@ import _Concurrency
 
 // CHECK-LABEL: define{{.*}} void @test_simple(
 // CHECK-SAME: %swift.context* swiftasync %0, [[INT]] %1, [[INT]] %2)
-// CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
-// CHECK: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
+// CHECK-DAG: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
+// CHECK-DAG: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
 // CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
 // CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
-// CHECK: unreachable
+// CHECK-WIN: ret void
+// CHECK-SYSV: unreachable
 
 sil @test_simple : $@async (@guaranteed Optional<Builtin.Executor>) -> () {
 bb0(%0 : $Optional<Builtin.Executor>):

--- a/test/IRGen/async/non_musttail_target.sil
+++ b/test/IRGen/async/non_musttail_target.sil
@@ -1,7 +1,8 @@
 // Ensure that IRGen don't emit unreachable after coro.end.async for targets that don't support musttail call.
-// RUN: %swift -disable-legacy-type-info -parse-stdlib -target wasm32-unknown-wasi %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -disable-legacy-type-info -parse-stdlib %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+
 // REQUIRES: concurrency
-// REQUIRES: CODEGENERATOR=WebAssembly
+// REQUIRES: OS=wasi || OS=windows-msvc
 
 sil_stage canonical
 

--- a/test/IRGen/async/non_musttail_target.sil
+++ b/test/IRGen/async/non_musttail_target.sil
@@ -1,0 +1,17 @@
+// Ensure that IRGen don't emit unreachable after coro.end.async for targets that don't support musttail call.
+// RUN: %swift -disable-legacy-type-info -parse-stdlib -target wasm32-unknown-wasi %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+sil_stage canonical
+
+import Builtin
+
+sil @test_simple : $@async () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+// CHECK:     call i1 (i8*, i1, ...) @llvm.coro.end.async
+// CHECK-NOT: unreachable
+// CHECK:     ret void
+}


### PR DESCRIPTION
This cherry-picks a change from main that ensures that async returns use `ret void` rather than `unreachable` on targets which do not support the LLVM `musttail` instruction.  Unfortunately, Windows does not support the `musttail` instruction as the PEI does not handle the lowering of the frame properly yet.