### PR TITLE
Modify reflection dumping to use std::ostream instead of FILE *

### DIFF
--- a/include/swift/Reflection/MetadataSource.h
+++ b/include/swift/Reflection/MetadataSource.h
@@ -178,7 +178,7 @@ public:
   }
 
   void dump() const;
-  void dump(FILE *file, unsigned Indent = 0) const;
+  void dump(std::ostream &stream, unsigned Indent = 0) const;
   template <typename Allocator>
   static const MetadataSource *decode(Allocator &A, const std::string &str) {
     auto begin = str.begin();

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -145,7 +145,7 @@ public:
   bool isBitwiseTakable() const { return BitwiseTakable; }
 
   void dump() const;
-  void dump(FILE *file, unsigned Indent = 0) const;
+  void dump(std::ostream &stream, unsigned Indent = 0) const;
 
   // Using the provided reader, inspect our value.
   // Return false if we can't inspect value.

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -25,7 +25,7 @@
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Remote/MetadataReader.h"
 #include "swift/Basic/Unreachable.h"
-
+#include <ostream>
 namespace swift {
 namespace reflection {
 
@@ -177,7 +177,7 @@ public:
   }
 
   void dump() const;
-  void dump(FILE *file, unsigned Indent = 0) const;
+  void dump(std::ostream &stream, unsigned Indent = 0) const;
 
   /// Build a demangle tree from this TypeRef.
   Demangle::NodePointer getDemangling(Demangle::Demangler &Dem) const;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -24,8 +24,9 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "llvm/ADT/Optional.h"
-#include <vector>
+#include <ostream>
 #include <unordered_map>
+#include <vector>
 
 namespace swift {
 namespace reflection {
@@ -209,7 +210,7 @@ struct ClosureContextInfo {
   unsigned NumBindings = 0;
 
   void dump() const;
-  void dump(FILE *file) const;
+  void dump(std::ostream &stream) const;
 };
 
 struct FieldTypeInfo {
@@ -728,12 +729,12 @@ public:
   ///
 
   void dumpTypeRef(RemoteRef<char> MangledName,
-                   FILE *file, bool printTypeName = false);
-  void dumpFieldSection(FILE *file);
-  void dumpAssociatedTypeSection(FILE *file);
-  void dumpBuiltinTypeSection(FILE *file);
-  void dumpCaptureSection(FILE *file);
-  void dumpAllSections(FILE *file);
+                   std::ostream &stream, bool printTypeName = false);
+  void dumpFieldSection(std::ostream &stream);
+  void dumpAssociatedTypeSection(std::ostream &stream);
+  void dumpBuiltinTypeSection(std::ostream &stream);
+  void dumpCaptureSection(std::ostream &stream);
+  void dumpAllSections(std::ostream &stream);
 };
 
 

--- a/stdlib/public/Reflection/MetadataSource.cpp
+++ b/stdlib/public/Reflection/MetadataSource.cpp
@@ -11,36 +11,37 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Reflection/MetadataSource.h"
+#include <iostream>
 
 using namespace swift;
 using namespace reflection;
 
 class PrintMetadataSource
   : public MetadataSourceVisitor<PrintMetadataSource, void> {
-  FILE *file;
+  std::ostream &stream;
   unsigned Indent;
 
-  FILE * indent(unsigned Amount) {
+  std::ostream &indent(unsigned Amount) {
     for (unsigned i = 0; i < Amount; ++i)
-      fprintf(file, " ");
-    return file;
+      stream << " ";
+    return stream;
   }
 
-  FILE * printHeader(std::string Name) {
-    fprintf(indent(Indent), "(%s", Name.c_str());
-    return file;
+  std::ostream &printHeader(std::string Name) {
+    indent(Indent) << "(" << Name;
+    return stream;
   }
 
-  FILE * printField(std::string name, std::string value) {
+  std::ostream &printField(std::string name, std::string value) {
     if (!name.empty())
-      fprintf(file, " %s=%s", name.c_str(), value.c_str());
+      stream << " " << name << "=" << value;
     else
-      fprintf(file, " %s", value.c_str());
-    return file;
+      stream << " " << value;
+    return stream;
   }
 
   void printRec(const MetadataSource *MS) {
-    fprintf(file, "\n");
+    stream << "\n";
 
     Indent += 2;
     visit(MS);
@@ -48,12 +49,12 @@ class PrintMetadataSource
   }
 
   void closeForm() {
-    fprintf(file, ")");
+    stream << ")";
   }
 
 public:
-  PrintMetadataSource(FILE *file, unsigned Indent)
-    : file(file), Indent(Indent) {}
+  PrintMetadataSource(std::ostream &stream, unsigned Indent)
+      : stream(stream), Indent(Indent) {}
 
   void
   visitClosureBindingMetadataSource(const ClosureBindingMetadataSource *CB) {
@@ -96,11 +97,9 @@ public:
   }
 };
 
-void MetadataSource::dump() const {
-  dump(stderr, 0);
-}
+void MetadataSource::dump() const { dump(std::cerr, 0); }
 
-void MetadataSource::dump(FILE *file, unsigned Indent) const {
-  PrintMetadataSource(file, Indent).visit(this);
-  fprintf(file, "\n");
+void MetadataSource::dump(std::ostream &stream, unsigned Indent) const {
+  PrintMetadataSource(stream, Indent).visit(this);
+  stream << "\n";
 }

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -19,35 +19,36 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
+#include <iostream>
 
 using namespace swift;
 using namespace reflection;
 
 class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
-  FILE *file;
+  std::ostream &stream;
   unsigned Indent;
 
-  FILE * &indent(unsigned Amount) {
+  std::ostream &indent(unsigned Amount) {
     for (unsigned i = 0; i < Amount; ++i)
-      fprintf(file, " ");
-    return file;
+      stream << " ";
+    return stream;
   }
 
-  FILE * &printHeader(std::string Name) {
-    fprintf(indent(Indent), "(%s", Name.c_str());
-    return file;
+  std::ostream &printHeader(std::string Name) {
+    indent(Indent) << "(" << Name;
+    return stream;
   }
 
-  FILE * &printField(std::string name, std::string value) {
+  std::ostream &printField(std::string name, std::string value) {
     if (!name.empty())
-      fprintf(file, " %s=%s", name.c_str(), value.c_str());
+      stream << " " << name << "=" << value;
     else
-      fprintf(file, " %s", value.c_str());
-    return file;
+      stream << " " << value;
+    return stream;
   }
 
   void printRec(const TypeRef *typeRef) {
-    fprintf(file, "\n");
+    stream << "\n";
 
     Indent += 2;
     visit(typeRef);
@@ -55,14 +56,14 @@ class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
   }
 
 public:
-  PrintTypeRef(FILE *file, unsigned Indent)
-    : file(file), Indent(Indent) {}
+  PrintTypeRef(std::ostream &stream, unsigned Indent)
+      : stream(stream), Indent(Indent) {}
 
   void visitBuiltinTypeRef(const BuiltinTypeRef *B) {
     printHeader("builtin");
     auto demangled = Demangle::demangleTypeAsString(B->getMangledName());
     printField("", demangled);
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitNominalTypeRef(const NominalTypeRef *N) {
@@ -76,8 +77,7 @@ public:
     else if (N->isProtocol()) {
       printHeader("protocol");
       mangledName = Demangle::dropSwiftManglingPrefix(mangledName);
-    }
-    else if (N->isAlias())
+    } else if (N->isAlias())
       printHeader("alias");
     else
       printHeader("nominal");
@@ -85,7 +85,7 @@ public:
     printField("", demangled);
     if (auto parent = N->getParent())
       printRec(parent);
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitBoundGenericTypeRef(const BoundGenericTypeRef *BG) {
@@ -104,7 +104,7 @@ public:
       printRec(param);
     if (auto parent = BG->getParent())
       printRec(parent);
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitTupleTypeRef(const TupleTypeRef *T) {
@@ -114,10 +114,10 @@ public:
     for (auto NameElement : llvm::zip_first(Labels, T->getElements())) {
       auto Label = std::get<0>(NameElement);
       if (!Label.empty())
-        fprintf(file, "%s = ", Label.str().c_str());
+        stream << Label.str() << " = ";
       printRec(std::get<1>(NameElement));
     }
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitFunctionTypeRef(const FunctionTypeRef *F) {
@@ -159,19 +159,19 @@ public:
     }
 
     if (auto globalActor = F->getGlobalActor()) {
-      fprintf(file, "\n");
+      stream << "\n";
       Indent += 2;
       printHeader("global-actor");
       {
         Indent += 2;
         printRec(globalActor);
-        fprintf(file, ")");
+        stream << ")";
         Indent -= 2;
       }
       Indent += 2;
     }
 
-    fprintf(file, "\n");
+    stream << "\n";
     Indent += 2;
     printHeader("parameters");
 
@@ -181,7 +181,7 @@ public:
 
       if (!flags.isNone()) {
         Indent += 2;
-        fprintf(file, "\n");
+        stream << "\n";
       }
 
       switch (flags.getValueOwnership()) {
@@ -209,17 +209,17 @@ public:
 
       if (!flags.isNone()) {
         Indent -= 2;
-        fprintf(file, ")");
+        stream << ")";
       }
     }
 
     if (parameters.empty())
-      fprintf(file, ")");
+      stream << ")";
 
-    fprintf(file, "\n");
+    stream << "\n";
     printHeader("result");
     printRec(F->getResult());
-    fprintf(file, ")");
+    stream << ")";
 
     Indent -= 2;
   }
@@ -227,12 +227,12 @@ public:
   void visitProtocolCompositionTypeRef(const ProtocolCompositionTypeRef *PC) {
     printHeader("protocol_composition");
     if (PC->hasExplicitAnyObject())
-      fprintf(file, " any_object");
+      stream << " any_object";
     if (auto superclass = PC->getSuperclass())
       printRec(superclass);
     for (auto protocol : PC->getProtocols())
       printRec(protocol);
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitMetatypeTypeRef(const MetatypeTypeRef *M) {
@@ -240,20 +240,21 @@ public:
     if (M->wasAbstract())
       printField("", "was_abstract");
     printRec(M->getInstanceType());
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitExistentialMetatypeTypeRef(const ExistentialMetatypeTypeRef *EM) {
     printHeader("existential_metatype");
     printRec(EM->getInstanceType());
-    fprintf(file, ")");
+    stream << ")";
   }
 
-  void visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP){
+  void
+  visitGenericTypeParameterTypeRef(const GenericTypeParameterTypeRef *GTP) {
     printHeader("generic_type_parameter");
     printField("depth", std::to_string(GTP->getDepth()));
     printField("index", std::to_string(GTP->getIndex()));
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {
@@ -261,41 +262,42 @@ public:
     printField("protocol", DM->getProtocol());
     printRec(DM->getBase());
     printField("member", DM->getMember());
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
     printHeader("foreign");
     if (!F->getName().empty())
       printField("name", F->getName());
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitObjCClassTypeRef(const ObjCClassTypeRef *OC) {
     printHeader("objective_c_class");
     if (!OC->getName().empty())
       printField("name", OC->getName());
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitObjCProtocolTypeRef(const ObjCProtocolTypeRef *OC) {
     printHeader("objective_c_protocol");
     if (!OC->getName().empty())
       printField("name", OC->getName());
-    fprintf(file, ")");
+    stream << ")";
   }
 
-#define REF_STORAGE(Name, name, ...) \
-  void visit##Name##StorageTypeRef(const Name##StorageTypeRef *US) { \
-    printHeader(#name "_storage"); \
-    printRec(US->getType()); \
-    fprintf(file, ")"); \
+#define REF_STORAGE(Name, name, ...)                                           \
+  void visit##Name##StorageTypeRef(const Name##StorageTypeRef *US) {           \
+    printHeader(#name "_storage");                                             \
+    printRec(US->getType());                                                   \
+    stream << ")";                                                             \
   }
 #include "swift/AST/ReferenceStorage.def"
 
   void visitSILBoxTypeRef(const SILBoxTypeRef *SB) {
-    printHeader("sil_box");  printRec(SB->getBoxedType());
-    fprintf(file, ")");
+    printHeader("sil_box");
+    printRec(SB->getBoxedType());
+    stream << ")";
   }
 
   void visitSILBoxTypeWithLayoutTypeRef(const SILBoxTypeWithLayoutTypeRef *SB) {
@@ -306,17 +308,17 @@ public:
     for (auto &f : SB->getFields()) {
       printHeader(f.isMutable() ? "var" : "let");
       printRec(f.getType());
-      fprintf(file, ")");
+      stream << ")";
     }
     Indent -= 2;
-    fprintf(file, ")\n");
+    stream << ")\n";
     printHeader("generic_signature\n");
     Indent += 2;
     for (auto &subst : SB->getSubstitutions()) {
       printHeader("substitution");
       printRec(subst.first);
       printRec(subst.second);
-      fprintf(file, ")");
+      stream << ")";
     }
     Indent -= 2;
     for (auto &req : SB->getRequirements()) {
@@ -325,43 +327,43 @@ public:
       case RequirementKind::Conformance:
       case RequirementKind::Superclass:
         printRec(req.getFirstType());
-        fprintf(file, " : ");
+        stream << " : ";
         printRec(req.getSecondType());
         break;
       case RequirementKind::SameType:
         printRec(req.getFirstType());
-        fprintf(file, " == ");
+        stream << " == ";
         printRec(req.getSecondType());
         break;
       case RequirementKind::Layout:
-        fprintf(file, "layout requirement");
+        stream << "layout requirement";
         break;
       }
-      fprintf(file, ")");
+      stream << ")";
     }
-    fprintf(file, ")");
-    fprintf(file, ")");
+    stream << ")";
+    stream << ")";
   }
 
   void visitOpaqueArchetypeTypeRef(const OpaqueArchetypeTypeRef *O) {
     printHeader("opaque_archetype");
     printField("id", O->getID().str());
     printField("description", O->getDescription().str());
-    fprintf(file, " ordinal %u ", O->getOrdinal());
+    stream << " ordinal " << O->getOrdinal() << " ";
     for (auto argList : O->getArgumentLists()) {
-      fprintf(file, "\n");
-      fprintf(indent(Indent + 2), "args: <");
+      stream << "\n";
+      indent(Indent + 2) << "args: <";
       for (auto arg : argList) {
         printRec(arg);
       }
-      fprintf(file, ">");
+      stream << ">";
     }
-    fprintf(file, ")");
+    stream << ")";
   }
 
   void visitOpaqueTypeRef(const OpaqueTypeRef *O) {
     printHeader("opaque");
-    fprintf(file, ")");
+    stream << ")";
   }
 };
 
@@ -478,13 +480,11 @@ const OpaqueTypeRef *OpaqueTypeRef::get() {
   return Singleton;
 }
 
-void TypeRef::dump() const {
-  dump(stderr);
-}
+void TypeRef::dump() const { dump(std::cerr); }
 
-void TypeRef::dump(FILE *file, unsigned Indent) const {
-  PrintTypeRef(file, Indent).visit(this);
-  fprintf(file, "\n");
+void TypeRef::dump(std::ostream &stream, unsigned Indent) const {
+  PrintTypeRef(stream, Indent).visit(this);
+  stream << "\n";
 }
 
 class DemanglingForTypeRef

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -22,6 +22,8 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Remote/MetadataReader.h"
+#include <iomanip>
+#include <iostream>
 
 using namespace swift;
 using namespace reflection;
@@ -361,67 +363,64 @@ TypeRefBuilder::getClosureContextInfo(RemoteRef<CaptureDescriptor> CD) {
 /// Dumping reflection metadata
 ///
 
-void
-TypeRefBuilder::dumpTypeRef(RemoteRef<char> MangledName,
-                            FILE *file, bool printTypeName) {
+void TypeRefBuilder::dumpTypeRef(RemoteRef<char> MangledName,
+                                 std::ostream &stream, bool printTypeName) {
   auto DemangleTree = demangleTypeRef(MangledName);
   auto TypeName = nodeToString(DemangleTree);
-  fprintf(file, "%s\n", TypeName.c_str());
+  stream << TypeName << "\n";
   auto Result = swift::Demangle::decodeMangledType(*this, DemangleTree);
   clearNodeFactory();
   if (Result.isError()) {
     auto *Error = Result.getError();
     char *ErrorStr = Error->copyErrorString();
     auto str = getTypeRefString(MangledName);
-    fprintf(file, "!!! Invalid typeref: %s - %s\n",
-            std::string(str.begin(), str.end()).c_str(), ErrorStr);
+    stream << "!!! Invalid typeref: " << str.str() << " - " << ErrorStr << "\n";
     Error->freeErrorString(ErrorStr);
     return;
   }
   auto TR = Result.getType();
-  TR->dump(file);
-  fprintf(file, "\n");
+  TR->dump(stream);
+  stream << "\n";
 }
 
-void TypeRefBuilder::dumpFieldSection(FILE *file) {
+void TypeRefBuilder::dumpFieldSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (auto descriptor : sections.Field) {
       auto TypeDemangling =
-        demangleTypeRef(readTypeRef(descriptor, descriptor->MangledTypeName));
+          demangleTypeRef(readTypeRef(descriptor, descriptor->MangledTypeName));
       auto TypeName = nodeToString(TypeDemangling);
       clearNodeFactory();
-      fprintf(file, "%s\n", TypeName.c_str());
+      stream << TypeName.c_str() << "\n";
       for (size_t i = 0; i < TypeName.size(); ++i)
-        fprintf(file, "-");
-      fprintf(file, "\n");
+        stream << "-";
+      stream << "\n";
       for (auto &fieldRef : *descriptor.getLocalBuffer()) {
         auto field = descriptor.getField(fieldRef);
         auto fieldName = getTypeRefString(readTypeRef(field, field->FieldName));
-        fprintf(file, "%*s", (int)fieldName.size(), fieldName.data());
+        stream.write(fieldName.data(), fieldName.size());
         if (field->hasMangledTypeName()) {
-          fprintf(file, ": ");
-          dumpTypeRef(readTypeRef(field, field->MangledTypeName), file);
+          stream << ": ";
+          dumpTypeRef(readTypeRef(field, field->MangledTypeName), stream);
         } else {
-          fprintf(file, "\n\n");
+          stream << "\n\n";
         }
       }
     }
   }
 }
 
-void TypeRefBuilder::dumpAssociatedTypeSection(FILE *file) {
+void TypeRefBuilder::dumpAssociatedTypeSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (auto descriptor : sections.AssociatedType) {
       auto conformingTypeNode = demangleTypeRef(
-                       readTypeRef(descriptor, descriptor->ConformingTypeName));
+          readTypeRef(descriptor, descriptor->ConformingTypeName));
       auto conformingTypeName = nodeToString(conformingTypeNode);
       auto protocolNode = demangleTypeRef(
-                         readTypeRef(descriptor, descriptor->ProtocolTypeName));
+          readTypeRef(descriptor, descriptor->ProtocolTypeName));
       auto protocolName = nodeToString(protocolNode);
       clearNodeFactory();
 
-      fprintf(file, "- %s : %s", conformingTypeName.c_str(), protocolName.c_str());
-      fprintf(file, "\n");
+      stream << "- " << conformingTypeName << " : " << protocolName << "\n";
 
       for (const auto &associatedTypeRef : *descriptor.getLocalBuffer()) {
         auto associatedType = descriptor.getField(associatedTypeRef);
@@ -429,82 +428,82 @@ void TypeRefBuilder::dumpAssociatedTypeSection(FILE *file) {
         std::string name =
             getTypeRefString(readTypeRef(associatedType, associatedType->Name))
                 .str();
-        fprintf(file, "typealias %s = ", name.c_str());
+        stream << "typealias " << name << " = ";
         dumpTypeRef(
-          readTypeRef(associatedType, associatedType->SubstitutedTypeName), file);
+            readTypeRef(associatedType, associatedType->SubstitutedTypeName),
+            stream);
       }
     }
   }
 }
 
-void TypeRefBuilder::dumpBuiltinTypeSection(FILE *file) {
+void TypeRefBuilder::dumpBuiltinTypeSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (auto descriptor : sections.Builtin) {
-      auto typeNode = demangleTypeRef(readTypeRef(descriptor,
-                                                  descriptor->TypeName));
+      auto typeNode =
+          demangleTypeRef(readTypeRef(descriptor, descriptor->TypeName));
       auto typeName = nodeToString(typeNode);
       clearNodeFactory();
-      
-      fprintf(file, "\n- %s:\n", typeName.c_str());
-      fprintf(file, "Size: %u\n", descriptor->Size);
-      fprintf(file, "Alignment: %u:\n", descriptor->getAlignment());
-      fprintf(file, "Stride: %u:\n", descriptor->Stride);
-      fprintf(file, "NumExtraInhabitants: %u:\n", descriptor->NumExtraInhabitants);
-      fprintf(file, "BitwiseTakable: %d:\n", descriptor->isBitwiseTakable());
+
+      stream << "\n- " << typeName << ":\n";
+      stream << "Size: " << descriptor->Size << "\n";
+      stream << "Alignment: " << descriptor->getAlignment() << ":\n";
+      stream << "Stride: " << descriptor->Stride << ":\n";
+      stream << "NumExtraInhabitants: " << descriptor->NumExtraInhabitants
+             << ":\n";
+      stream << "BitwiseTakable: " << descriptor->isBitwiseTakable() << ":\n";
     }
   }
 }
 
-void ClosureContextInfo::dump() const {
-  dump(stderr);
-}
+void ClosureContextInfo::dump() const { dump(std::cerr); }
 
-void ClosureContextInfo::dump(FILE *file) const {
-  fprintf(file, "- Capture types:\n");
+void ClosureContextInfo::dump(std::ostream &stream) const {
+  stream << "- Capture types:\n";
   for (auto *TR : CaptureTypes) {
     if (TR == nullptr)
-      fprintf(file, "!!! Invalid typeref\n");
+      stream << "!!! Invalid typeref\n";
     else
-      TR->dump(file);
+      TR->dump(stream);
   }
-  fprintf(file, "- Metadata sources:\n");
+  stream << "- Metadata sources:\n";
   for (auto MS : MetadataSources) {
     if (MS.first == nullptr)
-      fprintf(file, "!!! Invalid typeref\n");
+      stream << "!!! Invalid typeref\n";
     else
-      MS.first->dump(file);
+      MS.first->dump(stream);
     if (MS.second == nullptr)
-      fprintf(file, "!!! Invalid metadata source\n");
+      stream << "!!! Invalid metadata source\n";
     else
-      MS.second->dump(file);
+      MS.second->dump(stream);
   }
-  fprintf(file, "\n");
+  stream << "\n";
 }
 
-void TypeRefBuilder::dumpCaptureSection(FILE *file) {
+void TypeRefBuilder::dumpCaptureSection(std::ostream &stream) {
   for (const auto &sections : ReflectionInfos) {
     for (const auto descriptor : sections.Capture) {
       auto info = getClosureContextInfo(descriptor);
-      info.dump(file);
+      info.dump(stream);
     }
   }
 }
 
-void TypeRefBuilder::dumpAllSections(FILE *file) {
-  fprintf(file, "FIELDS:\n");
-  fprintf(file, "=======\n");
-  dumpFieldSection(file);
-  fprintf(file, "\n");
-  fprintf(file, "ASSOCIATED TYPES:\n");
-  fprintf(file, "=================\n");
-  dumpAssociatedTypeSection(file);
-  fprintf(file, "\n");
-  fprintf(file, "BUILTIN TYPES:\n");
-  fprintf(file, "==============\n");
-  dumpBuiltinTypeSection(file);
-  fprintf(file, "\n");
-  fprintf(file, "CAPTURE DESCRIPTORS:\n");
-  fprintf(file, "====================\n");
-  dumpCaptureSection(file);
-  fprintf(file, "\n");
+void TypeRefBuilder::dumpAllSections(std::ostream &stream) {
+  stream << "FIELDS:\n";
+  stream << "=======\n";
+  dumpFieldSection(stream);
+  stream << "\n";
+  stream << "ASSOCIATED TYPES:\n";
+  stream << "=================\n";
+  dumpAssociatedTypeSection(stream);
+  stream << "\n";
+  stream << "BUILTIN TYPES:\n";
+  stream << "==============\n";
+  dumpBuiltinTypeSection(stream);
+  stream << "\n";
+  stream << "CAPTURE DESCRIPTORS:\n";
+  stream << "====================\n";
+  dumpCaptureSection(stream);
+  stream << "\n";
 }

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SwiftRemoteMirror/Platform.h"
 #include "swift/SwiftRemoteMirror/SwiftRemoteMirror.h"
+#include <iostream>
 
 #define SWIFT_CLASS_IS_SWIFT_MASK swift_reflection_classIsSwiftMask
 extern "C" {
@@ -200,7 +201,7 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
       || Info.capture.offset != 0
       || Info.type_references.offset != 0
       || Info.reflection_strings.offset != 0) {
-    fprintf(stderr, "reserved field in swift_reflection_info_t is not zero\n");
+    std::cerr << "reserved field in swift_reflection_info_t is not zero\n";
     abort();
   }
   
@@ -621,9 +622,9 @@ int swift_reflection_projectEnumValue(SwiftReflectionContextRef ContextRef,
 void swift_reflection_dumpTypeRef(swift_typeref_t OpaqueTypeRef) {
   auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   if (TR == nullptr) {
-    fprintf(stdout, "<null type reference>\n");
+    std::cout << "<null type reference>\n";
   } else {
-    TR->dump(stdout);
+    TR->dump(std::cout);
   }
 }
 
@@ -633,27 +634,26 @@ void swift_reflection_dumpInfoForTypeRef(SwiftReflectionContextRef ContextRef,
   auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   auto TI = Context->getTypeInfo(TR, nullptr);
   if (TI == nullptr) {
-    fprintf(stdout, "<null type info>\n");
+    std::cout << "<null type info>\n";
   } else {
-    TI->dump(stdout);
+    TI->dump(std::cout);
     Demangle::Demangler Dem;
     auto Mangling = mangleNode(TR->getDemangling(Dem));
     std::string MangledName;
     if (Mangling.isSuccess()) {
       MangledName = Mangling.result();
-      fprintf(stdout, "Mangled name: %s%s\n", MANGLING_PREFIX_STR,
-              MangledName.c_str());
+      std::cout << "Mangled name: " << MANGLING_PREFIX_STR << MangledName
+                << "\n";
     } else {
       MangledName = "<failed to mangle name>";
-      fprintf(stdout, "Failed to get mangled name: Node %p, error %d:%u\n",
-              Mangling.error().node,
-              Mangling.error().code,
-              Mangling.error().line);
+      std::cout << "Failed to get mangled name: Node " << Mangling.error().node
+                << " error " << Mangling.error().code << ":"
+                << Mangling.error().line << "\n";
     }
 
     char *DemangledName =
-      swift_reflection_copyDemangledNameForTypeRef(ContextRef, OpaqueTypeRef);
-    fprintf(stdout, "Demangled name: %s\n", DemangledName);
+        swift_reflection_copyDemangledNameForTypeRef(ContextRef, OpaqueTypeRef);
+    std::cout << "Demangled name: " << DemangledName << "\n";
     free(DemangledName);
   }
 }
@@ -663,9 +663,9 @@ void swift_reflection_dumpInfoForMetadata(SwiftReflectionContextRef ContextRef,
   auto Context = ContextRef->nativeContext;
   auto TI = Context->getMetadataTypeInfo(Metadata, nullptr);
   if (TI == nullptr) {
-    fprintf(stdout, "<null type info>\n");
+    std::cout << "<null type info>\n";
   } else {
-    TI->dump(stdout);
+    TI->dump(std::cout);
   }
 }
 
@@ -674,9 +674,9 @@ void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
   auto Context = ContextRef->nativeContext;
   auto TI = Context->getInstanceTypeInfo(Object, nullptr);
   if (TI == nullptr) {
-    fprintf(stdout, "%s", "<null type info>\n");
+    std::cout << "<null type info>\n";
   } else {
-    TI->dump(stdout);
+    TI->dump(std::cout);
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change is necessary so lldb can use typeref dumping facilities directly.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
