### PR TITLE
[LoopRotate] Don't phi forwarded guaranteed value.

### DIFF
--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -8,6 +8,10 @@ class Klass {
 
 }
 
+struct BoxStruct {
+    var guts: Klass
+}
+
 sil [ossa] @useKlass : $@convention(thin) (@guaranteed Klass) -> ()
 
 sil [ossa] @klassIdentity : $@convention(thin) (@owned Klass) -> @owned Klass
@@ -194,4 +198,53 @@ exit:
   destroy_value %instance : $Klass
   %retval = tuple ()
   return %retval : $()
+}
+
+// A guaranteed value whose ownership has been forwarded must not be reborrowed. 
+//
+// CHECK-LABEL: sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
+// CHECK-NOT:   {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $BoxStruct, {{%[^,]+}} : @guaranteed $Klass):
+// CHECK-LABEL: } // end sil function 'forwarded_borrow_cant_be_reborrowed'
+sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
+bb0(%0 : @owned $BoxStruct):
+  br bb1
+
+bb1:
+  %2 = integer_literal $Builtin.Int1, 0
+  cond_br %2, bb2, bb3
+
+bb2:
+  br bb10
+
+bb3:
+  %5 = begin_borrow %0 : $BoxStruct
+  %6 = struct_extract %5 : $BoxStruct, #BoxStruct.guts
+  %7 = integer_literal $Builtin.Int1, 0
+  cond_br %7, bb4, bb5
+
+bb4:
+  unreachable
+
+bb5:
+  %10 = begin_borrow %6 : $Klass
+  end_borrow %10 : $Klass
+  end_borrow %5 : $BoxStruct
+  br bb6
+
+bb6:
+  br bb7
+
+
+bb7:
+  %16 = integer_literal $Builtin.Int1, -1
+  cond_br %16, bb8, bb9
+
+bb8:
+  br bb10
+
+bb9:
+  br bb1
+
+bb10:
+  unreachable
 }


### PR DESCRIPTION
A guaranteed value produced by a begin_borrow can't be both used as an operand of an ownership forwarding-instruction and also reborrowed by being used as a phi argument.

Avoid that by stopping rotation when encountering a header block containing an ownership-forwarding instruction whose forwarded ownership kind is guaranteed; such a rotation may result in using both the original guaranteed value and the resulting guaranteed value as phi arguments.
