### PR TITLE
[CanonicalizeInst] Remove redundant lexical bbis.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1206,6 +1206,14 @@ void visitTransitiveEndBorrows(
     BorrowedValue beginBorrow,
     function_ref<void(EndBorrowInst *)> visitEndBorrow);
 
+/// Whether the specified lexical begin_borrow instruction is nested.
+///
+/// A begin_borrow [lexical] is nested if the borrowed value's lifetime is
+/// guaranteed by another lexical scope.  That happens if:
+/// - the value is a guaranteed argument to the function
+/// - the value is itself a begin_borrow [lexical]
+bool isNestedLexicalBeginBorrow(BeginBorrowInst *bbi);
+
 } // namespace swift
 
 #endif

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1487,3 +1487,21 @@ void swift::visitTransitiveEndBorrows(
     }
   }
 }
+
+/// Whether the specified lexical begin_borrow instruction is nested.
+///
+/// A begin_borrow [lexical] is nested if the borrowed value's lifetime is
+/// guaranteed by another lexical scope.  That happens if:
+/// - the value is a guaranteed argument to the function
+/// - the value is itself a begin_borrow [lexical]
+bool swift::isNestedLexicalBeginBorrow(BeginBorrowInst *bbi) {
+  assert(bbi->isLexical());
+  auto value = bbi->getOperand();
+  if (auto *outerBBI = dyn_cast<BeginBorrowInst>(value)) {
+    return outerBBI->isLexical();
+  }
+  if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {
+    return arg->getOwnershipKind() == OwnershipKind::Guaranteed;
+  }
+  return false;
+}

--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -24,24 +24,6 @@
 using namespace swift;
 using namespace swift::semanticarc;
 
-/// Whether the provided lexical begin_borrow instruction is redundant.
-///
-/// A begin_borrow [lexical] is redundant if the borrowed value's lifetime is
-/// otherwise guaranteed.  That happens if:
-/// - the value is a guaranteed argument to the function
-/// - the value is itself a begin_borrow [lexical]
-static bool isRedundantLexicalBeginBorrow(BeginBorrowInst *bbi) {
-  assert(bbi->isLexical());
-  auto value = bbi->getOperand();
-  if (auto *outerBBI = dyn_cast<BeginBorrowInst>(value)) {
-    return outerBBI->isLexical();
-  }
-  if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {
-    return arg->getOwnershipKind() == OwnershipKind::Guaranteed;
-  }
-  return false;
-}
-
 bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   // Quickly check if we are supposed to perform this transformation.
   if (!ctx.shouldPerform(ARCTransformKind::RedundantBorrowScopeElimPeephole))
@@ -49,7 +31,7 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
 
   // Non-redundant, lexical borrow scopes must remain in order to ensure that
   // value lifetimes are not observably shortened.
-  if (bbi->isLexical() && !isRedundantLexicalBeginBorrow(bbi)) {
+  if (bbi->isLexical() && !isNestedLexicalBeginBorrow(bbi)) {
     return false;
   }
 

--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -47,8 +47,8 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
   if (!ctx.shouldPerform(ARCTransformKind::RedundantBorrowScopeElimPeephole))
     return false;
 
-  // Lexical borrow scopes must remain in order to ensure that value lifetimes
-  // are not observably shortened.
+  // Non-redundant, lexical borrow scopes must remain in order to ensure that
+  // value lifetimes are not observably shortened.
   if (bbi->isLexical() && !isRedundantLexicalBeginBorrow(bbi)) {
     return false;
   }

--- a/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/BorrowScopeOpts.cpp
@@ -49,9 +49,8 @@ bool SemanticARCOptVisitor::visitBeginBorrowInst(BeginBorrowInst *bbi) {
 
   // Lexical borrow scopes must remain in order to ensure that value lifetimes
   // are not observably shortened.
-  if (bbi->isLexical()) {
-    if (!isRedundantLexicalBeginBorrow(bbi))
-      return false;
+  if (bbi->isLexical() && !isRedundantLexicalBeginBorrow(bbi)) {
+    return false;
   }
 
   auto kind = bbi->getOperand().getOwnershipKind();

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -438,7 +438,7 @@ void CopyPropagation::run() {
   //       blocks and pushing begin_borrows as we see them and then popping them
   //       off the end will result in shrinking inner borrow scopes first.
   while (auto *bbi = beginBorrowsToShrink.pop()) {
-    shrinkBorrowScope(bbi, deleter);
+    changed |= shrinkBorrowScope(bbi, deleter);
   }
 
   // canonicalizer performs all modifications through deleter's callbacks, so we

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -445,9 +445,13 @@ static SILBasicBlock::iterator
 eliminateSimpleBorrows(BeginBorrowInst *bbi, CanonicalizeInstruction &pass) {
   auto next = std::next(bbi->getIterator());
 
-  // Never eliminate lexical borrow scopes.  They must be kept to ensure that
-  // value lifetimes aren't observably shortened.
-  if (bbi->isLexical())
+  // Lexical borrow scopes can only be eliminated under certain circumstances:
+  // (1) They can never be eliminated if the module is in the raw stage, because
+  //     they may be needed for diagnostic.
+  // (2) They can never be eliminated if there is no enclosing lexical scope
+  //     which guarantees the lifetime of the value.
+  if (bbi->isLexical() && (bbi->getModule().getStage() == SILStage::Raw ||
+                           !isNestedLexicalBeginBorrow(bbi)))
     return next;
 
   // We know that our borrow is completely within the lifetime of its base value


### PR DESCRIPTION
Previously, CanonicalizeInstruction::eliminateSimpleBorrows bailed out when encountering any any [lexical] begin_borrow.  While generally such borrow scopes must be preserved, they may be removed if they are redundant (when the borrowed value is guaranteed by another means: an outer lexical borrow scope or a guaranteed function argument).  Here, removing such redundant lexical borrow scopes is enabled.Previously, CanonicalizeInstruction::eliminateSimpleBorrows bailed out when encountering any any [lexical] begin_borrow.  While generally such borrow scopes must be preserved, they may be removed if they are redundant (when the borrowed value is guaranteed by another means: an outer lexical borrow scope or a guaranteed function argument).  Here, removing such redundant lexical borrow scopes is enabled.
