### PR TITLE
Fix pipes being opened in binary mode in `swift_build_support.shell.run()`

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -218,7 +218,7 @@ def run(*args, **kwargs):
         return(None, 0, args)
 
     my_pipe = subprocess.Popen(
-        *args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+        *args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, **kwargs)
     (stdout, stderr) = my_pipe.communicate()
     ret = my_pipe.wait()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Python 3 has changed to open pipes in binary mode by default. The `text=True` option to open pipes in text mode was added in Python 3.7.
This change will fix `update-checkout` printing the output of the child process as binary as shown below.
```console
+ git checkout main
b"Your branch is up to date with 'origin/main'.\n"b"Already on 'main'\n"
```
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
