### PR TITLE
RequirementMachine: Protocol requirement signature minimization fixes

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1231,6 +1231,11 @@ public:
   bool isRecursivelyConstructingRequirementMachine(
       CanGenericSignature sig);
 
+  /// This is a hack to break cycles. Don't introduce new callers of this
+  /// method.
+  bool isRecursivelyConstructingRequirementMachine(
+      const ProtocolDecl *proto);
+
   /// Retrieve a generic signature with a single unconstrained type parameter,
   /// like `<T>`.
   CanGenericSignature getSingleGenericParameterSignature() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2017,6 +2017,11 @@ bool ASTContext::isRecursivelyConstructingRequirementMachine(
   return getRewriteContext().isRecursivelyConstructingRequirementMachine(sig);
 }
 
+bool ASTContext::isRecursivelyConstructingRequirementMachine(
+      const ProtocolDecl *proto) {
+  return getRewriteContext().isRecursivelyConstructingRequirementMachine(proto);
+}
+
 Optional<llvm::TinyPtrVector<ValueDecl *>>
 OverriddenDeclsRequest::getCachedResult() const {
   auto decl = std::get<0>(getStorage());

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8876,9 +8876,23 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
-    if (rqmResult.size() != gsbResult.size() ||
-        !std::equal(rqmResult.begin(), rqmResult.end(),
-                    gsbResult.begin())) {
+    // For now, only compare conformance requirements, since those are the
+    // important ones from the ABI perspective.
+    SmallVector<Requirement, 2> rqmConformances;
+    for (auto req : rqmResult) {
+      if (req.getKind() == RequirementKind::Conformance)
+        rqmConformances.push_back(req);
+    }
+    SmallVector<Requirement, 2> gsbConformances;
+    for (auto req : gsbResult) {
+      if (req.getKind() == RequirementKind::Conformance)
+        gsbConformances.push_back(req);
+    }
+
+    if (rqmConformances.size() != gsbConformances.size() ||
+        !std::equal(rqmConformances.begin(),
+                    rqmConformances.end(),
+                    gsbConformances.begin())) {
       llvm::errs() << "RequirementMachine protocol signature minimization is broken:\n";
       llvm::errs() << "Protocol: " << proto->getName() << "\n";
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4159,6 +4159,8 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
     Type assocType =
       DependentMemberType::get(selfType.getDependentType(*this), assocTypeDecl);
     if (!onlySameTypeConstraints) {
+      (void) resolve(assocType, source);
+
       auto assocResult =
         addInheritedRequirements(assocTypeDecl, assocType, source,
                                  /*inferForModule=*/nullptr);

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -549,9 +549,9 @@ void RewriteSystem::verifyGeneratingConformanceEquations(
 
       if (baseTerm != otherTerm) {
         llvm::errs() << "Invalid equation: ";
-        llvm::errs() << "\n";
         dumpGeneratingConformanceEquation(llvm::errs(),
                                           pair.first, pair.second);
+        llvm::errs() << "\n";
         llvm::errs() << "Invalid conformance path:\n";
         llvm::errs() << "Expected: " << baseTerm << "\n";
         llvm::errs() << "Got: " << otherTerm << "\n\n";

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -646,6 +646,9 @@ void RewriteSystem::computeGeneratingConformances(
     if (rule.isRedundant())
       continue;
 
+    if (rule.containsUnresolvedSymbols())
+      continue;
+
     if (!rule.isProtocolConformanceRule())
       continue;
 

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -30,19 +30,13 @@
 //
 // Any occurrence of the rule in the remaining loops is replaced with the
 // alternate definition obtained by splitting the loop that witnessed the
-// redundancy. After substitution, every loop is normalized to a cyclically
-// reduced left-canonical form. The loop witnessing the redundancy normalizes
-// to the empty loop and is deleted.
+// redundancy.
 //
 // Iterating this process eventually produces a minimal set of rewrite rules.
 //
 // For a description of the general algorithm, see "A Homotopical Completion
 // Procedure with Applications to Coherence of Monoids",
 // https://hal.inria.fr/hal-00818253.
-//
-// The idea of computing a left-canonical form for rewrite loops is from
-// "Homotopy reduction systems for monoid presentations",
-// https://www.sciencedirect.com/science/article/pii/S0022404997000959
 //
 // Note that in the world of Swift, rewrite rules for introducing associated
 // type symbols are marked 'permanent'; they are always re-added when a new
@@ -321,232 +315,6 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
   return true;
 }
 
-/// Returns true if this rewrite step is an inverse of \p other
-/// (and vice versa).
-bool RewriteStep::isInverseOf(const RewriteStep &other) const {
-  if (Kind != other.Kind)
-    return false;
-
-  if (StartOffset != other.StartOffset)
-    return false;
-
-  if (Inverse != !other.Inverse)
-    return false;
-
-  switch (Kind) {
-  case RewriteStep::ApplyRewriteRule:
-    return RuleID == other.RuleID;
-
-  case RewriteStep::AdjustConcreteType:
-    return true;
-
-  case RewriteStep::Shift:
-    return true;
-
-  case RewriteStep::Decompose:
-    return RuleID == other.RuleID;
-
-  case RewriteStep::ConcreteConformance:
-  case RewriteStep::SuperclassConformance:
-    return true;
-  }
-
-  assert(EndOffset == other.EndOffset && "Bad whiskering?");
-  return true;
-}
-
-bool RewriteStep::maybeSwapRewriteSteps(RewriteStep &other,
-                                        const RewriteSystem &system) {
-  if (Kind != RewriteStep::ApplyRewriteRule ||
-      other.Kind != RewriteStep::ApplyRewriteRule)
-    return false;
-
-  // Two rewrite steps are _orthogonal_ if they rewrite disjoint subterms
-  // in context. Orthogonal rewrite steps commute, so we can canonicalize
-  // a path by placing the left-most step first.
-  //
-  // Eg, A.U.B.(X => Y).C ⊗ A.(U => V).B.Y == A.(U => V).B.X ⊗ A.V.B.(X => Y).
-  //
-  // Or, in diagram form. We want to turn this:
-  //
-  //   ----- time ----->
-  // +---------+---------+
-  // |    A    |    A    |
-  // +---------+---------+
-  // |    U    | U ==> V |
-  // +---------+---------+
-  // |    B    |    B    |
-  // +---------+---------+
-  // | X ==> Y |    Y    |
-  // +---------+---------+
-  // |    C    |    C    |
-  // +---------+---------+
-  //
-  // Into this:
-  //
-  // +---------+---------+
-  // |    A    |    A    |
-  // +---------+---------+
-  // | U ==> V |    V    |
-  // +---------+---------+
-  // |    B    |    B    |
-  // +---------+---------+
-  // |    X    | X ==> Y |
-  // +---------+---------+
-  // |    C    |    C    |
-  // +---------+---------+
-  //
-  // Note that
-  //
-  // StartOffset == |A|+|U|+|B|
-  // EndOffset = |C|
-  //
-  // other.StartOffset = |A|
-  // other.EndOffset = |B|+|Y|+|C|
-  //
-  // After interchange, we adjust:
-  //
-  // StartOffset = |A|
-  // EndOffset = |B|+|X|+|C|
-  //
-  // other.StartOffset = |A|+|V|+|B|
-  // other.EndOffset = |C|
-
-  const auto &rule = system.getRule(RuleID);
-  auto lhs = (Inverse ? rule.getRHS() : rule.getLHS());
-  auto rhs = (Inverse ? rule.getLHS() : rule.getRHS());
-
-  const auto &otherRule = system.getRule(other.RuleID);
-  auto otherLHS = (other.Inverse ? otherRule.getRHS() : otherRule.getLHS());
-  auto otherRHS = (other.Inverse ? otherRule.getLHS() : otherRule.getRHS());
-
-  if (StartOffset < other.StartOffset + otherLHS.size())
-    return false;
-
-  std::swap(*this, other);
-  EndOffset += (lhs.size() - rhs.size());
-  other.StartOffset += (otherRHS.size() - otherLHS.size());
-
-  return true;
-}
-
-/// Cancels out adjacent rewrite steps that are inverses of each other.
-/// This does not change either endpoint of the path, and the path does
-/// not necessarily need to be a loop.
-bool RewritePath::computeFreelyReducedPath() {
-  SmallVector<RewriteStep, 4> newSteps;
-  bool changed = false;
-
-  for (const auto &step : Steps) {
-    if (!newSteps.empty() &&
-        newSteps.back().isInverseOf(step)) {
-      changed = true;
-      newSteps.pop_back();
-      continue;
-    }
-
-    newSteps.push_back(step);
-  }
-
-  std::swap(newSteps, Steps);
-  return changed;
-}
-
-/// Given a path that is a loop around the given basepoint, cancels out
-/// pairs of terms from the ends that are inverses of each other, applying
-/// the corresponding translation to the basepoint.
-///
-/// For example, consider this loop with basepoint 'X':
-///
-///   (X => Y.A) * (Y.A => Y.B) * Y.(B => A) * (Y.A => X)
-///
-/// The first step is the inverse of the last step, so the cyclic
-/// reduction is the loop (Y.A => Y.B) * Y.(B => A), with a new
-/// basepoint 'Y.A'.
-bool RewritePath::computeCyclicallyReducedLoop(MutableTerm &basepoint,
-                                               const RewriteSystem &system) {
-  RewritePathEvaluator evaluator(basepoint);
-  unsigned count = 0;
-
-  while (2 * count + 1 < size()) {
-    auto left = Steps[count];
-    auto right = Steps[Steps.size() - count - 1];
-    if (!left.isInverseOf(right))
-      break;
-
-    // Update the basepoint by applying the first step in the path.
-    evaluator.apply(left, system);
-
-    ++count;
-  }
-
-  std::rotate(Steps.begin(), Steps.begin() + count, Steps.end() - count);
-  Steps.erase(Steps.end() - 2 * count, Steps.end());
-
-  basepoint = evaluator.getCurrentTerm();
-  return count > 0;
-}
-
-/// Apply the interchange rule until fixed point (see maybeSwapRewriteSteps()).
-bool RewritePath::computeLeftCanonicalForm(const RewriteSystem &system) {
-  bool changed = false;
-
-  for (unsigned i = 1, e = Steps.size(); i < e; ++i) {
-    auto &prevStep = Steps[i - 1];
-    auto &step = Steps[i];
-
-    if (prevStep.maybeSwapRewriteSteps(step, system))
-      changed = true;
-  }
-
-  return changed;
-}
-
-/// Compute cyclically-reduced left-canonical normal form of a loop.
-void RewriteLoop::normalize(const RewriteSystem &system) {
-  // FIXME: This can be more efficient.
-  bool changed;
-  do {
-    changed = false;
-    changed |= Path.computeFreelyReducedPath();
-    changed |= Path.computeCyclicallyReducedLoop(Basepoint, system);
-    changed |= Path.computeLeftCanonicalForm(system);
-  } while (changed);
-}
-
-/// A loop is "in context" if every rewrite step has a left or right whisker.
-bool RewriteLoop::isInContext(const RewriteSystem &system) const {
-  RewritePathEvaluator evaluator(Basepoint);
-
-  unsigned minStartOffset = (unsigned) -1;
-  unsigned minEndOffset = (unsigned) -1;
-
-  for (const auto &step : Path) {
-    if (!evaluator.isInContext()) {
-      switch (step.Kind) {
-      case RewriteStep::ApplyRewriteRule:
-        minStartOffset = std::min(minStartOffset, step.StartOffset);
-        minEndOffset = std::min(minEndOffset, step.EndOffset);
-        break;
-
-      case RewriteStep::AdjustConcreteType:
-      case RewriteStep::Shift:
-      case RewriteStep::Decompose:
-      case RewriteStep::ConcreteConformance:
-      case RewriteStep::SuperclassConformance:
-        break;
-      }
-
-      if (minStartOffset == 0 && minEndOffset == 0)
-        break;
-    }
-
-    evaluator.apply(step, system);
-  }
-
-  return (minStartOffset > 0 || minEndOffset > 0);
-}
-
 /// Check if a rewrite rule is a candidate for deletion in this pass of the
 /// minimization algorithm.
 bool RewriteSystem::
@@ -688,39 +456,6 @@ void RewriteSystem::deleteRule(unsigned ruleID,
     if (!changed)
       continue;
 
-    unsigned size = loop.Path.size();
-
-    loop.normalize(*this);
-
-    if (Debug.contains(DebugFlags::HomotopyReduction)) {
-      if (size != loop.Path.size()) {
-        llvm::dbgs() << "** Note: loop normalization eliminated "
-                     << (size - loop.Path.size()) << " steps\n";
-      }
-    }
-
-    if (loop.Path.empty()) {
-      if (Debug.contains(DebugFlags::HomotopyReduction)) {
-        llvm::dbgs() << "** Deleting trivial loop at basepoint ";
-        llvm::dbgs() << loop.Basepoint << "\n";
-      }
-
-      loop.markDeleted();
-      continue;
-    }
-
-    // FIXME: Is this correct?
-    if (loop.isInContext(*this)) {
-      if (Debug.contains(DebugFlags::HomotopyReduction)) {
-        llvm::dbgs() << "** Deleting loop in context: ";
-        loop.dump(llvm::dbgs(), *this);
-        llvm::dbgs() << "\n";
-      }
-
-      loop.markDeleted();
-      continue;
-    }
-
     if (Debug.contains(DebugFlags::HomotopyReduction)) {
       llvm::dbgs() << "** Updated loop: ";
       loop.dump(llvm::dbgs(), *this);
@@ -753,15 +488,6 @@ void RewriteSystem::minimizeRewriteSystem() {
   assert(Complete);
   assert(!Minimized);
   Minimized = 1;
-
-  /// Begin by normalizing all loops to cyclically-reduced left-canonical
-  /// form.
-  for (auto &loop : Loops) {
-    if (loop.isDeleted())
-      continue;
-
-    loop.normalize(*this);
-  }
 
   // Check invariants before homotopy reduction.
   verifyRewriteLoops();

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -384,13 +384,18 @@ findRuleToDelete(const llvm::DenseSet<unsigned> *redundantConformances,
                  RewritePath &replacementPath) {
   SmallVector<std::pair<unsigned, unsigned>, 2> redundancyCandidates;
   for (unsigned loopID : indices(Loops)) {
-    const auto &loop = Loops[loopID];
+    auto &loop = Loops[loopID];
     if (loop.isDeleted())
       continue;
 
+    bool foundAny = false;
     for (unsigned ruleID : loop.findRulesAppearingOnceInEmptyContext(*this)) {
       redundancyCandidates.emplace_back(loopID, ruleID);
+      foundAny = true;
     }
+
+    if (!foundAny)
+      loop.markDeleted();
   }
 
   Optional<std::pair<unsigned, unsigned>> found;

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -790,6 +790,23 @@ void RewriteSystem::minimizeRewriteSystem() {
   verifyMinimizedRules();
 }
 
+/// In a conformance-valid rewrite system, any rule with unresolved symbols on
+/// the left or right hand side should have been simplified by another rule.
+bool RewriteSystem::hasNonRedundantUnresolvedRules() const {
+  assert(Complete);
+  assert(Minimized);
+
+  for (const auto &rule : Rules) {
+    if (!rule.isRedundant() &&
+        !rule.isPermanent() &&
+        rule.containsUnresolvedSymbols()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /// Collect all non-permanent, non-redundant rules whose domain is equal to
 /// one of the protocols in \p proto. In other words, the first symbol of the
 /// left hand side term is either a protocol symbol or associated type symbol
@@ -805,11 +822,11 @@ RewriteSystem::getMinimizedProtocolRules(
   for (unsigned ruleID : indices(Rules)) {
     const auto &rule = getRule(ruleID);
 
-    if (rule.isPermanent())
+    if (rule.isPermanent() ||
+        rule.isRedundant() ||
+        rule.containsUnresolvedSymbols()) {
       continue;
-
-    if (rule.isRedundant())
-      continue;
+    }
 
     auto domain = rule.getLHS()[0].getProtocols();
     assert(domain.size() == 1);
@@ -834,11 +851,11 @@ RewriteSystem::getMinimizedGenericSignatureRules() const {
   for (unsigned ruleID : indices(Rules)) {
     const auto &rule = getRule(ruleID);
 
-    if (rule.isPermanent())
+    if (rule.isPermanent() ||
+        rule.isRedundant() ||
+        rule.containsUnresolvedSymbols()) {
       continue;
-
-    if (rule.isRedundant())
-      continue;
+    }
 
     if (rule.getLHS()[0].getKind() != Symbol::Kind::GenericParam)
       continue;
@@ -917,26 +934,14 @@ void RewriteSystem::verifyMinimizedRules() const {
       continue;
     }
 
-    if (rule.isRedundant())
-      continue;
-
     // Simplified rules should be redundant, unless they're protocol conformance
     // rules, which unfortunately might no be redundant, because we try to keep
     // them in the original protocol definition for compatibility with the
     // GenericSignatureBuilder's minimization algorithm.
-    if (rule.isSimplified() && !rule.isProtocolConformanceRule()) {
+    if (rule.isSimplified() &&
+        !rule.isRedundant() &&
+        !rule.isProtocolConformanceRule()) {
       llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
-    }
-
-    // Rules with unresolved name symbols (other than permanent rules for
-    // associated type introduction) should be redundant.
-    //
-    // FIXME: What about invalid code?
-    if (rule.getLHS().containsUnresolvedSymbols() ||
-        rule.getRHS().containsUnresolvedSymbols()) {
-      llvm::errs() << "Unresolved rule is not redundant: " << rule << "\n\n";
       dump(llvm::errs());
       abort();
     }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -354,7 +354,7 @@ isCandidateForDeletion(unsigned ruleID,
   // means that the set of generating conformances is always a superset
   // (or equal to) of the set of minimal protocol conformance
   // requirements that homotopy reduction alone would produce.
-  if (rule.isProtocolConformanceRule()) {
+  if (rule.isAnyConformanceRule()) {
     if (!redundantConformances)
       return false;
 
@@ -634,7 +634,7 @@ void RewriteSystem::verifyRedundantConformances(
            "Permanent rule cannot be redundant");
     assert(!rule.isIdentityConformanceRule() &&
            "Identity conformance cannot be redundant");
-    assert(rule.isProtocolConformanceRule() &&
+    assert(rule.isAnyConformanceRule() &&
            "Redundant conformance is not a conformance rule?");
 
     if (!rule.isRedundant()) {

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -454,7 +454,8 @@ RewriteSystem::computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
     if (xv.back().hasSubstitutions() &&
         !xv.back().getSubstitutions().empty() &&
         t.size() > 0) {
-      path.add(RewriteStep::forAdjustment(t.size(), /*inverse=*/true));
+      path.add(RewriteStep::forAdjustment(t.size(), /*endOffset=*/0,
+                                          /*inverse=*/true));
 
       xv.back() = xv.back().prependPrefixToConcreteSubstitutions(
           t, Context);

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -762,8 +762,8 @@ void PropertyMap::recordConcreteConformanceRule(
   unsigned adjustment = rhs.size() - concreteRule.getRHS().size();
   if (adjustment > 0 &&
       !concreteSymbol.getSubstitutions().empty()) {
-    // FIXME: This needs an endOffset!
-    path.add(RewriteStep::forAdjustment(adjustment, /*inverse=*/false));
+    path.add(RewriteStep::forAdjustment(adjustment, /*endOffset=*/1,
+                                        /*inverse=*/false));
 
     concreteSymbol = concreteSymbol.prependPrefixToConcreteSubstitutions(
         MutableTerm(rhs.begin(), rhs.begin() + adjustment),

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -130,22 +130,18 @@ static void desugarConformanceRequirement(Type subjectType, Type constraintType,
     return;
   }
 
-  auto layout = constraintType->getExistentialLayout();
+  auto *compositionType = constraintType->castTo<ProtocolCompositionType>();
+  if (compositionType->hasExplicitAnyObject()) {
+    desugarLayoutRequirement(subjectType,
+                             LayoutConstraint::getLayoutConstraint(
+                                 LayoutConstraintKind::Class), result);
+  }
 
-  if (auto layoutConstraint = layout.getLayoutConstraint())
-    desugarLayoutRequirement(subjectType, layoutConstraint, result);
-
-  if (auto superclass = layout.explicitSuperclass)
-    desugarSuperclassRequirement(subjectType, superclass, result);
-
-  for (auto *proto : layout.getProtocols()) {
-    if (!subjectType->isTypeParameter()) {
-      // FIXME: Check conformance, diagnose redundancy or conflict upstream
-      return;
-    }
-
-    result.emplace_back(RequirementKind::Conformance, subjectType,
-                        proto);
+  for (auto memberType : compositionType->getMembers()) {
+    if (memberType->isExistentialType())
+      desugarConformanceRequirement(subjectType, memberType, result);
+    else
+      desugarSuperclassRequirement(subjectType, memberType, result);
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -256,6 +256,12 @@ bool RequirementMachine::isComplete() const {
   return Complete;
 }
 
+bool RequirementMachine::hadError() const {
+  // FIXME: Implement other checks here
+  // FIXME: Assert if hadError() is true but we didn't emit any diagnostics?
+  return System.hasNonRedundantUnresolvedRules();
+}
+
 void RequirementMachine::dump(llvm::raw_ostream &out) const {
   out << "Requirement machine for ";
   if (Sig)

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -137,6 +137,8 @@ public:
 
   std::vector<Requirement> computeMinimalGenericSignatureRequirements();
 
+  bool hadError() const;
+
   void verify(const MutableTerm &term) const;
   void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -141,9 +141,9 @@ RequirementMachine::buildRequirementsFromRules(
       }
 
       case Symbol::Kind::ConcreteConformance:
-        // FIXME
-        llvm::errs() << "Concrete conformance: " << rule << "\n";
-        break;
+        // "Concrete conformance requirements" are not recorded in the generic
+        // signature.
+        return;
 
       case Symbol::Kind::Name:
       case Symbol::Kind::AssociatedType:

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -359,10 +359,9 @@ AbstractGenericSignatureRequestRQM::evaluate(
   auto minimalRequirements =
     machine->computeMinimalGenericSignatureRequirements();
 
-  // FIXME: Implement this
-  bool hadError = false;
-
   auto result = GenericSignature::get(genericParams, minimalRequirements);
+  bool hadError = machine->hadError();
+
   return GenericSignatureWithError(result, hadError);
 }
 
@@ -463,10 +462,8 @@ InferredGenericSignatureRequestRQM::evaluate(
   auto minimalRequirements =
     machine->computeMinimalGenericSignatureRequirements();
 
-  // FIXME: Implement this
-  bool hadError = false;
-
   auto result = GenericSignature::get(genericParams, minimalRequirements);
+  bool hadError = machine->hadError();
 
   // FIXME: Handle allowConcreteGenericParams
 

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -651,6 +651,7 @@ RequirementMachine *RewriteContext::getRequirementMachine(
                    << "machine for:";
       for (auto *proto : component.Protos)
         llvm::errs() << " " << proto->getName();
+      llvm::errs() << "\n";
       abort();
     }
 
@@ -666,6 +667,23 @@ RequirementMachine *RewriteContext::getRequirementMachine(
   // into Protos.
   newMachine->initWithProtocols(component.Protos);
   return newMachine;
+}
+
+bool RewriteContext::isRecursivelyConstructingRequirementMachine(
+    const ProtocolDecl *proto) {
+  auto found = Protos.find(proto);
+  if (found == Protos.end())
+    return false;
+
+  auto component = Components.find(found->second.ComponentID);
+  if (component == Components.end())
+    return false;
+
+  if (!component->second.Machine ||
+      component->second.Machine->isComplete())
+    return false;
+
+  return true;
 }
 
 /// We print stats in the destructor, which should get executed at the end of

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -180,6 +180,7 @@ public:
   bool isRecursivelyConstructingRequirementMachine(CanGenericSignature sig);
 
   RequirementMachine *getRequirementMachine(const ProtocolDecl *proto);
+  bool isRecursivelyConstructingRequirementMachine(const ProtocolDecl *proto);
 
   ~RewriteContext();
 };

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -139,8 +139,9 @@ struct RewriteStep {
     return RewriteStep(ApplyRewriteRule, startOffset, endOffset, ruleID, inverse);
   }
 
-  static RewriteStep forAdjustment(unsigned offset, bool inverse) {
-    return RewriteStep(AdjustConcreteType, /*startOffset=*/0, /*endOffset=*/0,
+  static RewriteStep forAdjustment(unsigned offset, unsigned endOffset,
+                                   bool inverse) {
+    return RewriteStep(AdjustConcreteType, /*startOffset=*/0, endOffset,
                        /*ruleID=*/offset, inverse);
   }
 
@@ -317,8 +318,9 @@ struct RewritePathEvaluator {
   AppliedRewriteStep applyRewriteRule(const RewriteStep &step,
                                       const RewriteSystem &system);
 
-  MutableTerm applyAdjustment(const RewriteStep &step,
-                              const RewriteSystem &system);
+  std::pair<MutableTerm, MutableTerm>
+  applyAdjustment(const RewriteStep &step,
+                  const RewriteSystem &system);
 
   void applyShift(const RewriteStep &step,
                   const RewriteSystem &system);

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -221,13 +221,6 @@ public:
 
   bool replaceRuleWithPath(unsigned ruleID, const RewritePath &path);
 
-  bool computeFreelyReducedPath();
-
-  bool computeCyclicallyReducedLoop(MutableTerm &basepoint,
-                                    const RewriteSystem &system);
-
-  bool computeLeftCanonicalForm(const RewriteSystem &system);
-
   void invert();
 
   void dump(llvm::raw_ostream &out,
@@ -265,8 +258,6 @@ public:
     assert(!Deleted);
     Deleted = true;
   }
-
-  void normalize(const RewriteSystem &system);
 
   bool isInContext(const RewriteSystem &system) const;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -43,12 +43,39 @@ Optional<Symbol> Rule::isPropertyRule() const {
   return property;
 }
 
-/// If this is a rule of the form T.[p] => T where [p] is a protocol symbol,
-/// return the protocol, otherwise return nullptr.
+/// If this is a rule of the form T.[P] => T where [P] is a protocol symbol,
+/// return the protocol P, otherwise return nullptr.
 const ProtocolDecl *Rule::isProtocolConformanceRule() const {
   if (auto property = isPropertyRule()) {
     if (property->getKind() == Symbol::Kind::Protocol)
       return property->getProtocol();
+  }
+
+  return nullptr;
+}
+
+/// If this is a rule of the form T.[concrete: C : P] => T where
+/// [concrete: C : P] is a concrete conformance symbol, return the protocol P,
+/// otherwise return nullptr.
+const ProtocolDecl *Rule::isAnyConformanceRule() const {
+  if (auto property = isPropertyRule()) {
+    switch (property->getKind()) {
+    case Symbol::Kind::ConcreteConformance:
+    case Symbol::Kind::Protocol:
+      return property->getProtocol();
+
+    case Symbol::Kind::Layout:
+    case Symbol::Kind::Superclass:
+    case Symbol::Kind::ConcreteType:
+      return nullptr;
+
+    case Symbol::Kind::Name:
+    case Symbol::Kind::AssociatedType:
+    case Symbol::Kind::GenericParam:
+      break;
+    }
+
+    llvm_unreachable("Bad symbol kind");
   }
 
   return nullptr;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -103,6 +103,11 @@ public:
     return Redundant;
   }
 
+  bool containsUnresolvedSymbols() const {
+    return (LHS.containsUnresolvedSymbols() ||
+            RHS.containsUnresolvedSymbols());
+  }
+
   void markSimplified() {
     assert(!Simplified);
     Simplified = true;
@@ -314,8 +319,6 @@ private:
 
   void checkMergedAssociatedType(Term lhs, Term rhs);
 
-public:
-
   //////////////////////////////////////////////////////////////////////////////
   ///
   /// Homotopy reduction
@@ -337,13 +340,17 @@ public:
   void performHomotopyReduction(
       const llvm::DenseSet<unsigned> *redundantConformances);
 
+public:
   void minimizeRewriteSystem();
+
+  bool hasNonRedundantUnresolvedRules() const;
 
   llvm::DenseMap<const ProtocolDecl *, std::vector<unsigned>>
   getMinimizedProtocolRules(ArrayRef<const ProtocolDecl *> protos) const;
 
   std::vector<unsigned> getMinimizedGenericSignatureRules() const;
 
+private:
   void verifyRewriteLoops() const;
 
   void verifyRedundantConformances(
@@ -398,6 +405,7 @@ public:
   void computeGeneratingConformances(
       llvm::DenseSet<unsigned> &redundantConformances);
 
+public:
   void dump(llvm::raw_ostream &out) const;
 };
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -82,6 +82,8 @@ public:
 
   const ProtocolDecl *isProtocolConformanceRule() const;
 
+  const ProtocolDecl *isAnyConformanceRule() const;
+
   bool isIdentityConformanceRule() const;
 
   bool isProtocolRefinementRule() const;
@@ -379,7 +381,7 @@ private:
   bool isValidConformancePath(
       llvm::SmallDenseSet<unsigned, 4> &visited,
       llvm::DenseSet<unsigned> &redundantConformances,
-      const llvm::SmallVectorImpl<unsigned> &path,
+      const llvm::SmallVectorImpl<unsigned> &path, bool allowConcrete,
       const llvm::MapVector<unsigned, SmallVector<unsigned, 2>> &parentPaths,
       const llvm::MapVector<unsigned,
                             std::vector<SmallVector<unsigned, 2>>>

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -242,6 +242,8 @@ public:
   /// Return the rewrite context used for allocating memory.
   RewriteContext &getRewriteContext() const { return Context; }
 
+  DebugOptions getDebugOptions() const { return Debug; }
+
   void initialize(bool recordLoops,
                   std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
                   std::vector<std::pair<MutableTerm, MutableTerm>> &&requirementRules);
@@ -261,6 +263,10 @@ public:
 
   const Rule &getRule(unsigned ruleID) const {
     return Rules[ruleID];
+  }
+
+  ArrayRef<RewriteLoop> getLoops() const {
+    return Loops;
   }
 
   bool addRule(MutableTerm lhs, MutableTerm rhs,
@@ -342,6 +348,9 @@ private:
   void performHomotopyReduction(
       const llvm::DenseSet<unsigned> *redundantConformances);
 
+  void computeGeneratingConformances(
+      llvm::DenseSet<unsigned> &redundantConformances);
+
 public:
   void minimizeRewriteSystem();
 
@@ -359,53 +368,6 @@ private:
       llvm::DenseSet<unsigned> redundantConformances) const;
 
   void verifyMinimizedRules() const;
-
-  //////////////////////////////////////////////////////////////////////////////
-  ///
-  /// Generating conformances
-  ///
-  //////////////////////////////////////////////////////////////////////////////
-
-  void decomposeTermIntoConformanceRuleLeftHandSides(
-      MutableTerm term,
-      SmallVectorImpl<unsigned> &result) const;
-  void decomposeTermIntoConformanceRuleLeftHandSides(
-      MutableTerm term, unsigned ruleID,
-      SmallVectorImpl<unsigned> &result) const;
-
-  void computeCandidateConformancePaths(
-      llvm::MapVector<unsigned,
-                      std::vector<SmallVector<unsigned, 2>>>
-          &conformancePaths) const;
-
-  bool isValidConformancePath(
-      llvm::SmallDenseSet<unsigned, 4> &visited,
-      llvm::DenseSet<unsigned> &redundantConformances,
-      const llvm::SmallVectorImpl<unsigned> &path, bool allowConcrete,
-      const llvm::MapVector<unsigned, SmallVector<unsigned, 2>> &parentPaths,
-      const llvm::MapVector<unsigned,
-                            std::vector<SmallVector<unsigned, 2>>>
-          &conformancePaths) const;
-
-  bool isValidRefinementPath(
-      const llvm::SmallVectorImpl<unsigned> &path) const;
-
-  void dumpConformancePath(
-      llvm::raw_ostream &out,
-      const SmallVectorImpl<unsigned> &path) const;
-
-  void dumpGeneratingConformanceEquation(
-      llvm::raw_ostream &out,
-      unsigned baseRuleID,
-      const std::vector<SmallVector<unsigned, 2>> &paths) const;
-
-  void verifyGeneratingConformanceEquations(
-      const llvm::MapVector<unsigned,
-                            std::vector<SmallVector<unsigned, 2>>>
-          &conformancePaths) const;
-
-  void computeGeneratingConformances(
-      llvm::DenseSet<unsigned> &redundantConformances);
 
 public:
   void dump(llvm::raw_ostream &out) const;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4562,19 +4562,29 @@ CheckTypeWitnessResult
 swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
                         const NormalProtocolConformance *Conf,
                         SubstOptions options) {
+  auto &ctx = assocType->getASTContext();
+
   if (type->hasError())
-    return ErrorType::get(assocType->getASTContext());
+    return ErrorType::get(ctx);
 
   const auto proto = Conf->getProtocol();
   const auto dc = Conf->getDeclContext();
-  const auto genericSig = proto->getGenericSignature();
+  const auto sig = proto->getGenericSignature();
+
+  // FIXME: The RequirementMachine will assert on re-entrant construction.
+  // We should find a more principled way of breaking this cycle.
+  if (ctx.isRecursivelyConstructingRequirementMachine(sig.getCanonicalSignature()) ||
+      ctx.isRecursivelyConstructingRequirementMachine(proto) ||
+      proto->isComputingRequirementSignature())
+    return ErrorType::get(ctx);
+
   const auto depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                               assocType);
 
   Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
                                               : type;
 
-  if (auto superclass = genericSig->getSuperclassBound(depTy)) {
+  if (auto superclass = sig->getSuperclassBound(depTy)) {
     if (superclass->hasTypeParameter()) {
       // Replace type parameters with other known or tentative type witnesses.
       superclass = superclass.subst(
@@ -4596,7 +4606,7 @@ swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
   auto *module = dc->getParentModule();
 
   // Check protocol conformances.
-  for (const auto reqProto : genericSig->getRequiredProtocols(depTy)) {
+  for (const auto reqProto : sig->getRequiredProtocols(depTy)) {
     if (module->lookupConformance(contextType, reqProto)
             .isInvalid())
       return CheckTypeWitnessResult(reqProto->getDeclaredInterfaceType());
@@ -4617,7 +4627,7 @@ swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
     }
   }
 
-  if (genericSig->requiresClass(depTy) &&
+  if (sig->requiresClass(depTy) &&
       !contextType->satisfiesClassConstraint())
     return CheckTypeWitnessResult(module->getASTContext().getAnyObjectType());
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -819,6 +819,7 @@ Type AssociatedTypeInference::computeFixedTypeWitness(
     // FIXME: The RequirementMachine will assert on re-entrant construction.
     // We should find a more principled way of breaking this cycle.
     if (ctx.isRecursivelyConstructingRequirementMachine(sig.getCanonicalSignature()) ||
+        ctx.isRecursivelyConstructingRequirementMachine(conformedProto) ||
         conformedProto->isComputingRequirementSignature())
       continue;
 

--- a/test/Constraints/associated_types.swift
+++ b/test/Constraints/associated_types.swift
@@ -112,11 +112,12 @@ struct UsesSameTypedDefaultDerivedWithoutSatisfyingReqts: SameTypedDefaultDerive
 // SR-12199
 
 protocol SR_12199_P1 {
-  associatedtype Assoc
+  associatedtype Assoc // expected-note {{'Assoc' declared here}}
 }
 
 enum SR_12199_E {}
 
 protocol SR_12199_P2: SR_12199_P1 where Assoc == SR_12199_E {
   associatedtype Assoc: SR_12199_E // expected-error {{type 'Self.Assoc' constrained to non-protocol, non-class type 'SR_12199_E'}}
+  // expected-warning@-1 {{redeclaration of associated type 'Assoc' from protocol 'SR_12199_P1' is better expressed as a 'where' clause on the protocol}}
 }

--- a/test/Generics/concrete_conformances_in_protocol.swift
+++ b/test/Generics/concrete_conformances_in_protocol.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype T
+}
+struct S : P {
+  typealias T = S
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).R0@
+// CHECK-LABEL: Requirement signature: <Self where Self.A == S>
+
+protocol R0 {
+  associatedtype A where A : P, A == S
+}
+
+////
+
+struct G<T> : P {}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).R1@
+// CHECK-LABEL: Requirement signature: <Self where Self.B == G<Self.A>>
+
+protocol R1 {
+  associatedtype A
+  associatedtype B where B : P, B == G<A>
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).R2@
+// CHECK-LABEL: Requirement signature: <Self where Self.A == G<Self.B>>
+
+protocol R2 {
+  associatedtype A where A : P, A == G<B>
+  associatedtype B
+}
+
+////
+
+protocol PP {
+  associatedtype T : P
+}
+
+struct GG<T : P> : PP {}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).RR3@
+// CHECK-LABEL: Requirement signature: <Self where Self.A : P, Self.B == GG<Self.A>>
+
+protocol RR3 {
+  associatedtype A : P
+  associatedtype B where B : PP, B == GG<A>
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).RR4@
+// CHECK-LABEL: Requirement signature: <Self where Self.A == GG<Self.B>, Self.B : P>
+
+protocol RR4 {
+  associatedtype A where A : PP, A == GG<B>
+  associatedtype B : P
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).RR5@
+// CHECK-LABEL: Requirement signature: <Self where Self.A : PP, Self.B == GG<Self.A.T>>
+
+protocol RR5 {
+  associatedtype A : PP
+  associatedtype B where B : PP, B == GG<A.T>
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).RR6@
+// CHECK-LABEL: Requirement signature: <Self where Self.A == GG<Self.B.T>, Self.B : PP>
+
+protocol RR6 {
+  associatedtype A where A : PP, A == GG<B.T>
+  associatedtype B : PP
+}

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -192,7 +192,7 @@ protocol AssociatedType1 {
 // TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
 
   associatedtype AssociatedTypeDecl5 : FooClass
-// CHECK: {{^}}  associatedtype AssociatedTypeDecl5{{$}}
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl5 : FooClass{{$}}
 }
 
 //===---


### PR DESCRIPTION
With these changes, more validation tests pass with -requirement-machine-protocol-signatures=verify.

There were a couple of highly-invalid cases where the requirement machine's result was more "correct", so I hacked the GSB just to make a few tests pass. If these GSB changes cause some unforseen breakage, they can be reverted separately without issue.

Also, a couple of optimizations to the homotopy reduction algorithm. It's still too slow.