### PR TITLE
[Build System] Propagate CMAKE_INSTALL_PREFIX to cmark

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -51,6 +51,8 @@ class CMark(cmake_product.CMakeProduct):
         """
         self.cmake_options.define('CMAKE_BUILD_TYPE:STRING',
                                   self.args.cmark_build_variant)
+        self.cmake_options.define('CMAKE_INSTALL_PREFIX:PATH',
+                                  self.args.install_prefix)
 
         (platform, arch) = host_target.split('-')
 


### PR DESCRIPTION
Currently, cmark's CMake config does not respect the `--install-prefix`
option and installs cmark into whatever the CMake default is.
This patch fixes this discrepancy.