### PR TITLE
[libswift] Call methods on `SILBuilder` directly and remove `createX` bridging functions.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -782,8 +782,18 @@ function(add_libswift name)
               "-emit-module-path" "${build_dir}/${module}.swiftmodule"
               "-parse-as-library" ${sources}
               "-wmo" ${libswift_compile_options}
-              "-I" "${SWIFT_SOURCE_DIR}/include/swift"
-              "-I" "${SWIFT_SOURCE_DIR}/include"
+              "-I" "${CMAKE_SOURCE_DIR}/include/swift"
+              # The Swift source header includes:
+              "-I" "${CMAKE_SOURCE_DIR}/include"
+              # LLVM and Clang source header includes:
+              "-I" "${LLVM_MAIN_SRC_DIR}/../clang/include"
+              "-I" "${LLVM_MAIN_INCLUDE_DIR}"
+              # Swift build includes:
+              "-I" "${CMAKE_BINARY_DIR}/include"
+              # LLVM and Clang build includes:
+              "-I" "${LLVM_BINARY_DIR}/tools/clang/include"
+              "-I" "${LLVM_BINARY_DIR}/include"
+              # libSwift build includes:
               "-I" "${build_dir}"
       COMMENT "Building libswift module ${module}")
 

--- a/include/swift/Basic/Unreachable.h
+++ b/include/swift/Basic/Unreachable.h
@@ -33,9 +33,6 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include "swift/Runtime/Config.h"
-
-SWIFT_RUNTIME_ATTRIBUTE_NORETURN
 inline static void swift_unreachable(const char *msg) {
   assert(false && msg);
   (void)msg;

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -26,6 +26,7 @@
 #include "swift/Basic/Unreachable.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Demangling/NamespaceMacros.h"
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -14,6 +14,12 @@
 #define SWIFT_SIL_SILBRIDGING_H
 
 #include "BridgedSwiftObject.h"
+
+#include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/ForeignAsyncConvention.h"
+#include "swift/SIL/SILBuilder.h"
+
 #include <stddef.h>
 #include <string>
 
@@ -144,6 +150,8 @@ typedef enum {
 
 typedef intptr_t SwiftInt;
 
+swift::SILBuilder SILBuilder_init(BridgedInstruction i);
+
 void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
 
 void OStream_write(BridgedOStream os, BridgedStringRef str);
@@ -235,10 +243,6 @@ BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
           BridgedInstruction insertionPoint,
           BridgedLocation loc, BridgedStringRef name,
           BridgedType operandType, BridgedType resultType, BridgedValueArray arguments);
-BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
-          BridgedLocation loc, BridgedValue condition, BridgedStringRef messge);
-BridgedInstruction SILBuilder_createIntegerLiteral(BridgedInstruction insertionPoint,
-          BridgedLocation loc, BridgedType type, SwiftInt value);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -27,6 +27,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/IRGen/IRGenPublic.h"
+#include "swift/Runtime/Config.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Config/config.h"

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -144,6 +144,10 @@ void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype) {
   nodeMetatypes[(unsigned)kind] = metatype;
 }
 
+SILBuilder SILBuilder_init(BridgedInstruction i) {
+  return SILBuilder(castToInst(i));
+}
+
 //===----------------------------------------------------------------------===//
 //                            Bridging C functions
 //===----------------------------------------------------------------------===//
@@ -506,18 +510,3 @@ BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
       getStringRef(name), getSILType(operandType), getSILType(resultType),
       getSILValues(arguments, argValues))};
 }
-
-BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
-          BridgedLocation loc, BridgedValue condition, BridgedStringRef messge) {
-  SILBuilder builder(castToInst(insertionPoint), getSILDebugScope(loc));
-  return {builder.createCondFail(getRegularLocation(loc),
-    castToSILValue(condition), getStringRef(messge))};
-}
-
-BridgedInstruction SILBuilder_createIntegerLiteral(BridgedInstruction insertionPoint,
-          BridgedLocation loc, BridgedType type, SwiftInt value) {
-  SILBuilder builder(castToInst(insertionPoint), getSILDebugScope(loc));
-  return {builder.createIntegerLiteral(getRegularLocation(loc),
-                                       getSILType(type), value)};
-}
-

--- a/libswift/Sources/SIL/Builder.swift
+++ b/libswift/Sources/SIL/Builder.swift
@@ -55,16 +55,27 @@ public struct Builder {
   public func createCondFail(condition: Value, message: String) -> CondFailInst {
     notifyInstructionsChanged()
     return message.withBridgedStringRef { messageStr in
-      let cf = SILBuilder_createCondFail(
-        bridgedInsPoint, location.bridgedLocation, condition.bridged, messageStr)
-      return cf.getAs(CondFailInst.self)
+      var builder = SILBuilder_init(bridgedInsPoint)
+      let cf = builder.createCondFail(
+        unsafeBitCast(location, to: swift.SILLocation.self),
+        unsafeBitCast(condition.bridged, to: swift.SILValue.self),
+        unsafeBitCast(messageStr, to: llvm.StringRef.self),
+        /*inverted*/false)
+      return Unmanaged<Instruction>.fromOpaque(UnsafeRawPointer(cf)!)
+        .takeUnretainedValue()
+        as! CondFailInst
     }
   }
   
   public func createIntegerLiteral(_ value: Int, type: Type) -> IntegerLiteralInst {
     notifyInstructionsChanged()
-    let literal = SILBuilder_createIntegerLiteral(
-      bridgedInsPoint, location.bridgedLocation, type.bridged, value)
-    return literal.getAs(IntegerLiteralInst.self)
+    var builder = SILBuilder_init(bridgedInsPoint)
+    let literal = builder.createIntegerLiteral(
+      unsafeBitCast(location, to: swift.SILLocation.self),
+      unsafeBitCast(type, to: swift.SILType.self),
+      value)
+    return Unmanaged<Instruction>.fromOpaque(UnsafeRawPointer(literal)!)
+      .takeUnretainedValue()
+      as! IntegerLiteralInst
   }
 }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -21,6 +21,7 @@
 #include "swift/ABI/TypeIdentity.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"


### PR DESCRIPTION
Refs #40469.