### PR TITLE
[Code Completion] Split code completion results into context free part that can be cached and contextual part displayed to the user

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -632,6 +632,15 @@ enum class CodeCompletionDiagnosticSeverity : uint8_t {
 
 /// Reasons why a code completion item might not be recommended in a certain
 /// context.
+/// This enum is split into two subsets: \c ContextFreeNotRecommendedReason and
+/// \c ContextualNotRecommendedReason. When adding a case to this enum also add
+/// it to either of those.
+/// Context-free diagnostics are independent of the context they are used in.
+/// The not-recommended reason can thus be cached as part of a context free
+/// code completion result.
+/// Contextual not recommended reasons depend on the context they are used in.
+/// E.g. \c InvalidAsyncContext depends on whether the usage context is async or
+/// not.
 enum class NotRecommendedReason : uint8_t {
   None = 0,                    // both contextual and context-free
   RedundantImport,             // contextual
@@ -645,6 +654,43 @@ enum class NotRecommendedReason : uint8_t {
   MAX_VALUE = VariableUsedInOwnDefinition
 };
 
+/// TODO: We consider deprecation warnings as context free although they don't
+/// produce deprecation warnings insdide context that have the same or a
+/// stronger deprecation attribute.
+/// E.g.
+/// In SDK:
+/// \code
+/// @available(iOS, deprecated: 12.0)
+/// func deprecatedFunc()
+/// \endcode
+///
+/// User code:
+/// \code
+/// @available(iOS, deprecated: 12.0)
+/// func insiderUserDeprecatedContext() {
+///   #^COMPLETE^#
+/// }
+/// \endcode
+/// suggests \c deprecatedFunc as deprecated although it doesn't produce a
+/// diagnostic during compilation. But this allows us to show deprecation
+/// warnings for cached results.
+enum class ContextFreeNotRecommendedReason : uint8_t {
+  None = 0,
+  Deprecated,
+  SoftDeprecated,
+  MAX_VALUE = SoftDeprecated
+};
+
+enum class ContextualNotRecommendedReason : uint8_t {
+  None = 0,
+  RedundantImport,
+  RedundantImportIndirect,
+  InvalidAsyncContext,
+  CrossActorReference,
+  VariableUsedInOwnDefinition,
+  MAX_VALUE = VariableUsedInOwnDefinition
+};
+
 enum class CodeCompletionResultKind : uint8_t {
   Declaration,
   Keyword,
@@ -655,10 +701,214 @@ enum class CodeCompletionResultKind : uint8_t {
   MAX_VALUE = BuiltinOperator
 };
 
-/// A single code completion result.
-class CodeCompletionResult {
-  friend class CodeCompletionResultBuilder;
+/// The parts of a \c CodeCompletionResult that are not dependent on the context
+/// it appears in and can thus be cached.
+class ContextFreeCodeCompletionResult {
+  CodeCompletionResultKind Kind : 3;
+  static_assert(int(CodeCompletionResultKind::MAX_VALUE) < 1 << 3, "");
 
+  union {
+    CodeCompletionDeclKind Decl;
+    CodeCompletionLiteralKind Literal;
+    CodeCompletionKeywordKind Keyword;
+    uint8_t Opaque;
+  } AssociatedKind;
+  static_assert(sizeof(AssociatedKind) == sizeof(AssociatedKind.Opaque),
+                "Opaque should cover all bits");
+
+  CodeCompletionOperatorKind KnownOperatorKind : 6;
+  static_assert(int(CodeCompletionOperatorKind::MAX_VALUE) < 1 << 6, "");
+
+  bool IsSystem : 1;
+  CodeCompletionString *CompletionString;
+  StringRef ModuleName;
+  StringRef BriefDocComment;
+  ArrayRef<StringRef> AssociatedUSRs;
+
+  ContextFreeNotRecommendedReason NotRecommended : 3;
+  static_assert(int(ContextFreeNotRecommendedReason::MAX_VALUE) < 1 << 3, "");
+
+  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
+  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
+
+  StringRef DiagnosticMessage;
+
+public:
+  /// Memberwise initializer. \p AssociatedKInd is opaque and will be
+  /// interpreted based on \p Kind. If \p KnownOperatorKind is \c None and the
+  /// completion item is an operator, it will be determined based on the
+  /// compleiton string.
+  ///
+  /// \note The caller must ensure that the \p CompleitonString and all the
+  /// \c Ref types outlive this result, typically by storing them in the same
+  /// \c CodeCompletionResultSink as the result itself.
+  ContextFreeCodeCompletionResult(
+      CodeCompletionResultKind Kind, uint8_t AssociatedKind,
+      CodeCompletionOperatorKind KnownOperatorKind, bool IsSystem,
+      CodeCompletionString *CompletionString, StringRef ModuleName,
+      StringRef BriefDocComment, ArrayRef<StringRef> AssociatedUSRs,
+      ContextFreeNotRecommendedReason NotRecommended,
+      CodeCompletionDiagnosticSeverity DiagnosticSeverity,
+      StringRef DiagnosticMessage)
+      : Kind(Kind), KnownOperatorKind(KnownOperatorKind), IsSystem(IsSystem),
+        CompletionString(CompletionString), ModuleName(ModuleName),
+        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
+        NotRecommended(NotRecommended), DiagnosticSeverity(DiagnosticSeverity),
+        DiagnosticMessage(DiagnosticMessage) {
+    this->AssociatedKind.Opaque = AssociatedKind;
+    assert((NotRecommended == ContextFreeNotRecommendedReason::None) ==
+               (DiagnosticSeverity == CodeCompletionDiagnosticSeverity::None) &&
+           "Result should be not recommended iff it has a diagnostic");
+    assert((DiagnosticSeverity == CodeCompletionDiagnosticSeverity::None) ==
+               DiagnosticMessage.empty() &&
+           "Completion item should have diagnostic message iff the diagnostics "
+           "severity is not none");
+    assert(CompletionString && "Result should have a completion string");
+    if (isOperator() && KnownOperatorKind == CodeCompletionOperatorKind::None) {
+      this->KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
+    }
+    assert(!isOperator() ||
+           getKnownOperatorKind() != CodeCompletionOperatorKind::None &&
+               "isOperator implies operator kind != None");
+  }
+
+  /// Constructs a \c Pattern, \c Keyword or \c BuiltinOperator result.
+  ///
+  /// \note The caller must ensure that the \p CompletionString and \c
+  /// StringRefs outlive this result, typically by storing them in the same
+  /// \c CodeCompletionResultSink as the result itself.
+  ContextFreeCodeCompletionResult(
+      CodeCompletionResultKind Kind, CodeCompletionString *CompletionString,
+      CodeCompletionOperatorKind KnownOperatorKind, StringRef BriefDocComment,
+      ContextFreeNotRecommendedReason NotRecommended,
+      CodeCompletionDiagnosticSeverity DiagnosticSeverity,
+      StringRef DiagnosticMessage)
+      : ContextFreeCodeCompletionResult(
+            Kind, /*AssociatedKind=*/0, KnownOperatorKind,
+            /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
+            BriefDocComment, /*AssociatedUSRs=*/{}, NotRecommended,
+            DiagnosticSeverity, DiagnosticMessage) {}
+
+  /// Constructs a \c Keyword result.
+  ///
+  /// \note The caller must ensure that the \p CompletionString and
+  /// \p BriefDocComment outlive this result, typically by storing them in the
+  /// same \c CodeCompletionResultSink as the result itself.
+  ContextFreeCodeCompletionResult(CodeCompletionKeywordKind Kind,
+                                  CodeCompletionString *CompletionString,
+                                  StringRef BriefDocComment)
+      : ContextFreeCodeCompletionResult(
+            CodeCompletionResultKind::Keyword, static_cast<uint8_t>(Kind),
+            CodeCompletionOperatorKind::None, /*IsSystem=*/false,
+            CompletionString, /*ModuleName=*/"", BriefDocComment,
+            /*AssociatedUSRs=*/{}, ContextFreeNotRecommendedReason::None,
+            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
+
+  /// Constructs a \c Literal result.
+  ///
+  /// \note The caller must ensure that the \p CompletionString outlives this
+  /// result, typically by storing them in the same \c CodeCompletionResultSink
+  /// as the result itself.
+  ContextFreeCodeCompletionResult(CodeCompletionLiteralKind LiteralKind,
+                                  CodeCompletionString *CompletionString)
+      : ContextFreeCodeCompletionResult(
+            CodeCompletionResultKind::Literal,
+            static_cast<uint8_t>(LiteralKind), CodeCompletionOperatorKind::None,
+            /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
+            /*BriefDocComment=*/"",
+            /*AssociatedUSRs=*/{}, ContextFreeNotRecommendedReason::None,
+            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
+
+  /// Constructs a \c Declaration result.
+  ///
+  /// \note The caller must ensure that the \p CompletionString and all
+  /// \c StringRefs outlive this result, typically by storing them in the same
+  /// \c CodeCompletionResultSink as the result itself.
+  ContextFreeCodeCompletionResult(
+      CodeCompletionString *CompletionString, const Decl *AssociatedDecl,
+      StringRef ModuleName, StringRef BriefDocComment,
+      ArrayRef<StringRef> AssociatedUSRs,
+      ContextFreeNotRecommendedReason NotRecommended,
+      CodeCompletionDiagnosticSeverity DiagnosticSeverity,
+      StringRef DiagnosticMessage)
+      : ContextFreeCodeCompletionResult(
+            CodeCompletionResultKind::Declaration,
+            static_cast<uint8_t>(getCodeCompletionDeclKind(AssociatedDecl)),
+            CodeCompletionOperatorKind::None, getDeclIsSystem(AssociatedDecl),
+            CompletionString, ModuleName, BriefDocComment, AssociatedUSRs,
+            NotRecommended, DiagnosticSeverity, DiagnosticMessage) {
+    assert(AssociatedDecl && "should have a decl");
+  }
+
+  CodeCompletionResultKind getKind() const { return Kind; }
+
+  /// Returns the raw associated kind which will be interpreted differently
+  /// depending on the completion item's kind.
+  uint8_t getOpaqueAssociatedKind() const { return AssociatedKind.Opaque; }
+
+  CodeCompletionDeclKind getAssociatedDeclKind() const {
+    assert(getKind() == CodeCompletionResultKind::Declaration);
+    return AssociatedKind.Decl;
+  }
+  CodeCompletionLiteralKind getLiteralKind() const {
+    assert(getKind() == CodeCompletionResultKind::Literal);
+    return AssociatedKind.Literal;
+  }
+  CodeCompletionKeywordKind getKeywordKind() const {
+    assert(getKind() == CodeCompletionResultKind::Keyword);
+    return AssociatedKind.Keyword;
+  }
+
+  CodeCompletionOperatorKind getKnownOperatorKind() const {
+    assert(isOperator());
+    return KnownOperatorKind;
+  }
+
+  bool isSystem() const { return IsSystem; };
+
+  CodeCompletionString *getCompletionString() const { return CompletionString; }
+
+  StringRef getModuleName() const { return ModuleName; }
+
+  StringRef getBriefDocComment() const { return BriefDocComment; }
+
+  ArrayRef<StringRef> getAssociatedUSRs() const { return AssociatedUSRs; }
+
+  ContextFreeNotRecommendedReason getNotRecommendedReason() const {
+    return NotRecommended;
+  }
+
+  CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
+    return DiagnosticSeverity;
+  }
+  StringRef getDiagnosticMessage() const { return DiagnosticMessage; };
+
+  bool isOperator() const {
+    if (getKind() == CodeCompletionResultKind::Declaration) {
+      switch (getAssociatedDeclKind()) {
+      case CodeCompletionDeclKind::PrefixOperatorFunction:
+      case CodeCompletionDeclKind::PostfixOperatorFunction:
+      case CodeCompletionDeclKind::InfixOperatorFunction:
+        return true;
+      default:
+        return false;
+      }
+    } else {
+      return getKind() == CodeCompletionResultKind::BuiltinOperator;
+    }
+  }
+
+  /// Helper methods used during initialization of
+  /// \c ContextFreeCodeCompletionResult.
+  static CodeCompletionOperatorKind
+  getCodeCompletionOperatorKind(const CodeCompletionString *str);
+  static CodeCompletionDeclKind getCodeCompletionDeclKind(const Decl *D);
+  static bool getDeclIsSystem(const Decl *D);
+};
+
+/// A single code completion result enriched with information that depend on
+/// the completion's usage context.
+class CodeCompletionResult {
 public:
   /// Describes the relationship between the type of the completion results and
   /// the expected type at the code completion position.
@@ -687,13 +937,21 @@ public:
 
 
 private:
-  CodeCompletionResultKind Kind : 3;
-  unsigned AssociatedKind : 8;
-  CodeCompletionOperatorKind KnownOperatorKind : 6;
+  const ContextFreeCodeCompletionResult &ContextFree;
   SemanticContextKind SemanticContext : 3;
+  static_assert(int(SemanticContextKind::MAX_VALUE) < 1 << 3, "");
+
   unsigned char Flair : 8;
-  NotRecommendedReason NotRecommended : 4;
-  bool IsSystem : 1;
+
+  /// Contextual diagnostics. If the contextual not recommended reason is
+  /// \c None, then the context free diagnostic will be shown to the user.
+  ContextualNotRecommendedReason NotRecommended : 4;
+  static_assert(int(ContextualNotRecommendedReason::MAX_VALUE) < 1 << 4, "");
+
+  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
+  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
+
+  StringRef DiagnosticMessage;
 
   /// The number of bytes to the left of the code completion point that
   /// should be erased first if this completion string is inserted in the
@@ -704,194 +962,101 @@ public:
   static const unsigned MaxNumBytesToErase = 127;
 
 private:
-  CodeCompletionString *CompletionString;
-  StringRef ModuleName;
-  StringRef BriefDocComment;
-  ArrayRef<StringRef> AssociatedUSRs;
   ExpectedTypeRelation TypeDistance : 3;
-  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
-  StringRef DiagnosticMessage;
-
-  // Assertions for limiting max values of enums.
-  static_assert(int(CodeCompletionResultKind::MAX_VALUE) < 1 << 3, "");
-  static_assert(int(CodeCompletionOperatorKind::MAX_VALUE) < 1 << 6, "");
-  static_assert(int(SemanticContextKind::MAX_VALUE) < 1 << 3, "");
-  static_assert(int(NotRecommendedReason::MAX_VALUE) < 1 << 4, "");
-  static_assert(int(ExpectedTypeRelation::MAX_VALUE) < 1 << 3, "");
-  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
-
 public:
-  /// Constructs a \c Pattern, \c Keyword or \c BuiltinOperator result.
-  ///
-  /// \note The caller must ensure \c CodeCompletionString outlives this result.
-  CodeCompletionResult(CodeCompletionResultKind Kind,
+  /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
+  /// information.
+  /// The \c ContextFree result must outlive this result. Typically, this is
+  /// done by allocating the two in the same sink or adopting the context free
+  /// sink in the sink that allocates this result.
+  CodeCompletionResult(const ContextFreeCodeCompletionResult &ContextFree,
                        SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, unsigned NumBytesToErase,
-                       CodeCompletionString *CompletionString,
+                       CodeCompletionFlair Flair, uint8_t NumBytesToErase,
                        ExpectedTypeRelation TypeDistance,
-                       CodeCompletionOperatorKind KnownOperatorKind =
-                           CodeCompletionOperatorKind::None,
-                       StringRef BriefDocComment = StringRef())
-      : Kind(Kind), KnownOperatorKind(KnownOperatorKind),
-        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
-        NotRecommended(NotRecommendedReason::None),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
-    assert(Kind != CodeCompletionResultKind::Declaration &&
-           "use the other constructor");
-    assert(CompletionString);
-    if (isOperator() && KnownOperatorKind == CodeCompletionOperatorKind::None)
-      this->KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
-    assert(!isOperator() ||
-           getOperatorKind() != CodeCompletionOperatorKind::None);
-    AssociatedKind = 0;
-    IsSystem = false;
-    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
+                       ContextualNotRecommendedReason NotRecommended,
+                       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
+                       StringRef DiagnosticMessage)
+      : ContextFree(ContextFree), SemanticContext(SemanticContext),
+        Flair(Flair.toRaw()), NotRecommended(NotRecommended),
+        DiagnosticSeverity(DiagnosticSeverity),
+        DiagnosticMessage(DiagnosticMessage), NumBytesToErase(NumBytesToErase),
+        TypeDistance(TypeDistance) {}
+
+  const ContextFreeCodeCompletionResult &getContextFreeResult() const {
+    return ContextFree;
   }
 
-  /// Constructs a \c Keyword result.
-  ///
-  /// \note The caller must ensure \c CodeCompletionString outlives this result.
-  CodeCompletionResult(CodeCompletionKeywordKind Kind,
-                       SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, unsigned NumBytesToErase,
-                       CodeCompletionString *CompletionString,
-                       ExpectedTypeRelation TypeDistance,
-                       StringRef BriefDocComment = StringRef())
-      : Kind(CodeCompletionResultKind::Keyword),
-        KnownOperatorKind(CodeCompletionOperatorKind::None),
-        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
-        NotRecommended(NotRecommendedReason::None),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
-    assert(CompletionString);
-    AssociatedKind = static_cast<unsigned>(Kind);
-    IsSystem = false;
-    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
-  }
-
-  /// Constructs a \c Literal result.
-  ///
-  /// \note The caller must ensure \c CodeCompletionString outlives this result.
-  CodeCompletionResult(CodeCompletionLiteralKind LiteralKind,
-                       SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, unsigned NumBytesToErase,
-                       CodeCompletionString *CompletionString,
-                       ExpectedTypeRelation TypeDistance)
-      : Kind(CodeCompletionResultKind::Literal),
-        KnownOperatorKind(CodeCompletionOperatorKind::None),
-        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
-        NotRecommended(NotRecommendedReason::None),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        TypeDistance(TypeDistance) {
-    AssociatedKind = static_cast<unsigned>(LiteralKind);
-    IsSystem = false;
-    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
-    assert(CompletionString);
-  }
-
-  /// Constructs a \c Declaration result.
-  ///
-  /// \note The caller must ensure \c CodeCompletionString and any StringRef
-  /// arguments outlive this result, typically by storing them in the same
-  /// \c CodeCompletionResultSink as the result itself.
-  CodeCompletionResult(SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, unsigned NumBytesToErase,
-                       CodeCompletionString *CompletionString,
-                       const Decl *AssociatedDecl, StringRef ModuleName,
-                       NotRecommendedReason NotRecReason,
-                       StringRef BriefDocComment,
-                       ArrayRef<StringRef> AssociatedUSRs,
-                       ExpectedTypeRelation TypeDistance)
-      : Kind(CodeCompletionResultKind::Declaration),
-        KnownOperatorKind(CodeCompletionOperatorKind::None),
-        SemanticContext(SemanticContext), Flair(Flair.toRaw()),
-        NotRecommended(NotRecReason), NumBytesToErase(NumBytesToErase),
-        CompletionString(CompletionString), ModuleName(ModuleName),
-        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
-        TypeDistance(TypeDistance) {
-    assert(AssociatedDecl && "should have a decl");
-    AssociatedKind = unsigned(getCodeCompletionDeclKind(AssociatedDecl));
-    IsSystem = getDeclIsSystem(AssociatedDecl);
-    DiagnosticSeverity = CodeCompletionDiagnosticSeverity::None;
-    assert(CompletionString);
-    if (isOperator())
-      KnownOperatorKind = getCodeCompletionOperatorKind(CompletionString);
-    assert(!isOperator() ||
-           getOperatorKind() != CodeCompletionOperatorKind::None);
-  }
-
-  // Used by deserialization.
-  CodeCompletionResult(SemanticContextKind SemanticContext,
-                       CodeCompletionFlair Flair, unsigned NumBytesToErase,
-                       CodeCompletionString *CompletionString,
-                       CodeCompletionDeclKind DeclKind, bool IsSystem,
-                       StringRef ModuleName, NotRecommendedReason NotRecReason,
-                       CodeCompletionDiagnosticSeverity diagSeverity,
-                       StringRef DiagnosticMessage, StringRef BriefDocComment,
-                       ArrayRef<StringRef> AssociatedUSRs,
-                       ExpectedTypeRelation TypeDistance,
-                       CodeCompletionOperatorKind KnownOperatorKind)
-      : Kind(CodeCompletionResultKind::Declaration),
-        KnownOperatorKind(KnownOperatorKind), SemanticContext(SemanticContext),
-        Flair(Flair.toRaw()), NotRecommended(NotRecReason), IsSystem(IsSystem),
-        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
-        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
-        AssociatedUSRs(AssociatedUSRs), TypeDistance(TypeDistance),
-        DiagnosticSeverity(diagSeverity), DiagnosticMessage(DiagnosticMessage) {
-    AssociatedKind = static_cast<unsigned>(DeclKind);
-    assert(CompletionString);
-    assert(!isOperator() ||
-           getOperatorKind() != CodeCompletionOperatorKind::None);
+  /// Return a pointer to the data structure storing the context free
+  /// properties.
+  /// The pointer is valid as long as this result is alive.
+  const ContextFreeCodeCompletionResult *getContextFreeResultPtr() {
+    return &ContextFree;
   }
 
   /// Copy this result to \p Sink with \p newFlair . Note that this does NOT
-  /// copy the value of \c CompletionString , \c AssociatedUSRs etc. it only
-  /// copies the pointers to them.
+  /// copy the context free result. Thus the caller needs to ensure that the
+  /// context free result outlives the result the result returned by this
+  /// method.
   CodeCompletionResult *withFlair(CodeCompletionFlair newFlair,
                                   CodeCompletionResultSink &Sink);
 
-  CodeCompletionResultKind getKind() const { return Kind; }
+  CodeCompletionResultKind getKind() const {
+    return getContextFreeResult().getKind();
+  }
 
   CodeCompletionDeclKind getAssociatedDeclKind() const {
-    assert(getKind() == CodeCompletionResultKind::Declaration);
-    return static_cast<CodeCompletionDeclKind>(AssociatedKind);
+    return getContextFreeResult().getAssociatedDeclKind();
   }
 
   CodeCompletionLiteralKind getLiteralKind() const {
-    assert(getKind() == CodeCompletionResultKind::Literal);
-    return static_cast<CodeCompletionLiteralKind>(AssociatedKind);
+    return getContextFreeResult().getLiteralKind();
   }
 
   CodeCompletionKeywordKind getKeywordKind() const {
-    assert(getKind() == CodeCompletionResultKind::Keyword);
-    return static_cast<CodeCompletionKeywordKind>(AssociatedKind);
+    return getContextFreeResult().getKeywordKind();
   }
 
-  bool isOperator() const {
-    if (getKind() != CodeCompletionResultKind::Declaration)
-      return getKind() == CodeCompletionResultKind::BuiltinOperator;
-    switch (getAssociatedDeclKind()) {
-    case CodeCompletionDeclKind::PrefixOperatorFunction:
-    case CodeCompletionDeclKind::PostfixOperatorFunction:
-    case CodeCompletionDeclKind::InfixOperatorFunction:
-      return true;
-    default:
-      return false;
-    }
-  }
+  bool isOperator() const { return getContextFreeResult().isOperator(); }
 
   CodeCompletionOperatorKind getOperatorKind() const {
-    assert(isOperator());
-    return KnownOperatorKind;
+    return getContextFreeResult().getKnownOperatorKind();
   }
 
-  bool isSystem() const { return IsSystem; }
+  bool isSystem() const { return getContextFreeResult().isSystem(); }
 
   ExpectedTypeRelation getExpectedTypeRelation() const { return TypeDistance; }
 
-  NotRecommendedReason getNotRecommendedReason() const {
+  /// Get the contextual not-recommended reason. This disregards context-free
+  /// not recommended reasons.
+  ContextualNotRecommendedReason getContextualNotRecommendedReason() const {
     return NotRecommended;
+  }
+
+  /// Return the contextual not recommended reason if there is one. If there is
+  /// no contextual not recommended reason, return the context-free not
+  /// recommended reason.
+  NotRecommendedReason getNotRecommendedReason() const {
+    switch (NotRecommended) {
+    case ContextualNotRecommendedReason::None:
+      switch (getContextFreeResult().getNotRecommendedReason()) {
+      case ContextFreeNotRecommendedReason::None:
+        return NotRecommendedReason::None;
+      case ContextFreeNotRecommendedReason::Deprecated:
+        return NotRecommendedReason::Deprecated;
+      case ContextFreeNotRecommendedReason::SoftDeprecated:
+        return NotRecommendedReason::SoftDeprecated;
+      }
+    case ContextualNotRecommendedReason::RedundantImport:
+      return NotRecommendedReason::RedundantImport;
+    case ContextualNotRecommendedReason::RedundantImportIndirect:
+      return NotRecommendedReason::RedundantImportIndirect;
+    case ContextualNotRecommendedReason::InvalidAsyncContext:
+      return NotRecommendedReason::InvalidAsyncContext;
+    case ContextualNotRecommendedReason::CrossActorReference:
+      return NotRecommendedReason::CrossActorReference;
+    case ContextualNotRecommendedReason::VariableUsedInOwnDefinition:
+      return NotRecommendedReason::VariableUsedInOwnDefinition;
+    }
   }
 
   SemanticContextKind getSemanticContext() const { return SemanticContext; }
@@ -910,42 +1075,56 @@ public:
   }
 
   CodeCompletionString *getCompletionString() const {
-    return CompletionString;
+    return getContextFreeResult().getCompletionString();
   }
 
-  StringRef getModuleName() const { return ModuleName; }
+  StringRef getModuleName() const {
+    return getContextFreeResult().getModuleName();
+  }
 
   StringRef getBriefDocComment() const {
-    return BriefDocComment;
+    return getContextFreeResult().getBriefDocComment();
   }
 
   ArrayRef<StringRef> getAssociatedUSRs() const {
-    return AssociatedUSRs;
+    return getContextFreeResult().getAssociatedUSRs();
   }
 
-  void setDiagnostics(CodeCompletionDiagnosticSeverity severity, StringRef message) {
-    DiagnosticSeverity = severity;
-    DiagnosticMessage = message;
-  }
-
-  CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
+  /// Get the contextual diagnostic severity. This disregards context-free
+  /// diagnostics.
+  CodeCompletionDiagnosticSeverity getContextualDiagnosticSeverity() const {
     return DiagnosticSeverity;
   }
 
+  /// Get the contextual diagnostic message. This disregards context-free
+  /// diagnostics.
+  StringRef getContextualDiagnosticMessage() const { return DiagnosticMessage; }
+
+  /// Return the contextual diagnostic severity if there was a contextual
+  /// diagnostic. If there is no contextual diagnostic, return the context-free
+  /// diagnostic severity.
+  CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
+    if (NotRecommended != ContextualNotRecommendedReason::None) {
+      return DiagnosticSeverity;
+    } else {
+      return getContextFreeResult().getDiagnosticSeverity();
+    }
+  }
+
+  /// Return the contextual diagnostic message if there was a contextual
+  /// diagnostic. If there is no contextual diagnostic, return the context-free
+  /// diagnostic message.
   StringRef getDiagnosticMessage() const {
-    return DiagnosticMessage;
+    if (NotRecommended != ContextualNotRecommendedReason::None) {
+      return DiagnosticMessage;
+    } else {
+      return getContextFreeResult().getDiagnosticMessage();
+    }
   }
 
   /// Print a debug representation of the code completion result to \p OS.
   void printPrefix(raw_ostream &OS) const;
   SWIFT_DEBUG_DUMP;
-
-  static CodeCompletionDeclKind getCodeCompletionDeclKind(const Decl *D);
-  static CodeCompletionOperatorKind
-  getCodeCompletionOperatorKind(StringRef name);
-  static CodeCompletionOperatorKind
-  getCodeCompletionOperatorKind(CodeCompletionString *str);
-  static bool getDeclIsSystem(const Decl *D);
 };
 
 struct CodeCompletionResultSink {
@@ -1130,14 +1309,6 @@ void lookupCodeCompletionResultsFromModule(CodeCompletionResultSink &targetSink,
                                            ArrayRef<std::string> accessPath,
                                            bool needLeadingDot,
                                            const SourceFile *SF);
-
-/// Copy code completion results from \p sourceSink to \p targetSink, possibly
-/// restricting by \p onlyTypes. Returns copied results in \p targetSink.
-MutableArrayRef<CodeCompletionResult *>
-copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
-                          CodeCompletionResultSink &sourceSink,
-                          bool onlyTypes,
-                          bool onlyPrecedenceGroups);
 
 } // end namespace ide
 } // end namespace swift

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -61,8 +61,14 @@ public:
   };
 
   struct Value : public llvm::ThreadSafeRefCountedBase<Value> {
+    /// The allocator used to allocate the results stored in this cache.
+    std::shared_ptr<llvm::BumpPtrAllocator> Allocator;
+
     llvm::sys::TimePoint<> ModuleModificationTime;
-    CodeCompletionResultSink Sink;
+
+    std::vector<const ContextFreeCodeCompletionResult *> Results;
+
+    Value() : Allocator(std::make_shared<llvm::BumpPtrAllocator>()) {}
   };
   using ValueRefCntPtr = llvm::IntrusiveRefCntPtr<Value>;
 

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -197,12 +197,11 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
 
   // RESULTS
   while (cursor != resultEnd) {
-    auto kind = static_cast<CodeCompletionResult::ResultKind>(*cursor++);
+    auto kind = static_cast<CodeCompletionResultKind>(*cursor++);
     auto declKind = static_cast<CodeCompletionDeclKind>(*cursor++);
     auto opKind = static_cast<CodeCompletionOperatorKind>(*cursor++);
     auto context = static_cast<SemanticContextKind>(*cursor++);
-    auto notRecommended =
-        static_cast<CodeCompletionResult::NotRecommendedReason>(*cursor++);
+    auto notRecommended = static_cast<NotRecommendedReason>(*cursor++);
     auto diagSeverity =
         static_cast<CodeCompletionDiagnosticSeverity>(*cursor++);
     auto isSystem = static_cast<bool>(*cursor++);
@@ -224,7 +223,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     auto diagMessage = getString(diagMessageIndex);
 
     CodeCompletionResult *result = nullptr;
-    if (kind == CodeCompletionResult::ResultKind::Declaration) {
+    if (kind == CodeCompletionResultKind::Declaration) {
       result = new (*V.Sink.Allocator) CodeCompletionResult(
           context, CodeCompletionFlair(), numBytesToErase, string, declKind,
           isSystem, moduleName, notRecommended, diagSeverity, diagMessage,
@@ -346,12 +345,12 @@ static void writeCachedModule(llvm::raw_ostream &out,
     for (CodeCompletionResult *R : V.Sink.Results) {
       assert(!R->getFlair().toRaw() && "Any flairs should not be cached");
       assert(R->getNotRecommendedReason() !=
-             CodeCompletionResult::NotRecommendedReason::InvalidAsyncContext &&
+                 NotRecommendedReason::InvalidAsyncContext &&
              "InvalidAsyncContext is decl context specific, cannot be cached");
 
       // FIXME: compress bitfield
       LE.write(static_cast<uint8_t>(R->getKind()));
-      if (R->getKind() == CodeCompletionResult::ResultKind::Declaration)
+      if (R->getKind() == CodeCompletionResultKind::Declaration)
         LE.write(static_cast<uint8_t>(R->getAssociatedDeclKind()));
       else
         LE.write(static_cast<uint8_t>(~0u));

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -41,7 +41,7 @@ namespace swift {
     struct CacheValueCostInfo<swift::ide::CodeCompletionCacheImpl::Value> {
       static size_t
       getCost(const swift::ide::CodeCompletionCacheImpl::Value &V) {
-        return V.Sink.Allocator->getTotalMemory();
+        return V.Allocator->getTotalMemory();
       }
     };
   } // namespace sys
@@ -102,7 +102,7 @@ CodeCompletionCache::~CodeCompletionCache() {}
 ///
 /// This should be incremented any time we commit a change to the format of the
 /// cached results. This isn't expected to change very often.
-static constexpr uint32_t onDiskCompletionCacheVersion = 3; // Removed "source file path".
+static constexpr uint32_t onDiskCompletionCacheVersion = 4; // Store ContextFreeCodeCompletionResults in cache
 
 /// Deserializes CodeCompletionResults from \p in and stores them in \p V.
 /// \see writeCacheModule.
@@ -166,7 +166,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
 
     const char *p = strings + index;
     auto size = read32le(p);
-    auto str = copyString(*V.Sink.Allocator, StringRef(p, size));
+    auto str = copyString(*V.Allocator, StringRef(p, size));
     knownStrings[index] = str;
     return str;
   };
@@ -192,20 +192,19 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
       }
     }
 
-    return CodeCompletionString::create(*V.Sink.Allocator, chunkList);
+    return CodeCompletionString::create(*V.Allocator, chunkList);
   };
 
   // RESULTS
   while (cursor != resultEnd) {
     auto kind = static_cast<CodeCompletionResultKind>(*cursor++);
-    auto declKind = static_cast<CodeCompletionDeclKind>(*cursor++);
+    auto associatedKind = static_cast<uint8_t>(*cursor++);
     auto opKind = static_cast<CodeCompletionOperatorKind>(*cursor++);
-    auto context = static_cast<SemanticContextKind>(*cursor++);
-    auto notRecommended = static_cast<NotRecommendedReason>(*cursor++);
+    auto notRecommended =
+        static_cast<ContextFreeNotRecommendedReason>(*cursor++);
     auto diagSeverity =
         static_cast<CodeCompletionDiagnosticSeverity>(*cursor++);
     auto isSystem = static_cast<bool>(*cursor++);
-    auto numBytesToErase = static_cast<unsigned>(*cursor++);
     auto chunkIndex = read32le(cursor);
     auto moduleIndex = read32le(cursor);
     auto briefDocIndex = read32le(cursor);
@@ -222,21 +221,14 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     auto briefDocComment = getString(briefDocIndex);
     auto diagMessage = getString(diagMessageIndex);
 
-    CodeCompletionResult *result = nullptr;
-    if (kind == CodeCompletionResultKind::Declaration) {
-      result = new (*V.Sink.Allocator) CodeCompletionResult(
-          context, CodeCompletionFlair(), numBytesToErase, string, declKind,
-          isSystem, moduleName, notRecommended, diagSeverity, diagMessage,
-          briefDocComment,
-          copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
-          CodeCompletionResult::ExpectedTypeRelation::Unknown, opKind);
-    } else {
-      result = new (*V.Sink.Allocator) CodeCompletionResult(
-          kind, context, CodeCompletionFlair(), numBytesToErase, string,
-          CodeCompletionResult::ExpectedTypeRelation::NotApplicable, opKind);
-    }
+    ContextFreeCodeCompletionResult *result =
+        new (*V.Allocator) ContextFreeCodeCompletionResult(
+            kind, associatedKind, opKind, isSystem, string, moduleName,
+            briefDocComment,
+            copyArray(*V.Allocator, ArrayRef<StringRef>(assocUSRs)),
+            notRecommended, diagSeverity, diagMessage);
 
-    V.Sink.Results.push_back(result);
+    V.Results.push_back(result);
   }
 
   return true;
@@ -342,27 +334,18 @@ static void writeCachedModule(llvm::raw_ostream &out,
   // RESULTS
   {
     endian::Writer LE(results, little);
-    for (CodeCompletionResult *R : V.Sink.Results) {
-      assert(!R->getFlair().toRaw() && "Any flairs should not be cached");
-      assert(R->getNotRecommendedReason() !=
-                 NotRecommendedReason::InvalidAsyncContext &&
-             "InvalidAsyncContext is decl context specific, cannot be cached");
-
+    for (const ContextFreeCodeCompletionResult *R : V.Results) {
       // FIXME: compress bitfield
       LE.write(static_cast<uint8_t>(R->getKind()));
-      if (R->getKind() == CodeCompletionResultKind::Declaration)
-        LE.write(static_cast<uint8_t>(R->getAssociatedDeclKind()));
-      else
-        LE.write(static_cast<uint8_t>(~0u));
-      if (R->isOperator())
-        LE.write(static_cast<uint8_t>(R->getOperatorKind()));
-      else
+      LE.write(static_cast<uint8_t>(R->getOpaqueAssociatedKind()));
+      if (R->isOperator()) {
+        LE.write(static_cast<uint8_t>(R->getKnownOperatorKind()));
+      } else {
         LE.write(static_cast<uint8_t>(CodeCompletionOperatorKind::None));
-      LE.write(static_cast<uint8_t>(R->getSemanticContext()));
+      }
       LE.write(static_cast<uint8_t>(R->getNotRecommendedReason()));
       LE.write(static_cast<uint8_t>(R->getDiagnosticSeverity()));
       LE.write(static_cast<uint8_t>(R->isSystem()));
-      LE.write(static_cast<uint8_t>(R->getNumBytesToErase()));
       LE.write(
           static_cast<uint32_t>(addCompletionString(R->getCompletionString())));
       LE.write(addString(R->getModuleName()));      // index into strings

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -145,10 +145,8 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 } // namespace
 
 bool swift::ide::getCompletionDiagnostics(
-    CodeCompletionResult::NotRecommendedReason reason, const ValueDecl *D,
+    NotRecommendedReason reason, const ValueDecl *D,
     CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out) {
-  using NotRecommendedReason = CodeCompletionResult::NotRecommendedReason;
-
   ASTContext &ctx = D->getASTContext();
 
   CodeCompletionDiagnostics Diag(ctx);
@@ -177,4 +175,3 @@ bool swift::ide::getCompletionDiagnostics(
   }
   return true;
 }
-

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -144,33 +144,43 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
 
 } // namespace
 
-bool swift::ide::getCompletionDiagnostics(
-    NotRecommendedReason reason, const ValueDecl *D,
-    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out) {
-  ASTContext &ctx = D->getASTContext();
+bool swift::ide::getContextFreeCompletionDiagnostics(
+    ContextFreeNotRecommendedReason Reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &Severity, llvm::raw_ostream &Out) {
+  CodeCompletionDiagnostics Diag(D->getASTContext());
+  switch (Reason) {
+  case ContextFreeNotRecommendedReason::Deprecated:
+  case ContextFreeNotRecommendedReason::SoftDeprecated:
+    return Diag.getDiagnosticForDeprecated(D, Severity, Out);
+  case ContextFreeNotRecommendedReason::None:
+    llvm_unreachable("invalid not recommended reason");
+  }
+  return true;
+}
 
-  CodeCompletionDiagnostics Diag(ctx);
-  switch (reason) {
-  case NotRecommendedReason::Deprecated:
-  case NotRecommendedReason::SoftDeprecated:
-    return Diag.getDiagnosticForDeprecated(D, severity, Out);
-  case NotRecommendedReason::InvalidAsyncContext:
+bool swift::ide::getContextualCompletionDiagnostics(
+    ContextualNotRecommendedReason Reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &Severity, llvm::raw_ostream &Out) {
+  CodeCompletionDiagnostics Diag(D->getASTContext());
+  switch (Reason) {
+  case ContextualNotRecommendedReason::InvalidAsyncContext:
     // FIXME: Could we use 'diag::async_in_nonasync_function'?
-    return Diag.getDiagnostics(severity, Out, diag::ide_async_in_nonasync_context,
-                        D->getName());
-  case NotRecommendedReason::CrossActorReference:
-    return Diag.getDiagnostics(severity, Out, diag::ide_cross_actor_reference_swift5,
-                        D->getName());
-  case NotRecommendedReason::RedundantImport:
-    return Diag.getDiagnostics(severity, Out, diag::ide_redundant_import,
-                        D->getName());
-  case NotRecommendedReason::RedundantImportIndirect:
-    return Diag.getDiagnostics(severity, Out, diag::ide_redundant_import_indirect,
-                        D->getName());
-  case NotRecommendedReason::VariableUsedInOwnDefinition:
-    return Diag.getDiagnostics(severity, Out, diag::recursive_accessor_reference,
-                        D->getName().getBaseIdentifier(), /*"getter"*/ 0);
-  case NotRecommendedReason::None:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_async_in_nonasync_context, D->getName());
+  case ContextualNotRecommendedReason::CrossActorReference:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_cross_actor_reference_swift5, D->getName());
+  case ContextualNotRecommendedReason::RedundantImport:
+    return Diag.getDiagnostics(Severity, Out, diag::ide_redundant_import,
+                               D->getName());
+  case ContextualNotRecommendedReason::RedundantImportIndirect:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::ide_redundant_import_indirect, D->getName());
+  case ContextualNotRecommendedReason::VariableUsedInOwnDefinition:
+    return Diag.getDiagnostics(
+        Severity, Out, diag::recursive_accessor_reference,
+        D->getName().getBaseIdentifier(), /*"getter"*/ 0);
+  case ContextualNotRecommendedReason::None:
     llvm_unreachable("invalid not recommended reason");
   }
   return true;

--- a/lib/IDE/CodeCompletionDiagnostics.h
+++ b/lib/IDE/CodeCompletionDiagnostics.h
@@ -23,8 +23,7 @@ namespace ide {
 
 /// Populate \p severity and \p Out with the diagnostics for \p D.
 /// Returns \c true if it fails to generate the diagnostics.
-bool getCompletionDiagnostics(CodeCompletionResult::NotRecommendedReason reason,
-                              const ValueDecl *D,
+bool getCompletionDiagnostics(NotRecommendedReason reason, const ValueDecl *D,
                               CodeCompletionDiagnosticSeverity &severity,
                               llvm::raw_ostream &Out);
 

--- a/lib/IDE/CodeCompletionDiagnostics.h
+++ b/lib/IDE/CodeCompletionDiagnostics.h
@@ -21,11 +21,21 @@ class ValueDecl;
 
 namespace ide {
 
-/// Populate \p severity and \p Out with the diagnostics for \p D.
+/// Populate \p severity and \p Out with the context-free diagnostics for \p D.
+/// See \c NotRecommendedReason for an explaination of context-free vs.
+/// contextual diagnostics.
 /// Returns \c true if it fails to generate the diagnostics.
-bool getCompletionDiagnostics(NotRecommendedReason reason, const ValueDecl *D,
-                              CodeCompletionDiagnosticSeverity &severity,
-                              llvm::raw_ostream &Out);
+bool getContextFreeCompletionDiagnostics(
+    ContextFreeNotRecommendedReason reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
+
+/// Populate \p severity and \p Out with the contextual diagnostics for \p D.
+/// See \c NotRecommendedReason for an explaination of context-free vs.
+/// contextual diagnostics.
+/// Returns \c true if it fails to generate the diagnostics.
+bool getContextualCompletionDiagnostics(
+    ContextualNotRecommendedReason reason, const ValueDecl *D,
+    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
 
 } // namespace ide
 } // namespace swift

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -74,7 +74,7 @@ class CodeCompletionResultBuilder {
   friend CodeCompletionStringPrinter;
   
   CodeCompletionResultSink &Sink;
-  CodeCompletionResult::ResultKind Kind;
+  CodeCompletionResultKind Kind;
   SemanticContextKind SemanticContext;
   CodeCompletionFlair Flair;
   unsigned NumBytesToErase = 0;
@@ -89,8 +89,7 @@ class CodeCompletionResultBuilder {
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
       CodeCompletionResult::ExpectedTypeRelation::Unknown;
   bool Cancelled = false;
-  CodeCompletionResult::NotRecommendedReason NotRecReason =
-      CodeCompletionResult::NotRecommendedReason::None;
+  NotRecommendedReason NotRecReason = NotRecommendedReason::None;
   StringRef BriefDocComment;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
@@ -117,7 +116,7 @@ class CodeCompletionResultBuilder {
 
 public:
   CodeCompletionResultBuilder(CodeCompletionResultSink &Sink,
-                              CodeCompletionResult::ResultKind Kind,
+                              CodeCompletionResultKind Kind,
                               SemanticContextKind SemanticContext,
                               const ExpectedTypeContext &declTypeContext)
       : Sink(Sink), Kind(Kind), SemanticContext(SemanticContext),
@@ -146,9 +145,7 @@ public:
 
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }
-  void setNotRecommended(CodeCompletionResult::NotRecommendedReason Reason) {
-    NotRecReason = Reason;
-  }
+  void setNotRecommended(NotRecommendedReason Reason) { NotRecReason = Reason; }
 
   void setSemanticContext(SemanticContextKind Kind) {
     SemanticContext = Kind;

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -89,7 +89,10 @@ class CodeCompletionResultBuilder {
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
       CodeCompletionResult::ExpectedTypeRelation::Unknown;
   bool Cancelled = false;
-  NotRecommendedReason NotRecReason = NotRecommendedReason::None;
+  ContextFreeNotRecommendedReason ContextFreeNotRecReason =
+      ContextFreeNotRecommendedReason::None;
+  ContextualNotRecommendedReason ContextualNotRecReason =
+      ContextualNotRecommendedReason::None;
   StringRef BriefDocComment;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
@@ -145,10 +148,11 @@ public:
 
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }
-  void setNotRecommended(NotRecommendedReason Reason) { NotRecReason = Reason; }
-
-  void setSemanticContext(SemanticContextKind Kind) {
-    SemanticContext = Kind;
+  void setContextFreeNotRecommended(ContextFreeNotRecommendedReason Reason) {
+    ContextFreeNotRecReason = Reason;
+  }
+  void setContextualNotRecommended(ContextualNotRecommendedReason Reason) {
+    ContextualNotRecReason = Reason;
   }
 
   void addFlair(CodeCompletionFlair Options) {

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -122,7 +122,7 @@ static void toDisplayString(CodeCompletionResult *Result,
     }
     if (C.is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotation) ||
         C.is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin)) {
-      if (Result->getKind() == CodeCompletionResult::ResultKind::Declaration) {
+      if (Result->getKind() == CodeCompletionResultKind::Declaration) {
         switch (Result->getAssociatedDeclKind()) {
         case CodeCompletionDeclKind::Module:
         case CodeCompletionDeclKind::PrecedenceGroup:

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -27,6 +27,7 @@ using swift::ide::CodeCompletionFlair;
 using swift::ide::CodeCompletionKeywordKind;
 using swift::ide::CodeCompletionLiteralKind;
 using swift::ide::CodeCompletionOperatorKind;
+using swift::ide::CodeCompletionResultKind;
 using swift::ide::CodeCompletionString;
 using swift::ide::SemanticContextKind;
 using SwiftResult = swift::ide::CodeCompletionResult;
@@ -110,7 +111,9 @@ public:
 
   // MARK: Methods that forward to the SwiftResult
 
-  SwiftResult::ResultKind getKind() const { return getSwiftResult().getKind(); }
+  CodeCompletionResultKind getKind() const {
+    return getSwiftResult().getKind();
+  }
 
   CodeCompletionDeclKind getAssociatedDeclKind() const {
     return getSwiftResult().getAssociatedDeclKind();

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -156,7 +156,7 @@ deliverCodeCompleteResults(SourceKit::CodeCompletionConsumer &SKConsumer,
     // FIXME: this adhoc filtering should be configurable like it is in the
     // codeCompleteOpen path.
     for (auto *Result : Results) {
-      if (Result->getKind() == CodeCompletionResult::ResultKind::Literal) {
+      if (Result->getKind() == CodeCompletionResultKind::Literal) {
         switch (Result->getLiteralKind()) {
         case CodeCompletionLiteralKind::NilLiteral:
         case CodeCompletionLiteralKind::BooleanLiteral:
@@ -401,18 +401,16 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   CodeCompletionInfo Info;
   if (Result->hasCustomKind()) {
     Info.CustomKind = Result->getCustomKind();
-  } else if (Result->getKind() == CodeCompletionResult::ResultKind::Keyword) {
+  } else if (Result->getKind() == CodeCompletionResultKind::Keyword) {
     Info.Kind = KeywordUID;
-  } else if (Result->getKind() == CodeCompletionResult::ResultKind::Pattern) {
+  } else if (Result->getKind() == CodeCompletionResultKind::Pattern) {
     Info.Kind = PatternUID;
-  } else if (Result->getKind() ==
-             CodeCompletionResult::ResultKind::BuiltinOperator) {
+  } else if (Result->getKind() == CodeCompletionResultKind::BuiltinOperator) {
     Info.Kind = PatternUID; // FIXME: add a UID for operators
-  } else if (Result->getKind() ==
-             CodeCompletionResult::ResultKind::Declaration) {
+  } else if (Result->getKind() == CodeCompletionResultKind::Declaration) {
     Info.Kind = SwiftLangSupport::getUIDForCodeCompletionDeclKind(
         Result->getAssociatedDeclKind());
-  } else if (Result->getKind() == CodeCompletionResult::ResultKind::Literal) {
+  } else if (Result->getKind() == CodeCompletionResultKind::Literal) {
     auto literalKind = Result->getLiteralKind();
     if (legacyLiteralToKeyword &&
         (literalKind == CodeCompletionLiteralKind::BooleanLiteral ||
@@ -863,8 +861,7 @@ static bool checkInnerResult(const CodeCompletionResult &result, bool &hasDot,
              chunks[1].is(CodeCompletionString::Chunk::ChunkKind::Dot)) {
     hasQDot = true;
     return true;
-  } else if (result.getKind() ==
-                 CodeCompletion::SwiftResult::ResultKind::Declaration &&
+  } else if (result.getKind() == CodeCompletionResultKind::Declaration &&
              result.getAssociatedDeclKind() ==
                  CodeCompletionDeclKind::Constructor) {
     hasInit = true;
@@ -923,7 +920,7 @@ static void transformAndForwardResults(
     auto *completionString =
         CodeCompletionString::create(innerSink.allocator, chunks);
     auto *paren = new (innerSink.allocator) CodeCompletion::SwiftResult(
-        CodeCompletion::SwiftResult::ResultKind::BuiltinOperator,
+        CodeCompletionResultKind::BuiltinOperator,
         SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
@@ -998,7 +995,7 @@ static void transformAndForwardResults(
   organizer.groupAndSort(options);
 
   if ((options.addInnerResults || options.addInnerOperators) && exactMatch &&
-      exactMatch->getKind() == CodeCompletionResult::ResultKind::Declaration) {
+      exactMatch->getKind() == CodeCompletionResultKind::Declaration) {
     std::vector<Completion *> innerResults;
     bool hasDot = false;
     bool hasQDot = false;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -919,12 +919,20 @@ static void transformAndForwardResults(
   auto buildInnerResult = [&](ArrayRef<CodeCompletionString::Chunk> chunks) {
     auto *completionString =
         CodeCompletionString::create(innerSink.allocator, chunks);
+    ContextFreeCodeCompletionResult *contextFreeResult =
+        new (innerSink.allocator) ContextFreeCodeCompletionResult(
+            CodeCompletionResultKind::BuiltinOperator, completionString,
+            CodeCompletionOperatorKind::None,
+            /*BriefDocComment=*/"", ContextFreeNotRecommendedReason::None,
+            CodeCompletionDiagnosticSeverity::None,
+            /*DiagnosticMessage=*/"");
     auto *paren = new (innerSink.allocator) CodeCompletion::SwiftResult(
-        CodeCompletionResultKind::BuiltinOperator,
-        SemanticContextKind::CurrentNominal,
+        *contextFreeResult, SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
-        exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
-        CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
+        exactMatch ? exactMatch->getNumBytesToErase() : 0,
+        CodeCompletionResult::ExpectedTypeRelation::NotApplicable,
+        ContextualNotRecommendedReason::None,
+        CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 
     SwiftCompletionInfo info;
     std::vector<Completion *> extended = extendCompletions(

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -983,7 +983,7 @@ public:
 
     unsigned ByteOffset = SM.getLocOffsetInBuffer(Range.getStart(), BufferID);
     unsigned Length = Range.getByteLength();
-    auto Kind = CodeCompletionResult::getCodeCompletionDeclKind(D);
+    auto Kind = ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(D);
     bool IsSystem = D->getModuleContext()->isSystemModule();
     SemaToks.emplace_back(Kind, ByteOffset, Length, IsRef, IsSystem);
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1069,7 +1069,7 @@ printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
   unsigned NumResults = 0;
   for (auto Result : Results) {
     if (!IncludeKeywords &&
-        Result->getKind() == CodeCompletionResult::ResultKind::Keyword)
+        Result->getKind() == CodeCompletionResultKind::Keyword)
       continue;
     ++NumResults;
   }
@@ -1079,7 +1079,7 @@ printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
   OS << "Begin completions, " << NumResults << " items\n";
   for (auto Result : Results) {
     if (!IncludeKeywords &&
-        Result->getKind() == CodeCompletionResult::ResultKind::Keyword)
+        Result->getKind() == CodeCompletionResultKind::Keyword)
       continue;
     Result->printPrefix(OS);
     if (PrintAnnotatedDescription) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4179,10 +4179,25 @@ int main(int argc, char *argv[]) {
         // FIXME: error?
         continue;
       }
+      // Make contextual CodeCompletionResults from the
+      // ContextFreeCodeCompletionResults so we can print them.
+      std::vector<CodeCompletionResult *> contextualResults;
+      contextualResults.reserve(resultsOpt->get()->Results.size());
+      for (auto contextFreeResult : resultsOpt->get()->Results) {
+        // We are leaking these results but it doesn't matter since the process
+        // just terminates afterwards anyway.
+        auto contextualResult = new CodeCompletionResult(
+            *contextFreeResult, SemanticContextKind::OtherModule,
+            CodeCompletionFlair(),
+            /*numBytesToErase=*/0,
+            CodeCompletionResult::ExpectedTypeRelation::Unknown,
+            ContextualNotRecommendedReason::None,
+            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
+        contextualResults.push_back(contextualResult);
+      }
       printCodeCompletionResultsImpl(
-          resultsOpt->get()->Sink.Results, llvm::outs(),
-          options::CodeCompletionKeywords, options::CodeCompletionComments,
-          options::CodeCompletionSourceText,
+          contextualResults, llvm::outs(), options::CodeCompletionKeywords,
+          options::CodeCompletionComments, options::CodeCompletionSourceText,
           options::CodeCompletionAnnotateResults);
     }
 


### PR DESCRIPTION
This is the first (of two) refactoring part of #40399, which has gotten a little big.

This allows makes the distinction between cachable and non-cachable properties cleaner and allows us to more easily compute contextual information (like type relations) for cached items later.

