### PR TITLE
Enabling copy propagation enables lexical lifetimes.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -80,6 +80,8 @@ ERROR(error_unknown_arg,none,
       "unknown argument: '%0'", (StringRef))
 ERROR(error_invalid_arg_value,none,
       "invalid value '%1' in '%0'", (StringRef, StringRef))
+ERROR(error_invalid_arg_combination,none,
+      "unsupported argument combination: '%0' and '%1'", (StringRef, StringRef))
 WARNING(warning_invalid_locale_code,none,
       "unsupported locale code; supported locale codes are: '%0'", (StringRef))
 WARNING(warning_locale_path_not_found,none,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -213,7 +213,8 @@ def dependency_scan_cache_remarks : Flag<["-"], "Rdependency-scan-cache">,
   HelpText<"Emit remarks indicating use of the serialized module dependency scanning cache.">;
 
 def enable_copy_propagation : Flag<["-"], "enable-copy-propagation">,
-  HelpText<"Run SIL copy propagation to shorten object lifetime.">;
+  HelpText<"Run SIL copy propagation with lexical lifetimes to shorten object "
+           "lifetimes while preserving variable lifetimes.">;
 def disable_copy_propagation : Flag<["-"], "disable-copy-propagation">,
   HelpText<"Don't run SIL copy propagation to preserve object lifetime.">;
 
@@ -259,15 +260,18 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
-def disable_lexical_lifetimes :
-  Flag<["-"], "disable-lexical-lifetimes">,
-  HelpText<"Disables early lexical lifetimes. Mutually exclusive with "
-           "-enable-lexical-lifetimes">;
-
+def enable_lexical_borrow_scopes :
+  Joined<["-"], "enable-lexical-borrow-scopes=">,
+  HelpText<"Whether to emit lexical borrow scopes (default: true)">,
+  MetaVarName<"true|false">;
+          
 def enable_lexical_lifetimes :
+  Joined<["-"], "enable-lexical-lifetimes=">,
+  HelpText<"Whether to enable lexical lifetimes">,
+  MetaVarName<"true|false">;
+def enable_lexical_lifetimes_noArg :
   Flag<["-"], "enable-lexical-lifetimes">,
-  HelpText<"Enable lexical lifetimes. Mutually exclusive with "
-           "-disable-lexical-lifetimes">;
+  HelpText<"Enable lexical lifetimes">;
 
 def enable_experimental_move_only :
   Flag<["-"], "enable-experimental-move-only">,

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -415,8 +415,8 @@ broadenSingleElementStores(StoreInst *storeInst,
 /// borrow scope--copy/destroy is insufficient by itself.
 ///
 /// FIXME: Technically this should be guarded by a compiler flag like
-/// -enable-copy-propagation until SILGen protects scoped variables by borrow
-/// scopes.
+/// -enable-copy-propagation until SILGen protects scoped variables by
+/// borrow scopes.
 static SILBasicBlock::iterator
 eliminateSimpleCopies(CopyValueInst *cvi, CanonicalizeInstruction &pass) {
   auto next = std::next(cvi->getIterator());

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-lexical-lifetimes)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-lexical-borrow-scopes=false)
 
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-lexical-lifetimes)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-lexical-borrow-scopes=false)
 
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/validation-test/optional_property.swift
+++ b/test/AutoDiff/validation-test/optional_property.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-lexical-lifetimes)
-// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -disable-lexical-lifetimes -module-name null -o /dev/null 2>&1 %s | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-lexical-borrow-scopes=false)
+// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -enable-lexical-borrow-scopes=false -module-name null -o /dev/null 2>&1 %s | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: asserts

--- a/test/Concurrency/Runtime/async_properties_actor.swift
+++ b/test/Concurrency/Runtime/async_properties_actor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-copy-propagation  -Xfrontend -disable-availability-checking %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-copy-propagation -Xfrontend -enable-lexical-lifetimes=false  -Xfrontend -disable-availability-checking %import-libdispatch) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/DebugInfo/if-branchlocations.swift
+++ b/test/DebugInfo/if-branchlocations.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-sil -disable-copy-propagation -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-NCP
-// RUN: %target-swift-frontend %s -emit-sil -enable-copy-propagation -disable-lexical-lifetimes -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-CP
+// RUN: %target-swift-frontend %s -emit-sil -enable-copy-propagation -enable-lexical-borrow-scopes=false -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-CP
 
 class NSURL {}
 

--- a/test/DebugInfo/linetable-do.swift
+++ b/test/DebugInfo/linetable-do.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle %s -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -disable-copy-propagation %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-NCP %s
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-copy-propagation -disable-lexical-lifetimes %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-CP %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-copy-propagation -enable-lexical-borrow-scopes=false %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-CP %s
 import StdlibUnittest
 
 class Obj {}

--- a/test/IRGen/debug_poison.swift
+++ b/test/IRGen/debug_poison.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -Onone -enable-copy-propagation -disable-lexical-lifetimes | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -Onone -enable-copy-propagation -enable-lexical-borrow-scopes=false | %FileCheck %s -DINT=i%target-ptrsize
 
 // Test debug_value [poison] emission
 

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -enable-copy-propagation %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-copy-propagation -enable-lexical-lifetimes=false %s | %FileCheck %s
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib
 

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -Xfrontend -disable-lexical-lifetimes) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
-// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -Xfrontend -disable-lexical-lifetimes) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
+// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -Xfrontend -enable-lexical-borrow-scopes=false) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
+// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -Xfrontend -enable-lexical-borrow-scopes=false) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -swift-version 5 -O -enable-copy-propagation -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -emit-ir -swift-version 5 -O -enable-copy-propagation -enable-lexical-lifetimes=false -primary-file %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 //
 // REQUIRES: VENDOR=apple
 // REQUIRES: swift_stdlib_no_asserts

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack -disable-lexical-lifetimes | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -disable-lexical-lifetimes | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/assemblyvision_remark/basic.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify -Xfrontend -disable-lexical-lifetimes
+// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify -Xfrontend -enable-lexical-borrow-scopes=false
 // REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 
 public class Klass {

--- a/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify -Xfrontend -disable-lexical-lifetimes
+// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify -Xfrontend -enable-lexical-borrow-scopes=false
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml -Xfrontend -disable-lexical-lifetimes %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
+// RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml -Xfrontend -enable-lexical-borrow-scopes=false %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
 
 // REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 

--- a/test/SILOptimizer/diagnose_lifetime_issues.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -disable-lexical-lifetimes -enable-copy-propagation %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-lexical-borrow-scopes=false -enable-copy-propagation %s -o /dev/null -verify
 
 class Delegate {
   func foo() { }

--- a/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -disable-lexical-lifetimes -enable-copy-propagation -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -enable-lexical-borrow-scopes=false -enable-copy-propagation -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/SILOptimizer/opaque_values_mandatory.sil
+++ b/test/SILOptimizer/opaque_values_mandatory.sil
@@ -1,7 +1,8 @@
 // RUN: %target-sil-opt -diagnostics -enable-sil-opaque-values %s | \
 // RUN:     %target-sil-opt -Onone-performance -enable-sil-verify-all \
 // RUN:                     -enable-sil-opaque-values -emit-sorted-sil \
-// RUN:                     -enable-ossa-modules -enable-copy-propagation | \
+// RUN:                     -enable-ossa-modules -enable-copy-propagation \
+// RUN:                     -enable-lexical-borrow-scopes | \
 // RUN:     %FileCheck %s
 
 import Builtin

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -Osize -import-objc-header %S/Inputs/Outliner.h %s -emit-sil -enforce-exclusivity=unchecked -enable-copy-propagation -disable-lexical-lifetimes | %FileCheck %s
-// RUN: %target-swift-frontend -Osize -g -import-objc-header %S/Inputs/Outliner.h %s -emit-sil -enforce-exclusivity=unchecked -enable-copy-propagation -disable-lexical-lifetimes | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -import-objc-header %S/Inputs/Outliner.h %s -emit-sil -enforce-exclusivity=unchecked -enable-copy-propagation -enable-lexical-borrow-scopes=false | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -g -import-objc-header %S/Inputs/Outliner.h %s -emit-sil -enforce-exclusivity=unchecked -enable-copy-propagation -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-ossa-modules -enable-copy-propagation -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+// RUN: %target-sil-opt -enable-ossa-modules -enable-copy-propagation -enable-lexical-lifetimes=false -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
 
 import Swift
 import Builtin

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -2,7 +2,7 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
 //
 // FIXME: check copy-propagation output instead once it is the default mode
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation | %FileCheck %s --check-prefix=CHECK_COPYPROP
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/validation-test/SILOptimizer/lexical-lifetimes.swift
+++ b/validation-test/SILOptimizer/lexical-lifetimes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-lexical-lifetimes -Xfrontend -enable-copy-propagation) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-copy-propagation) | %FileCheck %s
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
The effect of passing -enable-copy-propagation is both to enable the CopyPropagation pass to shorten object lifetimes and also to enable lexical lifetimes to ensure that object lifetimes aren't shortened while a variable is still in scope and used.

Add a new flag, -enable-lexical-borrow-scopes to override -enable-copy-propagation's effect (setting it to ::ExperimentalLate) on SILOptions::LexicalLifetimes that sets it to ::Early even in the face of -enable-copy-propagation.  The preexisting flag -disable-lexical-lifetimes continues to set that flag to ::Off even when -enable-copy-propagation is passed.