### PR TITLE
[move-function] Add support for loadable vars

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4028,6 +4028,9 @@ public:
   SILValue getSrc() const { return Operands[Src].get(); }
   SILValue getDest() const { return Operands[Dest].get(); }
 
+  void setSrc(SILValue V) { Operands[Src].set(V); }
+  void setDest(SILValue V) { Operands[Dest].set(V); }
+
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -430,6 +430,9 @@ PASS(LexicalLifetimeEliminator, "sil-lexical-lifetime-eliminator",
 PASS(MoveKillsCopyableAddressesChecker, "sil-move-kills-copyable-addresses-checker",
      "Pass that checks that any copyable (non-move only) address that is passed "
      "to _move do not have any uses later than the _move")
+PASS(MoveFunctionCanonicalization, "sil-move-function-canon",
+     "Pass that canonicalizes certain parts of the IR before we perform move "
+     "function checking.")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -18,9 +18,10 @@ target_sources(swiftSILOptimizer PRIVATE
   LexicalLifetimeEliminator.cpp
   LowerHopToActor.cpp
   MandatoryInlining.cpp
-  MoveOnlyChecker.cpp
-  MoveKillsCopyableValuesChecker.cpp
+  MoveFunctionCanonicalization.cpp
   MoveKillsCopyableAddressesChecker.cpp
+  MoveKillsCopyableValuesChecker.cpp
+  MoveOnlyChecker.cpp
   NestedSemanticFunctionCheck.cpp
   OptimizeHopToExecutor.cpp
   PerformanceDiagnostics.cpp

--- a/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
@@ -1,0 +1,248 @@
+//===--- MoveFunctionCanonicalization.cpp ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-move-function-canonicalization"
+
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/FrozenMultiMap.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/Consumption.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/ClosureScope.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+#include "llvm/ADT/PointerEmbeddedInt.h"
+#include "llvm/ADT/PointerSumType.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                                  Utility
+//===----------------------------------------------------------------------===//
+
+/// Attempts to perform several small optimizations to setup both the address
+/// and object checkers. Returns true if we made a change to the IR.
+static bool tryConvertSimpleMoveFromAllocStackTemporary(
+    MarkUnresolvedMoveAddrInst *markMoveAddr, AliasAnalysis *aa) {
+  LLVM_DEBUG(llvm::dbgs() << "Trying to fix up: " << *markMoveAddr);
+
+  // We need a non-lexical alloc_stack as our source.
+  auto *asi = dyn_cast<AllocStackInst>(markMoveAddr->getSrc());
+  if (!asi || asi->isLexical()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "    Source isnt an alloc_stack or is lexical... Bailing!\n");
+    return false;
+  }
+
+  DestroyAddrInst *dai = nullptr;
+  CopyAddrInst *cai = nullptr;
+  StoreInst *si = nullptr;
+  for (auto *use : asi->getUses()) {
+    auto *user = use->getUser();
+    LLVM_DEBUG(llvm::dbgs() << "    Visiting User: " << *user);
+
+    // If we find our own instruction or a dealloc stack, just skip.
+    if (user == markMoveAddr || isa<DeallocStackInst>(user)) {
+      LLVM_DEBUG(
+          llvm::dbgs()
+          << "        Found our original inst or a dealloc stack... Ok!\n");
+      continue;
+    }
+
+    if (auto *destroyAddrInst = dyn_cast<DestroyAddrInst>(user)) {
+      if (dai)
+        return false;
+      dai = destroyAddrInst;
+      continue;
+    }
+
+    if (auto *newCAI = dyn_cast<CopyAddrInst>(user)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found copy_addr... checking if legal...\n");
+      // We require that our copy_addr be an init into our temp and in the same
+      // block as markMoveAddr.
+      if (newCAI->getDest() == asi && bool(newCAI->isInitializationOfDest()) &&
+          !bool(newCAI->isTakeOfSrc()) &&
+          newCAI->getParent() == markMoveAddr->getParent()) {
+        if (cai || si)
+          return false;
+        cai = newCAI;
+        continue;
+      }
+    }
+
+    if (auto *newSI = dyn_cast<StoreInst>(user)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found store... checking if legal...\n");
+      // We require that our copy_addr be an init into our temp and in the same
+      // block as markMoveAddr.
+      if (newSI->getDest() == asi &&
+          newSI->getOwnershipQualifier() == StoreOwnershipQualifier::Init &&
+          newSI->getParent() == markMoveAddr->getParent()) {
+        if (cai || si)
+          return false;
+        si = newSI;
+        continue;
+      }
+    }
+
+    // If we do not find an instruction that we know about, return we can't
+    // optimize.
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "        Found instruction we did not understand! Bailing!\n");
+    return false;
+  }
+
+  // If we did not find an (init | store) or destroy_addr, just bail.
+  if (!(cai || si) || !dai) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "        Did not find a single init! Bailing!\n");
+    return false;
+  }
+
+  assert(bool(cai) != bool(si));
+
+  // Otherwise, lets walk from cai to markMoveAddr and make sure there aren't
+  // any side-effect having instructions in between them.
+  //
+  // NOTE: We know that cai must be before the markMoveAddr in the block since
+  // otherwise we would be moving from uninitialized memory.
+  SILInstruction *init = nullptr;
+  if (cai)
+    init = cai;
+  else
+    init = si;
+
+  auto range = llvm::make_range(std::next(init->getIterator()),
+                                markMoveAddr->getIterator());
+  if (llvm::any_of(range, [&](SILInstruction &iter) {
+        if (!iter.mayHaveSideEffects()) {
+          return false;
+        }
+
+        if (auto *dvi = dyn_cast<DestroyAddrInst>(&iter)) {
+          if (aa->isNoAlias(dvi->getOperand(), asi)) {
+            // We are going to be extending the lifetime of our
+            // underlying value, not shrinking it so we can ignore
+            // destroy_addr on other non-aliasing values.
+            return false;
+          }
+        }
+
+        // Ignore end of scope markers with side-effects.
+        if (isEndOfScopeMarker(&iter)) {
+          return false;
+        }
+
+        LLVM_DEBUG(llvm::dbgs()
+                   << "        Found side-effect inst... Bailing!: " << iter);
+        return true;
+      }))
+    return false;
+
+  LLVM_DEBUG(llvm::dbgs() << "        Success! Performing optimization!\n");
+  // Ok, we can perform our optimization! Change move_addr's source to be the
+  // original copy_addr's src and add add uses of the stack location to an
+  // instruction deleter. We will eliminate them later.
+  if (cai) {
+    markMoveAddr->setSrc(cai->getSrc());
+    return true;
+  }
+
+  // If we have a store [init], see if our src is a load [copy] from an
+  // alloc_stack that is lexical var. In this case, we want to move our
+  // mark_unresolved_move_addr onto that lexical var. This pattern occurs due to
+  // SILGen always loading loadable values from memory when retrieving an
+  // RValue. Calling _move then since _move is generic forces the value to be
+  // re-materialized into an alloc_stack. In this example remembering that
+  // mark_unresolved_move_addr is a copy_addr [init], we try to move the MUMA
+  // onto the original lexical alloc_stack.
+  //
+  // TODO: Implement.
+
+  // If we do not have a load [copy], transform this mark_resolved_move_addr
+  // into a move_value [diagnostic] + store [init]. Predictable mem opts is
+  // smart enough to handle this case and promote away loads from the
+  // allocation. This runs before the value move checker runs.
+  SILBuilderWithScope builder(si);
+  auto *newValue = builder.createMoveValue(si->getLoc(), si->getSrc());
+  newValue->setAllowsDiagnostics(true);
+  si->setSrc(newValue);
+  markMoveAddr->eraseFromParent();
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class MoveFunctionCanonicalization : public SILFunctionTransform {
+  void run() override {
+    auto *fn = getFunction();
+
+    // If we do not have experimental move only enabled, do not emit
+    // diagnostics.
+    if (!astContext.LangOpts.EnableExperimentalMoveOnly)
+      return;
+
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
+    bool madeChange = false;
+
+    assert(fn->getModule().getStage() == SILStage::Raw &&
+           "Should only run on Raw SIL");
+
+    auto *aa = getAnalysis<AliasAnalysis>(fn);
+
+    for (auto &block : *fn) {
+      for (auto ii = block.begin(), ie = block.end(); ii != ie;) {
+        auto *inst = &*ii;
+        ++ii;
+
+        // See if we see a mark_unresolved_move_addr inst from a simple
+        // temporary and move it onto the temporary's source. This ensures that
+        // the mark_unresolved_move_addr is always on the operand regardless if
+        // in the caller we materalized the address into a temporary.
+        if (auto *markMoveAddr = dyn_cast<MarkUnresolvedMoveAddrInst>(inst)) {
+          madeChange |=
+              tryConvertSimpleMoveFromAllocStackTemporary(markMoveAddr, aa);
+          continue;
+        }
+      }
+    }
+
+    if (madeChange) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // anonymous namespace
+
+SILTransform *swift::createMoveFunctionCanonicalization() {
+  return new MoveFunctionCanonicalization();
+}

--- a/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
@@ -272,11 +272,6 @@ class MoveFunctionCanonicalization : public SILFunctionTransform {
   void run() override {
     auto *fn = getFunction();
 
-    // If we do not have experimental move only enabled, do not emit
-    // diagnostics.
-    if (!astContext.LangOpts.EnableExperimentalMoveOnly)
-      return;
-
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -172,113 +172,6 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
 }
 
 //===----------------------------------------------------------------------===//
-//                                  Utility
-//===----------------------------------------------------------------------===//
-
-/// Returns false if we found a malformed
-static void tryConvertSimpleMoveFromAllocStackTemporary(
-    MarkUnresolvedMoveAddrInst *markMoveAddr) {
-  LLVM_DEBUG(llvm::dbgs() << "Trying to fix up: " << *markMoveAddr);
-
-  // We need a non-lexical alloc_stack as our source.
-  auto *asi = dyn_cast<AllocStackInst>(markMoveAddr->getSrc());
-  if (!asi || asi->isLexical()) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "    Source isnt an alloc_stack or is lexical... Bailing!\n");
-    return;
-  }
-
-  DestroyAddrInst *dai = nullptr;
-  CopyAddrInst *init = nullptr;
-  for (auto *use : asi->getUses()) {
-    auto *user = use->getUser();
-    LLVM_DEBUG(llvm::dbgs() << "    Visiting User: " << *user);
-
-    // If we find our own instruction or a dealloc stack, just skip.
-    if (user == markMoveAddr || isa<DeallocStackInst>(user)) {
-      LLVM_DEBUG(
-          llvm::dbgs()
-          << "        Found our original inst or a dealloc stack... Ok!\n");
-      continue;
-    }
-
-    if (auto *destroyAddrInst = dyn_cast<DestroyAddrInst>(user)) {
-      if (dai)
-        return;
-      dai = destroyAddrInst;
-      continue;
-    }
-
-    if (auto *cai = dyn_cast<CopyAddrInst>(user)) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "        Found copy_addr... checking if legal...\n");
-      // We require that our copy_addr be an init into our temp and in the same
-      // block as markMoveAddr.
-      if (cai->getDest() == asi && bool(cai->isInitializationOfDest()) &&
-          !bool(cai->isTakeOfSrc()) &&
-          cai->getParent() == markMoveAddr->getParent()) {
-        if (init)
-          return;
-        init = cai;
-        continue;
-      }
-    }
-
-    // If we do not find an instruction that we know about, return we can't
-    // optimize.
-    LLVM_DEBUG(
-        llvm::dbgs()
-        << "        Found instruction we did not understand! Bailing!\n");
-    return;
-  }
-
-  // If we did not find an init or destroy_addr, just bail.
-  if (!init || !dai) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "        Did not find a single init! Bailing!\n");
-    return;
-  }
-
-  // Otherwise, lets walk from cai to markMoveAddr and make sure there aren't
-  // any side-effect having instructions in between them.
-  //
-  // NOTE: We know that cai must be before the markMoveAddr in the block since
-  // otherwise we would be moving from uninitialized memory.
-  if (llvm::any_of(llvm::make_range(std::next(init->getIterator()),
-                                    markMoveAddr->getIterator()),
-                   [](SILInstruction &iter) {
-                     if (!iter.mayHaveSideEffects()) {
-                       return false;
-                     }
-
-                     if (isa<DestroyAddrInst>(iter)) {
-                       // We are going to be extending the lifetime of our
-                       // underlying value, not shrinking it so we can ignore
-                       // destroy_addr on other values.
-                       return false;
-                     }
-
-                     // Ignore end of scope markers with side-effects.
-                     if (isEndOfScopeMarker(&iter)) {
-                       return false;
-                     }
-
-                     LLVM_DEBUG(
-                         llvm::dbgs()
-                         << "        Found side-effect inst... Bailing!: "
-                         << iter);
-                     return true;
-                   }))
-    return;
-
-  LLVM_DEBUG(llvm::dbgs() << "        Success! Performing optimization!\n");
-  // Ok, we can perform our optimization! Change move_addr's source to be the
-  // original copy_addr's src and add add uses of the stack location to an
-  // instruction deleter. We will eliminate them later.
-  markMoveAddr->setSrc(init->getSrc());
-}
-
-//===----------------------------------------------------------------------===//
 //                               Use Gathering
 //===----------------------------------------------------------------------===//
 
@@ -1103,15 +996,6 @@ class MoveKillsCopyableAddressesCheckerPass : public SILFunctionTransform {
             checker.addressesToCheck.insert(asi);
             continue;
           }
-        }
-
-        // See if we see a mark_unresolved_move_addr inst from a simple
-        // temporary and move it onto the temporary's source. This ensures that
-        // the mark_unresolved_move_addr is always on the operand regardless if
-        // in the caller we materalized the address into a temporary.
-        if (auto *markMoveAddr = dyn_cast<MarkUnresolvedMoveAddrInst>(inst)) {
-          tryConvertSimpleMoveFromAllocStackTemporary(markMoveAddr);
-          continue;
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -961,11 +961,6 @@ class MoveKillsCopyableAddressesCheckerPass : public SILFunctionTransform {
     auto *fn = getFunction();
     auto &astContext = fn->getASTContext();
 
-    // If we do not have experimental move only enabled, do not emit
-    // diagnostics.
-    if (!astContext.LangOpts.EnableExperimentalMoveOnly)
-      return;
-
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -431,11 +431,6 @@ class MoveKillsCopyableValuesCheckerPass : public SILFunctionTransform {
     auto *fn = getFunction();
     auto &astContext = fn->getASTContext();
 
-    // If we do not have experimental move only enabled, do not emit
-    // diagnostics.
-    if (!astContext.LangOpts.EnableExperimentalMoveOnly)
-      return;
-
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -147,6 +147,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addMandatorySILLinker();
 
   // Before we promote any loads, perform _move checking for addresses.
+  P.addMoveFunctionCanonicalization();
   P.addMoveKillsCopyableAddressesChecker();
 
   // Promote loads as necessary to ensure we have enough SSA formation to emit

--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_lets.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_lets.swift
@@ -277,3 +277,10 @@ public func performMoveOnOneEltOfTPair2<T>(_ p: __owned TPair<T>) {
     let _ = _move(p.x) // expected-error {{_move applied to value that the compiler does not support checking}}
     nonConsumingUse(p.y)
 }
+
+public func multipleVarsWithSubsequentBorrows<T : Equatable>(_ p: T) -> Bool {
+    let k = p
+    let k2 = k
+    let k3 = _move(k)
+    return k2 == k3
+}

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -1,0 +1,95 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
+
+// REQUIRES: optimized_stdlib
+
+import Swift
+
+public class Klass {}
+
+//////////////////
+// Declarations //
+//////////////////
+
+func consumingUse(_ k: __owned Klass) {}
+var booleanValue: Bool { false }
+func nonConsumingUse(_ k: Klass) {}
+
+///////////
+// Klassests //
+///////////
+
+public func performMoveOnVarSingleBlock(_ p: Klass) {
+    var x = p
+    let _ = _move(x)
+    x = p
+    nonConsumingUse(x)
+}
+
+public func performMoveOnVarSingleBlockError(_ p: Klass) {
+    var x = p // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+    nonConsumingUse(x) // expected-note {{use here}}
+    x = p
+    nonConsumingUse(x)
+}
+
+public func performMoveOnVarMultiBlock(_ p: Klass) {
+    var x = p
+    let _ = _move(x)
+
+    while booleanValue {
+        print("true")
+    }
+
+    while booleanValue {
+        print("true")
+    }
+
+    x = p
+    nonConsumingUse(x)
+}
+
+public func performMoveOnVarMultiBlockError1(_ p: Klass) {
+    var x = p // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+
+    nonConsumingUse(x) // expected-note {{use here}}
+
+    while booleanValue {
+        print("true")
+    }
+
+    // We only emit an error on the first one.
+    nonConsumingUse(x)
+
+    while booleanValue {
+        print("true")
+    }
+
+    // We only emit an error on the first one.
+    nonConsumingUse(x)
+
+    x = p
+    nonConsumingUse(x)
+}
+
+public func performMoveOnVarMultiBlockError2(_ p: Klass) {
+    var x = p // expected-error {{'x' used after being moved}}
+    let _ = _move(x) // expected-note {{move here}}
+
+    while booleanValue {
+        print("true")
+    }
+
+    nonConsumingUse(x) // expected-note {{use here}}
+
+    while booleanValue {
+        print("true")
+    }
+
+    // We only error on the first one.
+    nonConsumingUse(x)
+
+    x = p
+    nonConsumingUse(x)
+}

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -248,3 +248,10 @@ public func performMoveOnVarGlobalError() {
 public func performMoveOnLetGlobalError() {
     let _ = _move(myVarGlobal) // expected-error {{_move applied to value that the compiler does not support checking}}
 }
+
+public func multipleVarsWithSubsequentBorrows() -> Bool {
+    let k = Klass()
+    let k2 = k
+    let k3 = _move(k)
+    return k2 === k3
+}

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -245,13 +245,6 @@ public func performMoveOnVarGlobalError() {
     let _ = _move(myVarGlobal) // expected-error {{_move applied to value that the compiler does not support checking}}
 }
 
-// TODO: Support vars
-public func performMoveOnVarError() {
-    var k = myVarGlobal
-    let _ = _move(k) // expected-error {{_move applied to value that the compiler does not support checking}}
-    k = myVarGlobal
-}
-
 public func performMoveOnLetGlobalError() {
     let _ = _move(myVarGlobal) // expected-error {{_move applied to value that the compiler does not support checking}}
 }


### PR DESCRIPTION
I had to make two changes to do this:

1. In the first commit I made some changes to how we early in the pipeline handle mark_unresolved_move_addr and move_value [allows_diagnostics] (see the commit log for more info).
2. I built on top of that to add a small change that teaches that early munging how to modify the IR to make it so we properly support loadable vars.