### PR TITLE
[SR-15562] [Sema] Do not consider warning fixes for non-augmenting fix recording

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11661,9 +11661,16 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // current anchor or, in case of anchor being an expression, any of
   // its sub-expressions.
   llvm::SmallDenseSet<ASTNode> anchors;
-  for (const auto *fix : Fixes)
-    anchors.insert(fix->getAnchor());
+  for (const auto *fix : Fixes) {
+    // Warning fixes shouldn't be considered, because even if
+    // such fix is recorded at that anchor this should not
+    // have any affect in the recording of any other fix.
+    if (fix->isWarning())
+      continue;
 
+    anchors.insert(fix->getAnchor());
+  }
+  
   bool found = false;
   if (auto *expr = getAsExpr(anchor)) {
     forEachExpr(expr, [&](Expr *subExpr) -> Expr * {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11662,7 +11662,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // its sub-expressions.
   llvm::SmallDenseSet<ASTNode> anchors;
   for (const auto *fix : Fixes) {
-    // Warning fixes shouldn't be considered, because even if
+    // Warning fixes shouldn't be considered because even if
     // such fix is recorded at that anchor this should not
     // have any affect in the recording of any other fix.
     if (fix->isWarning())

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -651,3 +651,14 @@ struct SR15281_SC {
     a.flatMap(SR15281_CC.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_CC?' to return type 'SR15281_BC'}} {{35-35=!}}
   }
 }
+
+// SR-15562
+func test_SR_15562() {
+  let foo: [Int: Int] = [:]
+  let bar = [1, 2, 3, 4]
+
+  for baz in bar {
+    foo[baz] as! Int += 1 // expected-warning{{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
+    // expected-error@-1{{left side of mutating operator has immutable type 'Int'}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
The problem is that for non-augmenting fixes(TreatRValueAsLValue) if there is already a fix recorded at that anchor or subexpr, this fix is not recorded. The problem in this case is since we move the checked cast warning diagnostics to fix format in #34980, warning fixes were also considered so a failure was being skipped which seems incorrect and it was causing the issue. Warning fixes should not be considered in that logic because this will cause this issue where a warning fix recorded makes  it skip the recording of any error fix which may lead the solver in this state of not able to produce a diagnostic.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15562.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
