### PR TITLE
Ensure that Sendable is inherited properly, take 3.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3095,7 +3095,7 @@ public:
 /// the Sendable protocol.
 class GetImplicitSendableRequest :
     public SimpleRequest<GetImplicitSendableRequest,
-                         NormalProtocolConformance *(NominalTypeDecl *),
+                         ProtocolConformance *(NominalTypeDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3103,7 +3103,7 @@ public:
 private:
   friend SimpleRequest;
 
-  NormalProtocolConformance *evaluate(
+  ProtocolConformance *evaluate(
       Evaluator &evaluator, NominalTypeDecl *nominal) const;
 
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -354,7 +354,7 @@ SWIFT_REQUEST(TypeChecker, SimpleDidSetRequest,
 SWIFT_REQUEST(TypeChecker, SynthesizeMainFunctionRequest,
               FuncDecl *(Decl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
-              NormalProtocolConformance *(NominalTypeDecl *),
+              ProtocolConformance *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
               ValueDecl *(const ValueDecl *),

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -218,4 +218,14 @@ func testMirrored(instance: ClassWithAsync) async {
   }
 }
 
+@MainActor class MyView: NXView {
+  func f() {
+    Task {
+      await self.g()
+    }
+  }
+
+  func g() async { }
+}
+
 } // SwiftStdlib 5.5


### PR DESCRIPTION
Extend the implicit Sendable request to produce an inherited
conformance when queried, rather than depending on the conformance
lookup table to always have the right entries. This acknowledges that
implicit Sendable needs to happen more at the type checking level than
the name-binding level, which is needed to eliminate cyclic
dependencies.

Fixes rdar://85223889
