### PR TITLE
[Sema] Fix errors on async when checking only the API availability

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1710,6 +1710,9 @@ void TypeChecker::checkConcurrencyAvailability(SourceRange ReferenceRange,
   ASTContext &ctx = ReferenceDC->getASTContext();
   if (ctx.LangOpts.DisableAvailabilityChecking)
     return;
+
+  if (!shouldCheckAvailability(ReferenceDC->getAsDecl()))
+    return;
   
   auto runningOS =
     TypeChecker::overApproximateAvailabilityAtLocation(

--- a/test/Sema/api-availability-only-ok.swift
+++ b/test/Sema/api-availability-only-ok.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %swiftc_driver -emit-module %s -target %target-cpu-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -check-api-availability-only -verify-emitted-module-interface
+// RUN: %swiftc_driver -emit-module %s -target %target-cpu-apple-macosx10.14 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -check-api-availability-only -verify-emitted-module-interface
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/main.swiftinterface
 
 // REQUIRES: OS=macosx
@@ -101,4 +101,11 @@ public struct Struct {
     let _: NewProto
     newFunc()
   }
+}
+
+internal func asyncFunc() async -> InternalActor {
+    fatalError()
+}
+
+actor InternalActor {
 }

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -1,7 +1,7 @@
 /// Test that -check-api-availability-only skips what is expected while checking
 /// the module API and SPI.
 
-// RUN: %target-typecheck-verify-swift -module-name MyModule -target %target-cpu-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -module-name MyModule -target %target-cpu-apple-macosx10.14 -check-api-availability-only -enable-library-evolution
 
 /// The flag -check-api-availability-only should reject builds going up to IR and further.
 // RUN: not %target-build-swift -emit-executable %s -g -o %t -emit-module -Xfrontend -check-api-availability-only 2>&1 | %FileCheck %s
@@ -131,4 +131,25 @@ public struct Struct {
 // expected-note @+1 {{add @available attribute to enclosing}}
 extension NewProto { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
     public func foo() {}
+}
+
+func asyncFunc() async -> Bool {
+    fatalError()
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+public func publicAsyncFunc() async -> Bool { // expected-error {{concurrency is only available in macOS 10.15.0 or newer}}
+    fatalError()
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+@usableFromInline func usableFromInlineAsyncFunc() async -> Bool { // expected-error {{concurrency is only available in macOS 10.15.0 or newer}}
+    fatalError()
+}
+
+actor InternalActor {
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+public actor PublicActor { // expected-error {{concurrency is only available in macOS 10.15.0 or newer}}
 }


### PR DESCRIPTION
The flag `-check-api-availability-only` limits availability checking to the API only, ensuring that what will appear in the swiftinterface is sound without raising issues about implementation details. This patch ensures this mode correctly ignores non-public async functions as they wouldn't appear in the API.

rdar://86174644