### PR TITLE
Revert "[SourceKit] Don't build an AST if no semantic info is requested"

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
+++ b/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
@@ -6,7 +6,7 @@ func test() {
 
 // RUN: %sourcekitd-test \
 // RUN:   -req=open %s -- %s == \
-// RUN:   -req=edit -offset=0 -length=53 -replace="" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 -dont-print-response %s -- %s == \
+// RUN:   -req=edit -offset=0 -length=53 -replace="" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %s -- %s == \
 // RUN:   -req=expand-placeholder -offset=23 -length=18 %s \
 // RUN: | %FileCheck %s
 

--- a/test/SourceKit/CursorInfo/cursor_after_edit.swift
+++ b/test/SourceKit/CursorInfo/cursor_after_edit.swift
@@ -7,5 +7,5 @@
 // buffer to calculate line and column (before rdar://78161348).
 // RUN: %sourcekitd-test \
 // RUN:   -req=open -text-input %t/empty.swift %t/func.swift -- %t/func.swift == \
-// RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 -dont-print-response %t/func.swift -- %t/func.swift == \
+// RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
 // RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift

--- a/test/SourceKit/Sema/edit_nowait.swift
+++ b/test/SourceKit/Sema/edit_nowait.swift
@@ -15,10 +15,10 @@
 // EDIT_NOWAIT-NEXT: }
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=open -req-opts=enablesyntaxmap=0,enablesubstructure=1,enablediagnostics=0 %t/t.swift -- %t/t.swift == \
+// RUN:   -req=open -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -- %t/t.swift == \
 // RUN:   -req=print-annotations %t/t.swift  == \
-// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=16 -req-opts=enablesyntaxmap=0,enablesubstructure=1,enablediagnostics=0 %t/t.swift == \
-// RUN:   -req=edit -offset=13 -replace="print" -length=4 -req-opts=enablesyntaxmap=0,enablesubstructure=1,enablediagnostics=0 %t/t.swift == \
+// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=16 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
+// RUN:   -req=edit -offset=13 -replace="print" -length=4 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
 // RUN:   -req=print-annotations %t/t.swift \
 // RUN: | %FileCheck --check-prefix=ANNOTATION %s
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2664,18 +2664,7 @@ public:
   sourcekitd_response_t createResponse();
 
   bool needsSemanticInfo() override {
-    if (Opts.SyntacticOnly) {
-      return false;
-    } else if (isSemanticEditorDisabled()) {
-      return false;
-    } else if (!documentStructureEnabled() &&
-               !syntaxMapEnabled() &&
-               !diagnosticsEnabled() &&
-               !syntaxTreeEnabled()) {
-      return false;
-    } else {
-      return true;
-    }
+    return !Opts.SyntacticOnly && !isSemanticEditorDisabled();
   }
 
   void handleRequestError(const char *Description) override;


### PR DESCRIPTION
Reverts apple/swift#40353

---

The change actually wasn’t correct because we didn’t consider the following scenario:
- The client makes an edit and had `key_enablesyntaxmap = key_enablesubstructure = key_enablediagnostics = 0` and
syntax tree transfer mode set to off
- The request returned immediately without providing semantic information but build an AST in the background
- The client would later retrieve diagnostics using a `0,0` replace text request that had `key_enablediagnostics = 1`. That request doesn’t cause the AST to rebuild but just returns the latest semantic information.

With the PR that is being reverted we wouldn’t build an AST at all and thus we won’t have any diagnostics to return from the `0,0` replace text request.

rdar://86289587