### PR TITLE
RequirementMachine: Enable -requirement-machine-protocol-signatures=verify by default

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -876,6 +876,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableSubstSILFunctionTypes =
       Args.hasArg(OPT_disable_subst_sil_function_types);
 
+  Opts.RequirementMachineProtocolSignatures = RequirementMachineMode::Verify;
+
   if (auto A = Args.getLastArg(OPT_requirement_machine_protocol_signatures_EQ)) {
     auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(A->getValue())
         .Case("off", RequirementMachineMode::Disabled)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2619,9 +2619,11 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
         getDeclContext()->getSelfProtocolDecl()) {
       diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
                       diag::unchecked_not_inheritance_clause);
+      ty = ErrorType::get(getASTContext());
     } else if (!ty->isConstraintType()) {
       diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
                       diag::unchecked_not_existential, ty);
+      ty = ErrorType::get(getASTContext());
     }
 
     // Nothing to record in the type. Just clear the attribute.

--- a/test/Generics/derived_via_concrete_in_protocol.swift
+++ b/test/Generics/derived_via_concrete_in_protocol.swift
@@ -1,0 +1,59 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s -requirement-machine-protocol-signatures=off 2>&1 | %FileCheck %s
+
+// FIXME: Implement concrete contraction for the Requirement Machine's
+// RequirementSignatureRequest to get this to pass without turning off
+// -requirement-machine-protocol-signatures.
+
+protocol P24 {
+  associatedtype C: P20
+}
+
+protocol P20 { }
+
+struct X24<T: P20> : P24 {
+  typealias C = T
+}
+
+protocol P26 {
+  associatedtype C: X3
+}
+
+struct X26<T: X3> : P26 {
+  typealias C = T
+}
+
+class X3 { }
+
+// CHECK-LABEL: .P25a@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P25a]A == X24<Self.[P25a]B>, Self.[P25a]B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P25a]A == X24<τ_0_0.[P25a]B>, τ_0_0.[P25a]B : P20>
+protocol P25a {
+  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
+  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
+}
+
+// CHECK-LABEL: .P25b@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P25b]A == X24<Self.[P25b]B>, Self.[P25b]B : P20>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P25b]A == X24<τ_0_0.[P25b]B>, τ_0_0.[P25b]B : P20>
+protocol P25b {
+  associatedtype A
+  associatedtype B: P20 where A == X24<B>
+}
+
+// CHECK-LABEL: .P27a@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P27a]A == X26<Self.[P27a]B>, Self.[P27a]B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P27a]A == X26<τ_0_0.[P27a]B>, τ_0_0.[P27a]B : X3>
+protocol P27a {
+  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
+
+  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
+}
+
+// CHECK-LABEL: .P27b@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P27b]A == X26<Self.[P27b]B>, Self.[P27b]B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P27b]A == X26<τ_0_0.[P27b]B>, τ_0_0.[P27b]B : X3>
+protocol P27b {
+  associatedtype A
+  associatedtype B: X3 where A == X26<B>
+}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump -requirement-machine-protocol-signatures=verify 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 { 
@@ -323,22 +323,6 @@ struct X24<T: P20> : P24 {
   typealias C = T
 }
 
-// CHECK-LABEL: .P25a@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P25a]A == X24<Self.[P25a]B>, Self.[P25a]B : P20>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P25a]A == X24<τ_0_0.[P25a]B>, τ_0_0.[P25a]B : P20>
-protocol P25a {
-  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
-  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
-}
-
-// CHECK-LABEL: .P25b@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P25b]A == X24<Self.[P25b]B>, Self.[P25b]B : P20>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P25b]A == X24<τ_0_0.[P25b]B>, τ_0_0.[P25b]B : P20>
-protocol P25b {
-  associatedtype A
-  associatedtype B: P20 where A == X24<B>
-}
-
 protocol P25c {
   associatedtype A: P24
   associatedtype B where A == X<B> // expected-error{{cannot find type 'X' in scope}}
@@ -347,32 +331,6 @@ protocol P25c {
 protocol P25d {
   associatedtype A
   associatedtype B where A == X24<B> // expected-error{{type 'Self.B' does not conform to protocol 'P20'}}
-}
-
-// Similar to the above, but with superclass constraints.
-protocol P26 {
-  associatedtype C: X3
-}
-
-struct X26<T: X3> : P26 {
-  typealias C = T
-}
-
-// CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P27a]A == X26<Self.[P27a]B>, Self.[P27a]B : X3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P27a]A == X26<τ_0_0.[P27a]B>, τ_0_0.[P27a]B : X3>
-protocol P27a {
-  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
-
-  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
-}
-
-// CHECK-LABEL: .P27b@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P27b]A == X26<Self.[P27b]B>, Self.[P27b]B : X3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P27b]A == X26<τ_0_0.[P27b]B>, τ_0_0.[P27b]B : X3>
-protocol P27b {
-  associatedtype A
-  associatedtype B: X3 where A == X26<B>
 }
 
 // ----------------------------------------------------------------------------

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -requirement-machine-protocol-signatures=off
+
+// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
 
 //===----------------------------------------------------------------------===//
 // Use of protocols with Self or associated type requirements

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck -dump-type-witness-systems %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
+// RUN: not %target-swift-frontend -typecheck -dump-type-witness-systems %s -requirement-machine-protocol-signatures=off 2>&1 | %FileCheck %s
+
+// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
 
 protocol P1 where A == Never {
   associatedtype A

--- a/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -requirement-machine-protocol-signatures=off
+
+// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
 
 public protocol WrappedSignedInteger: SignedInteger where Stride == Int {
     typealias WrappedInteger = Int


### PR DESCRIPTION
If this needs to be reverted, please only revert the commit "RequirementMachine: Enable -requirement-machine-protocol-signatures=verify by default". The other two commits will still pass tests without this one.