### PR TITLE
[5.6][SR-15562] [Sema] Do not consider warning fixes for non-augmenting fix recording 

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11657,9 +11657,16 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // current anchor or, in case of anchor being an expression, any of
   // its sub-expressions.
   llvm::SmallDenseSet<ASTNode> anchors;
-  for (const auto *fix : Fixes)
-    anchors.insert(fix->getAnchor());
+  for (const auto *fix : Fixes) {
+    // Warning fixes shouldn't be considered because even if
+    // such fix is recorded at that anchor this should not
+    // have any affect in the recording of any other fix.
+    if (fix->isWarning())
+      continue;
 
+    anchors.insert(fix->getAnchor());
+  }
+  
   bool found = false;
   if (auto *expr = getAsExpr(anchor)) {
     forEachExpr(expr, [&](Expr *subExpr) -> Expr * {

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -651,3 +651,14 @@ struct SR15281_SC {
     a.flatMap(SR15281_CC.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_CC?' to return type 'SR15281_BC'}} {{35-35=!}}
   }
 }
+
+// SR-15562
+func test_SR_15562() {
+  let foo: [Int: Int] = [:]
+  let bar = [1, 2, 3, 4]
+
+  for baz in bar {
+    foo[baz] as! Int += 1 // expected-warning{{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
+    // expected-error@-1{{left side of mutating operator has immutable type 'Int'}}
+  }
+}


### PR DESCRIPTION
Cherry-pick: #40480

**Explanation:**
Warning fixes recorded would make solver to skip recording non-augmenting error fixes if they had the same anchor or is anchored in a sub-expression, leaving the type checker in a state where it could not produce a diagnostic.

**Scope:** Limited to constraint solver diagnostics.

**Main Branch PR:** #40480

**Resolves:** SR-15562

**Risk:** Low

**Reviewed By:** @xedin 

**Testing:** Regression tests added
