### PR TITLE
[SourceKit] Fix a crash that occurred when a document without an associated source file is reopened

### DIFF
--- a/test/SourceKit/Misc/no-crash-reopen-with-different-compiler-args.swift
+++ b/test/SourceKit/Misc/no-crash-reopen-with-different-compiler-args.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// This used to crash with a nullptr dereference because we didn't store a 
+// snapshot in the FileContents of primary.swift when it is opened for the first 
+// time but we are trying to access the snapshot when trying determining if we 
+// can reuse the AST for the cursor info request
+
+// RUN: %sourcekitd-test \
+// RUN: -req=open %t/primary.swift -- %t/primary.swift %t/secondary.swift \
+// RUN: == -req=close %t/primary.swift  \
+// RUN: == -req=open %t/primary.swift -- %t/primary.swift \
+// RUN: == -req=cursor -pos 2:8 %t/primary.swift -- %t/primary.swift %t/secondary.swift \
+// RUN: | %FileCheck %s
+
+// BEGIN primary.swift
+
+struct Foo {}
+// CHECK: source.lang.swift.decl.struct
+// CHECK-NEXT: Foo
+// CHECK-NEXT: s:4main3FooV
+
+// BEGIN secondary.swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1185,7 +1185,9 @@ ASTBuildOperationRef ASTProducer::getBuildOperationForConsumer(
     std::vector<ImmutableTextSnapshotRef> Snapshots;
     Snapshots.reserve(BuildOp->getFileContents().size());
     for (auto &FileContent : BuildOp->getFileContents()) {
-      Snapshots.push_back(FileContent.Snapshot);
+      if (FileContent.Snapshot) {
+        Snapshots.push_back(FileContent.Snapshot);
+      }
     }
     if (BuildOp->matchesSourceState(FileSystem)) {
       ++Mgr->Impl.Stats->numASTCacheHits;


### PR DESCRIPTION
If a file isn’t opened with a `key.sourcefile` argument, we don’t store a snapshot for it. This could cause a crash when trying to consult its snapshot to see whether an AST can be reused for cursor info.