### PR TITLE
[5.6][CSClosure] Support empty return when closure result is optional `Void`

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1473,11 +1473,13 @@ bool ConstraintSystem::applySolutionToBody(Solution &solution,
   auto closureType = cs.getType(closure)->castTo<FunctionType>();
   ClosureConstraintApplication application(
       solution, closure, closureType->getResult(), rewriteTarget);
-  application.visit(closure->getBody());
+  auto body = application.visit(closure->getBody());
 
-  if (application.hadError)
+  if (!body || application.hadError)
     return true;
 
+  closure->setBody(cast<BraceStmt>(body.get<Stmt *>()),
+                   closure->hasSingleExpressionBody());
   closure->setBodyState(ClosureExpr::BodyState::TypeCheckedWithSignature);
   return false;
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -139,3 +139,42 @@ let _ = {
     print(i)
   }
 }
+
+func test_workaround_for_optional_void_result() {
+  func test<T>(_: (Int?) -> T?) {}
+
+  test {
+    guard let x = $0 else {
+      return // Ok
+    }
+
+    print(x)
+  }
+
+  test {
+    if $0! > 0 {
+      return
+    }
+
+    let _ = $0
+  }
+
+  func test_concrete(_: (Int) -> Void?) {
+  }
+
+  test_concrete {
+    guard let x = Optional($0) else {
+      return // Ok
+    }
+
+    print(x)
+  }
+
+  test_concrete {
+    if $0 > 0 {
+      return // Ok
+    }
+
+    let _ = $0
+  }
+}


### PR DESCRIPTION
Source compatibility workaround.

```swift
func test<T>(_: () -> T?) {
  ...
}
```

A multi-statement closure passed to `test` that has an optional
`Void` result type inferred from the body allows:
   - empty `return`(s);
   - to skip `return nil` or `return ()` at the end.

 Implicit `return ()` has to be inserted as the last element
 of the body if there is none. This wasn't needed before SE-0326
 because result type was (incorrectly) inferred as `Void` due to
 the body being skipped.

 Resolves: rdar://85840941

(cherry picked from commit f287f7e6e458586fcb9fafa2248a130ec82d5ded)
(cherry picked from commit 5700516f2d81458a74c3db811f39ec992436bab4)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
