### PR TITLE
[testing] Better cross-platform testing

### DIFF
--- a/test/IRGen/exactcast2.sil
+++ b/test/IRGen/exactcast2.sil
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s -Xfrontend -enable-objc-interop -emit-ir -o -
+// RUN: %target-build-swift %s -emit-ir -o -
 // REQUIRES: executable_test
 
 // Make sure we are not crashing here.
@@ -13,12 +13,12 @@ class Hash {
   init()
   func update()
   func hash()
-  @objc deinit
+  deinit
 }
 
 final class MD5 : Hash {
   override init()
-  @objc deinit
+  deinit
 }
 
 sil @_TFC4main4HashcfMS0_FT_S0_ : $@convention(method) (@owned Hash) -> @owned Hash

--- a/test/SILOptimizer/devirt_access.sil
+++ b/test/SILOptimizer/devirt_access.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,7 +9,7 @@ import SwiftShims
 class K {
   func ping() -> Int
   private func pong() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
@@ -41,27 +41,27 @@ sil_vtable K {
 class X
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class Y : X
 {
-  @objc deinit
+  deinit
   override init()
 }
 
 class A
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class B : A
 {
   override func ping() -> Int
-  @objc deinit
+  deinit
   override init()
 }
 

--- a/test/SILOptimizer/devirt_access_ownership.sil
+++ b/test/SILOptimizer/devirt_access_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,7 +9,7 @@ import SwiftShims
 class K {
   func ping() -> Int
   private func pong() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
@@ -41,27 +41,27 @@ sil_vtable K {
 class X
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class Y : X
 {
-  @objc deinit
+  deinit
   override init()
 }
 
 class A
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class B : A
 {
   override func ping() -> Int
-  @objc deinit
+  deinit
   override init()
 }
 

--- a/test/SILOptimizer/devirt_access_serialized.sil
+++ b/test/SILOptimizer/devirt_access_serialized.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,13 +9,13 @@ import SwiftShims
 class X
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class Y : X
 {
-  @objc deinit
+  deinit
   override init()
 }
 

--- a/test/SILOptimizer/devirt_access_serialized_ownership.sil
+++ b/test/SILOptimizer/devirt_access_serialized_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,13 +9,13 @@ import SwiftShims
 class X
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class Y : X
 {
-  @objc deinit
+  deinit
   override init()
 }
 

--- a/test/SILOptimizer/devirtualize_protocol_composition_two_stores.sil
+++ b/test/SILOptimizer/devirtualize_protocol_composition_two_stores.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -O -wmo -enable-sil-verify-all %s | %FileCheck %s
 
-// REQUIRES: objc_interop
-
 sil_stage canonical
 
 import Builtin
@@ -9,7 +7,7 @@ import Swift
 import SwiftShims
 
 public class A {
-  @objc deinit
+  deinit
   init()
 }
 
@@ -19,13 +17,13 @@ public protocol P {
 
 public class B : A, P {
   public func foo() -> Int64
-  @objc deinit
+  deinit
   override init()
 }
 
 public class C : A, P {
   public func foo() -> Int64
-  @objc deinit
+  deinit
   override init()
 }
 

--- a/test/SILOptimizer/sil_combine_objc.sil
+++ b/test/SILOptimizer/sil_combine_objc.sil
@@ -1,5 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
-// REQUIRES: objc_interop
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // See https://bugs.swift.org/browse/SR-5065, rdar://32511494
 // XFAIL: *

--- a/test/SILOptimizer/sil_combine_objc_ossa.sil
+++ b/test/SILOptimizer/sil_combine_objc_ossa.sil
@@ -1,5 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
-// REQUIRES: objc_interop
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // See https://bugs.swift.org/browse/SR-5065, rdar://32511494
 // XFAIL: *

--- a/test/SILOptimizer/sil_simplify_instrs.sil
+++ b/test/SILOptimizer/sil_simplify_instrs.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 import Builtin
 import Swift
@@ -132,7 +132,7 @@ bb0(%x : $Builtin.Int64):
 class IntClass {
   @_hasStorage var value: Builtin.Int32 { get set }
   init(value: Builtin.Int32)
-  @objc deinit
+  deinit
 }
 
 enum SortaOptional1 {

--- a/test/SILOptimizer/sil_simplify_instrs_ossa.sil
+++ b/test/SILOptimizer/sil_simplify_instrs_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 sil_stage canonical
 
@@ -134,7 +134,7 @@ bb0(%x : $Builtin.Int64):
 class IntClass {
   @_hasStorage var value: Builtin.Int32 { get set }
   init(value: Builtin.Int32)
-  @objc deinit
+  deinit
 }
 
 enum SortaOptional1 {

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 //
 // Test SimplifyCFG's handling of address-type phis. In other words, makes sure it doesn't create them at all!
 
@@ -10,7 +10,7 @@ import SwiftShims
 
 class C {
   @_hasStorage @_hasInitialValue var field: Int { get set }
-  @objc deinit
+  deinit
     init()
 }
 

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -code-sinking | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -code-sinking | %FileCheck %s
 
 sil_stage canonical
 
@@ -9,13 +9,13 @@ import SwiftShims
 class X
 {
   private func ping() -> Int
-  @objc deinit
+  deinit
   init()
 }
 
 class Y : X
 {
-  @objc deinit
+  deinit
   override init()
 }
 


### PR DESCRIPTION
1) Don't force ObjC interop just to enable gratuitous `@objc deinit`.
2) Prefer `-enable-objc-interop` over `REQUIRES: objc_interop`.