### PR TITLE
[Driver] Respect -use-ld in DarwinToolChain

### DIFF
--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -85,6 +85,8 @@ protected:
 
   const Optional<llvm::Triple> TargetVariant;
 
+  std::string getLinkerPath(const JobContext &context) const;
+
 public:
   Darwin(const Driver &D, const llvm::Triple &Triple,
          const Optional<llvm::Triple> &TargetVariant) :

--- a/test/Driver/Inputs/fake-toolchain/lld
+++ b/test/Driver/Inputs/fake-toolchain/lld
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# lld - Fake lld to test finding the Darwin linker in the toolchain path
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ----------------------------------------------------------------------------
+
+from __future__ import print_function
+
+print("Sorry, wrong number!")

--- a/test/Driver/linker-use-ld-darwin.swift
+++ b/test/Driver/linker-use-ld-darwin.swift
@@ -1,0 +1,13 @@
+// REQUIRES: OS=macosx
+
+// RUN: %swiftc_driver -driver-print-jobs %s -target x86_64-apple-macosx10.9 | %FileCheck %s --check-prefix=CHECK-DEFAULT-LD
+// CHECK-DEFAULT-LD: /usr/bin/ld
+
+// RUN: %swiftc_driver -driver-print-jobs %s -target x86_64-apple-macosx10.9 -use-ld=some-ld | %FileCheck %s --check-prefix=CHECK-USE-LD-SOME-LD
+// CHECK-USE-LD-SOME-LD: some-ld
+
+// RUN: %swiftc_driver -driver-print-jobs %s -target x86_64-apple-macosx10.9 -use-ld=lld -tools-directory %S/Inputs/fake-toolchain | %FileCheck %s --check-prefix=CHECK-USE-LD-TOOLS-DIRECTORY
+// CHECK-USE-LD-TOOLS-DIRECTORY: lld
+
+// RUN: %swiftc_driver -driver-print-jobs %s -target x86_64-apple-macosx10.9 -use-ld=/full/path/to/ld | %FileCheck %s --check-prefix=CHECK-USE-LD-FULL-PATH
+// CHECK-USE-LD-FULL-PATH: /full/path/to/ld


### PR DESCRIPTION
The Darwin toolchain is the only toolchain that doesn't use Clang as the
linker driver, and the only one that doesn't respect the value of
-use-ld and completely ignores it. This makes it very complicated to
check Swift with alternative linkers like LLD, zld or mold.

In order to make the behaviour more consistent between toolchains,
introduce a small modification in DarwinToolChains to use the provided
value of `-use-ld`. The newly implement behaviour tries to keep all the
previous behaviour (using the system or the tools directory `ld`), but
opens the door to alternative linkers.

There is small test that checks for some of the new behaviours.
