### PR TITLE
Add a runtime-internal function, `_enumerateTypes(fromImageAt:conformingTo:_:)`, that will walk the protocol conformance tables looking for types that conform to a given protocol.

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -173,6 +173,7 @@ set(SWIFTLIB_ESSENTIAL
   SwiftNativeNSArray.swift
   TemporaryAllocation.swift
   ThreadLocalStorage.swift
+  TypeDiscovery.swift
   UIntBuffer.swift
   UnavailableStringAPIs.swift
   UnicodeData.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -155,7 +155,8 @@
     "Mirror.swift",
     "Mirrors.swift",
     "ReflectionMirror.swift",
-    "ObjectIdentifier.swift"
+    "ObjectIdentifier.swift",
+    "TypeDiscovery.swift"
   ],
   "Math": [
     "SetAlgebra.swift",

--- a/stdlib/public/core/TypeDiscovery.swift
+++ b/stdlib/public/core/TypeDiscovery.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A function that instantiates the type described by a type descriptor.
+///
+/// - Parameters:
+///   - descriptor: A type descriptor as passed to `_swift_enumerateTypes()`'s
+///     callback.
+///
+/// - Returns: The initialized type corresponding to `descriptor`, or `nil` if
+///   the type could not be initialized. This value can subsequently be cast to
+///   `Any.Type` using `unsafeBitCast(_:to:)`.
+private typealias _TypeGetter = @convention(c) (
+  _ descriptor: UnsafeRawPointer
+) -> UnsafeRawPointer?
+
+/// A type describing another type available in the current process.
+@available(SwiftStdlib 9999, *)
+public struct _TypeRecord {
+  /// Initialize an instance of this type.
+  ///
+  /// - Parameters:
+  ///   - name: The name of this type.
+  ///   - typeInstantiator: A function to call that calls back into the runtime
+  ///     to instantiate the type.
+  fileprivate init(
+    _name name: String,
+    instantiatingTypeUsing typeInstantiator: @escaping () -> Any.Type?
+  ) {
+    self.name = name
+    _typeInstantiator = typeInstantiator
+  }
+
+  /// The name of this type.
+  public let name: String
+
+  /// Storage for `type`.
+  ///
+  /// This function calls back into the runtime to instantiate the type.
+  private let _typeInstantiator: () -> Any.Type?
+
+  /// The Swift type described by this type record.
+  ///
+  /// On first use, this property will "instantiate" the type, meaning that the
+  /// type will become fully realized and will be available for use in Swift. If
+  /// that operation fails, the value of this property is `nil`.
+  public var type: Any.Type? {
+    return _typeInstantiator()
+  }
+}
+
+@_silgen_name("swift_enumerateAllTypesFromImage")
+private func _swift_enumerateTypes(
+  fromImageAt imageAddress: UnsafeRawPointer?,
+  _ body: (
+    _ name: UnsafePointer<CChar>,
+    _ descriptor: UnsafeRawPointer,
+    _ typeGetter: @escaping _TypeGetter,
+    _ stop: inout Bool
+  ) throws -> Void
+) rethrows
+
+/// Enumerate all types in a given image.
+///
+/// - Parameters:
+///   - imageAddress: A platform-specific pointer to the image of interest. The
+///     image must have been loaded into the current process. For the binary of
+///     the calling function, you can pass `#dsohandle`. For all binaries, pass
+///     `nil` (the default.)
+///   - body: A closure to invoke once per conforming type.
+///
+/// - Throws: Whatever is thrown by `body`.
+///
+/// This function walks all known types in the given image and passes them to
+/// `body` for evaluation.
+///
+/// Generic types are not enumerated.
+///
+/// - Bug: Objective-C class lookups are not supported yet.
+@available(SwiftStdlib 9999, *)
+public func _enumerateTypes(
+  fromImageAt imageAddress: UnsafeRawPointer? = nil,
+  _ body: (_ typeRecord: _TypeRecord, _ stop: inout Bool) throws -> Void
+) rethrows {
+  try _swift_enumerateTypes(
+    fromImageAt: imageAddress
+  ) { name, descriptor, getType, stop in
+    let typeRecord = _TypeRecord(
+      _name: String(cString: name),
+      instantiatingTypeUsing: {
+        getType(descriptor).map { unsafeBitCast($0, to: Any.Type.self) }
+      }
+    )
+    try body(typeRecord, &stop)
+  }
+}

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -74,17 +74,27 @@ void initializeTypeMetadataRecordLookup();
 void initializeDynamicReplacementLookup();
 
 // Callbacks to register metadata from an image to the runtime.
-void addImageProtocolsBlockCallback(const void *start, uintptr_t size);
-void addImageProtocolsBlockCallbackUnsafe(const void *start, uintptr_t size);
-void addImageProtocolConformanceBlockCallback(const void *start,
+void addImageProtocolsBlockCallback(const void *image,
+                                    const void *start,
+                                    uintptr_t size);
+void addImageProtocolsBlockCallbackUnsafe(const void *image,
+                                          const void *start,
+                                          uintptr_t size);
+void addImageProtocolConformanceBlockCallback(const void *image,
+                                              const void *start,
                                               uintptr_t size);
-void addImageProtocolConformanceBlockCallbackUnsafe(const void *start,
+void addImageProtocolConformanceBlockCallbackUnsafe(const void *image,
+                                                    const void *start,
                                                     uintptr_t size);
-void addImageTypeMetadataRecordBlockCallback(const void *start,
+void addImageTypeMetadataRecordBlockCallback(const void *image,
+                                             const void *start,
                                              uintptr_t size);
-void addImageTypeMetadataRecordBlockCallbackUnsafe(const void *start,
+void addImageTypeMetadataRecordBlockCallbackUnsafe(const void *image,
+                                                   const void *start,
                                                    uintptr_t size);
-void addImageDynamicReplacementBlockCallback(const void *start, uintptr_t size,
+void addImageDynamicReplacementBlockCallback(const void *image,
+                                             const void *start,
+                                             uintptr_t size,
                                              const void *start2,
                                              uintptr_t size2);
 

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -44,7 +44,7 @@ void record(swift::MetadataSections *sections) {
 }
 
 SWIFT_RUNTIME_EXPORT
-void swift_addNewDSOImage(const void *addr) {
+void swift_addNewDSOImage(const void *imageAddress, const void *addr) {
   // We cast off the const in order to update the linked list
   // data structure. This is safe to do since we don't touch 
   // any other fields.
@@ -56,19 +56,23 @@ void swift_addNewDSOImage(const void *addr) {
   const auto &protocols_section = sections->swift5_protocols;
   const void *protocols = reinterpret_cast<void *>(protocols_section.start);
   if (protocols_section.length)
-    swift::addImageProtocolsBlockCallback(protocols, protocols_section.length);
+    swift::addImageProtocolsBlockCallback(image,
+                                          protocols,
+                                          protocols_section.length);
 
   const auto &protocol_conformances = sections->swift5_protocol_conformances;
   const void *conformances =
       reinterpret_cast<void *>(protocol_conformances.start);
   if (protocol_conformances.length)
-    swift::addImageProtocolConformanceBlockCallback(conformances,
+    swift::addImageProtocolConformanceBlockCallback(image, conformances,
                                              protocol_conformances.length);
 
   const auto &type_metadata = sections->swift5_type_metadata;
   const void *metadata = reinterpret_cast<void *>(type_metadata.start);
   if (type_metadata.length)
-    swift::addImageTypeMetadataRecordBlockCallback(metadata, type_metadata.length);
+    swift::addImageTypeMetadataRecordBlockCallback(image,
+                                                   metadata,
+                                                   type_metadata.length);
 
   const auto &dynamic_replacements = sections->swift5_replace;
   const auto *replacements =
@@ -77,7 +81,7 @@ void swift_addNewDSOImage(const void *addr) {
     const auto &dynamic_replacements_some = sections->swift5_replac2;
     const auto *replacements_some =
       reinterpret_cast<void *>(dynamic_replacements_some.start);
-    swift::addImageDynamicReplacementBlockCallback(
+    swift::addImageDynamicReplacementBlockCallback(image,
         replacements, dynamic_replacements.length, replacements_some,
         dynamic_replacements_some.length);
   }
@@ -89,7 +93,7 @@ void swift::initializeProtocolLookup() {
     const swift::MetadataSectionRange &protocols =
       sections->swift5_protocols;
     if (protocols.length)
-      addImageProtocolsBlockCallbackUnsafe(
+      addImageProtocolsBlockCallbackUnsafe(image,
           reinterpret_cast<void *>(protocols.start), protocols.length);
 
     if (sections->next == registered)
@@ -104,7 +108,7 @@ void swift::initializeProtocolConformanceLookup() {
     const swift::MetadataSectionRange &conformances =
         sections->swift5_protocol_conformances;
     if (conformances.length)
-      addImageProtocolConformanceBlockCallbackUnsafe(
+      addImageProtocolConformanceBlockCallbackUnsafe(image,
           reinterpret_cast<void *>(conformances.start), conformances.length);
 
     if (sections->next == registered)
@@ -119,7 +123,7 @@ void swift::initializeTypeMetadataRecordLookup() {
     const swift::MetadataSectionRange &type_metadata =
         sections->swift5_type_metadata;
     if (type_metadata.length)
-      addImageTypeMetadataRecordBlockCallbackUnsafe(
+      addImageTypeMetadataRecordBlockCallbackUnsafe(image,
           reinterpret_cast<void *>(type_metadata.start), type_metadata.length);
 
     if (sections->next == registered)

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -59,7 +59,7 @@ struct SectionInfo {
 
 // Called by injected constructors when a dynamic library is loaded.
 SWIFT_RUNTIME_EXPORT
-void swift_addNewDSOImage(const void *addr);
+void swift_addNewDSOImage(const void *imageAddress, const void *addr);
 
 #ifndef NDEBUG
 

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -52,7 +52,8 @@ using mach_header_platform = mach_header;
 #endif
 
 template <const char *SEGMENT_NAME, const char *SECTION_NAME,
-         void CONSUME_BLOCK(const void *start, uintptr_t size)>
+         void CONSUME_BLOCK(const void *imageAddress,
+                            const void *start, uintptr_t size)>
 void addImageCallback(const mach_header *mh) {
 #if __POINTER_WIDTH__ == 64
   assert(mh->magic == MH_MAGIC_64 && "loaded non-64-bit image?!");
@@ -68,17 +69,19 @@ void addImageCallback(const mach_header *mh) {
   if (!section)
     return;
   
-  CONSUME_BLOCK(section, size);
+  CONSUME_BLOCK(mh, section, size);
 }
 template <const char *SEGMENT_NAME, const char *SECTION_NAME,
-         void CONSUME_BLOCK(const void *start, uintptr_t size)>
+         void CONSUME_BLOCK(const void *imageAddress,
+                            const void *start, uintptr_t size)>
 void addImageCallback(const mach_header *mh, intptr_t vmaddr_slide) {
   addImageCallback<SEGMENT_NAME, SECTION_NAME, CONSUME_BLOCK>(mh);
 }
 
 template <const char *SEGMENT_NAME, const char *SECTION_NAME,
           const char *SEGMENT_NAME2, const char *SECTION_NAME2,
-          void CONSUME_BLOCK(const void *start, uintptr_t size,
+          void CONSUME_BLOCK(const void *imageAddress,
+                             const void *start, uintptr_t size,
                              const void *start2, uintptr_t size2)>
 void addImageCallback2Sections(const mach_header *mh) {
 #if __POINTER_WIDTH__ == 64
@@ -104,11 +107,12 @@ void addImageCallback2Sections(const mach_header *mh) {
   if (!section2)
     size2 = 0;
 
-  CONSUME_BLOCK(section, size, section2, size2);
+  CONSUME_BLOCK(mh, section, size, section2, size2);
 }
 template <const char *SEGMENT_NAME, const char *SECTION_NAME,
           const char *SEGMENT_NAME2, const char *SECTION_NAME2,
-          void CONSUME_BLOCK(const void *start, uintptr_t size,
+          void CONSUME_BLOCK(const void *imageAddress,
+                             const void *start, uintptr_t size,
                              const void *start2, uintptr_t size2)>
 void addImageCallback2Sections(const mach_header *mh, intptr_t vmaddr_slide) {
   addImageCallback2Sections<SEGMENT_NAME, SECTION_NAME,

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -530,6 +530,7 @@ static void _registerProtocolConformances(ConformanceState &C,
 }
 
 void swift::addImageProtocolConformanceBlockCallbackUnsafe(
+    const void *imageAddress,
     const void *conformances, uintptr_t conformancesSize) {
   assert(conformancesSize % sizeof(ProtocolConformanceRecord) == 0 &&
          "conformances section not a multiple of ProtocolConformanceRecord");
@@ -574,9 +575,11 @@ void swift::addImageProtocolConformanceBlockCallbackUnsafe(
 }
 
 void swift::addImageProtocolConformanceBlockCallback(
+    const void *imageAddress,
     const void *conformances, uintptr_t conformancesSize) {
   Conformances.get();
-  addImageProtocolConformanceBlockCallbackUnsafe(conformances,
+  addImageProtocolConformanceBlockCallbackUnsafe(imageAddress,
+                                                 conformances,
                                                  conformancesSize);
 }
 

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -83,7 +83,7 @@ static void swift_image_constructor() {
 
 #undef SWIFT_SECTION_RANGE
 
-  swift_addNewDSOImage(&sections);
+  swift_addNewDSOImage(__ImageBase, &sections);
 }
 
 #pragma section(".CRT$XCIS", long, read)

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -37,6 +37,8 @@ DECLARE_SWIFT_SECTION(swift5_replace)
 DECLARE_SWIFT_SECTION(swift5_replac2)
 DECLARE_SWIFT_SECTION(swift5_builtin)
 DECLARE_SWIFT_SECTION(swift5_capture)
+
+extern void const *const __dso_handle;
 }
 
 #undef DECLARE_SWIFT_SECTION
@@ -74,7 +76,7 @@ static void swift_image_constructor() {
 
 #undef SWIFT_SECTION_RANGE
 
-  swift_addNewDSOImage(&sections);
+  swift_addNewDSOImage(__dso_handle, &sections);
 }
 
 __asm__(".section \".note.swift_reflection_metadata\", \"aw\"");

--- a/stdlib/public/runtime/TypeDiscovery.h
+++ b/stdlib/public/runtime/TypeDiscovery.h
@@ -1,0 +1,72 @@
+//===--- TypeDiscovery.h - Dynamic type lookup at runtime--------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions to look up types in the Swift type system at runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_TYPE_DISCOVERY_H
+#define SWIFT_RUNTIME_TYPE_DISCOVERY_H
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/Error.h"
+#include "swift/Runtime/Metadata.h"
+
+namespace swift {
+  /// The function type used by \c swift_enumerateConformingTypesFromImage().
+  ///
+  /// \param name The name of the type being enumerated.
+  /// \param tcd A pointer to the type context descriptor of the type being
+  ///   enumerated.
+  /// \param getType A function which, when passed \a tcd, will instantiate its
+  ///   corresponding \c Metadata value.
+  /// \param stop Whether the caller should continue enumerating types after
+  ///   this function returns.
+  /// \param context The Swift context pointer for this function. Ignored.
+  /// \param error An error pointer passed to \a body. If \a body throws an
+  /// 	error, enumeration is stopped and the error is rethrown.
+  typedef void (* TypeEnumerationFunction)(
+    const char *name,
+    const TypeContextDescriptor *tcd,
+    const Metadata *(* getType)(const TypeContextDescriptor *tcd),
+    bool *stop,
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT SwiftError **error) SWIFT_CC(swift);
+
+  /// Enumerate all types in a given image.
+  ///
+  /// \param imageAddress A platform-specific pointer to the image of interest.
+  ///   The image must have been loaded into the current process. Do not pass
+  ///   a handle acquired from \c dlopen() or platform equivalents. Pass
+  ///   \c nullptr to search all loaded images.
+  /// \param body A closure to invoke once per matching type.
+  /// \param bodyContext The Swift context pointer for \a body.
+  /// \param context The Swift context pointer for this function. Ignored.
+  /// \param error An error pointer passed to \a body. If \a body throws an
+  /// 	error, enumeration is stopped and the error is rethrown.
+  ///
+  /// This function walks all known types in the given image and passes them to
+  /// \c body for evaluation.
+  ///
+  /// Generic types are not enumerated.
+  ///
+  /// \bug Objective-C class lookups are not supported yet.
+  SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+  void swift_enumerateAllTypesFromImage(
+    const void *imageAddress,
+    TypeEnumerationFunction body,
+    void *bodyContext,
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT SwiftError **error);
+} // end namespace swift
+
+#endif /* SWIFT_RUNTIME_TYPE_DISCOVERY_H */

--- a/test/Runtime/type_discovery.swift
+++ b/test/Runtime/type_discovery.swift
@@ -1,0 +1,50 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+protocol P { }
+struct A: P { }
+class B: P { }
+enum C: P { }
+struct D /* does not conform */ { }
+
+guard #available(SwiftStdlib 9999, *) else {
+  print("Skipping tests in \(#fileID) due to unavailability.")
+  return
+}
+
+// Don't use #dsohandle on Windows because __ImageBase is not linked properly
+// when building the test target and we get a link-time error trying to use it.
+let address: UnsafeRawPointer?
+#if os(Windows)
+address = nil
+#else
+address = #dsohandle
+#endif
+
+// Test that we can resolve some types!
+do {
+  var typeList = [P.Type]()
+
+  _enumerateTypes(fromImageAt: address) { typeRecord, _ in
+    if let type = typeRecord.type as? P.Type {
+      typeList.append(type)
+    }
+  }
+  expectTrue(typeList.contains(where: { $0 == A.self }))
+  expectTrue(typeList.contains(where: { $0 == B.self }))
+  expectTrue(typeList.contains(where: { $0 == C.self }))
+  expectFalse(typeList.contains(where: { $0 == D.self }))
+}
+
+// Test that `stop` works.
+do {
+  var iterationCount = 0
+  _enumerateTypes(fromImageAt: address) { type, stop in
+    iterationCount += 1
+    stop = true
+  }
+  expectEqual(iterationCount, 1)
+}
+


### PR DESCRIPTION
Add a runtime-internal function, `_enumerateTypes(fromImageAt:conformingTo:_:)`, that will walk the protocol conformance tables looking for types that conform to a given protocol.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://67501458.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
