### PR TITLE
[AllocStackHoisting] New dealloc_stack's locs are cleanups.

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -118,7 +118,8 @@ insertDeallocStackAtEndOf(SmallVectorImpl<SILInstruction *> &FunctionExits,
   // Insert dealloc_stack in the exit blocks.
   for (auto *Exit : FunctionExits) {
     SILBuilderWithScope Builder(Exit);
-    Builder.createDeallocStack(AllocStack->getLoc(), AllocStack);
+    Builder.createDeallocStack(CleanupLocation(AllocStack->getLoc()),
+                               AllocStack);
   }
 }
 


### PR DESCRIPTION
AllocStackHoisting creates new dealloc_stack instructions.  The old dealloc_stack instructions' locations' kinds are ::CleanupKind  The new instructions' locations need to be of that same kind too in order not to trigger the sil verifier failure

    Basic block contains a non-contiguous lexical scope at -Onone

when building at Onone.
