### PR TITLE
Disable lexical-lifetimes with copy-propagation.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -31,15 +31,17 @@
 namespace swift {
 
 enum class LexicalLifetimesOption : uint8_t {
-  // Do not insert any lexical lifetimes.
+  // Do not insert lexical markers.
   Off = 0,
 
-  // Insert lexical lifetimes in SILGen, but remove them before leaving Raw SIL.
-  Early,
+  // Insert lexical markers via lexical borrow scopes and the lexical flag on
+  // alloc_stacks produced from alloc_boxes, but strip them when lowering out of
+  // Raw SIL.
+  DiagnosticMarkersOnly,
 
-  // Insert lexical lifetimes and do not remove them until OSSA is lowered. This
-  // is experimental.
-  ExperimentalLate,
+  // Insert lexical markers and use them to lengthen object lifetime based on
+  // lexical scope.
+  On,
 };
 
 class SILModule;
@@ -59,7 +61,8 @@ public:
   bool RemoveRuntimeAsserts = false;
 
   /// Enable experimental support for emitting defined borrow scopes.
-  LexicalLifetimesOption LexicalLifetimes = LexicalLifetimesOption::Early;
+  LexicalLifetimesOption LexicalLifetimes =
+      LexicalLifetimesOption::DiagnosticMarkersOnly;
 
   /// Force-run SIL copy propagation to shorten object lifetime in whatever
   /// optimization pipeline is currently used.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -911,14 +911,17 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){
 inline bool SILOptions::supportsLexicalLifetimes(const SILModule &mod) const {
   switch (mod.getStage()) {
   case SILStage::Raw:
-    // In Raw SIL, we support lexical lifetimes as long as lexical lifetimes is
-    // not turned off all the way. This means lexical lifetimes is set to either
-    // early or experimental late.
+    // In raw SIL, lexical markers are used for diagnostics.  These markers are
+    // present as long as the lexical lifetimes feature is not disabled
+    // entirely.
     return LexicalLifetimes != LexicalLifetimesOption::Off;
   case SILStage::Canonical:
-    // In Canonical SIL, we only support lexical lifetimes when in experimental
-    // late mode.
-    return LexicalLifetimes == LexicalLifetimesOption::ExperimentalLate;
+    // In Canonical SIL, lexical markers are used to ensure that object
+    // lifetimes do not get observably shortened from the end of a lexical
+    // scope.  That behavior only occurs when lexical lifetimes is (fully)
+    // enabled.  (When only diagnostic markers are enabled, the markers are
+    // stripped as part of lowering from raw to canonical SIL.)
+    return LexicalLifetimes == LexicalLifetimesOption::On;
   case SILStage::Lowered:
     // We do not support OSSA in Lowered SIL, so this is always false.
     return false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1519,6 +1519,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_copy_propagation))
     Opts.LexicalLifetimes = LexicalLifetimesOption::On;
 
+  // -disable-copy-propagation implies -enable-lexical-lifetimes=false
+  if (Args.hasArg(OPT_disable_copy_propagation))
+    Opts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
+
   // If move-only is enabled, always enable lexical lifetime as well.  Move-only
   // depends on lexical lifetimes.
   if (Args.hasArg(OPT_enable_experimental_move_only))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1517,23 +1517,23 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // -enable-copy-propagation implies -enable-lexical-lifetimes unless
   // otherwise specified.
   if (Args.hasArg(OPT_enable_copy_propagation))
-    Opts.LexicalLifetimes = LexicalLifetimesOption::ExperimentalLate;
+    Opts.LexicalLifetimes = LexicalLifetimesOption::On;
 
   // If move-only is enabled, always enable lexical lifetime as well.  Move-only
   // depends on lexical lifetimes.
   if (Args.hasArg(OPT_enable_experimental_move_only))
-    Opts.LexicalLifetimes = LexicalLifetimesOption::ExperimentalLate;
+    Opts.LexicalLifetimes = LexicalLifetimesOption::On;
 
   if (enableLexicalLifetimesFlag) {
     if (*enableLexicalLifetimesFlag) {
-      Opts.LexicalLifetimes = LexicalLifetimesOption::ExperimentalLate;
+      Opts.LexicalLifetimes = LexicalLifetimesOption::On;
     } else {
-      Opts.LexicalLifetimes = LexicalLifetimesOption::Early;
+      Opts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
     }
   }
   if (enableLexicalBorrowScopesFlag) {
     if (*enableLexicalBorrowScopesFlag) {
-      Opts.LexicalLifetimes = LexicalLifetimesOption::Early;
+      Opts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
     } else {
       Opts.LexicalLifetimes = LexicalLifetimesOption::Off;
     }

--- a/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/LexicalLifetimeEliminator.cpp
@@ -30,7 +30,7 @@ class LexicalLifetimeEliminatorPass : public SILFunctionTransform {
     // run this pass since we want lexical lifetimes to exist later in the
     // pipeline.
     if (fn->getModule().getOptions().LexicalLifetimes ==
-        LexicalLifetimesOption::ExperimentalLate)
+        LexicalLifetimesOption::On)
       return;
 
     bool madeChange = false;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -180,7 +180,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   // Now that we have finished performing diagnostics that rely on lexical
   // scopes, if lexical lifetimes are not enabled, eliminate lexical lfietimes.
-  if (Options.LexicalLifetimes != LexicalLifetimesOption::ExperimentalLate) {
+  if (Options.LexicalLifetimes != LexicalLifetimesOption::On) {
     P.addLexicalLifetimeEliminator();
   }
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -316,8 +316,7 @@ static bool shouldAddLexicalLifetime(AllocStackInst *asi) {
          asi->getFunction()
                  ->getModule()
                  .getASTContext()
-                 .SILOpts.LexicalLifetimes ==
-             LexicalLifetimesOption::ExperimentalLate &&
+                 .SILOpts.LexicalLifetimes == LexicalLifetimesOption::On &&
          asi->isLexical() &&
          !asi->getElementType().isTrivial(*asi->getFunction());
 }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -528,7 +528,7 @@ int main(int argc, char **argv) {
   SILOpts.DisableCopyPropagation = DisableCopyPropagation;
 
   if (EnableCopyPropagation)
-    SILOpts.LexicalLifetimes = LexicalLifetimesOption::ExperimentalLate;
+    SILOpts.LexicalLifetimes = LexicalLifetimesOption::On;
 
   // Enable lexical lifetimes if it is set or if experimental move only is
   // enabled. This is because move only depends on lexical lifetimes being
@@ -541,7 +541,7 @@ int main(int argc, char **argv) {
     exit(-1);
   }
   if (enableLexicalLifetimes)
-    SILOpts.LexicalLifetimes = LexicalLifetimesOption::ExperimentalLate;
+    SILOpts.LexicalLifetimes = LexicalLifetimesOption::On;
   if (!EnableLexicalBorrowScopes)
     SILOpts.LexicalLifetimes = LexicalLifetimesOption::Off;
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -529,6 +529,8 @@ int main(int argc, char **argv) {
 
   if (EnableCopyPropagation)
     SILOpts.LexicalLifetimes = LexicalLifetimesOption::On;
+  if (DisableCopyPropagation)
+    SILOpts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
 
   // Enable lexical lifetimes if it is set or if experimental move only is
   // enabled. This is because move only depends on lexical lifetimes being


### PR DESCRIPTION
If -disable-copy-propagation is passed, just emit lexical diagnostic markers but do not enable lexical lifetimes.
