### PR TITLE
Synchronize adding a child task to a TaskGroup with parent task

### DIFF
--- a/include/swift/ABI/TaskGroup.h
+++ b/include/swift/ABI/TaskGroup.h
@@ -42,6 +42,10 @@ public:
 
   /// Checks the cancellation status of the group.
   bool isCancelled();
+
+  // Add a child task to the group. Always called with the status record lock of
+  // the parent task held
+  void addChildTask(AsyncTask *task);
 };
 
 } // end namespace swift

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -241,7 +241,7 @@ OVERRIDE_TASK_GROUP(taskGroup_initialize, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group, const Metadata *T), (group, T))
 
-OVERRIDE_TASK_GROUP(taskGroup_attachChild, void,
+OVERRIDE_TASK_STATUS(taskGroup_attachChild, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group, AsyncTask *child),
                     (group, child))

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -472,15 +472,13 @@ static void swift_taskGroup_initializeImpl(TaskGroup *group, const Metadata *T) 
 // =============================================================================
 // ==== add / attachChild ------------------------------------------------------
 
-SWIFT_CC(swift)
-static void swift_taskGroup_attachChildImpl(TaskGroup *group,
-                                            AsyncTask *child) {
+void TaskGroup::addChildTask(AsyncTask *child) {
   SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, group);
 
   // The counterpart of this (detachChild) is performed by the group itself,
   // when it offers the completed (child) task's value to a waiting task -
   // during the implementation of `await group.next()`.
-  auto groupRecord = asImpl(group)->getTaskRecord();
+  auto groupRecord = asImpl(this)->getTaskRecord();
   groupRecord->attachChild(child);
 }
 

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -471,7 +471,6 @@ swift_task_detachChildImpl(ChildTaskStatusRecord *record) {
 SWIFT_CC(swift)
 static void swift_taskGroup_attachChildImpl(TaskGroup *group,
                                             AsyncTask *child) {
-  SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, group);
 
   // We are always called from the context of the parent
   //


### PR DESCRIPTION
When a task is adding adding new children to a task group, we need to synchronize with the task status record lock of the parent task that has the task group, to prevent races with concurrent cancellation and escalation.

In the future, we'd probably want a lock for the TaskGroup itself and not have it be the group's parent task's status record lock but for now, this will get us the right functionality. 

rdar://86311782