### PR TITLE
`ConcurrentReadableArray`: Use `std::uninitialized_copy_n()` instead of `std::copy()` to avoid calling destructors on uninitialized memory

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -548,7 +548,7 @@ public:
       auto newCapacity = std::max((size_t)16, count * 2);
       auto *newStorage = Storage::allocate(newCapacity);
       if (storage) {
-        std::copy(storage->data(), storage->data() + count, newStorage->data());
+        std::uninitialized_copy_n(storage->data(), count, newStorage->data());
         newStorage->Count.store(count, std::memory_order_release);
         ConcurrentFreeListNode::add(&FreeList, storage);
       }
@@ -622,10 +622,7 @@ using llvm::hash_value;
 /// outstanding readers, but this won't destroy the static mutex it uses.
 template <class ElemTy, class MutexTy = StaticMutex>
 struct ConcurrentReadableHashMap {
-  // We use memcpy and don't call destructors. Make sure the elements will put
-  // up with this.
-  static_assert(std::is_trivially_copyable<ElemTy>::value,
-                "Elements must be trivially copyable.");
+  // We don't call destructors. Make sure the elements will put up with this.
   static_assert(std::is_trivially_destructible<ElemTy>::value,
                 "Elements must not have destructors (they won't be called).");
 
@@ -884,8 +881,13 @@ private:
     auto *newElements = ElementStorage::allocate(newCapacity);
 
     if (elements) {
-      memcpy(newElements->data(), elements->data(),
-             elementCount * sizeof(ElemTy));
+      if constexpr (std::is_trivially_copyable<ElemTy>::value) {
+        memcpy(newElements->data(), elements->data(),
+               elementCount * sizeof(ElemTy));
+      } else {
+        std::uninitialized_copy_n(elements->data(), elementCount,
+                                  newElements->data());
+      }
       ConcurrentFreeListNode::add(&FreeList, elements);
     }
 


### PR DESCRIPTION
`ConcurrentReadableArray`: Use `std::uninitialized_copy_n()` instead of `std::copy()` to avoid calling destructors on uninitialized memory.

<!-- What's in this pull request? -->
This change fixes a (currently benign) misuse of `std::copy()` in `ConcurrentReadableArray` when it is resized. `std::copy()` will call destructors on the destination buffer before copying in new values. Because the memory being copied into is uninitialized, this is undefined behavior. There shouldn't be any impact in the real world though because the only users of `ConcurrentReadableArray` are POD types so there's nothing to destruct.

I also took the opportunity to switch from `memcpy()` to `std::uninitialized_copy_n()` for `ConcurrentReadableHashMap` which allows us to remove the `std::is_trivially_copyable` constraint on `ElemTy`. For POD types, the resulting generated code should be identical.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
