### PR TITLE
Remove Fix-it suggestion for unsafeBitcast

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3824,9 +3824,6 @@ WARNING(bitcasting_to_change_function_rep, none,
         "'unsafeBitCast' from function type %0 to %1 changes @convention and "
         "is undefined; use an implicit conversion to change conventions",
         (Type, Type))
-WARNING(bitcasting_to_downcast, none,
-        "'unsafeBitCast' from %0 to %1 can be replaced with 'unsafeDowncast'",
-        (Type, Type))
 WARNING(bitcasting_is_no_op, none,
         "'unsafeBitCast' from %0 to %1 is unnecessary and can be removed",
         (Type, Type))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -818,15 +818,6 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           return;
         }
       }
-      
-      // Unchecked casting to a subclass is better done by unsafeDowncast.
-      if (fromTy->isBindableToSuperclassOf(toTy)) {
-        Ctx.Diags.diagnose(DRE->getLoc(), diag::bitcasting_to_downcast,
-                           fromTy, toTy)
-          .fixItReplace(DRE->getNameLoc().getBaseNameLoc(),
-                        "unsafeDowncast");
-        return;
-      }
 
       // Casting among pointer types should use the Unsafe*Pointer APIs for
       // rebinding typed memory or accessing raw memory instead.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Remove Fix-it suggestion for unsafeBitcast to change it into unsafeDowncast. The compiler suggest this but on applying the fix it fails at debugPrecondition(x is T). The options were either to remove fix it entirely or apply only when we know x is T for sure. Tried to find if x is T but not able to get this data at this step of the pipeline (the dynamic type casting/ mimicking is operator using swiftDynamicCast seems to happen during runtime). Hence opted for entirely removing the fix it

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14943.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
