### PR TITLE
[move-function] A few additions

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveFunctionCanonicalization.cpp
@@ -112,14 +112,18 @@ tryHandlingLoadableVarMovePattern(MarkUnresolvedMoveAddrInst *markMoveAddr,
 
   LLVM_DEBUG(llvm::dbgs() << "Found LI: " << *li);
   SILValue operand = stripAccessMarkers(li->getOperand());
-  auto *originalASI = dyn_cast<AllocStackInst>(operand);
-  // Make sure that we have a lexical alloc_stack marked as a var or a let. We
-  // don't want properties.
-  if (!originalASI || !originalASI->isLexical() ||
-      !(originalASI->isVar() || originalASI->isLet()))
-    return false;
+  if (auto *originalASI = dyn_cast<AllocStackInst>(operand)) {
+    if (!originalASI->isLexical() ||
+        !(originalASI->isVar() || originalASI->isLet()))
+      return false;
+    LLVM_DEBUG(llvm::dbgs() << "Found OriginalASI: " << *originalASI);
+  } else {
+    auto *fArg = dyn_cast<SILFunctionArgument>(operand);
+    if (!fArg || !fArg->hasConvention(SILArgumentConvention::Indirect_Inout))
+      return false;
+    LLVM_DEBUG(llvm::dbgs() << "Found fArg: " << *fArg);
+  }
 
-  LLVM_DEBUG(llvm::dbgs() << "Found OriginalASI: " << *originalASI);
   // Make sure that there aren't any side-effect having instructions in
   // between our load/store.
   LLVM_DEBUG(llvm::dbgs() << "Checking for uses in between LI and SI.\n");
@@ -132,7 +136,7 @@ tryHandlingLoadableVarMovePattern(MarkUnresolvedMoveAddrInst *markMoveAddr,
         }
 
         if (auto *dvi = dyn_cast<DestroyAddrInst>(&iter)) {
-          if (aa->isNoAlias(dvi->getOperand(), originalASI)) {
+          if (aa->isNoAlias(dvi->getOperand(), operand)) {
             // We are going to be extending the lifetime of our
             // underlying value, not shrinking it so we can ignore
             // destroy_addr on other non-aliasing values.
@@ -157,7 +161,7 @@ tryHandlingLoadableVarMovePattern(MarkUnresolvedMoveAddrInst *markMoveAddr,
   // Ok, we know our original lexical alloc_stack is not written to in between
   // the load/store. Move the mark_move_addr onto the lexical alloc_stack.
   LLVM_DEBUG(llvm::dbgs() << "        Doing loadable var!\n");
-  markMoveAddr->setSrc(originalASI);
+  markMoveAddr->setSrc(operand);
   return true;
 }
 
@@ -239,13 +243,13 @@ static bool tryConvertSimpleMoveFromAllocStackTemporary(
   }
 
   // If we have a store [init], see if our src is a load [copy] from an
-  // alloc_stack that is lexical var. In this case, we want to move our
-  // mark_unresolved_move_addr onto that lexical var. This pattern occurs due to
-  // SILGen always loading loadable values from memory when retrieving an
-  // RValue. Calling _move then since _move is generic forces the value to be
-  // re-materialized into an alloc_stack. In this example remembering that
-  // mark_unresolved_move_addr is a copy_addr [init], we try to move the MUMA
-  // onto the original lexical alloc_stack.
+  // alloc_stack that is lexical var or an inout argument. In this case, we want
+  // to move our mark_unresolved_move_addr onto that lexical var. This pattern
+  // occurs due to SILGen always loading loadable values from memory when
+  // retrieving an RValue. Calling _move then since _move is generic forces the
+  // value to be re-materialized into an alloc_stack. In this example
+  // remembering that mark_unresolved_move_addr is a copy_addr [init], we try to
+  // move the MUMA onto the original lexical alloc_stack.
   if (tryHandlingLoadableVarMovePattern(markMoveAddr, si, aa))
     return true;
 

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -335,8 +335,7 @@ bool MoveKillsCopyableValuesChecker::check() {
   SmallSetVector<SILValue, 32> valuesToCheck;
 
   for (auto *arg : fn->getEntryBlock()->getSILFunctionArguments()) {
-    if (arg->getOwnershipKind() == OwnershipKind::Guaranteed ||
-        arg->getOwnershipKind() == OwnershipKind::Owned)
+    if (arg->getOwnershipKind() == OwnershipKind::Owned)
       valuesToCheck.insert(arg);
   }
 

--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -13,6 +13,7 @@ public class Klass {}
 func consumingUse<T>(_ k: __owned T) {}
 var booleanValue: Bool { false }
 func nonConsumingUse<T>(_ k: T) {}
+func exchangeUse<T>(_ k: __owned T) -> T { k }
 
 ///////////
 // Tests //
@@ -92,4 +93,107 @@ public func performMoveOnVarMultiBlockError2<T>(_ p: T) {
 
     x = p
     nonConsumingUse(x)
+}
+
+public func performMoveOnInOut<T>(_ p: inout T) { // expected-error {{'p' used after being moved}}
+    let buf = _move(p) // expected-note {{move here}}
+    let _ = buf
+} // expected-note {{use here}}
+
+public func performMoveOnInOut2<T>(_ p: inout T, _ p2: T) {
+    let buf = _move(p)
+    let _ = buf
+    p = p2
+}
+
+struct S<T> {
+    var buffer: T?
+
+    mutating func appendNoError() {
+        let b = _move(self).buffer
+        let maybeNewB = exchangeUse(b)
+        self = .init(buffer: maybeNewB)
+    }
+
+    mutating func appendError() { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer // expected-note {{move here}}
+        let _ = b
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingNoError1(_ f: () throws -> ()) throws {
+        let b = _move(self).buffer
+        let maybeNewB = exchangeUse(b)
+        // We have to initialize self before we call try since otherwise we will
+        // not initialize self along the throws path.
+        self = .init(buffer: maybeNewB)
+        try f()
+    }
+
+    mutating func appendThrowingNoError2(_ f: () throws -> ()) {
+        do {
+            let b = _move(self).buffer
+            try f()
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+        } catch {
+            self = .init(buffer: nil)
+        }
+    }
+
+    // In this case, since we initialize self before the try point, we will have
+    // re-initialized self before hitting either the code after the try that is
+    // inline or the catch block.
+    mutating func appendThrowingNoError3(_ f: () throws -> ()) {
+        do {
+            let b = _move(self).buffer
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+            try f()
+        } catch {
+        }
+    }
+
+    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer // expected-note {{move here}}
+        let maybeNewB = exchangeUse(b)
+        try f() // expected-note {{use here}}
+        self = .init(buffer: maybeNewB)
+    }
+
+
+    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer // expected-note {{move here}}
+        let maybeNewB = exchangeUse(b)
+        let _ = maybeNewB
+        try f() // expected-note {{use here}}
+    }
+
+    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer // expected-note {{move here}}
+            let _ = b
+            try f()
+        } catch {
+            self = .init(buffer: nil)
+        }
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer // expected-note {{move here}}
+            try f()
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+        } catch {
+        }
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer // expected-note {{move here}}
+            let _ = b
+            try f()
+        } catch {
+        }
+    } // expected-note {{use here}}
 }

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -14,6 +14,7 @@ func consumingUse(_ k: __owned Klass) {}
 var booleanValue: Bool { false }
 var booleanValue2: Bool { false }
 func nonConsumingUse(_ k: Klass) {}
+func exchangeUse(_ k: Klass) -> Klass { k }
 
 ///////////
 // Klassests //
@@ -164,4 +165,108 @@ public func performMoveOnLaterDefinedInit2(_ p: Klass) {
     }
     nonConsumingUse(x)
     let _ = _move(x)
+}
+
+public func performMoveOnInOut(_ p: inout Klass) { // expected-error {{'p' used after being moved}}
+    let buf = _move(p) // expected-note {{move here}}
+    let _ = buf
+} // expected-note {{use here}}
+
+public func performMoveOnInOut2(_ p: inout Klass, _ p2: Klass) {
+    let buf = _move(p)
+    p = p2
+    let _ = buf
+}
+
+// Mutating self is an inout argument.
+struct S {
+    var buffer: Klass?
+
+    mutating func appendNoError() {
+        let b = _move(self).buffer!
+        let maybeNewB = exchangeUse(b)
+        self = .init(buffer: maybeNewB)
+    }
+
+    mutating func appendError() { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer // expected-note {{move here}}
+        let _ = b
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingNoError1(_ f: () throws -> ()) throws {
+        let b = _move(self).buffer!
+        let maybeNewB = exchangeUse(b)
+        // We have to initialize self before we call try since otherwise we will
+        // not initialize self along the throws path.
+        self = .init(buffer: maybeNewB)
+        try f()
+    }
+
+    mutating func appendThrowingNoError2(_ f: () throws -> ()) {
+        do {
+            let b = _move(self).buffer!
+            try f()
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+        } catch {
+            self = .init(buffer: nil)
+        }
+    }
+
+    // In this case, since we initialize self before the try point, we will have
+    // re-initialized self before hitting either the code after the try that is
+    // inline or the catch block.
+    mutating func appendThrowingNoError3(_ f: () throws -> ()) {
+        do {
+            let b = _move(self).buffer!
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+            try f()
+        } catch {
+        }
+    }
+
+    mutating func appendThrowingError0(_ f: () throws -> ()) throws { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer! // expected-note {{move here}}
+        let maybeNewB = exchangeUse(b)
+        try f() // expected-note {{use here}}
+        self = .init(buffer: maybeNewB)
+    }
+
+
+    mutating func appendThrowingError1(_ f: () throws -> ()) throws { // expected-error {{'self' used after being moved}}
+        let b = _move(self).buffer! // expected-note {{move here}}
+        let maybeNewB = exchangeUse(b)
+        let _ = maybeNewB
+        try f() // expected-note {{use here}}
+    }
+
+    mutating func appendThrowingError2(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer // expected-note {{move here}}
+            let _ = b
+            try f()
+        } catch {
+            self = .init(buffer: nil)
+        }
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingError3(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer! // expected-note {{move here}}
+            try f()
+            let maybeNewB = exchangeUse(b)
+            self = .init(buffer: maybeNewB)
+        } catch {
+        }
+    } // expected-note {{use here}}
+
+    mutating func appendThrowingError4(_ f: () throws -> ()) { // expected-error {{'self' used after being moved}}
+        do {
+            let b = _move(self).buffer // expected-note {{move here}}
+            let _ = b
+            try f()
+        } catch {
+        }
+    } // expected-note {{use here}}
 }

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -22,7 +22,7 @@ func nonConsumingUse(_ k: Klass) {}
 // Let + Non Consuming Use
 //
 
-public func simpleLinearUse(_ x: Klass) {
+public func simpleLinearUse(_ x: __owned Klass) {
     let y = x // expected-error {{'y' used after being moved}}
     let _ = _move(y) // expected-note {{move here}}
     nonConsumingUse(y) // expected-note {{use here}}
@@ -110,24 +110,23 @@ public func conditionalBadConsumingUseLoop(_ x: Klass) {
 //===
 // Parameters
 
-// This is ok, no uses after.
-public func simpleMoveOfParameter(_ x: Klass) -> () {
+public func simpleMoveOfParameter(_ x: __owned Klass) -> () {
     let _ = _move(x)
 }
 
-public func errorSimpleMoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorSimpleMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     let _ = _move(x) // expected-note {{use here}}
 }
 
-public func errorSimple2MoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorSimple2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     let _ = consumingUse(x) // expected-note {{use here}}
 }
 
 // TODO: I wonder if we could do better for the 2nd error. At least we tell the
 // user it is due to the loop.
-public func errorLoopMultipleMove(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorLoopMultipleMove(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
                                                       // expected-error @-1 {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     for _ in 0..<1024 {
@@ -137,26 +136,26 @@ public func errorLoopMultipleMove(_ x: Klass) -> () { // expected-error {{'x' us
     }
 }
 
-public func errorLoopMoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorLoopMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     for _ in 0..<1024 {
         consumingUse(x) // expected-note {{use here}}
     }
 }
 
-public func errorLoop2MoveOfParameter(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorLoop2MoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     for _ in 0..<1024 {
         nonConsumingUse(x) // expected-note {{use here}}
     }
 }
 
-public func errorSimple2MoveOfParameterNonConsume(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorSimple2MoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     let _ = nonConsumingUse(x) // expected-note {{use here}}
 }
 
-public func errorLoopMoveOfParameterNonConsume(_ x: Klass) -> () { // expected-error {{'x' used after being moved}}
+public func errorLoopMoveOfParameterNonConsume(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     for _ in 0..<1024 {
         nonConsumingUse(x) // expected-note {{use here}}
@@ -167,14 +166,14 @@ public func errorLoopMoveOfParameterNonConsume(_ x: Klass) -> () { // expected-e
 // Pattern Match Lets //
 ////////////////////////
 
-public func patternMatchIfCaseLet(_ x: Klass?) {
+public func patternMatchIfCaseLet(_ x: __owned Klass?) {
     if case let .some(y) = x { // expected-error {{'y' used after being moved}}
         let _ = _move(y) // expected-note {{move here}}
         nonConsumingUse(y) // expected-note {{use here}}
     }
 }
 
-public func patternMatchSwitchLet(_ x: Klass?) {
+public func patternMatchSwitchLet(_ x: __owned Klass?) {
     switch x {
     case .none:
         break
@@ -184,7 +183,7 @@ public func patternMatchSwitchLet(_ x: Klass?) {
     }
 }
 
-public func patternMatchSwitchLet2(_ x: (Klass?, Klass?)?) {
+public func patternMatchSwitchLet2(_ x: __owned (Klass?, Klass?)?) {
     switch x {
     case .some((.some(let y), _)): // expected-error {{'y' used after being moved}}
         let _ = _move(y) // expected-note {{move here}}
@@ -194,7 +193,7 @@ public func patternMatchSwitchLet2(_ x: (Klass?, Klass?)?) {
     }
 }
 
-public func patternMatchSwitchLet3(_ x: (Klass?, Klass?)?) { // expected-error {{'x' used after being moved}}
+public func patternMatchSwitchLet3(_ x: __owned (Klass?, Klass?)?) { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     switch x { // expected-note {{use here}}
     case .some((.some(_), .some(let z))): // expected-error {{'z' used after being moved}}
@@ -219,11 +218,10 @@ public struct Pair {
 // have invalidated a part of pair. We can be less restrictive in the future.
 //
 // TODO: Why are we emitting two uses here.
-public func performMoveOnOneEltOfPair(_ p: Pair) { // expected-error {{'p' used after being moved}}
-    let _ = p.z // Make sure we don't crash when we access a trivial value from Pair.
-    let _ = _move(p.x) // expected-note {{move here}}
-    nonConsumingUse(p.y) // expected-note {{use here}}
-                         // expected-note @-1 {{use here}}
+public func performMoveOnOneEltOfPair(_ p: __owned Pair) {
+    let _ = p.z
+    let _ = _move(p.x) // expected-error {{_move applied to value that the compiler does not support checking}}
+    nonConsumingUse(p.y)
 }
 
 public class KlassPair {
@@ -233,7 +231,7 @@ public class KlassPair {
 
 // TODO: Emit a better error here! We should state that we are applying _move to
 // a class field and that is illegal.
-public func performMoveOnOneEltOfKlassPair(_ p: KlassPair) {
+public func performMoveOnOneEltOfKlassPair(_ p: __owned KlassPair) {
     let _ = _move(p.x) // expected-error {{_move applied to value that the compiler does not support checking}}
     nonConsumingUse(p.y)
 }


### PR DESCRIPTION
This PR is doing a few things:

1. I added a few new tests.
2. I disabled support in the object move checker for guaranteed arguments. We do not support this for address only types, so we should be consistent.
3. I added support for moving out of inout params with a diagnostic to make sure before end of function one re-initializes the parameter. It works also with self in mutating methods.