### PR TITLE
[TypeChecker] Fix two last warnings

### DIFF
--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -70,8 +70,6 @@ private:
         IncludeDerivedRequirements(0), IncludeProtocolExtensionMembers(0) {}
 
 public:
-  LookupState(const LookupState &) = default;
-
   static LookupState makeQualified() {
     LookupState Result;
     Result.IsQualified = 1;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -71,14 +71,12 @@ using namespace swift;
 /// file.
 static void checkInheritanceClause(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion) {
-  const DeclContext *DC;
   ArrayRef<InheritedEntry> inheritedClause;
   const ExtensionDecl *ext = nullptr;
   const TypeDecl *typeDecl = nullptr;
   const Decl *decl;
   if ((ext = declUnion.dyn_cast<const ExtensionDecl *>())) {
     decl = ext;
-    DC = ext;
 
     inheritedClause = ext->getInherited();
 
@@ -95,12 +93,6 @@ static void checkInheritanceClause(
   } else {
     typeDecl = declUnion.get<const TypeDecl *>();
     decl = typeDecl;
-    if (auto nominal = dyn_cast<NominalTypeDecl>(typeDecl)) {
-      DC = nominal;
-    } else {
-      DC = typeDecl->getDeclContext();
-    }
-
     inheritedClause = typeDecl->getInherited();
   }
 


### PR DESCRIPTION
- Unused variable in `checkInheritanceClause`
- Deprecated implicit copy assignment operator in `LookupState`

Resolves: rdar://84035249

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
