### PR TITLE
Add missing `else` to guard statements in code listing

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -32,7 +32,7 @@ import Swift
 /// If you need more control or only a few results,
 /// you can call `next()` directly:
 ///
-///     guard let first = await group.next() {
+///     guard let first = await group.next() else {
 ///         group.cancelAll()
 ///         return 0
 ///     }
@@ -106,7 +106,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// If you need more control or only a few results,
 /// you can call `next()` directly:
 ///
-///     guard let first = await group.next() {
+///     guard let first = await group.next() else {
 ///         group.cancelAll()
 ///         return 0
 ///     }


### PR DESCRIPTION
Fixes rdar://84895831

Cherry-pick of https://github.com/apple/swift/pull/40019