### PR TITLE
Fixed flag checking for lexical borrow scopes.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1495,7 +1495,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   }
 
   if (Args.hasArg(OPT_enable_experimental_move_only) &&
-      (enableLexicalBorrowScopesFlag.getValueOr(false))) {
+      !enableLexicalBorrowScopesFlag.getValueOr(true)) {
     // Error if move-only is enabled and lexical borrow scopes--on which it
     // depends--has been disabled.
     Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
@@ -1505,7 +1505,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   }
 
   if (Args.hasArg(OPT_enable_experimental_move_only) &&
-      (enableLexicalLifetimesFlag.getValueOr(false))) {
+      !enableLexicalLifetimesFlag.getValueOr(true)) {
     // Error if move-only is enabled and lexical lifetimes--on which it
     // depends--has been disabled.
     Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,


### PR DESCRIPTION
Previously the following pairs were prohibited incorrectly:
- -enable-lexical-borrow-scopes=true, -enable-experimental-move-only
- -enable-lexical-lifetimes=true, -enable-experimental-move-only
and the following pairs were allowed incorrectly:
- -enable-lexical-borrow-scopes=false, -enable-experimental-move-only
- -enable-lexical-lifetimes=false, -enable-experimental-move-only
Here, that's fixed.  The first two pairs are allowed and the second two pairs prohibited.
