### PR TITLE
[move-function] After emitting an error for a move [allows_diagnostic], remove allows_diagnostic flag.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -458,6 +458,7 @@ class MoveKillsCopyableValuesCheckerPass : public SILFunctionTransform {
             auto diag = diag::
                 sil_movekillscopyablevalue_move_applied_to_unsupported_move;
             diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
+            mvi->setAllowsDiagnostics(false);
           }
         }
       }


### PR DESCRIPTION
Just a small thing I noticed.
