### PR TITLE
use `compare_exchange_strong` to protect agianst spurious failures

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -394,14 +394,14 @@ public:
   ///
   /// This is used to atomically perform a waiting task completion.
   bool statusCompletePendingReadyWaiting(GroupStatus &old) {
-    return status.compare_exchange_weak(
+    return status.compare_exchange_strong(
       old.status, old.completingPendingReadyWaiting().status,
       /*success*/ std::memory_order_relaxed,
       /*failure*/ std::memory_order_relaxed);
   }
 
   bool statusCompletePendingReady(GroupStatus &old) {
-    return status.compare_exchange_weak(
+    return status.compare_exchange_strong(
       old.status, old.completingPendingReady().status,
       /*success*/ std::memory_order_relaxed,
       /*failure*/ std::memory_order_relaxed);
@@ -588,7 +588,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
       assert(assumed.pendingTasks() && "offered to group with no pending tasks!");
       // We are the "first" completed task to arrive,
       // and since there is a task waiting we immediately claim and complete it.
-      if (waitQueue.compare_exchange_weak(
+      if (waitQueue.compare_exchange_strong(
           waitingTask, nullptr,
           /*success*/ std::memory_order_release,
           /*failure*/ std::memory_order_acquire) &&
@@ -755,7 +755,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
 
     auto assumedStatus = assumed.status;
     auto newStatus = TaskGroupImpl::GroupStatus{assumedStatus};
-    if (status.compare_exchange_weak(
+    if (status.compare_exchange_strong(
         assumedStatus, newStatus.completingPendingReadyWaiting().status,
         /*success*/ std::memory_order_relaxed,
         /*failure*/ std::memory_order_acquire)) {
@@ -821,7 +821,7 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
       waitingTask->flagAsSuspended();
     }
     // Put the waiting task at the beginning of the wait queue.
-    if (waitQueue.compare_exchange_weak(
+    if (waitQueue.compare_exchange_strong(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {


### PR DESCRIPTION
A `compare_exchange_weak` can spuriously return false, regardless of
whether a concurrent access happened. This was causing a null-pointer
dereference in TaskGroupImpl::poll in a narrow circumstance.

The dereference failure only appears when using the `arm64`
slice of the runtime library, since Clang will use `ldxr/stxr` for
synchronization on such targets. The weak form does not retry on a
spurious failure, but the strong version will.

resolves rdar://84192672
