### PR TITLE
[Concurrency] Fix memory_order for not apple platform

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -120,7 +120,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (numericPriority >= globalQueueCacheCount)
     swift_Concurrency_fatalError(0, "invalid job priority %#zx");
 
-#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || !defined(__APPLE__)
   std::memory_order loadOrder = std::memory_order_acquire;
 #else
   std::memory_order loadOrder = std::memory_order_relaxed;


### PR DESCRIPTION
I probably found a small bug.

At https://github.com/apple/swift/pull/39288 , it introduces switching concurrent queue and the `loadOrder` has changed a bit.

At https://github.com/apple/swift/pull/39732 , it introduces considering not apple platform. 
but here, I think it is forgotten to change `loadOrder` according to #39288.

I think this is not intentional so this PR align the conditions of the `#if` expression