### PR TITLE
Eliminate priority inversions in the metadata completion runtime

### DIFF
--- a/include/swift/Runtime/AtomicWaitQueue.h
+++ b/include/swift/Runtime/AtomicWaitQueue.h
@@ -1,0 +1,431 @@
+//===--- AtomicWaitQueue.h - A "condition variable" for atomics -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the AtomicWaitQueue class template, which can be
+// used to create a sort of condition variable associated with an atomic
+// object which clients can wait on until some condition is satisfied.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_ATOMICWAITQUEUE_H
+#define SWIFT_RUNTIME_ATOMICWAITQUEUE_H
+
+#include "swift/Runtime/Mutex.h"
+#include <assert.h>
+
+namespace swift {
+
+/// A wait queue designed to be used with an atomic object.  Somewhat
+/// like a condition variable, it can be used to cause threads to block.
+/// Unlike a condition variable, the queue is created on a particular
+/// thread, called the worker thread, which is responsible for unblocking
+/// all the waiting threads.  This means that wait queues can be used
+/// without introducing priority inversions.
+///
+/// Wait queues are implemented as a shared object that stores a lock
+/// held by the worker thread.  Becoming the worker thread therefore
+/// requires an allocation.  Furthermore, because a shared reference
+/// cannot be atomically read out of an atomic, a "global" lock (in
+/// contrast with internal lock of the wait queue) must be acquired
+/// around any change of the atomic's queue reference.  All of this
+/// is suboptimal but unavoidable without introducing deeper problems.
+/// The global lock could be avoided with generational approaches,
+/// but these are not portably available.
+///
+/// AtomicWaitQueue imposes no constraints on the atomic object that
+/// holds the wait queue reference, except that loads of the reference
+/// which lead to uses by AtomicWaitQueue should happen-after the store
+/// which originally set the reference in the atomic ("published" it).
+/// Loads of the reference must happen while holding the global lock,
+/// so changes to the reference must either also happen only while
+/// holding the lock or must be release-ordered (and loads for AWQ's
+/// purposes must therefore be acquires).
+///
+/// The API of this class attempts to tightly constrain the use of
+/// the wait queue to avoid predictable errors in use.  The worker
+/// thread creates a Worker object and then performs calls on it to
+/// become the worker and then finish the work.
+///
+/// This class is a CRTP superclass, and clients should inherit from it:
+///
+/// ```
+///   class MyQueue : public AtomicWaitQueue<MyQueue> {
+///     ...
+///   };
+/// ```
+template <class Impl, class GlobalLockType = Mutex>
+class AtomicWaitQueue {
+  Impl &asImpl() { return static_cast<Impl&>(*this); }
+
+  /// The reference count; only manipulated under the associated
+  /// global lock.
+  size_t referenceCount = 1;
+
+  /// The lock on which clients will wait.  This is not the global lock.
+  Mutex WaitQueueLock;
+
+  /// Add a reference to this queue.  Must be called while holding the
+  /// globaal lock.
+  void retain_locked() {
+    referenceCount++;
+  }
+
+  /// Drop a reference to this queue.  Must be called while holding the
+  /// global lock and while *not* holding the wait queue lock.
+  void release_locked() {
+    if (referenceCount == 1) {
+      delete &asImpl();
+    } else {
+      referenceCount--;
+    }
+  }
+
+  void wait(GlobalLockType &globalLock) {
+    // Attempt to acquire the queue lock and then immediately discard it.
+    WaitQueueLock.withLock([]{});
+
+    // Acquire the global lock so that we can drop the reference count.
+    globalLock.withLock([&]{
+      release_locked();
+    });
+  }
+
+public:
+  /// Is this queue uniquely referenced?  This should only be called
+  /// under the global lock.
+  bool isUniquelyReferenced_locked() const {
+    return referenceCount == 1;
+  }
+
+  /// An RAII helper class for signalling that the current thread is a
+  /// worker thread which has acquired the lock.
+  ///
+  /// The expected use pattern is something like:
+  ///
+  /// ```
+  ///   MyQueue::Worker worker(myGlobalLock);
+  ///   auto oldStatus = myAtomic.load(std::memory_order_acquire);
+  ///   while (true) {
+  ///     if (oldStatus.isDone()) return;
+  ///
+  ///     // Try to publish the wait queue.  If this succeeds, we've become
+  ///     // the worker thread.
+  ///     bool published = worker.tryPublishQueue([&] {
+  ///       auto newStatus = oldStatus.withLock(worker.createQueue());
+  ///       return myAtomic.compare_exchange_weak(oldStatus, newStatus,
+  ///                                 /*success*/ std::memory_order_release,
+  ///                                 /*failure*/ std::memory_order_acquire);
+  ///     });
+  ///     if (!published) continue;
+  ///
+  ///     // Do the actual work here.
+  ///
+  ///     // "Unpublish" the queue from the the atomic.
+  ///     while (true) {
+  ///       auto newStatus = oldStatus.withDone(true);
+  ///       if (myAtomic.compare_exchange_weak(oldStatus, newStatus,
+  ///                                 /*success*/ std::memory_order_release,
+  ///                                 /*failure*/ std::memory_order_acquire))
+  ///         break;
+  ///     }
+  ///     worker.finishAndUnpublishQueue([]{});
+  ///     return;
+  ///   }
+  /// ```
+  class Worker {
+  protected:
+    typename Impl::Worker &asImpl() {
+      return static_cast<typename Impl::Worker&>(*this);
+    }
+
+    GlobalLockType &GlobalLock;
+
+    /// The queue object.  The current thread always holds the lock on
+    /// this if it's non-null.
+    Impl *CurrentQueue = nullptr;
+
+    /// True if the queue has been published and may have other references
+    /// to it.
+    bool Published = false;
+  public:
+    explicit Worker(GlobalLockType &globalLock) : GlobalLock(globalLock) {}
+
+    Worker(const Worker &) = delete;
+    Worker &operator=(const Worker &) = delete;
+
+    ~Worker() {
+      assert(!Published &&
+             "should not allow Worker object to go out of scope after "
+             "publishing without somehow finishing the work");
+
+      // If we created the queue but never published it, destroy it.
+      if (CurrentQueue) {
+        CurrentQueue->WaitQueueLock.unlock();
+        delete CurrentQueue;
+      }
+    }
+
+    /// Is this thread the worker thread, meaning that it holds the
+    /// lock on a published queue?
+    ///
+    /// Generally, this should only be used for assertions.
+    bool isWorkerThread() const {
+      return Published;
+    }
+
+    /// Given that this thread is the worker thread, return the queue
+    /// that's been created and published for it.
+    Impl *getPublishedQueue() const {
+      assert(CurrentQueue && Published);
+      return CurrentQueue;
+    }
+
+    /// Given that this thread is not (yet) the worker thread, create
+    /// a queue that can be published to make this the worker thread.
+    /// Usually this will be called before or during `tryPublishQueue()`.
+    ///
+    /// The Worker object takes ownership of the queue until it's
+    /// published, so you can safely call this even if publishing
+    /// might fail.  Note that the same queue will be returned on
+    /// successive invocations, so take care if the arguments might
+    /// change during the loop.
+    template <class... Args>
+    Impl *createQueue(Args &&...args) {
+      assert(!Published);
+      if (!CurrentQueue)
+        CurrentQueue = asImpl().createNewQueue(std::forward<Args>(args)...);
+      return CurrentQueue;
+    }
+
+    /// Given that this Worker object owns a queue that was created
+    /// with `createQueue()` but not yet published, flag that the
+    /// queue been published, transferring ownership to the atomic;
+    /// this is now the worker thread.
+    void flagQueueIsPublished(Impl *publishedQueue) {
+      assert(CurrentQueue);
+      assert(CurrentQueue == publishedQueue);
+      assert(!Published);
+      Published = true;
+    }
+
+    /// Flag that the created queue has been published.  Necessary
+    /// because of some awkward abstraction in MetadataCache;
+    /// generally prefer to use flagQueueIsPublished.
+    void flagCreatedQueueIsPublished() {
+      assert(CurrentQueue);
+      assert(!Published);
+      Published = true;
+    }
+
+    /// Try to publish a queue.  The queue will be passed to the
+    /// argument function, which should return true if the queue was
+    /// published.  Do not also call `flagQueueIsPublished` when
+    /// using this.
+    template <class Fn>
+    bool tryPublishQueue(Fn &&fn) {
+      return GlobalLock.withLock([&]{
+        if (fn(CurrentQueue))
+          asImpl().flagQueueIsPublished(CurrentQueue);
+        return Published;
+      });
+    }
+
+    /// Given that this is the worker thread, create a replacement
+    /// queue.  This should be used with `maybeReplaceQueue`.  The
+    /// caller owns the replacement queue until it publishes it as
+    /// a replacement.
+    template <class... Args>
+    Impl *createReplacementQueue(Args &&...args) {
+      assert(CurrentQueue && Published);
+      return asImpl().createNewQueue(std::forward<Args>(args)...);
+    }
+
+    /// Given that the queue has been published and so we've become
+    /// the worker thread, possibly replace the queue with a new
+    /// queue returned by the given function.  The function will be
+    /// called under the global lock, so it is legal to call
+    /// `isUniquelyReferenced_locked()` on the current queue.
+    ///
+    /// If replacement is required, the function should create it
+    /// with `createReplacementQueue()`.  The replacement queue should
+    /// published before returning from the function.  The reference
+    /// to the old queue will be destroyed, and pointers to it
+    /// should be considered invalidated.  If the function returns
+    /// null, the original queue is left in place.
+    template <class Fn>
+    void maybeReplaceQueue(Fn &&fn) {
+      assert(CurrentQueue && Published);
+
+      GlobalLock.withLock([&] {
+        if (auto newQueue = fn()) {
+          assert(newQueue != CurrentQueue &&
+                 "replacement queue is current queue?");
+          CurrentQueue->WaitQueueLock.unlock();
+          CurrentQueue->release_locked();
+          CurrentQueue = newQueue;
+        }
+      });
+    }
+
+    /// Given that the queue has been published and so we've become
+    /// the worker thread, finish the work, calling the given function
+    /// while holding the global lock.
+    ///
+    /// The actual unpublishing doesn't have to happen during this
+    /// operation, but it might help to create a general rule that
+    /// all modifications are done while holding the lock.  (The lock
+    /// has to be acquired anyway in order to drop the reference to
+    /// the queue.)
+    template <class Fn>
+    void finishAndUnpublishQueue(Fn &&fn) {
+      assert(CurrentQueue && Published);
+      GlobalLock.withLock([&] {
+        fn();
+        CurrentQueue->WaitQueueLock.unlock();
+        CurrentQueue->release_locked();
+      });
+      Published = false;
+      CurrentQueue = nullptr;
+    }
+
+    /// A helper class for `withLock`.
+    class Operation {
+      friend class Worker;
+      Worker &TheWorker;
+      Impl *QueueToAwait = nullptr;
+
+      Operation(Worker &worker) : TheWorker(worker) {}
+
+      Operation(const Operation &) = delete;
+      Operation &operator=(const Operation &) = delete;
+
+    public:
+      /// Tell the worker to wait on the given queue and then call
+      /// the callback function again.
+      void waitAndRepeat(Impl *queue) {
+        // Take a reference to the queue.
+        queue->retain_locked();
+
+        // Set the queue to await.
+        assert(!QueueToAwait);
+        QueueToAwait = queue;
+      }
+
+      /// Create a wait queue that can be published.
+      Impl *createQueue() {
+        return TheWorker.asImpl().createQueue();
+      }
+
+      /// Record that we've published the wait queue.
+      void flagQueueIsPublished(Impl *queue) {
+        TheWorker.asImpl().flagQueueIsPublished(queue);
+      }
+    };
+
+    /// Perform a complex operation under the global lock by making
+    /// calls on the Operation object that is passed to the function.
+    template <class Fn>
+    void withLock(Fn &&fn) {
+      assert(!Published);
+
+      Operation operation(*this);
+      Impl *queueToDrop = nullptr;
+
+      while (true) {
+        GlobalLock.withLock([&] {
+          // If we have an awaited queue from a previous iteration,
+          // drop the reference to it now that we're holding the lock.
+          if (queueToDrop) {
+            queueToDrop->release_locked();
+          }
+
+          // Perform the operation.
+          fn(operation);
+        });
+
+        // We're done until waitAndRepeat was called.
+        queueToDrop = operation.QueueToAwait;
+        if (!queueToDrop)
+          return;
+
+        // Wait on the queue and then repeat the operation.
+        // We'll drop the reference count when we get the lock again.
+        operation.QueueToAwait = nullptr;
+        queueToDrop->WaitQueueLock.withLock([]{});
+      }
+    }
+
+  private:
+    template <class... Args>
+    static Impl *createNewQueue(Args &&...args) {
+      auto queue = new Impl(std::forward<Args>(args)...);
+      queue->WaitQueueLock.lock();
+      return queue;
+    }
+  };
+
+  /// An RAII helper class for waiting for the worker thread to finish.
+  ///
+  /// The expected use pattern is:
+  ///
+  /// ```
+  ///   MyQueue::Waiter waiter(myGlobalLock);
+  ///
+  ///   auto status = myAtomic.load(std::memory_order_acquire);
+  ///   while (status.isLocked()) {
+  ///     if (waiter.tryReloadAndWait([&] {
+  ///       status = myAtomic.load(std::memory_order_acquire);
+  ///       return (status.isLocked() ? status.getLock() : nullptr);
+  ///     }) {
+  ///       status = myAtomic.load(std::memory_order_acquire);
+  ///     }
+  ///   }
+  /// ```
+  class Waiter {
+    GlobalLockType &GlobalLock;
+  public:
+    explicit Waiter(GlobalLockType &globalLock) : GlobalLock(globalLock) {}
+
+    /// Acquire the global lock and call the given function.  If it
+    /// returns a wait queue, wait on that queue and return true;
+    /// otherwise, return false.
+    template <class Fn>
+    bool tryReloadAndWait(Fn &&fn) {
+      Impl *queue;
+      GlobalLock.withLock([&] {
+        queue = fn();
+        if (queue) {
+          queue->retain_locked();
+        }
+      });
+
+      if (!queue) return false;
+
+      // Wait for the queue lock.
+      queue->WaitQueueLock.withLock([]{});
+
+      // Release the queue.
+      GlobalLock.withLock([&] {
+        queue->release_locked();
+      });
+
+      return true;
+    }
+  };
+};
+
+template <class GlobalLockType = Mutex>
+struct SimpleAtomicWaitQueue
+  : AtomicWaitQueue<SimpleAtomicWaitQueue<GlobalLockType>, GlobalLockType> {};
+
+} // end namespace swift
+#endif

--- a/include/swift/Runtime/Mutex.h
+++ b/include/swift/Runtime/Mutex.h
@@ -19,6 +19,7 @@
 #define SWIFT_RUNTIME_MUTEX_H
 
 #include <type_traits>
+#include <utility>
 
 #if __has_include(<unistd.h>)
 #include <unistd.h>
@@ -211,10 +212,10 @@ public:
     ///
     /// Precondition: Mutex not held by this thread, undefined otherwise.
     template <typename CriticalSection>
-    auto withLock(CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+    auto withLock(CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       ScopedLock guard(*this);
-      return criticalSection();
+      return std::forward<CriticalSection>(criticalSection)();
     }
 
     /// Acquires lock before calling the supplied critical section. If critical
@@ -242,7 +243,7 @@ public:
     /// Precondition: Mutex not held by this thread, undefined otherwise.
     template <typename CriticalSection>
     void withLockOrWait(ConditionVariable &condition,
-                        CriticalSection criticalSection) {
+                        CriticalSection &&criticalSection) {
       withLock([&] {
         while (!criticalSection()) {
           wait(condition);
@@ -266,11 +267,11 @@ public:
     /// Precondition: Mutex not held by this thread, undefined otherwise.
     template <typename CriticalSection>
     auto withLockThenNotifyOne(ConditionVariable &condition,
-                               CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+                               CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       return withLock([&] {
         ScopedNotifyOne guard(condition);
-        return criticalSection();
+        return std::forward<CriticalSection>(criticalSection)();
       });
     }
 
@@ -290,11 +291,11 @@ public:
     /// Precondition: Mutex not held by this thread, undefined otherwise.
     template <typename CriticalSection>
     auto withLockThenNotifyAll(ConditionVariable &condition,
-                               CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+                               CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       return withLock([&] {
         ScopedNotifyAll guard(condition);
-        return criticalSection();
+        return std::forward<CriticalSection>(criticalSection)();
       });
     }
 
@@ -389,10 +390,10 @@ public:
   ///
   /// Precondition: Mutex not held by this thread, undefined otherwise.
   template <typename CriticalSection>
-  auto withLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     ScopedLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
   /// A stack based object that locks the supplied mutex on construction
@@ -613,10 +614,10 @@ public:
   ///
   /// Precondition: ReadWriteLock not held by this thread, undefined otherwise.
   template <typename CriticalSection>
-  auto withReadLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withReadLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     ScopedReadLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
   /// Acquires write lock before calling the supplied critical section and
@@ -633,10 +634,10 @@ public:
   ///
   /// Precondition: ReadWriteLock not held by this thread, undefined otherwise.
   template <typename CriticalSection>
-  auto withWriteLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withWriteLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     ScopedWriteLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
 private:
@@ -683,7 +684,7 @@ public:
 #if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
     constexpr
 #endif
-        StaticMutex()
+    StaticMutex()
         : Handle(MutexPlatformHelper::conditionStaticInit()) {
     }
 
@@ -706,16 +707,16 @@ public:
 
     /// See Mutex::lock
     template <typename CriticalSection>
-    auto withLock(CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+    auto withLock(CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       ScopedLock guard(*this);
-      return criticalSection();
+      return std::forward<CriticalSection>(criticalSection)();
     }
 
     /// See Mutex::withLockOrWait
     template <typename CriticalSection>
     void withLockOrWait(StaticConditionVariable &condition,
-                        CriticalSection criticalSection) {
+                        CriticalSection &&criticalSection) {
       withLock([&] {
         while (!criticalSection()) {
           wait(condition);
@@ -726,22 +727,22 @@ public:
     /// See Mutex::withLockThenNotifyOne
     template <typename CriticalSection>
     auto withLockThenNotifyOne(StaticConditionVariable &condition,
-                               CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+                               CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       return withLock([&] {
         StaticConditionVariable::ScopedNotifyOne guard(condition);
-        return criticalSection();
+        return std::forward<CriticalSection>(criticalSection)();
       });
     }
 
     /// See Mutex::withLockThenNotifyAll
     template <typename CriticalSection>
     auto withLockThenNotifyAll(StaticConditionVariable &condition,
-                               CriticalSection criticalSection)
-        -> decltype(criticalSection()) {
+                               CriticalSection &&criticalSection)
+        -> decltype(std::forward<CriticalSection>(criticalSection)()) {
       return withLock([&] {
         StaticConditionVariable::ScopedNotifyAll guard(condition);
-        return criticalSection();
+        return std::forward<CriticalSection>(criticalSection)();
       });
     }
 
@@ -779,7 +780,7 @@ public:
 #if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
   constexpr
 #endif
-      StaticMutex()
+  StaticMutex()
       : Handle(MutexPlatformHelper::staticInit()) {
   }
 
@@ -794,10 +795,10 @@ public:
 
   /// See Mutex::lock
   template <typename CriticalSection>
-  auto withLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     ScopedLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
   /// A stack based object that locks the supplied mutex on construction
@@ -830,7 +831,7 @@ public:
 #if SWIFT_READWRITELOCK_SUPPORTS_CONSTEXPR
   constexpr
 #endif
-      StaticReadWriteLock()
+  StaticReadWriteLock()
       : Handle(ReadWriteLockPlatformHelper::staticInit()) {
   }
 
@@ -858,18 +859,18 @@ public:
 
   /// See ReadWriteLock::withReadLock
   template <typename CriticalSection>
-  auto withReadLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withReadLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     StaticScopedReadLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
   /// See ReadWriteLock::withWriteLock
   template <typename CriticalSection>
-  auto withWriteLock(CriticalSection criticalSection)
-      -> decltype(criticalSection()) {
+  auto withWriteLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
     StaticScopedWriteLock guard(*this);
-    return criticalSection();
+    return std::forward<CriticalSection>(criticalSection)();
   }
 
 private:
@@ -895,7 +896,7 @@ public:
 #if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
   constexpr
 #endif
-      StaticUnsafeMutex()
+  StaticUnsafeMutex()
       : Handle(MutexPlatformHelper::staticInit()) {
   }
 
@@ -920,6 +921,16 @@ public:
   /// - Ignores errors that may happen, undefined when an error happens.
   void unlock() { MutexPlatformHelper::unsafeUnlock(Handle); }
 
+  template <typename CriticalSection>
+  auto withLock(CriticalSection &&criticalSection)
+      -> decltype(std::forward<CriticalSection>(criticalSection)()) {
+    ScopedLock guard(*this);
+    return std::forward<CriticalSection>(criticalSection)();
+  }
+
+  typedef ScopedLockT<StaticUnsafeMutex, false> ScopedLock;
+  typedef ScopedLockT<StaticUnsafeMutex, true> ScopedUnlock;
+
 private:
   MutexHandle Handle;
 };
@@ -942,6 +953,12 @@ public:
   void unlock() { Ptr->unlock(); }
 
   bool try_lock() { return Ptr->try_lock(); }
+
+  template <typename CriticalSection>
+  auto withLock(CriticalSection &&criticalSection)
+      -> decltype(criticalSection()) {
+    return Ptr->withLock(std::forward<CriticalSection>(criticalSection));
+  }
 
   /// A stack based object that locks the supplied mutex on construction
   /// and unlocks it on destruction.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -258,14 +258,41 @@ namespace {
       VariadicMetadataCacheEntryBase<GenericCacheEntry> {
     static const char *getName() { return "GenericCache"; }
 
-    template <class... Args>
-    GenericCacheEntry(MetadataCacheKey key, Args &&...args)
-      : VariadicMetadataCacheEntryBase(key) {}
+    // The constructor/allocate operations that take a `const Metadata *`
+    // are used for the insertion of canonical specializations.
+    // The metadata is always complete after construction.
+
+    GenericCacheEntry(MetadataCacheKey key,
+                      MetadataWaitQueue::Worker &worker,
+                      MetadataRequest request,
+                      const Metadata *candidate)
+      : VariadicMetadataCacheEntryBase(key, worker,
+                                       PrivateMetadataState::Complete,
+                                       const_cast<Metadata*>(candidate)) {}
 
     AllocationResult allocate(const Metadata *candidate) {
-      return {const_cast<Metadata *>(candidate),
-              PrivateMetadataState::Complete};
+      swift_unreachable("always short-circuited");
     }
+
+    static bool allowMangledNameVerification(const Metadata *candidate) {
+      // Disallow mangled name verification for specialized candidates
+      // because it will trigger recursive entry into the swift_once
+      // in cacheCanonicalSpecializedMetadata.
+      // TODO: verify mangled names in a second pass in that function.
+      return false;
+    }
+
+    // The constructor/allocate operations that take a descriptor
+    // and arguments are used along the normal allocation path.
+
+    GenericCacheEntry(MetadataCacheKey key,
+                      MetadataWaitQueue::Worker &worker,
+                      MetadataRequest request,
+                      const TypeContextDescriptor *description,
+                      const void * const *arguments)
+      : VariadicMetadataCacheEntryBase(key, worker,
+                                       PrivateMetadataState::Allocating,
+                                       /*candidate*/ nullptr) {}
 
     AllocationResult allocate(const TypeContextDescriptor *description,
                               const void * const *arguments) {
@@ -295,7 +322,13 @@ namespace {
       return { metadata, state };
     }
 
-    TryInitializeResult tryInitialize(Metadata *metadata,
+    static bool allowMangledNameVerification(
+                                  const TypeContextDescriptor *description,
+                                             const void * const *arguments) {
+      return true;
+    }
+
+    MetadataStateWithDependency tryInitialize(Metadata *metadata,
                                       PrivateMetadataState state,
                                PrivateMetadataCompletionContext *context) {
       assert(state != PrivateMetadataState::Complete);
@@ -829,7 +862,10 @@ namespace {
 
     static const char *getName() { return "SingletonMetadataCache"; }
 
-    SingletonMetadataCacheEntry() {}
+    SingletonMetadataCacheEntry(MetadataWaitQueue::Worker &worker,
+                                MetadataRequest request,
+                                const TypeContextDescriptor *description)
+      : MetadataCacheEntryBase(worker) {}
 
     AllocationResult allocate(const TypeContextDescriptor *description) {
       auto &initialization = description->getSingletonMetadataInitialization();
@@ -842,7 +878,7 @@ namespace {
       return { metadata, state };
     }
 
-    TryInitializeResult tryInitialize(Metadata *metadata,
+    MetadataStateWithDependency tryInitialize(Metadata *metadata,
                                       PrivateMetadataState state,
                                PrivateMetadataCompletionContext *context) {
       assert(state != PrivateMetadataState::Complete);
@@ -909,7 +945,8 @@ namespace {
       // If there isn't one there, optimistically create an entry and
       // try to swap it in.
       if (!existingEntry) {
-        auto allocatedEntry = new SingletonMetadataCacheEntry();
+        auto allocatedEntry =
+          new SingletonMetadataCacheEntry(std::forward<ArgTys>(args)...);
         if (cache.Private.compare_exchange_strong(existingEntry,
                                                   allocatedEntry,
                                                   std::memory_order_acq_rel,
@@ -1353,16 +1390,19 @@ public:
     assert(value == &Data);
   }
 
-  TupleCacheEntry(const Key &key, MetadataRequest request,
+  TupleCacheEntry(const Key &key, MetadataWaitQueue::Worker &worker,
+                  MetadataRequest request,
                   const ValueWitnessTable *proposedWitnesses);
 
-  AllocationResult allocate(const ValueWitnessTable *proposedWitnesses);
+  AllocationResult allocate(const ValueWitnessTable *proposedWitnesses) {
+    swift_unreachable("allocated during construction");
+  }
 
-  TryInitializeResult tryInitialize(Metadata *metadata,
+  MetadataStateWithDependency tryInitialize(Metadata *metadata,
                                     PrivateMetadataState state,
                                     PrivateMetadataCompletionContext *context);
 
-  TryInitializeResult checkTransitiveCompleteness() {
+  MetadataStateWithDependency checkTransitiveCompleteness() {
     auto dependency = ::checkTransitiveCompleteness(&Data);
     return { dependency ? PrivateMetadataState::NonTransitiveComplete
                         : PrivateMetadataState::Complete,
@@ -1867,8 +1907,11 @@ swift::swift_getTupleTypeMetadata(MetadataRequest request,
   return result;
 }
 
-TupleCacheEntry::TupleCacheEntry(const Key &key, MetadataRequest request,
-                                 const ValueWitnessTable *proposedWitnesses) {
+TupleCacheEntry::TupleCacheEntry(const Key &key,
+                                 MetadataWaitQueue::Worker &worker,
+                                 MetadataRequest request,
+                                 const ValueWitnessTable *proposedWitnesses)
+    : MetadataCacheEntryBase(worker, PrivateMetadataState::Abstract) {
   Data.setKind(MetadataKind::Tuple);
   Data.NumElements = key.NumElements;
   Data.Labels = key.Labels;
@@ -1882,13 +1925,7 @@ TupleCacheEntry::TupleCacheEntry(const Key &key, MetadataRequest request,
   assert(TupleCacheStorage::resolveExistingEntry(&Data) == this);
 }
 
-TupleCacheEntry::AllocationResult
-TupleCacheEntry::allocate(const ValueWitnessTable *proposedWitnesses) {
-  // All the work we can reasonably do here was done in the constructor.
-  return { &Data, PrivateMetadataState::Abstract };
-}
-
-TupleCacheEntry::TryInitializeResult
+MetadataStateWithDependency
 TupleCacheEntry::tryInitialize(Metadata *metadata,
                                PrivateMetadataState state,
                                PrivateMetadataCompletionContext *context) {
@@ -4142,41 +4179,11 @@ public:
 
   static const char *getName() { return "ForeignMetadataCache"; }
 
-  template <class... Args>
-  ForeignMetadataCacheEntry(Key key,
+  ForeignMetadataCacheEntry(Key key, MetadataWaitQueue::Worker &worker,
                             MetadataRequest request, Metadata *candidate)
-      : Value(candidate) {
-    // Remember that the metadata is still just a candidate until this
-    // is actually successfully installed in the concurrent map.
-
-    auto &init = key.Description->getForeignMetadataInitialization();
-
-    PrivateMetadataState state;
-    if (!init.CompletionFunction) {
-      if (areAllTransitiveMetadataComplete_cheap(candidate)) {
-        state = PrivateMetadataState::Complete;
-      } else {
-        state = PrivateMetadataState::NonTransitiveComplete;
-      }
-    } else {
-      if (candidate->getValueWitnesses() == nullptr) {
-        assert(isa<ForeignClassMetadata>(candidate) &&
-               "cannot set default value witnesses for non-class foreign types");
-        // Fill in the default VWT if it was not set in the candidate at build
-        // time.
-#if SWIFT_OBJC_INTEROP
-        candidate->setValueWitnesses(&VALUE_WITNESS_SYM(BO));
-#else
-        candidate->setValueWitnesses(&VALUE_WITNESS_SYM(Bo));
-#endif
-      }
-      state = inferStateForMetadata(candidate);
-    }
-
-    flagAllocatedDuringConstruction(state);
+      : MetadataCacheEntryBase(worker, configureCandidate(key, candidate)),
+        Value(candidate) {
   }
-
-  enum : bool { MayFlagAllocatedDuringConstruction = true };
 
   const TypeContextDescriptor *getDescription() const {
     return getForeignTypeDescription(Value);
@@ -4203,10 +4210,10 @@ public:
   }
 
   AllocationResult allocate(Metadata *candidate) {
-    swift_unreachable("always flags allocation complete during construction");
+    swift_unreachable("allocation is short-circuited during construction");
   }
 
-  TryInitializeResult tryInitialize(Metadata *metadata,
+  MetadataStateWithDependency tryInitialize(Metadata *metadata,
                                     PrivateMetadataState state,
                                     PrivateMetadataCompletionContext *ctxt) {
     assert(state != PrivateMetadataState::Complete);
@@ -4232,6 +4239,36 @@ public:
 
     // We're done.
     return { PrivateMetadataState::Complete, MetadataDependency() };
+  }
+
+private:
+  /// Do as much candidate initialization as we reasonably can during
+  /// construction.  Remember, though, that this is just construction;
+  /// we won't have committed to this candidate as the metadata until
+  /// this entry is successfully installed in the concurrent map.
+  static PrivateMetadataState configureCandidate(Key key, Metadata *candidate) {
+    auto &init = key.Description->getForeignMetadataInitialization();
+
+    if (!init.CompletionFunction) {
+      if (areAllTransitiveMetadataComplete_cheap(candidate)) {
+        return PrivateMetadataState::Complete;
+      } else {
+        return PrivateMetadataState::NonTransitiveComplete;
+      }
+    }
+
+    if (candidate->getValueWitnesses() == nullptr) {
+      assert(isa<ForeignClassMetadata>(candidate) &&
+             "cannot set default value witnesses for non-class foreign types");
+      // Fill in the default VWT if it was not set in the candidate at build
+      // time.
+#if SWIFT_OBJC_INTEROP
+      candidate->setValueWitnesses(&VALUE_WITNESS_SYM(BO));
+#else
+      candidate->setValueWitnesses(&VALUE_WITNESS_SYM(Bo));
+#endif
+    }
+    return inferStateForMetadata(candidate);
   }
 };
 
@@ -4521,9 +4558,11 @@ public:
   /// Do the structural initialization necessary for this entry to appear
   /// in a concurrent map.
   WitnessTableCacheEntry(const Metadata *type,
+                         WaitQueue::Worker &worker,
                          const ProtocolConformanceDescriptor *conformance,
                          const void * const *instantiationArgs)
-    : Type(type), Conformance(conformance) {}
+    : SimpleLockingCacheEntryBase(worker),
+      Type(type), Conformance(conformance) {}
 
   intptr_t getKeyIntValueForDump() const {
     return reinterpret_cast<intptr_t>(Type);
@@ -4540,6 +4579,7 @@ public:
 
   static size_t getExtraAllocationSize(
                              const Metadata *type,
+                             WaitQueue::Worker &worker,
                              const ProtocolConformanceDescriptor *conformance,
                              const void * const *instantiationArgs) {
     return getWitnessTableSize(conformance);
@@ -5382,75 +5422,6 @@ static Result performOnMetadataCache(const Metadata *metadata,
                                                  cache, key);
 }
 
-bool swift::addToMetadataQueue(MetadataCompletionQueueEntry *queueEntry,
-                               MetadataDependency dependency) {
-  struct EnqueueCallbacks {
-    MetadataCompletionQueueEntry *QueueEntry;
-    MetadataDependency Dependency;
-
-    bool forGenericMetadata(const Metadata *metadata,
-                            const TypeContextDescriptor *description,
-                            GenericMetadataCache &cache,
-                            MetadataCacheKey key) && {
-      return cache.enqueue(key, QueueEntry, Dependency);
-    }
-
-    bool forForeignMetadata(const Metadata *metadata,
-                            const TypeContextDescriptor *description) {
-      ForeignMetadataCacheEntry::Key key{description};
-      return ForeignMetadata.get().enqueue(key, QueueEntry, Dependency);
-    }
-
-    bool forSingletonMetadata(const TypeContextDescriptor *description) && {
-      return SingletonMetadata.get().enqueue(description, QueueEntry, Dependency);
-    }
-
-    bool forTupleMetadata(const TupleTypeMetadata *metadata) {
-      return TupleTypes.get().enqueue(metadata, QueueEntry, Dependency);
-    }
-
-    bool forOtherMetadata(const Metadata *metadata) && {
-      swift_unreachable("metadata should always be complete");
-    }
-  } callbacks = { queueEntry, dependency };
-
-  return performOnMetadataCache<bool>(dependency.Value, std::move(callbacks));
-}
-
-void swift::resumeMetadataCompletion(MetadataCompletionQueueEntry *queueEntry) {
-  struct ResumeCallbacks {
-    MetadataCompletionQueueEntry *QueueEntry;
-
-    void forGenericMetadata(const Metadata *metadata,
-                            const TypeContextDescriptor *description,
-                            GenericMetadataCache &cache,
-                            MetadataCacheKey key) && {
-      cache.resumeInitialization(key, QueueEntry);
-    }
-
-    void forForeignMetadata(const Metadata *metadata,
-                            const TypeContextDescriptor *description) {
-      ForeignMetadataCacheEntry::Key key{description};
-      ForeignMetadata.get().resumeInitialization(key, QueueEntry);
-    }
-
-    void forSingletonMetadata(const TypeContextDescriptor *description) && {
-      SingletonMetadata.get().resumeInitialization(description, QueueEntry);
-    }
-
-    void forTupleMetadata(const TupleTypeMetadata *metadata) {
-      TupleTypes.get().resumeInitialization(metadata, QueueEntry);
-    }
-
-    void forOtherMetadata(const Metadata *metadata) && {
-      swift_unreachable("metadata should always be complete");
-    }
-  } callbacks = { queueEntry };
-
-  auto metadata = queueEntry->Value;
-  performOnMetadataCache<void>(metadata, std::move(callbacks));
-}
-
 MetadataResponse swift::swift_checkMetadataState(MetadataRequest request,
                                                  const Metadata *type) {
   struct CheckStateCallbacks {
@@ -5685,43 +5656,44 @@ checkTransitiveCompleteness(const Metadata *initialType) {
   }
 
   // Otherwise, we're transitively complete.
-  return { nullptr, MetadataState::Complete };
+  return MetadataDependency();
 }
 
 /// Diagnose a metadata dependency cycle.
 SWIFT_NORETURN static void
-diagnoseMetadataDependencyCycle(const Metadata *start,
-                                llvm::ArrayRef<MetadataDependency> links) {
-  assert(start == links.back().Value);
+diagnoseMetadataDependencyCycle(llvm::ArrayRef<MetadataDependency> links) {
+  assert(links.size() >= 2);
+  assert(links.front().Value == links.back().Value);
+
+  auto stringForRequirement = [](MetadataState req) -> const char * {
+    switch (req) {
+    case MetadataState::Complete:
+      return "transitive completion of ";
+    case MetadataState::NonTransitiveComplete:
+      return "completion of ";
+    case MetadataState::LayoutComplete:
+      return "layout of ";
+    case MetadataState::Abstract:
+      return "abstract metadata for ";
+    }
+    return "<corrupted requirement> for ";
+  };
 
   std::string diagnostic =
-    "runtime error: unresolvable type metadata dependency cycle detected\n  ";
-  diagnostic += nameForMetadata(start);
+    "runtime error: unresolvable type metadata dependency cycle detected\n"
+    "  Request for ";
+  diagnostic += stringForRequirement(links.front().Requirement);
+  diagnostic += nameForMetadata(links.front().Value);
 
-  for (auto &link : links) {
+  for (auto &link : links.drop_front()) {
     // If the diagnostic gets too large, just cut it short.
     if (diagnostic.size() >= 128 * 1024) {
-      diagnostic += "\n  (limiting diagnostic text at 128KB)";
+      diagnostic += "\n  (cycle too long, limiting diagnostic text)";
       break;
     }
 
     diagnostic += "\n  depends on ";
-
-    switch (link.Requirement) {
-    case MetadataState::Complete:
-      diagnostic += "transitive completion of ";
-      break;
-    case MetadataState::NonTransitiveComplete:
-      diagnostic += "completion of ";
-      break;
-    case MetadataState::LayoutComplete:
-      diagnostic += "layout of ";
-      break;
-    case MetadataState::Abstract:
-      diagnostic += "<corruption> of ";
-      break;
-    }
-
+    diagnostic += stringForRequirement(link.Requirement);
     diagnostic += nameForMetadata(link.Value);
   }
 
@@ -5735,7 +5707,7 @@ diagnoseMetadataDependencyCycle(const Metadata *start,
       .errorType = "type-metadata-cycle",
       .currentStackDescription = "fetching metadata", // TODO?
       .framesToSkip = 1, // skip out to the check function
-      .memoryAddress = start
+      .memoryAddress = links.front().Value
       // TODO: describe the cycle using notes instead of one huge message?
     };
 #pragma GCC diagnostic pop
@@ -5749,65 +5721,86 @@ diagnoseMetadataDependencyCycle(const Metadata *start,
 
 /// Check whether the given metadata dependency is satisfied, and if not,
 /// return its current dependency, if one exists.
-static MetadataDependency
+static MetadataStateWithDependency
 checkMetadataDependency(MetadataDependency dependency) {
-  struct IsIncompleteCallbacks {
+  struct CheckDependencyResult {
     MetadataState Requirement;
-    MetadataDependency forGenericMetadata(const Metadata *type,
-                                          const TypeContextDescriptor *desc,
-                                          GenericMetadataCache &cache,
-                                          MetadataCacheKey key) && {
+
+    MetadataStateWithDependency
+    forGenericMetadata(const Metadata *type,
+                       const TypeContextDescriptor *desc,
+                       GenericMetadataCache &cache,
+                       MetadataCacheKey key) && {
       return cache.checkDependency(key, Requirement);
     }
 
-    MetadataDependency forForeignMetadata(const Metadata *metadata,
-                                    const TypeContextDescriptor *description) {
+    MetadataStateWithDependency
+    forForeignMetadata(const Metadata *metadata,
+                       const TypeContextDescriptor *description) {
       ForeignMetadataCacheEntry::Key key{description};
       return ForeignMetadata.get().checkDependency(key, Requirement);
     }
 
-    MetadataDependency forSingletonMetadata(
-                              const TypeContextDescriptor *description) && {
+    MetadataStateWithDependency
+    forSingletonMetadata(const TypeContextDescriptor *description) {
       return SingletonMetadata.get().checkDependency(description, Requirement);
     }
 
-    MetadataDependency forTupleMetadata(const TupleTypeMetadata *metadata) {
+    MetadataStateWithDependency
+    forTupleMetadata(const TupleTypeMetadata *metadata) {
       return TupleTypes.get().checkDependency(metadata, Requirement);
     }
 
-    MetadataDependency forOtherMetadata(const Metadata *type) && {
-      return MetadataDependency();
+    MetadataStateWithDependency forOtherMetadata(const Metadata *type) {
+      return { PrivateMetadataState::Complete, MetadataDependency() };
     }
   } callbacks = { dependency.Requirement };
 
-  return performOnMetadataCache<MetadataDependency>(dependency.Value,
-                                                    std::move(callbacks));
+  return performOnMetadataCache<MetadataStateWithDependency>(dependency.Value,
+                                                       std::move(callbacks));
 }
 
 /// Check for an unbreakable metadata-dependency cycle.
-void swift::checkMetadataDependencyCycle(const Metadata *startMetadata,
-                                         MetadataDependency firstLink,
-                                         MetadataDependency secondLink) {
+void swift::blockOnMetadataDependency(MetadataDependency root,
+                                      MetadataDependency firstLink) {
   std::vector<MetadataDependency> links;
   auto checkNewLink = [&](MetadataDependency newLink) {
     links.push_back(newLink);
-    if (newLink.Value == startMetadata)
-      diagnoseMetadataDependencyCycle(startMetadata, links);
     for (auto i = links.begin(), e = links.end() - 1; i != e; ++i) {
       if (i->Value == newLink.Value) {
-        auto next = i + 1;
-        diagnoseMetadataDependencyCycle(i->Value,
-                                llvm::makeArrayRef(&*next, links.end() - next));
+        diagnoseMetadataDependencyCycle(
+          llvm::makeArrayRef(&*i, links.end() - i));
       }
     }
   };
 
+  links.push_back(root);
+
+  // Iteratively add each link, checking for a cycle, until we reach
+  // something without a known dependency.
   checkNewLink(firstLink);
-  checkNewLink(secondLink);
   while (true) {
-    auto newLink = checkMetadataDependency(links.back());
-    if (!newLink) return;
-    checkNewLink(newLink);
+    // Try to get a dependency for the metadata in the last link we added.
+    auto checkResult = checkMetadataDependency(links.back());
+
+    // If there isn't a known dependency, we can't do any more checking.
+    if (!checkResult.Dependency) {
+      // In the special case where it's the first link that doesn't have
+      // a known dependency and its current metadata state now satisfies
+      // the dependency leading to it, we can skip waiting.
+      if (links.size() == 2 && 
+          satisfies(checkResult.NewState, links.back().Requirement))
+        return;
+
+      // Otherwise, just make a blocking request for the first link in
+      // the chain.
+      auto request = MetadataRequest(firstLink.Requirement);
+      swift_checkMetadataState(request, firstLink.Value);
+      return;
+    }
+
+    // Check the new link.
+    checkNewLink(checkResult.Dependency);
   }
 }
 

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -17,6 +17,7 @@
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Mutex.h"
+#include "swift/Runtime/AtomicWaitQueue.h"
 #include <condition_variable>
 #include <thread>
 
@@ -79,53 +80,84 @@ public:
   constexpr TaggedMetadataAllocator() : MetadataAllocator(StaticTag) {}
 };
 
+using RawPrivateMetadataState = uint8_t;
+enum class PrivateMetadataState : RawPrivateMetadataState {
+  /// The metadata is being allocated.
+  Allocating,
+
+  /// The metadata has been allocated, but is not yet complete for
+  /// external layout: that is, it does not have a size.
+  Abstract,
+
+  /// The metadata has a complete external layout, but may not have
+  /// been fully initialized.
+  LayoutComplete,
+
+  /// The metadata has a complete external layout and has been fully
+  /// initialized, but has not yet satisfied its transitive completeness
+  /// requirements.
+  NonTransitiveComplete,
+
+  /// The metadata is fully complete.  There should no longer be waiters.
+  Complete
+};
+inline bool operator<(PrivateMetadataState lhs, PrivateMetadataState rhs) {
+  return RawPrivateMetadataState(lhs) < RawPrivateMetadataState(rhs);
+}
+inline bool operator<=(PrivateMetadataState lhs, PrivateMetadataState rhs) {
+  return RawPrivateMetadataState(lhs) <= RawPrivateMetadataState(rhs);
+}
+inline bool operator>(PrivateMetadataState lhs, PrivateMetadataState rhs) {
+  return RawPrivateMetadataState(lhs) > RawPrivateMetadataState(rhs);
+}
+inline bool operator>=(PrivateMetadataState lhs, PrivateMetadataState rhs) {
+  return RawPrivateMetadataState(lhs) >= RawPrivateMetadataState(rhs);
+}
+inline bool satisfies(PrivateMetadataState state, MetadataState requirement) {
+  switch (requirement) {
+  case MetadataState::Abstract:
+    return state >= PrivateMetadataState::Abstract;
+  case MetadataState::LayoutComplete:
+    return state >= PrivateMetadataState::LayoutComplete;
+  case MetadataState::NonTransitiveComplete:
+    return state >= PrivateMetadataState::NonTransitiveComplete;
+  case MetadataState::Complete:
+    return state >= PrivateMetadataState::Complete;
+  }
+  swift_unreachable("unsupported requirement kind");
+}
+inline MetadataState getAccomplishedRequestState(PrivateMetadataState state) {
+  switch (state) {
+  case PrivateMetadataState::Allocating:
+    swift_unreachable("cannot call on allocating state");
+  case PrivateMetadataState::Abstract:
+    return MetadataState::Abstract;
+  case PrivateMetadataState::LayoutComplete:
+    return MetadataState::LayoutComplete;
+  case PrivateMetadataState::NonTransitiveComplete:
+    return MetadataState::NonTransitiveComplete;
+  case PrivateMetadataState::Complete:
+    return MetadataState::Complete;
+  }
+  swift_unreachable("bad state");
+}
+
+struct MetadataStateWithDependency {
+  /// The current state of the metadata.
+  PrivateMetadataState NewState;
+  /// The known dependency that the metadata has, if any.
+  MetadataDependency Dependency;
+};
+
 /// A typedef for simple global caches with stable addresses for the entries.
 template <class EntryTy, uint16_t Tag>
 using SimpleGlobalCache =
     StableAddressConcurrentReadableHashMap<EntryTy,
                                            TaggedMetadataAllocator<Tag>>;
 
-template <class T, bool ProvideDestructor = true>
-class StaticOwningPointer {
-  T *Ptr;
-public:
-  StaticOwningPointer(T *ptr = nullptr) : Ptr(ptr) {}
-  StaticOwningPointer(const StaticOwningPointer &) = delete;
-  StaticOwningPointer &operator=(const StaticOwningPointer &) = delete;
-  ~StaticOwningPointer() { delete Ptr; }
-
-  T &operator*() const { return *Ptr; }
-  T *operator->() const { return Ptr; }
-};
-
-template <class T>
-class StaticOwningPointer<T, false> {
-  T *Ptr;
-public:
-  StaticOwningPointer(T *ptr = nullptr) : Ptr(ptr) {}
-  StaticOwningPointer(const StaticOwningPointer &) = delete;
-  StaticOwningPointer &operator=(const StaticOwningPointer &) = delete;
-
-  T &operator*() const { return *Ptr; }
-  T *operator->() const { return Ptr; }
-};
-
-enum class ConcurrencyRequest {
-  /// No special requests; proceed to calling finish.
-  None,
-
-  /// Acquire the lock and call the appropriate function.
-  AcquireLockAndCallBack,
-
-  /// Notify all waiters on the condition variable without acquiring the lock.
-  NotifyAll,
-};
-
 struct ConcurrencyControl {
-  ConditionVariable::Mutex Lock;
-  ConditionVariable Queue;
-
-  ConcurrencyControl() = default;
+  using LockType = SmallMutex;
+  LockType Lock;
 };
 
 template <class EntryType, uint16_t Tag>
@@ -139,12 +171,12 @@ class LockingConcurrentMapStorage {
   StableAddressConcurrentReadableHashMap<EntryType,
                                          TaggedMetadataAllocator<Tag>, MutexTy>
       Map;
-  StaticOwningPointer<ConcurrencyControl, false> Concurrency;
+  ConcurrencyControl Concurrency;
 
 public:
-  LockingConcurrentMapStorage() : Concurrency(new ConcurrencyControl()) {}
+  LockingConcurrentMapStorage() {}
 
-  ConcurrencyControl &getConcurrency() { return *Concurrency; }
+  ConcurrencyControl &getConcurrency() { return Concurrency; }
 
   template <class KeyType, class... ArgTys>
   std::pair<EntryType*, bool>
@@ -184,31 +216,25 @@ public:
 ///   /// Perform allocation.  If this returns a status, initialization
 ///   /// is skipped.
 ///   Optional<Status>
-///   beginAllocation(ConcurrencyControl &concurrency, ArgTys...);
+///   beginAllocation(WaitQueue::Worker &worker, ArgTys...);
 ///
 ///   /// Attempt to initialize an entry.  This is called once for the entry,
 ///   /// immediately after construction, by the thread that successfully
 ///   /// constructed the entry.
-///   Status beginInitialization(ConcurrencyControl &concurrency, ArgTys...);
-///
-///   /// Attempt to resume initializing an entry.  Only one thread will be
-///   /// trying this at once.  This only need to be implemented if
-///   /// resumeInitialization is called on the map.
-///   Status resumeInitialization(ConcurrencyControl &concurrency, ArgTys...);
-///
-///   /// Perform an enqueue operation.
-///   /// This only needs to be implemented if enqueue is called on the map.
-///   bool enqueue(ConcurrencyControl &concurrency, ArgTys...);
+///   Status beginInitialization(WaitQueue::Worker &worker, ArgTys...);
 ///
 ///   /// Perform a checkDependency operation.  This only needs to be
 ///   /// implemented if checkDependency is called on the map.
-///   MetadataDependency checkDependency(ConcurrencyControl &concurrency,
-///                                      ArgTys...);
+///   MetadataStateWithDependency
+///   checkDependency(ConcurrencyControl &concurrency, ArgTys...);
 template <class EntryType,
           class StorageType = LockingConcurrentMapStorage<EntryType, true>>
 class LockingConcurrentMap {
   StorageType Storage;
   using Status = typename EntryType::Status;
+  using WaitQueue = typename EntryType::WaitQueue;
+  using Worker = typename WaitQueue::Worker;
+  using Waiter = typename WaitQueue::Waiter;
 
 public:
   LockingConcurrentMap() = default;
@@ -216,7 +242,9 @@ public:
   template <class KeyType, class... ArgTys>
   std::pair<EntryType*, Status>
   getOrInsert(KeyType key, ArgTys &&...args) {
-    auto result = Storage.getOrInsert(key, args...);
+    Worker worker(Storage.getConcurrency().Lock);
+
+    auto result = Storage.getOrInsert(key, worker, args...);
     auto entry = result.first;
 
     // If we are not inserting the entry, we need to potentially block on 
@@ -230,15 +258,18 @@ public:
     // Okay, we inserted.  We are responsible for allocating and
     // subsequently trying to initialize the entry.
 
+    // Insertion should have called worker.createQueue(); tell the Worker
+    // object that we published it.
+    worker.flagCreatedQueueIsPublished();
+
     // Allocation.  This can fast-path and bypass initialization by returning
     // a status.
-    if (auto status =
-          entry->beginAllocation(Storage.getConcurrency(), args...)) {
+    if (auto status = entry->beginAllocation(worker, args...)) {
       return { entry, *status };
     }
 
     // Initialization.
-    auto status = entry->beginInitialization(Storage.getConcurrency(),
+    auto status = entry->beginInitialization(worker,
                                              std::forward<ArgTys>(args)...);
     return { entry, status };
   }
@@ -246,23 +277,6 @@ public:
   template <class KeyType>
   EntryType *find(KeyType key) {
     return Storage.find(key);
-  }
-
-  template <class KeyType, class... ArgTys>
-  std::pair<EntryType*, Status>
-  resumeInitialization(KeyType key, ArgTys &&...args) {
-    EntryType *entry = Storage.resolveExistingEntry(key);
-    auto status =
-      entry->resumeInitialization(Storage.getConcurrency(),
-                                  std::forward<ArgTys>(args)...);
-    return { entry, status };
-  }
-
-  template <class KeyType, class... ArgTys>
-  bool enqueue(KeyType key, ArgTys &&...args) {
-    EntryType *entry = Storage.resolveExistingEntry(key);
-    return entry->enqueue(Storage.getConcurrency(),
-                          std::forward<ArgTys>(args)...);
   }
 
   /// Given that an entry already exists, await it.
@@ -285,7 +299,8 @@ public:
   /// Given that an entry already exists, check whether it has an active
   /// dependency.
   template <class KeyType, class... ArgTys>
-  MetadataDependency checkDependency(KeyType key, ArgTys &&...args) {
+  MetadataStateWithDependency
+  checkDependency(KeyType key, ArgTys &&...args) {
     EntryType *entry = Storage.resolveExistingEntry(key);
     return entry->checkDependency(Storage.getConcurrency(),
                                   std::forward<ArgTys>(args)...);
@@ -293,7 +308,7 @@ public:
 };
 
 /// A base class for metadata cache entries which supports an unfailing
-/// one-phase allocation strategy.
+/// one-phase allocation strategy that should not be done by trial.
 ///
 /// In addition to the requirements of ConcurrentMap, subclasses should
 /// provide:
@@ -302,13 +317,22 @@ public:
 ///   ValueType allocate(ArgTys...);
 template <class Impl, class ValueType>
 class SimpleLockingCacheEntryBase {
+public:
+  using WaitQueue = SimpleAtomicWaitQueue<ConcurrencyControl::LockType>;
+
+private:
   static_assert(std::is_pointer<ValueType>::value,
                 "value type must be a pointer type");
 
-  static const uintptr_t Empty_NoWaiters = 0;
-  static const uintptr_t Empty_HasWaiters = 1;
-  static bool isSpecialValue(uintptr_t value) {
-    return value <= Empty_HasWaiters;
+  static const uintptr_t IsWaitQueue = 1;
+  static WaitQueue *getAsWaitQueue(uintptr_t value) {
+    if (value & IsWaitQueue)
+      return reinterpret_cast<WaitQueue*>(value & ~IsWaitQueue);
+    return nullptr;
+  }
+  static ValueType castAsValue(uintptr_t value) {
+    assert(!(value & IsWaitQueue));
+    return reinterpret_cast<ValueType>(value);
   }
 
   std::atomic<uintptr_t> Value;
@@ -317,80 +341,58 @@ protected:
   Impl &asImpl() { return static_cast<Impl &>(*this); }
   const Impl &asImpl() const { return static_cast<const Impl &>(*this); }
 
-  SimpleLockingCacheEntryBase() : Value(Empty_NoWaiters) {}
+  SimpleLockingCacheEntryBase(WaitQueue::Worker &worker)
+    : Value(reinterpret_cast<uintptr_t>(worker.createQueue()) | IsWaitQueue) {}
 
 public:
   using Status = ValueType;
 
   template <class... ArgTys>
   Status await(ConcurrencyControl &concurrency, ArgTys &&...args) {
-    // Load the value.  If this is not a special value, we're done.
+    WaitQueue::Waiter waiter(concurrency.Lock);
+
+    // Load the value.  If this is not a queue, we're done.
     auto value = Value.load(std::memory_order_acquire);
-    if (!isSpecialValue(value)) {
-      return reinterpret_cast<ValueType>(value);
+    if (getAsWaitQueue(value)) {
+      bool waited = waiter.tryReloadAndWait([&] {
+        // We can use a relaxed load because we're already ordered
+        // by the lock.
+        value = Value.load(std::memory_order_relaxed);
+        return getAsWaitQueue(value);
+      });
+
+      if (waited) {
+        // This load can be relaxed because we acquired the wait queue
+        // lock, which was released by the worker thread after
+        // initializing Value to the value.
+        value = Value.load(std::memory_order_relaxed);
+        assert(!getAsWaitQueue(value));
+      }
     }
-
-    // The initializing thread will try to atomically swap in a valid value.
-    // It can do that while we're holding the lock.  If it sees that there
-    // aren't any waiters, it will not acquire the lock and will not try
-    // to notify any waiters.  If it does see that there are waiters, it will
-    // acquire the lock before notifying them in order to ensure that it
-    // catches them all.  On the waiter side, we must set the has-waiters
-    // flag while holding the lock.  This is because we otherwise can't be
-    // sure that we'll have started waiting before the initializing thread
-    // notifies the queue.
-    //
-    // We're adding a bit of complexity here for the advantage that, in the
-    // absence of early contention, we never touch the lock at all.
-    concurrency.Lock.withLockOrWait(concurrency.Queue, [&] {
-      // Reload the current value.
-      value = Value.load(std::memory_order_acquire);
-
-      // If the value is still no-waiters, try to flag that
-      // there's a waiter.  If that succeeds, we can go ahead and wait.
-      if (value == Empty_NoWaiters &&
-          Value.compare_exchange_strong(value, Empty_HasWaiters,
-                                        std::memory_order_relaxed,
-                                        std::memory_order_acquire))
-        return false; // wait
-
-      assert(value != Empty_NoWaiters);
-
-      // If the value is already in the has-waiters state, we can go
-      // ahead and wait.
-      if (value == Empty_HasWaiters)
-        return false; // wait
-
-      // Otherwise, the initializing thread has finished, and we must not wait.
-      return true;
-    });
-
-    return reinterpret_cast<ValueType>(value);
+    return castAsValue(value);
   }
 
   template <class... ArgTys>
-  llvm::Optional<Status> beginAllocation(ConcurrencyControl &concurrency,
+  llvm::Optional<Status> beginAllocation(WaitQueue::Worker &worker,
                                          ArgTys &&... args) {
+
     // Delegate to the implementation class.
-    ValueType origValue = asImpl().allocate(std::forward<ArgTys>(args)...);
+    ValueType origValue =
+      asImpl().allocate(std::forward<ArgTys>(args)...);
 
     auto value = reinterpret_cast<uintptr_t>(origValue);
-    assert(!isSpecialValue(value) && "allocate returned a special value");
+    assert(!getAsWaitQueue(value) && "allocate returned an unaligned value");
 
-    // Publish the value.
-    auto oldValue = Value.exchange(value, std::memory_order_release);
-    assert(isSpecialValue(oldValue));
-
-    // If there were any waiters, acquire the lock and notify the queue.
-    if (oldValue != Empty_NoWaiters) {
-      concurrency.Lock.withLockThenNotifyAll(concurrency.Queue, []{});
-    }
+    // Publish the value, which unpublishes the queue.
+    worker.finishAndUnpublishQueue([&] {
+      Value.store(value, std::memory_order_release);      
+    });
 
     return origValue;
   }
 
   template <class... ArgTys>
-  Status beginInitialization(ConcurrencyControl &concurrency,
+  Status beginInitialization(WaitQueue::Worker &worker,
                              ArgTys &&...args) {
     swift_unreachable("beginAllocation always short-circuits");
   }
@@ -578,77 +580,136 @@ public:
   }
 };
 
-using RawPrivateMetadataState = uint8_t;
-enum class PrivateMetadataState : RawPrivateMetadataState {
-  /// The metadata is being allocated.
-  Allocating,
-
-  /// The metadata has been allocated, but is not yet complete for
-  /// external layout: that is, it does not have a size.
-  Abstract,
-
-  /// The metadata has a complete external layout, but may not have
-  /// been fully initialized.
-  LayoutComplete,
-
-  /// The metadata has a complete external layout and has been fully
-  /// initialized, but has not yet satisfied its transitive completeness
-  /// requirements.
-  NonTransitiveComplete,
-
-  /// The metadata is fully complete.  There should no longer be waiters.
-  Complete
+/// Reserve the runtime extra space to use for its own tracking.
+struct PrivateMetadataCompletionContext {
+  MetadataCompletionContext Public;
 };
-inline bool operator<(PrivateMetadataState lhs, PrivateMetadataState rhs) {
-  return RawPrivateMetadataState(lhs) < RawPrivateMetadataState(rhs);
-}
-inline bool operator<=(PrivateMetadataState lhs, PrivateMetadataState rhs) {
-  return RawPrivateMetadataState(lhs) <= RawPrivateMetadataState(rhs);
-}
-inline bool operator>(PrivateMetadataState lhs, PrivateMetadataState rhs) {
-  return RawPrivateMetadataState(lhs) > RawPrivateMetadataState(rhs);
-}
-inline bool operator>=(PrivateMetadataState lhs, PrivateMetadataState rhs) {
-  return RawPrivateMetadataState(lhs) >= RawPrivateMetadataState(rhs);
-}
-inline bool satisfies(PrivateMetadataState state, MetadataState requirement) {
-  switch (requirement) {
-  case MetadataState::Abstract:
-    return state >= PrivateMetadataState::Abstract;
-  case MetadataState::LayoutComplete:
-    return state >= PrivateMetadataState::LayoutComplete;
-  case MetadataState::NonTransitiveComplete:
-    return state >= PrivateMetadataState::NonTransitiveComplete;
-  case MetadataState::Complete:
-    return state >= PrivateMetadataState::Complete;
-  }
-  swift_unreachable("unsupported requirement kind");
-}
+
+/// The alignment required for objects that will be stored in
+/// PrivateMetadataTrackingInfo.
+const size_t PrivateMetadataTrackingAlignment = 16;
+
+/// The wait queue object that we create for metadata that are
+/// being actively initialized right now.
+struct alignas(PrivateMetadataTrackingAlignment) MetadataWaitQueue :
+  public AtomicWaitQueue<MetadataWaitQueue, ConcurrencyControl::LockType> {
+
+  /// A pointer to the completion context being used to complete this
+  /// metadata.  This is only actually filled in if:
+  ///
+  /// - the initializing thread is unable to complete the metadata,
+  ///   but its request doesn't need it to, and
+  /// - the current completion context is non-zero.  (Completion contexts
+  ///   are initially zeroed, so this only happens if the initialization
+  ///   actually stores to the context, which is uncommon.)
+  ///
+  /// This should only be touched by the initializing thread, i.e. the
+  /// thread that holds the lock embedded in this object.
+  std::unique_ptr<PrivateMetadataCompletionContext> PersistentContext;
+
+  /// The dependency that is currently blocking this initialization.
+  /// This should only be touched while holding the global lock
+  /// for this metadata cache.
+  MetadataDependency BlockingDependency;
+
+  class Worker : public AtomicWaitQueue::Worker {
+    using super = AtomicWaitQueue::Worker;
+    PrivateMetadataState State = PrivateMetadataState::Allocating;
+  public:
+    Worker(ConcurrencyControl::LockType &globalLock) : super(globalLock) {}
+
+    void flagCreatedQueueIsPublished() {
+      // This method is called after successfully inserting an entry into
+      // the atomic storage, at a point that just assumes that a queue
+      // was created.  However, we may not have created a queue if the
+      // metadata was completed during construction.
+      //
+      // Testing CurrentQueue to see if we published a queue is generally
+      // suspect because we might be looping and calling createQueue()
+      // on each iteration.  However, the metadata cache system won't do
+      // this, at least on the path leading to the call to this method,
+      // so this works in this one case.
+      if (CurrentQueue) {
+        assert(State < PrivateMetadataState::Complete);
+        super::flagCreatedQueueIsPublished();
+      } else {
+        assert(State == PrivateMetadataState::Complete);
+      }
+    }
+
+    void setState(PrivateMetadataState newState) {
+      // It would be nice to assert isWorkerThread() here, but we need
+      // this to be callable before we've published the queue.
+      State = newState;
+    }
+    PrivateMetadataState getState() const {
+      assert(isWorkerThread() || State == PrivateMetadataState::Complete);
+      return State;
+    }
+  };
+};
+
+/// A record used to store information about an attempt to
+/// complete a metadata when there's no active worker thread.
+struct alignas(PrivateMetadataTrackingAlignment) SuspendedMetadataCompletion {
+  MetadataDependency BlockingDependency;
+  std::unique_ptr<PrivateMetadataCompletionContext> PersistentContext;
+
+  SuspendedMetadataCompletion(MetadataDependency blockingDependency,
+                              PrivateMetadataCompletionContext *context)
+    : BlockingDependency(blockingDependency),
+      PersistentContext(context) {}
+};
 
 class PrivateMetadataTrackingInfo {
 public:
-  using RawType = RawPrivateMetadataState;
+  using RawType = uintptr_t;
 
 private:
   enum : RawType {
-    State_mask =      0x7,
-    HasWaiters_mask = 0x8,
+    StateMask = 0x7,
+    PointerIsWaitQueueMask = 0x8,
+    AllBitsMask = StateMask | PointerIsWaitQueueMask,
+    PointerMask = ~AllBitsMask,
   };
+
+  static_assert(AllBitsMask < PrivateMetadataTrackingAlignment,
+                "too many bits for alignment");
 
   RawType Data;
 
 public:
-  explicit constexpr PrivateMetadataTrackingInfo(RawType data)
-    : Data(data) {}
-  explicit constexpr PrivateMetadataTrackingInfo(PrivateMetadataState state)
+  // Some std::atomic implementations require a default constructor
+  // for no apparent reason.
+  PrivateMetadataTrackingInfo() : Data(0) {}
+
+  explicit PrivateMetadataTrackingInfo(PrivateMetadataState state)
     : Data(RawType(state)) {}
 
-  static constexpr PrivateMetadataTrackingInfo initial() {
-    return PrivateMetadataTrackingInfo(PrivateMetadataState::Allocating);
+  explicit PrivateMetadataTrackingInfo(PrivateMetadataState state,
+                                       MetadataWaitQueue *queue)
+    : Data(RawType(state) | reinterpret_cast<RawType>(queue)
+                          | PointerIsWaitQueueMask) {
+    assert(queue);
+    assert(!(reinterpret_cast<RawType>(queue) & AllBitsMask));
+  }
+  explicit PrivateMetadataTrackingInfo(PrivateMetadataState state,
+                                       SuspendedMetadataCompletion *suspended)
+    : Data(RawType(state) | reinterpret_cast<RawType>(suspended)) {
+    assert(!(reinterpret_cast<RawType>(suspended) & AllBitsMask));
+  }
+
+  static PrivateMetadataTrackingInfo
+  initial(MetadataWaitQueue::Worker &worker,
+          PrivateMetadataState initialState) {
+    worker.setState(initialState);
+    if (initialState != PrivateMetadataState::Complete)
+      return PrivateMetadataTrackingInfo(initialState, worker.createQueue());
+    return PrivateMetadataTrackingInfo(initialState);
   }
 
   PrivateMetadataState getState() const {
-    return PrivateMetadataState(Data & State_mask);
+    return PrivateMetadataState(Data & StateMask);
   }
 
   /// Does the state mean that we've allocated metadata?
@@ -660,108 +721,110 @@ public:
     return getState() == PrivateMetadataState::Complete;
   }
 
-  bool hasWaiters() const { return Data & HasWaiters_mask; }
-  PrivateMetadataTrackingInfo addWaiters() const {
-    assert(!isComplete() && "adding waiters to completed state");
-    return PrivateMetadataTrackingInfo(Data | HasWaiters_mask);
+  bool hasWaitQueue() const {
+    return Data & PointerIsWaitQueueMask;
   }
-  PrivateMetadataTrackingInfo removeWaiters() const {
-    return PrivateMetadataTrackingInfo(Data & ~HasWaiters_mask);
+  MetadataWaitQueue *getWaitQueue() const {
+    if (hasWaitQueue())
+      return reinterpret_cast<MetadataWaitQueue*>(Data & PointerMask);
+    return nullptr;
   }
 
-  MetadataState getAccomplishedRequestState() const {
-    switch (getState()) {
-    case PrivateMetadataState::Allocating:
-      swift_unreachable("cannot call on allocating state");
-    case PrivateMetadataState::Abstract:
-      return MetadataState::Abstract;
-    case PrivateMetadataState::LayoutComplete:
-      return MetadataState::LayoutComplete;
-    case PrivateMetadataState::NonTransitiveComplete:
-      return MetadataState::NonTransitiveComplete;
-    case PrivateMetadataState::Complete:
-      return MetadataState::Complete;
-    }
-    swift_unreachable("bad state");
+  SuspendedMetadataCompletion *getSuspendedCompletion() const {
+    if (!hasWaitQueue())
+      return reinterpret_cast<SuspendedMetadataCompletion*>(Data & PointerMask);
+    return nullptr;
+  }
+
+  /// Return the blocking dependency for this metadata.  Should only
+  /// be called while holding the global lock for the metadata cache.
+  MetadataDependency getBlockingDependency_locked() const {
+    if (auto queue = getWaitQueue())
+      return queue->BlockingDependency;
+    if (auto dependency = getSuspendedCompletion())
+      return dependency->BlockingDependency;
+    return MetadataDependency();
   }
 
   bool satisfies(MetadataState requirement) {
     return swift::satisfies(getState(), requirement);
   }
 
-  bool shouldWait(MetadataRequest request) {
-    switch (getState()) {
-    // Always wait if we're allocating.  Non-blocking requests still need
-    // to have an allocation that the downstream consumers can report
-    // a dependency on.
-    case PrivateMetadataState::Allocating:
-      return true;
+  enum CheckResult {
+    /// The request is satisfied.
+    Satisfied,
 
-    // We never need to wait if we're complete.  This is the most common
-    // result.
+    /// The request is not satisfied, and the requesting thread
+    /// should report that immediately.
+    Unsatisfied,
+
+    /// The request is not satisfied, and the requesting thread
+    /// must wait for another thread to complete the initialization.
+    Wait,
+
+    /// The request is not satisfied, and the requesting thread
+    /// should try to complete the initialization itself.
+    Resume,
+  };
+
+  CheckResult check(MetadataRequest request) {
+    switch (getState()) {
+    // Always wait if the metadata is still allocating.  Non-blocking
+    // requests still need to allocate abstract metadata that
+    // downstream consumers can report a dependency on.
+    case PrivateMetadataState::Allocating:
+      return Wait;
+
+    // We never need to do anything if we're complete.  This is the
+    // most common result.
     case PrivateMetadataState::Complete:
-      return false;
+      return Satisfied;
 
     case PrivateMetadataState::Abstract:
     case PrivateMetadataState::LayoutComplete:
     case PrivateMetadataState::NonTransitiveComplete:
-      // Otherwise, if it's a non-blocking request, we do not need to block.
-      return (request.isBlocking() && !satisfies(request.getState()));
+      // If the request is satisfied, we don't need to do anything.
+      if (satisfies(request.getState()))
+        return Satisfied;
+
+      // If there isn't an running thread, we should take over
+      // initialization.
+      if (!hasWaitQueue())
+        return Resume;
+
+      // If this is a blocking request, we should wait.
+      if (request.isBlocking())
+        return Wait;
+
+      // Otherwise, we should return that the request is unsatisfied.
+      return Unsatisfied;
     }
     swift_unreachable("bad state");
   }
-
-  constexpr RawType getRawValue() const { return Data; }
-  RawType &getRawValueRef() { return Data; }
 };
 
-/// Reserve the runtime extra space to use for its own tracking.
-struct PrivateMetadataCompletionContext {
-  MetadataCompletionContext Public;
-};
+/// Given that this is the initializing thread, and we've reached the
+/// given state, should we block wait for further initialization?
+inline bool shouldBlockInitialization(PrivateMetadataState currentState,
+                                      MetadataRequest request) {
+  switch (currentState) {
+  case PrivateMetadataState::Allocating:
+    swift_unreachable("initialization hasn't allocated?");
+  case PrivateMetadataState::Complete:
+    return false;
+  case PrivateMetadataState::Abstract:
+  case PrivateMetadataState::LayoutComplete:
+  case PrivateMetadataState::NonTransitiveComplete:
+    if (satisfies(currentState, request.getState()))
+      return false;
+    return request.isBlocking();
+  }
+  swift_unreachable("bad state");
+}
 
-struct MetadataCompletionQueueEntry {
-  /// The owning metadata, i.e. the metadata whose completion is blocked.
-  Metadata * const Value;
-
-  /// The completion queue for the blocked metadata.
-  /// Only accessed under the lock for the owning metadata.
-  MetadataCompletionQueueEntry *CompletionQueue = nullptr;
-
-  /// The next entry in the completion queue.
-  MetadataCompletionQueueEntry *Next = nullptr;
-
-  /// The saved state of the completion function.
-  PrivateMetadataCompletionContext CompletionContext;
-
-  /// The metadata we're enqueued on and the state we're waiting for it
-  /// to achieve.  These fields are only ever modified under the lock for
-  /// the owning metadata, and only when the metadata is not enqueued
-  /// on another metadata's completion queue.  This latter condition is
-  /// important because it allows these fields to be read outside of the
-  /// lock by the initializing thread of the dependent metadata.
-  MetadataDependency Dependency;
-
-  MetadataCompletionQueueEntry(Metadata *value,
-                               const PrivateMetadataCompletionContext &context)
-    : Value(value), CompletionContext(context) {}
-};
-
-/// Add the given queue entry to the queue for the given metadata.
-///
-/// \return false if the entry was not added because the dependency
-///   has already reached the desired requirement
-bool addToMetadataQueue(MetadataCompletionQueueEntry *queueEntry,
-                        MetadataDependency dependency);
-
-/// Resume completion of the given queue entry, given that it has been
-/// removed from its dependency's metadata queue.
-void resumeMetadataCompletion(MetadataCompletionQueueEntry *queueEntry);
-
-/// Check for an unbreakable metadata-dependency cycle.
-void checkMetadataDependencyCycle(const Metadata *start,
-                                  MetadataDependency firstLink,
-                                  MetadataDependency secondLink);
+/// Block until the dependency is satisfied.
+void blockOnMetadataDependency(MetadataDependency request,
+                               MetadataDependency dependency);
 
 /// A cache entry class which provides the basic mechanisms for two-phase
 /// metadata initialization.  Suitable for more heavyweight metadata kinds
@@ -789,7 +852,7 @@ void checkMetadataDependencyCycle(const Metadata *start,
 ///   AllocationResult allocate(ExtraArgTys...);
 ///
 ///   /// Try to initialize the metadata.
-///   TryInitializeResult tryInitialize(Metadata *metadata,
+///   MetadataStateWithDependency tryInitialize(Metadata *metadata,
 ///                                     PrivateMetadataState state,
 ///                                     PrivateMetadataCompletionContext *ctxt);
 template <class Impl, class... Objects>
@@ -799,100 +862,52 @@ class MetadataCacheEntryBase
 public:
   using ValueType = Metadata *;
   using Status = MetadataResponse;
+  using WaitQueue = MetadataWaitQueue;
 
 protected:
   using TrailingObjectsEntry = super;
   using super::asImpl;
 
 private:
-  #ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-  using ThreadID = int;
-  static ThreadID CurrentThreadID() {
-    return 0;
-  }
-  #else
-  using ThreadID = std::thread::id;
-  static ThreadID CurrentThreadID() {
-    return std::this_thread::get_id();
-  }
-  #endif
-
-  /// Additional storage that is only ever accessed under the lock.
-  union LockedStorage_t {
-    /// The thread that is allocating the entry.
-    ThreadID AllocatingThread;
-
-    /// The completion queue.
-    MetadataCompletionQueueEntry *CompletionQueue;
-
-    /// The metadata's own queue entry.
-    MetadataCompletionQueueEntry *QueueEntry;
-
-    LockedStorage_t() {}
-    ~LockedStorage_t() {}
-  } LockedStorage;
-
-  /// What kind of data is stored in the LockedStorage field below?
-  ///
-  /// This is only ever modified under the lock.
-  enum class LSK : uint8_t {
-    /// We're just storing the allocating thread.  The cache entry will be
-    /// in this state initially, and it will stay in this state until either
-    /// the metadata needs to enqueue itself on another metadata's completion
-    /// queue or another metadata needs to enqueue itself on this metadata's
-    /// completion queue.  It's possible (likely, even) that the cache entry
-    /// will just stay in this state forever, e.g. if it manages to complete
-    /// itself before another metadata needs to wait on it.
-    AllocatingThread,
-
-    /// We're storing a completion queue without having a queue entry
-    /// ourselves.  This can happen if another metadata needs to add itself
-    /// to the completion queue for this metadata during its first attempt
-    /// at initialization.
-    CompletionQueue,
-
-    /// We're storing a queue entry, meaning that the metadata has set itself
-    /// up to be enqueued at least once.  (It's possible that the actual
-    /// enqueuing never actually succeeded.)  The metadata's completion
-    /// queue can be found at LockedStorage.QueueEntry->CompletionQueue.
-    /// 
-    /// The cache entry owns its queue entry, but it must not destroy it
-    /// while it is blocked on another queue.
-    QueueEntry,
-
-    /// We've completed ourselves and are storing nothing.
-    Complete
-  };
-  LSK LockedStorageKind;
-
   /// The current state of this metadata cache entry.
   ///
-  /// This has to be stored as a PrivateMetadataTrackingInfo::RawType
-  /// instead of a PrivateMetadataTrackingInfo because some of our
-  /// targets don't support interesting structs as atomic types.
-  std::atomic<PrivateMetadataTrackingInfo::RawType> TrackingInfo;
+  /// All modifications of this field are performed while holding
+  /// the global lock associated with this metadata cache.  This is
+  /// because these modifications all coincide with changes to the wait
+  /// queue reference: either installing, removing, or replacing it.
+  /// The proper reference-counting of the queue object requires the
+  /// lock to be held during these operations.  However, this field
+  /// can be read without holding the global lock, as part of the fast
+  /// path of several operations on the entry, most importantly
+  /// requesting the metadata.
+  ///
+  /// Acquiring and releasing the global lock provides a certain
+  /// amount of memory ordering.  Thus:
+  /// - Reads from the field performed in fast paths without holding
+  ///   the lock must be acquires in order to properly order memory
+  ///   with the initializing thread.
+  /// - Reads from the field that are performed under the lock can
+  ///   be relaxed because the lock will properly order them.
+  /// - Modifications of the field can be stores rather than
+  ///   compare-exchanges, although they must still use release
+  ///   ordering to guarantee proper ordering with code in the
+  ///   fast paths.
+  std::atomic<PrivateMetadataTrackingInfo> TrackingInfo;
 
-  // Note that GenericMetadataCacheEntryBase is set up to place fields
-  // into the tail padding of this class.
+  static constexpr std::memory_order TrackingInfoIsLockedOrder =
+    std::memory_order_relaxed;
 
 public:
-  MetadataCacheEntryBase()
-      : LockedStorageKind(LSK::AllocatingThread),
-        TrackingInfo(PrivateMetadataTrackingInfo::initial().getRawValue()) {
-    LockedStorage.AllocatingThread = CurrentThreadID();
+  MetadataCacheEntryBase(MetadataWaitQueue::Worker &worker,
+                         PrivateMetadataState initialState =
+                           PrivateMetadataState::Allocating)
+      : TrackingInfo(PrivateMetadataTrackingInfo::initial(worker, initialState)) {
   }
 
   // Note that having an explicit destructor here is important to make this
   // a non-POD class and allow subclass fields to be allocated in our
   // tail-padding.
   ~MetadataCacheEntryBase() {
-    if (LockedStorageKind == LSK::QueueEntry)
-      delete LockedStorage.QueueEntry;
-  }
-
-  bool isBeingAllocatedByCurrentThread() const {
-    return LockedStorageKind == LSK::AllocatingThread &&
-           LockedStorage.AllocatingThread == CurrentThreadID();
   }
 
   /// Given that this thread doesn't own the right to initialize the
@@ -900,15 +915,12 @@ public:
   template <class... Args>
   Status await(ConcurrencyControl &concurrency, MetadataRequest request,
                Args &&...extraArgs) {
-    auto trackingInfo =
-      PrivateMetadataTrackingInfo(TrackingInfo.load(std::memory_order_acquire));
+    return awaitSatisfyingState(concurrency, request);
+  }
 
-    if (trackingInfo.shouldWait(request)) {
-      awaitSatisfyingState(concurrency, request, trackingInfo);
-    }
-
-    assert(trackingInfo.hasAllocatedMetadata());
-    return { asImpl().getValue(), trackingInfo.getAccomplishedRequestState() };
+  Status getStatusToReturn(PrivateMetadataState state) {
+    assert(state != PrivateMetadataState::Allocating);
+    return { asImpl().getValue(), getAccomplishedRequestState(state) };
   }
 
   /// The expected return type of allocate.
@@ -919,466 +931,380 @@ public:
 
   /// Perform the allocation operation.
   template <class... Args>
-  llvm::Optional<Status> beginAllocation(ConcurrencyControl &concurrency,
+  llvm::Optional<Status> beginAllocation(MetadataWaitQueue::Worker &worker,
                                          MetadataRequest request,
                                          Args &&... args) {
     // Returning a non-None value here will preempt initialization, so we
     // should only do it if we're reached PrivateMetadataState::Complete.
 
-    // Fast-track out if flagAllocatedDuringConstruction was called.
-    if (Impl::MayFlagAllocatedDuringConstruction) {
-      // This can be a relaxed load because beginAllocation is called on the
-      // same thread that called the constructor.
-      auto trackingInfo =
-        PrivateMetadataTrackingInfo(
-          TrackingInfo.load(std::memory_order_relaxed));
+    // We can skip allocation if we were allocated during construction.
+    auto state = worker.getState();
+    if (state != PrivateMetadataState::Allocating) {
+#ifndef NDEBUG
+      // We've already published the metadata as part of construction,
+      // so we can verify that the mangled name round-trips.
+      if (asImpl().allowMangledNameVerification(std::forward<Args>(args)...))
+        verifyMangledNameRoundtrip(asImpl().getValue());
+#endif
 
-      // If we've already allocated metadata, we can skip the rest of
-      // allocation.
-      if (trackingInfo.hasAllocatedMetadata()) {
-        // Skip initialization, too, if we're fully complete.
-        if (trackingInfo.isComplete()) {
-          return Status{asImpl().getValue(), MetadataState::Complete};
-
-        // Otherwise go directly to the initialization phase.
-        } else {
-          return None;
-        }
+      // Skip initialization, too, if we're fully complete.
+      if (state == PrivateMetadataState::Complete) {
+        assert(!worker.isWorkerThread());
+        return Status{asImpl().getValue(), MetadataState::Complete};
       }
+
+      // Otherwise, go directly to the initialization phase.
+      assert(worker.isWorkerThread());
+      return None;
     }
+
+    assert(worker.isWorkerThread());
 
     // Allocate the metadata.
     AllocationResult allocationResult =
       asImpl().allocate(std::forward<Args>(args)...);
+    state = allocationResult.State;
+    worker.setState(state);
 
-    // Publish the value.
-    asImpl().setValue(const_cast<ValueType>(allocationResult.Value));
-    PrivateMetadataState newState = allocationResult.State;
-    publishPrivateMetadataState(concurrency, newState);
+    // Set the self-link before publishing the new status.
+    auto value = const_cast<ValueType>(allocationResult.Value);
+    asImpl().setValue(value);
 
-    // If allocation gave us completed metadata, short-circuit initialization.
-    if (allocationResult.State == PrivateMetadataState::Complete) {
+    // If allocation gave us complete metadata, we can short-circuit
+    // initialization; publish and report that we've finished.
+    if (state == PrivateMetadataState::Complete) {
+      finishAndPublishProgress(worker, MetadataDependency(), nullptr);
+
+#ifndef NDEBUG
+      // Now that we've published the allocated metadata, verify that
+      // the mangled name round-trips.
+      if (asImpl().allowMangledNameVerification(std::forward<Args>(args)...))
+        verifyMangledNameRoundtrip(value);
+#endif
+
       return Status{allocationResult.Value, MetadataState::Complete};
     }
+
+    // Otherwise, we always try at least one round of initialization
+    // even if the request is for abstract metadata, just to avoid
+    // doing more unnecessary bookkeeping.  Publish the current
+    // state so that e.g. recursive uses of this metadata are
+    // satisfiable.
+    notifyWaitingThreadsOfProgress(worker, MetadataDependency());
+
+#ifndef NDEBUG
+    // Now that we've published the allocated metadata, verify that
+    // the mangled name round-trips.
+    if (asImpl().allowMangledNameVerification(std::forward<Args>(args)...))
+      verifyMangledNameRoundtrip(value);
+#endif
 
     return None;
   }
 
-  enum : bool { MayFlagAllocatedDuringConstruction = false };
-
-  /// As an alternative to allocate(), flag that allocation was
-  /// completed within the entry's constructor.  This should only be
-  /// called from within the constructor.
-  ///
-  /// If this is called, allocate() will not be called.
-  ///
-  /// If this is called, the subclass must define
-  ///   enum { MayFlagAllocatedDuringConstruction = true };
-  void flagAllocatedDuringConstruction(PrivateMetadataState state) {
-    assert(Impl::MayFlagAllocatedDuringConstruction);
-    assert(state != PrivateMetadataState::Allocating);
-    TrackingInfo.store(PrivateMetadataTrackingInfo(state).getRawValue(),
-                       std::memory_order_relaxed);
+  template <class... Args>
+  static bool allowMangledNameVerification(Args &&...args) {
+    // By default, always allow mangled name verification.
+    return true;
   }
 
   /// Begin initialization immediately after allocation.
   template <class... Args>
-  Status beginInitialization(ConcurrencyControl &concurrency,
+  Status beginInitialization(WaitQueue::Worker &worker,
                              MetadataRequest request, Args &&...args) {
     // Note that we ignore the extra arguments; those are just for the
     // constructor and allocation.
-    return doInitialization(concurrency, nullptr, request);
+    return doInitialization(worker, request);
   }
-
-  /// Resume initialization after a previous failure resulted in the
-  /// metadata being enqueued on another metadata cache.
-  Status resumeInitialization(ConcurrencyControl &concurrency,
-                              MetadataCompletionQueueEntry *queueEntry) {
-    return doInitialization(concurrency, queueEntry,
-                            MetadataRequest(MetadataState::Complete,
-                                            /*non-blocking*/ true));
-  }
-
-protected:
-  /// The expected return type of tryInitialize.
-  struct TryInitializeResult {
-    PrivateMetadataState NewState;
-    MetadataDependency Dependency;
-  };
 
 private:
   /// Try to complete the metadata.
   ///
   /// This is the initializing thread.  The lock is not held.
-  Status doInitialization(ConcurrencyControl &concurrency,
-                          MetadataCompletionQueueEntry *queueEntry,
+  Status doInitialization(WaitQueue::Worker &worker,
                           MetadataRequest request) {
-    // We should always have fully synchronized with any previous threads
-    // that were processing the initialization, so a relaxed load is fine
-    // here.  (This ordering is achieved by the locking which occurs as part
-    // of queuing and dequeuing metadata.)
-    auto curTrackingInfo =
-      PrivateMetadataTrackingInfo(TrackingInfo.load(std::memory_order_relaxed));
-    assert(curTrackingInfo.hasAllocatedMetadata());
-    assert(!curTrackingInfo.isComplete());
+    assert(worker.isWorkerThread());
 
+    assert(worker.getState() > PrivateMetadataState::Allocating);
     auto value = asImpl().getValue();
 
-    // Figure out the completion context.
+    auto queue = worker.getPublishedQueue();
+
+    // Figure out a completion context to use.
+    static const constexpr PrivateMetadataCompletionContext zeroContext = {};
     PrivateMetadataCompletionContext scratchContext;
     PrivateMetadataCompletionContext *context;
-    if (queueEntry) {
-      context = &queueEntry->CompletionContext;
+    if (auto persistent = queue->PersistentContext.get()) {
+      context = persistent;
     } else {
-      memset(&scratchContext, 0, sizeof(PrivateMetadataCompletionContext));
+      // Initialize the scratch context to zero.
+      scratchContext = zeroContext;
       context = &scratchContext;
     }
-
-    bool hasProgressSinceLastEnqueueAttempt = false;
-    MetadataCompletionQueueEntry *claimedQueue = nullptr;
 
     // Try the complete the metadata.  This only loops if initialization
     // has a dependency, but the new dependency is resolved when we go to
     // add ourselves to its queue.
     while (true) {
-      TryInitializeResult tryInitializeResult =
-        asImpl().tryInitialize(value, curTrackingInfo.getState(), context);
-      auto newState = tryInitializeResult.NewState;
+      assert(worker.getState() < PrivateMetadataState::Complete);
 
-      assert(curTrackingInfo.getState() <= newState &&
+      // Try a round of initialization.
+      auto oldState = worker.getState();
+      MetadataStateWithDependency MetadataStateWithDependency =
+        asImpl().tryInitialize(value, oldState, context);
+      auto newState = MetadataStateWithDependency.NewState;
+      auto dependency = MetadataStateWithDependency.Dependency;
+      worker.setState(newState);
+
+      assert(oldState <= newState &&
              "initialization regressed to an earlier state");
 
-      // Publish the new state of the metadata (waking any waiting
-      // threads immediately) if we've made any progress.  This seems prudent,
-      // but it might mean acquiring the lock multiple times.
-      if (curTrackingInfo.getState() < newState) {
-        hasProgressSinceLastEnqueueAttempt = true;
-        curTrackingInfo = PrivateMetadataTrackingInfo(newState);
-        publishPrivateMetadataState(concurrency, newState);
-      }
-
       // If we don't have a dependency, we're finished.
-      if (!tryInitializeResult.Dependency) {
+      bool done, willWait;
+      if (!dependency) {
         assert(newState == PrivateMetadataState::Complete &&
                "initialization didn't report a dependency but isn't complete");
-        assert(hasProgressSinceLastEnqueueAttempt);
-
-        // Claim any satisfied completion-queue entries (i.e. all of them).
-        concurrency.Lock.withLock([&] {
-          claimSatisfiedQueueEntriesWithLock(curTrackingInfo, claimedQueue);
-        });
-
-        // That will destroy the queue entry if we had one, so make sure we
-        // don't try to use it.
-        queueEntry = nullptr;
-        break;
+        done = true;
+        willWait = false;
+      } else {
+        assert(newState != PrivateMetadataState::Complete &&
+               "initialization reported a dependency but is complete");
+        done = false;
+        willWait = shouldBlockInitialization(newState, request);
       }
 
-      assert(newState != PrivateMetadataState::Complete &&
-             "completed initialization reported a dependency");
-
-      // Otherwise, we need to block this metadata on the dependency's queue.
-
-      // Create a queue entry if necessary.  Start using its context
-      // as the continuation context.
-      if (!queueEntry) {
-        queueEntry = new MetadataCompletionQueueEntry(value, scratchContext);
-        context = &queueEntry->CompletionContext;
+      // If we're not going to wait, but we're not done, and the
+      // completion context is no longer zero, copy the completion
+      // context into the persistent state (if it isn't already there).
+      if (!willWait && !done && !queue->PersistentContext) {
+        if (memcmp(&scratchContext, &zeroContext, sizeof(zeroContext)) != 0)
+          queue->PersistentContext.reset(
+            new PrivateMetadataCompletionContext(scratchContext));
       }
 
-      // Set the dependency on the queue entry.  This has to happen under
-      // the lock to protect against other threads checking for dependency
-      // cycles.
-      concurrency.Lock.withLock([&] {
-        prepareToEnqueueWithLock(queueEntry, tryInitializeResult.Dependency);
-        assert(LockedStorageKind == LSK::QueueEntry);
-
-        // Grab any satisfied queue entries while we have the lock.
-        if (hasProgressSinceLastEnqueueAttempt) {
-          hasProgressSinceLastEnqueueAttempt = false;
-          claimSatisfiedQueueEntriesWithLock(curTrackingInfo, claimedQueue);
-        }
-      });
-
-      // Try to block this metadata initialization on that queue.
-      // If this succeeds, we can't consider ourselves the initializing
-      // thread anymore.  The small amount of notification we do at the
-      // end of this function is okay to race with another thread
-      // potentially taking over initialization.
-      if (addToMetadataQueue(queueEntry, tryInitializeResult.Dependency))
-        break;
-
-      // If that failed, we should still have ownership of the entry.
-      assert(queueEntry);
-    }
-
-    // Immediately process all the queue entries we claimed.
-    while (auto cur = claimedQueue) {
-      claimedQueue = cur->Next;
-      resumeMetadataCompletion(cur);
-    }
-
-    // If we're not actually satisfied by the current state, we might need
-    // to block here.
-    if (curTrackingInfo.shouldWait(request)) {
-      awaitSatisfyingState(concurrency, request, curTrackingInfo);
-    }
-
-#if !NDEBUG
-    verifyMangledNameRoundtrip(value);
-#endif
-
-    return { value, curTrackingInfo.getAccomplishedRequestState() };
-  }
-
-  /// Prepare to enqueue this metadata on another metadata's completion
-  /// queue, given that we're holding the lock.
-  void prepareToEnqueueWithLock(MetadataCompletionQueueEntry *queueEntry,
-                                MetadataDependency dependency) {
-    assert(dependency);
-    queueEntry->Dependency = dependency;
-
-    switch (LockedStorageKind) {
-    case LSK::QueueEntry:
-      assert(LockedStorage.QueueEntry == queueEntry);
-      return;
-
-    case LSK::CompletionQueue:
-      // Move the existing completion queue to the cache entry.
-      queueEntry->CompletionQueue = LockedStorage.CompletionQueue;
-      SWIFT_FALLTHROUGH;
-
-    case LSK::AllocatingThread:
-      LockedStorageKind = LSK::QueueEntry;
-      LockedStorage.QueueEntry = queueEntry;
-      return;
-
-    case LSK::Complete:
-      swift_unreachable("preparing to enqueue when already complete?");
-    }
-    swift_unreachable("bad kind");
-  }
-
-  /// Claim all the satisfied completion queue entries, given that
-  /// we're holding the lock.
-  void claimSatisfiedQueueEntriesWithLock(PrivateMetadataTrackingInfo newInfo,
-                                  MetadataCompletionQueueEntry *&claimedQueue) {
-    // Collect anything in the metadata's queue whose target state has been
-    // reached to the queue in result.  Note that we repurpose the Next field
-    // in the collected entries.
-
-    MetadataCompletionQueueEntry **completionQueue;
-    if (LockedStorageKind == LSK::CompletionQueue) {
-      completionQueue = &LockedStorage.CompletionQueue;
-    } else if (LockedStorageKind == LSK::QueueEntry) {
-      completionQueue = &LockedStorage.QueueEntry->CompletionQueue;
-    } else {
-      // If we're not even currently storing a completion queue,
-      // there's nothing to do but wake waiting threads.
-      return;
-    }
-
-    // We want to append to the claimed queue, so find the end.
-    auto nextToResume = &claimedQueue;
-    while (auto next = *nextToResume) {
-      nextToResume = &next->Next;
-    }
-    assert(!*nextToResume);
-
-    // If the new state is complete, we can just claim the entire queue
-    // and destroy the metadata's own queue entry if it exists.
-    if (newInfo.isComplete()) {
-      *nextToResume = *completionQueue;
-      *completionQueue = nullptr;
-
-      if (LockedStorageKind == LSK::QueueEntry) {
-        delete LockedStorage.QueueEntry;
+      // If we're not going to wait, publish the new state and finish
+      // execution.
+      if (!willWait) {
+        finishAndPublishProgress(worker, dependency,
+                                 queue->PersistentContext.release());
+        return getStatusToReturn(newState);
       }
 
-      // Mark that we're no longer storing a queue.
-      LockedStorageKind = LSK::Complete;
+      // We're going to wait.  If we've made progress, make sure we notify
+      // any waiting threads about that progress; if they're satisfied
+      // by that progress, they shouldn't be blocked.
+      if (oldState < newState) {
+        notifyWaitingThreadsOfProgress(worker, dependency);
 
-      return;
-    }
+        // This might change the queue pointer.
+        queue = worker.getPublishedQueue();
 
-    // Otherwise, we have to walk the completion queue looking specifically
-    // for entries that match.
-    auto *nextWaiter = completionQueue;
-    while (auto waiter = *nextWaiter) {
-      // If the new state of this entry doesn't satisfy the waiter's
-      // requirements, skip over it.
-      if (!newInfo.satisfies(waiter->Dependency.Requirement)) {
-        nextWaiter = &waiter->Next;
-        continue;
+        assert(!queue->PersistentContext ||
+               queue->PersistentContext.get() == context);
       }
 
-      // Add the waiter to the end of the next-to-resume queue, and update
-      // the end to the waiter's Next field.
-      *nextToResume = *nextWaiter;
-      nextToResume = &waiter->Next;
+      // Block on the target dependency.
+      blockOnDependency(worker, request, MetadataStateWithDependency.Dependency);
 
-      // Splice the waiter out of the completion queue.
-      *nextWaiter = waiter->Next;
-
-      assert(!*nextToResume);
+      // Go back and try initialization again.
     }
   }
 
   /// Publish a new metadata state.  Wake waiters if we had any.
-  void publishPrivateMetadataState(ConcurrencyControl &concurrency,
-                                   PrivateMetadataState newState) {
-    auto newInfo = PrivateMetadataTrackingInfo(newState);
-    assert(newInfo.hasAllocatedMetadata());
-    assert(!newInfo.hasWaiters());
+  void finishAndPublishProgress(MetadataWaitQueue::Worker &worker,
+                                MetadataDependency dependency,
+                                PrivateMetadataCompletionContext *context) {
+    auto newState = worker.getState();
 
-    auto oldInfo = PrivateMetadataTrackingInfo(
-      TrackingInfo.exchange(newInfo.getRawValue(), std::memory_order_release));
-    assert(!oldInfo.isComplete());
-
-    // If we have existing waiters, wake them now, since we no longer
-    // remember in State that we have any.
-    if (oldInfo.hasWaiters()) {
-      // We need to acquire the lock.  There could be an arbitrary number
-      // of threads simultaneously trying to set the has-waiters flag, and we
-      // have to make sure they start waiting before we notify the queue.
-      concurrency.Lock.withLockThenNotifyAll(concurrency.Queue, [] {});
+    // Create a suspended completion if there's something to record there.
+    // This will be deallocated when some other thread takes over
+    // initialization.
+    SuspendedMetadataCompletion *suspended = nullptr;
+    if (dependency || context) {
+      assert(newState != PrivateMetadataState::Complete);
+      suspended = new SuspendedMetadataCompletion(dependency, context);
     }
+
+    // We're done with this worker thread; replace the wait queue
+    // with the dependency record.  We still want to do these stores
+    // under the lock, though.
+    worker.finishAndUnpublishQueue([&] { 
+      auto newInfo = PrivateMetadataTrackingInfo(newState, suspended);
+      assert(newInfo.hasAllocatedMetadata());
+
+      // Set the new state and unpublish the reference to the queue.
+      TrackingInfo.store(newInfo, std::memory_order_release);
+    });
   }
 
-  /// Wait for the request to be satisfied by the current state.
-  void awaitSatisfyingState(ConcurrencyControl &concurrency,
-                            MetadataRequest request,
-                            PrivateMetadataTrackingInfo &trackingInfo) {
-    concurrency.Lock.withLockOrWait(concurrency.Queue, [&] {
-      // Re-load the state now that we have the lock.  If we don't
-      // need to wait, we're done.  Otherwise, flag the existence of a
-      // waiter; if that fails, start over with the freshly-loaded state.
-      trackingInfo = PrivateMetadataTrackingInfo(
-                                  TrackingInfo.load(std::memory_order_acquire));
-      while (true) {
-        if (!trackingInfo.shouldWait(request))
-          return true;
+  /// Notify any waiting threads that metadata has made progress.
+  void notifyWaitingThreadsOfProgress(MetadataWaitQueue::Worker &worker,
+                                      MetadataDependency dependency) {
+    worker.maybeReplaceQueue([&] {
+      MetadataWaitQueue *oldQueue = worker.getPublishedQueue();
+      MetadataWaitQueue *newQueue;
 
-        if (trackingInfo.hasWaiters())
-          break;
+      // If there aren't any other references to the existing queue,
+      // we don't need to replace anything.
+      if (oldQueue->isUniquelyReferenced_locked()) {
+        newQueue = oldQueue;
 
-        // Try to swap in the has-waiters bit.  If this succeeds, we can
-        // ahead and wait.
-        if (TrackingInfo.compare_exchange_weak(trackingInfo.getRawValueRef(),
-                                        trackingInfo.addWaiters().getRawValue(),
-                                        std::memory_order_relaxed,
-                                        std::memory_order_acquire))
-          break;
+      // Otherwise, make a new queue.  Cycling queues this way allows
+      // waiting threads to unblock if they are satisfied with the given
+      // progress.  If they aren't, they'll wait on the new queue.
+      } else {
+        newQueue = worker.createReplacementQueue();
+        newQueue->PersistentContext = std::move(oldQueue->PersistentContext);
       }
 
-      // As a QoI safe-guard against the simplest form of cyclic
-      // dependency, check whether this thread is the one responsible
-      // for allocating the metadata.
-      if (isBeingAllocatedByCurrentThread()) {
-        fprintf(stderr,
-                "%s(%p): cyclic metadata dependency detected, aborting\n",
-                Impl::getName(), static_cast<const void*>(this));
-        abort();
-      }
+      // Update the current blocking dependency.
+      newQueue->BlockingDependency = dependency;
 
-      return false;
+      // Only the worker thread modifies TrackingInfo, so we can do a
+      // simple store instead of a compare-exchange.
+      PrivateMetadataTrackingInfo newTrackingInfo =
+        PrivateMetadataTrackingInfo(worker.getState(), newQueue);
+      TrackingInfo.store(newTrackingInfo, std::memory_order_release);
+
+      // We signal to maybeReplaceQueue that replacement is required by
+      // returning a non-null queue.
+      return (newQueue != oldQueue ? newQueue : nullptr);
     });
+  }
+
+  /// Given that the request is not satisfied by the current state of
+  /// the metadata, wait for the request to be satisfied.
+  ///
+  /// If there's a thread that currently owns initialization for this
+  /// metadata (i.e. it has published a wait queue into TrackingInfo),
+  /// we simply wait on that thread.  Otherwise, we take over
+  /// initialization on the current thread.
+  ///
+  /// If the request is non-blocking, we do not wait, but we may need
+  /// to take over initialization.
+  Status awaitSatisfyingState(ConcurrencyControl &concurrency,
+                              MetadataRequest request) {
+    // Try loading the current state before acquiring the lock.
+    auto trackingInfo = TrackingInfo.load(std::memory_order_acquire);
+
+    // Return if the current state says to do so.
+    auto checkResult = trackingInfo.check(request);
+    if (checkResult == PrivateMetadataTrackingInfo::Satisfied ||
+        checkResult == PrivateMetadataTrackingInfo::Unsatisfied)
+      return getStatusToReturn(trackingInfo.getState());
+
+    MetadataWaitQueue::Worker worker(concurrency.Lock);
+
+    std::unique_ptr<SuspendedMetadataCompletion> suspendedCompletionToDelete;
+    worker.withLock([&](MetadataWaitQueue::Worker::Operation &op) {
+      assert(!worker.isWorkerThread());
+
+      // Reload the tracking info, since it might have been
+      // changed by a concurrent worker thread.
+      trackingInfo = TrackingInfo.load(TrackingInfoIsLockedOrder);
+      checkResult = trackingInfo.check(request);
+
+      switch (checkResult) {
+      // Either the request is satisfied or we should tell the
+      // requester immediately that it isn't.
+      case PrivateMetadataTrackingInfo::Satisfied:
+      case PrivateMetadataTrackingInfo::Unsatisfied:
+        return;
+
+      // There's currently an initializing thread for this metadata,
+      // and either we've got a blocking request that isn't yet
+      // satisfied or the metadata hasn't even been allocated yet.
+      // Wait on the thread and then call this lambda again.
+      case PrivateMetadataTrackingInfo::Wait:
+        assert(trackingInfo.hasWaitQueue());
+        return op.waitAndRepeat(trackingInfo.getWaitQueue());
+
+      // There isn't a thread currently building the metadata,
+      // and the request isn't satisfied.  Become the initializing
+      // thread and try to build the metadata ourselves.
+      case PrivateMetadataTrackingInfo::Resume: {
+        assert(!trackingInfo.hasWaitQueue());
+
+        // Create a queue and publish it, taking over execution.
+        auto queue = op.createQueue();
+
+        // Copy the information from the suspended completion, if any,
+        // into the queue.
+        if (auto suspendedCompletion =
+              trackingInfo.getSuspendedCompletion()) {
+          queue->BlockingDependency =
+            suspendedCompletion->BlockingDependency;
+          queue->PersistentContext =
+            std::move(suspendedCompletion->PersistentContext);
+
+          // Make sure we delete the suspended completion later.
+          suspendedCompletionToDelete.reset(suspendedCompletion);
+        }
+
+        // Publish the wait queue we just made.
+        auto newTrackingInfo =
+          PrivateMetadataTrackingInfo(trackingInfo.getState(), queue);
+        TrackingInfo.store(newTrackingInfo, std::memory_order_release);
+
+        return op.flagQueueIsPublished(queue);
+      }
+      }
+    });
+
+    // If the check result wasn't Resume, it must have been Satisfied
+    // or Unsatisfied, and we should return immediately.
+    if (checkResult != PrivateMetadataTrackingInfo::Resume) {
+      assert(checkResult == PrivateMetadataTrackingInfo::Satisfied ||
+             checkResult == PrivateMetadataTrackingInfo::Unsatisfied);
+      return getStatusToReturn(trackingInfo.getState());
+    }
+
+    // Otherwise, we published and are now the worker thread owning
+    // this metadata's initialization.  Do the initialization.
+    worker.setState(trackingInfo.getState());
+    return doInitialization(worker, request);
+  }
+
+  /// Given that we are the active worker thread for this initialization,
+  /// block until the given dependency is satisfied.
+  void blockOnDependency(MetadataWaitQueue::Worker &worker,
+                         MetadataRequest request,
+                         MetadataDependency dependency) {
+    assert(worker.isWorkerThread());
+    assert(request.isBlocking());
+
+    // Formulate the request for this metadata as a dependency.
+    auto requestDependency = MetadataDependency(asImpl().getValue(),
+                                                request.getState());
+
+    // Block on the metadata dependency.
+    blockOnMetadataDependency(requestDependency, dependency);
   }
 
 public:
-  /// Block a metadata initialization on progress in the initialization
-  /// of this metadata.
+  /// Check whether this metadata has reached the given state and,
+  /// if not, return a further metadata dependency if possible.
   ///
-  /// That is, this cache entry is for metadata Y, and we have been
-  /// handed a queue entry showing a dependency for a metadata X on Y
-  /// reaching state S_Y.  Add the queue entry to the completion queue
-  /// for Y (which is to say, on this cache entry) unless Y has already
-  /// reached state S.  If it has reached that state, return false.
-  ///
-  /// This is always called from the initializing thread.  The lock is not held.
-  bool enqueue(ConcurrencyControl &concurrency,
-               MetadataCompletionQueueEntry *queueEntry,
-               MetadataDependency dependency) {
-    assert(queueEntry);
-    assert(!queueEntry->Next);
-    assert(dependency == queueEntry->Dependency);
+  /// It's possible for this to not return a dependency, but only if some
+  /// other thread is currently still attempting to complete the first
+  /// full round of attempted initialization.  It's also possible
+  /// for the reported dependency to be out of date.
+  MetadataStateWithDependency
+  checkDependency(ConcurrencyControl &concurrency, MetadataState requirement) {
+    // Do a quick check while not holding the lock.
+    auto curInfo = TrackingInfo.load(std::memory_order_acquire);
+    if (curInfo.satisfies(requirement))
+      return { curInfo.getState(), MetadataDependency() };
 
-    MetadataDependency otherDependency;
-    bool success = concurrency.Lock.withLock([&] {
-      auto curInfo = PrivateMetadataTrackingInfo(
-                                  TrackingInfo.load(std::memory_order_acquire));
-      if (curInfo.satisfies(dependency.Requirement))
-        return false;
+    // Alright, try again while holding the lock, which is required
+    // in order to safely read the blocking dependency.
+    return concurrency.Lock.withLock([&]() -> MetadataStateWithDependency {
+      curInfo = TrackingInfo.load(TrackingInfoIsLockedOrder);
 
-      // Note that we don't set the waiters bit because we're not actually
-      // blocking any threads.
-
-      // Ensure that there's a completion queue.
-      MetadataCompletionQueueEntry **completionQueue;
-
-      switch (LockedStorageKind) {
-      case LSK::Complete:
-        swift_unreachable("enqueuing on complete cache entry?");
-
-      case LSK::AllocatingThread:
-        LockedStorageKind = LSK::CompletionQueue;
-        LockedStorage.CompletionQueue = nullptr;
-        completionQueue = &LockedStorage.CompletionQueue;
-        break;
-
-      case LSK::CompletionQueue:
-        completionQueue = &LockedStorage.CompletionQueue;
-        break;
-
-      case LSK::QueueEntry:
-        otherDependency = LockedStorage.QueueEntry->Dependency;
-        completionQueue = &LockedStorage.QueueEntry->CompletionQueue;
-        break;
-      }
-
-      queueEntry->Next = *completionQueue;
-      *completionQueue = queueEntry;
-      return true;
-    });
-
-    // Diagnose unbreakable dependency cycles.
-    //
-    // Note that we only do this if we find a second dependency link ---
-    // that is, if metadata Y is itself dependent on metadata Z reaching
-    // state S_Z --- but that this will fire even only a cycle of length 1
-    // (i.e. if X == Y) because of course Y will already be showing the
-    // dependency on Y in this case.
-    if (otherDependency) {
-      checkMetadataDependencyCycle(queueEntry->Value, dependency,
-                                   otherDependency);
-    }
-
-    return success;
-  }
-
-  MetadataDependency checkDependency(ConcurrencyControl &concurrency,
-                                     MetadataState requirement) {
-    return concurrency.Lock.withLock([&] {
-      // Load the current state.
-      auto curInfo = PrivateMetadataTrackingInfo(
-                                  TrackingInfo.load(std::memory_order_acquire));
-
-      // If the requirement is satisfied, there no further dependency for now.
       if (curInfo.satisfies(requirement))
-        return MetadataDependency();
+        return { curInfo.getState(), MetadataDependency() };
 
-      // Check for an existing dependency.
-      switch (LockedStorageKind) {
-      case LSK::Complete:
-        swift_unreachable("dependency on complete cache entry?");
-
-      case LSK::AllocatingThread:
-      case LSK::CompletionQueue:
-        return MetadataDependency();
-
-      case LSK::QueueEntry:
-        return LockedStorage.QueueEntry->Dependency;
-      }
+      return { curInfo.getState(), curInfo.getBlockingDependency_locked() };
     });
   }
 };
@@ -1416,8 +1342,6 @@ protected:
   }
 
 private:
-  // These are arranged to fit into the tail-padding of the superclass.
-
   /// These are set during construction and never changed.
   const uint16_t NumKeyParameters;
   const uint16_t NumWitnessTables;
@@ -1435,10 +1359,17 @@ private:
   }
 
 public:
-  VariadicMetadataCacheEntryBase(const MetadataCacheKey &key)
-      : NumKeyParameters(key.numKeyParameters()),
+  VariadicMetadataCacheEntryBase(const MetadataCacheKey &key,
+                                 MetadataWaitQueue::Worker &worker,
+                                 PrivateMetadataState initialState,
+                                 ValueType value)
+      : super(worker, initialState),
+        NumKeyParameters(key.numKeyParameters()),
         NumWitnessTables(key.numWitnessTables()),
-        Hash(key.hash()) {
+        Hash(key.hash()),
+        Value(value) {
+    assert((value != nullptr) ==
+           (initialState != PrivateMetadataState::Allocating));
     memcpy(this->template getTrailingObjects<const void *>(),
            key.begin(), key.size() * sizeof(const void *));
   }

--- a/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
+++ b/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
@@ -37,7 +37,7 @@ enum test0_Node {
 
 DynamicMetadataCycleTests.test("cycle through enum")
   .crashOutputMatches("runtime error: unresolvable type metadata dependency cycle detected")
-  .crashOutputMatches("  main.test0_Node")
+  .crashOutputMatches("  Request for transitive completion of main.test0_Node")
   .crashOutputMatches("  depends on layout of resil.ResilientGenericStruct<main.test0_Node")
   .crashOutputMatches("  depends on layout of main.test0_Node")
   .code {


### PR DESCRIPTION
The current system is based on `MetadataCompletionQueueEntry` objects which are allocated and then enqueued on dependencies. Blocking is achieved using a condition variable associated with the lock on the appropriate metadata cache.  Condition variables are inherently susceptible to priority inversions because the waiting threads have no dynamic knowledge of which thread will notify the condition.  In the current system, threads that unblock dependencies synchronously advance their dependent metadata completions, which means the signaling thread is unreliable even if we could represent it in condition variables.  As a result, the current system is wholly unsuited for eliminating these priority inversions.
    
The new system uses `AtomicWaitQueue`, basically an object containing a lock.  The queue is eagerly allocated, and the lock is held, whenever a thread is doing work that other threads might wish to block on.  In the metadata completion system, this means whenever we construct a metadata cache entry and the metadata isn't already allocated and transitively complete after said construction.  Blocking is done by safely acquiring a shared reference to the queue object (which, in the current implementation, requires briefly taking a lock that's global to the surrounding metadata cache) and then acquiring the contained lock.  For typical lock implementations, this will avoid priority inversions by ensuring that the priority of waiting threads is temporarily propagated to the thread responsible for advancing the metadata's completion.
    
Dependencies are unblocked by simply releasing the lock contained in the queue.  The unblocking thread doesn't know exactly what metadata are blocked on it and doesn't make any effort to directly advance their completion; instead, the blocking thread will wake up and then attempt to advance the dependent metadata completion itself, eliminating a source of priority overhang that affected the old system.  Successive rounds of unblocking (e.g. when a metadata makes partial progress but isn't yet complete) can be achieved by creating a new queue and unlocking the old one.  We can still record dependencies and use them to dynamically diagnose metadata cycles.
    
The new system allocates more eagerly than the old one.  Formerly, metadata completions which were never blocked never needed to allocate a `MetadataCompletionQueueEntry`.  (As a downside, we were unable to actually deallocate those entries if they did need to be allocated.)  The new system will allocate a queue for most metadata completions.  (As an upside, they can be reliably deallocated.)  Cache entries are also now slightly smaller because some of the excess storage for status has been folded into the queue.
    
The fast path of an actual read of the metadata remains a simple load-acquire.  Slow paths may require a bit more locking.  On Darwin, the metadata cache lock can now use `os_unfair_lock` instead of `pthread_mutex_t` (which is a massive improvement) because it does not need to support associated condition variables.
    
In the future, the excess locking could be eliminated with some sort of generational scheme.  Sadly, those are not portable, and I didn't want to take it on up-front.
    
rdar://76127798