### PR TITLE
RequirementMachine: Implement minimization for concrete nested type requirements

### DIFF
--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -138,6 +138,7 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::ConcreteConformance:
       case RewriteStep::SuperclassConformance:
       case RewriteStep::ConcreteTypeWitness:
+      case RewriteStep::SameTypeWitness:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/GeneratingConformances.cpp
+++ b/lib/AST/RequirementMachine/GeneratingConformances.cpp
@@ -137,6 +137,7 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::Decompose:
       case RewriteStep::ConcreteConformance:
       case RewriteStep::SuperclassConformance:
+      case RewriteStep::ConcreteTypeWitness:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -93,6 +93,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
+    case RewriteStep::SameTypeWitness:
       break;
     }
 
@@ -210,6 +211,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
+    case RewriteStep::SameTypeWitness:
       break;
     }
 
@@ -309,6 +311,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
+    case RewriteStep::SameTypeWitness:
       newSteps.push_back(step);
       break;
     }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -92,6 +92,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     case RewriteStep::Decompose:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
+    case RewriteStep::ConcreteTypeWitness:
       break;
     }
 
@@ -208,6 +209,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
     case RewriteStep::Decompose:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
+    case RewriteStep::ConcreteTypeWitness:
       break;
     }
 
@@ -306,6 +308,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
     case RewriteStep::Decompose:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
+    case RewriteStep::ConcreteTypeWitness:
       newSteps.push_back(step);
       break;
     }

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -227,8 +227,10 @@ private:
                    SmallVectorImpl<InducedRule> &inducedRules) const;
 
   MutableTerm computeConstraintTermForTypeWitness(
-      Term key, CanType concreteType, CanType typeWitness,
-      const MutableTerm &subjectType, ArrayRef<Term> substitutions,
+      Term key, RequirementKind requirementKind,
+      CanType concreteType, CanType typeWitness,
+      const MutableTerm &subjectType,
+      ArrayRef<Term> substitutions,
       RewritePath &path) const;
 
   void recordConcreteConformanceRule(

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -228,7 +228,8 @@ private:
 
   MutableTerm computeConstraintTermForTypeWitness(
       Term key, CanType concreteType, CanType typeWitness,
-      const MutableTerm &subjectType, ArrayRef<Term> substitutions) const;
+      const MutableTerm &subjectType, ArrayRef<Term> substitutions,
+      RewritePath &path) const;
 
   void recordConcreteConformanceRule(
     unsigned concreteRuleID,

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -753,6 +753,9 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
     MutableTerm result(key);
     result.add(concreteConformanceSymbol);
 
+    path.add(RewriteStep::forSameTypeWitness(
+        witnessID, /*inverse=*/true));
+
     return result;
   }
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -616,34 +616,9 @@ void PropertyMap::concretizeTypeWitnessInConformance(
 
   RewritePath path;
 
-  auto simplify = [&](CanType t) -> CanType {
-    return CanType(t.transformRec([&](Type t) -> Optional<Type> {
-      if (!t->isTypeParameter())
-        return None;
-
-      auto term = Context.getRelativeTermForType(t->getCanonicalType(),
-                                                 substitutions);
-      System.simplify(term);
-      return Context.getTypeForTerm(term, { });
-    }));
-  };
-
-  if (simplify(concreteType) == simplify(typeWitness) &&
-      requirementKind == RequirementKind::SameType) {
-    // FIXME: ConcreteTypeInDomainMap should support substitutions so
-    // that we can remove this.
-
-    if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
-      llvm::dbgs() << "^^ Type witness is the same as the concrete type\n";
-    }
-
-    // Add a rule T.[P:A] => T.
-    constraintType = MutableTerm(key);
-  } else {
-    constraintType = computeConstraintTermForTypeWitness(
-        key, concreteType, typeWitness, subjectType,
-        substitutions, path);
-  }
+  constraintType = computeConstraintTermForTypeWitness(
+      key, requirementKind, concreteType, typeWitness, subjectType,
+      substitutions, path);
 
   inducedRules.emplace_back(constraintType, subjectType, path);
   if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
@@ -721,9 +696,69 @@ RewriteSystem::getConcreteTypeWitness(unsigned index) const {
 ///
 ///        T.[P:A] => V
 MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
-    Term key, CanType concreteType, CanType typeWitness,
-    const MutableTerm &subjectType, ArrayRef<Term> substitutions,
+    Term key, RequirementKind requirementKind,
+    CanType concreteType, CanType typeWitness,
+    const MutableTerm &subjectType,
+    ArrayRef<Term> substitutions,
     RewritePath &path) const {
+  // If the type witness is abstract, introduce a same-type requirement
+  // between two type parameters.
+  if (typeWitness->isTypeParameter()) {
+    // The type witness is a type parameter of the form τ_0_n.X.Y...Z,
+    // where 'n' is an index into the substitution array.
+    //
+    // Add a rule:
+    //
+    // T.[concrete: C : P].[P:X] => S[n].X.Y...Z
+    //
+    // Where S[n] is the nth substitution term.
+
+    // FIXME: Record a rewrite path.
+    return Context.getRelativeTermForType(typeWitness, substitutions);
+  }
+
+  // Otherwise the type witness is concrete, but may contain type
+  // parameters in structural position.
+
+  // Compute the concrete type symbol [concrete: C.X].
+  SmallVector<Term, 3> result;
+  auto typeWitnessSchema =
+      remapConcreteSubstitutionSchema(typeWitness, substitutions,
+                                      Context, result);
+  auto typeWitnessSymbol =
+      Symbol::forConcreteType(typeWitnessSchema, result, Context);
+  System.simplifySubstitutions(typeWitnessSymbol);
+
+  auto concreteConformanceSymbol = *(subjectType.end() - 2);
+  auto assocTypeSymbol = *(subjectType.end() - 1);
+
+  RewriteSystem::ConcreteTypeWitness witness(concreteConformanceSymbol,
+                                             assocTypeSymbol,
+                                             typeWitnessSymbol);
+  unsigned witnessID = System.recordConcreteTypeWitness(witness);
+
+  // If it is equal to the parent type, introduce a same-type requirement
+  // between the two parameters.
+  if (requirementKind == RequirementKind::SameType &&
+      typeWitnessSymbol.getConcreteType() == concreteType &&
+      typeWitnessSymbol.getSubstitutions() == substitutions) {
+    // FIXME: ConcreteTypeInDomainMap should support substitutions so
+    // that we can remove this.
+
+    if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
+      llvm::dbgs() << "^^ Type witness is the same as the concrete type\n";
+    }
+
+    // Add a rule T.[concrete: C : P].[P:X] => T.[concrete: C : P].
+    MutableTerm result(key);
+    result.add(concreteConformanceSymbol);
+
+    return result;
+  }
+
+  // If the type witness is completely concrete, try to introduce a
+  // same-type requirement with another representative type parameter,
+  // if we have one.
   if (!typeWitness->hasTypeParameter()) {
     // Check if we have a shorter representative we can use.
     auto domain = key.getRootProtocols();
@@ -737,46 +772,23 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
           llvm::dbgs() << "^^ Type witness can re-use property bag of "
                        << found->second << "\n";
         }
+
+        // FIXME: Record a rewrite path.
         return result;
       }
     }
   }
 
-  if (typeWitness->isTypeParameter()) {
-    // The type witness is a type parameter of the form τ_0_n.X.Y...Z,
-    // where 'n' is an index into the substitution array.
-    //
-    // Add a rule:
-    //
-    // T.[concrete: C : P].[P:X] => S[n].X.Y...Z
-    //
-    // Where S[n] is the nth substitution term.
-    return Context.getRelativeTermForType(typeWitness, substitutions);
-  }
-
-  // The type witness is a concrete type.
+  // Otherwise, add a concrete type requirement for the type witness.
   //
   // Add a rule:
   //
-  // T.[concrete: C : P].[P:X].[concrete: Foo.A] => T.[concrete: C : P].[P:A].
+  // T.[concrete: C : P].[P:X].[concrete: C.X] => T.[concrete: C : P].[P:X].
   MutableTerm constraintType = subjectType;
-
-  SmallVector<Term, 3> result;
-  auto typeWitnessSchema =
-      remapConcreteSubstitutionSchema(typeWitness, substitutions,
-                                      Context, result);
-
-  constraintType.add(
-      Symbol::forConcreteType(
-          typeWitnessSchema, result, Context));
-
-  RewriteSystem::ConcreteTypeWitness witness(*(constraintType.end() - 3),
-                                             *(constraintType.end() - 2),
-                                             *(constraintType.end() - 1));
-  unsigned index = System.recordConcreteTypeWitness(witness);
+  constraintType.add(typeWitnessSymbol);
 
   path.add(RewriteStep::forConcreteTypeWitness(
-      index, /*inverse=*/false));
+      witnessID, /*inverse=*/false));
 
   return constraintType;
 }

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -95,7 +95,21 @@ struct RewriteStep {
     /// concrete conformance symbol [concrete: C : P]. This symbol is replaced
     /// with the superclass symbol [superclass: C] followed by the protocol
     /// symbol [P].
-    SuperclassConformance
+    SuperclassConformance,
+
+    /// If not inverted: the top of the A stack must be a term ending in a
+    /// concrete conformance symbol [concrete: C : P] followed by an associated
+    /// type symbol [P:X], and the concrete type symbol [concrete: C.X] for the
+    /// type witness of 'X' in the conformance 'C : P'. The concrete type symbol
+    /// is eliminated.
+    ///
+    /// If inverted: the concrete type symbol [concrete: C.X] is introduced.
+    ///
+    /// The RuleID field is repurposed to store the result of calling
+    /// RewriteSystem::recordConcreteTypeWitness(). This index is then
+    /// passed in to RewriteSystem::getConcreteTypeWitness() when applying
+    /// the step.
+    ConcreteTypeWitness
   };
 
   /// The rewrite step kind.
@@ -163,6 +177,11 @@ struct RewriteStep {
   static RewriteStep forSuperclassConformance(bool inverse) {
     return RewriteStep(SuperclassConformance, /*startOffset=*/0, /*endOffset=*/0,
                        /*ruleID=*/0, inverse);
+  }
+
+  static RewriteStep forConcreteTypeWitness(unsigned witnessID, bool inverse) {
+    return RewriteStep(ConcreteTypeWitness, /*startOffset=*/0, /*endOffset=*/0,
+                       /*ruleID=*/witnessID, inverse);
   }
 
   bool isInContext() const {
@@ -329,6 +348,9 @@ struct RewritePathEvaluator {
                       const RewriteSystem &system);
 
   void applyConcreteConformance(const RewriteStep &step,
+                                const RewriteSystem &system);
+
+  void applyConcreteTypeWitness(const RewriteStep &step,
                                 const RewriteSystem &system);
 
   void dump(llvm::raw_ostream &out) const;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -197,44 +197,6 @@ class RewriteSystem final {
   /// type is an index into the Rules array defined above.
   Trie<unsigned, MatchKind::Shortest> Trie;
 
-  /// Constructed from a rule of the form X.[P2:T] => X.[P1:T] by
-  /// checkMergedAssociatedType().
-  struct MergedAssociatedType {
-    /// The *right* hand side of the original rule, X.[P1:T].
-    Term rhs;
-
-    /// The associated type symbol appearing at the end of the *left*
-    /// hand side of the original rule, [P2:T].
-    Symbol lhsSymbol;
-
-    /// The merged associated type symbol, [P1&P2:T].
-    Symbol mergedSymbol;
-  };
-
-  /// A list of pending terms for the associated type merging completion
-  /// heuristic. Entries are added by checkMergedAssociatedType(), and
-  /// consumed in processMergedAssociatedTypes().
-  std::vector<MergedAssociatedType> MergedAssociatedTypes;
-
-  /// Pairs of rules which have already been checked for overlap.
-  llvm::DenseSet<std::pair<unsigned, unsigned>> CheckedOverlaps;
-
-  /// Homotopy generators for this rewrite system. These are the
-  /// rewrite loops which rewrite a term back to itself.
-  ///
-  /// In the category theory interpretation, a rewrite rule is a generating
-  /// 2-cell, and a rewrite path is a 2-cell made from a composition of
-  /// generating 2-cells.
-  ///
-  /// Homotopy generators, in turn, are 3-cells. The special case of a
-  /// 3-cell discovered during completion can be viewed as two parallel
-  /// 2-cells; this is actually represented as a single 2-cell forming a
-  /// loop around a base point.
-  ///
-  /// This data is used by the homotopy reduction and generating conformances
-  /// algorithms.
-  std::vector<RewriteLoop> Loops;
-
   DebugOptions Debug;
 
   /// Whether we've initialized the rewrite system with a call to initialize().
@@ -288,10 +250,6 @@ public:
     return Rules[ruleID];
   }
 
-  ArrayRef<RewriteLoop> getLoops() const {
-    return Loops;
-  }
-
   bool addRule(MutableTerm lhs, MutableTerm rhs,
                const RewritePath *path=nullptr);
 
@@ -309,6 +267,9 @@ public:
   ///
   //////////////////////////////////////////////////////////////////////////////
 
+  /// Pairs of rules which have already been checked for overlap.
+  llvm::DenseSet<std::pair<unsigned, unsigned>> CheckedOverlaps;
+
   std::pair<CompletionResult, unsigned>
   computeConfluentCompletion(unsigned maxIterations,
                              unsigned maxDepth);
@@ -325,6 +286,89 @@ public:
   void verifyRewriteRules(ValidityPolicy policy) const;
 
 private:
+  bool
+  computeCriticalPair(
+      ArrayRef<Symbol>::const_iterator from,
+      const Rule &lhs, const Rule &rhs,
+      std::vector<std::pair<MutableTerm, MutableTerm>> &pairs,
+      std::vector<RewritePath> &paths,
+      std::vector<RewriteLoop> &loops) const;
+
+  /// Constructed from a rule of the form X.[P2:T] => X.[P1:T] by
+  /// checkMergedAssociatedType().
+  struct MergedAssociatedType {
+    /// The *right* hand side of the original rule, X.[P1:T].
+    Term rhs;
+
+    /// The associated type symbol appearing at the end of the *left*
+    /// hand side of the original rule, [P2:T].
+    Symbol lhsSymbol;
+
+    /// The merged associated type symbol, [P1&P2:T].
+    Symbol mergedSymbol;
+  };
+
+  /// A list of pending terms for the associated type merging completion
+  /// heuristic. Entries are added by checkMergedAssociatedType(), and
+  /// consumed in processMergedAssociatedTypes().
+  std::vector<MergedAssociatedType> MergedAssociatedTypes;
+
+  void processMergedAssociatedTypes();
+
+  void checkMergedAssociatedType(Term lhs, Term rhs);
+
+  //////////////////////////////////////////////////////////////////////////////
+  ///
+  /// "Pseudo-rules" for the property map
+  ///
+  //////////////////////////////////////////////////////////////////////////////
+
+public:
+  struct ConcreteTypeWitness {
+    Symbol ConcreteConformance;
+    Symbol AssocType;
+    Symbol ConcreteType;
+
+    ConcreteTypeWitness(Symbol concreteConformance,
+                        Symbol assocType,
+                        Symbol concreteType);
+
+    friend bool operator==(const ConcreteTypeWitness &lhs,
+                           const ConcreteTypeWitness &rhs);
+  };
+
+private:
+  /// Cache for concrete type witnesses. The value in the map is an index
+  /// into the vector.
+  llvm::DenseMap<std::pair<Symbol, Symbol>, unsigned> ConcreteTypeWitnessMap;
+  std::vector<ConcreteTypeWitness> ConcreteTypeWitnesses;
+
+public:
+  unsigned recordConcreteTypeWitness(ConcreteTypeWitness witness);
+  const ConcreteTypeWitness &getConcreteTypeWitness(unsigned index) const;
+
+  //////////////////////////////////////////////////////////////////////////////
+  ///
+  /// Homotopy reduction
+  ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  /// Homotopy generators for this rewrite system. These are the
+  /// rewrite loops which rewrite a term back to itself.
+  ///
+  /// In the category theory interpretation, a rewrite rule is a generating
+  /// 2-cell, and a rewrite path is a 2-cell made from a composition of
+  /// generating 2-cells.
+  ///
+  /// Homotopy generators, in turn, are 3-cells. The special case of a
+  /// 3-cell discovered during completion can be viewed as two parallel
+  /// 2-cells; this is actually represented as a single 2-cell forming a
+  /// loop around a base point.
+  ///
+  /// This data is used by the homotopy reduction and generating conformances
+  /// algorithms.
+  std::vector<RewriteLoop> Loops;
+
   void recordRewriteLoop(RewriteLoop loop) {
     if (!RecordLoops)
       return;
@@ -339,24 +383,6 @@ private:
 
     Loops.emplace_back(basepoint, path);
   }
-
-  bool
-  computeCriticalPair(
-      ArrayRef<Symbol>::const_iterator from,
-      const Rule &lhs, const Rule &rhs,
-      std::vector<std::pair<MutableTerm, MutableTerm>> &pairs,
-      std::vector<RewritePath> &paths,
-      std::vector<RewriteLoop> &loops) const;
-
-  void processMergedAssociatedTypes();
-
-  void checkMergedAssociatedType(Term lhs, Term rhs);
-
-  //////////////////////////////////////////////////////////////////////////////
-  ///
-  /// Homotopy reduction
-  ///
-  //////////////////////////////////////////////////////////////////////////////
 
   void propagateExplicitBits();
 
@@ -377,6 +403,10 @@ private:
       llvm::DenseSet<unsigned> &redundantConformances);
 
 public:
+  ArrayRef<RewriteLoop> getLoops() const {
+    return Loops;
+  }
+
   void minimizeRewriteSystem();
 
   bool hadError() const;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -259,7 +259,7 @@ public:
 
   bool simplify(MutableTerm &term, RewritePath *path=nullptr) const;
 
-  bool simplifySubstitutions(Symbol &symbol, RewritePath &path) const;
+  bool simplifySubstitutions(Symbol &symbol, RewritePath *path=nullptr) const;
 
   //////////////////////////////////////////////////////////////////////////////
   ///

--- a/test/Generics/same_type_requirements_in_protocol.swift
+++ b/test/Generics/same_type_requirements_in_protocol.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend -typecheck %s -requirement-machine-protocol-signatures=on -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).P1@
+// CHECK-NEXT: Requirement signature: <Self where Self.X : P3, Self.X == Self.Y.X, Self.Y : P2>
+public protocol P1 {
+  associatedtype X: P3
+  associatedtype Y: P2 where Y.X == X
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).P2@
+// CHECK-NEXT: Requirement signature: <Self where Self : P1>
+public protocol P2 : P1 {}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).P3@
+// CHECK-NEXT: Requirement signature: <Self where Self == Self.Z.X, Self.Z : P2>
+public protocol P3 {
+  associatedtype Z: P2 where Z.X == Self
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).Q1@
+// CHECK-NEXT: Requirement signature: <Self>
+public protocol Q1 {
+    associatedtype X
+    associatedtype Y
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).Q2@
+// CHECK-NEXT: Requirement signature: <Self where Self == Self.Z.B, Self.Z : Q3>
+public protocol Q2 {
+    associatedtype Y
+    associatedtype Z: Q3 where Z.B == Self
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).Q3@
+// CHECK-NEXT: Requirement signature: <Self where Self.A : Q2, Self.B : Q1, Self.A.Y == Self.B.Y>
+public protocol Q3 {
+    associatedtype A: Q2
+    associatedtype B: Q1 where A.Y == B.Y
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).R1@
+// CHECK-NEXT: Requirement signature: <Self where Self.B : R1>
+protocol R1 {
+  associatedtype A
+  associatedtype B : R1
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).R2@
+// CHECK-NEXT: Requirement signature: <Self>
+protocol R2 {
+  associatedtype C
+}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).R3@
+// CHECK-NEXT: Requirement signature: <Self where Self : R1, Self : R2, Self.A == Self.C, Self.B : R3, Self.C == Self.B.A>
+protocol R3 : R1, R2 where B : R3, A == B.A, C == A {}
+
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).S1@
+// CHECK-NEXT: Requirement signature: <Self>
+protocol S1 {}
+
+// CHECK-LABEL: same_type_requirements_in_protocol.(file).S2@
+// CHECK-NEXT: Requirement signature: <Self where Self.X : S1, Self.X == Self.Y.X, Self.Y : S2>
+protocol S2 {
+  associatedtype X : S1
+  associatedtype Y: S2 where Y.X == X
+}

--- a/test/Generics/sr14510.swift
+++ b/test/Generics/sr14510.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: Requirement signature: <Self where Self == Self.Dual.Dual, Self.Dual : Adjoint>
 public protocol Adjoint {
@@ -21,11 +21,8 @@ where Self.Patch: Adjoint, Self.Dual: AdjointDiffable,
 // conformance requirements 'A : P', 'B : P' or 'C : P' can be dropped and
 // proven from the other two, but dropping two or more conformance requirements
 // leaves us with an invalid signature.
-//
-// Note that this minimization is still not quite correct; the requirement
-// 'Self.B.C == Self.A.A.A' is unnecessary.
 
-// CHECK-LABEL: Requirement signature: <Self where Self.A : P, Self.A == Self.B.C, Self.B : P, Self.B == Self.A.C, Self.C == Self.A.B, Self.B.C == Self.A.A.A>
+// CHECK-LABEL: Requirement signature: <Self where Self.A : P, Self.A == Self.B.C, Self.B : P, Self.B == Self.A.C, Self.C == Self.A.B>
 protocol P {
   associatedtype A : P where A == B.C
   associatedtype B : P where B == A.C

--- a/test/Interpreter/polymorphic_builtins.swift
+++ b/test/Interpreter/polymorphic_builtins.swift
@@ -7,20 +7,20 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(mysimd)) -enable-library-evolution %S/../Inputs/polymorphic_builtins.swift -emit-module -emit-module-path %t/mysimd.swiftmodule -module-name mysimd -parse-stdlib -D DEBUG -Onone
+// RUN: %target-build-swift-dylib(%t/%target-library-name(mysimd)) -enable-library-evolution %S/../Inputs/polymorphic_builtins.swift -emit-module -emit-module-path %t/mysimd.swiftmodule -module-name mysimd -parse-stdlib -D DEBUG -Onone -Xfrontend -requirement-machine-protocol-signatures=on
 // RUN: %target-codesign %t/%target-library-name(mysimd)
 
-// RUN: %target-build-swift %s -L %t -I %t -lmysimd -parse-stdlib -Xfrontend -disable-access-control -Xfrontend -sil-verify-all %target-rpath(%t) -o %t/a.out -D DEBUG -Onone
+// RUN: %target-build-swift %s -L %t -I %t -lmysimd -parse-stdlib -Xfrontend -disable-access-control -Xfrontend -sil-verify-all %target-rpath(%t) -o %t/a.out -D DEBUG -Onone -Xfrontend -requirement-machine-protocol-signatures=on
 // RUN: %target-codesign %t/a.out
 
 // RUN: %target-run %t/a.out %t/%target-library-name(mysimd)
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(mysimd)) -enable-library-evolution %S/../Inputs/polymorphic_builtins.swift -emit-module -emit-module-path %t/mysimd.swiftmodule -module-name mysimd -parse-stdlib -O
+// RUN: %target-build-swift-dylib(%t/%target-library-name(mysimd)) -enable-library-evolution %S/../Inputs/polymorphic_builtins.swift -emit-module -emit-module-path %t/mysimd.swiftmodule -module-name mysimd -parse-stdlib -O -Xfrontend -requirement-machine-protocol-signatures=on
 // RUN: %target-codesign %t/%target-library-name(mysimd)
 
-// RUN: %target-build-swift %s -L %t -I %t -lmysimd -parse-stdlib -Xfrontend -disable-access-control -Xfrontend -sil-verify-all %target-rpath(%t) -o %t/a.out -O
+// RUN: %target-build-swift %s -L %t -I %t -lmysimd -parse-stdlib -Xfrontend -disable-access-control -Xfrontend -sil-verify-all %target-rpath(%t) -o %t/a.out -O -Xfrontend -requirement-machine-protocol-signatures=on
 // RUN: %target-codesign %t/a.out
 
 // RUN: %target-run %t/a.out %t/%target-library-name(mysimd)

--- a/test/decl/protocol/recursive_requirement_ok.swift
+++ b/test/decl/protocol/recursive_requirement_ok.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P {
@@ -88,6 +88,8 @@ protocol P11 {
 // Redundances within a requirement signature.
 protocol P12 { }
 
+// CHECK-LABEL: .P13@
+// CHECK: Requirement signature: <Self where Self.AT1 : P12, Self.AT1 == Self.AT2.AT1, Self.AT2 : P13>
 protocol P13 {
   associatedtype AT1 : P12
   associatedtype AT2: P13 where AT2.AT1 == AT1

--- a/validation-test/compiler_crashers_2_fixed/0182-rdar45680857.swift
+++ b/validation-test/compiler_crashers_2_fixed/0182-rdar45680857.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s -requirement-machine-protocol-signatures=on
 
 public protocol Graph: class, Collection {
     associatedtype V

--- a/validation-test/compiler_crashers_2_fixed/0192-rdar39826863.swift
+++ b/validation-test/compiler_crashers_2_fixed/0192-rdar39826863.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s
+// RUN: %target-swift-frontend -emit-ir %s -requirement-machine-protocol-signatures=on
 
 protocol Tuple {
   associatedtype Head


### PR DESCRIPTION
Consider the following protocol:

```
protocol P {
  associatedtype T : Sequence where T == Array<Int>
}
```

The requirements `T : Sequence` and `T == Array<Int>` together imply that `T.Element == Int`. When property map construction adds this rule while walking nested types of conformances, we now record a rewrite path that relates this rule with the concrete conformance rule. This allows the nested type rules to be dropped from the minimized signature.

There are other cases where the property map still records new rules without a rewrite path. For now, these rules are never minimized away. The goal is to never do this; eventually we will assert that new rules recorded after completion always have a rewrite path relating them to existing rules.