### PR TITLE
[IMPORTANT] Add missing year and Apple INC. in license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-    Copyright [yyyy] [name of copyright owner]
+    Copyright 2010 - 2021 Apple INC.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -175,7 +175,7 @@
 
     END OF TERMS AND CONDITIONS
 
-    Copyright 2010 - 2021 Apple INC.
+    Copyright 2010 - 2021 Apple Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -175,17 +175,6 @@
 
     END OF TERMS AND CONDITIONS
 
-    APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
     Copyright 2010 - 2021 Apple INC.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -199,7 +188,6 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
 
 
 ## Runtime Library Exception to the Apache 2.0 License: ##


### PR DESCRIPTION
<!-- What's in this pull request? -->
The LICENSE in this repository had a missing Year and org. This PR adds the relavant date and Apple INC. org to the license

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
