### PR TITLE
Clarified copy-prop/lexical-lifetime flags.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -215,8 +215,10 @@ def dependency_scan_cache_remarks : Flag<["-"], "Rdependency-scan-cache">,
 def enable_copy_propagation : Flag<["-"], "enable-copy-propagation">,
   HelpText<"Run SIL copy propagation with lexical lifetimes to shorten object "
            "lifetimes while preserving variable lifetimes.">;
-def disable_copy_propagation : Flag<["-"], "disable-copy-propagation">,
-  HelpText<"Don't run SIL copy propagation to preserve object lifetime.">;
+def copy_propagation_state_EQ :
+  Joined<["-"], "enable-copy-propagation=">,
+  HelpText<"Whether to enable copy propagation">,
+  MetaVarName<"true|requested-passes-only|false">;
 
 def enable_infer_public_concurrent_value : Flag<["-"], "enable-infer-public-sendable">,
     HelpText<"Enable inference of Sendable conformances for public structs and enums">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1463,6 +1463,42 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // -Ounchecked might also set removal of runtime asserts (cond_fail).
   Opts.RemoveRuntimeAsserts |= Args.hasArg(OPT_RemoveRuntimeAsserts);
 
+  Optional<CopyPropagationOption> specifiedCopyPropagationOption;
+  if (Arg *A = Args.getLastArg(OPT_copy_propagation_state_EQ)) {
+    specifiedCopyPropagationOption =
+        llvm::StringSwitch<Optional<CopyPropagationOption>>(A->getValue())
+            .Case("true", CopyPropagationOption::On)
+            .Case("false", CopyPropagationOption::Off)
+            .Case("requested-passes-only",
+                  CopyPropagationOption::RequestedPassesOnly)
+            .Default(None);
+  }
+  if (Args.hasArg(OPT_enable_copy_propagation)) {
+    if (specifiedCopyPropagationOption) {
+      if (*specifiedCopyPropagationOption == CopyPropagationOption::Off) {
+        // Error if copy propagation has been set to ::Off via the meta-var form
+        // and enabled via the flag.
+        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
+                       "enable-copy-propagation",
+                       "enable-copy-propagation=false");
+        return true;
+      } else if (*specifiedCopyPropagationOption ==
+                 CopyPropagationOption::RequestedPassesOnly) {
+        // Error if copy propagation has been set to ::RequestedPassesOnly via
+        // the meta-var form and enabled via the flag.
+        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
+                       "enable-copy-propagation",
+                       "enable-copy-propagation=requested-passes-only");
+        return true;
+      }
+    } else {
+      specifiedCopyPropagationOption = CopyPropagationOption::On;
+    }
+  }
+  if (specifiedCopyPropagationOption) {
+    Opts.CopyPropagation = *specifiedCopyPropagationOption;
+  }
+
   Optional<bool> enableLexicalBorrowScopesFlag;
   if (Arg *A = Args.getLastArg(OPT_enable_lexical_borrow_scopes)) {
     enableLexicalBorrowScopesFlag =
@@ -1550,24 +1586,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     } else {
       Opts.LexicalLifetimes = LexicalLifetimesOption::Off;
     }
-  }
-
-  if (Args.hasArg(OPT_enable_copy_propagation) &&
-      Args.hasArg(OPT_disable_copy_propagation)) {
-    // Error if copy propagation is enabled and copy propagation is disabled.
-    Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
-                   "enable-copy-propagation", "disable-copy-propagation");
-    return true;
-  } else if (Args.hasArg(OPT_enable_copy_propagation) &&
-             !Args.hasArg(OPT_disable_copy_propagation)) {
-    Opts.CopyPropagation = CopyPropagationOption::On;
-  } else if (!Args.hasArg(OPT_enable_copy_propagation) &&
-             Args.hasArg(OPT_disable_copy_propagation)) {
-    Opts.CopyPropagation = CopyPropagationOption::Off;
-  } else /*if (!Args.hasArg(OPT_enable_copy_propagation) &&
-            !Args.hasArg(OPT_disable_copy_propagation))*/
-  {
-    Opts.CopyPropagation = CopyPropagationOption::RequestedPassesOnly;
   }
 
   Opts.EnableARCOptimizations &= !Args.hasArg(OPT_disable_arc_opts);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1522,13 +1522,14 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     return true;
   }
 
-  // -enable-copy-propagation implies -enable-lexical-lifetimes unless
-  // otherwise specified.
-  if (Args.hasArg(OPT_enable_copy_propagation))
+  // Unless overridden below, enabling copy propagation means enabling lexical
+  // lifetimes.
+  if (Opts.CopyPropagation == CopyPropagationOption::On)
     Opts.LexicalLifetimes = LexicalLifetimesOption::On;
 
-  // -disable-copy-propagation implies -enable-lexical-lifetimes=false
-  if (Args.hasArg(OPT_disable_copy_propagation))
+  // Unless overridden below, disable copy propagation means disabling lexical
+  // lifetimes.
+  if (Opts.CopyPropagation == CopyPropagationOption::Off)
     Opts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
 
   // If move-only is enabled, always enable lexical lifetime as well.  Move-only

--- a/test/ClangImporter/serialization-sil.swift
+++ b/test/ClangImporter/serialization-sil.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -emit-module-path %t/Test.swiftmodule -emit-sil -o /dev/null -module-name Test %s -sdk "" -import-objc-header %S/Inputs/serialization-sil.h
 // RUN: %target-sil-func-extractor %t/Test.swiftmodule -sil-print-debuginfo  -func='$s4Test16testPartialApplyyySoAA_pF' -o - | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/DebugInfo/allocstack.swift
+++ b/test/DebugInfo/allocstack.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
-// RUN: %target-swift-frontend %s -emit-sil -g -o - | %FileCheck -check-prefix=CHECK-SIL %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -emit-sil -g -o - | %FileCheck -check-prefix=CHECK-SIL %s
 import StdlibUnittest
 
 // Test that debug info for local variables is preserved by the

--- a/test/DebugInfo/if-branchlocations.swift
+++ b/test/DebugInfo/if-branchlocations.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -disable-copy-propagation -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-NCP
+// RUN: %target-swift-frontend %s -emit-sil -enable-copy-propagation=false -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-NCP
 // RUN: %target-swift-frontend %s -emit-sil -enable-copy-propagation -enable-lexical-borrow-scopes=false -emit-verbose-sil -g -o - | %FileCheck %s --check-prefixes=CHECK,CHECK-CP
 
 class NSURL {}

--- a/test/DebugInfo/linetable-do.swift
+++ b/test/DebugInfo/linetable-do.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle %s -emit-ir -g -o - | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -disable-copy-propagation %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-NCP %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-copy-propagation=false %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-NCP %s
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -enable-copy-propagation -enable-lexical-borrow-scopes=false %s -emit-sil -emit-verbose-sil -g -o - | %FileCheck --check-prefixes=CHECK-SIL,CHECK-CP %s
 import StdlibUnittest
 

--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -g -emit-ir %s -o %t.ll
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -g -emit-ir %s -o %t.ll
 
 // REQUIRES: objc_interop
 

--- a/test/DebugInfo/sil_based_dbg.swift
+++ b/test/DebugInfo/sil_based_dbg.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -O -sil-based-debuginfo -Xllvm -sil-print-debuginfo -emit-ir -o %t/out.ir
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -O -sil-based-debuginfo -Xllvm -sil-print-debuginfo -emit-ir -o %t/out.ir
 // RUN: %FileCheck %s < %t/out.ir
 // RUN: %FileCheck %s --check-prefix=CHECK_OUT_SIL < %t/out.ir.sil_dbg_0.sil
 
 // Second test: check that we don't crash with multi-threaded IRGen
-// RUN: %target-swift-frontend -c %s %S/Inputs/testclass.swift -wmo -O -num-threads 1 -sil-based-debuginfo -o %t/sil_based_dbg.o -o %t/testclass.o
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -c %s %S/Inputs/testclass.swift -wmo -O -num-threads 1 -sil-based-debuginfo -o %t/sil_based_dbg.o -o %t/testclass.o
 
 // CHECK: !DIFile(filename: "{{.+}}sil_based_dbg.swift", directory: "{{.+}}")
 // CHECK: [[F:![0-9]+]] = !DIFile(filename: "{{.+}}out.ir.sil_dbg_0.sil",
@@ -19,10 +19,10 @@ public func testit() {
 // in sil-based-dbg mode.
 // To create something like `alloc_stack ..., (name "foo", loc ..., scope 0)...`
 // as our testing input, we're only running SROA over the input swift code.
-// RUN: %target-swift-frontend %s -disable-debugger-shadow-copies -emit-sil -g -o %t/stage1.sil
-// RUN: %target-sil-opt -sil-print-debuginfo -access-marker-elim -sroa %t/stage1.sil -o %t/stage2.sil
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -disable-debugger-shadow-copies -emit-sil -g -o %t/stage1.sil
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -sil-print-debuginfo -access-marker-elim -sroa %t/stage1.sil -o %t/stage2.sil
 // The verification shouldn't fail
-// RUN: %target-swift-frontend %t/stage2.sil -sil-verify-all -sil-based-debuginfo -g -emit-sil -o %t/out.sil
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %t/stage2.sil -sil-verify-all -sil-based-debuginfo -g -emit-sil -o %t/out.sil
 // RUN: %FileCheck %s --check-prefix=CHECK_DBG_SCOPE < %t/out.sil
 struct TheStruct {
     var the_member : Int

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -1,7 +1,7 @@
 
-// RUN: %target-swift-emit-sil -parse-stdlib %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-stdlib %s | %FileCheck %s -check-prefix=SILGEN
-// RUN: %target-swift-emit-ir -parse-stdlib %s
+// RUN: %target-swift-emit-sil -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -parse-stdlib %s | %FileCheck %s -check-prefix=SILGEN
+// RUN: %target-swift-emit-ir -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -parse-stdlib %s
 
 // This test includes some calls to transparent stdlib functions.
 // We pattern match for the absence of access markers in the inlined code.

--- a/test/SILGen/copy_operator.swift
+++ b/test/SILGen/copy_operator.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-silgen -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck %s
-// RUN: %target-swift-emit-sil -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL %s
-// RUN: %target-swift-emit-sil -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL-OPT %s
+// RUN: %target-swift-emit-silgen -enable-copy-propagation=requested-passes-only -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck %s
+// RUN: %target-swift-emit-sil -enable-copy-propagation=requested-passes-only -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL %s
+// RUN: %target-swift-emit-sil -enable-copy-propagation=requested-passes-only -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL-OPT %s
 
 import Swift
 

--- a/test/SILOptimizer/OSLogMandatoryOptTest.swift
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -swift-version 5 -emit-sil -primary-file %s -Xllvm -sil-print-after=OSLogOptimization -o /dev/null 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -swift-version 5 -emit-sil -primary-file %s -Xllvm -sil-print-after=OSLogOptimization -o /dev/null 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 //
 // REQUIRES: VENDOR=apple
 

--- a/test/SILOptimizer/access_enforcement_noescape.swift
+++ b/test/SILOptimizer/access_enforcement_noescape.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -module-name access_enforcement_noescape -enforce-exclusivity=checked -Onone -emit-sil -swift-version 4 -parse-as-library %s | %FileCheck %s
 
 // This tests SILGen and AccessEnforcementSelection as a single set of tests.
 // (Some static/dynamic enforcement selection is done in SILGen, and some is

--- a/test/SILOptimizer/access_marker_mandatory.swift
+++ b/test/SILOptimizer/access_marker_mandatory.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name access_marker_mandatory -parse-as-library -Xllvm -sil-full-demangle -emit-sil -Onone -enforce-exclusivity=checked %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -module-name access_marker_mandatory -parse-as-library -Xllvm -sil-full-demangle -emit-sil -Onone -enforce-exclusivity=checked %s | %FileCheck %s
 
 public struct S {
   var i: Int

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack -enable-lexical-borrow-scopes=false | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-debuginfo -enable-sil-verify-all %s -allocbox-to-stack -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-lexical-borrow-scopes=false | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/allocboxtostack_localapply.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/allocboxtostack_localapply.swift
+++ b/test/SILOptimizer/allocboxtostack_localapply.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -O | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -emit-sil %s -O | %FileCheck %s
 
 
 @_optimize(none)

--- a/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
+++ b/test/SILOptimizer/allocboxtostack_localapply_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false %s -allocbox-to-stack -sil-deadfuncelim | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/assemblyvision_remark/attributes.swift
+++ b/test/SILOptimizer/assemblyvision_remark/attributes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -verify -Osize -o /dev/null -module-name main
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false -emit-sil %s -verify -Osize -o /dev/null -module-name main
 //
 // NOTE: We only emit opt-remarks with -Osize,-O today! -O does drop way more
 // stuff though, so we test with -Osize.

--- a/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
+++ b/test/SILOptimizer/assemblyvision_remark/cast_remarks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
+// RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xfrontend -enable-copy-propagation=requested-passes-only -Xfrontend -enable-lexical-lifetimes=false -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_stdlib_no_asserts

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/../Inputs/resilient_struct.swift -enable-library-evolution -emit-module -emit-module-path %t/resilient_struct.swiftmodule
 // RUN: %target-swift-frontend %S/../Inputs/resilient_enum.swift -I %t -enable-library-evolution -emit-module -emit-module-path %t/resilient_enum.swiftmodule
-// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -enable-copy-propagation=false -I %t -o - | %FileCheck %s
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -sil-verify-all  -disable-availability-checking -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all  -disable-availability-checking -emit-sil -enable-copy-propagation=false -I %t -o - | %FileCheck %s
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil @$s34closure_lifetime_fixup_concurrency12testAsyncLetyS2SYaF : $@convention(thin) @async (@guaranteed String) -> @owned String {

--- a/test/SILOptimizer/closure_lifetime_fixup_objc.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_objc.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -disable-copy-propagation -o - -I %S/Inputs/usr/include | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -enable-copy-propagation=false -o - -I %S/Inputs/usr/include | %FileCheck %s
 // REQUIRES: objc_interop
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite-init-convert-to-escape.swift
+++ b/test/SILOptimizer/definite-init-convert-to-escape.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-copy-propagation -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
-// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -disable-copy-propagation -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-convert-escape-to-noescape-switch-peephole %s | %FileCheck %s --check-prefix=NOPEEPHOLE
+// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -enable-copy-propagation=false -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name A -verify -emit-sil -import-objc-header %S/Inputs/Closure.h -enable-copy-propagation=false -disable-objc-attr-requires-foundation-module -Xllvm -sil-disable-convert-escape-to-noescape-switch-peephole %s | %FileCheck %s --check-prefix=NOPEEPHOLE
 //
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -emit-sil -disable-copy-propagation %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-copy-propagation=false %s | %FileCheck %s
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite_init_failable_initializers_objc.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers_objc.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -emit-sil -disable-copy-propagation -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-copy-propagation=false -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite_init_objc_factory_init.swift
+++ b/test/SILOptimizer/definite_init_objc_factory_init.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s -emit-sil -disable-copy-propagation | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../IDE/Inputs/custom-modules %s -emit-sil -enable-copy-propagation=false | %FileCheck %s
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -swift-version 5 -verify | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -emit-sil %s -swift-version 5 -verify | %FileCheck %s
 
 // Ensure that convenience initializers on concrete types can
 // delegate to factory initializers defined in protocol

--- a/test/SILOptimizer/definite_init_root_class.swift
+++ b/test/SILOptimizer/definite_init_root_class.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -emit-sil -disable-copy-propagation %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-copy-propagation=false %s | %FileCheck %s
 
-// Using -disable-copy-propagation to pattern match against older SIL
+// Using -enable-copy-propagation=false to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around
 // long enough in the same form to be worth rewriting CHECK lines.
 

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -emit-sil %s | %FileCheck %s
 
 enum ValueEnum {
   case a(String)

--- a/test/SILOptimizer/lexical_lifetime_elim.sil
+++ b/test/SILOptimizer/lexical_lifetime_elim.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-lexical-lifetime-eliminator %s -enable-sil-verify-all | %FileCheck %s
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -sil-lexical-lifetime-eliminator %s -enable-sil-verify-all | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
 //
 // FIXME: check copy-propagation output instead once it is the default mode
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP

--- a/test/SILOptimizer/sil_combine_uncheck_ossa.sil
+++ b/test/SILOptimizer/sil_combine_uncheck_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -remove-runtime-asserts | %FileCheck %s
+// RUN: %target-sil-opt -enable-copy-propagation=requested-passes-only -enable-sil-verify-all %s -sil-combine -remove-runtime-asserts | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_2.swift -module-name External -emit-module -emit-module-path %t/External.swiftmodule
-// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -enable-library-evolution -module-name External2 -emit-module -emit-module-path %t/External2.swiftmodule
-// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_4.swift -I %t -enable-library-evolution -module-name External3 -emit-module -emit-module-path %t/External3.swiftmodule
-// RUN: %target-swift-frontend -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -I %t -enable-library-evolution -module-name External2 -Osize -emit-module -o - | %target-sil-opt -module-name External2 | %FileCheck --check-prefix=RESILIENT %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_2.swift -module-name External -emit-module -emit-module-path %t/External.swiftmodule
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -enable-library-evolution -module-name External2 -emit-module -emit-module-path %t/External2.swiftmodule
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_4.swift -I %t -enable-library-evolution -module-name External3 -emit-module -emit-module-path %t/External3.swiftmodule
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking %S/Inputs/specialize_opaque_type_archetypes_3.swift -I %t -enable-library-evolution -module-name External2 -Osize -emit-module -o - | %target-sil-opt -module-name External2 | %FileCheck --check-prefix=RESILIENT %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -disable-availability-checking -I %t -module-name A -enforce-exclusivity=checked -enable-library-evolution -Osize -emit-sil -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 
 import External

--- a/test/SILOptimizer/sroa_unreferenced_members.swift
+++ b/test/SILOptimizer/sroa_unreferenced_members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -sdk %S/Inputs -O -emit-sil -I %S/Inputs -enable-source-import -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-copy-propagation=requested-passes-only -enable-lexical-lifetimes=false -sdk %S/Inputs -O -emit-sil -I %S/Inputs -enable-source-import -primary-file %s | %FileCheck %s
 
 import gizmo
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -537,9 +537,14 @@ int main(int argc, char **argv) {
     SILOpts.CopyPropagation = CopyPropagationOption::RequestedPassesOnly;
   }
 
-  if (EnableCopyPropagation)
+  // Unless overridden below, enabling copy propagation means enabling lexical
+  // lifetimes.
+  if (SILOpts.CopyPropagation == CopyPropagationOption::On)
     SILOpts.LexicalLifetimes = LexicalLifetimesOption::On;
-  if (DisableCopyPropagation)
+
+  // Unless overridden below, disable copy propagation means disabling lexical
+  // lifetimes.
+  if (SILOpts.CopyPropagation == CopyPropagationOption::Off)
     SILOpts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
 
   // Enable lexical lifetimes if it is set or if experimental move only is


### PR DESCRIPTION
A few changes around the flags that control the behavior of copy-propagation and of lexical-lifetimes, in preparation to default copy-propagation on.

(1) Base SILOptions::LexicalLifetimes off SILOptions::CopyPropagation.

Before, swift-frontend and sil-opt would set an initial value for ::LexicalLifetimes when flags that control copy propagation were passed.  Clarify what's going on by first using the flags to set ::CopyPropagation and then, on the basis of that field, set ::LexicalLifetimes.

(4) Make various sil-opt flags optional.

Make use of llvm::cl::opt<boolOrDefault> in place of llvm::cl::opt<bool> to determine whether an override of the default behavior was specified by a flag.  Only override the defaults in SILOptions if a value was specified.

(2) Updated tests to specify which copy-propagation setting they want explicitly.

The tests will still run as they do now regardless of the default changing.

(3) Replaced -disable-copy-propagation -enable-copy-propagation=... .

The new multi-var setting can be true, false, or requested-passes-only.  In sil-opt, to get this right and continue to allow `-enable-copy-propagation` with no arguments, added a new llvm::cl::parser for Optional<CopyPropagationOption>.
