### PR TITLE
Always enable copy propagation.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -74,16 +74,15 @@ public:
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 
-  /// Enable experimental support for emitting defined borrow scopes.
-  LexicalLifetimesOption LexicalLifetimes =
-      LexicalLifetimesOption::DiagnosticMarkersOnly;
+  /// Both emit lexical markers and use them to extend object lifetime to the
+  /// observable end of lexical scope.
+  LexicalLifetimesOption LexicalLifetimes = LexicalLifetimesOption::On;
 
   /// Whether to run SIL copy propagation to shorten object lifetime in whatever
   /// optimization pipeline is currently used.
   ///
-  /// When this is 'RequestedPassesOnly' the pipeline has default behavior.
-  CopyPropagationOption CopyPropagation =
-      CopyPropagationOption::RequestedPassesOnly;
+  /// When this is 'On' the pipeline has default behavior.
+  CopyPropagationOption CopyPropagation = CopyPropagationOption::On;
 
   /// Controls whether the SIL ARC optimizations are run.
   bool EnableARCOptimizations = true;

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1713,6 +1713,7 @@ function(add_swift_target_library name)
   if (SWIFTLIB_IS_STDLIB)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
   endif()
 
   if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE AND

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -2,7 +2,8 @@
 
 // CHECK: ---
 // CHECK: name:            non-Diagnostic Enabling Mandatory Optimizations
-// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-combine", "mandatory-arc-opts" ]
+// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-combine", "mandatory-copy-propagation",
+// CHECK: "mandatory-arc-opts" ]
 // CHECK: ---
 // CHECK: name:            Serialization
 // CHECK: passes:          [ "serialize-sil", "ownership-model-eliminator" ]


### PR DESCRIPTION
Update the default SILOptions value for CopyPropagation and LexicalLifetimes.