### PR TITLE
Don't resolve protocol typealiases as DependentMemberTypes in Structural mode

### DIFF
--- a/lib/AST/GenericSignatureBuilder.h
+++ b/lib/AST/GenericSignatureBuilder.h
@@ -571,7 +571,6 @@ public:
   ConstraintResult addRequirement(const Requirement &req,
                                   const RequirementRepr *reqRepr,
                                   FloatingRequirementSource source,
-                                  const SubstitutionMap *subMap,
                                   ModuleDecl *inferForModule);
 
   /// Add all of a generic signature's parameters and requirements.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3408,7 +3408,7 @@ NeverNullType TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
-  ASTContext &ctx = baseTy->getASTContext();
+  ASTContext &ctx = getASTContext();
   // If the standard library isn't loaded, we ought to let the user know
   // something has gone terribly wrong, since the rest of the compiler is going
   // to assume it can canonicalize [T] to Array<T>.

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -452,11 +452,6 @@ public:
                                   SourceRange baseRange,
                                   ComponentIdentTypeRepr *ref) const;
 
-  /// Resolve an unqualified reference to an associated type or type alias
-  /// in a protocol.
-  Type resolveSelfAssociatedType(Type baseTy, DeclContext *DC,
-                                 Identifier name) const;
-
   /// Determine whether the given two types are equivalent within this
   /// type resolution context.
   bool areSameType(Type type1, Type type2) const;

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -1,36 +1,27 @@
 // RUN: %target-typecheck-verify-swift
 
-// Reference to associated type from 'where' clause should not be
+// References to associated type from 'where' clause should be
 // ambiguous when there's a typealias with the same name in another
-// protocol.
-//
-// FIXME: The semantics here are still really iffy. There's also a
-// case to be made that type aliases in protocol extensions should
-// only act as defaults and not as same-type constraints. However,
-// if we decide to go down that route, it's important that *both*
-// the unqualified (T) and qualified (Self.T) lookups behave the
-// same.
+// unrelated protocol.
+
 protocol P1 {
-  typealias T = Int // expected-note {{found this candidate}}
+  typealias T = Int // expected-note 3{{found this candidate}}
 }
 
 protocol P2 {
-  associatedtype T // expected-note {{found this candidate}}
+  associatedtype T // expected-note 3{{found this candidate}}
 }
 
-// FIXME: This extension's generic signature is still minimized differently from
-// the next one. We need to decide if 'T == Int' is a redundant requirement or
-// not.
-extension P1 where Self : P2, T == Int {
-  func takeT1(_: T) {}
-  func takeT2(_: Self.T) {}
+extension P1 where Self : P2, T == Int { // expected-error {{'T' is ambiguous for type lookup in this context}}
+  func takeT11(_: T) {} // expected-error {{'T' is ambiguous for type lookup in this context}}
+  func takeT12(_: Self.T) {}
 }
 
 extension P1 where Self : P2 {
   // FIXME: This doesn't make sense -- either both should
   // succeed, or both should be ambiguous.
-  func takeT1(_: T) {} // expected-error {{'T' is ambiguous for type lookup in this context}}
-  func takeT2(_: Self.T) {}
+  func takeT21(_: T) {} // expected-error {{'T' is ambiguous for type lookup in this context}}
+  func takeT22(_: Self.T) {}
 }
 
 // Same as above, but now we have two visible associated types with the same
@@ -39,20 +30,17 @@ protocol P3 {
   associatedtype T
 }
 
-// FIXME: This extension's generic signature is still minimized differently from
-// the next one. We need to decide if 'T == Int' is a redundant requirement or
-// not.
 extension P2 where Self : P3, T == Int {
-  func takeT1(_: T) {}
-  func takeT2(_: Self.T) {}
+  func takeT31(_: T) {}
+  func takeT32(_: Self.T) {}
 }
 
 extension P2 where Self : P3 {
-  func takeT1(_: T) {}
-  func takeT2(_: Self.T) {}
+  func takeT41(_: T) {}
+  func takeT42(_: Self.T) {}
 }
 
 protocol P4 : P2, P3 {
-  func takeT1(_: T)
-  func takeT2(_: Self.T)
+  func takeT51(_: T)
+  func takeT52(_: Self.T)
 }

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -268,7 +268,7 @@ extension P10 {
   typealias U = Float
 }
 
-extension P10 where T == Int { } // expected-warning{{neither type in same-type constraint ('Self.T' (aka 'Int') or 'Int') refers to a generic parameter or associated type}}
+extension P10 where T == Int { } // expected-warning{{neither type in same-type constraint ('Int' or 'Int') refers to a generic parameter or associated type}}
 
 extension P10 where A == X<T> { }
 
@@ -277,7 +277,7 @@ extension P10 where A == X<U> { }
 extension P10 where A == X<Self.U> { }
 
 extension P10 where V == Int { } // expected-warning {{'V' is deprecated: just use Int, silly}}
-// expected-warning@-1{{neither type in same-type constraint ('Self.V' (aka 'Int') or 'Int') refers to a generic parameter or associated type}}
+// expected-warning@-1{{neither type in same-type constraint ('Int' or 'Int') refers to a generic parameter or associated type}}
 
 // rdar://problem/36003312
 protocol P11 {

--- a/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
+++ b/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
@@ -2,7 +2,6 @@
 
 protocol P {
     associatedtype A : P where A.X == Self
-    // expected-error@-1{{'X' is not a member type of type 'Self.A'}}
     associatedtype X : P where P.A == Self
     // expected-error@-1{{associated type 'A' can only be used with a concrete type or generic parameter base}}
 }


### PR DESCRIPTION
The requirement machine does not perform arbitrary name lookup to resolve DependentMemberTypes with a type parameter base. This PR changes Sema's type resolution to ensure that in Structural mode, unqualified references to protocol typealiases on Self immediately resolve to the TypeDecl, and not a DependentMemberType.

This allows references to protocol type aliases in 'where' clauses to work with the requirement machine enabled, since the requirement machine does not have a mechanism to map an unresolved DependentMemberType down to a typealias.

As a bonus, apply the same change for AssociatedTypeDecls. We still map them to the anchor, but don't erase them to an unresolved DependentMemberType.