### PR TITLE
Sendable checking for an an isolated witnesses to a nonisolated requirement

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3266,6 +3266,13 @@ ActorIsolation ActorIsolationRequest::evaluate(
     ASTContext &ctx = value->getASTContext();
     switch (inferred) {
     case ActorIsolation::Independent:
+      // Stored properties cannot be non-isolated, so don't infer it.
+      if (auto var = dyn_cast<VarDecl>(value)) {
+        if (!var->isStatic() && var->hasStorage())
+          return ActorIsolation::forUnspecified();
+      }
+
+
       if (onlyGlobal)
         return ActorIsolation::forUnspecified();
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -967,13 +967,13 @@ func testCrossActorProtocol<T: P>(t: T) async {
 
 @available(SwiftStdlib 5.1, *)
 protocol Server {
-  func send<Message: Codable>(message: Message) async throws -> String
+  func send<Message: Codable & Sendable>(message: Message) async throws -> String
 }
 
 @available(SwiftStdlib 5.1, *)
 actor MyServer : Server {
   // okay, asynchronously accessed from clients of the protocol
-  func send<Message: Codable>(message: Message) throws -> String { "" }
+  func send<Message: Codable & Sendable>(message: Message) throws -> String { "" }
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -94,6 +94,17 @@ func testNotAllInP1(nap1: NotAllInP1) { // expected-note{{add '@SomeGlobalActor'
   nap1.other() // okay
 }
 
+// Make sure we don't infer 'nonisolated' for stored properties.
+@MainActor
+protocol Interface {
+  nonisolated var baz: Int { get } // expected-note{{'baz' declared here}}
+}
+
+@MainActor
+class Object: Interface {
+  var baz: Int = 42 // expected-warning{{property 'baz' isolated to global actor 'MainActor' can not satisfy corresponding requirement from protocol 'Interface'}}
+}
+
 
 // ----------------------------------------------------------------------
 // Global actor inference for classes and extensions

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -1,0 +1,147 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+class NotSendable { // expected-note 8{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension NotSendable: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+protocol IsolatedWithNotSendableRequirements: Actor {
+  func f() -> NotSendable
+  var prop: NotSendable { get }
+}
+
+// Okay, everything is isolated the same way
+@available(SwiftStdlib 5.1, *)
+actor A1: IsolatedWithNotSendableRequirements {
+  func f() -> NotSendable { NotSendable() }
+  var prop: NotSendable { NotSendable() }
+}
+
+// Okay, sendable checking occurs when calling through the protocol
+// and also inside the bodies.
+@available(SwiftStdlib 5.1, *)
+actor A2: IsolatedWithNotSendableRequirements {
+  nonisolated func f() -> NotSendable { NotSendable() }
+  nonisolated var prop: NotSendable { NotSendable() }
+}
+
+@available(SwiftStdlib 5.1, *)
+protocol AsyncProtocolWithNotSendable {
+  func f() async -> NotSendable
+  var prop: NotSendable { get async }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A3: AsyncProtocolWithNotSendable {
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A4: AsyncProtocolWithNotSendable {
+  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A5: AsyncProtocolWithNotSendable {
+  nonisolated func f() async -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A6: AsyncProtocolWithNotSendable {
+  nonisolated func f() -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get {
+      NotSendable()
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+protocol AsyncThrowingProtocolWithNotSendable {
+  func f() async throws -> NotSendable
+  var prop: NotSendable { get async throws }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A7: AsyncThrowingProtocolWithNotSendable {
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A8: AsyncThrowingProtocolWithNotSendable {
+  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A9: AsyncThrowingProtocolWithNotSendable {
+  nonisolated func f() async -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A10: AsyncThrowingProtocolWithNotSendable {
+  nonisolated func f() -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get {
+      NotSendable()
+    }
+  }
+}

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -126,7 +126,7 @@ protocol Server {
   func send<Message: Codable>(message: Message) async throws -> String
 }
 actor MyServer : Server {
-  func send<Message: Codable>(message: Message) throws -> String { "" }  // okay, asynchronously accessed from clients of the protocol
+  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{cannot pass argument of non-sendable type 'Message' across actors}}
 }
 
 protocol AsyncThrowsAll {


### PR DESCRIPTION
When a non-isolated requirement is witnessed by an actor-isolated
witness, we are crossing into the actor. Ensure that we perform
Sendable checking across the actor boundary here.

Fixes rdar://80424675.