### PR TITLE
RequirementMachine: Implement minimization for abstract nested type requirements

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -74,10 +74,10 @@ add_swift_host_library(swiftAST STATIC
   ProtocolConformance.cpp
   RawComment.cpp
   RequirementEnvironment.cpp
-  RequirementMachine/GeneratingConformances.cpp
   RequirementMachine/GenericSignatureQueries.cpp
   RequirementMachine/HomotopyReduction.cpp
   RequirementMachine/KnuthBendix.cpp
+  RequirementMachine/MinimalConformances.cpp
   RequirementMachine/PropertyMap.cpp
   RequirementMachine/PropertyUnification.cpp
   RequirementMachine/RequirementLowering.cpp

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -41,8 +41,8 @@ enum class DebugFlags : unsigned {
   /// Print debug output from the homotopy reduction algorithm.
   HomotopyReduction = (1<<6),
 
-  /// Print debug output from the generating conformances algorithm.
-  GeneratingConformances = (1<<7),
+  /// Print debug output from the minimal conformances algorithm.
+  MinimalConformances = (1<<7),
 
   /// Print debug output from the protocol dependency graph.
   ProtocolDependencies = (1<<8),

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -101,6 +101,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
     case RewriteStep::SameTypeWitness:
+    case RewriteStep::AbstractTypeWitness:
       break;
     }
 
@@ -223,6 +224,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
     case RewriteStep::SameTypeWitness:
+    case RewriteStep::AbstractTypeWitness:
       break;
     }
 
@@ -323,6 +325,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
     case RewriteStep::SameTypeWitness:
+    case RewriteStep::AbstractTypeWitness:
       newSteps.push_back(step);
       break;
     }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -903,15 +903,8 @@ void MinimalConformances::verifyMinimalConformances() const {
       continue;
     }
 
-    if (rule.isRedundant()) {
-      llvm::errs() << "Generating conformance is redundant: ";
-      llvm::errs() << rule << "\n\n";
-      dumpMinimalConformanceEquations(llvm::errs());
-      abort();
-    }
-
     if (rule.getLHS().containsUnresolvedSymbols()) {
-      llvm::errs() << "Generating conformance contains unresolved symbols: ";
+      llvm::errs() << "Minimal conformance contains unresolved symbols: ";
       llvm::errs() << rule << "\n\n";
       dumpMinimalConformanceEquations(llvm::errs());
       abort();
@@ -922,7 +915,7 @@ void MinimalConformances::verifyMinimalConformances() const {
 
 void MinimalConformances::dumpMinimalConformances(
     llvm::raw_ostream &out) const {
-  out << "Generating conformances:\n";
+  out << "Minimal conformances:\n";
 
   for (const auto &pair : ConformancePaths) {
     if (RedundantConformances.count(pair.first) > 0)

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -141,6 +141,7 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::SuperclassConformance:
       case RewriteStep::ConcreteTypeWitness:
       case RewriteStep::SameTypeWitness:
+      case RewriteStep::AbstractTypeWitness:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -1,4 +1,4 @@
-//===--- GeneratingConformances.cpp - Reasoning about conformance rules ---===//
+//===--- MinimalConformances.cpp - Reasoning about conformance rules ------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,11 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements an algorithm to find a minimal set of "generating
-// conformances", which are rules (V1.[P1] => V1), ..., (Vn.[Pn] => Vn) such
-// that any valid term of the form T.[P] can be written as a product of terms
-// (Vi.[Pi]), where each Vi.[Pi] is a left hand side of a generating
-// conformance.
+// This file implements an algorithm to find a minimal set of conformance
+// rules (V1.[P1] => V1), ..., (Vn.[Pn] => Vn) whose left hand sides
+// _generate_ the set of conformance-valid terms.
+//
+// That is, any valid term of the form T.[P] where T.[P] reduces to T can be
+// written as a product of terms (Vi.[Pi]), where each Vi.[Pi] is a left hand
+// side of a minimal conformance.
 //
 // A "conformance-valid" rewrite system is one where if we can write
 // T == U.V for arbitrary non-empty U and V, then U.[domain(V)] is joinable
@@ -32,25 +34,25 @@
 //
 // Using the rewrite loops that generate the homotopy relation on rewrite paths,
 // decompositions can be found for all "derived" conformance rules, producing
-// a minimal set of generating conformances.
+// a set of minimal conformances.
 //
 // There are two small complications to handle implementation details of
 // Swift generics:
 //
 // 1) Inherited witness tables must be derivable by following other protocol
 //    refinement requirements only, without looking at non-Self associated
-//    types. This is expressed by saying that the generating conformance
+//    types. This is expressed by saying that the minimal conformance
 //    equations for a protocol refinement can only be written in terms of
 //    other protocol refinements; conformance paths involving non-Self
 //    associated types are not considered.
 //
 // 2) The subject type of each conformance requirement must be derivable at
-//    runtime as well, so for each generating conformance, it must be
+//    runtime as well, so for each minimal conformance, it must be
 //    possible to write down a conformance path for the parent type without
-//    using any generating conformance recursively in the parent path of
+//    using any minimal conformance recursively in the parent path of
 //    itself.
 //
-// The generating conformances finds fewer conformance requirements to be
+// The minimal conformances algorithm finds fewer conformance requirements to be
 // redundant than homotopy reduction, which is why homotopy reduction only
 // deletes non-protocol conformance requirements.
 //
@@ -150,7 +152,7 @@ void RewriteLoop::findProtocolConformanceRules(
 namespace {
 
 /// Utility class to encapsulate some shared state.
-class GeneratingConformances {
+class MinimalConformances {
   const RewriteSystem &System;
 
   RewriteContext &Context;
@@ -204,14 +206,14 @@ class GeneratingConformances {
       llvm::raw_ostream &out,
       const SmallVectorImpl<unsigned> &path) const;
 
-  void dumpGeneratingConformanceEquation(
+  void dumpMinimalConformanceEquation(
       llvm::raw_ostream &out,
       unsigned baseRuleID,
       const std::vector<SmallVector<unsigned, 2>> &paths) const;
 
 public:
-  explicit GeneratingConformances(const RewriteSystem &system,
-                                  llvm::DenseSet<unsigned> &redundantConformances)
+  explicit MinimalConformances(const RewriteSystem &system,
+                               llvm::DenseSet<unsigned> &redundantConformances)
     : System(system),
       Context(system.getRewriteContext()),
       Debug(system.getDebugOptions()),
@@ -221,15 +223,15 @@ public:
 
   void computeCandidateConformancePaths();
 
-  void dumpGeneratingConformanceEquations(llvm::raw_ostream &out) const;
+  void dumpMinimalConformanceEquations(llvm::raw_ostream &out) const;
 
-  void verifyGeneratingConformanceEquations() const;
+  void verifyMinimalConformanceEquations() const;
 
-  void computeGeneratingConformances(bool firstPass);
+  void computeMinimalConformances(bool firstPass);
 
-  void verifyGeneratingConformances() const;
+  void verifyMinimalConformances() const;
 
-  void dumpGeneratingConformances(llvm::raw_ostream &out) const;
+  void dumpMinimalConformances(llvm::raw_ostream &out) const;
 };
 
 } // end namespace
@@ -239,7 +241,7 @@ public:
 ///
 /// The term should be irreducible, except for a protocol symbol at the end.
 void
-GeneratingConformances::decomposeTermIntoConformanceRuleLeftHandSides(
+MinimalConformances::decomposeTermIntoConformanceRuleLeftHandSides(
     MutableTerm term, SmallVectorImpl<unsigned> &result) const {
   assert(term.back().getKind() == Symbol::Kind::Protocol);
 
@@ -284,7 +286,7 @@ GeneratingConformances::decomposeTermIntoConformanceRuleLeftHandSides(
 /// product of left hand sdies of conformance rules. The term U should
 /// be irreducible.
 void
-GeneratingConformances::decomposeTermIntoConformanceRuleLeftHandSides(
+MinimalConformances::decomposeTermIntoConformanceRuleLeftHandSides(
     MutableTerm term, unsigned ruleID,
     SmallVectorImpl<unsigned> &result) const {
   const auto &rule = System.getRule(ruleID);
@@ -298,7 +300,7 @@ GeneratingConformances::decomposeTermIntoConformanceRuleLeftHandSides(
   auto protocol = Symbol::forProtocol(protocols[0], Context);
 
   // A same-type requirement of the form 'Self.Foo == Self' can induce a
-  // conformance rule [P].[P] => [P], and we can end up with a generating
+  // conformance rule [P].[P] => [P], and we can end up with a minimal
   // conformance decomposition of the form
   //
   //   (V.[Q] => V) := [P].(V'.[Q] => V'),
@@ -365,7 +367,7 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
 
 /// Collect conformance rules and parent paths, and record an initial
 /// equation where each conformance is equivalent to itself.
-void GeneratingConformances::collectConformanceRules() {
+void MinimalConformances::collectConformanceRules() {
   // Prepare the initial set of equations.
   for (unsigned ruleID : indices(System.getRules())) {
     const auto &rule = System.getRule(ruleID);
@@ -474,7 +476,7 @@ void GeneratingConformances::collectConformanceRules() {
 ///
 /// That is, we can choose to eliminate <X>.[P], but not <Y>.[P], or vice
 /// versa; but it is never valid to eliminate both.
-void GeneratingConformances::computeCandidateConformancePaths() {
+void MinimalConformances::computeCandidateConformancePaths() {
   for (const auto &loop : System.getLoops()) {
     if (loop.isDeleted())
       continue;
@@ -487,7 +489,7 @@ void GeneratingConformances::computeCandidateConformancePaths() {
     if (result.empty())
       continue;
 
-    if (Debug.contains(DebugFlags::GeneratingConformances)) {
+    if (Debug.contains(DebugFlags::MinimalConformances)) {
       llvm::dbgs() << "Candidate homotopy generator: ";
       loop.dump(llvm::dbgs(), System);
       llvm::dbgs() << "\n";
@@ -503,7 +505,7 @@ void GeneratingConformances::computeCandidateConformancePaths() {
       if (inEmptyContext.empty())
         continue;
 
-      if (Debug.contains(DebugFlags::GeneratingConformances)) {
+      if (Debug.contains(DebugFlags::MinimalConformances)) {
         llvm::dbgs() << "* Protocol " << proto->getName() << ":\n";
         llvm::dbgs() << "** Conformance rules not in context:\n";
         for (unsigned ruleID : inEmptyContext) {
@@ -600,7 +602,7 @@ void GeneratingConformances::computeCandidateConformancePaths() {
 
   for (const auto &pair : ConformancePaths) {
     if (pair.second.size() > 1)
-      Context.GeneratingConformancesHistogram.add(pair.second.size());
+      Context.MinimalConformancesHistogram.add(pair.second.size());
   }
 }
 
@@ -612,7 +614,7 @@ void GeneratingConformances::computeCandidateConformancePaths() {
 /// The \p conformancePaths map sends conformance rules to a list of
 /// disjunctions, where each disjunction is a product of other conformance
 /// rules.
-bool GeneratingConformances::isValidConformancePath(
+bool MinimalConformances::isValidConformancePath(
     llvm::SmallDenseSet<unsigned, 4> &visited,
     const llvm::SmallVectorImpl<unsigned> &path, bool allowConcrete) const {
 
@@ -681,7 +683,7 @@ bool GeneratingConformances::isValidConformancePath(
 /// This helps ensure that the inheritance clause of a protocol is complete
 /// and correct, allowing name lookup to find associated types of inherited
 /// protocols while building the protocol requirement signature.
-bool GeneratingConformances::isValidRefinementPath(
+bool MinimalConformances::isValidRefinementPath(
     const llvm::SmallVectorImpl<unsigned> &path) const {
   for (unsigned ruleID : path) {
     if (!System.getRule(ruleID).isProtocolRefinementRule())
@@ -691,12 +693,12 @@ bool GeneratingConformances::isValidRefinementPath(
   return true;
 }
 
-void GeneratingConformances::dumpGeneratingConformanceEquations(
+void MinimalConformances::dumpMinimalConformanceEquations(
     llvm::raw_ostream &out) const {
   out << "Initial set of equations:\n";
   for (const auto &pair : ConformancePaths) {
     out << "- ";
-    dumpGeneratingConformanceEquation(out, pair.first, pair.second);
+    dumpMinimalConformanceEquation(out, pair.first, pair.second);
     out << "\n";
   }
 
@@ -708,7 +710,7 @@ void GeneratingConformances::dumpGeneratingConformanceEquations(
   }
 }
 
-void GeneratingConformances::dumpConformancePath(
+void MinimalConformances::dumpConformancePath(
     llvm::raw_ostream &out,
     const SmallVectorImpl<unsigned> &path) const {
   if (path.empty()) {
@@ -720,7 +722,7 @@ void GeneratingConformances::dumpConformancePath(
     out << "(" << System.getRule(ruleID).getLHS() << ")";
 }
 
-void GeneratingConformances::dumpGeneratingConformanceEquation(
+void MinimalConformances::dumpMinimalConformanceEquation(
     llvm::raw_ostream &out,
     unsigned baseRuleID,
     const std::vector<SmallVector<unsigned, 2>> &paths) const {
@@ -737,7 +739,7 @@ void GeneratingConformances::dumpGeneratingConformanceEquation(
   }
 }
 
-void GeneratingConformances::verifyGeneratingConformanceEquations() const {
+void MinimalConformances::verifyMinimalConformanceEquations() const {
 #ifndef NDEBUG
   for (const auto &pair : ConformancePaths) {
     const auto &rule = System.getRule(pair.first);
@@ -755,13 +757,13 @@ void GeneratingConformances::verifyGeneratingConformanceEquations() const {
 
       if (proto != otherProto) {
         llvm::errs() << "Invalid equation: ";
-        dumpGeneratingConformanceEquation(llvm::errs(),
-                                          pair.first, pair.second);
+        dumpMinimalConformanceEquation(llvm::errs(),
+                                       pair.first, pair.second);
         llvm::errs() << "\n";
         llvm::errs() << "Mismatched conformance:\n";
         llvm::errs() << "Base rule: " << rule << "\n";
         llvm::errs() << "Final rule: " << otherRule << "\n\n";
-        dumpGeneratingConformanceEquations(llvm::errs());
+        dumpMinimalConformanceEquations(llvm::errs());
         abort();
       }
 
@@ -774,11 +776,11 @@ void GeneratingConformances::verifyGeneratingConformanceEquations() const {
         if ((isLastElement && !rule.isAnyConformanceRule()) ||
             (!isLastElement && !rule.isProtocolConformanceRule())) {
           llvm::errs() << "Equation term is not a conformance rule: ";
-          dumpGeneratingConformanceEquation(llvm::errs(),
-                                            pair.first, pair.second);
+          dumpMinimalConformanceEquation(llvm::errs(),
+                                         pair.first, pair.second);
           llvm::errs() << "\n";
           llvm::errs() << "Term: " << rule << "\n";
-          dumpGeneratingConformanceEquations(llvm::errs());
+          dumpMinimalConformanceEquations(llvm::errs());
           abort();
         }
 
@@ -789,13 +791,13 @@ void GeneratingConformances::verifyGeneratingConformanceEquations() const {
 
       if (baseTerm != otherTerm) {
         llvm::errs() << "Invalid equation: ";
-        dumpGeneratingConformanceEquation(llvm::errs(),
-                                          pair.first, pair.second);
+        dumpMinimalConformanceEquation(llvm::errs(),
+                                       pair.first, pair.second);
         llvm::errs() << "\n";
         llvm::errs() << "Invalid conformance path:\n";
         llvm::errs() << "Expected: " << baseTerm << "\n";
         llvm::errs() << "Got: " << otherTerm << "\n\n";
-        dumpGeneratingConformanceEquations(llvm::errs());
+        dumpMinimalConformanceEquations(llvm::errs());
         abort();
       }
     }
@@ -803,13 +805,12 @@ void GeneratingConformances::verifyGeneratingConformanceEquations() const {
 #endif
 }
 
-/// Find a minimal set of generating conformances by marking all other
+/// Find a set of minimal conformances by marking all non-minimal
 /// conformances redundant.
 ///
 /// In the first pass, we only consider conformance requirements that are
 /// made redundant by concrete conformances.
-void GeneratingConformances::computeGeneratingConformances(
-    bool firstPass) {
+void MinimalConformances::computeMinimalConformances(bool firstPass) {
   for (unsigned ruleID : ConformanceRules) {
     const auto &paths = ConformancePaths[ruleID];
 
@@ -836,9 +837,9 @@ void GeneratingConformances::computeGeneratingConformances(
       if (!derivedViaConcrete)
         continue;
 
-      if (Debug.contains(DebugFlags::GeneratingConformances)) {
+      if (Debug.contains(DebugFlags::MinimalConformances)) {
         llvm::dbgs() << "Derived-via-concrete: ";
-        dumpGeneratingConformanceEquation(llvm::dbgs(), ruleID, paths);
+        dumpMinimalConformanceEquation(llvm::dbgs(), ruleID, paths);
         llvm::dbgs() << "\n";
       }
     } else {
@@ -860,7 +861,7 @@ void GeneratingConformances::computeGeneratingConformances(
 
       if (isValidConformancePath(visited, path,
                                  /*allowConcrete=*/true)) {
-        if (Debug.contains(DebugFlags::GeneratingConformances)) {
+        if (Debug.contains(DebugFlags::MinimalConformances)) {
           llvm::dbgs() << "Redundant rule in ";
           llvm::dbgs() << (firstPass ? "first" : "second");
           llvm::dbgs() << " pass: ";
@@ -876,7 +877,7 @@ void GeneratingConformances::computeGeneratingConformances(
 }
 
 /// Check invariants.
-void GeneratingConformances::verifyGeneratingConformances() const {
+void MinimalConformances::verifyMinimalConformances() const {
 #ifndef NDEBUG
   for (const auto &pair : ConformancePaths) {
     unsigned ruleID = pair.first;
@@ -884,7 +885,7 @@ void GeneratingConformances::verifyGeneratingConformances() const {
 
     if (RedundantConformances.count(ruleID) > 0) {
       // Check that redundant conformances are recoverable via
-      // generating conformances.
+      // minimal conformances.
       llvm::SmallDenseSet<unsigned, 4> visited;
 
       llvm::SmallVector<unsigned, 1> path;
@@ -894,7 +895,7 @@ void GeneratingConformances::verifyGeneratingConformances() const {
                                   /*allowConcrete=*/true)) {
         llvm::errs() << "Redundant conformance is not recoverable:\n";
         llvm::errs() << rule << "\n\n";
-        dumpGeneratingConformanceEquations(llvm::errs());
+        dumpMinimalConformanceEquations(llvm::errs());
         abort();
       }
 
@@ -904,21 +905,21 @@ void GeneratingConformances::verifyGeneratingConformances() const {
     if (rule.isRedundant()) {
       llvm::errs() << "Generating conformance is redundant: ";
       llvm::errs() << rule << "\n\n";
-      dumpGeneratingConformanceEquations(llvm::errs());
+      dumpMinimalConformanceEquations(llvm::errs());
       abort();
     }
 
     if (rule.getLHS().containsUnresolvedSymbols()) {
       llvm::errs() << "Generating conformance contains unresolved symbols: ";
       llvm::errs() << rule << "\n\n";
-      dumpGeneratingConformanceEquations(llvm::errs());
+      dumpMinimalConformanceEquations(llvm::errs());
       abort();
     }
   }
 #endif
 }
 
-void GeneratingConformances::dumpGeneratingConformances(
+void MinimalConformances::dumpMinimalConformances(
     llvm::raw_ostream &out) const {
   out << "Generating conformances:\n";
 
@@ -930,26 +931,26 @@ void GeneratingConformances::dumpGeneratingConformances(
   }
 }
 
-/// Computes a minimal set of generating conformances, assuming that homotopy
-/// reduction has already eliminated all redundant rewrite rules that are not
+/// Computes minimal conformances, assuming that homotopy reduction has
+/// already eliminated all redundant rewrite rules that are not
 /// conformance rules.
-void RewriteSystem::computeGeneratingConformances(
+void RewriteSystem::computeMinimalConformances(
     llvm::DenseSet<unsigned> &redundantConformances) {
-  GeneratingConformances builder(*this, redundantConformances);
+  MinimalConformances builder(*this, redundantConformances);
 
   builder.collectConformanceRules();
   builder.computeCandidateConformancePaths();
 
-  if (Debug.contains(DebugFlags::GeneratingConformances)) {
-    builder.dumpGeneratingConformanceEquations(llvm::dbgs());
+  if (Debug.contains(DebugFlags::MinimalConformances)) {
+    builder.dumpMinimalConformanceEquations(llvm::dbgs());
   }
 
-  builder.verifyGeneratingConformanceEquations();
-  builder.computeGeneratingConformances(/*firstPass=*/true);
-  builder.computeGeneratingConformances(/*firstPass=*/false);
-  builder.verifyGeneratingConformances();
+  builder.verifyMinimalConformanceEquations();
+  builder.computeMinimalConformances(/*firstPass=*/true);
+  builder.computeMinimalConformances(/*firstPass=*/false);
+  builder.verifyMinimalConformances();
 
-  if (Debug.contains(DebugFlags::GeneratingConformances)) {
-    builder.dumpGeneratingConformances(llvm::dbgs());
+  if (Debug.contains(DebugFlags::MinimalConformances)) {
+    builder.dumpMinimalConformances(llvm::dbgs());
   }
 }

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -35,6 +35,7 @@ namespace llvm {
 
 namespace swift {
 
+class ProtocolConformance;
 class ProtocolDecl;
 enum class RequirementKind : unsigned;
 
@@ -172,7 +173,8 @@ class PropertyMap {
   using ConcreteTypeInDomain = std::pair<CanType, ArrayRef<const ProtocolDecl *>>;
   llvm::DenseMap<ConcreteTypeInDomain, Term> ConcreteTypeInDomainMap;
 
-  llvm::DenseSet<std::pair<unsigned, unsigned>> ConcreteConformanceRules;
+  llvm::DenseMap<std::pair<unsigned, unsigned>, ProtocolConformance *>
+      ConcreteConformances;
 
   DebugOptions Debug;
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -727,8 +727,15 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
     //
     // Where S[n] is the nth substitution term.
 
-    // FIXME: Record a rewrite path.
-    return Context.getRelativeTermForType(typeWitness, substitutions);
+    auto result = Context.getRelativeTermForType(typeWitness, substitutions);
+
+    RewriteSystem::TypeWitness witness(Term::get(subjectType, Context),
+                                       Term::get(result, Context));
+    unsigned witnessID = System.recordTypeWitness(witness);
+    path.add(RewriteStep::forAbstractTypeWitness(
+        witnessID, /*inverse=*/false));
+
+    return result;
   }
 
   // Otherwise the type witness is concrete, but may contain type

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -14,7 +14,7 @@
 // signatures using the requirement machine via the request evaluator.
 //
 // The actual logic for finding a minimal set of rewrite rules is implemented in
-// HomotopyReduction.cpp and GeneratingConformances.cpp.
+// HomotopyReduction.cpp and MinimalConformances.cpp.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -35,7 +35,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("concrete-unification", DebugFlags::ConcreteUnification)
       .Case("concretize-nested-types", DebugFlags::ConcretizeNestedTypes)
       .Case("homotopy-reduction", DebugFlags::HomotopyReduction)
-      .Case("generating-conformances", DebugFlags::GeneratingConformances)
+      .Case("minimal-conformances", DebugFlags::MinimalConformances)
       .Case("protocol-dependencies", DebugFlags::ProtocolDependencies)
       .Case("minimization", DebugFlags::Minimization)
       .Default(None);
@@ -61,7 +61,7 @@ RewriteContext::RewriteContext(ASTContext &ctx)
       PropertyTrieHistogram(16, /*Start=*/1),
       PropertyTrieRootHistogram(16),
       ConformanceRulesHistogram(16),
-      GeneratingConformancesHistogram(8, /*Start=*/2) {
+      MinimalConformancesHistogram(8, /*Start=*/2) {
   auto debugFlags = StringRef(ctx.LangOpts.DebugRequirementMachine);
   if (!debugFlags.empty())
     Debug = parseDebugFlags(debugFlags);
@@ -699,6 +699,6 @@ RewriteContext::~RewriteContext() {
     llvm::dbgs() << "\n* Conformance rules:\n";
     ConformanceRulesHistogram.dump(llvm::dbgs());
     llvm::dbgs() << "\n* Generating conformance equations:\n";
-    GeneratingConformancesHistogram.dump(llvm::dbgs());
+    MinimalConformancesHistogram.dump(llvm::dbgs());
   }
 }

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -131,7 +131,7 @@ public:
   Histogram PropertyTrieHistogram;
   Histogram PropertyTrieRootHistogram;
   Histogram ConformanceRulesHistogram;
-  Histogram GeneratingConformancesHistogram;
+  Histogram MinimalConformancesHistogram;
 
   explicit RewriteContext(ASTContext &ctx);
 

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -92,6 +92,13 @@ void RewriteStep::dump(llvm::raw_ostream &out,
                     : "SameTypeWitness");
     break;
   }
+  case AbstractTypeWitness: {
+    evaluator.applyAbstractTypeWitness(*this, system);
+
+    out << (Inverse ? "AbstractTypeWitness⁻¹"
+                    : "AbstractTypeWitness");
+    break;
+  }
 
   }
 }
@@ -561,6 +568,42 @@ void RewritePathEvaluator::applySameTypeWitness(const RewriteStep &step,
   }
 }
 
+void
+RewritePathEvaluator::applyAbstractTypeWitness(const RewriteStep &step,
+                                               const RewriteSystem &system) {
+  checkA();
+  auto &term = A.back();
+
+  const auto &witness = system.getTypeWitness(step.RuleID);
+  auto fail = [&]() {
+    llvm::errs() << "Bad abstract type witness term:\n";
+    llvm::errs() << term << "\n\n";
+    witness.dump(llvm::errs());
+    abort();
+  };
+
+  auto typeWitness = witness.getAbstractType();
+
+  Term origTerm = (step.Inverse ? witness.LHS : typeWitness);
+  Term substTerm = (step.Inverse ? typeWitness : witness.LHS);
+
+  if (term.size() != step.StartOffset + origTerm.size() + step.EndOffset) {
+    fail();
+  }
+
+  if (!std::equal(origTerm.begin(),
+                  origTerm.end(),
+                  term.begin() + step.StartOffset)) {
+    fail();
+  }
+
+  MutableTerm newTerm(term.begin(), term.begin() + step.StartOffset);
+  newTerm.append(substTerm);
+  newTerm.append(term.end() - step.EndOffset, term.end());
+
+  term = newTerm;
+}
+
 void RewritePathEvaluator::apply(const RewriteStep &step,
                                  const RewriteSystem &system) {
   switch (step.Kind) {
@@ -591,6 +634,10 @@ void RewritePathEvaluator::apply(const RewriteStep &step,
 
   case RewriteStep::SameTypeWitness:
     applySameTypeWitness(step, system);
+    break;
+
+  case RewriteStep::AbstractTypeWitness:
+    applyAbstractTypeWitness(step, system);
     break;
   }
 }

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -118,8 +118,8 @@ struct RewriteStep {
     /// If inverted: the concrete type symbol [concrete: C.X] is introduced.
     ///
     /// The RuleID field is repurposed to store the result of calling
-    /// RewriteSystem::recordConcreteTypeWitness(). This index is then
-    /// passed in to RewriteSystem::getConcreteTypeWitness() when applying
+    /// RewriteSystem::recordTypeWitness(). This index is then passed in
+    /// to RewriteSystem::getTypeWitness() when applying
     /// the step.
     ConcreteTypeWitness,
 
@@ -129,9 +129,7 @@ struct RewriteStep {
     ///
     /// If inverted: the associated type symbol [P:X] is introduced.
     ///
-    /// The RuleID field is repurposed to store the result of calling
-    /// RewriteSystem::recordConcreteTypeWitness(). This index is then
-    /// passed in to RewriteSystem::getConcreteTypeWitness() when applying
+    /// The RuleID field is a TypeWitness ID as above.
     /// the step.
     SameTypeWitness,
   };

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -132,18 +132,31 @@ struct RewriteStep {
     /// The RuleID field is a TypeWitness ID as above.
     /// the step.
     SameTypeWitness,
+
+    /// If not inverted: replaces the abstract type witness term with the
+    /// subject type term.
+    ///
+    /// If inverted: replaces the subject type term with the abstract type
+    /// term.
+    ///
+    /// The RuleID field is a TypeWitness ID as above.
+    AbstractTypeWitness,
   };
 
   /// The rewrite step kind.
-  StepKind Kind : 3;
+  StepKind Kind : 4;
+
+  /// If false, the step replaces an occurrence of the rule's left hand side
+  /// with the right hand side. If true, vice versa.
+  unsigned Inverse : 1;
 
   /// The size of the left whisker, which is the position within the term where
   /// the rule is being applied. In A.(X => Y).B, this is |A|=1.
-  unsigned StartOffset : 14;
+  unsigned StartOffset : 16;
 
   /// The size of the right whisker, which is the length of the remaining suffix
   /// after the rule is applied. In A.(X => Y).B, this is |B|=1.
-  unsigned EndOffset : 14;
+  unsigned EndOffset : 16;
 
   /// If Kind is ApplyRewriteRule, the index of the rule in the rewrite system.
   ///
@@ -151,11 +164,7 @@ struct RewriteStep {
   /// at the beginning of each concrete substitution.
   ///
   /// If Kind is Concrete, the number of substitutions to push or pop.
-  unsigned RuleID : 15;
-
-  /// If false, the step replaces an occurrence of the rule's left hand side
-  /// with the right hand side. If true, vice versa.
-  unsigned Inverse : 1;
+  unsigned RuleID : 16;
 
   RewriteStep(StepKind kind, unsigned startOffset, unsigned endOffset,
               unsigned ruleID, bool inverse) {
@@ -208,6 +217,11 @@ struct RewriteStep {
 
   static RewriteStep forSameTypeWitness(unsigned witnessID, bool inverse) {
     return RewriteStep(SameTypeWitness, /*startOffset=*/0, /*endOffset=*/0,
+                       /*ruleID=*/witnessID, inverse);
+  }
+
+  static RewriteStep forAbstractTypeWitness(unsigned witnessID, bool inverse) {
+    return RewriteStep(AbstractTypeWitness, /*startOffset=*/0, /*endOffset=*/0,
                        /*ruleID=*/witnessID, inverse);
   }
 
@@ -399,6 +413,9 @@ struct RewritePathEvaluator {
 
   void applySameTypeWitness(const RewriteStep &step,
                             const RewriteSystem &system);
+
+  void applyAbstractTypeWitness(const RewriteStep &step,
+                                const RewriteSystem &system);
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -249,7 +249,7 @@ public:
   }
 
   // Horizontal composition of paths.
-  void append(RewritePath other) {
+  void append(const RewritePath &other) {
     Steps.append(other.begin(), other.end());
   }
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -461,9 +461,10 @@ private:
   void verifyRewriteLoops() const;
 
   void verifyRedundantConformances(
-      llvm::DenseSet<unsigned> redundantConformances) const;
+      const llvm::DenseSet<unsigned> &redundantConformances) const;
 
-  void verifyMinimizedRules() const;
+  void verifyMinimizedRules(
+      const llvm::DenseSet<unsigned> &redundantConformances) const;
 
 public:
   void dump(llvm::raw_ostream &out) const;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -14,6 +14,7 @@
 #define SWIFT_REWRITESYSTEM_H
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/PointerUnion.h"
 
 #include "Debug.h"
 #include "RewriteLoop.h"
@@ -324,28 +325,68 @@ private:
   //////////////////////////////////////////////////////////////////////////////
 
 public:
-  struct ConcreteTypeWitness {
-    Symbol ConcreteConformance;
-    Symbol AssocType;
-    Symbol ConcreteType;
+  /// A type witness has a subject type, stored in LHS, which takes the form:
+  ///
+  /// T.[concrete: C : P].[P:X]
+  ///
+  /// For some concrete type C, protocol P and associated type X.
+  ///
+  /// The type witness of X in the conformance C : P is either a concrete type,
+  /// or an abstract type parameter.
+  ///
+  /// If it is a concrete type, then RHS stores the concrete type symbol.
+  ///
+  /// If it is an abstract type parameter, then RHS stores the type term.
+  ///
+  /// Think of these as rewrite rules which are lazily created, but always
+  /// "there" -- they encode information about concrete conformances, which
+  /// are solved outside of the requirement machine itself.
+  ///
+  /// We don't want to eagerly pull in all concrete conformances and walk
+  /// them recursively introducing rewrite rules.
+  ///
+  /// The RewriteStep::{Concrete,Same,Abstract}TypeWitness rewrite step kinds
+  /// reference TypeWitnesses via their RuleID field.
+  ///
+  /// Type witnesses are recorded lazily in property map construction, in
+  /// PropertyMap::computeConstraintTermForTypeWitness().
+  struct TypeWitness {
+    Term LHS;
+    llvm::PointerUnion<Symbol, Term> RHS;
 
-    ConcreteTypeWitness(Symbol concreteConformance,
-                        Symbol assocType,
-                        Symbol concreteType);
+    TypeWitness(Term lhs, llvm::PointerUnion<Symbol, Term> rhs);
 
-    friend bool operator==(const ConcreteTypeWitness &lhs,
-                           const ConcreteTypeWitness &rhs);
+    friend bool operator==(const TypeWitness &lhs,
+                           const TypeWitness &rhs);
+
+    Symbol getConcreteConformance() const {
+      return *(LHS.end() - 2);
+    }
+
+    Symbol getAssocType() const {
+      return *(LHS.end() - 1);
+    }
+
+    Symbol getConcreteType() const {
+      return RHS.get<Symbol>();
+    }
+
+    Term getAbstractType() const {
+      return RHS.get<Term>();
+    }
+
+    void dump(llvm::raw_ostream &out) const;
   };
 
 private:
   /// Cache for concrete type witnesses. The value in the map is an index
   /// into the vector.
-  llvm::DenseMap<std::pair<Symbol, Symbol>, unsigned> ConcreteTypeWitnessMap;
-  std::vector<ConcreteTypeWitness> ConcreteTypeWitnesses;
+  llvm::DenseMap<Term, unsigned> TypeWitnessMap;
+  std::vector<TypeWitness> TypeWitnesses;
 
 public:
-  unsigned recordConcreteTypeWitness(ConcreteTypeWitness witness);
-  const ConcreteTypeWitness &getConcreteTypeWitness(unsigned index) const;
+  unsigned recordTypeWitness(TypeWitness witness);
+  const TypeWitness &getTypeWitness(unsigned index) const;
 
   //////////////////////////////////////////////////////////////////////////////
   ///

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -365,7 +365,7 @@ public:
   /// 2-cells; this is actually represented as a single 2-cell forming a
   /// loop around a base point.
   ///
-  /// This data is used by the homotopy reduction and generating conformances
+  /// This data is used by the homotopy reduction and minimal conformances
   /// algorithms.
   std::vector<RewriteLoop> Loops;
 
@@ -399,7 +399,7 @@ public:
   void performHomotopyReduction(
       const llvm::DenseSet<unsigned> *redundantConformances);
 
-  void computeGeneratingConformances(
+  void computeMinimalConformances(
       llvm::DenseSet<unsigned> &redundantConformances);
 
 public:

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -427,18 +427,14 @@ public:
 
   void propagateExplicitBits();
 
-  bool
-  isCandidateForDeletion(unsigned ruleID,
-                         const llvm::DenseSet<unsigned> *redundantConformances) const;
-
   Optional<unsigned>
-  findRuleToDelete(const llvm::DenseSet<unsigned> *redundantConformances,
+  findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn,
                    RewritePath &replacementPath);
 
   void deleteRule(unsigned ruleID, const RewritePath &replacementPath);
 
   void performHomotopyReduction(
-      const llvm::DenseSet<unsigned> *redundantConformances);
+      llvm::function_ref<bool(unsigned)> isRedundantRuleFn);
 
   void computeMinimalConformances(
       llvm::DenseSet<unsigned> &redundantConformances);

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -277,6 +277,18 @@ namespace llvm {
       return LHS == RHS;
     }
   };
+
+  template<>
+  struct PointerLikeTypeTraits<swift::rewriting::Symbol> {
+  public:
+    static inline void *getAsVoidPointer(swift::rewriting::Symbol Val) {
+      return const_cast<void *>(Val.getOpaquePointer());
+    }
+    static inline swift::rewriting::Symbol getFromVoidPointer(void *Ptr) {
+      return swift::rewriting::Symbol::fromOpaquePointer(Ptr);
+    }
+    enum { NumLowBitsAvailable = 1 };
+  };
 } // end namespace llvm
 
 #endif

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -229,6 +229,18 @@ namespace llvm {
       return LHS == RHS;
     }
   };
+
+  template<>
+  struct PointerLikeTypeTraits<swift::rewriting::Term> {
+  public:
+    static inline void *getAsVoidPointer(swift::rewriting::Term Val) {
+      return const_cast<void *>(Val.getOpaquePointer());
+    }
+    static inline swift::rewriting::Term getFromVoidPointer(void *Ptr) {
+      return swift::rewriting::Term::fromOpaquePointer(Ptr);
+    }
+    enum { NumLowBitsAvailable = 1 };
+  };
 } // end namespace llvm
 
 #endif

--- a/test/Generics/abstract_type_witnesses_in_protocols.swift
+++ b/test/Generics/abstract_type_witnesses_in_protocols.swift
@@ -1,0 +1,62 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype T
+}
+
+struct G<T> : P {}
+
+
+protocol Q {
+  associatedtype A : P
+}
+
+protocol R {}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T == Self.B.T>
+
+// GSB: Non-canonical requirement
+protocol Q1 : Q {
+  associatedtype B : P where A == G<B.T>
+}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1a@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T : R, Self.A.T == Self.B.T>
+
+// GSB: Missing requirement
+protocol Q1a : Q {
+  associatedtype B : P where A.T : R, A == G<B.T>
+}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q1b@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T : R, Self.A.T == Self.B.T>
+
+// GSB: Non-canonical requirement
+protocol Q1b : Q {
+  associatedtype B : P where B.T : R, A == G<B.T>
+}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q2@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T == Self.B.T>
+
+// GSB: Missing requirement
+protocol Q2 : Q {
+  associatedtype B : P where A.T == B.T, A == G<B.T>
+}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q3@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T == Self.B.T>
+
+// GSB: Unsupported recursive requirement
+protocol Q3 : Q {
+  associatedtype B : P where A == G<A.T>, A.T == B.T
+}
+
+// CHECK-LABEL: abstract_type_witnesses_in_protocols.(file).Q4@
+// CHECK-NEXT: Requirement signature: <Self where Self : Q, Self.A == G<Self.A.T>, Self.B : P, Self.A.T == Self.B.T>
+
+// GSB: Unsupported recursive requirement
+protocol Q4 : Q {
+  associatedtype B : P where A.T == B.T, A == G<A.T>
+}

--- a/test/Generics/rdar83308672.swift
+++ b/test/Generics/rdar83308672.swift
@@ -32,25 +32,25 @@ protocol B {
 // we can drop one requirement but not both.
 
 // CHECK: rdar83308672.(file).G1@
-// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T : B>
+// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T.X == Self.T.Y>
 protocol G1 {
   associatedtype T : A where T.X == T.Y
 }
 
 // CHECK: rdar83308672.(file).G2@
-// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T : B>
+// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T.X == Self.T.Y>
 protocol G2 {
   associatedtype T : A where T : B, T.X == T.Y
 }
 
 // CHECK: rdar83308672.(file).G3@
-// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T : B>
+// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T.X == Self.T.Y>
 protocol G3 {
   associatedtype T : A where T.X == T.Y, T : B
 }
 
 // CHECK: rdar83308672.(file).G4@
-// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T : B>
+// CHECK-NEXT: Requirement signature: <Self where Self.T : A, Self.T.X == Self.T.Y>
 protocol G4 {
   associatedtype T : A where T : B
 }

--- a/test/Generics/sr10532.swift
+++ b/test/Generics/sr10532.swift
@@ -15,7 +15,7 @@ public protocol ScalarMultiplicative {
 public protocol MapReduceArithmetic : ScalarMultiplicative, Collection where Element : ScalarMultiplicative, Scalar == Element.Scalar { }
 
 // CHECK: sr10532.(file).Tensor@
-// CHECK-NEXT: Requirement signature: <Self where Self : MapReduceArithmetic, Self.Element : BinaryFloatingPoint, Self.Element : ScalarProtocol>
+// CHECK-NEXT: Requirement signature: <Self where Self : MapReduceArithmetic, Self.Element : BinaryFloatingPoint, Self.Element == Self.Scalar>
 public protocol Tensor : MapReduceArithmetic where Scalar : BinaryFloatingPoint, Element == Scalar {
   var magnitude: Scalar { get set }
 }

--- a/validation-test/compiler_crashers_2_fixed/0173-circular-generic-type-alias-deserialization.swift
+++ b/validation-test/compiler_crashers_2_fixed/0173-circular-generic-type-alias-deserialization.swift
@@ -1,10 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module-path %t/foo.swiftmodule %s
+// RUN: %target-build-swift -emit-module-path %t/foo.swiftmodule -Xfrontend -debug-generic-signatures -Xfrontend -requirement-machine-protocol-signatures=on %s 2>&1 | %FileCheck %s
 
 public protocol P { }
 public struct X<T: P> {
   public init() { }
 }
+
+// CHECK-LABEL: main.(file).Q@
+// CHECK-NEXT: Requirement signature: <Self where Self.A : P, Self.C : Collection, Self.C.Element == X<Self.A>>
 public protocol Q {
   associatedtype A: P
   associatedtype C: Collection where C.Element == MyX

--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
 
 public protocol FooProtocol {
   associatedtype Bar
@@ -13,3 +13,6 @@ public protocol BazProtocol: FooProtocol {
   associatedtype Foo2Bar
   typealias Foo2 = Foo<Foo2Bar>
 }
+
+// CHECK-LABEL: sr11639.(file).BazProtocol@
+// CHECK-NEXT: Requirement signature: <Self where Self : FooProtocol, Self.Foo1 : FooProtocol, Self.Foo2Bar == Self.Foo1.Bar>


### PR DESCRIPTION
This is the follow-up to https://github.com/apple/swift/pull/40543.

If a concrete conformance defines an abstract type witness, the corresponding nested type of the concrete type becomes a type parameter. For example,

```
protocol P {
  associatedtype T
}

struct G<T> : P {}

protocol Q {
  associatedtype A : P, A == G<B>
  associatedtype B
}
```

The type witness for `T` in the conformance `G<B> : P` is `Self.B`. This means that the nested type `Self.A.T` is equivalent to `Self.B`.

The property map unification algorithm would previously introduce same-type requirement. This PR adds the rewrite step relating it to the concrete conformance, allowing it to be minimized away.