### PR TITLE
The test Sema/api-availability-only.swift fails on arm64 on the bots

### DIFF
--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -8,6 +8,7 @@
 // CHECK: the flag -check-api-availability-only does not support emitting IR
 
 // REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
 
 @available(macOS 11.0, *)
 public protocol NewProto {}


### PR DESCRIPTION
rdar://86537686