### PR TITLE
Disable the test IRGen/thinlto.swift under ASAN

### DIFF
--- a/test/IRGen/thinlto.swift
+++ b/test/IRGen/thinlto.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
+// REQUIRES: no_asan
 
 #if MODULE
 


### PR DESCRIPTION
It fails on the ASAN bot.

rdar://86544116