### PR TITLE
[gardening] Two small refactorings

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -420,6 +420,18 @@ bool MoveKillsCopyableValuesChecker::check() {
 }
 
 //===----------------------------------------------------------------------===//
+//                        Unsupported Use Case Errors
+//===----------------------------------------------------------------------===//
+
+static void emitUnsupportedUseCaseError(MoveValueInst *mvi) {
+  auto &astContext = mvi->getModule().getASTContext();
+  auto diag = diag::
+    sil_movekillscopyablevalue_move_applied_to_unsupported_move;
+  diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
+  mvi->setAllowsDiagnostics(false);
+}
+
+//===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
@@ -455,10 +467,7 @@ class MoveKillsCopyableValuesCheckerPass : public SILFunctionTransform {
       for (auto &inst : block) {
         if (auto *mvi = dyn_cast<MoveValueInst>(&inst)) {
           if (mvi->getAllowDiagnostics()) {
-            auto diag = diag::
-                sil_movekillscopyablevalue_move_applied_to_unsupported_move;
-            diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
-            mvi->setAllowsDiagnostics(false);
+            emitUnsupportedUseCaseError(mvi);
           }
         }
       }

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -363,17 +363,7 @@ bool MoveKillsCopyableValuesChecker::check() {
 
     // Before we do anything, see if we can find a name for our value. We do
     // this early since we need this for all of our diagnostics below.
-    StringRef varName = "unknown";
-    if (auto *use = getSingleDebugUse(lexicalValue)) {
-      DebugVarCarryingInst debugVar(use->getUser());
-      if (auto varInfo = debugVar.getVarInfo()) {
-        varName = varInfo->Name;
-      } else {
-        if (auto *decl = debugVar.getDecl()) {
-          varName = decl->getBaseName().userFacingName();
-        }
-      }
-    }
+    StringRef varName = getDebugVarName(lexicalValue);
 
     // Then compute liveness.
     SWIFT_DEFER { livenessInfo.clear(); };


### PR DESCRIPTION
1. First commit refactors the move diagnostic emission code in the move function address checker into its own function instead of inline in preparation for adding some more complex diagnostics via pattern matching.
2. I found an inline instance of the function getDebugVarName() and just replaced the inlined version with a call to the out of line function.