### PR TITLE
RequirementMachine: Disable getCanonicalType() consistency check in noassert builds

### DIFF
--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -378,6 +378,7 @@ Type RequirementMachine::getCanonicalTypeInContext(
     // If U is not concrete, we have an invalid member type of a dependent
     // type, which is not valid in this generic signature. Give up.
     if (prefixType->isTypeParameter()) {
+#ifndef NDEBUG
       llvm::errs() << "Invalid type parameter in getCanonicalTypeInContext()\n";
       llvm::errs() << "Original type: " << type << "\n";
       llvm::errs() << "Simplified term: " << term << "\n";
@@ -386,6 +387,9 @@ Type RequirementMachine::getCanonicalTypeInContext(
       llvm::errs() << "\n";
       dump(llvm::errs());
       abort();
+#else
+      return type;
+#endif
     }
 
     // Compute the type of the unresolved suffix term V, rooted in the


### PR DESCRIPTION
rdar://86431977