### PR TITLE
RequirementMachine: A workaround [5.6]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -283,6 +283,9 @@ namespace swift {
     /// Whether to dump debug info for request evaluator cycles.
     bool DebugDumpCycles = false;
 
+    /// Disable SIL substituted function types.
+    bool DisableSubstSILFunctionTypes = false;
+
     /// Whether to diagnose an ephemeral to non-ephemeral conversion as an
     /// error.
     bool DiagnoseInvalidEphemeralnessAsError = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -464,6 +464,10 @@ def enable_experimental_static_assert :
   Flag<["-"], "enable-experimental-static-assert">,
   HelpText<"Enable experimental #assert">;
 
+def disable_subst_sil_function_types :
+  Flag<["-"], "disable-subst-sil-function-types">,
+  HelpText<"Disable substituted function types for SIL type lowering of function values">;
+
 def enable_experimental_named_opaque_types :
   Flag<["-"], "enable-experimental-named-opaque-types">,
   HelpText<"Enable experimental support for named opaque result types">;

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -377,6 +377,7 @@ Type RequirementMachine::getCanonicalTypeInContext(
     // If U is not concrete, we have an invalid member type of a dependent
     // type, which is not valid in this generic signature. Give up.
     if (prefixType->isTypeParameter()) {
+#ifndef NDEBUG
       llvm::errs() << "Invalid type parameter in getCanonicalTypeInContext()\n";
       llvm::errs() << "Original type: " << type << "\n";
       llvm::errs() << "Simplified term: " << term << "\n";
@@ -385,6 +386,9 @@ Type RequirementMachine::getCanonicalTypeInContext(
       llvm::errs() << "\n";
       dump(llvm::errs());
       abort();
+#else
+      return type;
+#endif
     }
 
     // Compute the type of the unresolved suffix term V, rooted in the

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -838,6 +838,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.DisableSubstSILFunctionTypes =
+      Args.hasArg(OPT_disable_subst_sil_function_types);
+
   if (auto A = Args.getLastArg(OPT_requirement_machine_EQ)) {
     auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(A->getValue())
         .Case("off", RequirementMachineMode::Disabled)

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1928,6 +1928,9 @@ static CanSILFunctionType getSILFunctionType(
   }
 
   bool shouldBuildSubstFunctionType = [&]{
+    if (TC.Context.LangOpts.DisableSubstSILFunctionTypes)
+      return false;
+
     // If there is no genericity in the abstraction pattern we're lowering
     // against, we don't need to introduce substitutions into the lowered
     // type.


### PR DESCRIPTION
SIL type lowering uses the GenericSignatureBuilder to build GenericSignatures. Sometimes the GenericSignatureBuilder drops requirements or otherwise screws something up. This triggers errors in the RequirementMachine. Make one of these errors a no-op in noassert builds.

Also, add a flag to disable substituted SIL function types in case the above doesn't help. Unfortunately we can't disable them by default anymore because AutoDiff relies on them.

This is a temporary state of affairs. The underlying problem goes away once we start using the RequirementMachine to build new GenericSignatures.

Fixes rdar://86431977.