### PR TITLE
SIL: Workaround for GenericSignatureBuilder bug

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1649,8 +1649,8 @@ public:
       newGPMapping.insert({gp, newParamTy});
       auto substGPTy = Type(gp).subst(substGPMap)->castTo<GenericTypeParamType>();
       substRequirements.push_back(Requirement(RequirementKind::SameType,
-                                              substGPTy,
-                                              newParamTy));
+                                              newParamTy,
+                                              substGPTy));
       assert(!substReplacementTypes[substGPTy->getIndex()]);
       substReplacementTypes[substGPTy->getIndex()] = substParamTy;
     }

--- a/test/Generics/rdar86431977.swift
+++ b/test/Generics/rdar86431977.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype A
+  associatedtype B : P1 where B.A == A, B.B == B
+}
+
+protocol P2 : P1 where A == Self {}
+
+struct G<T, U> {}
+
+// The GSB used to get the signature of bar() wrong.
+
+extension G {
+  // CHECK-LABEL: rdar86431977.(file).G extension.foo()@
+  // CHECK: Generic signature: <T, U where T : P2, T == U>
+  func foo() where T : P2, U == T {}
+
+  // CHECK-LABEL: rdar86431977.(file).G extension.bar()@
+  // CHECK: Generic signature: <T, U where T : P2, T == U>
+  func bar() where T : P2, T == U {}
+}

--- a/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
+++ b/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen %s -requirement-machine-abstract-signatures=verify | %FileCheck %s
+
+struct G<Key: CaseIterable, Value> where Key: RawRepresentable, Value: Codable {
+  var key: Key.RawValue
+}
+
+protocol P: CaseIterable, RawRepresentable {}
+
+struct Value: Codable {}
+
+enum Key: Int, P {
+  case elt
+}
+
+func callee<Key: P>(_: Key.Type, _: @escaping (G<Key, Value>) -> Void) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s029type_lowering_subst_function_A20_requirement_machine6calleryyF : $@convention(thin) () -> () {
+// CHECK: function_ref @$s029type_lowering_subst_function_A20_requirement_machine6calleryyFyAA1GVyAA3KeyOAA5ValueVGcfU_ : $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : CaseIterable, τ_0_0 : RawRepresentable, τ_0_0 == τ_0_2, τ_0_1 == Value> (@in_guaranteed G<τ_0_0, Value>) -> () for <Key, Value, Key>
+func caller() {
+  callee(Key.self, { _ in })
+}
+


### PR DESCRIPTION
The GSB will drop same-type requirements sometimes, when the
right hand side is smaller than the left. Change the order
when adding these requirements, which seems to work well
enough for my reduced testcase.

Also, ensure that everything works correctly with the
RequirementMachine, which doesn't have the same underlying
problems with same-type requirement handling.

Fixes rdar://86431977.