### PR TITLE
SIL: Workaround for GenericSignatureBuilder bug [5.6]

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -283,6 +283,9 @@ namespace swift {
     /// Whether to dump debug info for request evaluator cycles.
     bool DebugDumpCycles = false;
 
+    /// Disable SIL substituted function types.
+    bool DisableSubstSILFunctionTypes = false;
+
     /// Whether to diagnose an ephemeral to non-ephemeral conversion as an
     /// error.
     bool DiagnoseInvalidEphemeralnessAsError = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -464,6 +464,10 @@ def enable_experimental_static_assert :
   Flag<["-"], "enable-experimental-static-assert">,
   HelpText<"Enable experimental #assert">;
 
+def disable_subst_sil_function_types :
+  Flag<["-"], "disable-subst-sil-function-types">,
+  HelpText<"Disable substituted function types for SIL type lowering of function values">;
+
 def enable_experimental_named_opaque_types :
   Flag<["-"], "enable-experimental-named-opaque-types">,
   HelpText<"Enable experimental support for named opaque result types">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -838,6 +838,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.DisableSubstSILFunctionTypes =
+      Args.hasArg(OPT_disable_subst_sil_function_types);
+
   if (auto A = Args.getLastArg(OPT_requirement_machine_EQ)) {
     auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(A->getValue())
         .Case("off", RequirementMachineMode::Disabled)

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1649,8 +1649,8 @@ public:
       newGPMapping.insert({gp, newParamTy});
       auto substGPTy = Type(gp).subst(substGPMap)->castTo<GenericTypeParamType>();
       substRequirements.push_back(Requirement(RequirementKind::SameType,
-                                              substGPTy,
-                                              newParamTy));
+                                              newParamTy,
+                                              substGPTy));
       assert(!substReplacementTypes[substGPTy->getIndex()]);
       substReplacementTypes[substGPTy->getIndex()] = substParamTy;
     }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1928,6 +1928,9 @@ static CanSILFunctionType getSILFunctionType(
   }
 
   bool shouldBuildSubstFunctionType = [&]{
+    if (TC.Context.LangOpts.DisableSubstSILFunctionTypes)
+      return false;
+
     // If there is no genericity in the abstraction pattern we're lowering
     // against, we don't need to introduce substitutions into the lowered
     // type.

--- a/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
+++ b/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+struct G<Key: CaseIterable, Value> where Key: RawRepresentable, Value: Codable {
+  var key: Key.RawValue
+}
+
+protocol P: CaseIterable, RawRepresentable {}
+
+struct Value: Codable {}
+
+enum Key: Int, P {
+  case elt
+}
+
+func callee<Key: P>(_: Key.Type, _: @escaping (G<Key, Value>) -> Void) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s029type_lowering_subst_function_A20_requirement_machine6calleryyF : $@convention(thin) () -> () {
+// CHECK: function_ref @$s029type_lowering_subst_function_A20_requirement_machine6calleryyFyAA1GVyAA3KeyOAA5ValueVGcfU_ : $@convention(thin) @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : CaseIterable, τ_0_0 : RawRepresentable, τ_0_0 == τ_0_2, τ_0_1 == Value> (@in_guaranteed G<τ_0_0, Value>) -> () for <Key, Value, Key>
+func caller() {
+  callee(Key.self, { _ in })
+}
+


### PR DESCRIPTION
The GSB will drop same-type requirements sometimes, when the
right hand side is smaller than the left. Change the order
when adding these requirements, which seems to work well
enough for my reduced testcase.

Fixes rdar://86431977.