### PR TITLE
[5.6] Fully Check Decls in Result Builders

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1122,10 +1122,15 @@ private:
       if (!resultTarget)
         continue;
 
+      // FIXME: It's unfortunate that we're duplicating code from CSApply here.
+      // If there were a request for the fully-typechecked initializer of a
+      // pattern binding we may be able to eliminate the duplication here.
       patternBinding->setPattern(
           index, resultTarget->getInitializationPattern(),
-          resultTarget->getDeclContext());
+          resultTarget->getDeclContext(),
+          /*isFullyValidated=*/true);
       patternBinding->setInit(index, resultTarget->getAsExpr());
+      patternBinding->setInitializerChecked(index);
     }
   }
 
@@ -1226,6 +1231,7 @@ public:
       // Skip variable declarations; they're always part of a pattern
       // binding.
       if (isa<VarDecl>(decl)) {
+        TypeChecker::typeCheckDecl(decl);
         newElements.push_back(decl);
         continue;
       }
@@ -1233,6 +1239,7 @@ public:
       // Handle pattern bindings.
       if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
         finishPatternBindingDecl(patternBinding);
+        TypeChecker::typeCheckDecl(decl);
         newElements.push_back(decl);
         continue;
       }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -815,3 +815,14 @@ func test_missing_member_in_optional_context() {
     }
   }
 }
+
+func test_redeclations() {
+  tuplify(true) { c in
+    let foo = 0 // expected-note {{'foo' previously declared here}}
+    let foo = foo // expected-error {{invalid redeclaration of 'foo'}}
+  }
+
+  tuplify(true) { c in
+    let (foo, foo) = (5, 6) // expected-error {{invalid redeclaration of 'foo'}} expected-note {{'foo' previously declared here}}
+  }
+}


### PR DESCRIPTION
Cherry picked from #40512 

------

In particular, this turns redeclaration checking on for variables in
pattern bindings.

rdar://86566912