### PR TITLE
[NFC] Refactor Pattern Binding Application in Result Builders

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1109,31 +1109,6 @@ private:
     elements.push_back(pbd);
   }
 
-  /// Produce a final type-checked pattern binding.
-  void finishPatternBindingDecl(PatternBindingDecl *patternBinding) {
-    for (unsigned index : range(patternBinding->getNumPatternEntries())) {
-      // Find the solution application target for this.
-      auto knownTarget =
-          *solution.getConstraintSystem().getSolutionApplicationTarget(
-            {patternBinding, index});
-
-      // Rewrite the target.
-      auto resultTarget = rewriteTarget(knownTarget);
-      if (!resultTarget)
-        continue;
-
-      // FIXME: It's unfortunate that we're duplicating code from CSApply here.
-      // If there were a request for the fully-typechecked initializer of a
-      // pattern binding we may be able to eliminate the duplication here.
-      patternBinding->setPattern(
-          index, resultTarget->getInitializationPattern(),
-          resultTarget->getDeclContext(),
-          /*isFullyValidated=*/true);
-      patternBinding->setInit(index, resultTarget->getAsExpr());
-      patternBinding->setInitializerChecked(index);
-    }
-  }
-
 public:
   BuilderClosureRewriter(
       const Solution &solution,
@@ -1238,9 +1213,11 @@ public:
 
       // Handle pattern bindings.
       if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
-        finishPatternBindingDecl(patternBinding);
-        TypeChecker::typeCheckDecl(decl);
-        newElements.push_back(decl);
+        auto resultTarget = rewriteTarget(SolutionApplicationTarget{patternBinding});
+        assert(resultTarget.hasValue()
+               && "Could not rewrite pattern binding entries!");
+        TypeChecker::typeCheckDecl(resultTarget->getAsPatternBinding());
+        newElements.push_back(resultTarget->getAsPatternBinding());
         continue;
       }
 


### PR DESCRIPTION
Remove the duplication between this code and CSApply by targeting the pattern binding decl instead of all of its entries.