### PR TITLE
[5.6] Frontend: support emitting ABI descriptor when specifying the path in supplementary output map. rdar://86559811

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -95,4 +95,6 @@ TYPE("pcm",                 ClangModuleFile,           "pcm",             "")
 TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
 
+TYPE("abi-baseline-json",   SwiftABIDescriptor,        "abi.json",        "")
+
 #undef TYPE

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -84,6 +84,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
+  case file_types::TY_SwiftABIDescriptor:
     return true;
   case file_types::TY_Image:
   case file_types::TY_Object:
@@ -157,6 +158,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
   case file_types::TY_IndexUnitOutputPath:
+  case file_types::TY_SwiftABIDescriptor:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -208,6 +210,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
   case file_types::TY_IndexUnitOutputPath:
+  case file_types::TY_SwiftABIDescriptor:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2080,6 +2080,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_SwiftOverlayFile:
       case file_types::TY_JSONDependencies:
       case file_types::TY_JSONFeatures:
+      case file_types::TY_SwiftABIDescriptor:
         // We could in theory handle assembly or LLVM input, but let's not.
         // FIXME: What about LTO?
         Diags.diagnose(SourceLoc(), diag::error_unexpected_input_file,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -681,6 +681,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftCrossImportDir:
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_IndexUnitOutputPath:
+  case file_types::TY_SwiftABIDescriptor:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -940,6 +941,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_SwiftCrossImportDir:
     case file_types::TY_SwiftOverlayFile:
     case file_types::TY_IndexUnitOutputPath:
+    case file_types::TY_SwiftABIDescriptor:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -599,6 +599,7 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
        paths.PrivateModuleInterfaceOutputPath},
       {file_types::TY_YAMLOptRecord, paths.YAMLOptRecordPath},
       {file_types::TY_BitstreamOptRecord, paths.BitstreamOptRecordPath},
+      {file_types::TY_SwiftABIDescriptor, paths.ABIDescriptorOutputPath},
   };
   for (const std::pair<file_types::ID, std::string &> &typeAndString :
        typesAndStrings) {

--- a/test/Frontend/emit-module-abi-descriptor.swift
+++ b/test/Frontend/emit-module-abi-descriptor.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'print("Hello, World!")' >%t/main.swift
+// RUN: cd %t
+
+// RUN: %target-swift-frontend -emit-module -emit-abi-descriptor-path %t/main.abi.json %t/main.swift
+// RUN: test -f %t/main.abi.json
+
+// RUN: echo '"%/t/main.swift": { abi-baseline-json: "%/t/foo.abi.json" }' > %/t/filemap.yaml
+// RUN: %target-swift-frontend -emit-module -supplementary-output-file-map %/t/filemap.yaml %/t/main.swift
+// RUN: test -f %t/foo.abi.json


### PR DESCRIPTION
rdar://86559811