### PR TITLE
Use the API Name of Enum Parameters to Determine Coding Keys

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -54,7 +54,13 @@ static bool superclassConformsTo(ClassDecl *target, KnownProtocolKind kpk) {
 static Identifier getVarNameForCoding(VarDecl *var,
                                       Optional<int> paramIndex = None) {
   auto &C = var->getASTContext();
-  Identifier identifier = var->getName();
+  Identifier identifier;
+  if (auto *PD = dyn_cast<ParamDecl>(var)) {
+    identifier = PD->getArgumentName();
+  } else {
+    identifier = var->getName();
+  }
+
   if (auto originalVar = var->getOriginalWrappedProperty())
     identifier = originalVar->getName();
 

--- a/test/decl/protocol/special/coding/enum_codable_simple.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple.swift
@@ -6,6 +6,7 @@ enum SimpleEnum : Codable {
     case a(x: Int, y: Double)
     case b(z: String)
     case c(Int, String, b: Bool)
+    case d(_ inner: Int)
 
     // These lines have to be within the SimpleEnum type because CodingKeys
     // should be private.
@@ -15,6 +16,7 @@ enum SimpleEnum : Codable {
         let _ = SimpleEnum.ACodingKeys.self
         let _ = SimpleEnum.BCodingKeys.self
         let _ = SimpleEnum.CCodingKeys.self
+        let _ = SimpleEnum.DCodingKeys.self
 
         // The enum should have a case for each of the cases.
         let _ = SimpleEnum.CodingKeys.a
@@ -29,6 +31,8 @@ enum SimpleEnum : Codable {
         let _ = SimpleEnum.CCodingKeys._0
         let _ = SimpleEnum.CCodingKeys._1
         let _ = SimpleEnum.CCodingKeys.b
+
+        let _ = SimpleEnum.DCodingKeys._0
     }
 }
 

--- a/validation-test/compiler_crashers_2_fixed/rdar86339848.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar86339848.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -emit-silgen
+
+struct Boom: Decodable {}
+
+enum Whiz: Decodable {
+  case bang(_ boom: Boom)
+}


### PR DESCRIPTION
Covers a missing case in codable synthesis for enums with argument
payloads that have internal and external labels. When the name of the
var decl is used, the internal name of the parameter becomes the key
instead of the API name. In this case, this causes an invalid reference
to an enum case with the internal name as an argument to be synthesized
in the derived Decodable conformance which (hopefully) crashes
downstream.

rdar://86339848