### PR TITLE
[5.6] Don't try to import variants for FieldDecls

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4206,6 +4206,13 @@ namespace {
       if (!importedName) {
         return nullptr;
       }
+      if (correctSwiftName) {
+        // FIXME: We should import this as a variant, but to do that, we'll also
+        // need to make this a computed variable or otherwise fix how the rest
+        // of the compiler thinks about stored properties in imported structs.
+        // For now, just don't import it at all. (rdar://86069786)
+        return nullptr;
+      }
 
       auto name = importedName.getDeclName().getBaseIdentifier();
 
@@ -4248,6 +4255,7 @@ namespace {
 
       // If this is a compatibility stub, handle it as such.
       if (correctSwiftName)
+        // FIXME: Temporarily unreachable because of check above.
         markAsVariant(result, *correctSwiftName);
 
       return result;

--- a/test/ClangImporter/ctypes_ir.swift
+++ b/test/ClangImporter/ctypes_ir.swift
@@ -45,3 +45,12 @@ func testBigArrays(_ maxSize: UnsafeMutablePointer<Int8>?, _ maxSizePlusOne: Uns
 func testBigArrays2d(_ maxSize: UnsafeMutablePointer<IntTuple4096>?, _ maxSizePlusOne: OpaquePointer?) {
     useBigArray2d(maxSize, maxSizePlusOne)
 }
+
+
+// Make sure fields with a swift_name attribute only produce one stored
+// property, not two. (rdar://86069786)
+// CHECK-LABEL: define swiftcc void @"$s9ctypes_ir22testFieldWithSwiftName1oySo12Rdar86069786V_tF"
+// CHECK-SAME: (double %0)
+
+public func testFieldWithSwiftName(o : Rdar86069786) {
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -196,6 +196,11 @@ STDLIB_TYPEDEF(unsigned int, UInt);
 void noreturnFunction() __attribute__((noreturn));
 void couldReturnFunction() __attribute__((noreturn));
 
+// Struct with an __attribute((swift_name)) field.
+struct Rdar86069786 {
+    double c_name __attribute__((swift_name("swiftName")));
+};
+
 
 //===---
 // Function pointers


### PR DESCRIPTION
Cherry-pick of #40599:

> Back when we were eagerly importing struct fields, we only attempted to import fields under the names they have in the current version; previous versions and the raw name were ignored. Now that we're importing them lazily, we're passing through code that attempts to import all versions. That's a nice idea in theory, but neither ImportDecl nor the rest of the compiler was prepared for this, and so ImportDecl has started adding redundant stored properties to clang structs. This trips an assertion in IRGen.
> 
> This commit returns to the old behavior of only importing struct fields under their current name by simply early-exiting from SwiftDeclConverter::VisitFieldDecl(). We can come up with a solution that imports the variants in the future.
> 
> Fixes rdar://86069786.