### PR TITLE
Don't emit `@main` into SIL

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -150,7 +150,7 @@ SIMPLE_DECL_ATTR(dynamicCallable, DynamicCallable,
   OnNominalType |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   6)
-SIMPLE_DECL_ATTR(main, MainType,
+DECL_ATTR(main, MainType,
   OnClass | OnStruct | OnEnum | OnExtension |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   7)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -915,6 +915,25 @@ public:
   }
 };
 
+class MainTypeAttr final : public DeclAttribute {
+public:
+  MainTypeAttr(bool isImplicit)
+      : DeclAttribute(DAK_MainType, SourceLoc(), SourceLoc(), isImplicit) {}
+
+  MainTypeAttr(SourceLoc AtLoc, SourceLoc NameLoc)
+      : DeclAttribute(DAK_MainType, AtLoc,
+                      SourceRange(AtLoc.isValid() ? AtLoc : NameLoc, NameLoc),
+                      /*Implicit=*/false) {}
+
+  MainTypeAttr(SourceLoc NameLoc)
+      : DeclAttribute(DAK_MainType, SourceLoc(), SourceRange(NameLoc, NameLoc),
+                      /*Implicit=*/false) {}
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_MainType;
+  }
+};
+
 class PrivateImportAttr final
 : public DeclAttribute {
   StringRef SourceFile;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -895,6 +895,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     }
     return true;
 
+  case DAK_MainType:
+    Printer.printSimpleAttr(getAttrName(), /*needAt=*/true);
+    return true;
+
   case DAK_SetterAccess:
     Printer.printKeyword(getAttrName(), Options, "(set)");
     return true;
@@ -1241,6 +1245,8 @@ StringRef DeclAttribute::getAttrName() const {
   case DAK_ObjC:
   case DAK_ObjCRuntimeName:
     return "objc";
+  case DAK_MainType:
+    return "main";
   case DAK_DynamicReplacement:
     return "_dynamicReplacement";
   case DAK_TypeEraser:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -895,9 +895,13 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     }
     return true;
 
-  case DAK_MainType:
+  case DAK_MainType: {
+    // Don't print into SIL. Necessary bits have already been generated.
+    if (Options.PrintForSIL)
+      return false;
     Printer.printSimpleAttr(getAttrName(), /*needAt=*/true);
     return true;
+  }
 
   case DAK_SetterAccess:
     Printer.printKeyword(getAttrName(), Options, "(set)");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1943,6 +1943,11 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
 #include "swift/AST/Attr.def"
 
+  case DAK_MainType:
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) MainTypeAttr(AtLoc, Loc));
+    break;
+
   case DAK_Effects: {
     auto kind = parseSingleAttrOption<EffectsKind>
                          (*this, Loc, AttrRange, AttrName, DK)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4485,6 +4485,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::MainType_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::MainTypeDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) MainTypeAttr(isImplicit);
+        break;
+      }
+
       case decls_block::Specialize_DECL_ATTR: {
         unsigned exported;
         SpecializeAttr::SpecializationKind specializationKind;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 651; // existential requires any
+const uint16_t SWIFTMODULE_VERSION_MINOR = 652; // @main cleanup
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1828,6 +1828,11 @@ namespace decls_block {
     SwiftNativeObjCRuntimeBase_DECL_ATTR,
     BCFixed<1>, // implicit flag
     IdentifierIDField // name
+  >;
+
+  using MainTypeDeclAttrLayout = BCRecordLayout<
+    MainType_DECL_ATTR,
+    BCFixed<1> // implicit flag
   >;
 
   using SemanticsDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2590,6 +2590,13 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_MainType: {
+      auto abbrCode = S.DeclTypeAbbrCodes[MainTypeDeclAttrLayout::Code];
+      MainTypeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                         DA->isImplicit());
+      return;
+    }
+
     case DAK_Specialize: {
       auto abbrCode = S.DeclTypeAbbrCodes[SpecializeDeclAttrLayout::Code];
       auto attr = cast<SpecializeAttr>(DA);

--- a/test/attr/ApplicationMain/attr_main_struct.swift
+++ b/test/attr/ApplicationMain/attr_main_struct.swift
@@ -1,7 +1,11 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend -emit-silgen -parse-as-library %s | %FileCheck %s
 
 @main
 struct EntryPoint {
   static func main() {
   }
 }
+
+// CHECK-NOT: @main struct EntryPoint {
+// CHECK: struct EntryPoint {


### PR DESCRIPTION
We emit all the necessary entry point bits directly into SIL. Specifically, `Entrypoint.$main`.
When re-injesting SIL files, `@main` handling would re-trigger, attempting to add another `Entrypoint.$main` resulting in the following error message: `error: invalid redeclaration of synthesized static method '$main()'`.
We don't need to keep the attribute after we've generated the main function, so drop it.

https://bugs.swift.org/browse/SR-14957
rdar://80971052