### PR TITLE
Revert [cxx-interop][libswift] Use `std::string` instead of `BridgedStringRef`

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -15,7 +15,10 @@
 
 #include "BridgedSwiftObject.h"
 #include <stddef.h>
-#include <string>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -161,19 +164,19 @@ BridgedSlab PassContext_freeSlab(BridgedPassContext passContext,
                                  BridgedSlab slab);
 
 BridgedStringRef SILFunction_getName(BridgedFunction function);
-std::string SILFunction_debugDescription(BridgedFunction function);
+BridgedStringRef SILFunction_debugDescription(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_lastBlock(BridgedFunction function);
 SwiftInt SILFunction_numIndirectResultArguments(BridgedFunction function);
 SwiftInt SILFunction_getSelfArgumentIndex(BridgedFunction function);
 
 BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global);
-std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global);
+BridgedStringRef SILGlobalVariable_debugDescription(BridgedGlobalVar global);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
 OptionalBridgedBasicBlock SILBasicBlock_previous(BridgedBasicBlock block);
 BridgedFunction SILBasicBlock_getFunction(BridgedBasicBlock block);
-std::string SILBasicBlock_debugDescription(BridgedBasicBlock block);
+BridgedStringRef SILBasicBlock_debugDescription(BridgedBasicBlock block);
 OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block);
 OptionalBridgedInstruction SILBasicBlock_lastInst(BridgedBasicBlock block);
 SwiftInt SILBasicBlock_getNumArguments(BridgedBasicBlock block);
@@ -188,7 +191,7 @@ OptionalBridgedOperand Operand_nextUse(BridgedOperand);
 BridgedInstruction Operand_getUser(BridgedOperand);
 SwiftInt Operand_isTypeDependent(BridgedOperand);
 
-std::string SILNode_debugDescription(BridgedNode node);
+BridgedStringRef SILNode_debugDescription(BridgedNode node);
 OptionalBridgedOperand SILValue_firstUse(BridgedValue value);
 BridgedType SILValue_getType(BridgedValue value);
 
@@ -241,5 +244,9 @@ BridgedInstruction SILBuilder_createIntegerLiteral(BridgedInstruction insertionP
           BridgedLocation loc, BridgedType type, SwiftInt value);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -15,8 +15,6 @@
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/SILBuilder.h"
 
-#include <string>
-
 using namespace swift;
 
 namespace {
@@ -165,12 +163,11 @@ BridgedStringRef SILFunction_getName(BridgedFunction function) {
   return getBridgedStringRef(castToFunction(function)->getName());
 }
 
-std::string SILFunction_debugDescription(BridgedFunction function) {
+BridgedStringRef SILFunction_debugDescription(BridgedFunction function) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToFunction(function)->print(os);
-  str.pop_back(); // Remove trailing newline.
-  return str;
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
 }
 
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function) {
@@ -226,12 +223,11 @@ BridgedFunction SILBasicBlock_getFunction(BridgedBasicBlock block) {
   return {castToBasicBlock(block)->getParent()};
 }
 
-std::string SILBasicBlock_debugDescription(BridgedBasicBlock block) {
+BridgedStringRef SILBasicBlock_debugDescription(BridgedBasicBlock block) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToBasicBlock(block)->print(os);
-  str.pop_back(); // Remove trailing newline.
-  return str;
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
 }
 
 OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block) {
@@ -291,12 +287,11 @@ BridgedBasicBlock SILArgument_getParent(BridgedArgument argument) {
 static_assert(BridgedOperandSize == sizeof(Operand),
               "wrong bridged Operand size");
 
-std::string SILNode_debugDescription(BridgedNode node) {
+BridgedStringRef SILNode_debugDescription(BridgedNode node) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToSILNode(node)->print(os);
-  str.pop_back(); // Remove trailing newline.
-  return str;
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
 }
 
 static Operand *castToOperand(BridgedOperand operand) {
@@ -347,12 +342,11 @@ BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global) {
   return getBridgedStringRef(castToGlobal(global)->getName());
 }
 
-std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
+BridgedStringRef SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToGlobal(global)->print(os);
-  str.pop_back(); // Remove trailing newline.
-  return str;
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
 }
 
 //===----------------------------------------------------------------------===//

--- a/libswift/Sources/SIL/BasicBlock.swift
+++ b/libswift/Sources/SIL/BasicBlock.swift
@@ -19,8 +19,7 @@ final public class BasicBlock : ListNode, CustomStringConvertible {
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    var s = SILBasicBlock_debugDescription(bridged)
-    return String(cString: s.c_str())
+    SILBasicBlock_debugDescription(bridged).takeString()
   }
 
   public var arguments: ArgumentArray { ArgumentArray(block: self) }

--- a/libswift/Sources/SIL/Function.swift
+++ b/libswift/Sources/SIL/Function.swift
@@ -18,8 +18,7 @@ final public class Function : CustomStringConvertible {
   }
 
   final public var description: String {
-    var s = SILFunction_debugDescription(bridged)
-    return String(cString: s.c_str())
+    return SILFunction_debugDescription(bridged).takeString()
   }
 
   public var entryBlock: BasicBlock {

--- a/libswift/Sources/SIL/GlobalVariable.swift
+++ b/libswift/Sources/SIL/GlobalVariable.swift
@@ -18,8 +18,7 @@ final public class GlobalVariable : CustomStringConvertible {
   }
 
   public var description: String {
-    var s = SILGlobalVariable_debugDescription(bridged)
-    return String(cString: s.c_str())
+    return SILGlobalVariable_debugDescription(bridged).takeString()
   }
 
   // TODO: initializer instructions

--- a/libswift/Sources/SIL/Instruction.swift
+++ b/libswift/Sources/SIL/Instruction.swift
@@ -30,8 +30,7 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   }
 
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    SILNode_debugDescription(bridgedNode).takeString()
   }
   
   final public var operands: OperandArray {
@@ -124,8 +123,7 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    SILNode_debugDescription(bridgedNode).takeString()
   }
 
   public var instruction: Instruction {

--- a/libswift/Sources/SIL/Value.swift
+++ b/libswift/Sources/SIL/Value.swift
@@ -20,8 +20,7 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
 extension Value {
   public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    SILNode_debugDescription(bridgedNode).takeString()
   }
 
   public var uses: UseList {


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/39356

To unblock the Windows build (as a replacement of https://github.com/apple/swift/pull/40299).
And to unblock https://github.com/apple/swift/pull/40589, which fails due to a de-serialization crash of the C++ string type.

rdar://86627515