### PR TITLE
Require optimized stdlib for stdlib/move_function test

### DIFF
--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -5,6 +5,7 @@
 // test to fail only when optimizations are enabled.
 
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
rdar://86543481
