### PR TITLE
[CMake] Begin moving Standard Library options in a separate file

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -1,3 +1,10 @@
+# In some configurations (e.g. back deploy concurrency) we
+# configure the build from the root of the Swift repo but we skip
+# stdlib/CMakeLists.txt, with the risk of missing important parameters.
+# To account for this scenario, we include the stdlib options
+# before the guard
+include(${CMAKE_CURRENT_LIST_DIR}/../../stdlib/cmake/modules/StdlibOptions.cmake)
+
 # CMAKE_SOURCE_DIR is the directory that cmake got initially invoked on.
 # CMAKE_CURRENT_SOURCE_DIR is the current directory. If these are equal, it's
 # a top-level build of the CMAKE_SOURCE_DIR. Otherwise, define a guard variable
@@ -84,10 +91,6 @@ set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
   "Semicolon-separated list of architectures to configure Swift module-only \
 targets on Darwin platforms. These targets are in addition to the full \
 library targets.")
-
-option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
-       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
-       TRUE)
 
 # -----------------------------------------------------------------------------
 # Constants

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -72,8 +72,13 @@ endif()
 # User-configurable options for the standard library.
 #
 
+# New options should be added to stdlib/cmake/modules/StdlibOptions.cmake,
+# so that they are considered in configurations using StandaloneOverlay.cmake
+
 # NOTE: Some of these variables are also initialized in StandaloneOverlay.cmake
 # so that interfaces are emitted when overlays are separately built.
+
+# TODO: migrate this section to StdlibOptions.cmake to reduce duplication
 
 set(SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS "" CACHE STRING
     "Extra flags to pass when compiling swift stdlib files")
@@ -88,10 +93,6 @@ option(SWIFT_STDLIB_STABLE_ABI
 option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        "${SWIFT_STDLIB_STABLE_ABI}")
-
-option(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
-       "Support back-deployment of built binaries to older OS versions."
-       TRUE)
 
 option(SWIFT_STDLIB_HAS_DLADDR
        "Build stdlib assuming the runtime environment runtime environment provides dladdr API."
@@ -133,10 +134,6 @@ option(SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR
        "Build stdlib without a custom implementation of MetadataAllocator, relying on malloc+free instead."
        FALSE)
 
-option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
-       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
-       TRUE)
-
 option(SWIFT_STDLIB_HAS_COMMANDLINE
        "Build stdlib with the CommandLine enum and support for argv/argc."
        TRUE)
@@ -164,10 +161,6 @@ option(SWIFT_ENABLE_REFLECTION
   "Build stdlib with support for runtime reflection and mirrors."
   TRUE)
 
-option(SWIFT_STDLIB_BUILD_PRIVATE
-  "Build private part of the Standard Library."
-  TRUE)
-
 if(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
   set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default "singlethreaded")
 else()
@@ -177,6 +170,10 @@ endif()
 set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR
     "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default}" CACHE STRING
     "Build the concurrency library to use the given global executor (options: dispatch, singlethreaded, hooked)")
+
+# New options should be added to stdlib/cmake/modules/StdlibOptions.cmake,
+# so that they are considered in configurations using StandaloneOverlay.cmake
+include(StdlibOptions)
 
 #
 # End of user-configurable options.

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -1,0 +1,13 @@
+include_guard(GLOBAL)
+
+option(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
+       "Support back-deployment of built binaries to older OS versions."
+       TRUE)
+
+option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
+       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
+       TRUE)
+
+option(SWIFT_STDLIB_BUILD_PRIVATE
+       "Build private part of the Standard Library."
+       TRUE)


### PR DESCRIPTION
This allows the file to be easily included where needed (e.g.
`StandaloneOverlay.cmake`) and reduce the likelihood of miscompilation
due to missing sensible defaults.

As a start, focus on a handful of parameters that got added/modified in
recent PRs.

Addresses rdar://85978195