### PR TITLE
unresolvable_dynamic_metadata_cycles.swift expects output only available on newer runtimes

### DIFF
--- a/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
+++ b/test/Interpreter/unresolvable_dynamic_metadata_cycles.swift
@@ -13,6 +13,9 @@
 
 // REQUIRES: executable_test
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 
 // We build this code against a version of 'resil' where


### PR DESCRIPTION
The runtime was changed in "Eliminate priority inversions in the metadata
completion runtime".

rdar://86643295
