### PR TITLE
Use list comprehension for filter in swift_build_support

### DIFF
--- a/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
+++ b/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
@@ -141,7 +141,7 @@ class ProductPipelineListBuilder(object):
 
             # Filter out any of the pipelines that before inference were not
             # selected.
-            enabled_pipeline = filter(lambda x: x is not None, pipeline)
+            enabled_pipeline = [p for p in pipeline if p is not None]
 
             if self.args.verbose_build:
                 print("-- Build Graph Inference --")


### PR DESCRIPTION
In python3, `filter` returns an iterable which doesn't support using `len()`. This switches to a list comprehension, so that we can check the length of `enabled_pipeline` when switching to python3.

This is required to move `build-script` to Python3.
