### PR TITLE
Explicit Sendable conformances for `@frozen` types

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -46,7 +46,7 @@ public protocol SerialExecutor: Executor {
 /// actor.
 @available(SwiftStdlib 5.1, *)
 @frozen
-public struct UnownedSerialExecutor {
+public struct UnownedSerialExecutor: Sendable {
   #if compiler(>=5.5) && $BuiltinExecutor
   @usableFromInline
   internal var executor: Builtin.Executor

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -718,6 +718,10 @@ public struct UnsafeCurrentTask {
 }
 
 @available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension UnsafeCurrentTask: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -383,6 +383,10 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension TaskGroup: Sendable { }
+
 // Implementation note:
 // We are unable to just™ abstract over Failure == Error / Never because of the
 // complicated relationship between `group.spawn` which dictates if `group.next`
@@ -638,6 +642,10 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     return _taskGroupIsCancelled(group: _group)
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension ThrowingTaskGroup: Sendable { }
 
 /// ==== TaskGroup: AsyncSequence ----------------------------------------------
 


### PR DESCRIPTION
Task groups and `UnsafeCurrentTask` are non-`Sendable`.
`UnownedSerialExecutor` is always `Sendable`.

Fixes rdar://86496341.
