### PR TITLE
Sendable checking for an an isolated witnesses to a nonisolated requirement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4578,8 +4578,15 @@ WARNING(non_sendable_param_type,none,
         "cannot pass argument of non-sendable type %0 across actors",
         (Type))
 WARNING(non_sendable_result_type,none,
-        "cannot call function returning non-sendable type %0 across "
-        "actors", (Type))
+        "non-sendable type %0 returned by %select{call to %4 %2 %3|"
+        "implicitly asynchronous call to %4 %2 %3|"
+        "%4 %2 %3 satisfying non-isolated protocol requirement|"
+        "%4 '@objc' %2 %3}1 cannot cross actor boundary",
+        (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
+WARNING(non_sendable_call_result_type,none,
+        "non-sendable type %0 returned by %select{implicitly asynchronous |}1"
+        "call to %2 function cannot cross actor boundary",
+        (Type, bool, ActorIsolation))
 WARNING(non_sendable_property_type,none,
         "cannot use %1 %2 with a non-sendable type %0 "
         "%select{across actors|from concurrently-executed code}3",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4573,10 +4573,18 @@ NOTE(protocol_isolated_to_global_actor_here,none,
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter has non-actor type %0", (Type))
-      
+
 WARNING(non_sendable_param_type,none,
-        "cannot pass argument of non-sendable type %0 across actors",
-        (Type))
+        "non-sendable type %0 %select{passed in call to %4 %2 %3|"
+        "passed in implicitly asynchronous call to %4 %2 %3|"
+        "in parameter of %4 %2 %3 satisfying non-isolated protocol "
+        "requirement|"
+        "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
+        (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
+WARNING(non_sendable_call_param_type,none,
+        "non-sendable type %0 passed in %select{implicitly asynchronous |}1"
+        "call to %2 function cannot cross actor boundary",
+        (Type, bool, ActorIsolation))
 WARNING(non_sendable_result_type,none,
         "non-sendable type %0 returned by %select{call to %4 %2 %3|"
         "implicitly asynchronous call to %4 %2 %3|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4596,9 +4596,13 @@ WARNING(non_sendable_call_result_type,none,
         "call to %2 function cannot cross actor boundary",
         (Type, bool, ActorIsolation))
 WARNING(non_sendable_property_type,none,
-        "cannot use %1 %2 with a non-sendable type %0 "
-        "%select{across actors|from concurrently-executed code}3",
-        (Type, DescriptiveDeclKind, DeclName, bool))
+        "non-sendable type %0 in %select{"
+        "%select{asynchronous access to %5 %1 %2|"
+        "implicitly asynchronous access to %5 %1 %2|"
+        "conformance of %5 %1 %2 to non-isolated protocol requirement|"
+        "%5 '@objc' %1 %2}4|captured local %1 %2}3 cannot "
+        "cross %select{actor|task}3 boundary",
+        (Type, DescriptiveDeclKind, DeclName, bool, unsigned, ActorIsolation))
 WARNING(non_sendable_keypath_capture,none,
         "cannot form key path that captures non-sendable type %0",
         (Type))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -815,7 +815,9 @@ bool swift::diagnoseNonSendableTypesInReference(
             propertyType, fromDC, loc,
             diag::non_sendable_property_type,
             var->getDescriptiveKind(), var->getName(),
-            var->isLocalCapture()))
+            var->isLocalCapture(),
+            (unsigned)reason,
+            getActorIsolation(var)))
       return true;
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3266,6 +3266,13 @@ ActorIsolation ActorIsolationRequest::evaluate(
     ASTContext &ctx = value->getASTContext();
     switch (inferred) {
     case ActorIsolation::Independent:
+      // Stored properties cannot be non-isolated, so don't infer it.
+      if (auto var = dyn_cast<VarDecl>(value)) {
+        if (!var->isStatic() && var->hasStorage())
+          return ActorIsolation::forUnspecified();
+      }
+
+
       if (onlyGlobal)
         return ActorIsolation::forUnspecified();
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -70,19 +70,21 @@ void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 ClosureActorIsolation
 determineClosureActorIsolation(AbstractClosureExpr *closure);
 
-/// Describes the kind of operation that introduced the concurrent refernece.
-enum class ConcurrentReferenceKind {
-  /// A synchronous operation that was "promoted" to an asynchronous call
-  /// because it was out of the actor's domain.
-  SynchronousAsAsyncCall,
-  /// A cross-actor reference.
+/// States the reason for checking the Sendability of a given declaration.
+enum class SendableCheckReason {
+  /// A reference to an actor from outside that actor.
   CrossActor,
-  /// A local capture referenced from concurrent code.
-  LocalCapture,
-  /// Concurrent function
-  ConcurrentFunction,
-  /// Nonisolated declaration.
-  Nonisolated,
+
+  /// A synchronous operation that was "promoted" to an asynchronous one
+  /// because it was out of the actor's domain.
+  SynchronousAsAsync,
+
+  /// A protocol conformance where the witness/requirement have different
+  /// actor isolation.
+  Conformance,
+
+  /// The declaration is being exposed to Objective-C.
+  ObjC,
 };
 
 /// The isolation restriction in effect for a given declaration that is
@@ -241,7 +243,7 @@ bool contextRequiresStrictConcurrencyChecking(
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
-    ConcurrentReferenceKind refKind);
+    SendableCheckReason refKind);
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -439,7 +439,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
     // FIXME: Substitution map?
     diagnoseNonSendableTypesInReference(
         const_cast<ValueDecl *>(VD), VD->getDeclContext(),
-        VD->getLoc(), ConcurrentReferenceKind::CrossActor);
+        VD->getLoc(), SendableCheckReason::ObjC);
     return false;
   case ActorIsolationRestriction::ActorSelf:
     // Actor-isolated functions cannot be @objc.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3018,7 +3018,7 @@ bool ConformanceChecker::checkActorIsolation(
       if (isValidImplicitAsync(witness, requirement)) {
         diagnoseNonSendableTypesInReference(
             getConcreteWitness(), DC, witness->getLoc(),
-            ConcurrentReferenceKind::CrossActor);
+            SendableCheckReason::Conformance);
 
         return false;
       }
@@ -3057,7 +3057,7 @@ bool ConformanceChecker::checkActorIsolation(
   case ActorIsolationRestriction::CrossActorSelf: {
     if (diagnoseNonSendableTypesInReference(
             getConcreteWitness(), DC, witness->getLoc(),
-            ConcurrentReferenceKind::CrossActor)) {
+            SendableCheckReason::Conformance)) {
       return true;
     }
 
@@ -3188,7 +3188,7 @@ bool ConformanceChecker::checkActorIsolation(
 
     return diagnoseNonSendableTypesInReference(
         getConcreteWitness(), DC, witness->getLoc(),
-        ConcurrentReferenceKind::CrossActor);
+        SendableCheckReason::Conformance);
   }
 
   // If the witness has a global actor but the requirement does not, we have

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -358,23 +358,23 @@ actor Calculator {
 
 @OrangeActor func doSomething() async {
   let _ = (await bananaAdd(1))(2)
-  // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
-  // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
-  // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
-  // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))
-  // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-warning@-1{{non-sendable type '(Int) -> Int' returned by implicitly asynchronous call to actor-isolated instance method 'addCurried' cannot cross actor boundary}}
   // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = plusOne(2)
 }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -289,28 +289,28 @@ func blender(_ peeler : () -> Void) {
 
 
   await wisk({})
-  // expected-warning@-1{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   await wisk(1)
-  // expected-warning@-1{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   await (peelBanana)()
   await (((((peelBanana)))))()
   await (((wisk)))((wisk)((wisk)(1)))
-  // expected-warning@-1 3{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1 3{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 
   blender((peelBanana))
   // expected-error@-1{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
   await wisk(peelBanana)
-  // expected-warning@-1{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 
   await wisk(wisk)
-  // expected-warning@-1{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   await (((wisk)))(((wisk)))
-  // expected-warning@-1{{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 
-  // expected-warning@+1 {{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@+1 {{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   await {wisk}()(1)
 
-  // expected-warning@+1 {{cannot pass argument of non-sendable type 'Any' across actors}}
+  // expected-warning@+1 {{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
   await (true ? wisk : {n in return})(1)
 }
 

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -175,11 +175,11 @@ func someAsyncFunc() async {
   ////////////
   // effectful properties from outside the actor instance
 
-  // expected-warning@+2 {{cannot use property 'effPropA' with a non-sendable type 'Box' across actors}}
+  // expected-warning@+2 {{non-sendable type 'Box' in asynchronous access to actor-isolated property 'effPropA' cannot cross actor boundary}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropA
 
-  // expected-warning@+3 {{cannot use property 'effPropT' with a non-sendable type 'Box' across actors}}
+  // expected-warning@+3 {{non-sendable type 'Box' in implicitly asynchronous access to actor-isolated property 'effPropT' cannot cross actor boundary}}
   // expected-error@+2{{property access can throw, but it is not marked with 'try' and the error is not handled}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropT
@@ -189,8 +189,8 @@ func someAsyncFunc() async {
   _ = a.effPropAT
 
   // (mostly) corrected ones
-  _ = await a.effPropA  // expected-warning {{cannot use property 'effPropA' with a non-sendable type 'Box' across actors}}
-  _ = try! await a.effPropT // expected-warning {{cannot use property 'effPropT' with a non-sendable type 'Box' across actors}}
+  _ = await a.effPropA  // expected-warning {{non-sendable type 'Box' in asynchronous access to actor-isolated property 'effPropA' cannot cross actor boundary}}
+  _ = try! await a.effPropT // expected-warning {{non-sendable type 'Box' in implicitly asynchronous access to actor-isolated property 'effPropT' cannot cross actor boundary}}
   _ = try? await a.effPropAT
 
   print("ok!")

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -967,13 +967,13 @@ func testCrossActorProtocol<T: P>(t: T) async {
 
 @available(SwiftStdlib 5.1, *)
 protocol Server {
-  func send<Message: Codable>(message: Message) async throws -> String
+  func send<Message: Codable & Sendable>(message: Message) async throws -> String
 }
 
 @available(SwiftStdlib 5.1, *)
 actor MyServer : Server {
   // okay, asynchronously accessed from clients of the protocol
-  func send<Message: Codable>(message: Message) throws -> String { "" }
+  func send<Message: Codable & Sendable>(message: Message) throws -> String { "" }
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -106,7 +106,7 @@ func checkAsyncPropertyAccess() async {
 
   act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a non-isolated context}}
 
-  _ = act.point  // expected-warning{{cannot use property 'point' with a non-sendable type 'Point' across actors}}
+  _ = act.point  // expected-warning{{non-sendable type 'Point' in asynchronous access to actor-isolated property 'point' cannot cross actor boundary}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -872,8 +872,8 @@ func testCrossModuleLets(actor: OtherModuleActor) async {
   _ = actor.b         // okay
   _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{property access is 'async'}}
-  // expected-warning@-2{{cannot use property 'c' with a non-sendable type 'SomeClass' across actors}}
-  _ = await actor.c // expected-warning{{cannot use property 'c' with a non-sendable type 'SomeClass' across actors}}
+  // expected-warning@-2{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
+  _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' in implicitly asynchronous access to actor-isolated property 'c' cannot cross actor boundary}}
   _ = await actor.d // okay
 }
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -50,7 +50,7 @@ extension A1 {
     _ = await self.asynchronous(nil)
 
     // Across to a different actor, so Sendable restriction is enforced.
-    _ = other.localLet // expected-warning{{cannot use property 'localLet' with a non-sendable type 'NotConcurrent' across actors}}
+    _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' in asynchronous access to actor-isolated property 'localLet' cannot cross actor boundary}}
     _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by implicitly asynchronous call to actor-isolated instance method 'synchronous()' cannot cross actor boundary}}
     _ = await other.asynchronous(nil) // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to actor-isolated instance method 'asynchronous' cannot cross actor boundary}}
   }
@@ -80,7 +80,7 @@ func globalAsync(_: NotConcurrent?) async {
 }
 
 func globalTest() async {
-  let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-sendable type 'NotConcurrent?' across actors}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }
@@ -101,7 +101,7 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
-  let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-sendable type 'NotConcurrent?' across actors}}
+  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' in asynchronous access to global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot cross actor boundary}}
   await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   _ = await ClassWithGlobalActorInits(nc) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
@@ -180,7 +180,7 @@ actor ANI {
 }
 
 func testANI(ani: ANI) async {
-  _ = ani.nc // expected-warning{{cannot use property 'nc' with a non-sendable type 'NC' across actors}}
+  _ = ani.nc // expected-warning{{non-sendable type 'NC' in asynchronous access to nonisolated property 'nc' cannot cross actor boundary}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -51,7 +51,7 @@ extension A1 {
 
     // Across to a different actor, so Sendable restriction is enforced.
     _ = other.localLet // expected-warning{{cannot use property 'localLet' with a non-sendable type 'NotConcurrent' across actors}}
-    _ = await other.synchronous() // expected-warning{{cannot call function returning non-sendable type 'NotConcurrent?' across actors}}
+    _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by implicitly asynchronous call to actor-isolated instance method 'synchronous()' cannot cross actor boundary}}
     _ = await other.asynchronous(nil) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
   }
 }
@@ -105,8 +105,8 @@ func globalTestMain(nc: NotConcurrent) async {
   await globalAsync(a) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
   await globalSync(a)  // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
   _ = await ClassWithGlobalActorInits(nc) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
-  // expected-warning@-1{{cannot call function returning non-sendable type 'ClassWithGlobalActorInits' across actors}}
-  _ = await ClassWithGlobalActorInits() // expected-warning{{cannot call function returning non-sendable type 'ClassWithGlobalActorInits' across actors}}
+  // expected-warning@-1{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }
 
 @SomeGlobalActor

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -25,17 +25,17 @@ actor A2 {
   }
 
   convenience init(delegatingSync value: NotConcurrent) {
-    self.init(value: value) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+    self.init(value: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to nonisolated initializer 'init(value:)' cannot cross actor boundary}}
   }
 
   convenience init(delegatingAsync value: NotConcurrent) async {
-    await self.init(valueAsync: value) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+    await self.init(valueAsync: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to actor-isolated initializer 'init(valueAsync:)' cannot cross actor boundary}}
   }
 }
 
 func testActorCreation(value: NotConcurrent) async {
-  _ = A2(value: value) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
-  _ = await A2(valueAsync: value) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+  _ = A2(value: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to nonisolated initializer 'init(value:)' cannot cross actor boundary}}
+  _ = await A2(valueAsync: value) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to actor-isolated initializer 'init(valueAsync:)' cannot cross actor boundary}}
 }
 
 extension A1 {
@@ -52,7 +52,7 @@ extension A1 {
     // Across to a different actor, so Sendable restriction is enforced.
     _ = other.localLet // expected-warning{{cannot use property 'localLet' with a non-sendable type 'NotConcurrent' across actors}}
     _ = await other.synchronous() // expected-warning{{non-sendable type 'NotConcurrent?' returned by implicitly asynchronous call to actor-isolated instance method 'synchronous()' cannot cross actor boundary}}
-    _ = await other.asynchronous(nil) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
+    _ = await other.asynchronous(nil) // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to actor-isolated instance method 'asynchronous' cannot cross actor boundary}}
   }
 }
 
@@ -81,8 +81,8 @@ func globalAsync(_: NotConcurrent?) async {
 
 func globalTest() async {
   let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-sendable type 'NotConcurrent?' across actors}}
-  await globalAsync(a) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
-  await globalSync(a)  // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
+  await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }
 
 struct HasSubscript {
@@ -102,9 +102,9 @@ class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActo
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
   let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-sendable type 'NotConcurrent?' across actors}}
-  await globalAsync(a) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
-  await globalSync(a)  // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
-  _ = await ClassWithGlobalActorInits(nc) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+  await globalAsync(a) // expected-warning{{non-sendable type 'NotConcurrent?' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  await globalSync(a)  // expected-warning{{non-sendable type 'NotConcurrent?' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
+  _ = await ClassWithGlobalActorInits(nc) // expected-warning{{non-sendable type 'NotConcurrent' passed in call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   // expected-warning@-1{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
   _ = await ClassWithGlobalActorInits() // expected-warning{{non-sendable type 'ClassWithGlobalActorInits' returned by call to global actor 'SomeGlobalActor'-isolated function cannot cross actor boundary}}
 }
@@ -191,8 +191,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  // FIXME: Poor diagnostic.
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of actor-isolated instance method 'asyncMethod' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 }
 
 protocol MainActorProto {
@@ -201,7 +200,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -94,6 +94,17 @@ func testNotAllInP1(nap1: NotAllInP1) { // expected-note{{add '@SomeGlobalActor'
   nap1.other() // okay
 }
 
+// Make sure we don't infer 'nonisolated' for stored properties.
+@MainActor
+protocol Interface {
+  nonisolated var baz: Int { get } // expected-note{{'baz' declared here}}
+}
+
+@MainActor
+class Object: Interface {
+  var baz: Int = 42 // expected-warning{{property 'baz' isolated to global actor 'MainActor' can not satisfy corresponding requirement from protocol 'Interface'}}
+}
+
 
 // ----------------------------------------------------------------------
 // Global actor inference for classes and extensions

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -40,7 +40,7 @@ protocol AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A3: AsyncProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
   var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
     get async {
@@ -53,7 +53,7 @@ actor A3: AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A4: AsyncProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
   var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
     get {
@@ -98,7 +98,7 @@ protocol AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A7: AsyncThrowingProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
   var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
     get async {
@@ -111,7 +111,7 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A8: AsyncThrowingProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
   var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
     get {

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -1,0 +1,147 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+class NotSendable { // expected-note 8{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension NotSendable: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+protocol IsolatedWithNotSendableRequirements: Actor {
+  func f() -> NotSendable
+  var prop: NotSendable { get }
+}
+
+// Okay, everything is isolated the same way
+@available(SwiftStdlib 5.1, *)
+actor A1: IsolatedWithNotSendableRequirements {
+  func f() -> NotSendable { NotSendable() }
+  var prop: NotSendable { NotSendable() }
+}
+
+// Okay, sendable checking occurs when calling through the protocol
+// and also inside the bodies.
+@available(SwiftStdlib 5.1, *)
+actor A2: IsolatedWithNotSendableRequirements {
+  nonisolated func f() -> NotSendable { NotSendable() }
+  nonisolated var prop: NotSendable { NotSendable() }
+}
+
+@available(SwiftStdlib 5.1, *)
+protocol AsyncProtocolWithNotSendable {
+  func f() async -> NotSendable
+  var prop: NotSendable { get async }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A3: AsyncProtocolWithNotSendable {
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A4: AsyncProtocolWithNotSendable {
+  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A5: AsyncProtocolWithNotSendable {
+  nonisolated func f() async -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A6: AsyncProtocolWithNotSendable {
+  nonisolated func f() -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get {
+      NotSendable()
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+protocol AsyncThrowingProtocolWithNotSendable {
+  func f() async throws -> NotSendable
+  var prop: NotSendable { get async throws }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A7: AsyncThrowingProtocolWithNotSendable {
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking required because calls through protocol cross into the
+// actor's domain.
+@available(SwiftStdlib 5.1, *)
+actor A8: AsyncThrowingProtocolWithNotSendable {
+  func f() -> NotSendable { NotSendable() } // expected-warning{{cannot call function returning non-sendable type 'NotSendable' across actors}}
+
+  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+    get {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A9: AsyncThrowingProtocolWithNotSendable {
+  nonisolated func f() async -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get async {
+      NotSendable()
+    }
+  }
+}
+
+// Sendable checking not required because we never cross into the actor's
+// domain.
+@available(SwiftStdlib 5.1, *)
+actor A10: AsyncThrowingProtocolWithNotSendable {
+  nonisolated func f() -> NotSendable { NotSendable() }
+
+  nonisolated var prop: NotSendable {
+    get {
+      NotSendable()
+    }
+  }
+}

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -42,7 +42,7 @@ protocol AsyncProtocolWithNotSendable {
 actor A3: AsyncProtocolWithNotSendable {
   func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
     get async {
       NotSendable()
     }
@@ -55,7 +55,7 @@ actor A3: AsyncProtocolWithNotSendable {
 actor A4: AsyncProtocolWithNotSendable {
   func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
     get {
       NotSendable()
     }
@@ -100,7 +100,7 @@ protocol AsyncThrowingProtocolWithNotSendable {
 actor A7: AsyncThrowingProtocolWithNotSendable {
   func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
     get async {
       NotSendable()
     }
@@ -113,7 +113,7 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 actor A8: AsyncThrowingProtocolWithNotSendable {
   func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{cannot use property 'prop' with a non-sendable type 'NotSendable' across actors}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
     get {
       NotSendable()
     }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -126,7 +126,7 @@ protocol Server {
   func send<Message: Codable>(message: Message) async throws -> String
 }
 actor MyServer : Server {
-  func send<Message: Codable>(message: Message) throws -> String { "" }  // okay, asynchronously accessed from clients of the protocol
+  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{cannot pass argument of non-sendable type 'Message' across actors}}
 }
 
 protocol AsyncThrowsAll {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -126,7 +126,7 @@ protocol Server {
   func send<Message: Codable>(message: Message) async throws -> String
 }
 actor MyServer : Server {
-  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{cannot pass argument of non-sendable type 'Message' across actors}}
+  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{non-sendable type 'Message' in parameter of actor-isolated instance method 'send(message:)' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 }
 
 protocol AsyncThrowsAll {

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -34,7 +34,7 @@ actor MyActor {
   // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
   // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> (),completion_handler_param=1,error_param=2
   @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
-  // expected-warning@-1{{cannot call function returning non-sendable type '(AnyObject, Int)' across actors}}
+  // expected-warning@-1{{non-sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFail' cannot cross actor boundary}}
 
   // Actor-isolated entities cannot be exposed to Objective-C.
   @objc func synchronousBad() { } // expected-error{{actor-isolated instance method 'synchronousBad()' cannot be @objc}}


### PR DESCRIPTION
When a non-isolated requirement is witnessed by an actor-isolated
witness, we are crossing into the actor. Ensure that we perform
`Sendable` checking across the actor boundary here.

While here, improve `Sendable` diagnostics across the board.

Fixes rdar://80424675.