### PR TITLE
[TypeChecker] Support `_openExistential` with async functions

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2278,6 +2278,7 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
                                          FunctionType::ExtInfoBuilder()
                                              .withNoEscape(true)
                                              .withThrows(true)
+                                             .withAsync(true)
                                              .build());
     FunctionType::Param args[] = {
       FunctionType::Param(existentialTy),
@@ -2287,6 +2288,7 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
                                      FunctionType::ExtInfoBuilder()
                                          .withNoEscape(false)
                                          .withThrows(true)
+                                         .withAsync(true)
                                          .build());
     return {refType, refType};
   }

--- a/test/decl/func/async.swift
+++ b/test/decl/func/async.swift
@@ -48,3 +48,17 @@ func thereIsNoEscape(_ body: () async -> Void) async {
     await takeEscaping(escapingBody)
   }
 }
+
+func testAsyncExistentialOpen(_ v: P1) async {
+  func syncUnderlyingType<T>(u: T) {}
+  func syncThrowsUnderlyingType<T>(u: T) throws {}
+
+  func asyncUnderlyingType<T>(u: T) async {}
+  func asyncThrowsUnderlyingType<T>(u: T) async throws {}
+
+  _openExistential(v, do: syncUnderlyingType)
+  await _openExistential(v, do: asyncUnderlyingType)
+
+  try! _openExistential(v, do: syncThrowsUnderlyingType)
+  try! await _openExistential(v, do: asyncThrowsUnderlyingType)
+}


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
