### PR TITLE
Sendable fixes 5.6

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8589,7 +8589,8 @@ bool ClassDecl::isNSObject() const {
   if (!getName().is("NSObject")) return false;
   ASTContext &ctx = getASTContext();
   return (getModuleContext()->getName() == ctx.Id_Foundation ||
-          getModuleContext()->getName() == ctx.Id_ObjectiveC);
+          getModuleContext()->getName() == ctx.Id_ObjectiveC ||
+          getModuleContext()->getName().is("SwiftFoundation"));
 }
 
 Type ClassDecl::getSuperclass() const {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -46,7 +46,7 @@ public protocol SerialExecutor: Executor {
 /// actor.
 @available(SwiftStdlib 5.1, *)
 @frozen
-public struct UnownedSerialExecutor {
+public struct UnownedSerialExecutor: Sendable {
   #if compiler(>=5.5) && $BuiltinExecutor
   @usableFromInline
   internal var executor: Builtin.Executor

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -763,6 +763,10 @@ public struct UnsafeCurrentTask {
 }
 
 @available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension UnsafeCurrentTask: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
 extension UnsafeCurrentTask: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -394,6 +394,10 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension TaskGroup: Sendable { }
+
 // Implementation note:
 // We are unable to just™ abstract over Failure == Error / Never because of the
 // complicated relationship between `group.spawn` which dictates if `group.next`
@@ -693,6 +697,10 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     return _taskGroupIsCancelled(group: _group)
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension ThrowingTaskGroup: Sendable { }
 
 /// ==== TaskGroup: AsyncSequence ----------------------------------------------
 


### PR DESCRIPTION
* Explicit Sendable conformances for @frozen types  (rdar://86496341)
* Allow SwiftFoundation to declare NSObject, too (rdar://86495060)