### PR TITLE
Reflections: remove some VS2015 support code

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -38,22 +38,13 @@ enum class TypeRefKind {
 #undef TYPEREF
 };
 
-// MSVC reports an error if we use "template"
-// Clang reports an error if we don't use "template"
-#if defined(__clang__) || defined(__GNUC__)
-#  define DEPENDENT_TEMPLATE template
-#else
-#  define DEPENDENT_TEMPLATE
-#endif
-
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
   auto ID = Profile(__VA_ARGS__);                                              \
-  const auto Entry = Allocator.TypeRefTy##s.find(ID);      \
-  if (Entry != Allocator.TypeRefTy##s.end())               \
+  const auto Entry = Allocator.TypeRefTy##s.find(ID);                          \
+  if (Entry != Allocator.TypeRefTy##s.end())                                   \
     return Entry->second;                                                      \
-  const auto TR =                                                              \
-      Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
-  Allocator.TypeRefTy##s.insert({ID, TR});                 \
+  const auto TR = Allocator.template makeTypeRef<TypeRefTy>(__VA_ARGS__);      \
+  Allocator.TypeRefTy##s.insert({ID, TR});                                     \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the


### PR DESCRIPTION
This cleans up the workaround for VS2015 which hasn't been needed for
quite some time now as the minimum requirements was VS2017.  We are now
looking to move to VS2019 as a minimum compiler version on Windows, and
so clean this up.

Fixes: SR-3422

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
