### PR TITLE
AST: make `RequirementMachine/PropertyUnification.cpp` build on VS2022

### DIFF
--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -650,11 +650,13 @@ RewriteSystem::TypeWitness::TypeWitness(
          getConcreteConformance().getProtocol());
 }
 
-bool swift::rewriting::operator==(
-    const RewriteSystem::TypeWitness &lhs,
-    const RewriteSystem::TypeWitness &rhs) {
-  return (lhs.LHS == rhs.LHS &&
-          lhs.RHS == rhs.RHS);
+namespace swift {
+namespace rewriting {
+bool operator==(const RewriteSystem::TypeWitness &lhs,
+                const RewriteSystem::TypeWitness &rhs) {
+  return lhs.LHS == rhs.LHS && lhs.RHS == rhs.RHS;
+}
+}
 }
 
 void RewriteSystem::TypeWitness::dump(llvm::raw_ostream &out) const {


### PR DESCRIPTION
Using the qualified name is subtly different from scoping the function.
Use the latter, which correctly places the function into the namespace,
to enable building with VS2022.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
