### PR TITLE
[Regex] Infer capture types of regex literals.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4763,6 +4763,9 @@ ERROR(async_unavailable_decl,none,
 ERROR(string_processing_lib_missing,none,
       "missing '%0' declaration, probably because the '_StringProcessing' "
       "module was not imported properly", (StringRef))
+ERROR(regex_capture_types_failed_to_decode,none,
+      "failed to decode capture types for regular expression literal; this may "
+      "be a compiler bug", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type Check Types

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -967,21 +967,36 @@ class RegexLiteralExpr : public LiteralExpr {
   SourceLoc Loc;
   StringRef RegexText;
   unsigned Version;
+  ArrayRef<uint8_t> SerializedCaptureStructure;
 
   RegexLiteralExpr(SourceLoc loc, StringRef regexText, unsigned version,
+                   ArrayRef<uint8_t> serializedCaps,
                    bool isImplicit)
       : LiteralExpr(ExprKind::RegexLiteral, isImplicit), Loc(loc),
-        RegexText(regexText), Version(version) {}
+        RegexText(regexText), Version(version),
+        SerializedCaptureStructure(serializedCaps) {}
 
 public:
-  static RegexLiteralExpr *createParsed(ASTContext &ctx, SourceLoc loc,
-                                        StringRef regexText, unsigned version);
+  static RegexLiteralExpr *createParsed(
+      ASTContext &ctx, SourceLoc loc, StringRef regexText, unsigned version,
+      ArrayRef<uint8_t> serializedCaptureStructure);
+
+  typedef uint16_t CaptureStructureSerializationVersion;
+
+  static unsigned getCaptureStructureSerializationAllocationSize(
+      unsigned regexLength) {
+    return sizeof(CaptureStructureSerializationVersion) + regexLength + 1;
+  }
 
   /// Retrieve the raw regex text.
   StringRef getRegexText() const { return RegexText; }
 
   /// Retrieve the version of the regex string.
   unsigned getVersion() const { return Version; }
+
+  ArrayRef<uint8_t> getSerializedCaptureStructure() {
+    return SerializedCaptureStructure;
+  }
 
   SourceRange getSourceRange() const { return Loc; }
 

--- a/include/swift/Parse/ExperimentalRegexBridging.h
+++ b/include/swift/Parse/ExperimentalRegexBridging.h
@@ -32,11 +32,11 @@ void Parser_registerRegexLiteralLexingFn(RegexLiteralLexingFn fn);
 /// - CaptureStructureOut: A buffer accepting a byte sequence representing the
 ///                        capture structure of the literal.
 /// - CaptureStructureSize: The size of the capture structure buffer. Must be
-///                         greater than or equal to `strlen(InputPtr)`.
+///                         greater than or equal to `strlen(InputPtr) + 3`.
 typedef void(* RegexLiteralParsingFn)(/*InputPtr*/ const char *,
                                       /*ErrorOut*/ const char **,
                                       /*VersionOut*/ unsigned *,
-                                      /*CaptureStructureOut*/ char *,
+                                      /*CaptureStructureOut*/ void *,
                                       /*CaptureStructureSize*/ unsigned);
 void Parser_registerRegexLiteralParsingFn(RegexLiteralParsingFn fn);
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2246,8 +2246,9 @@ SourceLoc TapExpr::getEndLoc() const {
 
 RegexLiteralExpr *
 RegexLiteralExpr::createParsed(ASTContext &ctx, SourceLoc loc,
-                               StringRef regexText, unsigned version) {
-  return new (ctx) RegexLiteralExpr(loc, regexText, version,
+                               StringRef regexText, unsigned version,
+                               ArrayRef<uint8_t> serializedCaps) {
+  return new (ctx) RegexLiteralExpr(loc, regexText, version, serializedCaps,
                                     /*implicit*/ false);
 }
 

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -45,13 +45,18 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
   // at.
   const char *errorStr = nullptr;
   unsigned version;
+  auto capturesBuf = Context.AllocateUninitialized<uint8_t>(
+      RegexLiteralExpr::getCaptureStructureSerializationAllocationSize(
+          regexText.size()));
   regexLiteralParsingFn(regexText.str().c_str(), &errorStr, &version,
-                        /*captureStructureOut*/ nullptr,
-                        /*captureStructureSize*/ 0);
-  if (errorStr)
+                        /*captureStructureOut*/ capturesBuf.data(),
+                        /*captureStructureSize*/ capturesBuf.size());
+  if (errorStr) {
     diagnose(Tok, diag::regex_literal_parsing_error, errorStr);
+    return makeParserError();
+  }
 
   auto loc = consumeToken();
-  return makeParserResult(
-      RegexLiteralExpr::createParsed(Context, loc, regexText, version));
+  return makeParserResult(RegexLiteralExpr::createParsed(
+      Context, loc, regexText, version, capturesBuf));
 }

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -62,6 +62,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckPropertyWrapper.cpp
   TypeCheckProtocol.cpp
   TypeCheckProtocolInference.cpp
+  TypeCheckRegex.cpp
   TypeCheckRequestFunctions.cpp
   TypeCheckStmt.cpp
   TypeCheckStorage.cpp

--- a/lib/Sema/TypeCheckRegex.cpp
+++ b/lib/Sema/TypeCheckRegex.cpp
@@ -1,0 +1,106 @@
+//===--- TypeCheckRegex.cpp - Regex type checking utilities ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeCheckRegex.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
+
+using namespace swift;
+
+// Encoding rules:
+// encode(〚`T`〛) ==> <version>, 〚`T`〛, .end
+// 〚`T` (atom)〛 ==> .atom
+// 〚`name: T` (atom)〛 ==> .atom, `name`, '\0'
+// 〚`[T]`〛 ==> 〚`T`〛, .formArray
+// 〚`T?`〛 ==> 〚`T`〛, .formOptional
+// 〚`(T0, T1, ...)`〛 ==> .beginTuple, 〚`T0`〛, 〚`T1`〛, ..., .endTuple
+//
+// For details, see apple/swift-experimental-string-processing.
+bool swift::decodeRegexCaptureTypes(ASTContext &ctx,
+                                    ArrayRef<uint8_t> serialization,
+                                    Type atomType,
+                                    SmallVectorImpl<TupleTypeElt> &result) {
+  using Version = RegexLiteralExpr::CaptureStructureSerializationVersion;
+  static const Version implVersion = 1;
+  unsigned size = serialization.size();
+  // A serialization should store a version and `.end` at the very least.
+  unsigned minSize = sizeof(Version) + sizeof(RegexCaptureStructureCode);
+  if (size < minSize)
+    return false;
+  // Read version.
+  Version version = *reinterpret_cast<const Version *>(serialization.data());
+  if (version != implVersion)
+    return true;
+  // Read contents.
+  SmallVector<SmallVector<TupleTypeElt, 4>, 4> scopes(1);
+  unsigned offset = sizeof(Version);
+  auto consumeCode = [&]() -> Optional<RegexCaptureStructureCode> {
+    auto rawValue = serialization[offset];
+    if (rawValue >= (uint8_t)RegexCaptureStructureCode::CaseCount)
+      return None;
+    offset += sizeof(RegexCaptureStructureCode);
+    return (RegexCaptureStructureCode)rawValue;
+  };
+  do {
+    auto code = consumeCode();
+    if (!code)
+      return false;
+    switch (*code) {
+    case RegexCaptureStructureCode::End:
+      offset = size;
+      break;
+    case RegexCaptureStructureCode::Atom:
+      scopes.back().push_back(atomType);
+      break;
+    case RegexCaptureStructureCode::NamedAtom: {
+      auto *namePtr = reinterpret_cast<const char *>(
+          serialization.slice(offset).data());
+      auto length = strnlen(namePtr, size - offset);
+      if (length >= size - offset)
+        return true; // Unterminated string.
+      StringRef name(namePtr, length);
+      scopes.back().push_back(TupleTypeElt(atomType, ctx.getIdentifier(name)));
+      offset += length + /*NUL*/ 1;
+      break;
+    }
+    case RegexCaptureStructureCode::FormArray: {
+      auto &type = scopes.back().back();
+      type = TupleTypeElt(ArraySliceType::get(type.getRawType()));
+      break;
+    }
+    case RegexCaptureStructureCode::FormOptional: {
+      auto &type = scopes.back().back();
+      type = TupleTypeElt(OptionalType::get(type.getRawType()));
+      break;
+    }
+    case RegexCaptureStructureCode::BeginTuple:
+      scopes.push_back({});
+      break;
+    case RegexCaptureStructureCode::EndTuple: {
+      auto children = scopes.pop_back_val();
+      scopes.back().push_back(TupleType::get(children, ctx));
+      break;
+    }
+    case RegexCaptureStructureCode::CaseCount:
+      llvm_unreachable("Handled earlier");
+    }
+  } while (offset < size);
+  if (scopes.size() != 1)
+    return true; // Unterminated tuple.
+  auto &elements = scopes.back();
+  result.append(elements.begin(), elements.end());
+  return false;
+}

--- a/lib/Sema/TypeCheckRegex.h
+++ b/lib/Sema/TypeCheckRegex.h
@@ -1,0 +1,47 @@
+//===--- TypeCheckRegex.h - Regex type checking utilities -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TYPE_CHECK_REGEX_H
+#define SWIFT_TYPE_CHECK_REGEX_H
+
+#include <cstdint>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
+
+namespace swift {
+
+class ASTContext;
+class TupleTypeElt;
+class Type;
+
+enum class RegexCaptureStructureCode: uint8_t {
+  End           = 0,
+  Atom          = 1,
+  NamedAtom     = 2,
+  FormArray     = 3,
+  FormOptional  = 4,
+  BeginTuple    = 5,
+  EndTuple      = 6,
+  CaseCount
+};
+
+/// Decodes regex capture types from the given serialization and appends the
+/// decoded capture types to @p result. Returns true if the serialization is
+/// malformed.
+bool decodeRegexCaptureTypes(ASTContext &ctx,
+                             llvm::ArrayRef<uint8_t> serialization,
+                             Type atomType,
+                             llvm::SmallVectorImpl<TupleTypeElt> &result);
+
+} // end namespace swift
+
+#endif // SWIFT_TYPE_CHECK_REGEX_H

--- a/test/StringProcessing/Runtime/regex_basic.swift
+++ b/test/StringProcessing/Runtime/regex_basic.swift
@@ -25,11 +25,11 @@ RegexBasicTests.test("Basic") {
 
   let match1 = input.expectMatch('/aabcc./')
   expectEqual("aabccd", input[match1.range])
-  expectEqual(.empty, match1.captures)
+  expectTrue(() == match1.captures)
 
   let match2 = input.expectMatch('/a*b.+./')
   expectEqual("aabccd", input[match2.range])
-  expectEqual(.empty, match2.captures)
+  expectTrue(() == match2.captures)
 }
 
 RegexBasicTests.test("Modern") {
@@ -37,7 +37,7 @@ RegexBasicTests.test("Modern") {
 
   let match1 = input.expectMatch('|a a  bc c /*hello*/ .|')
   expectEqual("aabccd", input[match1.range])
-  expectEqual(.empty, match1.captures)
+  expectTrue(() == match1.captures)
 }
 
 RegexBasicTests.test("Captures") {
@@ -46,15 +46,13 @@ RegexBasicTests.test("Captures") {
     COMBINING MARK TUKWENTIS
     """
   let regex = '/([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*/'
+  // Test inferred type.
+  let _: Regex<(Substring, Substring?, Substring)>.Type = type(of: regex)
   let match1 = input.expectMatch(regex)
   expectEqual(input[...], input[match1.range])
-  expectEqual(
-    .tuple([
-      .substring("A6F0"),
-      .optional(.substring("A6F1")),
-      .substring("Extend")
-    ]),
-    match1.captures)
+  expectTrue("A6F0" == match1.captures.0)
+  expectTrue("A6F1" == match1.captures.1)
+  expectTrue("Extend" == match1.captures.2)
 }
 
 runAllTests()

--- a/test/StringProcessing/SILGen/regex_literal_silgen.swift
+++ b/test/StringProcessing/SILGen/regex_literal_silgen.swift
@@ -11,4 +11,4 @@ var s = '/abc/'
 // CHECK: [[VERSION_INT:%[0-9]+]] = apply [[INT_INIT]]([[VERSION_LITERAL]]
 
 // CHECK: [[REGEX_INIT:%[0-9]+]] = function_ref @$s17_StringProcessing5RegexV06_regexA07versionACyxGSS_SitcfC : $@convention(method) <τ_0_0> (@owned String, Int, @thin Regex<τ_0_0>.Type) -> @out Regex<τ_0_0>
-// CHECK: apply [[REGEX_INIT]]<DynamicCaptures>({{%.+}}, [[REGEX_STR]], [[VERSION_INT]], {{%.+}}) : $@convention(method) <τ_0_0> (@owned String, Int, @thin Regex<τ_0_0>.Type) -> @out Regex<τ_0_0>
+// CHECK: apply [[REGEX_INIT]]<{{.+}}>({{%.+}}, [[REGEX_STR]], [[VERSION_INT]], {{%.+}}) : $@convention(method) <τ_0_0> (@owned String, Int, @thin Regex<τ_0_0>.Type) -> @out Regex<τ_0_0>

--- a/test/StringProcessing/Sema/regex_literal_type_inference.swift
+++ b/test/StringProcessing/Sema/regex_literal_type_inference.swift
@@ -1,13 +1,45 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
 // REQUIRES: libswift
 
-let r0 = '/./' // okay
-
-let r1: Regex<DynamicCaptures> = '/.(.)/' // okay
-
-// expected-error @+2 {{cannot assign value of type 'Regex<DynamicCaptures>' to type 'Regex<Substring>'}}
-// expected-note @+1 {{arguments to generic parameter 'Capture' ('DynamicCaptures' and 'Substring') are expected to be equal}}
-let r2: Regex<Substring> = '/.(.)/'
+let r0 = '/./'
+let _: Regex<()> = r0
 
 func takesRegex<Match>(_: Regex<Match>) {}
 takesRegex('//') // okay
+
+let r1 = '/.(.)/'
+// Note: We test its type with a separate statement so that we know the type
+// checker inferred the regex's type independently without contextual types.
+let _: Regex<Substring>.Type = type(of: r1)
+
+struct S {}
+// expected-error @+2 {{cannot assign value of type 'Regex<Substring>' to type 'Regex<S>'}}
+// expected-note @+1 {{arguments to generic parameter 'Capture' ('Substring' and 'S') are expected to be equal}}
+let r2: Regex<S> = '/.(.)/'
+
+let r3 = '/(.)(.)/'
+let _: Regex<(Substring, Substring)>.Type = type(of: r3)
+
+let r4 = '/(?<label>.)(.)/'
+let _: Regex<(label: Substring, Substring)>.Type = type(of: r4)
+
+let r5 = '/(.(.(.)))/'
+let _: Regex<(Substring, Substring, Substring)>.Type = type(of: r5)
+
+let r6 = '/(?'we'.(?'are'.(?'regex'.)))/'
+let _: Regex<(we: Substring, are: Substring, regex: Substring)>.Type = type(of: r6)
+
+let r7 = '/(?:(?:(.(.(.)*)?))*?)?/'
+//               ^ 1
+//                 ^ 2
+//                   ^ 3
+let _: Regex<([Substring]?, [Substring?]?, [[Substring]?]?)>.Type = type(of: r7)
+
+let r8 = '/well(?<theres_no_single_element_tuple_what_can_we>do)/'
+let _: Regex<Substring>.Type = type(of: r8)
+
+let r9 = '/(a)|(b)|(c)|d/'
+let _: Regex<(Substring?, Substring?, Substring?)>.Type = type(of: r9)
+
+let r10 = '/(a)|b/'
+let _: Regex<Substring?>.Type = type(of: r10)

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -123,7 +123,7 @@
                 "swift-cmark-gfm": "gfm",
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
-                "swift-experimental-string-processing": "dev/3"
+                "swift-experimental-string-processing": "dev/4"
             }
         },
         "rebranch": {
@@ -157,7 +157,7 @@
                 "sourcekit-lsp": "main",
                 "swift-format": "main",
                 "swift-installer-scripts": "main",
-                "swift-experimental-string-processing": "dev/3"
+                "swift-experimental-string-processing": "dev/4"
             }
         },
         "release/5.6": {
@@ -308,7 +308,7 @@
                 "sourcekit-lsp": "main",
                 "swift-format": "main",
                 "swift-installer-scripts": "main",
-                "swift-experimental-string-processing": "dev/3"
+                "swift-experimental-string-processing": "dev/4"
             }
         },
         "release/5.4": {


### PR DESCRIPTION
When parsing a regular expression literal, accept a serialized capture structure from the regex parser. During type checking, decode it and form Swift types.

Examples:
```swift
'/(.)(.)/' // ==> `Regex<(Substring, Substring)>`
'/(?<label>.)(.)/' // ==> `Regex<(label: Substring, Substring)`
'/((.))*((.)?)/' //==> `Regex<([Substring], [Substring], Substring, Substring?)>`
```

Also:
- Fix a bug where a regex literal parsing error is not returning an error parser result.

Note:
- This needs to land after apple/swift-experimental-string-processing#92 and after `dev/4` tag has been created.
- See apple/swift-experimental-string-processing#92 for regex parser changes and the capture structure encoding.
- The `RegexLiteralParsingFn` `CaptureStructureOut` pointer type change from `char *` to `void *` will not break builds due to implicit pointer conversion (SE-0324) and unchanged ABI.

Resolves rdar://83253511.