### PR TITLE
[Docs] withCheckedThrowingContinuation `body` fix

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -281,7 +281,7 @@ public func withCheckedContinuation<T>(
 ///   - function: A string identifying the declaration that is the notional
 ///     source for the continuation, used to identify the continuation in
 ///     runtime diagnostics related to misuse of this continuation.
-///   - body: A closure that takes an `UnsafeContinuation` parameter.
+///   - body: A closure that takes a `CheckedContinuation` parameter.
 ///     You must resume the continuation exactly once.
 ///
 /// If `resume(throwing:)` is called on the continuation,


### PR DESCRIPTION
`withCheckedThrowingContinuation`'s `body` says that it takes an `UnsafeContinuation`... seems like a copy/paste error.