### PR TITLE
[build] Add a flag that allows disabling appending the host target's name to the install-destdir for a cross-compiled toolchain

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -249,6 +249,7 @@ KNOWN_SETTINGS=(
     cross-compile-with-host-tools                 ""                "set to use the clang we build for the host to then build the cross-compile hosts"
     cross-compile-install-prefixes                ""                "semicolon-separated list of install prefixes to use for the cross-compiled hosts. The list expands, so if there are more cross-compile hosts than prefixes, unmatched hosts use the last prefix in the list"
     cross-compile-deps-path                       ""                "path for CMake to look for cross-compiled library dependencies, such as libXML2"
+    cross-compile-append-host-target-to-destdir   "1"               "turns on appending the host target name of each cross-compiled toolchain to its install-destdir, to keep them separate from the natively-built toolchain"
     skip-merge-lipo-cross-compile-tools           ""                "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     coverage-db                                   ""                "If set, coverage database to use when prioritizing testing"
     skip-local-host-install                       ""                "If we are cross-compiling multiple targets, skip an install pass locally if the hosts match"
@@ -1133,8 +1134,10 @@ function get_host_install_destdir() {
         if [[ $(should_include_host_in_lipo ${host}) ]]; then
             # If this is one of the hosts we should lipo, install in to a temporary subdirectory.
             local host_install_destdir="${BUILD_DIR}/intermediate-install/${host}"
-        elif [[ "${host}" == "merged-hosts" ]]; then
-            # This assumes that all hosts are merged to the lipo.
+        elif [[ "${host}" == "merged-hosts" ]] ||
+             [[ "$(true_false ${CROSS_COMPILE_APPEND_HOST_TARGET_TO_DESTDIR})" == "FALSE" ]]; then
+            # This assumes that all hosts are merged to the lipo, or the build
+            # was told not to append anything.
             local host_install_destdir="${INSTALL_DESTDIR}"
         else
             local host_install_destdir="${INSTALL_DESTDIR}/${host}"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -568,6 +568,12 @@ def create_argument_parser():
                 'library dependencies of the corelibs and other Swift repos, '
                 'such as the libcurl dependency of FoundationNetworking')
 
+    option('--cross-compile-append-host-target-to-destdir', toggle_true,
+           default=True,
+           help="Append each cross-compilation host target's name as a subdirectory "
+                "for each cross-compiled toolchain's destdir, useful when building "
+                "multiple toolchains and can be disabled if only cross-compiling one.")
+
     option('--stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=None,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -128,6 +128,7 @@ EXPECTED_DEFAULTS = {
     'cmark_build_variant': 'Debug',
     'compiler_vendor': defaults.COMPILER_VENDOR,
     'coverage_db': None,
+    'cross_compile_append_host_target_to_destdir': True,
     'cross_compile_deps_path': None,
     'cross_compile_hosts': [],
     'darwin_deployment_version_ios':
@@ -538,6 +539,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--build-swift-stdlib-static-print'),
     EnableOption('--build-swift-private-stdlib'),
     EnableOption('--build-swift-stdlib-unicode-data'),
+    EnableOption('--cross-compile-append-host-target-to-destdir'),
     EnableOption('--distcc'),
     EnableOption('--sccache'),
     EnableOption('--enable-asan'),

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -124,6 +124,8 @@ class BuildScriptInvocation(object):
             "--lldb-assertions", str(
                 args.lldb_assertions).lower(),
             "--cmake-generator", args.cmake_generator,
+            "--cross-compile-append-host-target-to-destdir", str(
+                args.cross_compile_append_host_target_to_destdir).lower(),
             "--build-jobs", str(args.build_jobs),
             "--common-cmake-options=%s" % ' '.join(
                 pipes.quote(opt) for opt in cmake.common_options()),

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -230,8 +230,10 @@ class Product(object):
                 # install in to a temporary subdirectory.
                 return '%s/intermediate-install/%s' % \
                     (os.path.dirname(self.build_dir), host_target)
-            elif host_target == "merged-hosts":
-                # This assumes that all hosts are merged to the lipo.
+            elif host_target == "merged-hosts" or \
+                    not self.args.cross_compile_append_host_target_to_destdir:
+                # This assumes that all hosts are merged to the lipo, or the build
+                # was told not to append anything.
                 return self.args.install_destdir
             else:
                 return '%s/%s' % (self.args.install_destdir, host_target)


### PR DESCRIPTION
This is useful if you're cross-compiling the toolchain for a single host and don't want your specified install path modified.

I have been [patching out the hostname for years when cross-compiling the toolchain for Android](https://github.com/termux/termux-packages/blob/master/packages/swift/swift-utils-build-script-impl-flags.patch#L10), so I just came up with this `build-script` flag instead, buttaface/termux-packages@17cb147, and that worked. Another advantage is [when cross-compiling standalone SDKs, these unnecessary hostname directories won't be applied](https://github.com/buttaface/swift-android-sdk/blob/c7144992bdf638363815d4c083c5af673ac98fa5/swift-android-5.5.patch#L93).

 I'm not particular about hacking in a build flag like this, so if someone has a better idea, I'm all ears. @karwa, you added this in #2497 more than five years ago and @gribozavr approved it, any input welcome.