### PR TITLE
libswift: properly generate the path to the executable

### DIFF
--- a/libswift/CMakeLists.txt
+++ b/libswift/CMakeLists.txt
@@ -60,14 +60,14 @@ else()
     # Bootstrapping - stage 1, using the compiler from level 0
 
     add_libswift(libswift-bootstrapping1
-      SWIFT_EXEC "${CMAKE_BINARY_DIR}/bootstrapping0/bin/swiftc"
+      SWIFT_EXEC $<TARGET_FILE_DIR:swift-frontend-bootstrapping0>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
       DEPENDS ${b0_deps}
       BOOTSTRAPPING 1)
 
     # The final build, using the compiler from stage 1
 
     add_libswift(libswift
-        SWIFT_EXEC "${CMAKE_BINARY_DIR}/bootstrapping1/bin/swiftc"
+        SWIFT_EXEC $<TARGET_FILE_DIR:swift-frontend-bootstrapping1>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
         DEPENDS ${b1_deps})
 
     if(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")


### PR DESCRIPTION
This uses a generator expression to get the location and adds the host
dependent suffix to generate the proper tool location.  This aids in
getting the correct command on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
