### PR TITLE
regex: make `ExperimentalRegexBridging.h` C friendly

### DIFF
--- a/include/swift/Parse/ExperimentalRegexBridging.h
+++ b/include/swift/Parse/ExperimentalRegexBridging.h
@@ -1,6 +1,8 @@
 #ifndef EXPERIMENTAL_REGEX_BRIDGING
 #define EXPERIMENTAL_REGEX_BRIDGING
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,9 +21,9 @@ extern "C" {
 /// Returns: A bool indicating whether lexing was completely erroneous, and
 ///          cannot be recovered from, or false if there either was no error,
 ///          or there was a recoverable error.
-typedef bool(* RegexLiteralLexingFn)(/*CurPtrPtr*/ const char **,
-                                     /*BufferEnd*/ const char *,
-                                     /*ErrorOut*/ const char **);
+typedef bool (* RegexLiteralLexingFn)(/*CurPtrPtr*/ const char **,
+                                      /*BufferEnd*/ const char *,
+                                      /*ErrorOut*/ const char **);
 void Parser_registerRegexLiteralLexingFn(RegexLiteralLexingFn fn);
 
 /// Parse a regex literal string. Takes the following arguments:


### PR DESCRIPTION
`bool` is not a valid type in C.  However, C99 does provide `stdboo.h`
to help bridge that type.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
