### PR TITLE
driver: add a link against swiftCore

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -31,6 +31,7 @@ if(${LIBSWIFT_BUILD_MODE} MATCHES "BOOTSTRAPPING.*")
   )
   target_link_libraries(swift-frontend-bootstrapping1
                         PRIVATE
+                          swiftCore-bootstrapping0
                           swiftDriverTool
                           libswift-bootstrapping1)
 


### PR DESCRIPTION
This was a missing dependency which results in undefined references.
Add the missing dependency which will also ensure that the build graph
is correct.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
