### PR TITLE
libswift: libswift is built as a static library

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -142,7 +142,7 @@ function(add_swift_compiler_modules_library name)
               "-target" ${target}
               "-module-name" ${module} "-emit-module"
               "-emit-module-path" "${build_dir}/${module}.swiftmodule"
-              "-parse-as-library" ${sources}
+              "-static" "-parse-as-library" ${sources}
               "-wmo" ${swift_compile_options}
               "-I" "${SWIFT_SOURCE_DIR}/include/swift"
               "-I" "${SWIFT_SOURCE_DIR}/include"


### PR DESCRIPTION
This indicates that the library is statically linked and that it does
not export any interfaces and will be used for static linking.  This is
required to use the library for the bootstrap compiler on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
