### PR TITLE
Introduce SWIFT_STDLIB_HAS_TYPE_PRINTING flag to remove the ability to print types at runtime (to save codesize)

### DIFF
--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -10,7 +10,8 @@ add_swift_host_library(swiftDemangling STATIC
   Remangler.cpp)
 target_compile_definitions(swiftDemangling PRIVATE
   LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1
-  SWIFT_SUPPORT_OLD_MANGLING=1)
+  SWIFT_SUPPORT_OLD_MANGLING=1
+  SWIFT_STDLIB_HAS_TYPE_PRINTING=1)
 
 # NOTE: Runtime libraries that depend on swiftDemangling should define
 # SWIFT_INLINE_NAMESPACE to specify the identifier that will be used for an

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -14,6 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if SWIFT_STDLIB_HAS_TYPE_PRINTING
+
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/AST/Ownership.h"
@@ -3093,3 +3095,5 @@ std::string Demangle::nodeToString(NodePointer root,
 
   return NodePrinter(options).printRoot(root);
 }
+
+#endif

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -360,6 +360,10 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_STDLIB_SHORT_MANGLING_LOOKUPS")
   endif()
 
+  if(SWIFT_STDLIB_HAS_TYPE_PRINTING)
+    list(APPEND result "-DSWIFT_STDLIB_HAS_TYPE_PRINTING")
+  endif()
+
   if(SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING)
     list(APPEND result "-DSWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING")
   endif()

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -8,6 +8,10 @@ option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
        "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
        TRUE)
 
+option(SWIFT_STDLIB_HAS_TYPE_PRINTING
+       "Build stdlib with support for printing user-friendly type name as strings at runtime"
+       TRUE)
+
 option(SWIFT_STDLIB_BUILD_PRIVATE
        "Build private part of the Standard Library."
        TRUE)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -79,15 +79,21 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
 
+  set(swift_demangling_cflags)
+
   # The old mangling support is only needed on platforms with ObjC.
   if(SWIFT_STDLIB_ENABLE_OBJC_INTEROP)
     list(APPEND swiftDemanglingSources
       "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
       "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
       )
-    set(swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=1)
+    list(APPEND swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=1)
   else()
-    set(swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=0)
+    list(APPEND swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=0)
+  endif()
+
+  if(SWIFT_STDLIB_HAS_TYPE_PRINTING)
+    list(APPEND swift_demangling_cflags -DSWIFT_STDLIB_HAS_TYPE_PRINTING)
   endif()
 
   add_swift_target_library(swiftDemangling OBJECT_LIBRARY

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -76,6 +76,8 @@ extern "C" const void *swift_dynamicCastObjCProtocolConditional(
                          Protocol * const *protocols);
 #endif
 
+#if SWIFT_STDLIB_HAS_TYPE_PRINTING
+
 // Build a user-comprehensible name for a type.
 static void _buildNameForMetadata(const Metadata *type,
                                   bool qualified,
@@ -124,6 +126,13 @@ std::string swift::nameForMetadata(const Metadata *type,
   return result;
 }
 
+#else // SWIFT_STDLIB_HAS_TYPE_PRINTING
+
+std::string swift::nameForMetadata(const Metadata *type, bool qualified) {
+  return "<<< type printer not available >>>";
+}
+
+#endif // SWIFT_STDLIB_HAS_TYPE_PRINTING
 
 /// Used as part of cache key for `TypeNameCache`.
 enum class TypeNameKind {

--- a/test/stdlib/TypeName.swift
+++ b/test/stdlib/TypeName.swift
@@ -8,6 +8,9 @@
 
 // REQUIRES: executable_test
 
+// Freestanding/minimal runtime does not support printing type names at runtime.
+// UNSUPPORTED: freestanding
+
 import StdlibUnittest
 
 let TypeNameTests = TestSuite("TypeName")

--- a/test/stdlib/TypeNameInterpolation.swift
+++ b/test/stdlib/TypeNameInterpolation.swift
@@ -11,6 +11,9 @@
 
 // REQUIRES: executable_test
 
+// Freestanding/minimal runtime does not support printing type names at runtime.
+// UNSUPPORTED: freestanding
+
 import StdlibUnittest
 
 let TypeNameTests = TestSuite("TypeName")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2539,6 +2539,7 @@ swift-stdlib-enable-prespecialization=0
 swift-stdlib-passthrough-metadata-allocator=1
 swift-stdlib-short-mangling-lookups=0
 swift-stdlib-experimental-hermetic-seal-at-link=1
+swift-stdlib-has-type-printing=0
 
 [preset: stdlib_S_standalone_minimal_macho_x86_64,build]
 mixin-preset=

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -223,6 +223,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-passthrough-metadata-allocator   "0"               "whether stdlib should be built without a custom implementation of MetadataAllocator, relying on malloc+free instead"
     swift-stdlib-short-mangling-lookups           "1"               "whether to build stdlib with fast-path context descriptor lookups based on well-known short manglings"
     swift-stdlib-experimental-hermetic-seal-at-link     "0"         "whether stdlib should be built with -experimental-hermetic-seal-at-link"
+    swift-stdlib-has-type-printing                "1"               "whether stdlib should support printing user-friendly type name as strings at runtime"
     swift-disable-dead-stripping                  "0"               "turns off Darwin-specific dead stripping for Swift host tools"
     common-swift-flags                            ""                "Flags used for Swift targets other than the stdlib, like the corelibs"
     swift-enable-experimental-string-processing   "1"               "whether to build experimental string processing feature"
@@ -2012,6 +2013,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_STDLIB_ENABLE_LTO:STRING="${SWIFT_STDLIB_LTO}"
                     -DSWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR:BOOL=$(true_false "${SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR}")
                     -DSWIFT_STDLIB_SHORT_MANGLING_LOOKUPS:BOOL=$(true_false "${SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS}")
+                    -DSWIFT_STDLIB_HAS_TYPE_PRINTING:BOOL=$(true_false "${SWIFT_STDLIB_HAS_TYPE_PRINTING}")
                     -DSWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK:BOOL=$(true_false "${SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK}")
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"
                     -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING="${native_clang_tools_path}"

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Freestanding/minimal runtime does not support printing type names at runtime.
+// UNSUPPORTED: freestanding
+
 import StdlibUnittest
 
 class TestHashableBase : Hashable {


### PR DESCRIPTION
This saves 52 kB of runtime size on x86_64 (by avoiding usage of NodePrinter.cpp).

Most of the usage of type printing in the stdlib/runtime itself is for diagnostic and error-reporting purposes. But eventually, getting a user-friendly type string is public API/SPI exposed by the stdlib, so this means programs running with the "minimal" runtime cannot rely on that.