### PR TITLE
Update main namelookup resolution

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3180,6 +3180,7 @@ ERROR(nscopying_doesnt_conform,none,
 #define SELECT_APPLICATION_DELEGATE "select{'UIApplicationDelegate'|'NSApplicationDelegate'}"
 #define SELECT_APPLICATION_TYPE "select{class|class|type}"
 #define SELECT_APPLICATION_TYPES "select{classes|classes|types}"
+#define SELECT_APPLICATION_MAIN_TYPES "select{() -> Void or () throws -> Void|() -> Void, () throws -> Void, () async -> Void, or () async throws -> Void}"
 
 ERROR(attr_ApplicationMain_not_ApplicationDelegate,none,
       "%" SELECT_APPLICATION_MAIN "0 class must conform to the %" SELECT_APPLICATION_DELEGATE "0 protocol",
@@ -3199,9 +3200,11 @@ NOTE(attr_ApplicationMain_script_here,none,
      ())
 
 ERROR(attr_MainType_without_main,none,
-      "%0 is annotated with @main and must provide a main static function of type () -> Void or () throws -> Void.",
-      (DeclName))
+      "%0 is annotated with @main and must provide a main static function of type %"
+      SELECT_APPLICATION_MAIN_TYPES "1",
+      (DeclName, bool))
 
+#undef SELECT_APPLICATION_MAIN_TYPES
 #undef SELECT_APPLICATION_MAIN
 #undef SELECT_APPLICATION_DELEGATE
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1994,6 +1994,70 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
   return std::make_pair(body, /*typechecked=*/false);
 }
 
+static FuncDecl *resolveMainFunctionDecl(DeclContext *declContext,
+                                         ResolvedMemberResult &resolution,
+                                         ASTContext &ctx) {
+  // The normal resolution mechanism won't choose the asynchronous main function
+  // unless no other options are available because extensions and generic types
+  // (structs/classes) are not considered asynchronous contexts.
+  // We want them to be promoted to a viable entrypoint if the deployment target
+  // is high enough.
+  SmallVector<FuncDecl *, 4> viableCandidates;
+  for (ValueDecl *candidate : resolution.getMemberDecls(Viable)) {
+    if (FuncDecl *function = dyn_cast<FuncDecl>(candidate)) {
+      if (function->isMainTypeMainMethod())
+        viableCandidates.push_back(function);
+    }
+  }
+  if (viableCandidates.empty()) {
+    return nullptr;
+  }
+
+  AvailabilityContext contextAvailability =
+      AvailabilityContext::forDeploymentTarget(ctx);
+  const bool hasAsyncSupport = contextAvailability.isContainedIn(
+      ctx.getBackDeployedConcurrencyAvailability());
+
+  FuncDecl *best = nullptr;
+  for (FuncDecl *candidate : viableCandidates) {
+    // The candidate will work if it's synchronous, or if we support concurrency
+    // and it is async, or if we are in YOLO mode
+    const bool candidateWorks = !candidate->hasAsync() ||
+                                (hasAsyncSupport && candidate->hasAsync()) ||
+                                ctx.LangOpts.DisableAvailabilityChecking;
+
+    // Skip it if it won't work
+    if (!candidateWorks)
+      continue;
+
+    // If we don't have a best, the candidate is the best so far
+    if (!best) {
+      best = candidate;
+      continue;
+    }
+
+    // If the candidate is better and it's synchronous, just swap it right in.
+    // If the candidate is better and it's async, make sure we support async
+    // before selecting it.
+    //
+    // If it's unordered (equally bestest), use the async version if we support
+    // it or use the sync version if we don't.
+    const Comparison rank =
+        TypeChecker::compareDeclarations(declContext, candidate, best);
+    const bool isBetter = rank == Comparison::Better;
+    const bool isUnordered = rank == Comparison::Unordered;
+    const bool swapForAsync =
+        hasAsyncSupport && candidate->hasAsync() && !best->hasAsync();
+    const bool swapForSync =
+        !hasAsyncSupport && !candidate->hasAsync() && best->hasAsync();
+    const bool selectCandidate =
+        isBetter || (isUnordered && (swapForAsync || swapForSync));
+    if (selectCandidate)
+      best = candidate;
+  }
+  return best;
+}
+
 FuncDecl *
 SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
                                         Decl *D) const {
@@ -2049,37 +2113,17 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
 
   auto resolution = resolveValueMember(
       *declContext, nominal->getInterfaceType(), context.Id_main);
-
-  FuncDecl *mainFunction = nullptr;
-
-  if (resolution.hasBestOverload()) {
-    auto best = resolution.getBestOverload();
-    if (auto function = dyn_cast<FuncDecl>(best)) {
-      if (function->isMainTypeMainMethod()) {
-        mainFunction = function;
-      }
-    }
-  }
-
-  if (mainFunction == nullptr) {
-    SmallVector<FuncDecl *, 4> viableCandidates;
-
-    for (auto *candidate : resolution.getMemberDecls(Viable)) {
-      if (auto func = dyn_cast<FuncDecl>(candidate)) {
-        if (func->isMainTypeMainMethod()) {
-          viableCandidates.push_back(func);
-        }
-      }
-    }
-
-    if (viableCandidates.size() != 1) {
-      context.Diags.diagnose(attr->getLocation(),
-                             diag::attr_MainType_without_main,
-                             nominal->getBaseName());
-      attr->setInvalid();
-      return nullptr;
-    }
-    mainFunction = viableCandidates[0];
+  FuncDecl *mainFunction =
+      resolveMainFunctionDecl(declContext, resolution, context);
+  if (!mainFunction) {
+    const bool hasAsyncSupport =
+        AvailabilityContext::forDeploymentTarget(context).isContainedIn(
+            context.getBackDeployedConcurrencyAvailability());
+    context.Diags.diagnose(attr->getLocation(),
+                           diag::attr_MainType_without_main,
+                           nominal->getBaseName(), hasAsyncSupport);
+    attr->setInvalid();
+    return nullptr;
   }
 
   auto where = ExportContext::forDeclSignature(D);

--- a/test/Concurrency/Runtime/actor_init.swift
+++ b/test/Concurrency/Runtime/actor_init.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(%import-libdispatch -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(%import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-parse-as-library %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -disable-availability-checking %import-libdispatch) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -parse-as-library)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -parse-as-library)
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test

--- a/test/Concurrency/async_main_resolution.swift
+++ b/test/Concurrency/async_main_resolution.swift
@@ -1,0 +1,90 @@
+// async main is nested deeper in protocols than sync, should use sync (always)
+// sync main is nested deeper in protocols than async, use async if supported
+// async and sync are same level, use async if supported
+
+// async main is nested in the protocol chain from `MyMain`
+// Always choose Sync overload
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DASYNC_NESTED -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.0 -DASYNC_NESTED -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// sync main is deeper in the protocol chain from `MyMain`
+// Choose async when available
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.0 -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// sync and async main are at same level (In MainProtocol) to `MyMain`.
+// Choose async when available
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DBOTH -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DBOTH -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// async main is the only option on the protocol chain
+// Choose async if we support it, error otherwise
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DASYNC_NESTED -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DASYNC_NESTED -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// sync main is the only option on the protocol chain
+// Always choose sync
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// No synchronous, choose async if we support it, error otherwise
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_SYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// No asynchronous, choose sync
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// No main functions
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_SYNC -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_SYNC -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR-ASYNC
+
+// REQUIRES: concurrency
+
+#if ASYNC_NESTED
+protocol AsyncMainProtocol { }
+protocol MainProtocol : AsyncMainProtocol { }
+#else
+protocol MainProtocol { }
+protocol AsyncMainProtocol : MainProtocol { }
+#endif
+
+#if NO_SYNC
+#else
+extension MainProtocol {
+    static func main() { }
+}
+#endif
+
+#if NO_ASYNC
+#else
+extension AsyncMainProtocol {
+    @available(macOS 10.15, *)
+    static func main() async { }
+}
+#endif
+
+#if BOTH
+extension MainProtocol {
+    @available(macOS 10.15, *)
+    static func main() async { }
+}
+#endif
+
+
+#if INHERIT_SYNC
+@main struct MyMain : MainProtocol {}
+#else
+@main struct MyMain : AsyncMainProtocol {}
+#endif
+
+
+// CHECK-IS-SYNC-LABEL: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () -> ()'
+// CHECK-IS-SYNC:       (declref_expr implicit type='(MyMain.Type) -> () -> ()'
+
+// CHECK-IS-ASYNC-LABEL: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () async -> ()'
+// CHECK-IS-ASYNC:       (declref_expr implicit type='(MyMain.Type) -> () async -> ()'
+
+// CHECK-IS-ERROR: error: 'MyMain' is annotated with @main and must provide a main static function of type () -> Void or () throws -> Void
+
+// CHECK-IS-ERROR-ASYNC: error: 'MyMain' is annotated with @main and must provide a main static function of type () -> Void, () throws -> Void, () async -> Void, or () async throws -> Void

--- a/test/Concurrency/async_main_resolution_macos.swift
+++ b/test/Concurrency/async_main_resolution_macos.swift
@@ -1,0 +1,93 @@
+// async main is nested deeper in protocols than sync, should use sync (always)
+// sync main is nested deeper in protocols than async, use async if supported
+// async and sync are same level, use async if supported
+
+// async main is nested in the protocol chain from `MyMain`
+// Always choose Sync overload
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DASYNC_NESTED -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.0 -DASYNC_NESTED -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// sync main is deeper in the protocol chain from `MyMain`
+// Choose async when available
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.0 -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// sync and async main are at same level (In MainProtocol) to `MyMain`.
+// Choose async when available
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DBOTH -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DBOTH -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// async main is the only option on the protocol chain
+// Choose async if we support it, error otherwise
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DASYNC_NESTED -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DASYNC_NESTED -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// sync main is the only option on the protocol chain
+// Always choose sync
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// No synchronous, choose async if we support it, error otherwise
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_SYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+
+// No asynchronous, choose sync
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+
+// No main functions
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx10.9 -DNO_SYNC -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR
+// RUN: not %target-swift-frontend -target x86_64-apple-macosx11.9 -DNO_SYNC -DNO_ASYNC -typecheck -dump-ast -parse-as-library %s 2>&1 | %FileCheck %s --check-prefix=CHECK-IS-ERROR-ASYNC
+
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+#if ASYNC_NESTED
+protocol AsyncMainProtocol { }
+protocol MainProtocol : AsyncMainProtocol { }
+#else
+protocol MainProtocol { }
+protocol AsyncMainProtocol : MainProtocol { }
+#endif
+
+#if NO_SYNC
+#else
+extension MainProtocol {
+    static func main() { }
+}
+#endif
+
+#if NO_ASYNC
+#else
+extension AsyncMainProtocol {
+    @available(macOS 10.15, *)
+    static func main() async { }
+}
+#endif
+
+#if BOTH
+extension MainProtocol {
+    @available(macOS 10.15, *)
+    static func main() async { }
+}
+#endif
+
+
+#if INHERIT_SYNC
+@main struct MyMain : MainProtocol {}
+#else
+@main struct MyMain : AsyncMainProtocol {}
+#endif
+
+
+// CHECK-IS-SYNC-LABEL: "MyMain" interface type='MyMain.Type'
+// CHECK-IS-SYNC: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () -> ()'
+// CHECK-IS-SYNC:       (declref_expr implicit type='(MyMain.Type) -> () -> ()'
+
+// CHECK-IS-ASYNC-LABEL: "MyMain" interface type='MyMain.Type'
+// CHECK-IS-ASYNC: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () async -> ()'
+// CHECK-IS-ASYNC:       (declref_expr implicit type='(MyMain.Type) -> () async -> ()'
+
+// CHECK-IS-ERROR: error: 'MyMain' is annotated with @main and must provide a main static function of type () -> Void or () throws -> Void
+
+// CHECK-IS-ERROR-ASYNC: error: 'MyMain' is annotated with @main and must provide a main static function of type () -> Void, () throws -> Void, () async -> Void, or () async throws -> Void

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -1,4 +1,4 @@
-// RUN: %target-fail-simple-swift(-Xfrontend -enable-experimental-distributed -parse-as-library %import-libdispatch) 2>&1 | %FileCheck %s
+// RUN: %target-fail-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library %import-libdispatch) 2>&1 | %FileCheck %s
 //
 // // TODO: could not figure out how to use 'not --crash' it never is used with target-run-simple-swift
 // This test is intended to *crash*, so we're using target-fail-simple-swift

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( %import-libdispatch -parse-as-library -sanitize=thread)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(  %import-libdispatch -parse-as-library -sanitize=thread)
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/40577 to the release/5.6 branch.

The typesystem was avoiding the async main function if any synchronous
main was available. This is because the decl contexts where the main
function is looked up from aren't async contexts (extension contexts,
generic type contexts), so if a synchronous main function exists
anywhere, it will be a better "fit" for the context.

Since we're the main function, we decide on whether or not we want to be
async, so looking at the decl-context's asyncness is really the wrong
thing to do. Plumbing this info through the constraint system seems
risky at best, catastrophic at worst, so instead, I'm just grabbing the
buffer of resolved decls and doing my own scoring and selection.

We want to ensure that we are picking the main function that is closest
to the decl marked with @main in the protocol conformance chain. This
means that if your @main struct directly conforms to a protocol that
implements a main function, you should probably use it. If that protocol
implements two main functions, one sync and one async, we look at
whether we support async before selecting it.

Things get a little bit weird if you have implemented an async main in
the closest protocol, but are targeting something that doesn't support
concurrency. The @available checking should handle this with a nice
error saying you're doing bad things, but if you circumvent that
checking for bad reasons, it will still fall back on a synchronous main
function if one is available.

https://bugs.swift.org/browse/SR-15211
rdar://83316060