### PR TITLE
[SE-0335] Enable explicit existential types.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -532,6 +532,7 @@ public:
   /// Retrieve the declaration of Swift.Error.
   ProtocolDecl *getErrorDecl() const;
   CanType getExceptionType() const;
+  CanType getErrorExistentialType() const;
   
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \
   /** Retrieve the declaration of Swift.NAME. */ \

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -531,7 +531,6 @@ public:
 
   /// Retrieve the declaration of Swift.Error.
   ProtocolDecl *getErrorDecl() const;
-  CanType getExceptionType() const;
   CanType getErrorExistentialType() const;
   
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -66,7 +66,7 @@ public:
 
   Demangle::NodeFactory &getNodeFactory() { return Factory; }
 
-  Type decodeMangledType(NodePointer node);
+  Type decodeMangledType(NodePointer node, bool forRequirement = true);
   Type createBuiltinType(StringRef builtinName, StringRef mangledName);
 
   TypeDecl *createTypeDecl(NodePointer node);
@@ -109,7 +109,8 @@ public:
 
   Type createProtocolCompositionType(ArrayRef<ProtocolDecl *> protocols,
                                      Type superclass,
-                                     bool isClassBound);
+                                     bool isClassBound,
+                                     bool forRequirement = true);
 
   Type createExistentialMetatypeType(Type instance,
                      Optional<Demangle::ImplMetatypeRepresentation> repr=None);

--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -56,7 +56,7 @@ inline Type synthesizeType(SynthesisContext &SC,
   switch (kind) {
   case _any: return SC.Context.TheAnyType;
   case _bridgeObject: return SC.Context.TheBridgeObjectType;
-  case _error: return SC.Context.getExceptionType();
+  case _error: return SC.Context.getErrorExistentialType();
   case _executor: return SC.Context.TheExecutorType;
   case _job: return SC.Context.TheJobType;
   case _nativeObject: return SC.Context.TheNativeObjectType;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4363,6 +4363,11 @@ public:
   /// not exist.
   AssociatedTypeDecl *getAssociatedType(Identifier name) const;
 
+  /// Returns the existential type for this protocol.
+  Type getExistentialType() const {
+    return ExistentialType::get(getDeclaredInterfaceType());
+  }
+
   /// Walk this protocol and all of the protocols inherited by this protocol,
   /// transitively, invoking the callback function for each protocol.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4648,8 +4648,6 @@ ERROR(unchecked_not_inheritance_clause,none,
 ERROR(unchecked_not_existential,none,
       "'unchecked' attribute cannot apply to non-protocol type %0", (Type))
 
-WARNING(unnecessary_any,none,
-         "'any' is redundant on type %0", (Type))
 ERROR(any_not_existential,none,
        "'any' has no effect on %select{concrete type|type parameter}0 %1",
        (bool, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2441,8 +2441,8 @@ ERROR(protocol_composition_one_class,none,
       "contains class %1", (Type, Type))
 
 ERROR(requires_conformance_nonprotocol,none,
-      "type %0 constrained to non-protocol, non-class type %1",
-      (Type, Type))
+      "type %0 constrained to non-protocol, non-class type '%1'",
+      (Type, StringRef))
 NOTE(requires_conformance_nonprotocol_fixit,none,
      "use '%0 == %1' to require '%0' to be '%1'",
      (StringRef, StringRef))

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -278,6 +278,10 @@ struct PrintOptions {
 
   bool PrintImplicitAttrs = true;
 
+  /// Whether to print the \c any keyword for existential
+  /// types.
+  bool PrintExplicitAny = false;
+
   /// Whether to skip keywords with a prefix of underscore such as __consuming.
   bool SkipUnderscoredKeywords = false;
 

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -660,7 +660,7 @@ class SelfProtocolConformance : public RootProtocolConformance {
 public:
   /// Get the protocol being conformed to.
   ProtocolDecl *getProtocol() const {
-    return getType()->castTo<ProtocolType>()->getDecl();
+    return dyn_cast<ProtocolDecl>(getType()->getAnyNominal());
   }
 
   /// Get the declaration context in which this conformance was declared.

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -385,6 +385,7 @@ class CanType : public Type {
 
   static bool isReferenceTypeImpl(CanType type, const GenericSignatureImpl *sig,
                                   bool functionsCount);
+  static bool isConstraintTypeImpl(CanType type);
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
@@ -455,6 +456,10 @@ public:
     return isReferenceTypeImpl(*this,
                                /*signature*/ nullptr,
                                /*functions count*/ false);
+  }
+
+  bool isConstraintType() const {
+    return isConstraintTypeImpl(*this);
   }
 
   /// Is this type existential?

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5248,7 +5248,7 @@ class ExistentialType final : public TypeBase {
         ConstraintType(constraintType) {}
 
 public:
-  static ExistentialType *get(Type constraint);
+  static Type get(Type constraint);
 
   Type getConstraintType() const { return ConstraintType; }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2734,6 +2734,8 @@ public:
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::ExistentialMetatype;
   }
+
+  Type getExistentialInstanceType();
   
 private:
   ExistentialMetatypeType(Type T, const ASTContext *C,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6455,6 +6455,8 @@ inline NominalTypeDecl *TypeBase::getNominalOrBoundGenericNominal() {
 inline NominalTypeDecl *CanType::getNominalOrBoundGenericNominal() const {
   if (auto Ty = dyn_cast<NominalOrBoundGenericNominalType>(*this))
     return Ty->getDecl();
+  if (auto Ty = dyn_cast<ExistentialType>(*this))
+    return Ty->getConstraintType()->getNominalOrBoundGenericNominal();
   return nullptr;
 }
 
@@ -6463,6 +6465,9 @@ inline NominalTypeDecl *TypeBase::getAnyNominal() {
 }
 
 inline Type TypeBase::getNominalParent() {
+  if (auto existential = getAs<ExistentialType>())
+    return existential->getConstraintType()->getNominalParent();
+
   return castTo<AnyGenericType>()->getParent();
 }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -727,6 +727,9 @@ public:
     return getRecursiveProperties().hasDependentMember();
   }
 
+  /// Whether this type represents a generic constraint.
+  bool isConstraintType() const;
+
   /// isExistentialType - Determines whether this type is an existential type,
   /// whose real (runtime) type is unknown but which is known to conform to
   /// some set of protocols. Protocol and protocol-conformance types are
@@ -6333,6 +6336,15 @@ inline GenericTypeParamType *TypeBase::getRootGenericParam() {
     t = memberTy->getBase();
 
   return t->castTo<GenericTypeParamType>();
+}
+
+inline bool TypeBase::isConstraintType() const {
+  return getCanonicalType().isConstraintType();
+}
+
+inline bool CanType::isConstraintTypeImpl(CanType type) {
+  return (isa<ProtocolType>(type) ||
+          isa<ProtocolCompositionType>(type));
 }
 
 inline bool TypeBase::isExistentialType() {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -315,7 +315,7 @@ namespace swift {
 
     /// Enable support for explicit existential types via the \c any
     /// keyword.
-    bool EnableExplicitExistentialTypes = false;
+    bool EnableExplicitExistentialTypes = true;
 
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -289,7 +289,7 @@ public:
 
   void clearNodeFactory() { Dem.clear(); }
 
-  BuiltType decodeMangledType(Node *node);
+  BuiltType decodeMangledType(Node *node, bool forRequirement = true);
 
   ///
   /// Factory methods for all TypeRef kinds
@@ -492,7 +492,8 @@ public:
 
   const ProtocolCompositionTypeRef *
   createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
-                                BuiltType superclass, bool isClassBound) {
+                                BuiltType superclass, bool isClassBound,
+                                bool forRequirement = true) {
     std::vector<const TypeRef *> protocolRefs;
     for (const auto &protocol : protocols) {
       if (!protocol)

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2220,7 +2220,7 @@ visitOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *Inst) {
   auto openedType = Inst->getType().getASTType();
   auto exType = Inst->getOperand()->getType().getASTType();
   while (auto exMetatype = dyn_cast<ExistentialMetatypeType>(exType)) {
-    exType = exMetatype.getInstanceType();
+    exType = exMetatype->getExistentialInstanceType()->getCanonicalType();
     openedType = cast<MetatypeType>(openedType).getInstanceType();
   }
   remapOpenedType(cast<OpenedArchetypeType>(openedType));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7072,7 +7072,7 @@ public:
     auto exType = getType().getASTType();
     auto concreteType = getOperand()->getType().getASTType();
     while (auto exMetatype = dyn_cast<ExistentialMetatypeType>(exType)) {
-      exType = exMetatype.getInstanceType();
+      exType = exMetatype->getExistentialInstanceType()->getCanonicalType();
       concreteType = cast<MetatypeType>(concreteType).getInstanceType();
     }
     assert(exType.isExistentialType());

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1017,6 +1017,12 @@ static StringRef getTypeName(SDKContext &Ctx, Type Ty,
   if (auto *NAT = dyn_cast<TypeAliasType>(Ty.getPointer())) {
     return NAT->getDecl()->getNameStr();
   }
+
+  if (auto existential = Ty->getAs<ExistentialType>()) {
+    return getTypeName(Ctx, existential->getConstraintType(),
+                       IsImplicitlyUnwrappedOptional);
+  }
+
   if (Ty->getAnyNominal()) {
     if (IsImplicitlyUnwrappedOptional) {
       assert(Ty->getOptionalObjectType());

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3329,6 +3329,11 @@ MetatypeType::MetatypeType(Type T, const ASTContext *C,
 ExistentialMetatypeType *
 ExistentialMetatypeType::get(Type T, Optional<MetatypeRepresentation> repr,
                              const ASTContext &ctx) {
+  // If we're creating an existential metatype from an
+  // existential type, wrap the constraint type direcly.
+  if (auto existential = T->getAs<ExistentialType>())
+    T = existential->getConstraintType();
+
   auto properties = T->getRecursiveProperties();
   auto arena = getArena(properties);
 
@@ -3359,6 +3364,18 @@ ExistentialMetatypeType::ExistentialMetatypeType(Type T,
     assert(getASTContext().LangOpts.EnableObjCInterop ||
            *repr != MetatypeRepresentation::ObjC);
   }
+}
+
+Type ExistentialMetatypeType::getExistentialInstanceType() {
+  auto instanceType = getInstanceType();
+  // Note that Any and AnyObject don't yet use ExistentialType.
+  if (getASTContext().LangOpts.EnableExplicitExistentialTypes &&
+      !instanceType->is<ExistentialMetatypeType>() &&
+      !(instanceType->isAny() || instanceType->isAnyObject())) {
+    instanceType = ExistentialType::get(instanceType);
+  }
+
+  return instanceType;
 }
 
 ModuleType *ModuleType::get(ModuleDecl *M) {
@@ -4326,7 +4343,7 @@ GenericEnvironment *OpenedArchetypeType::getGenericEnvironment() const {
 
 CanType OpenedArchetypeType::getAny(Type existential) {
   if (auto metatypeTy = existential->getAs<ExistentialMetatypeType>()) {
-    auto instanceTy = metatypeTy->getInstanceType();
+    auto instanceTy = metatypeTy->getExistentialInstanceType();
     return CanMetatypeType::get(OpenedArchetypeType::getAny(instanceTy));
   }
   assert(existential->isExistentialType());

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -860,6 +860,16 @@ ProtocolDecl *ASTContext::getErrorDecl() const {
   return getProtocol(KnownProtocolKind::Error);
 }
 
+CanType ASTContext::getErrorExistentialType() const {
+  Type errorType = getExceptionType();
+  if (LangOpts.EnableExplicitExistentialTypes &&
+      errorType->isConstraintType()) {
+    errorType = ExistentialType::get(errorType);
+  }
+
+  return errorType->getCanonicalType();
+}
+
 EnumElementDecl *ASTContext::getOptionalSomeDecl() const {
   if (!getImpl().OptionalSomeDecl)
     getImpl().OptionalSomeDecl = getOptionalDecl()->getUniqueElement(/*hasVal*/true);
@@ -4865,7 +4875,7 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
     if (auto nsErrorTy = getNSErrorType()) {
       // The corresponding value type is Error.
       if (bridgedValueType)
-        *bridgedValueType = getErrorDecl()->getDeclaredInterfaceType();
+        *bridgedValueType = getErrorExistentialType();
 
       return nsErrorTy;
     }
@@ -4902,7 +4912,7 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
   if (findConformance(KnownProtocolKind::Error)) {
     // The corresponding value type is Error.
     if (bridgedValueType)
-      *bridgedValueType = getErrorDecl()->getDeclaredInterfaceType();
+      *bridgedValueType = getErrorExistentialType();
 
     // Bridge to NSError.
     if (auto nsErrorTy = getNSErrorType())

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -584,11 +584,15 @@ Type ASTBuilder::createProtocolCompositionType(
     members.push_back(protocol->getDeclaredInterfaceType());
   if (superclass && superclass->getClassOrBoundGenericClass())
     members.push_back(superclass);
+
+  // FIXME: When explicit existential types are enabled, protocol
+  // compositions should be wrapped in ExistentialType based on
+  // context, similar to how protocol compositions are resolved
+  // during type resolution. For example, protocol compositions
+  // in parameter types should be wrapped in ExistentialType, but
+  // protocol compositions on the right side of a conformance
+  // requirement should not.
   Type composition = ProtocolCompositionType::get(Ctx, members, isClassBound);
-  if (Ctx.LangOpts.EnableExplicitExistentialTypes &&
-      !(composition->isAny() || composition->isAnyObject())) {
-    composition = ExistentialType::get(composition);
-  }
   return composition;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4852,6 +4852,9 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
             isSimpleUnderPrintOptions(opaque->getExistentialType());
       }
       llvm_unreachable("bad opaque-return-type printing mode");
+    } else if (auto existential = dyn_cast<ExistentialType>(T.getPointer())) {
+      if (!Options.PrintExplicitAny)
+        return isSimpleUnderPrintOptions(existential->getConstraintType());
     }
     return T->hasSimpleTypeRepr();
   }
@@ -5272,9 +5275,7 @@ public:
       }
     }
 
-    auto &ctx = T->getASTContext();
-    if (T->is<ExistentialMetatypeType>() &&
-        ctx.LangOpts.EnableExplicitExistentialTypes)
+    if (T->is<ExistentialMetatypeType>() && Options.PrintExplicitAny)
       Printer << "any ";
 
     printWithParensIfNotSimple(T->getInstanceType());
@@ -5282,7 +5283,7 @@ public:
     // We spell normal metatypes of existential types as .Protocol.
     if (isa<MetatypeType>(T) &&
         T->getInstanceType()->isAnyExistentialType() &&
-        !ctx.LangOpts.EnableExplicitExistentialTypes) {
+        !Options.PrintExplicitAny) {
       Printer << ".Protocol";
     } else {
       Printer << ".Type";
@@ -5875,7 +5876,9 @@ public:
   }
 
   void visitExistentialType(ExistentialType *T) {
-    Printer << "any ";
+    if (Options.PrintExplicitAny)
+      Printer << "any ";
+
     visit(T->getConstraintType());
   }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3422,11 +3422,12 @@ public:
     }
 
     Type checkExceptionTypeExists(const char *where) {
-      auto exn = Ctx.getErrorDecl();
-      if (exn) return exn->getDeclaredInterfaceType();
+      if (!Ctx.getErrorDecl()) {
+        Out << "exception type does not exist in " << where << "\n";
+        abort();
+      }
 
-      Out << "exception type does not exist in " << where << "\n";
-      abort();
+      return Ctx.getErrorExistentialType();
     }
 
     bool isGoodSourceRange(SourceRange SR) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2067,7 +2067,10 @@ public:
         abort();
       }
 
-      checkSameType(E->getBase()->getType(), metatype->getInstanceType(),
+      auto instance = metatype->getInstanceType();
+      if (auto existential = metatype->getAs<ExistentialMetatypeType>())
+        instance = existential->getExistentialInstanceType();
+      checkSameType(E->getBase()->getType(), instance,
                     "base type of .Type expression");
       verifyCheckedBase(E);
     }

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -751,6 +751,11 @@ ClangTypeConverter::visitProtocolCompositionType(ProtocolCompositionType *type) 
 }
 
 clang::QualType
+ClangTypeConverter::visitExistentialType(ExistentialType *type) {
+  return visit(type->getConstraintType());
+}
+
+clang::QualType
 ClangTypeConverter::visitBuiltinRawPointerType(BuiltinRawPointerType *type) {
   return ClangASTContext.VoidPtrTy;
 }
@@ -828,6 +833,9 @@ clang::QualType ClangTypeConverter::convert(Type type) {
     return it->second;
 
   // Try to do this without making cache entries for obvious cases.
+  if (auto existential = type->getAs<ExistentialType>())
+    type = existential->getConstraintType();
+
   if (auto nominal = type->getAs<NominalType>()) {
     auto decl = nominal->getDecl();
     if (auto clangDecl = decl->getClangDecl()) {

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -122,6 +122,7 @@ private:
   clang::QualType visitEnumType(EnumType *type);
   clang::QualType visitFunctionType(FunctionType *type);
   clang::QualType visitProtocolCompositionType(ProtocolCompositionType *type);
+  clang::QualType visitExistentialType(ExistentialType *type);
   clang::QualType visitBuiltinRawPointerType(BuiltinRawPointerType *type);
   clang::QualType visitBuiltinIntegerType(BuiltinIntegerType *type);
   clang::QualType visitBuiltinFloatType(BuiltinFloatType *type);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5164,7 +5164,10 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
     return SelfReferenceInfo::forSelfRef(SelfReferencePosition::Invariant);
 
   // Protocol compositions preserve variance.
-  if (auto *comp = type->getAs<ProtocolCompositionType>()) {
+  auto constraint = type;
+  if (auto existential = constraint->getAs<ExistentialType>())
+    constraint = existential->getConstraintType();
+  if (auto *comp = constraint->getAs<ProtocolCompositionType>()) {
     // 'Self' may be referenced only in a superclass component.
     if (const auto superclass = comp->getSuperclass()) {
       return findProtocolSelfReferences(proto, superclass, position);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -549,6 +549,24 @@ static bool typeSpellingIsAmbiguous(Type type,
       auto argType = arg.getAsType();
       if (argType && argType->getWithoutParens().getPointer() != type.getPointer() &&
           argType->getWithoutParens().getString(PO) == type.getString(PO)) {
+        // Currently, existential types are spelled the same way
+        // as protocols and compositions. We can remove this once
+        // existenials are printed with 'any'.
+        if (type->is<ExistentialType>() || argType->isExistentialType()) {
+          auto constraint = type;
+          if (auto existential = type->getAs<ExistentialType>())
+            constraint = existential->getConstraintType();
+
+          auto argConstraint = argType;
+          if (auto existential = argType->getAs<ExistentialType>())
+            argConstraint = existential->getConstraintType();
+
+          if (constraint.getPointer() != argConstraint.getPointer())
+            return true;
+
+          continue;
+        }
+
         return true;
       }
     }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4500,7 +4500,8 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
   }
 
   // Check whether we have a reasonable constraint type at all.
-  if (!constraintType->isExistentialType() &&
+  if (!constraintType->is<ProtocolType>() &&
+      !constraintType->is<ProtocolCompositionType>() &&
       !constraintType->getClassOrBoundGenericClass()) {
     if (source.getLoc().isValid() && !constraintType->hasError()) {
       Impl->HadAnyError = true;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6293,8 +6293,16 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
       auto source = constraint.source;
       auto loc = source->getLoc();
 
+      // FIXME: The constraint string is printed directly here because
+      // the current default is to not print `any` for existential
+      // types, but this error message is super confusing without `any`
+      // if the user wrote it explicitly.
+      PrintOptions options;
+      options.PrintExplicitAny = true;
+      auto constraintString = constraintType.getString(options);
+
       Diags.diagnose(loc, diag::requires_conformance_nonprotocol,
-                     subjectType, constraintType);
+                     subjectType, constraintString);
       
       auto getNameWithoutSelf = [&](std::string subjectTypeName) {
         std::string selfSubstring = "Self.";
@@ -6312,7 +6320,7 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
         auto subjectTypeName = subjectType.getString();
         auto subjectTypeNameWithoutSelf = getNameWithoutSelf(subjectTypeName);
         Diags.diagnose(loc, diag::requires_conformance_nonprotocol_fixit,
-                       subjectTypeNameWithoutSelf, constraintType.getString())
+                       subjectTypeNameWithoutSelf, constraintString)
              .fixItReplace(loc, " == ");
       }
     }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -978,13 +978,17 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   // existential to an archetype parameter, so for now we restrict this to
   // @objc protocols and marker protocols.
   if (!layout.isObjC() && !protocol->isMarkerProtocol()) {
+    auto constraint = type;
+    if (auto existential = constraint->getAs<ExistentialType>())
+      constraint = existential->getConstraintType();
+
     // There's a specific exception for protocols with self-conforming
     // witness tables, but the existential has to be *exactly* that type.
     // TODO: synthesize witness tables on-demand for protocol compositions
     // that can satisfy the requirement.
     if (protocol->requiresSelfConformanceWitnessTable() &&
-        type->is<ProtocolType>() &&
-        type->castTo<ProtocolType>()->getDecl() == protocol)
+        constraint->is<ProtocolType>() &&
+        constraint->castTo<ProtocolType>()->getDecl() == protocol)
       return ProtocolConformanceRef(ctx.getSelfConformance(protocol));
 
     return ProtocolConformanceRef::forInvalid();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -104,6 +104,8 @@ NominalTypeDecl *CanType::getAnyNominal() const {
 }
 
 GenericTypeDecl *CanType::getAnyGeneric() const {
+  if (auto existential = dyn_cast<ExistentialType>(*this))
+    return existential->getConstraintType()->getAnyGeneric();
   if (auto Ty = dyn_cast<AnyGenericType>(*this))
     return Ty->getDecl();
   return nullptr;
@@ -2643,13 +2645,16 @@ getForeignRepresentable(Type type, ForeignLanguage language,
   // If type has an error let's fail early.
   if (type->hasError())
     return failure();
-  
+
   // Look through one level of optional type, but remember that we did.
   bool wasOptional = false;
   if (auto valueType = type->getOptionalObjectType()) {
     type = valueType;
     wasOptional = true;
   }
+
+  if (auto existential = type->getAs<ExistentialType>())
+    type = existential->getConstraintType();
 
   // Objective-C object types, including metatypes.
   if (language == ForeignLanguage::ObjectiveC) {
@@ -3242,9 +3247,14 @@ Type ArchetypeType::getExistentialType() const {
   for (auto proto : getConformsTo()) {
     constraintTypes.push_back(proto->getDeclaredInterfaceType());
   }
-  return ProtocolCompositionType::get(
-     const_cast<ArchetypeType*>(this)->getASTContext(), constraintTypes,
-                                      requiresClass());
+  auto &ctx = const_cast<ArchetypeType*>(this)->getASTContext();
+  auto constraint = ProtocolCompositionType::get(
+     ctx, constraintTypes, requiresClass());
+
+  if (ctx.LangOpts.EnableExplicitExistentialTypes)
+    return ExistentialType::get(constraint);
+
+  return constraint;
 }
 
 PrimaryArchetypeType::PrimaryArchetypeType(const ASTContext &Ctx,
@@ -5555,6 +5565,10 @@ bool Type::isPrivateStdlibType(bool treatNonBuiltinProtocolsAsPublic) const {
   if (!Ty)
     return false;
 
+  if (auto existential = dyn_cast<ExistentialType>(Ty.getPointer()))
+    return existential->getConstraintType()
+        .isPrivateStdlibType(treatNonBuiltinProtocolsAsPublic);
+
   // A 'public' typealias can have an 'internal' type.
   if (auto *NAT = dyn_cast<TypeAliasType>(Ty.getPointer())) {
     auto *AliasDecl = NAT->getDecl();
@@ -5739,7 +5753,7 @@ SILBoxType::SILBoxType(ASTContext &C,
 Type TypeBase::openAnyExistentialType(OpenedArchetypeType *&opened) {
   assert(isAnyExistentialType());
   if (auto metaty = getAs<ExistentialMetatypeType>()) {
-    opened = OpenedArchetypeType::get(metaty->getInstanceType());
+    opened = OpenedArchetypeType::get(metaty->getExistentialInstanceType());
     if (metaty->hasRepresentation())
       return MetatypeType::get(opened, metaty->getRepresentation());
     else

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1501,7 +1501,7 @@ CanType TypeBase::computeCanonicalType() {
   case TypeKind::Existential: {
     auto *existential = cast<ExistentialType>(this);
     auto constraint = existential->getConstraintType()->getCanonicalType();
-    Result = ExistentialType::get(constraint);
+    Result = ExistentialType::get(constraint).getPointer();
     break;
   }
   case TypeKind::ExistentialMetatype: {
@@ -3251,10 +3251,7 @@ Type ArchetypeType::getExistentialType() const {
   auto constraint = ProtocolCompositionType::get(
      ctx, constraintTypes, requiresClass());
 
-  if (ctx.LangOpts.EnableExplicitExistentialTypes)
-    return ExistentialType::get(constraint);
-
-  return constraint;
+  return ExistentialType::get(constraint);
 }
 
 PrimaryArchetypeType::PrimaryArchetypeType(const ASTContext &Ctx,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -464,6 +464,8 @@ Type TypeBase::eraseOpenedExistential(OpenedArchetypeType *opened) {
       auto instanceType = metatypeType->getInstanceType();
       if (instanceType->hasOpenedExistential()) {
         instanceType = instanceType->eraseOpenedExistential(opened);
+        if (auto existential = instanceType->getAs<ExistentialType>())
+          instanceType = existential->getConstraintType();
         return ExistentialMetatypeType::get(instanceType);
       }
     }
@@ -1199,6 +1201,9 @@ Type TypeBase::replaceSelfParameterType(Type newSelf) {
 /// Look through a metatype, or just return the original type if it is
 /// not a metatype.
 Type TypeBase::getMetatypeInstanceType() {
+  if (auto existentialMetaType = getAs<ExistentialMetatypeType>())
+    return existentialMetaType->getExistentialInstanceType();
+
   if (auto metaTy = getAs<AnyMetatypeType>())
     return metaTy->getInstanceType();
 

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -287,11 +287,6 @@ CanType TypeJoin::visitExistentialType(CanType second) {
   if (!joinInstance)
     return CanType();
 
-  if (joinInstance->is<ExistentialMetatypeType>() ||
-      joinInstance->isAny() ||
-      joinInstance->isAnyObject())
-    return joinInstance;
-
   return ExistentialType::get(joinInstance)->getCanonicalType();
 }
 

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -66,6 +66,7 @@ struct TypeJoin : CanTypeVisitor<TypeJoin, CanType> {
   CanType visitBoundGenericStructType(CanType second);
   CanType visitMetatypeType(CanType second);
   CanType visitExistentialMetatypeType(CanType second);
+  CanType visitExistentialType(CanType second);
   CanType visitModuleType(CanType second);
   CanType visitDynamicSelfType(CanType second);
   CanType visitArchetypeType(CanType second);
@@ -269,6 +270,29 @@ CanType TypeJoin::visitExistentialMetatypeType(CanType second) {
     return CanType();
 
   return ExistentialMetatypeType::get(joinInstance)->getCanonicalType();
+}
+
+CanType TypeJoin::visitExistentialType(CanType second) {
+  assert(First != second);
+
+  if (First->getKind() != second->getKind())
+    return TheAnyType;
+
+  auto firstConstraint = First->castTo<ExistentialType>()
+      ->getConstraintType()->getCanonicalType();
+  auto secondConstraint = second->castTo<ExistentialType>()
+      ->getConstraintType()->getCanonicalType();
+
+  auto joinInstance = join(firstConstraint, secondConstraint);
+  if (!joinInstance)
+    return CanType();
+
+  if (joinInstance->is<ExistentialMetatypeType>() ||
+      joinInstance->isAny() ||
+      joinInstance->isAnyObject())
+    return joinInstance;
+
+  return ExistentialType::get(joinInstance)->getCanonicalType();
 }
 
 CanType TypeJoin::visitModuleType(CanType second) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6244,6 +6244,9 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
   // Local function to add a known protocol only when the
   // underlying type conforms to it.
   auto computedNominal = computedPropertyUnderlyingType->getAnyNominal();
+  if (auto existential =
+          computedPropertyUnderlyingType->getAs<ExistentialType>())
+    computedNominal = existential->getConstraintType()->getAnyNominal();
   auto transferKnown = [&](KnownProtocolKind kind) {
     if (!computedNominal)
       return false;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1183,6 +1183,10 @@ namespace {
             }
           }
 
+          if (bridgedType->isConstraintType() &&
+              Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes)
+            bridgedType = ExistentialType::get(bridgedType);
+
           return { importedType,
                    ImportHint(ImportHint::ObjCBridged, bridgedType) };
         }
@@ -2505,6 +2509,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     if (kind == SpecialMethodKind::NSDictionarySubscriptGetter &&
         paramTy->isObjCIdType()) {
       swiftParamTy = SwiftContext.getNSCopyingType();
+      if (SwiftContext.LangOpts.EnableExplicitExistentialTypes)
+        swiftParamTy = ExistentialType::get(swiftParamTy);
       if (!swiftParamTy)
         return {Type(), false};
       if (optionalityOfParam != OTK_None)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1052,6 +1052,9 @@ namespace {
               Type importedTypeArg = ProtocolCompositionType::get(
                   Impl.SwiftContext, memberTypes,
                   hasExplicitAnyObject);
+              if (Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes) {
+                importedTypeArg = ExistentialType::get(importedTypeArg);
+              }
               importedTypeArgs.push_back(importedTypeArg);
             }
           }
@@ -1203,6 +1206,10 @@ namespace {
         importedType = ProtocolCompositionType::get(Impl.SwiftContext,
                                                     members,
                                                     /*HasExplicitAnyObject=*/false);
+
+        if (Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes) {
+          importedType = ExistentialType::get(importedType);
+        }
       }
 
       // Class or Class<P> maps to an existential metatype.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1049,12 +1049,10 @@ namespace {
               if (memberTypes.empty())
                 hasExplicitAnyObject = true;
 
-              Type importedTypeArg = ProtocolCompositionType::get(
-                  Impl.SwiftContext, memberTypes,
-                  hasExplicitAnyObject);
-              if (Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes) {
-                importedTypeArg = ExistentialType::get(importedTypeArg);
-              }
+              Type importedTypeArg = ExistentialType::get(
+                  ProtocolCompositionType::get(
+                      Impl.SwiftContext, memberTypes,
+                      hasExplicitAnyObject));
               importedTypeArgs.push_back(importedTypeArg);
             }
           }
@@ -1183,8 +1181,7 @@ namespace {
             }
           }
 
-          if (bridgedType->isConstraintType() &&
-              Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes)
+          if (bridgedType->isConstraintType())
             bridgedType = ExistentialType::get(bridgedType);
 
           return { importedType,
@@ -1207,13 +1204,9 @@ namespace {
           members.push_back(proto->getDeclaredInterfaceType());
         }
 
-        importedType = ProtocolCompositionType::get(Impl.SwiftContext,
-                                                    members,
-                                                    /*HasExplicitAnyObject=*/false);
-
-        if (Impl.SwiftContext.LangOpts.EnableExplicitExistentialTypes) {
-          importedType = ExistentialType::get(importedType);
-        }
+        importedType = ExistentialType::get(
+            ProtocolCompositionType::get(Impl.SwiftContext, members,
+                                         /*HasExplicitAnyObject=*/false));
       }
 
       // Class or Class<P> maps to an existential metatype.
@@ -2508,9 +2501,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     bool paramIsIUO;
     if (kind == SpecialMethodKind::NSDictionarySubscriptGetter &&
         paramTy->isObjCIdType()) {
-      swiftParamTy = SwiftContext.getNSCopyingType();
-      if (SwiftContext.LangOpts.EnableExplicitExistentialTypes)
-        swiftParamTy = ExistentialType::get(swiftParamTy);
+      swiftParamTy = ExistentialType::get(SwiftContext.getNSCopyingType());
       if (!swiftParamTy)
         return {Type(), false};
       if (optionalityOfParam != OTK_None)

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -7831,7 +7831,8 @@ private:
                                  const AsyncHandlerDesc &HandlerDesc) {
     // If the error type is already Error, we can pass it as-is.
     auto ErrorType = *HandlerDesc.getErrorType();
-    if (ErrorType->getCanonicalType() == getASTContext().getExceptionType()) {
+    if (ErrorType->getCanonicalType() ==
+        getASTContext().getErrorExistentialType()) {
       OS << ErrorName;
       return;
     }

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -158,6 +158,8 @@ TypeDecl *DebugTypeInfo::getDecl() const {
     return UBG->getDecl();
   if (auto *BG = dyn_cast<BoundGenericType>(Type))
     return BG->getDecl();
+  if (auto *E = dyn_cast<ExistentialType>(Type))
+    return E->getConstraintType()->getAnyNominal();
   return nullptr;
 }
 

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -592,10 +592,9 @@ if (Builtin.ID == BuiltinValueKind::id) { \
   
     auto *fn = cast<llvm::Function>(IGF.IGM.getWillThrowFn());
     auto error = args.claimNext();
+    auto errorTy = IGF.IGM.Context.getErrorExistentialType();
     auto errorBuffer = IGF.getCalleeErrorResultSlot(
-        SILType::getPrimitiveObjectType(IGF.IGM.Context.getErrorDecl()
-                                            ->getDeclaredInterfaceType()
-                                            ->getCanonicalType()));
+        SILType::getPrimitiveObjectType(errorTy));
     IGF.Builder.CreateStore(error, errorBuffer);
     
     auto context = llvm::UndefValue::get(IGF.IGM.Int8PtrTy);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -97,6 +97,22 @@ public:
   };
 };
 
+static bool equalWithoutExistentialTypes(Type t1, Type t2) {
+  if (!t1->getASTContext().LangOpts.EnableExplicitExistentialTypes)
+    return false;
+
+  auto withoutExistentialTypes = [](Type type) -> Type {
+    return type.transform([](Type type) -> Type {
+      if (auto existential = type->getAs<ExistentialType>())
+        return existential->getConstraintType();
+      return type;
+    });
+  };
+
+  return withoutExistentialTypes(t1)
+      ->isEqual(withoutExistentialTypes(t2));
+}
+
 class IRGenDebugInfoImpl : public IRGenDebugInfo {
   friend class IRGenDebugInfoImpl;
   const IRGenOptions &Opts;
@@ -900,14 +916,9 @@ private:
         Ty->dump(llvm::errs());
         abort();
       } else if (!Reconstructed->isEqual(Ty) &&
-                 // FIXME: Existential types are reconstructed without
+                 // FIXME: Some existential types are reconstructed without
                  // an explicit ExistentialType wrapping the constraint.
-                 !(Ty->getASTContext().LangOpts.EnableExplicitExistentialTypes &&
-                   Ty.transform([](Type type) -> Type {
-                     if (auto existential = type->getAs<ExistentialType>())
-                       return existential->getConstraintType();
-                     return type;
-                   })->isEqual(Reconstructed)) &&
+                 !equalWithoutExistentialTypes(Reconstructed, Ty) &&
                  !EqualUpToClangTypes().check(Reconstructed, Ty)) {
         // [FIXME: Include-Clang-type-in-mangling] Remove second check
         llvm::errs() << "Incorrect reconstructed type for " << Result << "\n";

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -900,6 +900,14 @@ private:
         Ty->dump(llvm::errs());
         abort();
       } else if (!Reconstructed->isEqual(Ty) &&
+                 // FIXME: Existential types are reconstructed without
+                 // an explicit ExistentialType wrapping the constraint.
+                 !(Ty->getASTContext().LangOpts.EnableExplicitExistentialTypes &&
+                   Ty.transform([](Type type) -> Type {
+                     if (auto existential = type->getAs<ExistentialType>())
+                       return existential->getConstraintType();
+                     return type;
+                   })->isEqual(Reconstructed)) &&
                  !EqualUpToClangTypes().check(Reconstructed, Ty)) {
         // [FIXME: Include-Clang-type-in-mangling] Remove second check
         llvm::errs() << "Incorrect reconstructed type for " << Result << "\n";

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -216,6 +216,8 @@ std::string IRGenMangler::mangleTypeForLLVMTypeName(CanType Ty) {
   // To make LLVM IR more readable we always add a 'T' prefix so that type names
   // don't start with a digit and don't need to be quoted.
   Buffer << 'T';
+  if (auto existential = Ty->getAs<ExistentialType>())
+    Ty = existential->getConstraintType()->getCanonicalType();
   if (auto P = dyn_cast<ProtocolType>(Ty)) {
     appendProtocolName(P->getDecl(), /*allowStandardSubstitution=*/false);
     appendOperator("P");

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -45,7 +45,7 @@ CanArchetypeType swift::getOpenedArchetypeOf(CanType Ty) {
 }
 
 SILType SILType::getExceptionType(const ASTContext &C) {
-  return SILType::getPrimitiveObjectType(C.getExceptionType());
+  return SILType::getPrimitiveObjectType(C.getErrorExistentialType());
 }
 
 SILType SILType::getNativeObjectType(const ASTContext &C) {

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -144,8 +144,8 @@ void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
     case 1: {
       assert(AACI->getErrorBB());
       auto &C = AACI->getFunction()->getASTContext();
-      auto errorTy = C.getErrorDecl()->getDeclaredType();
-      auto errorSILTy = SILType::getPrimitiveObjectType(errorTy->getCanonicalType());
+      auto errorTy = C.getErrorExistentialType();
+      auto errorSILTy = SILType::getPrimitiveObjectType(errorTy);
       // error BB. this takes the error value argument
       args.push_back(
           newEdgeBB->createPhiArgument(errorSILTy, OwnershipKind::Owned));

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -468,8 +468,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
                              : DynamicCastFeasibility::WillFail;
     }
 
-    if (targetMetatype.isAnyExistentialType() &&
-        (isa<ProtocolType>(target) || isa<ProtocolCompositionType>(target))) {
+    if (targetMetatype.isAnyExistentialType() && target->isExistentialType()) {
       auto Feasibility =
           classifyDynamicCastToProtocol(M, source, target, isWholeModuleOpts);
       // Cast from existential metatype to existential metatype may still

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2960,8 +2960,19 @@ public:
             "value_metatype instruction must have a metatype representation");
     require(MI->getOperand()->getType().isAnyExistentialType(),
             "existential_metatype operand must be of protocol type");
+
+    // The result of an existential_metatype instruction is an existential
+    // metatype with the same constraint type as its existential operand.
     auto formalInstanceTy
       = MI->getType().castTo<ExistentialMetatypeType>().getInstanceType();
+    if (M->getASTContext().LangOpts.EnableExplicitExistentialTypes &&
+        formalInstanceTy->isConstraintType() &&
+        !(formalInstanceTy->isAny() || formalInstanceTy->isAnyObject())) {
+      require(MI->getOperand()->getType().is<ExistentialType>(),
+              "existential_metatype operand must be an existential type");
+      formalInstanceTy =
+          ExistentialType::get(formalInstanceTy)->getCanonicalType();
+    }
     require(isLoweringOf(MI->getOperand()->getType(), formalInstanceTy),
             "existential_metatype result must be formal metatype of "
             "lowered operand type");

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5252,7 +5252,7 @@ public:
       require(AACI->getErrorBB()->getNumArguments() == 1,
               "error successor must take one argument");
       auto arg = AACI->getErrorBB()->getArgument(0);
-      auto errorType = C.getErrorDecl()->getDeclaredType()->getCanonicalType();
+      auto errorType = C.getErrorExistentialType();
       requireSameType(arg->getType(),
                       SILType::getPrimitiveObjectType(errorType),
               "error successor argument must have Error type");

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -508,7 +508,7 @@ public:
     auto continuationDecl = SGF.getASTContext().getUnsafeContinuationDecl();
 
     auto errorTy = throws
-      ? SGF.getASTContext().getExceptionType()
+      ? SGF.getASTContext().getErrorExistentialType()
       : SGF.getASTContext().getNeverType();
     auto continuationTy = BoundGenericType::get(continuationDecl, Type(),
                                                 { calleeTypeInfo.substResultType, errorTy })
@@ -618,7 +618,7 @@ public:
 
         auto continuationDecl = SGF.getASTContext().getUnsafeContinuationDecl();
 
-        auto errorTy = SGF.getASTContext().getExceptionType();
+        auto errorTy = SGF.getASTContext().getErrorExistentialType();
         auto continuationBGT =
             BoundGenericType::get(continuationDecl, Type(),
                                   {calleeTypeInfo.substResultType, errorTy});
@@ -666,9 +666,8 @@ public:
       SGF.B.emitBlock(errorBlock);
       
       Scope errorScope(SGF, loc);
-      
-      auto errorTy = SGF.getASTContext().getErrorDecl()->getDeclaredType()
-        ->getCanonicalType();
+
+      auto errorTy = SGF.getASTContext().getErrorExistentialType();
       auto errorVal = SGF.B.createTermResult(
         SILType::getPrimitiveObjectType(errorTy), OwnershipKind::Owned);
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -168,6 +168,7 @@ getBridgingFn(Optional<SILDeclRef> &cacheSlot,
 
 #define REQUIRED(X) Types.get##X##Type()
 #define OPTIONAL(X) OptionalType::get(Types.get##X##Type())
+#define EXISTENTIAL(X) getASTContext().get##X##ExistentialType()
 
 #define GET_BRIDGING_FN(Module, FromKind, FromTy, ToKind, ToTy) \
   SILDeclRef SILGenModule::get##FromTy##To##ToTy##Fn() { \
@@ -182,8 +183,8 @@ GET_BRIDGING_FN(Darwin, REQUIRED, Bool, REQUIRED, DarwinBoolean)
 GET_BRIDGING_FN(Darwin, REQUIRED, DarwinBoolean, REQUIRED, Bool)
 GET_BRIDGING_FN(ObjectiveC, REQUIRED, Bool, REQUIRED, ObjCBool)
 GET_BRIDGING_FN(ObjectiveC, REQUIRED, ObjCBool, REQUIRED, Bool)
-GET_BRIDGING_FN(Foundation, OPTIONAL, NSError, REQUIRED, Error)
-GET_BRIDGING_FN(Foundation, REQUIRED, Error, REQUIRED, NSError)
+GET_BRIDGING_FN(Foundation, OPTIONAL, NSError, EXISTENTIAL, Error)
+GET_BRIDGING_FN(Foundation, EXISTENTIAL, Error, REQUIRED, NSError)
 GET_BRIDGING_FN(WinSDK, REQUIRED, Bool, REQUIRED, WindowsBool)
 GET_BRIDGING_FN(WinSDK, REQUIRED, WindowsBool, REQUIRED, Bool)
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1252,7 +1252,7 @@ ManagedValue SILGenFunction::emitNativeToBridgedError(SILLocation loc,
   // FIXME: maybe we should use a different entrypoint for this case, to
   // avoid the code size and performance overhead of forming the box?
   nativeError = emitUnabstractedCast(*this, loc, nativeError, nativeType,
-                                     getASTContext().getExceptionType());
+                                     getASTContext().getErrorExistentialType());
 
   auto bridgeFn = emitGlobalFunctionRef(loc, SGM.getErrorToNSErrorFn());
   auto bridgeFnType = bridgeFn->getType().castTo<SILFunctionType>();

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1564,8 +1564,7 @@ static ManagedValue emitBuiltinWithUnsafeContinuation(
 
     Scope errorScope(SGF, loc);
 
-    auto errorTy = SGF.getASTContext().getErrorDecl()->getDeclaredType()
-      ->getCanonicalType();
+    auto errorTy = SGF.getASTContext().getErrorExistentialType();
     auto errorVal = SGF.B.createTermResult(
         SILType::getPrimitiveObjectType(errorTy), OwnershipKind::Owned);
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -913,8 +913,11 @@ ManagedValue SILGenFunction::emitExistentialMetatypeToObject(SILLocation loc,
 ManagedValue SILGenFunction::emitProtocolMetatypeToObject(SILLocation loc,
                                                           CanType inputTy,
                                                           SILType resultTy) {
-  ProtocolDecl *protocol = inputTy->castTo<MetatypeType>()
-    ->getInstanceType()->castTo<ProtocolType>()->getDecl();
+  auto protocolType = inputTy->castTo<MetatypeType>()->getInstanceType();
+  if (auto existential = protocolType->getAs<ExistentialType>())
+    protocolType = existential->getConstraintType();
+
+  ProtocolDecl *protocol = protocolType->castTo<ProtocolType>()->getDecl();
 
   SILValue value = B.createObjCProtocol(loc, protocol, resultTy);
   

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1037,8 +1037,7 @@ SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc, SILType ty,
   if (auto *DRE = loc.getAsASTNode<DeclRefExpr>())
     if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
       if (!isa<ParamDecl>(VD) && VD->isImplicit() &&
-          (VD->getType()->is<ProtocolType>() ||
-           VD->getType()->is<ProtocolCompositionType>()) &&
+          VD->getType()->isExistentialType() &&
           VD->getType()->getExistentialLayout().isErrorExistential()) {
         DbgVar = SILDebugVariable(VD->isLet(), 0);
         loc = SILLocation(VD);

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -134,7 +134,7 @@ namespace {
     SILValue emitBridged(SILGenFunction &SGF, SILLocation loc,
                          CanType bridgedErrorProto) const override {
       auto nativeErrorType = NativeError->getType().getASTType();
-      assert(nativeErrorType == SGF.SGM.getASTContext().getExceptionType());
+      assert(nativeErrorType == SGF.SGM.getASTContext().getErrorExistentialType());
 
       SILValue bridgedError = SGF.emitNativeToBridgedError(loc,
                                 SGF.emitManagedRValueWithCleanup(NativeError),

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -220,7 +220,7 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
     fromInstanceType = cast<MetatypeType>(fromInstanceType)
       .getInstanceType();
     toInstanceType = cast<ExistentialMetatypeType>(toInstanceType)
-      .getInstanceType();
+      ->getExistentialInstanceType()->getCanonicalType();
   }
 
   ArrayRef<ProtocolConformanceRef> conformances =

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3052,8 +3052,13 @@ buildThunkSignature(SILGenFunction &SGF,
   // Add a new generic parameter to replace the opened existential.
   auto *newGenericParam =
       GenericTypeParamType::get(/*type sequence*/ false, depth, 0, ctx);
+
+  auto constraint = openedExistential->getOpenedExistentialType();
+  if (auto existential = constraint->getAs<ExistentialType>())
+    constraint = existential->getConstraintType();
+
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
-                             openedExistential->getOpenedExistentialType());
+                             constraint);
 
   auto genericSig = buildGenericSignature(ctx, baseGenericSig,
                                           { newGenericParam },

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -842,10 +842,7 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
                                           ProtocolConformanceRef(conformance));
 
   // Open the protocol type.
-  Type existential = protocolType;
-  if (SGM.getASTContext().LangOpts.EnableExplicitExistentialTypes)
-    existential = ExistentialType::get(protocolType);
-  auto openedType = OpenedArchetypeType::get(existential);
+  auto openedType = OpenedArchetypeType::get(protocol->getExistentialType());
 
   // Form the substitutions for calling the witness.
   auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -842,7 +842,10 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
                                           ProtocolConformanceRef(conformance));
 
   // Open the protocol type.
-  auto openedType = OpenedArchetypeType::get(protocolType);
+  Type existential = protocolType;
+  if (SGM.getASTContext().LangOpts.EnableExplicitExistentialTypes)
+    existential = ExistentialType::get(protocolType);
+  auto openedType = OpenedArchetypeType::get(existential);
 
   // Form the substitutions for calling the witness.
   auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -66,8 +66,13 @@ CanGenericSignature buildThunkSignature(SILFunction *fn, bool inheritGenericSig,
   // Add a new generic parameter to replace the opened existential.
   auto *newGenericParam =
       GenericTypeParamType::get(/*type sequence*/ false, depth, 0, ctx);
+
+  auto constraint = openedExistential->getOpenedExistentialType();
+  if (auto existential = constraint->getAs<ExistentialType>())
+    constraint = existential->getConstraintType();
+
   Requirement newRequirement(RequirementKind::Conformance, newGenericParam,
-                             openedExistential->getOpenedExistentialType());
+                             constraint);
 
   auto genericSig = buildGenericSignature(ctx, baseGenericSig,
                                           { newGenericParam },

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialSpecializer.cpp
@@ -95,12 +95,16 @@ bool ExistentialSpecializer::findConcreteTypeFromSoleConformingType(
   auto ArgType = Arg->getType();
   auto SwiftArgType = ArgType.getASTType();
 
+  CanType constraint = SwiftArgType;
+  if (auto existential = constraint->getAs<ExistentialType>())
+    constraint = existential->getConstraintType()->getCanonicalType();
+
   /// Do not handle composition types yet.
-  if (isa<ProtocolCompositionType>(SwiftArgType))
+  if (isa<ProtocolCompositionType>(constraint))
     return false;
   assert(ArgType.isExistentialType());
   /// Find the protocol decl.
-  auto *PD = dyn_cast<ProtocolDecl>(SwiftArgType->getAnyNominal());
+  auto *PD = dyn_cast<ProtocolDecl>(constraint->getAnyNominal());
   if (!PD)
     return false;
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -304,12 +304,17 @@ void ExistentialTransform::convertExistentialArgTypesToGenericArgTypes(
     auto &param = params[Idx];
     auto PType = param.getArgumentType(M, FTy, F->getTypeExpansionContext());
     assert(PType.isExistentialType());
+
+    CanType constraint = PType;
+    if (auto existential = PType->getAs<ExistentialType>())
+      constraint = existential->getConstraintType()->getCanonicalType();
+
     /// Generate new generic parameter.
     auto *NewGenericParam =
         GenericTypeParamType::get(/*type sequence*/ false, Depth, GPIdx++, Ctx);
     genericParams.push_back(NewGenericParam);
     Requirement NewRequirement(RequirementKind::Conformance, NewGenericParam,
-                               PType);
+                               constraint);
     requirements.push_back(NewRequirement);
     ArgToGenericTypeMap.insert(
         std::pair<int, GenericTypeParamType *>(Idx, NewGenericParam));

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -914,14 +914,14 @@ protected:
 
   /// Visit a throw statement, which never produces a result.
   VarDecl *visitThrowStmt(ThrowStmt *throwStmt) {
-    Type exnType = ctx.getErrorDecl()->getDeclaredInterfaceType();
-    if (!exnType) {
+    if (!ctx.getErrorDecl()) {
       hadError = true;
     }
 
     if (cs) {
      SolutionApplicationTarget target(
-         throwStmt->getSubExpr(), dc, CTP_ThrowStmt, exnType,
+         throwStmt->getSubExpr(), dc, CTP_ThrowStmt,
+         ctx.getErrorExistentialType(),
          /*isDiscarded=*/false);
      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
        hadError = true;

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -621,13 +621,12 @@ private:
     assert(isSupportedMultiStatementClosure() &&
            "Unsupported statement: Throw");
 
-    Type errType =
-        cs.getASTContext().getErrorDecl()->getDeclaredInterfaceType();
-    if (!errType) {
+    if (!cs.getASTContext().getErrorDecl()) {
       hadError = true;
       return;
     }
 
+    auto errType = cs.getASTContext().getErrorExistentialType();
     auto *errorExpr = throwStmt->getSubExpr();
 
     createConjunction(
@@ -739,7 +738,7 @@ private:
         auto *switchStmt = cast<SwitchStmt>(parent.get<Stmt *>());
         contextualTy = cs.getType(switchStmt->getSubjectExpr());
       } else if (parent.isStmt(StmtKind::DoCatch)) {
-        contextualTy = cs.getASTContext().getExceptionType();
+        contextualTy = cs.getASTContext().getErrorExistentialType();
       } else {
         hadError = true;
         return;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7009,12 +7009,7 @@ static bool isCastToExpressibleByNilLiteral(ConstraintSystem &cs, Type fromType,
   if (!nilLiteral)
     return false;
 
-  auto nilLiteralType = nilLiteral->getDeclaredType();
-  if (ctx.LangOpts.EnableExplicitExistentialTypes) {
-    nilLiteralType = ExistentialType::get(nilLiteralType);
-  }
-
-  return toType->isEqual(nilLiteralType) &&
+  return toType->isEqual(nilLiteral->getExistentialType()) &&
          fromType->getOptionalObjectType();
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2150,7 +2150,8 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
     } else if (isa<AbstractFunctionDecl>(decl) || isa<EnumElementDecl>(decl)) {
       if (decl->isInstanceMember() &&
           (!overload.getBaseType() ||
-           !overload.getBaseType()->getAnyNominal()))
+           (!overload.getBaseType()->getAnyNominal() &&
+            !overload.getBaseType()->is<ExistentialType>())))
         return Type();
 
       // Cope with 'Self' returns.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2506,14 +2506,16 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
       // Okay, now it should be safe to coerce the pattern.
       // Pull the top-level pattern back out.
       pattern = LabelItem.getPattern();
-      Type exnType = DC->getASTContext().getErrorDecl()->getDeclaredInterfaceType();
 
-      if (!exnType)
+      auto &ctx = DC->getASTContext();
+      if (!ctx.getErrorDecl())
         return false;
+
       auto contextualPattern =
           ContextualPattern::forRawPattern(pattern, DC);
       pattern = TypeChecker::coercePatternToType(
-        contextualPattern, exnType, TypeResolverContext::InExpression);
+        contextualPattern, ctx.getErrorExistentialType(),
+        TypeResolverContext::InExpression);
       if (!pattern)
         return false;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1995,8 +1995,12 @@ ConstraintSystem::getTypeOfMemberReference(
         if (t->isEqual(selfTy))
           return baseObjTy;
       if (auto *metatypeTy = t->getAs<MetatypeType>())
-        if (metatypeTy->getInstanceType()->isEqual(selfTy))
-          return ExistentialMetatypeType::get(baseObjTy);
+        if (metatypeTy->getInstanceType()->isEqual(selfTy)) {
+          auto constraint = baseObjTy;
+          if (auto existential = baseObjTy->getAs<ExistentialType>())
+            constraint = existential->getConstraintType();
+          return ExistentialMetatypeType::get(constraint);
+        }
       return t;
     });
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1767,6 +1767,13 @@ ConstraintSystem::getTypeOfMemberReference(
     auto memberTy = TypeChecker::substMemberTypeWithBase(DC->getParentModule(),
                                                          typeDecl, baseObjTy);
 
+    // If the member type is a constraint, e.g. because the
+    // reference is to a typealias with an underlying protocol
+    // or composition type, the member reference has existential
+    // type.
+    if (memberTy->isConstraintType())
+      memberTy = ExistentialType::get(memberTy);
+
     checkNestedTypeConstraints(*this, memberTy, locator);
 
     // Convert any placeholders and open any generics.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1211,10 +1211,7 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   //                         output: ()
   // Create from the inside out:
 
-  auto encoderType = C.getEncoderType();
-  if (C.LangOpts.EnableExplicitExistentialTypes)
-    encoderType = ExistentialType::get(encoderType);
-
+  auto encoderType = ExistentialType::get(C.getEncoderType());
   auto returnType = TupleType::getEmpty(C);
 
   // Params: (Encoder)
@@ -1805,10 +1802,7 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
   // Compute from the inside out:
 
   // Params: (Decoder)
-  auto decoderType = C.getDecoderType();
-  if (C.LangOpts.EnableExplicitExistentialTypes)
-    decoderType = ExistentialType::get(decoderType);
-
+  auto decoderType = ExistentialType::get(C.getDecoderType());
   auto *decoderParamDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_from,
       SourceLoc(), C.Id_decoder, conformanceDC);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1212,6 +1212,9 @@ static FuncDecl *deriveEncodable_encode(DerivedConformance &derived) {
   // Create from the inside out:
 
   auto encoderType = C.getEncoderType();
+  if (C.LangOpts.EnableExplicitExistentialTypes)
+    encoderType = ExistentialType::get(encoderType);
+
   auto returnType = TupleType::getEmpty(C);
 
   // Params: (Encoder)
@@ -1803,6 +1806,9 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
 
   // Params: (Decoder)
   auto decoderType = C.getDecoderType();
+  if (C.LangOpts.EnableExplicitExistentialTypes)
+    decoderType = ExistentialType::get(decoderType);
+
   auto *decoderParamDecl = new (C) ParamDecl(
       SourceLoc(), SourceLoc(), C.Id_from,
       SourceLoc(), C.Id_decoder, conformanceDC);

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -783,7 +783,12 @@ public:
                               Type());
     }
 
-    auto declKindForType = [](Type type) {
+    auto declKindForType = [](Type type) -> DescriptiveDeclKind {
+      // If this is an existential type, use the decl kind of
+      // its constraint type.
+      if (auto existential = type->getAs<ExistentialType>())
+        type = existential->getConstraintType();
+
       if (isa<TypeAliasType>(type.getPointer()))
         return DescriptiveDeclKind::TypeAlias;
       else if (auto nominal = type->getAnyNominal())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3000,8 +3000,10 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 
   Type T = attr->getProtocolType();
   if (!T && attr->getProtocolTypeRepr()) {
+    auto context = TypeResolverContext::GenericRequirement;
     T = TypeResolution::resolveContextualType(attr->getProtocolTypeRepr(), DC,
-                                              None, /*unboundTyOpener*/ nullptr,
+                                              TypeResolutionOptions(context),
+                                              /*unboundTyOpener*/ nullptr,
                                               /*placeholderHandler*/ nullptr);
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1712,13 +1712,16 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //   }
     // }
     //
+    auto constraint = fromType;
+    if (auto existential = constraint->getAs<ExistentialType>())
+      constraint = existential->getConstraintType();
     if (auto *protocolDecl =
-          dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())) {
+          dyn_cast_or_null<ProtocolDecl>(constraint->getAnyNominal())) {
       if (!couldDynamicallyConformToProtocol(toType, protocolDecl, module)) {
         return failed();
       }
     } else if (auto protocolComposition =
-                   fromType->getAs<ProtocolCompositionType>()) {
+                   constraint->getAs<ProtocolCompositionType>()) {
       if (llvm::any_of(protocolComposition->getMembers(),
                        [&](Type protocolType) {
                          if (auto protocolDecl = dyn_cast_or_null<ProtocolDecl>(
@@ -1971,6 +1974,12 @@ static bool checkForDynamicAttribute(CanType ty,
       if (hasAttribute(superclass))
         return true;
     }
+  }
+
+  // If this is an existential type, check if its constraint type
+  // has the attribute.
+  if (auto existential = ty->getAs<ExistentialType>()) {
+    return hasAttribute(existential->getConstraintType());
   }
 
   // If this is a protocol composition, check if any of its members have the

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1899,6 +1899,13 @@ bool swift::isMemberOperator(FuncDecl *decl, Type type) {
     }
 
     if (isProtocol) {
+      // FIXME: Source compatibility hack for Swift 5. The compiler
+      // accepts member operators on protocols with existential
+      // type arguments. We should consider banning this in Swift 6.
+      if (auto existential = paramType->getAs<ExistentialType>()) {
+        return selfNominal == existential->getConstraintType()->getAnyNominal();
+      }
+
       // For a protocol, is it the 'Self' type parameter?
       if (auto genericParam = paramType->getAs<GenericTypeParamType>())
         if (genericParam->isEqual(DC->getSelfInterfaceType()))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1903,7 +1903,8 @@ bool swift::isMemberOperator(FuncDecl *decl, Type type) {
       // accepts member operators on protocols with existential
       // type arguments. We should consider banning this in Swift 6.
       if (auto existential = paramType->getAs<ExistentialType>()) {
-        return selfNominal == existential->getConstraintType()->getAnyNominal();
+        if (selfNominal == existential->getConstraintType()->getAnyNominal())
+          return true;
       }
 
       // For a protocol, is it the 'Self' type parameter?

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -806,7 +806,8 @@ bool swift::isRepresentableInObjC(
     Optional<unsigned> completionHandlerErrorParamIndex;
     if (FD->hasThrows()) {
       completionHandlerErrorParamIndex = completionHandlerParams.size();
-      addCompletionHandlerParam(OptionalType::get(ctx.getExceptionType()));
+      auto errorType = ctx.getErrorExistentialType();
+      addCompletionHandlerParam(OptionalType::get(errorType));
     }
 
     Type completionHandlerType = FunctionType::get(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4792,11 +4792,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
     // With SE-0335, using a type alias as both a type witness and a generic
     // constraint will be disallowed in Swift 6, because existential types
     // must be explicit, and a generic constraint isn't a valid type witness.
-    //
-    // Note that Any and AnyObject aren't yet resolved using ExistentialType.
-    if (getASTContext().LangOpts.EnableExplicitExistentialTypes &&
-        memberType->isConstraintType() &&
-        !(memberType->isAny() || memberType->isAnyObject())) {
+    if (memberType->isConstraintType()) {
       memberType = ExistentialType::get(memberType);
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4783,6 +4783,23 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
     auto memberType = TypeChecker::substMemberTypeWithBase(DC->getParentModule(),
                                                            typeDecl, Adoptee);
 
+    // Type witnesses that resolve to constraint types are always
+    // existential types. This can only happen when the type witness
+    // is explicitly written with a type alias. The type alias itself
+    // is still a constraint type because it can be used as both a
+    // type witness and as a generic constraint.
+    //
+    // With SE-0335, using a type alias as both a type witness and a generic
+    // constraint will be disallowed in Swift 6, because existential types
+    // must be explicit, and a generic constraint isn't a valid type witness.
+    //
+    // Note that Any and AnyObject aren't yet resolved using ExistentialType.
+    if (getASTContext().LangOpts.EnableExplicitExistentialTypes &&
+        memberType->isConstraintType() &&
+        !(memberType->isAny() || memberType->isAnyObject())) {
+      memberType = ExistentialType::get(memberType);
+    }
+
     if (!viableTypes.insert(memberType->getCanonicalType()).second)
       continue;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5273,8 +5273,11 @@ void swift::diagnoseConformanceFailure(Type T,
       TypeChecker::containsProtocol(T, Proto, DC->getParentModule())) {
 
     if (!T->isObjCExistentialType()) {
+      Type constraintType = T;
+      if (auto existential = T->getAs<ExistentialType>())
+        constraintType = existential->getConstraintType();
       diags.diagnose(ComplainLoc, diag::type_cannot_conform, true,
-                     T, T->isEqual(Proto->getDeclaredInterfaceType()), 
+                     T, constraintType->isEqual(Proto->getDeclaredInterfaceType()),
                      Proto->getDeclaredInterfaceType());
       diags.diagnose(ComplainLoc,
                      diag::only_concrete_types_conform_to_protocols);
@@ -5407,7 +5410,10 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
   if (T->isExistentialType()) {
     // Handle the special case of the Error protocol, which self-conforms
     // *and* has a witness table.
-    if (T->isEqual(Proto->getDeclaredInterfaceType()) &&
+    auto constraint = T;
+    if (auto existential = T->getAs<ExistentialType>())
+      constraint = existential->getConstraintType();
+    if (constraint->isEqual(Proto->getDeclaredInterfaceType()) &&
         Proto->requiresSelfConformanceWitnessTable()) {
       auto &ctx = M->getASTContext();
       return ProtocolConformanceRef(ctx.getSelfConformance(Proto));

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -855,10 +855,11 @@ public:
     // Coerce the operand to the exception type.
     auto E = TS->getSubExpr();
 
-    Type exnType = getASTContext().getErrorDecl()->getDeclaredInterfaceType();
-    if (!exnType) return TS;
+    if (!getASTContext().getErrorDecl())
+      return TS;
 
-    TypeChecker::typeCheckExpression(E, DC, {exnType, CTP_ThrowStmt});
+    Type errorType = getASTContext().getErrorExistentialType();
+    TypeChecker::typeCheckExpression(E, DC, {errorType, CTP_ThrowStmt});
     TS->setSubExpr(E);
 
     return TS;
@@ -1205,7 +1206,7 @@ public:
     auto catches = S->getCatches();
     checkSiblingCaseStmts(catches.begin(), catches.end(),
                           CaseParentKind::DoCatch, limitExhaustivityChecks,
-                          getASTContext().getExceptionType());
+                          getASTContext().getErrorExistentialType());
 
     return S;
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3862,13 +3862,6 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
     return constraintType;
   }
 
-  // Warn about `any Any` and `any AnyObject`.
-  if (constraintType->isAny() || constraintType->isAnyObject()) {
-    diagnose(repr->getLoc(), diag::unnecessary_any,
-             constraintType)
-      .fixItRemove({anyStart, anyEnd});
-  }
-
   return ExistentialType::get(constraintType);
 }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4085,7 +4085,8 @@ public:
       if (proto->existentialRequiresAny()) {
         Ctx.Diags.diagnose(comp->getNameLoc(),
                            diag::existential_requires_any,
-                           proto->getName());
+                           proto->getName())
+            .limitBehavior(DiagnosticBehavior::Warning);
       }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
       auto type = Type(alias->getDeclaredInterfaceType()->getDesugaredType());
@@ -4101,7 +4102,8 @@ public:
 
             Ctx.Diags.diagnose(comp->getNameLoc(),
                                diag::existential_requires_any,
-                               protoDecl->getName());
+                               protoDecl->getName())
+                .limitBehavior(DiagnosticBehavior::Warning);
           }
         }
         return false;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3449,9 +3449,7 @@ TypeResolver::resolveIdentifierType(IdentTypeRepr *IdType,
     return ErrorType::get(getASTContext());
   }
 
-  // FIXME: Don't use ExistentialType for AnyObject for now.
-  if (result->isConstraintType() && !result->isAnyObject() &&
-      getASTContext().LangOpts.EnableExplicitExistentialTypes &&
+  if (result->isConstraintType() &&
       options.isConstraintImplicitExistential()) {
     return ExistentialType::get(result);
   }
@@ -3840,10 +3838,8 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
   auto composition =
       ProtocolCompositionType::get(getASTContext(), Members,
                                    /*HasExplicitAnyObject=*/false);
-  if (getASTContext().LangOpts.EnableExplicitExistentialTypes &&
-      options.isConstraintImplicitExistential() &&
-      !composition->isAny()) {
-    composition = ExistentialType::get(composition);
+  if (options.isConstraintImplicitExistential()) {
+    return ExistentialType::get(composition);
   }
   return composition;
 }
@@ -3871,7 +3867,6 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
     diagnose(repr->getLoc(), diag::unnecessary_any,
              constraintType)
       .fixItRemove({anyStart, anyEnd});
-    return constraintType;
   }
 
   return ExistentialType::get(constraintType);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6117,6 +6117,7 @@ Expected<Type> TypeDeserializer::getTypeCheckedImpl() {
   CASE(SequenceArchetype)
   CASE(GenericTypeParam)
   CASE(ProtocolComposition)
+  CASE(Existential)
   CASE(DependentMember)
   CASE(BoundGeneric)
   CASE(SILBlockStorage)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 655; // dealloc_stack_ref
+const uint16_t SWIFTMODULE_VERSION_MINOR = 656; // enable explicit existentials
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -30,8 +30,10 @@
 using namespace swift;
 using namespace reflection;
 
-TypeRefBuilder::BuiltType TypeRefBuilder::decodeMangledType(Node *node) {
-  return swift::Demangle::decodeMangledType(*this, node).getType();
+TypeRefBuilder::BuiltType
+TypeRefBuilder::decodeMangledType(Node *node, bool forRequirement) {
+  return swift::Demangle::decodeMangledType(*this, node, forRequirement)
+      .getType();
 }
 
 RemoteRef<char> TypeRefBuilder::readTypeRef(uint64_t remoteAddr) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1314,8 +1314,10 @@ public:
   using BuiltTypeDecl = const ContextDescriptor *;
   using BuiltProtocolDecl = ProtocolDescriptorRef;
 
-  BuiltType decodeMangledType(NodePointer node) {
-    return Demangle::decodeMangledType(*this, node).getType();
+  BuiltType decodeMangledType(NodePointer node,
+                              bool forRequirement = true) {
+    return Demangle::decodeMangledType(*this, node, forRequirement)
+        .getType();
   }
 
   Demangle::NodeFactory &getNodeFactory() { return demangler; }
@@ -1483,7 +1485,8 @@ public:
 
   TypeLookupErrorOr<BuiltType>
   createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
-                                BuiltType superclass, bool isClassBound) const {
+                                BuiltType superclass, bool isClassBound,
+                                bool forRequirement = true) const {
     // Determine whether we have a class bound.
     ProtocolClassConstraint classConstraint = ProtocolClassConstraint::Any;
     if (isClassBound || superclass) {

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 4 -I %S/Inputs/custom-modules %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -enable-explicit-existential-types -verify -swift-version 4 -I %S/Inputs/custom-modules %s
 
 // REQUIRES: objc_interop
 

--- a/test/Constraints/common_type_objc.swift
+++ b/test/Constraints/common_type_objc.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s -debug-constraints 2>%t.err
 // RUN: %FileCheck %s < %t.err
 
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -enable-explicit-existential-types %s -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/Constraints/openExistential.swift
+++ b/test/Constraints/openExistential.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-explicit-existential-types
 
 protocol P { }
 

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-explicit-existential-types
 
 protocol Fooable { func foo() }
 protocol Barable { func bar() }

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -34,7 +34,7 @@ func min<T : MethodLessComparable>(_ x: T, y: T) -> T {
 //===----------------------------------------------------------------------===//
 
 func existential<T : EqualComparable, U : EqualComparable>(_ t1: T, t2: T, u: U) {
-  var eqComp : EqualComparable = t1 // Ok
+  var eqComp : EqualComparable = t1 // expected-warning {{protocol 'EqualComparable' as a type must be explicitly marked as 'any'}}
   eqComp = u
   if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'EqualComparable' to expected argument type 'T'}}
   if eqComp.isEqual(t2) {} // expected-error{{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; use a generic constraint instead}}
@@ -49,11 +49,11 @@ func otherExistential<T : EqualComparable>(_ t1: T) {
   otherEqComp = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
   _ = otherEqComp
   
-  var otherEqComp2 : OtherEqualComparable // Ok
+  var otherEqComp2 : any OtherEqualComparable // Ok
   otherEqComp2 = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
   _ = otherEqComp2
 
-  _ = t1 as EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'EqualComparable & OtherEqualComparable' in coercion}}
+  _ = t1 as any EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'EqualComparable & OtherEqualComparable' in coercion}}
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/SILGen/protocol_with_superclass.swift
+++ b/test/SILGen/protocol_with_superclass.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
+// RUN: %target-swift-emit-silgen -enable-explicit-existential-types %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-explicit-existential-types %s
+
 // Protocols with superclass-constrained Self.
 
 class Concrete {

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -2,6 +2,9 @@
 // RUN: %target-swift-emit-silgen -module-name subclass_existentials -Xllvm -sil-full-demangle -parse-as-library -primary-file %s -verify | %FileCheck %s
 // RUN: %target-swift-emit-ir -module-name subclass_existentials -parse-as-library -primary-file %s
 
+// RUN: %target-swift-emit-silgen -module-name subclass_existentials -Xllvm -sil-full-demangle -parse-as-library -enable-explicit-existential-types -primary-file %s -verify | %FileCheck %s
+// RUN: %target-swift-emit-ir -module-name subclass_existentials -parse-as-library -enable-explicit-existential-types -primary-file %s
+
 // Note: we pass -verify above to ensure there are no spurious
 // compiler warnings relating to casts.
 

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -parse-stdlib
+// RUN: %target-typecheck-verify-swift -parse-stdlib -enable-explicit-existential-types
 
 import Swift
 

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -31,7 +31,7 @@ protocol OuterProtocol {
 struct ConformsToOuterProtocol : OuterProtocol {
   typealias Hen = Int
 
-  func f() { let _ = InnerProtocol.self } // Ok
+  func f() { let _ = InnerProtocol.self } // expected-warning {{protocol 'InnerProtocol' as a type must be explicitly marked as 'any'}}
 }
 
 protocol Racoon {

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -167,13 +167,13 @@ class B : A {
 }
 
 func testB(_ b: B) {
-  var _: P1 = b
-  var _: P4 = b
+  var _: P1 = b // expected-warning {{protocol 'P1' as a type must be explicitly marked as 'any'}}
+  var _: P4 = b // expected-warning {{protocol 'P4' as a type must be explicitly marked as 'any'}}
   var _: P5 = b
   var _: P6 = b
-  var _: P7 = b
+  var _: P7 = b // expected-warning {{protocol 'P7' as a type must be explicitly marked as 'any'}}
   var _: P8 = b
-  var _: P9 = b
+  var _: P9 = b // expected-warning {{protocol 'P9' as a type must be explicitly marked as 'any'}}
 }
 
 // Class A5 conforms to P5 in an inheritable manner.

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -119,7 +119,7 @@ struct Circle {
 func testCircular(_ circle: Circle) {
   // FIXME: It would be nice if this failure were suppressed because the protocols
   // have circular definitions.
-  _ = circle as CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
+  _ = circle as any CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
 }
 
 // <rdar://problem/14750346>
@@ -439,17 +439,17 @@ func g<T : C2>(_ x : T) {
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}
 func h<T : C3>(_ x : T) {
-  _ = x as P1
+  _ = x as any P1
 }
 func i<T : C3>(_ x : T?) -> Bool {
-  return x is P1
+  return x is any P1
   // expected-warning@-1 {{checking a value with optional type 'T?' against type 'P1' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
 }
 func j(_ x : C1) -> Bool {
-  return x is P1
+  return x is P1 // expected-warning {{protocol 'P1' as a type must be explicitly marked as 'any'}}
 }
 func k(_ x : C1?) -> Bool {
-  return x is P1
+  return x is any P1
 }
 
 

--- a/test/decl/protocol/protocols_with_self_or_assoc_reqs.swift
+++ b/test/decl/protocol/protocols_with_self_or_assoc_reqs.swift
@@ -57,7 +57,7 @@ protocol P1 {
   func invariantSelf7(_: (G<Self>) -> Void)
   func invariantSelf8(_: G<(Self) -> Void>)
   func invariantSelf9(_: G<() -> Self>)
-  func invariantSelf10(_: P1 & C<Self>)
+  func invariantSelf10(_: any P1 & C<Self>)
   func invariantSelf11() -> G<Self>.InnerG<Void>
   func invariantAssoc1(_: inout Q)
   func invariantAssoc2(_: (inout Q) -> Void)
@@ -68,7 +68,7 @@ protocol P1 {
   func invariantAssoc7(_: (G<Q>) -> Void)
   func invariantAssoc8(_: G<(Q) -> Void>)
   func invariantAssoc9(_: G<() -> Q>)
-  func invariantAssoc10(_: P1 & C<Q>)
+  func invariantAssoc10(_: any P1 & C<Q>)
   func invariantAssoc11() -> G<Q>.InnerG<Void>
 
   // Properties
@@ -117,7 +117,7 @@ protocol P1 {
   var invariantSelfProp7: ((G<Self>) -> Void) -> Void { get }
   var invariantSelfProp8: (G<(Self) -> Void>) -> Void { get }
   var invariantSelfProp9: (G<() -> Self>) -> Void { get }
-  var invariantSelfProp10: (P1 & C<Self>) -> Void { get }
+  var invariantSelfProp10: (any P1 & C<Self>) -> Void { get }
   var invariantSelfProp11: G<Self>.InnerG<Void> { get }
   var invariantAssocProp1: (inout Q) -> Void { get }
   var invariantAssocProp2: ((inout Q) -> Void) -> Void { get }
@@ -128,7 +128,7 @@ protocol P1 {
   var invariantAssocProp7: ((G<Q>) -> Void) { get }
   var invariantAssocProp8: (G<(Q) -> Void>) { get }
   var invariantAssocProp9: (G<() -> Q>) -> Void { get }
-  var invariantAssocProp10: (P1 & C<Q>) -> Void { get }
+  var invariantAssocProp10: (any P1 & C<Q>) -> Void { get }
   var invariantAssocProp11: G<Q>.InnerG<Void> { get }
 
   // Subscripts
@@ -172,7 +172,7 @@ protocol P1 {
   subscript(invariantSelfSubscript4 _: (G<Self>) -> Void) -> Void { get }
   subscript(invariantSelfSubscript5 _: G<(Self) -> Void>) -> Void { get }
   subscript(invariantSelfSubscript6 _: G<() -> Self>) -> Void { get }
-  subscript(invariantSelfSubscript7 _: P1 & C<Self>) -> Void { get }
+  subscript(invariantSelfSubscript7 _: any P1 & C<Self>) -> Void { get }
   subscript(invariantSelfSubscript8 _: Void) -> G<Self>.InnerG<Void> { get }
   subscript(invariantAssocSubscript1 _: G<Q>) -> Void { get }
   subscript(invariantAssocSubscript2 _: Void) -> G<Q> { get }
@@ -180,7 +180,7 @@ protocol P1 {
   subscript(invariantAssocSubscript4 _: (G<Q>) -> Void) -> Void { get }
   subscript(invariantAssocSubscript5 _: G<(Q) -> Void>) -> Void { get }
   subscript(invariantAssocSubscript6 _: G<() -> Q>) -> Void { get }
-  subscript(invariantAssocSubscript7 _: P1 & C<Q>) -> Void { get }
+  subscript(invariantAssocSubscript7 _: any P1 & C<Q>) -> Void { get }
   subscript(invariantAssocSubscript8 _: Void) -> G<Q>.InnerG<Void> { get }
 }
 @available(macOS 10.15, *)
@@ -191,40 +191,40 @@ extension P1 {
 }
 
 do {
-  func testP1(arg: P1) {
+  func testP1(arg: any P1) {
     _ = arg.covariantSelfSimple() // ok
-    let _: P1 = arg.covariantSelfSimple() // ok
+    let _: any P1 = arg.covariantSelfSimple() // ok
     _ = arg.covariantSelfComplex({ _ in },  { _ in }, { _ in }, { _ in }) // ok
-    let _: [String : () -> (P1, P1)] = arg.covariantSelfComplex(
-      { (x: P1) in },
-      { (x: P1?) in },
-      { (x: Array<P1>) in },
-      { (x: Array<Array<P1>?>) in }
+    let _: [String : () -> (any P1, any P1)] = arg.covariantSelfComplex(
+      { (x: any P1) in },
+      { (x: (any P1)?) in },
+      { (x: Array<any P1>) in },
+      { (x: Array<Array<any P1>?>) in }
     ) // ok
     arg.covariantAssocSimple // expected-error {{member 'covariantAssocSimple' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     arg.covariantAssocComplex({ _ in }, { _ in }, { _ in }, { _ in }) // expected-error {{member 'covariantAssocComplex' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     // FIXME: expected-error@-1 {{unable to infer type of a closure parameter '_' in the current context}}
 
     _ = arg.covariantSelfPropSimple // ok
-    let _: P1 = arg.covariantSelfPropSimple // ok
+    let _: any P1 = arg.covariantSelfPropSimple // ok
     _ = arg.covariantSelfPropComplex // ok
     let _: (
-      _: (P1) -> Void,
-      _: (P1?) -> Void,
-      _: (Array<P1>) -> Void,
-      _: (Array<Array<P1>?>) -> Void
-    ) -> [String : () -> (P1, P1)] = arg.covariantSelfPropComplex // ok
+      _: (any P1) -> Void,
+      _: ((any P1)?) -> Void,
+      _: (Array<any P1>) -> Void,
+      _: (Array<Array<any P1>?>) -> Void
+    ) -> [String : () -> (any P1, any P1)] = arg.covariantSelfPropComplex // ok
     arg.covariantAssocPropSimple // expected-error {{member 'covariantAssocPropSimple' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     arg.covariantAssocPropComplex // expected-error {{member 'covariantAssocPropComplex' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
 
     _ = arg[covariantSelfSubscriptSimple: ()] // ok
-    let _: P1 = arg[covariantSelfSubscriptSimple: ()] // ok
+    let _: any P1 = arg[covariantSelfSubscriptSimple: ()] // ok
     _ = arg[covariantSelfSubscriptComplex: { _ in },  { _ in }, { _ in }, { _ in }] // ok
-    let _: [String : () -> (P1, P1)] = arg[
-      covariantSelfSubscriptComplex: { (x: P1) in },
-      { (x: P1?) in },
-      { (x: Array<P1>) in },
-      { (x: Array<Array<P1>?>) in }
+    let _: [String : () -> (any P1, any P1)] = arg[
+      covariantSelfSubscriptComplex: { (x: any P1) in },
+      { (x: (any P1)?) in },
+      { (x: Array<any P1>) in },
+      { (x: Array<Array<any P1>?>) in }
     ] // ok
     arg[covariantAssocSubscriptSimple: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     arg[covariantAssocSubscriptComplex: { _ in }, { _ in }, { _ in }, { _ in }] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
@@ -444,15 +444,15 @@ protocol P1_TypeMemberOnInstanceAndViceVersa {
 do {
   // Test that invalid reference errors prevail over unsupported existential
   // member accesses.
-  func test(protoMeta: P1_TypeMemberOnInstanceAndViceVersa.Protocol,
-            existMeta: P1_TypeMemberOnInstanceAndViceVersa.Type,
-            instance: P1_TypeMemberOnInstanceAndViceVersa) {
+  func test(protoMeta: (any P1_TypeMemberOnInstanceAndViceVersa).Type,
+            existMeta: any P1_TypeMemberOnInstanceAndViceVersa.Type,
+            instance: any P1_TypeMemberOnInstanceAndViceVersa) {
     // P1_TypeMemberOnInstanceAndViceVersa.Protocol
-    protoMeta.static_invariantSelfMethod() // expected-error {{static member 'static_invariantSelfMethod' cannot be used on protocol metatype 'P1_TypeMemberOnInstanceAndViceVersa.Protocol'}}
-    protoMeta.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on protocol metatype 'P1_TypeMemberOnInstanceAndViceVersa.Protocol'}}
-    protoMeta[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P1_TypeMemberOnInstanceAndViceVersa.Protocol'}}
+    protoMeta.static_invariantSelfMethod() // expected-error {{static member 'static_invariantSelfMethod' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
+    protoMeta.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
+    protoMeta[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
     _ = protoMeta.covariantSelfMethod // ok
-    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Protocol'; use a generic constraint instead}}
+    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of protocol type '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'; use a generic constraint instead}}
     protoMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     protoMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
 
@@ -481,7 +481,7 @@ protocol P2 {
 
   var prop: Self { get set }
 }
-func takesP2(p2: P2) {
+func takesP2(p2: any P2) {
   _ = p2[]
   // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P2'; use a generic constraint instead}}
   _ = p2.prop
@@ -500,7 +500,7 @@ protocol MiscTestsProto {
   subscript(intToInt _: Int) -> Int { get }
 }
 do {
-  func miscTests(_ arg: MiscTestsProto) { // ok
+  func miscTests(_ arg: any MiscTestsProto) { // ok
     arg.runce(5)
 
     do {
@@ -515,7 +515,7 @@ do {
     _ = arg[intToAssoc: 17] // expected-error{{member 'subscript' cannot be used on value of protocol type 'MiscTestsProto'; use a generic constraint instead}}
   }
 
-  func existentialSequence(_ e: Sequence) {
+  func existentialSequence(_ e: any Sequence) {
     var x = e.makeIterator() // expected-error{{member 'makeIterator' cannot be used on value of protocol type 'Sequence'; use a generic constraint instead}}
     x.next()
     x.nonexistent()

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -91,7 +91,7 @@ protocol AsExistentialB {
 }
 
 protocol AsExistentialAssocTypeA {
-  var delegate : AsExistentialAssocTypeB? { get }
+  var delegate : AsExistentialAssocTypeB? { get } // expected-warning {{protocol 'AsExistentialAssocTypeB' as a type must be explicitly marked as 'any'}}
 }
 protocol AsExistentialAssocTypeB {
   func aMethod(_ object : AsExistentialAssocTypeA)
@@ -103,7 +103,7 @@ protocol AsExistentialAssocTypeAgainA {
   associatedtype Bar
 }
 protocol AsExistentialAssocTypeAgainB {
-  func aMethod(_ object : AsExistentialAssocTypeAgainA)
+  func aMethod(_ object : AsExistentialAssocTypeAgainA) // expected-warning {{protocol 'AsExistentialAssocTypeAgainA' as a type must be explicitly marked as 'any'}}
 }
 
 // SR-547

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -176,7 +176,7 @@ func testOptionalSequence() {
 }
 
 // FIXME: Should this be allowed?
-func testExistentialSequence(s: Sequence) {
+func testExistentialSequence(s: any Sequence) {
   for x in s { // expected-error {{protocol 'Sequence' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
     _ = x
   }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -162,3 +162,5 @@ func testMetatypes() {
   let _: any P1.Type = ConcreteComposition.self
   let _: any (P1 & P2).Type = ConcreteComposition.self
 }
+
+func generic<T: any P1>(_ t: T) {} // expected-error {{type 'T' constrained to non-protocol, non-class type 'any P1'}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -164,3 +164,24 @@ func testMetatypes() {
 }
 
 func generic<T: any P1>(_ t: T) {} // expected-error {{type 'T' constrained to non-protocol, non-class type 'any P1'}}
+
+protocol RawRepresentable {
+  associatedtype RawValue
+  var rawValue: RawValue { get }
+}
+
+enum E1: RawRepresentable {
+  typealias RawValue = P1
+
+  var rawValue: P1 {
+    return ConcreteComposition()
+  }
+}
+
+enum E2: RawRepresentable {
+  typealias RawValue = any P1
+
+  var rawValue: any P1 {
+    return ConcreteComposition()
+  }
+}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -193,3 +193,12 @@ extension MyError {
     return true
   }
 }
+
+struct Wrapper {
+  typealias E = Error
+}
+
+func typealiasMemberReferences(metatype: Wrapper.Type) {
+  let _: Wrapper.E.Protocol = metatype.E.self
+  let _: (any Wrapper.E).Type = metatype.E.self
+}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -149,9 +149,9 @@ func testInvalidAny() {
   let _: any ((S) -> Void) = generic // expected-error{{'any' has no effect on concrete type '(S) -> Void'}}
 }
 
-func testRedundantAnyWarning() {
-  let _: any Any // expected-warning {{'any' is redundant on type 'Any'}}
-  let _: any AnyObject // expected-warning {{'any' is redundant on type 'AnyObject'}}
+func anyAny() {
+  let _: any Any
+  let _: any AnyObject
 }
 
 protocol P1 {}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -185,3 +185,11 @@ enum E2: RawRepresentable {
     return ConcreteComposition()
   }
 }
+
+public protocol MyError {}
+
+extension MyError {
+  static func ~=(lhs: any Error, rhs: Self) -> Bool {
+    return true
+  }
+}

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -3,7 +3,7 @@
 protocol HasSelfRequirements {
   func foo(_ x: Self)
 
-  func returnsOwnProtocol() -> HasSelfRequirements
+  func returnsOwnProtocol() -> HasSelfRequirements // expected-warning {{protocol 'HasSelfRequirements' as a type must be explicitly marked as 'any'}}
 }
 protocol Bar {
   // init() methods should not prevent use as an existential.
@@ -36,10 +36,10 @@ func useCompoAsWhereRequirement<T>(_ x: T) where T: HasSelfRequirements & Bar {}
 func useCompoAliasAsWhereRequirement<T>(_ x: T) where T: Compo {}
 func useNestedCompoAliasAsWhereRequirement<T>(_ x: T) where T: CompoAssocType.Compo {}
 
-func useAsType(_: HasSelfRequirements,
-               _: HasSelfRequirements & Bar,
-               _: Compo,
-               _: CompoAssocType.Compo) { }
+func useAsType(_: any HasSelfRequirements,
+               _: any HasSelfRequirements & Bar,
+               _: any Compo,
+               _: any CompoAssocType.Compo) { }
 
 struct TypeRequirement<T: HasSelfRequirements> {}
 struct CompoTypeRequirement<T: HasSelfRequirements & Bar> {}
@@ -74,7 +74,7 @@ do {
 
   func checkIt(_ js: Any) throws {
     switch js {
-    case let dbl as HasAssoc:
+    case let dbl as HasAssoc: // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
       throw MyError.bad(dbl)
 
     default:
@@ -83,8 +83,8 @@ do {
   }
 }
 
-func testHasAssoc(_ x: Any, _: HasAssoc) {
-  if let p = x as? HasAssoc {
+func testHasAssoc(_ x: Any, _: HasAssoc) { // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
+  if let p = x as? any HasAssoc {
     p.foo() // don't crash here.
   }
 
@@ -92,18 +92,18 @@ func testHasAssoc(_ x: Any, _: HasAssoc) {
     typealias Assoc = Int
     func foo() {}
 
-    func method() -> HasAssoc {}
+    func method() -> HasAssoc {} // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
   }
 }
 
 // SR-38
-var b: HasAssoc
+var b: HasAssoc // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
 
 // Further generic constraint error testing - typealias used inside statements
 protocol P {}
 typealias MoreHasAssoc = HasAssoc & P
 func testHasMoreAssoc(_ x: Any) {
-  if let p = x as? MoreHasAssoc {
+  if let p = x as? any MoreHasAssoc {
     p.foo() // don't crash here.
   }
 }
@@ -118,34 +118,34 @@ typealias X = Struct1<Pub & Bar>
 _ = Struct1<Pub & Bar>.self
 
 typealias AliasWhere<T> = T
-where T : HasAssoc, T.Assoc == HasAssoc
+where T : HasAssoc, T.Assoc == HasAssoc // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
 
 struct StructWhere<T>
 where T : HasAssoc,
-      T.Assoc == HasAssoc {}
+      T.Assoc == any HasAssoc {}
 
-protocol ProtocolWhere where T == HasAssoc {
+protocol ProtocolWhere where T == HasAssoc { // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
   associatedtype T
 
   associatedtype U : HasAssoc
-    where U.Assoc == HasAssoc
+    where U.Assoc == any HasAssoc
 }
 
-extension HasAssoc where Assoc == HasAssoc {}
+extension HasAssoc where Assoc == HasAssoc {} // expected-warning {{protocol 'HasAssoc' as a type must be explicitly marked as 'any'}}
 
 func FunctionWhere<T>(_: T)
 where T : HasAssoc,
-      T.Assoc == HasAssoc {}
+      T.Assoc == any HasAssoc {}
 
 struct SubscriptWhere {
   subscript<T>(_: T) -> Int
   where T : HasAssoc,
-        T.Assoc == HasAssoc {
+        T.Assoc == any HasAssoc {
     get {}
     set {}
   }
 }
 
 struct OuterGeneric<T> {
-  func contextuallyGenericMethod() where T == HasAssoc {}
+  func contextuallyGenericMethod() where T == any HasAssoc {}
 }


### PR DESCRIPTION
This change enables explicit existential types by default, which changes the representation of existential types to use `ExistentialType`, and allows the `any` keyword in the source language.

Note that many of the conditional `getAs<ExistentialType>()` variable bindings are temporary. After explicit existential types are enabled, existential types will always resolve to `ExistentialType` (regardless of whether or not they're spelled with `any`), and the `isExistentialType()` checks can be changed to `is<ExistentialType>()`. I'm holding off on making that change for now to allow explicit existential types to be turned off if needed.

Resolves: rdar://86347236