### PR TITLE
[runtime] Fixed typo.

### DIFF
--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -81,7 +81,7 @@ void swift::initializeAccessibleFunctionsLookup() {
                              MachOAccessibleFunctionsSection);
   if (start == nullptr || size == 0)
     return;
-  addImageAccessibleFunctionBlockCallbackUnsafe(start, size);
+  addImageAccessibleFunctionsBlockCallbackUnsafe(start, size);
 }
 
 #endif // defined(__MACH__) && defined(SWIFT_RUNTIME_STATIC_IMAGE_INSPECTION)


### PR DESCRIPTION
There was a call to addImageAccessibleFunctionBlockCallbackUnsafe but no function with that name.  Change the called function to addImageAccessibleFunctionsBlockCallbackUnsafe.
