### PR TITLE
Fix miss-parse diagnostic to say "actor"

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -366,6 +366,12 @@ ERROR(expected_rbrace_class,none,
 ERROR(expected_colon_class, PointsToFirstBadToken,
       "expected ':' to begin inheritance clause",())
 
+// Actor
+ERROR(expected_lbrace_actor,PointsToFirstBadToken,
+      "expected '{' in actor", ())
+ERROR(expected_rbrace_actor,none,
+      "expected '}' in actor", ())
+
 // Protocol
 ERROR(generic_arguments_protocol,PointsToFirstBadToken,
       "protocols do not allow generic parameters; use associated types instead",

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7757,8 +7757,10 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   {
     // Parse the body.
     if (parseMemberDeclList(LBLoc, RBLoc,
-                            diag::expected_lbrace_class,
-                            diag::expected_rbrace_class,
+                            isExplicitActorDecl ? diag::expected_lbrace_actor
+                                                : diag::expected_lbrace_class,
+                            isExplicitActorDecl ? diag::expected_rbrace_actor
+                                                : diag::expected_rbrace_class,
                             CD))
       Status.setIsParseError();
   }

--- a/test/Parse/actor.swift
+++ b/test/Parse/actor.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+// REQUIRES: concurrency
+
+
+
+actor MyActor1 // expected-error {{expected '{' in actor}}
+
+actor MyActor2 { // expected-note@:16 {{to match this opening '{'}}
+    init() {
+    }
+func hello() { } // expected-error@+1 {{expected '}' in actor}}


### PR DESCRIPTION
Diagnostic for miss-parsing actors for missing '{' and '}' would say
"class" instead of "actor". This patch fixes it.

rdar://76615460