### PR TITLE
[5.6 CMake] Move most Standard Library options in a separate file

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -1,3 +1,10 @@
+# In some configurations (e.g. back deploy concurrency) we
+# configure the build from the root of the Swift repo but we skip
+# stdlib/CMakeLists.txt, with the risk of missing important parameters.
+# To account for this scenario, we include the stdlib options
+# before the guard
+include(${CMAKE_CURRENT_LIST_DIR}/../../stdlib/cmake/modules/StdlibOptions.cmake)
+
 # CMAKE_SOURCE_DIR is the directory that cmake got initially invoked on.
 # CMAKE_CURRENT_SOURCE_DIR is the current directory. If these are equal, it's
 # a top-level build of the CMAKE_SOURCE_DIR. Otherwise, define a guard variable
@@ -84,10 +91,6 @@ set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
   "Semicolon-separated list of architectures to configure Swift module-only \
 targets on Darwin platforms. These targets are in addition to the full \
 library targets.")
-
-option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
-       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
-       TRUE)
 
 # -----------------------------------------------------------------------------
 # Constants

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -72,14 +72,14 @@ endif()
 # User-configurable options for the standard library.
 #
 
+# New options should be added to stdlib/cmake/modules/StdlibOptions.cmake,
+# so that they are considered in configurations using StandaloneOverlay.cmake
+
 # NOTE: Some of these variables are also initialized in StandaloneOverlay.cmake
 # so that interfaces are emitted when overlays are separately built.
 
-set(SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS "" CACHE STRING
-    "Extra flags to pass when compiling swift stdlib files")
+# TODO: migrate this section to StdlibOptions.cmake to reduce duplication
 
-set(SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS "" CACHE STRING
-    "Extra flags to pass when compiling C/C++ stdlib files")
 
 option(SWIFT_STDLIB_STABLE_ABI
        "Should stdlib be built with stable ABI (library evolution, resilience)."
@@ -89,57 +89,13 @@ option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        "${SWIFT_STDLIB_STABLE_ABI}")
 
-option(SWIFT_ENABLE_COMPATIBILITY_OVERRIDES
-       "Support back-deploying compatibility fixes for newer apps running on older runtimes."
-       TRUE)
-
-option(SWIFT_STDLIB_HAS_DLADDR
-       "Build stdlib assuming the runtime environment runtime environment provides dladdr API."
-       TRUE)
-
 option(SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING
        "Build stdlib assuming the runtime environment provides the backtrace(3) API."
        "${SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING_default}")
 
-option(SWIFT_RUNTIME_STATIC_IMAGE_INSPECTION
-       "Build stdlib assuming the runtime environment runtime environment only supports a single runtime image with Swift code."
-       FALSE)
-
-option(SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
-       "Build stdlib assuming the Darwin build of stdlib can use extended libmalloc APIs"
-       TRUE)
-
 option(SWIFT_STDLIB_HAS_ASL
        "Build stdlib assuming we can use the asl_log API."
        "${SWIFT_STDLIB_HAS_ASL_default}")
-
-option(SWIFT_STDLIB_HAS_STDIN
-       "Build stdlib assuming the platform supports stdin and getline API."
-       TRUE)
-
-option(SWIFT_STDLIB_HAS_ENVIRON
-       "Build stdlib assuming the platform supports environment variables."
-       TRUE)
-
-option(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-       "Build the standard libraries assuming that they will be used in an environment with only a single thread."
-       FALSE)
-
-option(SWIFT_STDLIB_OS_VERSIONING
-       "Build stdlib with availability based on OS versions (Darwin only)."
-       TRUE)
-
-option(SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR
-       "Build stdlib without a custom implementation of MetadataAllocator, relying on malloc+free instead."
-       FALSE)
-
-option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
-       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
-       TRUE)
-
-option(SWIFT_STDLIB_HAS_COMMANDLINE
-       "Build stdlib with the CommandLine enum and support for argv/argc."
-       TRUE)
 
 option(SWIFT_BUILD_TEST_SUPPORT_MODULES
        "Whether to build StdlibUnittest and other test support modules. Defaults to On when SWIFT_BUILD_SDK_OVERLAY is On, or when SWIFT_INCLUDE_TESTS is On."
@@ -152,18 +108,6 @@ option(SWIFT_STDLIB_ENABLE_PRESPECIALIZATION
        "Should stdlib be built with generic metadata prespecialization enabled. Defaults to On on Darwin and on Linux."
        "${SWIFT_STDLIB_ENABLE_PRESPECIALIZATION_default}")
 
-option(SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK
-       "Should stdlib be built with -experimental-hermetic-seal-at-link"
-       FALSE)
-
-set(SWIFT_STDLIB_ENABLE_LTO OFF CACHE STRING "Build Swift stdlib with LTO. One
-    must specify the form of LTO by setting this to one of: 'full', 'thin'. This
-    option only affects the standard library and runtime, not tools.")
-
-option(SWIFT_ENABLE_REFLECTION
-  "Build stdlib with support for runtime reflection and mirrors."
-  TRUE)
-
 if(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
   set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default "singlethreaded")
 else()
@@ -173,6 +117,10 @@ endif()
 set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR
     "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default}" CACHE STRING
     "Build the concurrency library to use the given global executor (options: dispatch, singlethreaded, hooked)")
+
+# New options should be added to stdlib/cmake/modules/StdlibOptions.cmake,
+# so that they are considered in configurations using StandaloneOverlay.cmake
+include(StdlibOptions)
 
 #
 # End of user-configurable options.

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -1,0 +1,63 @@
+include_guard(GLOBAL)
+
+set(SWIFT_STDLIB_EXTRA_SWIFT_COMPILE_FLAGS "" CACHE STRING
+    "Extra flags to pass when compiling swift stdlib files")
+
+set(SWIFT_STDLIB_EXTRA_C_COMPILE_FLAGS "" CACHE STRING
+    "Extra flags to pass when compiling C/C++ stdlib files")
+
+option(SWIFT_ENABLE_COMPATIBILITY_OVERRIDES
+       "Support back-deploying compatibility fixes for newer apps running on older runtimes."
+       TRUE)
+
+option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
+       "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
+       TRUE)
+
+option(SWIFT_STDLIB_HAS_DLADDR
+       "Build stdlib assuming the runtime environment runtime environment provides dladdr API."
+       TRUE)
+
+option(SWIFT_RUNTIME_STATIC_IMAGE_INSPECTION
+       "Build stdlib assuming the runtime environment runtime environment only supports a single runtime image with Swift code."
+       FALSE)
+
+option(SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
+       "Build stdlib assuming the Darwin build of stdlib can use extended libmalloc APIs"
+       TRUE)
+
+option(SWIFT_STDLIB_HAS_STDIN
+       "Build stdlib assuming the platform supports stdin and getline API."
+       TRUE)
+
+option(SWIFT_STDLIB_HAS_ENVIRON
+       "Build stdlib assuming the platform supports environment variables."
+       TRUE)
+
+option(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+       "Build the standard libraries assuming that they will be used in an environment with only a single thread."
+       FALSE)
+
+option(SWIFT_STDLIB_OS_VERSIONING
+       "Build stdlib with availability based on OS versions (Darwin only)."
+       TRUE)
+
+option(SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR
+       "Build stdlib without a custom implementation of MetadataAllocator, relying on malloc+free instead."
+       FALSE)
+
+option(SWIFT_STDLIB_HAS_COMMANDLINE
+       "Build stdlib with the CommandLine enum and support for argv/argc."
+       TRUE)
+
+option(SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK
+       "Should stdlib be built with -experimental-hermetic-seal-at-link"
+       FALSE)
+
+set(SWIFT_STDLIB_ENABLE_LTO OFF CACHE STRING "Build Swift stdlib with LTO. One
+    must specify the form of LTO by setting this to one of: 'full', 'thin'. This
+    option only affects the standard library and runtime, not tools.")
+
+option(SWIFT_ENABLE_REFLECTION
+  "Build stdlib with support for runtime reflection and mirrors."
+  TRUE)


### PR DESCRIPTION
This allows the file to be easily included where needed (e.g.
`StandaloneOverlay.cmake`) and reduce the likelihood of miscompilation
due to missing sensible defaults.

Focus on parameters only in stdlib/CMakeLists.txt whose defaults are not
computed.

This matches #40610 + #40640

Addresses rdar://86740965