### PR TITLE
test: enable SILOptimizer.definite-init-wrongscope

### DIFF
--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -3,9 +3,6 @@
 // RUN:   -sil-print-functions=$s3del1MC4fromAcA12WithDelegate_p_tKcfc \
 // RUN:   -Xllvm -sil-print-debuginfo -o /dev/null -module-name del 2>&1 | %FileCheck %s
 
-// Unsupported on Windows due to SR-14267
-// UNSUPPORTED: OS=windows-msvc
-
 public protocol DelegateA {}
 public protocol DelegateB {}
 public protocol WithDelegate
@@ -33,14 +30,18 @@ public class M {
 
 // CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:23:12, scope 5
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:23:12, scope 5
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:26:20, scope 5
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 5
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 5
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 5
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:29:5, scope 5
-// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 5
-// CHECK:   throw %{{.*}} : $Error, loc {{.*}}:23:12, scope 1
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 5
+// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
+
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 5
+// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
+// CHECK-NEXT:   throw %{{.*}} : $Error, loc {{.*}}:26:5, scope 5
+// CHECK: end sil function '$s3del1MC4fromAcA12WithDelegate_p_tKcfc'


### PR DESCRIPTION
This was matching the wrong `throw` as the scope was incorrect.  Correct
the scope which allows us to match the correct `throw` and enable the
test on Windows.

While here, add an additional check for the `destroy_addr`,
`dealloc_stack` to match the regular exit which is duplicated in the
throwing block.  Add an additional check to ensure that we do not escape
the bounds of the function.

Thanks to @adrian-prantl for helping ensure that the changes here are
valid!

Fixes: SR-14267

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
