### PR TITLE
Support `@_predatesConcurrency` on import declarations

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -690,7 +690,7 @@ SIMPLE_DECL_ATTR(_noAllocation, NoAllocation,
 
 SIMPLE_DECL_ATTR(_predatesConcurrency, PredatesConcurrency,
   OnFunc | OnConstructor | OnProtocol | OnGenericType | OnVar | OnSubscript |
-  OnEnumElement | UserInaccessible |
+  OnEnumElement | OnImport | UserInaccessible |
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   125)
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1956,6 +1956,8 @@ REMARK(add_predates_concurrency_import,none,
      "add '@_predatesConcurrency' to %select{suppress|treat}0 "
      "'Sendable'-related %select{warnings|errors}0 from module %1"
      "%select{| as warnings}0", (bool, Identifier))
+REMARK(remove_predates_concurrency_import,none,
+     "'@_predatesConcurrency' attribute on module %0 is unused", (Identifier))
 WARNING(public_decl_needs_sendable,none,
         "public %0 %1 does not specify whether it is 'Sendable' or not",
         (DescriptiveDeclKind, DeclName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1952,7 +1952,7 @@ NOTE(non_sendable_nominal,none,
 NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
-NOTE(add_predates_concurrency_import,none,
+REMARK(add_predates_concurrency_import,none,
      "add '@_predatesConcurrency' to %select{suppress|treat}0 "
      "'Sendable'-related %select{warnings|errors}0 from module %1"
      "%select{| as warnings}0", (bool, Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1952,6 +1952,10 @@ NOTE(non_sendable_nominal,none,
 NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
+NOTE(add_predates_concurrency_import,none,
+     "add '@_predatesConcurrency' to %select{suppress|treat}0 "
+     "'Sendable'-related %select{warnings|errors}0 from module %1"
+     "%select{| as warnings}0", (bool, Identifier))
 WARNING(public_decl_needs_sendable,none,
         "public %0 %1 does not specify whether it is 'Sendable' or not",
         (DescriptiveDeclKind, DeclName))

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -80,6 +80,10 @@ enum class ImportFlags {
   /// implementation detail of this file.
   SPIAccessControl = 0x10,
 
+  /// The module is imported assuming that the module itself predates
+  /// concurrency.
+  PredatesConcurrency = 0x20,
+
   /// Used for DenseMap.
   Reserved = 0x80
 };
@@ -542,6 +546,10 @@ struct AttributedImport {
 
   /// Names of explicitly imported SPI groups.
   ArrayRef<Identifier> spiGroups;
+
+  /// When the import declaration has a `@_predatesConcurrency` annotation, this
+  /// is the source range covering the annotation.
+  SourceRange predatesConcurrencyRange;
 
   AttributedImport(ModuleInfo module, ImportOptions options = ImportOptions(),
                    StringRef filename = {}, ArrayRef<Identifier> spiGroups = {})

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -739,15 +739,12 @@ struct DenseMapInfo<swift::AttributedImport<ModuleInfo>> {
     return detail::combineHashValue(
         ModuleInfoDMI::getHashValue(import.module),
         detail::combineHashValue(
-            SourceLocDMI::getHashValue(import.importLoc),
-            detail::combineHashValue(
-              ImportOptionsDMI::getHashValue(import.options),
-              StringRefDMI::getHashValue(import.sourceFileArg))));
+          ImportOptionsDMI::getHashValue(import.options),
+          StringRefDMI::getHashValue(import.sourceFileArg)));
   }
   static bool isEqual(const AttributedImport &a,
                       const AttributedImport &b) {
     return ModuleInfoDMI::isEqual(a.module, b.module) &&
-           SourceLocDMI::isEqual(a.importLoc, b.importLoc),
            ImportOptionsDMI::isEqual(a.options, b.options) &&
            StringRefDMI::isEqual(a.sourceFileArg, b.sourceFileArg) &&
            a.spiGroups == b.spiGroups;

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -556,9 +556,11 @@ struct AttributedImport {
 
   AttributedImport(ModuleInfo module, SourceLoc importLoc = SourceLoc(),
                    ImportOptions options = ImportOptions(),
-                   StringRef filename = {}, ArrayRef<Identifier> spiGroups = {})
+                   StringRef filename = {}, ArrayRef<Identifier> spiGroups = {},
+                   SourceRange predatesConcurrencyRange = {})
       : module(module), importLoc(importLoc), options(options),
-        sourceFileArg(filename), spiGroups(spiGroups) {
+        sourceFileArg(filename), spiGroups(spiGroups),
+        predatesConcurrencyRange(predatesConcurrencyRange) {
     assert(!(options.contains(ImportFlags::Exported) &&
              options.contains(ImportFlags::ImplementationOnly)) ||
            options.contains(ImportFlags::Reserved));
@@ -567,7 +569,8 @@ struct AttributedImport {
   template<class OtherModuleInfo>
   AttributedImport(ModuleInfo module, AttributedImport<OtherModuleInfo> other)
     : AttributedImport(module, other.importLoc, other.options,
-                       other.sourceFileArg, other.spiGroups) { }
+                       other.sourceFileArg, other.spiGroups,
+                       other.predatesConcurrencyRange) { }
 
   friend bool operator==(const AttributedImport<ModuleInfo> &lhs,
                          const AttributedImport<ModuleInfo> &rhs) {

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -84,6 +84,10 @@ private:
   /// This is \c None until it is filled in by the import resolution phase.
   Optional<ArrayRef<AttributedImport<ImportedModule>>> Imports;
 
+  /// Which imports have made use of @_predatesConcurrency.
+  llvm::SmallDenseSet<AttributedImport<ImportedModule>>
+      PredatesConcurrencyImportsUsed;
+
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
   /// same module.
@@ -292,6 +296,14 @@ public:
   /// Set the imports for this source file. This gets called by import
   /// resolution.
   void setImports(ArrayRef<AttributedImport<ImportedModule>> imports);
+
+  /// Whether the given import has used @_predatesConcurrency.
+  bool hasImportUsedPredatesConcurrency(
+      AttributedImport<ImportedModule> import) const;
+
+  /// Note that the given import has used @_predatesConcurrency/
+  void setImportUsedPredatesConcurrency(
+      AttributedImport<ImportedModule> import);
 
   enum ImportQueryKind {
     /// Return the results for testable or private imports.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2240,6 +2240,16 @@ SourceFile::setImports(ArrayRef<AttributedImport<ImportedModule>> imports) {
   Imports = getASTContext().AllocateCopy(imports);
 }
 
+bool SourceFile::hasImportUsedPredatesConcurrency(
+    AttributedImport<ImportedModule> import) const {
+  return PredatesConcurrencyImportsUsed.count(import) != 0;
+}
+
+void SourceFile::setImportUsedPredatesConcurrency(
+    AttributedImport<ImportedModule> import) {
+  PredatesConcurrencyImportsUsed.insert(import);
+}
+
 bool HasImplementationOnlyImportsRequest::evaluate(Evaluator &evaluator,
                                                    SourceFile *SF) const {
   return llvm::any_of(SF->getImports(),

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -844,7 +844,8 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
     ImportPath::Builder importPath(Context->getIdentifier(moduleStr));
     UnloadedImportedModule import(importPath.copyTo(*Context),
                                   /*isScoped=*/false);
-    imports.AdditionalUnloadedImports.emplace_back(import, options);
+    imports.AdditionalUnloadedImports.emplace_back(
+        import, SourceLoc(), options);
   };
 
   for (auto &moduleStrAndTestable : frontendOpts.getImplicitImportModuleNames()) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -548,6 +548,11 @@ UnboundImport::UnboundImport(ImportDecl *ID)
     spiGroups.append(attrSPIs.begin(), attrSPIs.end());
   }
   import.spiGroups = ID->getASTContext().AllocateCopy(spiGroups);
+
+  if (auto attr = ID->getAttrs().getAttribute<PredatesConcurrencyAttr>()) {
+    import.options |= ImportFlags::PredatesConcurrency;
+    import.predatesConcurrencyRange = attr->getRangeWithAt();
+  }
 }
 
 bool UnboundImport::checkNotTautological(const SourceFile &SF) {

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -4,6 +4,7 @@
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
+// expected-remark@-1{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
 if #available(SwiftStdlib 5.5, *) {
 

--- a/test/ClangImporter/predates_concurrency_import_swift6.swift
+++ b/test/ClangImporter/predates_concurrency_import_swift6.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -swift-version 6
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@_predatesConcurrency import Foundation
+
+func acceptSendable<T: Sendable>(_: T) { }
+
+func useSendable(ns: NSString) {
+  // Note: warning below is downgraded due to @_predatesConcurrency
+  acceptSendable(ns) // expected-warning{{type 'NSString' does not conform to the 'Sendable' protocol}}
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-import OtherActors // expected-note 2{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@_predatesConcurrency }}
+import OtherActors // expected-remark{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@_predatesConcurrency }}
 
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-import OtherActors
+import OtherActors // expected-note 2{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@_predatesConcurrency }}
 
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+
+// RUN: %target-typecheck-verify-swift -typecheck  -I %t %s
+
+@_predatesConcurrency import NonStrictModule
+@_predatesConcurrency import StrictModule
+
+func acceptSendable<T: Sendable>(_: T) { }
+
+@available(SwiftStdlib 5.1, *)
+func test(ss: StrictStruct, ns: NonStrictClass) async {
+  acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
+  acceptSendable(ns) // silence issue entirely
+}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -1,16 +1,24 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-typecheck-verify-swift -typecheck  -I %t %s
+// RUN: %target-typecheck-verify-swift -typecheck  -I %t
 
 @_predatesConcurrency import NonStrictModule
 @_predatesConcurrency import StrictModule
+@_predatesConcurrency import OtherActors
+// expected-remark@-1{{'@_predatesConcurrency' attribute on module 'OtherActors' is unused}}{{1-23=}}
 
 func acceptSendable<T: Sendable>(_: T) { }
 
 @available(SwiftStdlib 5.1, *)
-func test(ss: StrictStruct, ns: NonStrictClass) async {
+func test(
+  ss: StrictStruct, ns: NonStrictClass, oma: OtherModuleActor,
+  ssc: SomeSendableClass
+) async {
   acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
   acceptSendable(ns) // silence issue entirely
+  acceptSendable(oma) // okay
+  acceptSendable(ssc) // okay
 }

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+
+// RUN: %target-typecheck-verify-swift -typecheck  -swift-version 6 -I %t %s
+
+// REQUIRES: asserts
+
+@_predatesConcurrency import NonStrictModule
+@_predatesConcurrency import StrictModule
+
+func acceptSendable<T: Sendable>(_: T) { }
+
+@available(SwiftStdlib 5.1, *)
+func test(ss: StrictStruct, ns: NonStrictClass) {
+  acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
+  acceptSendable(ns) // expected-warning{{type 'NonStrictClass' does not conform to the 'Sendable' protocol}}
+}


### PR DESCRIPTION
A `@_predatesConcurrency` import declaration suppresses or downgrades `Sendable`-related diagnostics, providing a way to more smoothly adopt concurrency even when one depends on modules that have yet to adopt `Sendable`. Allow `@_predatesConcurrency` import declarations and provide them with the appropriate semantics:

* In a minimal context, a `@_predatesConcurrency import` of a module `X` suppresses `Sendable` diagnostics for nominal types defined in `X`.
* In a Swift 6 strict context, a `@_predatesConcurrency import` of a module `X` downgrades `Sendable` diagnostics for nominal types defined in `X` to warnings.

When we emit a `Sendable`-related diagnostic for a nominal type outside of the current module, produce a remark that suggests `@_predatesConcurrency` on the corresponding import to silence the diagnostic, but only do this once per file. This will help folks make `Sendable` diagnostics more manageable. When a `@_predatesConcurrency` attribute on an import isn't doing anything (because there were no failed `Sendable` checks from that module), emit a remark that removes the now-unnecessary `@_predatesConcurrency`.

Implements rdar://84449015.