### PR TITLE
Rename @_predatesConcurrency to @preconcurrency.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -70,7 +70,7 @@ protected:
   /// Whether the mangling predates concurrency, and therefore shouldn't
   /// include concurrency features such as global actors or @Sendable
   /// function types.
-  bool PredatesConcurrency = false;
+  bool Preconcurrency = false;
 
 public:
   using SymbolicReferent = llvm::PointerUnion<const NominalTypeDecl *,

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -688,9 +688,9 @@ SIMPLE_DECL_ATTR(_noAllocation, NoAllocation,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   124)
 
-SIMPLE_DECL_ATTR(_predatesConcurrency, PredatesConcurrency,
+SIMPLE_DECL_ATTR(preconcurrency, Preconcurrency,
   OnFunc | OnConstructor | OnProtocol | OnGenericType | OnVar | OnSubscript |
-  OnEnumElement | OnImport | UserInaccessible |
+  OnEnumElement | OnImport |
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   125)
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -898,7 +898,7 @@ public:
   void setHoisted(bool hoisted = true) { Bits.Decl.Hoisted = hoisted; }
 
   /// Whether this declaration predates the introduction of concurrency.
-  bool predatesConcurrency() const;
+  bool preconcurrency() const;
 
 public:
   bool escapedFromIfConfig() const {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1742,7 +1742,7 @@ ERROR(sil_inst_autodiff_invalid_witness_generic_signature,PointsToFirstBadToken,
       (StringRef, StringRef))
 
 WARNING(warn_attr_unsafe_removed,none,
-        "'%0' attribute has been removed in favor of @_predatesConcurrency",
+        "'%0' attribute has been removed in favor of @preconcurrency",
         (StringRef))
 
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1958,11 +1958,11 @@ NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
 REMARK(add_predates_concurrency_import,none,
-     "add '@_predatesConcurrency' to %select{suppress|treat}0 "
+     "add '@preconcurrency' to %select{suppress|treat}0 "
      "'Sendable'-related %select{warnings|errors}0 from module %1"
      "%select{| as warnings}0", (bool, Identifier))
 REMARK(remove_predates_concurrency_import,none,
-     "'@_predatesConcurrency' attribute on module %0 is unused", (Identifier))
+     "'@preconcurrency' attribute on module %0 is unused", (Identifier))
 WARNING(public_decl_needs_sendable,none,
         "public %0 %1 does not specify whether it is 'Sendable' or not",
         (DescriptiveDeclKind, DeclName))

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -82,7 +82,7 @@ enum class ImportFlags {
 
   /// The module is imported assuming that the module itself predates
   /// concurrency.
-  PredatesConcurrency = 0x20,
+  Preconcurrency = 0x20,
 
   /// Used for DenseMap.
   Reserved = 0x80
@@ -566,17 +566,17 @@ struct AttributedImport {
   /// Names of explicitly imported SPI groups.
   ArrayRef<Identifier> spiGroups;
 
-  /// When the import declaration has a `@_predatesConcurrency` annotation, this
+  /// When the import declaration has a `@preconcurrency` annotation, this
   /// is the source range covering the annotation.
-  SourceRange predatesConcurrencyRange;
+  SourceRange preconcurrencyRange;
 
   AttributedImport(ModuleInfo module, SourceLoc importLoc = SourceLoc(),
                    ImportOptions options = ImportOptions(),
                    StringRef filename = {}, ArrayRef<Identifier> spiGroups = {},
-                   SourceRange predatesConcurrencyRange = {})
+                   SourceRange preconcurrencyRange = {})
       : module(module), importLoc(importLoc), options(options),
         sourceFileArg(filename), spiGroups(spiGroups),
-        predatesConcurrencyRange(predatesConcurrencyRange) {
+        preconcurrencyRange(preconcurrencyRange) {
     assert(!(options.contains(ImportFlags::Exported) &&
              options.contains(ImportFlags::ImplementationOnly)) ||
            options.contains(ImportFlags::Reserved));
@@ -586,7 +586,7 @@ struct AttributedImport {
   AttributedImport(ModuleInfo module, AttributedImport<OtherModuleInfo> other)
     : AttributedImport(module, other.importLoc, other.options,
                        other.sourceFileArg, other.spiGroups,
-                       other.predatesConcurrencyRange) { }
+                       other.preconcurrencyRange) { }
 
   friend bool operator==(const AttributedImport<ModuleInfo> &lhs,
                          const AttributedImport<ModuleInfo> &rhs) {

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -84,9 +84,9 @@ private:
   /// This is \c None until it is filled in by the import resolution phase.
   Optional<ArrayRef<AttributedImport<ImportedModule>>> Imports;
 
-  /// Which imports have made use of @_predatesConcurrency.
+  /// Which imports have made use of @preconcurrency.
   llvm::SmallDenseSet<AttributedImport<ImportedModule>>
-      PredatesConcurrencyImportsUsed;
+      PreconcurrencyImportsUsed;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -301,12 +301,12 @@ public:
   /// resolution.
   void setImports(ArrayRef<AttributedImport<ImportedModule>> imports);
 
-  /// Whether the given import has used @_predatesConcurrency.
-  bool hasImportUsedPredatesConcurrency(
+  /// Whether the given import has used @preconcurrency.
+  bool hasImportUsedPreconcurrency(
       AttributedImport<ImportedModule> import) const;
 
-  /// Note that the given import has used @_predatesConcurrency/
-  void setImportUsedPredatesConcurrency(
+  /// Note that the given import has used @preconcurrency/
+  void setImportUsedPreconcurrency(
       AttributedImport<ImportedModule> import);
 
   enum ImportQueryKind {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3011,7 +3011,7 @@ CanType ASTMangler::getDeclTypeForMangling(
   // If this declaration predates concurrency, adjust its type to not
   // contain type features that were not available pre-concurrency. This
   // cannot alter the ABI in any way.
-  if (decl->predatesConcurrency()) {
+  if (decl->preconcurrency()) {
     ty = ty->stripConcurrency(/*recurse=*/true, /*dropGlobalActor=*/true);
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -725,8 +725,8 @@ Optional<CustomAttrNominalPair> Decl::getGlobalActorAttr() const {
                            None);
 }
 
-bool Decl::predatesConcurrency() const {
-  if (getAttrs().hasAttribute<PredatesConcurrencyAttr>())
+bool Decl::preconcurrency() const {
+  if (getAttrs().hasAttribute<PreconcurrencyAttr>())
     return true;
 
   // Imported C declarations always predate concurrency.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2302,14 +2302,14 @@ SourceFile::setImports(ArrayRef<AttributedImport<ImportedModule>> imports) {
   Imports = getASTContext().AllocateCopy(imports);
 }
 
-bool SourceFile::hasImportUsedPredatesConcurrency(
+bool SourceFile::hasImportUsedPreconcurrency(
     AttributedImport<ImportedModule> import) const {
-  return PredatesConcurrencyImportsUsed.count(import) != 0;
+  return PreconcurrencyImportsUsed.count(import) != 0;
 }
 
-void SourceFile::setImportUsedPredatesConcurrency(
+void SourceFile::setImportUsedPreconcurrency(
     AttributedImport<ImportedModule> import) {
-  PredatesConcurrencyImportsUsed.insert(import);
+  PreconcurrencyImportsUsed.insert(import);
 }
 
 bool HasImplementationOnlyImportsRequest::evaluate(Evaluator &evaluator,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3150,6 +3150,11 @@ ParserStatus Parser::parseDeclAttribute(
     AtLoc = SourceLoc();
   }
 
+  // Temporary name for @preconcurrency
+  checkInvalidAttrName(
+      "_predatesConcurrency", "preconcurrency", DAK_Preconcurrency,
+      diag::attr_renamed_warning);
+
   if (DK == DAK_Count && Tok.getText() == "warn_unused_result") {
     // The behavior created by @warn_unused_result is now the default. Emit a
     // Fix-It to remove.

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -550,9 +550,9 @@ UnboundImport::UnboundImport(ImportDecl *ID)
   }
   import.spiGroups = ID->getASTContext().AllocateCopy(spiGroups);
 
-  if (auto attr = ID->getAttrs().getAttribute<PredatesConcurrencyAttr>()) {
-    import.options |= ImportFlags::PredatesConcurrency;
-    import.predatesConcurrencyRange = attr->getRangeWithAt();
+  if (auto attr = ID->getAttrs().getAttribute<PreconcurrencyAttr>()) {
+    import.options |= ImportFlags::Preconcurrency;
+    import.preconcurrencyRange = attr->getRangeWithAt();
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -117,7 +117,7 @@ public:
   IGNORED_ATTR(ImplicitSelfCapture)
   IGNORED_ATTR(InheritActorContext)
   IGNORED_ATTR(Isolated)
-  IGNORED_ATTR(PredatesConcurrency)
+  IGNORED_ATTR(Preconcurrency)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1506,7 +1506,7 @@ namespace  {
     UNINTERESTING_ATTR(DynamicReplacement)
     UNINTERESTING_ATTR(PrivateImport)
     UNINTERESTING_ATTR(MainType)
-    UNINTERESTING_ATTR(PredatesConcurrency)
+    UNINTERESTING_ATTR(Preconcurrency)
 
     // Differentiation-related attributes.
     UNINTERESTING_ATTR(Differentiable)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6111,7 +6111,7 @@ static bool isImpliedByConformancePredatingConcurrency(
     return false;
 
   auto impliedProto = implied->getProtocol();
-  if (impliedProto->predatesConcurrency() ||
+  if (impliedProto->preconcurrency() ||
       impliedProto->isSpecificProtocol(KnownProtocolKind::Error) ||
       impliedProto->isSpecificProtocol(KnownProtocolKind::CodingKey))
     return true;
@@ -6145,7 +6145,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
 
   ProtocolConformance *SendableConformance = nullptr;
   bool sendableConformanceIsUnchecked = false;
-  bool sendableConformancePredatesConcurrency = false;
+  bool sendableConformancePreconcurrency = false;
   bool anyInvalid = false;
   for (auto conformance : conformances) {
     // Check and record normal conformances.
@@ -6179,7 +6179,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         if (normal->isUnchecked())
           sendableConformanceIsUnchecked = true;
         else if (isImpliedByConformancePredatingConcurrency(normal))
-          sendableConformancePredatesConcurrency = true;
+          sendableConformancePreconcurrency = true;
         else if (isa<InheritedProtocolConformance>(conformance))
           sendableConformanceIsUnchecked = true;
       }
@@ -6217,7 +6217,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   // Check constraints of Sendable.
   if (SendableConformance && !sendableConformanceIsUnchecked) {
     SendableCheck check = SendableCheck::Explicit;
-    if (sendableConformancePredatesConcurrency)
+    if (sendableConformancePreconcurrency)
       check = SendableCheck::ImpliedByStandardProtocol;
     else if (SendableConformance->getSourceKind() ==
                  ConformanceEntryKind::Synthesized)

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -264,19 +264,19 @@ void swift::performTypeChecking(SourceFile &SF) {
                                  TypeCheckSourceFileRequest{&SF}, {});
 }
 
-/// If any of the imports in this source file was @_predatesConcurrency but
+/// If any of the imports in this source file was @preconcurrency but
 /// there were no diagnostics downgraded or suppressed due to that
-/// @_predatesConcurrency, suggest that the attribute be removed.
-static void diagnoseUnnecessaryPredatesConcurrencyImports(SourceFile &sf) {
+/// @preconcurrency, suggest that the attribute be removed.
+static void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf) {
   ASTContext &ctx = sf.getASTContext();
   for (const auto &import : sf.getImports()) {
-    if (import.options.contains(ImportFlags::PredatesConcurrency) &&
+    if (import.options.contains(ImportFlags::Preconcurrency) &&
         import.importLoc.isValid() &&
-        !sf.hasImportUsedPredatesConcurrency(import)) {
+        !sf.hasImportUsedPreconcurrency(import)) {
       ctx.Diags.diagnose(
           import.importLoc, diag::remove_predates_concurrency_import,
           import.module.importedModule->getName())
-        .fixItRemove(import.predatesConcurrencyRange);
+        .fixItRemove(import.preconcurrencyRange);
     }
   }
 }
@@ -322,7 +322,7 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
     typeCheckDelayedFunctions(*SF);
   }
 
-  diagnoseUnnecessaryPredatesConcurrencyImports(*SF);
+  diagnoseUnnecessaryPreconcurrencyImports(*SF);
 
   // Check to see if there's any inconsistent @_implementationOnly imports.
   evaluateOrDefault(

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -4,7 +4,7 @@
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
-// expected-remark@-1{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
+// expected-remark@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
 if #available(SwiftStdlib 5.5, *) {
 
@@ -97,7 +97,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 }
 
 func testSendable(fn: () -> Void) {
-  doSomethingConcurrently(fn) // okay, due to implicit @_predatesConcurrency
+  doSomethingConcurrently(fn) // okay, due to implicit @preconcurrency
   doSomethingConcurrentlyButUnsafe(fn) // okay, @Sendable not part of the type
 
   var x = 17

--- a/test/ClangImporter/predates_concurrency_import_swift6.swift
+++ b/test/ClangImporter/predates_concurrency_import_swift6.swift
@@ -7,11 +7,11 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
-@_predatesConcurrency import Foundation
+@preconcurrency import Foundation
 
 func acceptSendable<T: Sendable>(_: T) { }
 
 func useSendable(ns: NSString) {
-  // Note: warning below is downgraded due to @_predatesConcurrency
+  // Note: warning below is downgraded due to @preconcurrency
   acceptSendable(ns) // expected-warning{{type 'NSString' does not conform to the 'Sendable' protocol}}
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-import OtherActors // expected-remark{{add '@_predatesConcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@_predatesConcurrency }}
+import OtherActors // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@preconcurrency }}
 
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -137,7 +137,7 @@ func testConcurrency() {
   }
 }
 
-@_predatesConcurrency func acceptUnsafeSendable(_ fn: @Sendable () -> Void) { }
+@preconcurrency func acceptUnsafeSendable(_ fn: @Sendable () -> Void) { }
 
 func testUnsafeSendableNothing() {
   var x = 5

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -137,7 +137,7 @@ func topLevelSyncFunction(_ number: inout Int) { }
 topLevelSyncFunction(&value)
 
 // Strict checking based on inferred Sendable/async/etc.
-@_predatesConcurrency @SomeGlobalActor class Super { }
+@preconcurrency @SomeGlobalActor class Super { }
 
 class Sub: Super {
   func f() { }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -516,7 +516,7 @@ func acceptClosure<T>(_: () -> T) { }
 // ----------------------------------------------------------------------
 // Main actor that predates concurrency
 // ----------------------------------------------------------------------
-@_predatesConcurrency func takesUnsafeMainActor(fn: @MainActor () -> Void) { }
+@preconcurrency func takesUnsafeMainActor(fn: @MainActor () -> Void) { }
 
 @MainActor func onlyOnMainActor() { }
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -1,22 +1,22 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking
 // REQUIRES: concurrency
 
-@_predatesConcurrency func unsafelySendableClosure(_ closure: @Sendable () -> Void) { }
+@preconcurrency func unsafelySendableClosure(_ closure: @Sendable () -> Void) { }
 
-@_predatesConcurrency func unsafelyMainActorClosure(_ closure: @MainActor () -> Void) { }
+@preconcurrency func unsafelyMainActorClosure(_ closure: @MainActor () -> Void) { }
 
-@_predatesConcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
+@preconcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
 
 struct X {
-  @_predatesConcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
+  @preconcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
 
-  @_predatesConcurrency var sendableVar: @Sendable () -> Void
-  @_predatesConcurrency var mainActorVar: @MainActor () -> Void
+  @preconcurrency var sendableVar: @Sendable () -> Void
+  @preconcurrency var mainActorVar: @MainActor () -> Void
 
-  @_predatesConcurrency
+  @preconcurrency
   subscript(_: @MainActor () -> Void) -> (@Sendable () -> Void) { {} }
 
-  @_predatesConcurrency
+  @preconcurrency
   static subscript(statically _: @MainActor () -> Void) -> (@Sendable () -> Void) { { } }
 }
 
@@ -50,9 +50,9 @@ func testElsewhere(x: X) {
   let _: Int = X[statically: { onMainActor() }] // expected-error{{type '() -> Void'}}
 }
 
-@MainActor @_predatesConcurrency func onMainActorAlways() { }
+@MainActor @preconcurrency func onMainActorAlways() { }
 
-@_predatesConcurrency @MainActor class MyModelClass {
+@preconcurrency @MainActor class MyModelClass {
   func f() { }
 }
 
@@ -97,7 +97,7 @@ func testCallsWithAsync() async {
 // ---------------------------------------------------------------------------
 // Protocols that inherit Sendable and predate concurrency.
 // ---------------------------------------------------------------------------
-@_predatesConcurrency protocol P: Sendable { }
+@preconcurrency protocol P: Sendable { }
 protocol Q: P { }
 
 class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
@@ -118,7 +118,7 @@ struct S3: Q, Sendable {
 // Historical attribute names do nothing (but are permitted)
 // ---------------------------------------------------------------------------
 func aFailedExperiment(@_unsafeSendable _ body: @escaping () -> Void) { }
-// expected-warning@-1{{'_unsafeSendable' attribute has been removed in favor of @_predatesConcurrency}}
+// expected-warning@-1{{'_unsafeSendable' attribute has been removed in favor of @preconcurrency}}
 
 func anothingFailedExperiment(@_unsafeMainActor _ body: @escaping () -> Void) { }
-// expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @_predatesConcurrency}}
+// expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @preconcurrency}}

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -5,10 +5,10 @@
 
 // RUN: %target-typecheck-verify-swift -typecheck  -I %t
 
-@_predatesConcurrency import NonStrictModule
-@_predatesConcurrency import StrictModule
-@_predatesConcurrency import OtherActors
-// expected-remark@-1{{'@_predatesConcurrency' attribute on module 'OtherActors' is unused}}{{1-23=}}
+@preconcurrency import NonStrictModule
+@_predatesConcurrency import StrictModule // expected-warning{{'@_predatesConcurrency' has been renamed to '@preconcurrency'}}
+@preconcurrency import OtherActors
+// expected-remark@-1{{'@preconcurrency' attribute on module 'OtherActors' is unused}}{{1-17=}}
 
 func acceptSendable<T: Sendable>(_: T) { }
 

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -6,8 +6,8 @@
 
 // REQUIRES: asserts
 
-@_predatesConcurrency import NonStrictModule
-@_predatesConcurrency import StrictModule
+@preconcurrency import NonStrictModule
+@preconcurrency import StrictModule
 
 func acceptSendable<T: Sendable>(_: T) { }
 

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -2,22 +2,22 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
-@_predatesConcurrency func unsafelySendableClosure(_ closure: @Sendable () -> Void) { }
+@preconcurrency func unsafelySendableClosure(_ closure: @Sendable () -> Void) { }
 
-@_predatesConcurrency func unsafelyMainActorClosure(_ closure: @MainActor () -> Void) { }
+@preconcurrency func unsafelyMainActorClosure(_ closure: @MainActor () -> Void) { }
 
-@_predatesConcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
+@preconcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
 
 struct X {
-  @_predatesConcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
+  @preconcurrency func unsafelyDoEverythingClosure(_ closure: @MainActor @Sendable () -> Void) { }
 
-  @_predatesConcurrency var sendableVar: @Sendable () -> Void
-  @_predatesConcurrency var mainActorVar: @MainActor () -> Void
+  @preconcurrency var sendableVar: @Sendable () -> Void
+  @preconcurrency var mainActorVar: @MainActor () -> Void
 
-  @_predatesConcurrency
+  @preconcurrency
   subscript(_: @MainActor () -> Void) -> (@Sendable () -> Void) { {} }
 
-  @_predatesConcurrency
+  @preconcurrency
   static subscript(statically _: @MainActor () -> Void) -> (@Sendable () -> Void) { { } }
 }
 
@@ -53,10 +53,10 @@ func testElsewhere(x: X) {
   let _: Int = X[statically: { onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
 }
 
-@MainActor @_predatesConcurrency func onMainActorAlways() { }
+@MainActor @preconcurrency func onMainActorAlways() { }
 // expected-note@-1{{are implicitly asynchronous}}
 
-@_predatesConcurrency @MainActor class MyModelClass {
+@preconcurrency @MainActor class MyModelClass {
  // expected-note@-1{{are implicitly asynchronous}}
  func f() { }
   // expected-note@-1{{are implicitly asynchronous}}
@@ -87,7 +87,7 @@ func testCallsWithAsync() async {
 // ---------------------------------------------------------------------------
 // Protocols that inherit Sendable and predate concurrency.
 // ---------------------------------------------------------------------------
-@_predatesConcurrency protocol P: Sendable { }
+@preconcurrency protocol P: Sendable { }
 protocol Q: P { }
 
 class NS { } // expected-note 3{{class 'NS' does not conform to the 'Sendable' protocol}}
@@ -108,7 +108,7 @@ struct S3: Q, Sendable {
 // Historical attribute names do nothing (but are permitted)
 // ---------------------------------------------------------------------------
 func aFailedExperiment(@_unsafeSendable _ body: @escaping () -> Void) { }
-// expected-warning@-1{{'_unsafeSendable' attribute has been removed in favor of @_predatesConcurrency}}
+// expected-warning@-1{{'_unsafeSendable' attribute has been removed in favor of @preconcurrency}}
 
 func anothingFailedExperiment(@_unsafeMainActor _ body: @escaping () -> Void) { }
-// expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @_predatesConcurrency}}
+// expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @preconcurrency}}

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -72,6 +72,7 @@ struct MyStruct {}
 // KEYWORD2-NEXT:             Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // KEYWORD2-NEXT:             Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
+// KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2:                  End completions
@@ -93,6 +94,7 @@ struct MyStruct {}
 // KEYWORD3-NEXT:             Keyword/None:                       propertyWrapper[#Class Attribute#]; name=propertyWrapper
 // KEYWORD3-NEXT:             Keyword/None:                       resultBuilder[#Class Attribute#]; name=resultBuilder
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
+// KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD3_2^#IB class C2 {}
@@ -110,6 +112,7 @@ struct MyStruct {}
 // KEYWORD4-NEXT:             Keyword/None:                       propertyWrapper[#Enum Attribute#]; name=propertyWrapper
 // KEYWORD4-NEXT:             Keyword/None:                       resultBuilder[#Enum Attribute#]; name=resultBuilder
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
+// KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
 // KEYWORD4-NEXT:             End completions
 
 
@@ -124,6 +127,7 @@ struct MyStruct {}
 // KEYWORD5-NEXT:             Keyword/None:                       propertyWrapper[#Struct Attribute#]; name=propertyWrapper
 // KEYWORD5-NEXT:             Keyword/None:                       resultBuilder[#Struct Attribute#]; name=resultBuilder
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
+// KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 // KEYWORD5-NEXT:             End completions
 
 @#^ON_GLOBALVAR^# var globalVar
@@ -142,6 +146,7 @@ struct MyStruct {}
 // ON_GLOBALVAR-DAG: Keyword/None:                       differentiable[#Var Attribute#]; name=differentiable
 // ON_GLOBALVAR-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
 // ON_GLOBALVAR-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
+// ON_GLOBALVAR-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
 // ON_GLOBALVAR-NOT: Keyword
 // ON_GLOBALVAR: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_GLOBALVAR: End completions
@@ -156,6 +161,7 @@ struct _S {
 // ON_INIT-DAG: Keyword/None:                       inlinable[#Constructor Attribute#]; name=inlinable
 // ON_INIT-DAG: Keyword/None:                       usableFromInline[#Constructor Attribute#]; name=usableFromInline
 // ON_INIT-DAG: Keyword/None:                       discardableResult[#Constructor Attribute#]; name=discardableResult
+// ON_INIT-DAG: Keyword/None:                       preconcurrency[#Constructor Attribute#]; name=preconcurrency
 // ON_INIT: End completions
 
   @#^ON_PROPERTY^# var foo
@@ -174,6 +180,7 @@ struct _S {
 // ON_PROPERTY-DAG: Keyword/None:                       differentiable[#Var Attribute#]; name=differentiable
 // ON_PROPERTY-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
 // ON_PROPERTY-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
+// ON_PROPERTY-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
 // ON_PROPERTY-NOT: Keyword
 // ON_PROPERTY: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_PROPERTY-NOT: Decl[PrecedenceGroup]
@@ -198,6 +205,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       transpose[#Func Attribute#]; name=transpose
 // ON_METHOD-DAG: Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
+// ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-NOT: Keyword
 // ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD: End completions
@@ -260,6 +268,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // ON_MEMBER_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
 // ON_MEMBER_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
+// ON_MEMBER_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
@@ -311,6 +320,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // KEYWORD_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
 // KEYWORD_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
+// KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST:                  End completions

--- a/test/SILGen/check_executor.swift
+++ b/test/SILGen/check_executor.swift
@@ -15,11 +15,11 @@ import _Concurrency
 
 // CHECK-CANONICAL-LABEL: sil [ossa] @$s4test17onMainActorUnsafeyyF
 // CHECK-CANONICAL: function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF
-@_predatesConcurrency @MainActor public func onMainActorUnsafe() { }
+@preconcurrency @MainActor public func onMainActorUnsafe() { }
 
 func takeClosure(_ fn: @escaping () -> Int) { }
 
-@_predatesConcurrency func takeUnsafeMainActorClosure(_ fn: @MainActor @escaping () -> Int) { }
+@preconcurrency func takeUnsafeMainActorClosure(_ fn: @MainActor @escaping () -> Int) { }
 
 public actor MyActor {
   var counter = 0

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -103,7 +103,7 @@ func testGlobalActor() async {
 // CHECK:   hop_to_executor [[B]] : $MyActor
 // CHECK: }
 @GlobalActor
-@_predatesConcurrency
+@preconcurrency
 func testGlobalActorUnsafe() async {
 }
 

--- a/test/SILGen/mangling_predates_concurrency.swift
+++ b/test/SILGen/mangling_predates_concurrency.swift
@@ -3,7 +3,7 @@
 
 
 // CHECK: sil [ossa] @$s29mangling_predates_concurrency16excitingFunction5value4bodyyycx_yycSgtlF : $@convention(thin) <T where T : Sendable> (@in_guaranteed T, @guaranteed Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned @callee_guaranteed () -> ()
-@_predatesConcurrency
+@preconcurrency
 public func excitingFunction<T: Sendable>(value: T, body: (@Sendable () -> Void)?) -> (@MainActor () -> Void) {
   { }
 }


### PR DESCRIPTION
Introduce the `@preconcurrency` attribute name for `@_predatesConcurrency`,
which has been the favored name in the pitch thread so far. Retain the
old name for now to help smooth migration.
