### PR TITLE
Serialization: normalize the path before use

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1228,6 +1228,7 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
   Ctx.addLoadedModule(M);
   SWIFT_DEFER { M->setHasResolvedImports(); };
 
+  llvm::sys::path::native(moduleInterfacePath);
   auto *file =
       loadAST(*M, moduleID.Loc, moduleInterfacePath,
               std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),

--- a/test/CrossImport/module-trace.swift
+++ b/test/CrossImport/module-trace.swift
@@ -1,8 +1,5 @@
 // This file tests that we emit cross-imports into module interfaces.
 
-// FIXME: Fix the path normalization issue and get rid of this.
-// UNSUPPORTED: OS=windows-msvc
-
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/lib-templates/* %t/
 

--- a/test/ModuleInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ModuleInterface/ModuleCache/SDKDependencies.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
 
-// XFAIL: OS=windows-msvc
-
 // 1) Build a prebuilt cache for our SDK
 //
 // RUN: mkdir %t/MCP %t/prebuilt-cache %t/my-sdk


### PR DESCRIPTION
This normalizes the path so that we always have the mapping in normal
form.  This fixes a bug in the cross-module import tracing, allowing us
to finally enable the test on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
