### PR TITLE
tests: enable Serialization test on Windows

### DIFF
--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -2,9 +2,6 @@
 // RUN: %empty-directory(%t/build)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-/// Unsupported on Windows for the use of env vars.
-// UNSUPPORTED: OS=windows-msvc
-
 /// 1. Compile Lib.swift as non-resilient untagged, resilient untagged, and resilient tagged
 // BEGIN Lib.swift
 public func foo() {}
@@ -12,7 +9,7 @@ public func foo() {}
 /// Build Lib as a resilient and non-resilient swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name ResilientLib -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name NonresilientLib
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
 // RUN:   %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name TaggedLib -enable-library-evolution
 
 
@@ -23,7 +20,7 @@ foo()
 
 /// Building a NonresilientLib client should always succeed
 // RUN: %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
 // RUN:   %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 
@@ -36,12 +33,12 @@ foo()
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 /// Building a ResilientLib client should reject the import for a tagged compiler
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
 // RUN:   not %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s
 // CHECK: compiled module was created by a different version of the compiler; rebuild 'ResilientLib' and try again: {{.*}}ResilientLib.swiftmodule
 
 /// Building a ResilientLib client should succeed for a tagged compiler with SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION=true \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION=true \
 // RUN:   %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 
@@ -51,11 +48,11 @@ import TaggedLib
 foo()
 
 /// Importing TaggedLib should success with the same tag or a dev compiler
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
 // RUN:   %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 // RUN: %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 /// Building a TaggedLib client should reject the import for a different tagged compiler
-// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
 // RUN:   not %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s --check-prefix=CHECK-TAGGED
 // CHECK-TAGGED: compiled module was created by a different version of the compiler; rebuild 'TaggedLib' and try again: {{.*}}TaggedLib.swiftmodule


### PR DESCRIPTION
Enable the Serialization/restrict-swiftmodule-to-revision on Windows.
This test was unnecessarily disabled on Windows due to the use of
environment variables which can be accommodated by using the `env`
command.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
