### PR TITLE
Revert "build: add a workaround for CMake[>=3.22] and SourceKit"

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -11,10 +11,6 @@ function(add_sourcekit_default_compiler_flags target)
   if(${SWIFT_HOST_VARIANT_SDK} STREQUAL WINDOWS)
     swift_windows_include_for_arch(${SWIFT_HOST_VARIANT_ARCH}
       ${SWIFT_HOST_VARIANT_ARCH}_INCLUDE)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
-      set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-I")
-      set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-I")
-    endif()
     target_include_directories(${target} SYSTEM PRIVATE
       ${${SWIFT_HOST_VARIANT_ARCH}_INCLUDE})
   endif()


### PR DESCRIPTION
This reverts commit 1e5df70d8924ff5f064cbd5009bd50106957380e.

This does not actually impact the build, so revert it to reduce the
complexity in the build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
