### PR TITLE
[ASTPrinter] Print expressions

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -128,6 +128,9 @@ struct PrintOptions {
   /// Whether to print function definitions.
   bool FunctionDefinitions = false;
 
+  /// Whether to print expressions.
+  bool PrintExprs = false;
+  
   /// Whether to print '{ get set }' on readwrite computed properties.
   bool PrintGetSetOnRWProperties = true;
 
@@ -644,6 +647,20 @@ struct PrintOptions {
   ///
   /// This is only intended for debug output.
   static PrintOptions printEverything() {
+    PrintOptions result = printVerbose();
+    result.ExcludeAttrList.clear();
+    result.ExcludeAttrList.push_back(DAK_FixedLayout);
+    result.PrintStorageRepresentationAttrs = true;
+    result.AbstractAccessors = false;
+    result.PrintAccess = true;
+    result.SkipEmptyExtensionDecls = false;
+    result.SkipMissingMemberPlaceholders = false;
+    result.FunctionDefinitions = true;
+    result.PrintExprs = true;
+    return result;
+  }
+
+  static PrintOptions printDeclarations() {
     PrintOptions result = printVerbose();
     result.ExcludeAttrList.clear();
     result.ExcludeAttrList.push_back(DAK_FixedLayout);

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -647,14 +647,7 @@ struct PrintOptions {
   ///
   /// This is only intended for debug output.
   static PrintOptions printEverything() {
-    PrintOptions result = printVerbose();
-    result.ExcludeAttrList.clear();
-    result.ExcludeAttrList.push_back(DAK_FixedLayout);
-    result.PrintStorageRepresentationAttrs = true;
-    result.AbstractAccessors = false;
-    result.PrintAccess = true;
-    result.SkipEmptyExtensionDecls = false;
-    result.SkipMissingMemberPlaceholders = false;
+    PrintOptions result = printDeclarations();
     result.FunctionDefinitions = true;
     result.PrintExprs = true;
     return result;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -118,6 +118,7 @@ public:
     EmitSyntax,        ///< Parse and dump Syntax tree as JSON
     DumpAST,           ///< Parse, type-check, and dump AST
     PrintAST,          ///< Parse, type-check, and pretty-print AST
+    PrintASTDecl,      ///< Parse, type-check, and pretty-print AST declarations
 
     /// Parse and dump scope map.
     DumpScopeMaps,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1051,6 +1051,10 @@ def print_ast : Flag<["-"], "print-ast">,
   HelpText<"Parse and type-check input file(s) and pretty print AST(s)">,
   ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def print_ast_decl : Flag<["-"], "print-ast-decl">,
+  HelpText<"Parse and type-check input file(s) and pretty print declarations from AST(s)">,
+  ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def dump_pcm : Flag<["-"], "dump-pcm">,
   HelpText<"Dump debugging information about a precompiled Clang module">,
   ModeOpt,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -908,6 +908,10 @@ private:
   /// to match the original function declaration.
   void printFunctionParameters(AbstractFunctionDecl *AFD);
 
+  void printArgument(const Argument &arg);
+
+  void printStmtCondition(StmtCondition stmt);
+
 #define DECL(Name,Parent) void visit##Name##Decl(Name##Decl *decl);
 #define ABSTRACT_DECL(Name, Parent)
 #define DECL_RANGE(Name,Start,End)
@@ -915,6 +919,11 @@ private:
 
 #define STMT(Name, Parent) void visit##Name##Stmt(Name##Stmt *stmt);
 #include "swift/AST/StmtNodes.def"
+
+#define EXPR(Name,Parent) void visit##Name##Expr(Name##Expr *expr);
+#define ABSTRACT_EXPR(Name, Parent)
+#define DECL_RANGE(Name,Start,End)
+#include "swift/AST/ExprNodes.def"
 
   void printSynthesizedExtension(Type ExtendedType, ExtensionDecl *ExtDecl);
 
@@ -946,6 +955,14 @@ public:
   }
 
   using ASTVisitor::visit;
+
+  bool visit(Expr *E) {
+    if (!Options.PrintExprs) {
+      return false;
+    }
+    ASTVisitor::visit(E);
+    return true;
+  }
 
   bool visit(Decl *D) {
     #if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
@@ -1291,7 +1308,7 @@ void PrintAST::printPattern(const Pattern *pattern) {
 
   case PatternKind::EnumElement: {
     auto elt = cast<EnumElementPattern>(pattern);
-    // FIXME: Print element expr.
+    Printer << "." << elt->getElementDecl()->getBaseName();
     if (elt->hasSubPattern())
       printPattern(elt->getSubPattern());
     break;
@@ -1299,7 +1316,6 @@ void PrintAST::printPattern(const Pattern *pattern) {
 
   case PatternKind::OptionalSome:
     printPattern(cast<OptionalSomePattern>(pattern)->getSubPattern());
-    Printer << '?';
     break;
 
   case PatternKind::Bool:
@@ -1307,15 +1323,21 @@ void PrintAST::printPattern(const Pattern *pattern) {
                                                        : tok::kw_false);
     break;
 
-  case PatternKind::Expr:
-    // FIXME: Print expr.
+  case PatternKind::Expr: {
+    if (Options.PrintExprs) {
+        auto expr = cast<ExprPattern>(pattern)->getSubExpr();
+        visit(expr);
+    }
     break;
+  }
 
-  case PatternKind::Binding:
+  case PatternKind::Binding: {
+    auto bPattern = cast<BindingPattern>(pattern);
     Printer.printIntroducerKeyword(
-        cast<BindingPattern>(pattern)->isLet() ? "let" : "var",
+        bPattern->isLet() ? "let" : "var",
         Options, " ");
-    printPattern(cast<BindingPattern>(pattern)->getSubPattern());
+    printPattern(bPattern->getSubPattern());
+  }
   }
 }
 
@@ -3050,7 +3072,12 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
       printPatternType(pattern);
     }
 
-    if (Options.VarInitializers) {
+    if (Options.PrintExprs) {
+      if (auto initExpr = decl->getInit(idx)) {
+        Printer << " = ";
+        visit(initExpr);
+      }
+    } else if (Options.VarInitializers) {
       auto *vd = decl->getAnchoringVarDecl(idx);
       if (decl->hasInitStringRepresentation(idx) &&
           vd->isInitExposedToClients()) {
@@ -3579,8 +3606,7 @@ bool PrintAST::printASTNodes(const ArrayRef<ASTNode> &Elements,
     } else if (auto stmt = element.dyn_cast<Stmt*>()) {
       visit(stmt);
     } else {
-      // FIXME: print expression
-      // visit(element.get<Expr*>());
+      visit(element.get<Expr*>());
     }
   }
   return PrintedSomething;
@@ -4047,15 +4073,489 @@ void PrintAST::visitMissingMemberDecl(MissingMemberDecl *decl) {
   Printer << " */";
 }
 
+void PrintAST::visitIntegerLiteralExpr(IntegerLiteralExpr *expr) {
+  Printer << expr->getDigitsText();
+}
+
+void PrintAST::visitFloatLiteralExpr(FloatLiteralExpr *expr) {
+  Printer << expr->getDigitsText();
+}
+
+void PrintAST::visitNilLiteralExpr(NilLiteralExpr *expr) {
+  Printer << "nil";
+}
+
+void PrintAST::visitStringLiteralExpr(StringLiteralExpr *expr) {
+  Printer << "\"" << expr->getValue() << "\"";
+}
+
+void PrintAST::visitBooleanLiteralExpr(BooleanLiteralExpr *expr) {
+  if (expr->getValue()) {
+    Printer << "true";
+  } else {
+    Printer << "false";
+  }
+}
+
+void PrintAST::visitRegexLiteralExpr(RegexLiteralExpr *expr) {
+  Printer << expr->getRegexText();
+}
+
+void PrintAST::visitErrorExpr(ErrorExpr *expr) {
+  Printer << "<error>";
+}
+
+void PrintAST::visitIfExpr(IfExpr *expr) {
+}
+
+void PrintAST::visitIsExpr(IsExpr *expr) {
+}
+
+void PrintAST::visitTapExpr(TapExpr *expr) {
+}
+
+void PrintAST::visitTryExpr(TryExpr *expr) {
+  Printer << "try ";
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitCallExpr(CallExpr *expr) {
+  visit(expr->getFn());
+  Printer << "(";
+  auto argList = expr->getArgs();
+  bool isFirst = true;
+  // FIXME: handle trailing closures.
+  if (argList) {
+    for (auto i = argList->begin(), iEnd = argList->end(); i != iEnd; ++i) {
+      auto arg = *i;
+      if (dyn_cast<DefaultArgumentExpr>(arg.getExpr())) {
+        // Don't print default arguments.
+        continue;
+      }
+      if (!isFirst) {
+        Printer << ", ";
+      }
+      printArgument(arg);
+      isFirst = false;
+    }
+  }
+  Printer << ")";
+}
+
+void PrintAST::printArgument(const Argument &arg) {
+  auto label = arg.getLabel();
+  if (!label.empty()) {
+    Printer << label.str();
+    Printer << ": ";
+  }
+  if (arg.isInOut()) {
+    Printer << "&";
+  }
+  visit(arg.getExpr());
+}
+
+void PrintAST::visitLoadExpr(LoadExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitTypeExpr(TypeExpr *expr) {
+  printType(expr->getType());
+}
+
+void PrintAST::visitArrayExpr(ArrayExpr *expr) {
+  Printer << "[";
+  bool isFirst = true;
+  auto elements = expr->getElements();
+  for (auto element : elements) {
+    if (!isFirst) {
+      Printer << ", ";
+    }
+    visit(element);
+    isFirst = false;
+  }
+  Printer << "]";
+}
+
+void PrintAST::visitDictionaryExpr(DictionaryExpr *expr) {
+  Printer << "[";
+  bool isFirst = true;
+  auto elements = expr->getElements();
+  for (auto element : elements) {
+    auto *tupleExpr = dyn_cast<TupleExpr>(element);
+    if (!isFirst) {
+      Printer << ", ";
+    }
+    bool isFirstTupleArg = true;
+    auto tupleElements = tupleExpr->getElements();
+    for (auto element : tupleElements) {
+      if (isFirstTupleArg) {
+        visit(element);
+        Printer << ": ";
+        isFirstTupleArg = false;
+      } else {
+        visit(element);
+        // Bail out if there's somehow more than 2.
+        break;
+      }
+    }
+    isFirst = false;
+  }
+  Printer << "]";
+}
+
+void PrintAST::visitArrowExpr(ArrowExpr *expr) {
+}
+
+void PrintAST::visitAwaitExpr(AwaitExpr *expr) {
+  Printer << "await ";
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitInOutExpr(InOutExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitParenExpr(ParenExpr *expr) {
+  Printer << "(";
+  visit(expr->getSubExpr());
+  Printer << ")";
+}
+
+void PrintAST::visitTupleExpr(TupleExpr *expr) {
+  Printer << "(";
+  bool isFirst = true;
+  auto elements = expr->getElements();
+  for (auto element : elements) {
+    if (!isFirst) {
+      Printer << ", ";
+    }
+    visit(element);
+    isFirst = false;
+  }
+  Printer << ")";
+}
+
+void PrintAST::visitAssignExpr(AssignExpr *expr) {
+  visit(expr->getDest());
+  Printer << " = ";
+  visit(expr->getSrc());
+}
+
+void PrintAST::visitBinaryExpr(BinaryExpr *expr) {
+  visit(expr->getLHS());
+  Printer << " ";
+  if (auto operatorRef = expr->getFn()->getMemberOperatorRef()) {
+    Printer << operatorRef->getDecl()->getBaseName();
+  }
+  Printer << " ";
+  visit(expr->getRHS());
+}
+
+void PrintAST::visitCoerceExpr(CoerceExpr *expr) {
+}
+
+void PrintAST::visitOneWayExpr(OneWayExpr *expr) {
+}
+
+void PrintAST::visitClosureExpr(ClosureExpr *expr) {
+}
+
+void PrintAST::visitDeclRefExpr(DeclRefExpr *expr) {
+  Printer << expr->getDecl()->getBaseName();
+}
+
+void PrintAST::visitDotSelfExpr(DotSelfExpr *expr) {
+  visit(expr->getSubExpr());
+  Printer << ".self";
+}
+
+void PrintAST::visitErasureExpr(ErasureExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitKeyPathExpr(KeyPathExpr *expr) {
+}
+
+void PrintAST::visitForceTryExpr(ForceTryExpr *expr) {
+  Printer << "try! ";
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitSequenceExpr(SequenceExpr *expr) {
+}
+
+void PrintAST::visitSuperRefExpr(SuperRefExpr *expr) {
+}
+
+void PrintAST::visitMemberRefExpr(MemberRefExpr *expr) {
+  visit(expr->getBase());
+  Printer << ".";
+  Printer << expr->getMember().getDecl()->getName();
+}
+
+void PrintAST::visitSubscriptExpr(SubscriptExpr *expr) {
+}
+
+void PrintAST::visitEnumIsCaseExpr(EnumIsCaseExpr *expr) {
+}
+
+void PrintAST::visitForceValueExpr(ForceValueExpr *expr) {
+}
+
+void PrintAST::visitKeyPathDotExpr(KeyPathDotExpr *expr) {
+}
+
+void PrintAST::visitAutoClosureExpr(AutoClosureExpr *expr) {
+  visit(expr->getSingleExpressionBody());
+}
+
+void PrintAST::visitCaptureListExpr(CaptureListExpr *expr) {
+}
+
+void PrintAST::visitDynamicTypeExpr(DynamicTypeExpr *expr) {
+}
+
+void PrintAST::visitOpaqueValueExpr(OpaqueValueExpr *expr) {
+}
+
+void PrintAST::visitOptionalTryExpr(OptionalTryExpr *expr) {
+}
+
+void PrintAST::visitPrefixUnaryExpr(PrefixUnaryExpr *expr) {
+}
+
+void PrintAST::visitBindOptionalExpr(BindOptionalExpr *expr) {
+}
+
+void PrintAST::visitBridgeToObjCExpr(BridgeToObjCExpr *expr) {
+}
+
+void PrintAST::visitObjCSelectorExpr(ObjCSelectorExpr *expr) {
+}
+
+void PrintAST::visitPostfixUnaryExpr(PostfixUnaryExpr *expr) {
+}
+
+void PrintAST::visitTupleElementExpr(TupleElementExpr *expr) {
+}
+
+void PrintAST::visitDerivedToBaseExpr(DerivedToBaseExpr *expr) {
+}
+
+void PrintAST::visitDotSyntaxCallExpr(DotSyntaxCallExpr *expr) {
+  visit(expr->getBase());
+  Printer << ".";
+  visit(expr->getFn());
+}
+
+void PrintAST::visitObjectLiteralExpr(ObjectLiteralExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedDotExpr(UnresolvedDotExpr *expr) {
+  visit(expr->getBase());
+  Printer << ".";
+  Printer << expr->getName().getBaseName();
+}
+
+void PrintAST::visitArrayToPointerExpr(ArrayToPointerExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitBridgeFromObjCExpr(BridgeFromObjCExpr *expr) {
+}
+
+void PrintAST::visitCodeCompletionExpr(CodeCompletionExpr *expr) {
+}
+
+void PrintAST::visitInOutToPointerExpr(InOutToPointerExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitLinearFunctionExpr(LinearFunctionExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitDefaultArgumentExpr(DefaultArgumentExpr *expr) {
+}
+
+void PrintAST::visitLazyInitializerExpr(LazyInitializerExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitOpenExistentialExpr(OpenExistentialExpr *expr) {
+  visit(expr->getValueProvidingExpr());
+  visit(expr->getExistentialValue());
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitStringToPointerExpr(StringToPointerExpr *expr) {
+}
+
+void PrintAST::visitVarargExpansionExpr(VarargExpansionExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitArchetypeToSuperExpr(ArchetypeToSuperExpr *expr) {
+}
+
+void PrintAST::visitDestructureTupleExpr(DestructureTupleExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitDynamicMemberRefExpr(DynamicMemberRefExpr *expr) {
+}
+
+void PrintAST::visitDynamicSubscriptExpr(DynamicSubscriptExpr *expr) {
+}
+
+void PrintAST::visitPointerToPointerExpr(PointerToPointerExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitUnresolvedMemberExpr(UnresolvedMemberExpr *expr) {
+}
+
+void PrintAST::visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
+}
+
+void PrintAST::visitEditorPlaceholderExpr(EditorPlaceholderExpr *expr) {
+}
+
+void PrintAST::visitForcedCheckedCastExpr(ForcedCheckedCastExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitOverloadedDeclRefExpr(OverloadedDeclRefExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedPatternExpr(UnresolvedPatternExpr *expr) {
+}
+
+void PrintAST::visitAnyHashableErasureExpr(AnyHashableErasureExpr *expr) {
+}
+
+void PrintAST::visitConstructorRefCallExpr(ConstructorRefCallExpr *expr) {
+  if (auto type = expr->getType()) {
+    if (auto *funcType = type->getAs<FunctionType>()) {
+      printType(funcType->getResult());
+    }
+  }
+}
+
+void PrintAST::visitFunctionConversionExpr(FunctionConversionExpr *expr) {
+}
+
+void PrintAST::visitInjectIntoOptionalExpr(InjectIntoOptionalExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitKeyPathApplicationExpr(KeyPathApplicationExpr *expr) {
+}
+
+void PrintAST::visitMetatypeConversionExpr(MetatypeConversionExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitOptionalEvaluationExpr(OptionalEvaluationExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitUnderlyingToOpaqueExpr(UnderlyingToOpaqueExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedSpecializeExpr(UnresolvedSpecializeExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitClassMetatypeToObjectExpr(ClassMetatypeToObjectExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitAppliedPropertyWrapperExpr(AppliedPropertyWrapperExpr *expr) {
+}
+
+void PrintAST::visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitDifferentiableFunctionExpr(DifferentiableFunctionExpr *expr) {
+  visit(expr->getSubExpr());
+}
+
+void PrintAST::visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *expr) {
+}
+
+void PrintAST::visitForeignObjectConversionExpr(ForeignObjectConversionExpr *expr) {
+}
+
+void PrintAST::visitOtherConstructorDeclRefExpr(OtherConstructorDeclRefExpr *expr) {
+}
+
+void PrintAST::visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *expr) {
+}
+
+void PrintAST::visitMakeTemporarilyEscapableExpr(MakeTemporarilyEscapableExpr *expr) {
+}
+
+void PrintAST::visitProtocolMetatypeToObjectExpr(ProtocolMetatypeToObjectExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedTypeConversionExpr(UnresolvedTypeConversionExpr *expr) {
+}
+
+void PrintAST::visitConditionalBridgeFromObjCExpr(ConditionalBridgeFromObjCExpr *expr) {
+}
+
+void PrintAST::visitCovariantReturnConversionExpr(CovariantReturnConversionExpr *expr) {
+}
+
+void PrintAST::visitInterpolatedStringLiteralExpr(InterpolatedStringLiteralExpr *expr) {
+}
+
+void PrintAST::visitCollectionUpcastConversionExpr(CollectionUpcastConversionExpr *expr) {
+}
+
+void PrintAST::visitCovariantFunctionConversionExpr(CovariantFunctionConversionExpr *expr) {
+}
+
+void PrintAST::visitExistentialMetatypeToObjectExpr(ExistentialMetatypeToObjectExpr *expr) {
+}
+
+void PrintAST::visitUnresolvedMemberChainResultExpr(swift::UnresolvedMemberChainResultExpr *expr) {
+}
+
+void PrintAST::visitLinearFunctionExtractOriginalExpr(swift::LinearFunctionExtractOriginalExpr *expr) {
+}
+
+void PrintAST::visitLinearToDifferentiableFunctionExpr(swift::LinearToDifferentiableFunctionExpr *expr) {
+}
+
+void PrintAST::visitPropertyWrapperValuePlaceholderExpr(swift::PropertyWrapperValuePlaceholderExpr *expr) {
+}
+
+void PrintAST::visitDifferentiableFunctionExtractOriginalExpr(swift::DifferentiableFunctionExtractOriginalExpr *expr) {
+}
+
 void PrintAST::visitBraceStmt(BraceStmt *stmt) {
   printBraceStmt(stmt);
 }
 
 void PrintAST::visitReturnStmt(ReturnStmt *stmt) {
-  Printer << tok::kw_return;
   if (stmt->hasResult()) {
+    Printer << tok::kw_return;
     Printer << " ";
-    // FIXME: print expression.
+    visit(stmt->getResult());
   }
 }
 
@@ -4080,7 +4580,7 @@ void PrintAST::visitYieldStmt(YieldStmt *stmt) {
 
 void PrintAST::visitThrowStmt(ThrowStmt *stmt) {
   Printer << tok::kw_throw << " ";
-  // FIXME: print expression.
+  visit(stmt->getSubExpr());
 }
 
 void PrintAST::visitPoundAssertStmt(PoundAssertStmt *stmt) {
@@ -4095,7 +4595,7 @@ void PrintAST::visitDeferStmt(DeferStmt *stmt) {
 
 void PrintAST::visitIfStmt(IfStmt *stmt) {
   Printer << tok::kw_if << " ";
-  // FIXME: print condition
+  printStmtCondition(stmt->getCond());
   Printer << " ";
   visit(stmt->getThenStmt());
   if (auto elseStmt = stmt->getElseStmt()) {
@@ -4105,23 +4605,39 @@ void PrintAST::visitIfStmt(IfStmt *stmt) {
 }
 void PrintAST::visitGuardStmt(GuardStmt *stmt) {
   Printer << tok::kw_guard << " ";
-  // FIXME: print condition
-  Printer << " ";
+  printStmtCondition(stmt->getCond());
+  Printer << " else ";
   visit(stmt->getBody());
 }
 
 void PrintAST::visitWhileStmt(WhileStmt *stmt) {
   Printer << tok::kw_while << " ";
-  // FIXME: print condition
+  printStmtCondition(stmt->getCond());
   Printer << " ";
   visit(stmt->getBody());
 }
 
 void PrintAST::visitRepeatWhileStmt(RepeatWhileStmt *stmt) {
-  Printer << tok::kw_do << " ";
+  Printer << tok::kw_repeat << " ";
   visit(stmt->getBody());
   Printer << " " << tok::kw_while << " ";
-  // FIXME: print condition
+  visit(stmt->getCond());
+}
+
+void PrintAST::printStmtCondition(StmtCondition stmt) {
+  for (auto elt : stmt) {
+    if (auto pattern = elt.getPatternOrNull()) {
+      printPattern(pattern);
+      auto initializer = elt.getInitializer();
+      if (initializer) {
+        Printer << " = ";
+        visit(initializer);
+      }
+    }
+    else if (auto boolean = elt.getBooleanOrNull()) {
+      visit(boolean);
+    }
+  }
 }
 
 void PrintAST::visitDoStmt(DoStmt *stmt) {
@@ -4160,16 +4676,16 @@ void PrintAST::visitFallthroughStmt(FallthroughStmt *stmt) {
 
 void PrintAST::visitSwitchStmt(SwitchStmt *stmt) {
   Printer << tok::kw_switch << " ";
-  // FIXME: print subject
-  Printer << "{";
+  visit(stmt->getSubjectExpr());
+  Printer << " {";
   Printer.printNewline();
   for (auto N : stmt->getRawCases()) {
     if (N.is<Stmt*>())
       visit(cast<CaseStmt>(N.get<Stmt*>()));
     else
       visit(cast<IfConfigDecl>(N.get<Decl*>()));
+    Printer.printNewline();
   }
-  Printer.printNewline();
   indent();
   Printer << "}";
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1316,6 +1316,7 @@ void PrintAST::printPattern(const Pattern *pattern) {
 
   case PatternKind::OptionalSome:
     printPattern(cast<OptionalSomePattern>(pattern)->getSubPattern());
+    Printer << '?';
     break;
 
   case PatternKind::Bool:
@@ -4366,7 +4367,6 @@ void PrintAST::visitLazyInitializerExpr(LazyInitializerExpr *expr) {
 }
 
 void PrintAST::visitOpenExistentialExpr(OpenExistentialExpr *expr) {
-  visit(expr->getValueProvidingExpr());
   visit(expr->getExistentialValue());
   visit(expr->getSubExpr());
 }
@@ -4399,6 +4399,7 @@ void PrintAST::visitUnresolvedMemberExpr(UnresolvedMemberExpr *expr) {
 }
 
 void PrintAST::visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
+  Printer << "_";
 }
 
 void PrintAST::visitEditorPlaceholderExpr(EditorPlaceholderExpr *expr) {
@@ -4406,6 +4407,14 @@ void PrintAST::visitEditorPlaceholderExpr(EditorPlaceholderExpr *expr) {
 
 void PrintAST::visitForcedCheckedCastExpr(ForcedCheckedCastExpr *expr) {
   visit(expr->getSubExpr());
+  Printer << " as! ";
+  printType(expr->getCastType());
+}
+
+void PrintAST::visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *expr) {
+  visit(expr->getSubExpr());
+  Printer << " as? ";
+  printType(expr->getCastType());
 }
 
 void PrintAST::visitOverloadedDeclRefExpr(OverloadedDeclRefExpr *expr) {
@@ -4466,10 +4475,6 @@ void PrintAST::visitClassMetatypeToObjectExpr(ClassMetatypeToObjectExpr *expr) {
 }
 
 void PrintAST::visitAppliedPropertyWrapperExpr(AppliedPropertyWrapperExpr *expr) {
-}
-
-void PrintAST::visitConditionalCheckedCastExpr(ConditionalCheckedCastExpr *expr) {
-  visit(expr->getSubExpr());
 }
 
 void PrintAST::visitDifferentiableFunctionExpr(DifferentiableFunctionExpr *expr) {
@@ -4535,8 +4540,8 @@ void PrintAST::visitBraceStmt(BraceStmt *stmt) {
 }
 
 void PrintAST::visitReturnStmt(ReturnStmt *stmt) {
+  Printer << tok::kw_return;
   if (stmt->hasResult()) {
-    Printer << tok::kw_return;
     Printer << " ";
     visit(stmt->getResult());
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1325,10 +1325,8 @@ void PrintAST::printPattern(const Pattern *pattern) {
     break;
 
   case PatternKind::Expr: {
-    if (Options.PrintExprs) {
-        auto expr = cast<ExprPattern>(pattern)->getSubExpr();
-        visit(expr);
-    }
+    auto expr = cast<ExprPattern>(pattern)->getSubExpr();
+    visit(expr);
     break;
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4217,6 +4217,12 @@ void PrintAST::visitTupleExpr(TupleExpr *expr) {
   Printer << ")";
 }
 
+void PrintAST::visitPackExpr(PackExpr *expr) {
+}
+
+void PrintAST::visitReifyPackExpr(ReifyPackExpr *expr) {
+}
+
 void PrintAST::visitAssignExpr(AssignExpr *expr) {
   visit(expr->getDest());
   Printer << " = ";

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -356,7 +356,7 @@ DeclAttributes::getSoftDeprecated(const ASTContext &ctx) const {
 
 void DeclAttributes::dump(const Decl *D) const {
   StreamPrinter P(llvm::errs());
-  PrintOptions PO = PrintOptions::printEverything();
+  PrintOptions PO = PrintOptions::printDeclarations();
   print(P, PO, D);
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -478,6 +478,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::DumpTypeInfo;
   if (Opt.matches(OPT_print_ast))
     return FrontendOptions::ActionType::PrintAST;
+  if (Opt.matches(OPT_print_ast_decl))
+    return FrontendOptions::ActionType::PrintASTDecl;
   if (Opt.matches(OPT_emit_pcm))
     return FrontendOptions::ActionType::EmitPCM;
   if (Opt.matches(OPT_dump_pcm))

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -39,6 +39,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::EmitSyntax:
   case ActionType::DumpInterfaceHash:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpPCM:
@@ -109,6 +110,7 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitSILGen:
@@ -154,6 +156,7 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitSILGen:
@@ -196,6 +199,7 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   case ActionType::Typecheck:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitSILGen:
@@ -256,6 +260,7 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
@@ -324,6 +329,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
@@ -367,6 +373,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
@@ -409,6 +416,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
@@ -451,6 +459,7 @@ bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
@@ -492,6 +501,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:
@@ -540,6 +550,7 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
@@ -584,6 +595,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
@@ -629,6 +641,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::EmitImportedModules:
   case ActionType::EmitPCH:
   case ActionType::DumpScopeMaps:
@@ -671,6 +684,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitSyntax:
   case ActionType::DumpInterfaceHash:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitPCH:
@@ -729,6 +743,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitImportedModules:
@@ -758,6 +773,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::EmitSyntax:
   case ActionType::DumpAST:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::EmitImportedModules:
@@ -798,6 +814,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpAST:
   case ActionType::EmitSyntax:
   case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
   case ActionType::DumpTypeInfo:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1197,6 +1197,13 @@ static bool performAction(CompilerInstance &Instance,
               llvm::outs(), PrintOptions::printEverything());
           return Instance.getASTContext().hadError();
         });
+  case FrontendOptions::ActionType::PrintASTDecl:
+    return withSemanticAnalysis(
+        Instance, observer, [](CompilerInstance &Instance) {
+          getPrimaryOrMainSourceFile(Instance).print(
+              llvm::outs(), PrintOptions::printDeclarations());
+          return Instance.getASTContext().hadError();
+        });
   case FrontendOptions::ActionType::DumpScopeMaps:
     return withSemanticAnalysis(
         Instance, observer, [](CompilerInstance &Instance) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1477,7 +1477,7 @@ static StringRef prettyPrintAttrs(const ValueDecl *VD,
   llvm::raw_svector_ostream os(out);
   StreamPrinter printer(os);
 
-  PrintOptions opts = PrintOptions::printEverything();
+  PrintOptions opts = PrintOptions::printDeclarations();
   VD->getAttrs().print(printer, opts, attrs, VD);
   return StringRef(out.begin(), out.size()).drop_back();
 }

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -print-ast %s | %FileCheck %s --check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -print-ast-decl %s | %FileCheck %s --check-prefix=CHECK-AST
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s --check-prefix=CHECK-SIL
 
 import _Differentiation

--- a/test/Sema/struct_equatable_hashable_access.swift
+++ b/test/Sema/struct_equatable_hashable_access.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -print-ast-decl %s 2>&1 | %FileCheck %s
 
 // Check that synthesized members show up as 'fileprivate', not 'private.
 

--- a/test/expr/print/callexpr.swift
+++ b/test/expr/print/callexpr.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+func test(a: Int, b: Int = 0, c: Int = 1) { }
+
+test(a: 0)
+test(a: 0, b: 0)
+test(a: 0, b: 0, c: 0)
+// CHECK: test(a: 0)
+// CHECK: test(a: 0, b: 0)
+// CHECK: test(a: 0, b: 0, c: 0)

--- a/test/expr/print/conditions.swift
+++ b/test/expr/print/conditions.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+if (5 + 5) == 10 {
+}
+// CHECK: if (5 + 5) == 10 {
+// CHECK: }
+
+if (5 + 5) == 9 {
+} else if (5 + 5) == 10 {
+} else {
+}
+// CHECK: if (5 + 5) == 9 {
+// CHECK: } else if (5 + 5) == 10 {
+// CHECK: } else {
+// CHECK: }
+
+guard (5 + 5) == 10 else {
+}
+// CHECK: guard (5 + 5) == 10 else {
+// CHECK: }
+
+var a = 0
+// CHECK: @_hasInitialValue internal var a: Int = 0
+// Note: the AST doesn't store whitespace,
+// so the output doesn't always match the input.
+while a < 10 { a += 1 }
+// CHECK: while a < 10 {
+// CHECK:   a += 1
+// CHECK: }
+
+var b = 0
+repeat {
+  b += 1
+} while b < 10
+// CHECK: @_hasInitialValue internal var b: Int = 0
+// CHECK: repeat {
+// CHECK:   b += 1
+// CHECK: } while b < 10

--- a/test/expr/print/literals.swift
+++ b/test/expr/print/literals.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: func test() {
+func test() {
+  log(1)
+  log(1.0)
+  log(true)
+  log([1, 2, 3])
+  log([1: true, 2: false])
+}
+// CHECK: log(1)
+// CHECK: log(1.0)
+// CHECK: log(true)
+// CHECK: log([1, 2, 3])
+// CHECK: log([1: true, 2: false])
+
+func log(_ a: Any) {
+}

--- a/test/expr/print/protocol.swift
+++ b/test/expr/print/protocol.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+protocol Archivable {
+  func archive(version: String)
+}
+// CHECK: internal protocol Archivable {
+// CHECK:   func archive(version: String)
+// CHECK: }
+
+func archive(_ a: Archivable) {
+  a.archive(version: "1")
+}
+// CHECK: internal func archive(_ a: Archivable) {
+// CHECK:   a.archive(version: "1")
+// CHECK: }
+
+func cast(_ a: Any) {
+  let conditional = a as? Archivable
+  let forced = a as! Archivable
+}
+// CHECK: internal func cast(_ a: Any) {
+// CHECK:   @_hasInitialValue private let conditional: Archivable? = a as? Archivable
+// CHECK:   @_hasInitialValue private let forced: Archivable = a as! Archivable
+// CHECK: }

--- a/test/expr/print/switch.swift
+++ b/test/expr/print/switch.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -print-ast %s 2>&1 | %FileCheck %s
+
+enum Payload {
+  case int(Int)
+  case keyValue(String, Int)
+  case empty
+}
+
+// CHECK-LABEL: internal func test(payload: Payload) -> Int? {
+func test(payload: Payload) -> Int? {
+  switch payload {
+  case .int(let int):
+    return int
+  case .keyValue(_, let int):
+    return int
+  case .empty:
+    return nil
+  }
+}
+// CHECK-LABEL: switch payload {
+// CHECK-LABEL: case .int(let int):
+// CHECK-LABEL:   return int
+// CHECK-LABEL: case .keyValue(_, let int):
+// CHECK-LABEL:   return int
+// CHECK-LABEL: case .empty:
+// CHECK-LABEL:   return nil
+// CHECK-LABEL: }
+// CHECK-LABEL:}

--- a/test/expr/print/switch.swift
+++ b/test/expr/print/switch.swift
@@ -26,3 +26,33 @@ func test(payload: Payload) -> Int? {
 // CHECK-LABEL:   return nil
 // CHECK-LABEL: }
 // CHECK-LABEL:}
+
+func process(payload: Payload) {
+  if case .empty = payload {
+    return
+  }
+  _ = test(payload: payload)
+}
+// CHECK-LABEL: internal func process(payload: Payload) {
+// CHECK-LABEL:   if .empty = payload {
+// CHECK-LABEL:     return
+// CHECK-LABEL:   }
+// CHECK-LABEL:   _ = test(payload: payload)
+// CHECK-LABEL: }
+
+func foo(_ x: Int?) {
+  switch x {
+  case let x?:
+    break
+  case nil:
+    break
+  }
+}
+// CHECK-LABEL: internal func foo(_ x: Int?) {
+// CHECK-LABEL:   switch x {
+// CHECK-LABEL:   case let x?:
+// CHECK-LABEL:     break
+// CHECK-LABEL:   case .none:
+// CHECK-LABEL:     break
+// CHECK-LABEL:   }
+// CHECK-LABEL: }

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -932,7 +932,7 @@ int swift::doGenerateModuleAPIDescription(StringRef MainExecutablePath,
   }
   CI.performSema();
 
-  PrintOptions Options = PrintOptions::printEverything();
+  PrintOptions Options = PrintOptions::printDeclarations();
 
   ModuleDecl *M = CI.getMainModule();
   M->getMainSourceFile().print(llvm::outs(), Options);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -527,6 +527,12 @@ FunctionDefinitions("function-definitions",
                     llvm::cl::init(true));
 
 static llvm::cl::opt<bool>
+Expressions("expressions",
+            llvm::cl::desc("Print expressions"),
+            llvm::cl::cat(Category),
+            llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 AbstractAccessors("abstract-accessors",
                   llvm::cl::desc("Hide the concrete accessors used to "
                                  "implement a property or subscript"),
@@ -2595,7 +2601,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
 
   int ExitCode = 0;
 
-  PrintOptions Options = PrintOptions::printEverything();
+  PrintOptions Options = PrintOptions::printDeclarations();
 
   for (StringRef ModuleName : ModulesToPrint) {
     auto *M = getModuleByFullName(Context, ModuleName);
@@ -2687,7 +2693,7 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
 
       llvm::outs() << remangled << "\n";
 
-      auto Options = PrintOptions::printEverything();
+      auto Options = PrintOptions::printDeclarations();
       Options.PrintAccess = false;
       LTD->print(llvm::outs(), Options);
       llvm::outs() << "\n";
@@ -3234,7 +3240,7 @@ static int doPrintTypes(const CompilerInvocation &InitInvok,
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   CI.performSema();
 
-  PrintOptions Options = PrintOptions::printEverything();
+  PrintOptions Options = PrintOptions::printDeclarations();
   Options.FullyQualifiedTypes = FullyQualifiedTypes;
   ASTTypePrinter Printer(CI.getSourceMgr(), Options);
 
@@ -4379,6 +4385,7 @@ int main(int argc, char *argv[]) {
     PrintOpts.SynthesizeSugarOnTypes = options::SynthesizeSugarOnTypes;
     PrintOpts.AbstractAccessors = options::AbstractAccessors;
     PrintOpts.FunctionDefinitions = options::FunctionDefinitions;
+    PrintOpts.PrintExprs = options::Expressions;
     PrintOpts.PreferTypeRepr = options::PreferTypeRepr;
     PrintOpts.ExplodePatternBindingDecls = options::ExplodePatternBindingDecls;
     PrintOpts.PrintImplicitAttrs = options::PrintImplicitAttrs;


### PR DESCRIPTION
Add new `-print-ast-decl` frontend option for only printing declarations,
to match existing behavior.
Some tests want to print the AST, but don't care about expressions.

The existing `-print-ast` option now prints function bodies and expressions.
Not all expressions are printed yet, but most common ones are.