### PR TITLE
[5.6] make initializing expressions for member stored properties nonisolated.

### DIFF
--- a/test/Concurrency/property_initializers.swift
+++ b/test/Concurrency/property_initializers.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-concurrency
+// REQUIRES: concurrency
+
+
+@MainActor
+func mainActorFn() -> Int { return 0 } // expected-note 2 {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
+
+@MainActor
+class C {
+  var x: Int = mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous nonisolated context}}
+
+  lazy var y: Int = mainActorFn()
+
+  static var z: Int = mainActorFn()
+}
+
+@MainActor
+var x: Int = mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous nonisolated context}}


### PR DESCRIPTION
**Explanation:** There was a mismatch between the isolation assigned to the initializing expressions of a stored property member and the actual implementation by the compiler. For example, this program was permitted by the type-checker
```swift
@MainActor func getStatus() -> Int { /* ... */ }
@PIDActor func genPID() -> ProcessID { /* ... */ }

class Process {
  @MainActor var status: Int = getStatus()
  @PIDActor var pid: ProcessID = genPID()

  init() {} // Problem: what is the isolation of this init?
}
```

but it has an impossible-to-satisfy set of constraints on the `init`. It's not possible to have the `init` be isolated to both global actors, in order for the init to execute the `genStatus` and `genPID` calls. In fact, the `init` has no isolation at all, and is non-async, so it cannot gain actor isolation in its body at all. So the implementation was ignoring the isolation, despite the typechecker providing it.

This patch changes the isolation for those initializer expressions for instance members, saying that the isolation is unspecified in order to match the implementation.

**Scope of Issue:** Programs could have concurrency bugs because isolation was not correctly gained at runtime, despite the type-checker permitting the program. It's limited specifically to any initializing expressions of a nominal type's property that is isolated to a global actor, most commonly the MainActor. If the type has a designated initializer that is not also isolated to that same global-actor, then the bug is present in their program.

**Risk:** (Medium) This patch will most commonly introduce a source break for code that calls or accesses something isolated to the MainActor specifically within an initializing expression of a stored property member. Users must move those expressions so they appear in each designated initializer. If those initializers had the correct isolation, then the source break is a very simple refactoring. But if those initializers had the wrong isolation, then their code previously had a runtime bug and a larger refactoring is required.

**Pull Request URL:** https://github.com/apple/swift/pull/40652
**Reviewed By:** Doug Gregor
**Automated Testing:** regression test is included
**Issue:** rdar://84225474