### PR TITLE
[SE-0345] Support `if let foo {` optional binding conditions

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1075,6 +1075,8 @@ ERROR(conditional_var_initializer_required,none,
 ERROR(wrong_condition_case_location,none,
       "pattern matching binding is spelled with 'case %0', not '%0 case'",
       (StringRef))
+ERROR(conditional_var_valid_identifiers_only,none,
+      "unwrap condition requires a valid identifier", ())
 
 // If Statement
 ERROR(expected_condition_if,PointsToFirstBadToken,

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1618,12 +1618,23 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     ThePattern = makeParserResult(AP);
   }
 
-  // Conditional bindings must have an initializer.
+  // Conditional bindings can have the format:
+  //  `let newBinding = <expr>`, or
+  //  `let newBinding`, which is shorthand for `let newBinding = newBinding`
   ParserResult<Expr> Init;
   if (Tok.is(tok::equal)) {
     SyntaxParsingContext InitCtxt(SyntaxContext, SyntaxKind::InitializerClause);
     consumeToken();
     Init = parseExprBasic(diag::expected_expr_conditional_var);
+  } else if (!ThePattern.isNull() && !ThePattern.getPtrOrNull()->getBoundName().empty()) {
+    auto bindingName = new DeclNameRef(ThePattern.getPtrOrNull()->getBoundName());
+    auto loc = new DeclNameLoc(ThePattern.getPtrOrNull()->getEndLoc());
+    auto declRefExpr = new (Context) UnresolvedDeclRefExpr(*bindingName,
+                                                           DeclRefKind::Ordinary,
+                                                           *loc);
+    
+    declRefExpr->setImplicit();
+    Init = makeParserResult(declRefExpr);
   } else {
     diagnose(Tok, diag::conditional_var_initializer_required);
   }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1635,6 +1635,13 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     
     declRefExpr->setImplicit();
     Init = makeParserResult(declRefExpr);
+  } else if (!ThePattern.isNull()) {
+    // If the pattern is present but isn't an identifier, the user wrote
+    // something invalid like `let foo.bar`. Emit a special diagnostic for this,
+    // with a fix-it prepending "<#identifier#> = "
+    auto diagLoc = ThePattern.get()->getSemanticsProvidingPattern()->getStartLoc();
+    diagnose(diagLoc, diag::conditional_var_valid_identifiers_only)
+      .fixItInsert(diagLoc, "<#identifier#> = ");
   } else {
     diagnose(Tok, diag::conditional_var_initializer_required);
   }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1635,10 +1635,12 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     
     declRefExpr->setImplicit();
     Init = makeParserResult(declRefExpr);
-  } else if (!ThePattern.isNull()) {
+  } else if (!ThePattern.isNull() && BindingKindStr != "case") {
     // If the pattern is present but isn't an identifier, the user wrote
     // something invalid like `let foo.bar`. Emit a special diagnostic for this,
     // with a fix-it prepending "<#identifier#> = "
+    //  - We don't emit this fix-it if the user wrote `case let` (etc),
+    //    since the shorthand syntax isn't available for pattern matching
     auto diagLoc = ThePattern.get()->getSemanticsProvidingPattern()->getStartLoc();
     diagnose(diagLoc, diag::conditional_var_valid_identifiers_only)
       .fixItInsert(diagLoc, "<#identifier#> = ");

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1626,16 +1626,16 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     SyntaxParsingContext InitCtxt(SyntaxContext, SyntaxKind::InitializerClause);
     consumeToken();
     Init = parseExprBasic(diag::expected_expr_conditional_var);
-  } else if (!ThePattern.isNull() && !ThePattern.getPtrOrNull()->getBoundName().empty()) {
-    auto bindingName = new DeclNameRef(ThePattern.getPtrOrNull()->getBoundName());
-    auto loc = new DeclNameLoc(ThePattern.getPtrOrNull()->getEndLoc());
-    auto declRefExpr = new (Context) UnresolvedDeclRefExpr(*bindingName,
+  } else if (!ThePattern.getPtrOrNull()->getBoundName().empty()) {
+    auto bindingName = DeclNameRef(ThePattern.getPtrOrNull()->getBoundName());
+    auto loc = DeclNameLoc(ThePattern.getPtrOrNull()->getEndLoc());
+    auto declRefExpr = new (Context) UnresolvedDeclRefExpr(bindingName,
                                                            DeclRefKind::Ordinary,
-                                                           *loc);
+                                                           loc);
     
     declRefExpr->setImplicit();
     Init = makeParserResult(declRefExpr);
-  } else if (!ThePattern.isNull() && BindingKindStr != "case") {
+  } else if (BindingKindStr != "case") {
     // If the pattern is present but isn't an identifier, the user wrote
     // something invalid like `let foo.bar`. Emit a special diagnostic for this,
     // with a fix-it prepending "<#identifier#> = "

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-struct NonOptionalStruct {}
+struct NonOptionalStruct { let property: Any }
 enum NonOptionalEnum { case foo }
 
 func foo() -> Int? { return .none }
@@ -21,10 +21,29 @@ if var x = foo() {
   modify(&x)
 }
 
+if let x { // expected-error{{cannot find 'x' in scope}}
+  use(x)
+}
+
+if var x { // expected-error{{cannot find 'x' in scope}}
+  use(x)
+}
+
 use(x) // expected-error{{cannot find 'x' in scope}}
+
+let nonOptional = nonOptionalStruct()
 
 if let x = nonOptionalStruct() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 if let x = nonOptionalEnum() { _ = x} // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
+
+if let nonOptional { _ = nonOptional } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+if var nonOptional { nonOptional = nonOptionalStruct(); _ = nonOptional } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+
+guard let nonOptional else { _ = nonOptional; fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+guard var nonOptional else { _ = nonOptional; fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
+
+if let nonOptional.property { } // expected-error{{variable binding in a condition requires an initializer}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
+if var nonOptional.property { } // expected-error{{variable binding in a condition requires an initializer}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
 
 guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
@@ -58,6 +77,16 @@ if let x = foo() {
 }
 
 var opt: Int? = .none
+
+if let opt {
+  use(opt)
+  opt = 10 // expected-error{{cannot assign to value: 'opt' is a 'let' constant}}
+}
+
+if var opt {
+  use(opt)
+  opt = 10
+}
 
 if let x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}} {{4-12=}} {{15-15= != nil}}
 if var x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}} {{4-12=}} {{15-15= != nil}}
@@ -137,11 +166,24 @@ func testShadowing(_ a: Int?, b: Int?, c: Int?, d: Int?) {
   }
 }
 
+func testShadowingWithShorthand(_ a: Int?, b: Int?, c: Int?, d: Int?) {
+  guard let a, let b = a > 0 ? b : nil else { return }
+  _ = b
+
+  if let c, let d = c > 0 ? d : nil {
+    _ = d
+  }
+}
+
 func useInt(_ x: Int) {}
 
-func testWhileScoping(_ a: Int?) {// expected-note {{did you mean 'a'?}}
+func testWhileScoping(_ a: Int?) {
   while let x = a { }
   useInt(x) // expected-error{{cannot find 'x' in scope}}
+}
+
+func testWhileShorthand(_ b: Int?) {
+  while let b { _ = b }
 }
 
 // Matching a case with a single, labeled associated value.

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -48,8 +48,18 @@ if var nonOptional.property { } // expected-error{{unwrap condition requires a v
 guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}
 
+let optional: String? = nil
+if case let optional? { _ = optional } // expected-error{{variable binding in a condition requires an initializer}}
+if case let .some(optional) { _ = optional } // expected-error{{variable binding in a condition requires an initializer}}
+if case .some(let optional) { _ = optional } // expected-error{{variable binding in a condition requires an initializer}}
+
 if case let x? = nonOptionalStruct() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalStruct'}}
 if case let x? = nonOptionalEnum() { _ = x } // expected-error{{'?' pattern cannot match values of type 'NonOptionalEnum'}}
+
+if let x { _ = x } // expected-error{{cannot find 'x' in scope}}
+
+if let optional: String { _ = optional }
+if let optional: Int { _ = optional } // expected-error{{cannot convert value of type 'String?' to specified type 'Int?'}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -55,8 +55,8 @@ class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}
 
 // TODO poor recovery in these cases
-if let {} // expected-error {{expected '{' after 'if' condition}} expected-error {{pattern matching in a condition requires the 'case' keyword}}
-if let x = { } // expected-error{{'{' after 'if'}} expected-error {{variable binding in a condition requires an initializer}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
+if let {} // expected-error {{expected '{' after 'if' condition}} expected-error {{pattern matching in a condition requires the 'case' keyword}} expected-error {{unwrap condition requires a valid identifier}}
+if let x = { } // expected-error{{'{' after 'if'}} expected-error{{initializer for conditional binding must have Optional type, not '() -> ()'}}
 // expected-warning@-1{{value 'x' was defined but never used}}
 
 if let x = foo() {

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -42,8 +42,8 @@ if var nonOptional { nonOptional = nonOptionalStruct(); _ = nonOptional } // exp
 guard let nonOptional else { _ = nonOptional; fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard var nonOptional else { _ = nonOptional; fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 
-if let nonOptional.property { } // expected-error{{variable binding in a condition requires an initializer}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
-if var nonOptional.property { } // expected-error{{variable binding in a condition requires an initializer}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
+if let nonOptional.property { } // expected-error{{unwrap condition requires a valid identifier}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
+if var nonOptional.property { } // expected-error{{unwrap condition requires a valid identifier}} expected-error{{pattern matching in a condition requires the 'case' keyword}}
 
 guard let _ = nonOptionalStruct() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalStruct'}}
 guard let _ = nonOptionalEnum() else { fatalError() } // expected-error{{initializer for conditional binding must have Optional type, not 'NonOptionalEnum'}}

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -357,7 +357,7 @@ func testMyEnumWithCaseLabels(_ a : MyEnumWithCaseLabels) {
 }
 
 
-func test_guard(_ x : Int, y : Int??, cond : Bool) {
+func test_guard(_ x : Int, y : Int??, z: Int?, cond : Bool) {
   
   // These are all ok.
   guard let a = y else {}
@@ -366,9 +366,9 @@ func test_guard(_ x : Int, y : Int??, cond : Bool) {
   guard case let c = x, cond else {}
   guard case let Optional.some(d) = y else {}
   guard x != 4, case _ = x else { }
-
-
-  guard let e, cond else {}    // expected-error {{variable binding in a condition requires an initializer}}
+  guard let z, cond else {}
+  
+  
   guard case let f? : Int?, cond else {}    // expected-error {{variable binding in a condition requires an initializer}}
 
   // FIXME: Bring back the tailored diagnostic


### PR DESCRIPTION
This PR adds support for `if let foo {` optional binding conditions. 

This implements [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md).

For example:

```swift
var foo: String? = "hello world"

if let foo {
  // `foo` is unwrapped to `String`
  print(foo) // prints "hello world"
}
```