### PR TITLE
[5.6][Frontend] Remove warning for missing `-index-store-path`

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -232,8 +232,6 @@ ERROR(error_index_failed_status_check,none,
       "failed file status check: %0", (StringRef))
 ERROR(error_index_inputs_more_than_outputs,none,
       "index output filenames do not match input source files", ())
-WARNING(warn_index_unit_output_path_without_index_store,none,
-      "-index-unit-output-path is ignored without -index-store-path", ())
 
 ERROR(error_wrong_number_of_arguments,none,
       "wrong number of '%0' arguments (expected %1, got %2)",

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -50,12 +50,6 @@ bool ArgsToFrontendOutputsConverter::convert(
   Optional<std::vector<std::string>> indexMains;
   if (Args.hasArg(options::OPT_index_unit_output_path,
                   options::OPT_index_unit_output_path_filelist)) {
-
-    if (!Args.hasArg(options::OPT_index_store_path)) {
-      Diags.diagnose(SourceLoc(),
-                     diag::warn_index_unit_output_path_without_index_store);
-    }
-
     Optional<OutputFilesComputer> iuofc =
         OutputFilesComputer::create(Args, Diags, InputsAndOutputs, {
           "index unit output path", options::OPT_index_unit_output_path,

--- a/test/Index/Store/unit-custom-output-path.swift
+++ b/test/Index/Store/unit-custom-output-path.swift
@@ -239,12 +239,8 @@
 //    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist 2>&1 \
 //    RUN: | %FileCheck --check-prefixes=ERROR_MISMATCH %s
 //
-// C) Check -index-unit-output-path without -index-store warns
-//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+// C) Check -index-unit-output-path without -index-store-path does not cause a warning/error
+//    RUN: %target-typecheck-verify-swift -parse-stdlib \
 //    RUN:     -module-name mod_name \
 //    RUN:     -primary-file %t/main.swift %t/second.swift \
-//    RUN:     -o %t/main_out.o -index-unit-output-path %t/custom_output.o 2>&1 \
-//    RUN: | %FileCheck --check-prefixes=ERROR_IGNORED %s
-//
-//    ERROR_IGNORED: warning: -index-unit-output-path is ignored without -index-store-path
-
+//    RUN:     -o %t/main_out.o -index-unit-output-path %t/custom_output.o


### PR DESCRIPTION
Cherry-picks 6e683ca823cc987544faa7a2696d3c5e70901432 (https://github.com/apple/swift/pull/40698)

-----

Do not produce a warning when `-index-unit-output-path` is given without
`-index-store-path`.

Resolves rdar://86833719.