### PR TITLE
[NFC] Replace `if`s with `guard`s in `lexicographicallyPrecedes`

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -412,20 +412,11 @@ extension Sequence {
     var iter1 = self.makeIterator()
     var iter2 = other.makeIterator()
     while true {
-      if let e1 = iter1.next() {
-        if let e2 = iter2.next() {
-          if try areInIncreasingOrder(e1, e2) {
-            return true
-          }
-          if try areInIncreasingOrder(e2, e1) {
-            return false
-          }
-          continue // Equivalent
-        }
-        return false
-      }
-
-      return iter2.next() != nil
+      guard let e1 = iter1.next() else { return iter2.next() != nil }
+      guard let e2 = iter2.next() else { return false }
+      if try areInIncreasingOrder(e1, e2) { return true }
+      if try areInIncreasingOrder(e2, e1) { return false }
+      continue // e1 and e2 are equivalent
     }
   }
 }


### PR DESCRIPTION
`guard`s flatten the structure, making the code easier to read than 3 layers of `if`s.