### PR TITLE
[Gardening] Use apostrophes around symbols (but not file names) in diagnostic messages

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -84,7 +84,7 @@ WARNING(incremental_requires_output_file_map,none,
         "ignoring -incremental (currently requires an output file map)", ())
 WARNING(incremental_requires_build_record_entry,none,
         "ignoring -incremental; output file map has no master dependencies "
-        "entry (\"%0\" under \"\")", (StringRef))
+        "entry ('%0' under '')", (StringRef))
 
 WARNING(unable_to_open_incremental_comparison_log,none,
 "unable to open incremental comparison log file '%0'", (StringRef))

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -148,27 +148,27 @@ WARNING(emit_reference_dependencies_without_primary_file,none,
         "ignoring -emit-reference-dependencies (requires -primary-file)", ())
 
 WARNING(warn_implicit_concurrency_import_failed,none,
-        "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())
+        "unable to perform implicit import of '_Concurrency' module: no such module found", ())
 WARNING(warn_implicit_string_processing_import_failed,none,
-        "unable to perform implicit import of \"_StringProcessing\" module: no such module found", ())
+        "unable to perform implicit import of '_StringProcessing' module: no such module found", ())
 
 ERROR(error_module_name_required,none, "-module-name is required", ())
 ERROR(error_bad_module_name,none,
-      "module name \"%0\" is not a valid identifier"
+      "module name '%0' is not a valid identifier"
       "%select{|; use -module-name flag to specify an alternate name}1",
       (StringRef, bool))
 ERROR(error_stdlib_module_name,none,
-      "module name \"%0\" is reserved for the standard library"
+      "module name '%0' is reserved for the standard library"
       "%select{|; use -module-name flag to specify an alternate name}1",
       (StringRef, bool))
 ERROR(error_stdlib_not_found,Fatal,
       "unable to load standard library for target '%0'", (StringRef))
 ERROR(error_module_alias_invalid_format,none,
-      "invalid module alias format \"%0\"; make sure to use the format '-module-alias alias_name=underlying_name'", (StringRef))
+      "invalid module alias format '%0'; make sure to use the format '-module-alias alias_name=underlying_name'", (StringRef))
 ERROR(error_module_alias_forbidden_name,none,
-      "invalid module alias \"%0\"; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name", (StringRef))
+      "invalid module alias '%0'; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name", (StringRef))
 ERROR(error_module_alias_duplicate,none,
-      "duplicate module alias; the name \"%0\" is already used for a module alias or an underlying name", (StringRef))
+      "duplicate module alias; the name '%0' is already used for a module alias or an underlying name", (StringRef))
 
 ERROR(error_unable_to_load_supplementary_output_file_map, none,
       "unable to load supplementary output file map '%0': %1",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -255,12 +255,12 @@ ERROR(assignment_to_immutable_value,none,
       (StringRef))
 
 WARNING(designated_init_in_cross_module_extension,none,
-        "initializer for struct %0 must use \"self.init(...)\" or \"self = ...\""
+        "initializer for struct %0 must use 'self.init(...)' or 'self = ...'"
         "%select{| on all paths}1 because "
         "%select{it is not in module %2|the struct was imported from C}3",
         (Type, bool, Identifier, bool))
 NOTE(designated_init_c_struct_fix,none,
-     "use \"self.init()\" to initialize the struct with zero values", ())
+     "use 'self.init()' to initialize the struct with zero values", ())
 
 
 // Control flow diagnostics.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -729,7 +729,7 @@ ERROR(sema_no_import_repl,none,
 NOTE(sema_no_import_no_sdk,none,
      "did you forget to set an SDK using -sdk or SDKROOT?", ())
 NOTE(sema_no_import_no_sdk_xcrun,none,
-     "use \"xcrun swiftc\" to select the default macOS SDK "
+     "use 'xcrun swiftc' to select the default macOS SDK "
      "installed with Xcode", ())
 WARNING(sema_import_current_module,none,
         "this file is part of module %0; ignoring import", (Identifier))
@@ -4060,7 +4060,7 @@ NOTE(masked_mutable_property,none,
 
 ERROR(assignment_let_property_delegating_init,none,
       "'let' property %0 may not be initialized directly; use "
-      "\"self.init(...)\" or \"self = ...\" instead", (DeclNameRef))
+      "'self.init(...)' or 'self = ...' instead", (DeclNameRef))
 
 ERROR(label_shadowed, none,
       "label %0 cannot be reused on an inner statement", (Identifier))
@@ -4109,7 +4109,7 @@ ERROR(type_mismatch_fallthrough_pattern_list,none,
       "pattern variable bound to type %0, fallthrough case bound to type %1", (Type, Type))
 
 ERROR(unknown_case_must_be_catchall,none,
-      "'@unknown' is only supported for catch-all cases (\"case _\")", ())
+      "'@unknown' is only supported for catch-all cases ('case _')", ())
 ERROR(unknown_case_where_clause,none,
       "'where' cannot be used with '@unknown'", ())
 ERROR(unknown_case_multiple_patterns,none,
@@ -5794,7 +5794,7 @@ NOTE(missing_several_cases,none,
      "%select{missing cases|a default clause}0"
      "?", (bool))
 NOTE(missing_unknown_case,none,
-     "handle unknown values using \"@unknown default\"", ())
+     "handle unknown values using '@unknown default'", ())
 
 NOTE(non_exhaustive_switch_drop_unknown,none,
      "remove '@unknown' to handle remaining values", ())

--- a/test/ClangImporter/availability_open_enums.swift
+++ b/test/ClangImporter/availability_open_enums.swift
@@ -8,7 +8,7 @@ import AvailabilityExtras
 func exhaustiveSwitch(e: NSEnumAddedCasesIn2017) {
   switch e { // expected-error{{switch must be exhaustive}}
     // expected-note@-1{{add missing case: '.newCaseOne'}}
-    // expected-note@-2{{handle unknown values using "@unknown default"}}
+    // expected-note@-2{{handle unknown values using '@unknown default'}}
   case .existingCaseOne:
     return
   case .existingCaseTwo:

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -90,7 +90,7 @@ func testError() {
   let terr = getErr()
   switch (terr) { case .TENone, .TEOne, .TETwo: break }
   // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: warning: switch covers known cases, but 'TestError.Code' may have additional unknown values
-  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: handle unknown values using "@unknown default"
+  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: handle unknown values using '@unknown default'
 
   switch (terr) { case .TENone, .TEOne: break }
   // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: error: switch must be exhaustive

--- a/test/ClangImporter/enum-exhaustivity-system.swift
+++ b/test/ClangImporter/enum-exhaustivity-system.swift
@@ -3,7 +3,7 @@
 import EnumExhaustivity
 
 func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
-  switch value { // expected-warning {{switch covers known cases, but 'RegularEnum' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value { // expected-warning {{switch covers known cases, but 'RegularEnum' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using '@unknown default'}}
   case .A: break
   case .B: break
   }
@@ -29,7 +29,7 @@ func testAttributes(
   case .A, .B: break
   }
 
-  switch retetb { // expected-warning {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using "@unknown default"}}
+  switch retetb { // expected-warning {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values, possibly added in future versions}} expected-note {{handle unknown values using '@unknown default'}}
   case .A, .B: break
   }
 

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -16,7 +16,7 @@
 import EnumExhaustivity
 
 func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
-  switch value { // expected-error {{switch covers known cases, but 'RegularEnum' may have additional unknown values}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value { // expected-error {{switch covers known cases, but 'RegularEnum' may have additional unknown values}} expected-note {{handle unknown values using '@unknown default'}}
   case .A: break
   case .B: break
   }
@@ -42,7 +42,7 @@ func testAttributes(
   case .A, .B: break
   }
 
-  switch retetb { // expected-error {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values}} expected-note {{handle unknown values using "@unknown default"}}
+  switch retetb { // expected-error {{switch covers known cases, but 'RegularEnumTurnedExhaustiveThenBackViaAPINotes' may have additional unknown values}} expected-note {{handle unknown values using '@unknown default'}}
   case .A, .B: break
   }
 

--- a/test/ClangImporter/enum-inferred-exhaustivity.swift
+++ b/test/ClangImporter/enum-inferred-exhaustivity.swift
@@ -6,14 +6,14 @@
 
 func test(_ value: EnumWithDefaultExhaustivity) {
   // We want to assume such enums are non-frozen.
-  switch value { // expected-error {{switch covers known cases, but 'EnumWithDefaultExhaustivity' may have additional unknown values}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value { // expected-error {{switch covers known cases, but 'EnumWithDefaultExhaustivity' may have additional unknown values}} expected-note {{handle unknown values using '@unknown default'}}
   case .loneCase: break
   }
 }
 
 func test(_ value: EnumWithSpecialAttributes) {
   // Same, but with the attributes macro shipped in the Xcode 9 SDKs.
-  switch value { // expected-error {{switch covers known cases, but 'EnumWithSpecialAttributes' may have additional unknown values}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value { // expected-error {{switch covers known cases, but 'EnumWithSpecialAttributes' may have additional unknown values}} expected-note {{handle unknown values using '@unknown default'}}
   case .loneCase: break
   }
 }

--- a/test/ClangImporter/enum-new.swift
+++ b/test/ClangImporter/enum-new.swift
@@ -5,11 +5,11 @@ _ = .Red as Color
 _ = .Cyan as MoreColor
 
 func test() {
-  switch getColor() { // expected-warning {{switch covers known cases, but 'Color' may have additional unknown values}} expected-note{{handle unknown values using "@unknown default"}}
+  switch getColor() { // expected-warning {{switch covers known cases, but 'Color' may have additional unknown values}} expected-note{{handle unknown values using '@unknown default'}}
   case .Red, .Blue, .Green: break
   }
 
-  switch getMoreColor() { // expected-warning {{switch covers known cases, but 'MoreColor' may have additional unknown values}} expected-note{{handle unknown values using "@unknown default"}}
+  switch getMoreColor() { // expected-warning {{switch covers known cases, but 'MoreColor' may have additional unknown values}} expected-note{{handle unknown values using '@unknown default'}}
   case .Yellow, .Magenta, .Black, .Cyan: break
   }
 

--- a/test/ClangImporter/enum-objc.swift
+++ b/test/ClangImporter/enum-objc.swift
@@ -3,7 +3,7 @@
 // REQUIRES: objc_interop
 
 func test(_ value: SwiftEnum, _ exhaustiveValue: ExhaustiveEnum) {
-  switch value { // expected-warning {{switch covers known cases, but 'SwiftEnum' may have additional unknown values}} expected-note {{handle unknown values using "@unknown default"}}
+  switch value { // expected-warning {{switch covers known cases, but 'SwiftEnum' may have additional unknown values}} expected-note {{handle unknown values using '@unknown default'}}
   case .one: break
   case .two: break
   case .three: break

--- a/test/Concurrency/fail_implicit_concurrency_load.swift
+++ b/test/Concurrency/fail_implicit_concurrency_load.swift
@@ -18,4 +18,4 @@
 
 // RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules  -disable-availability-checking 2>&1 | %FileCheck %s
 import Swift
-// CHECK: warning: unable to perform implicit import of "_Concurrency" module: no such module found
+// CHECK: warning: unable to perform implicit import of '_Concurrency' module: no such module found

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -497,7 +497,7 @@ func testUnknownInSwitchSwitch(e: E) {
       s + "!"
     default:
       "nothing"
-    @unknown case .a: // expected-error{{'@unknown' is only supported for catch-all cases ("case _")}}
+    @unknown case .a: // expected-error{{'@unknown' is only supported for catch-all cases ('case _')}}
       // expected-error@-1{{'case' blocks cannot appear after the 'default' block of a 'switch'}}
       "a"
     }

--- a/test/Driver/Inputs/invalid-module-name.swift
+++ b/test/Driver/Inputs/invalid-module-name.swift
@@ -2,13 +2,13 @@
 // a valid Swift identifier.
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid-module-name.swift 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_NAME %s
-// INVALID_MODULE_NAME: error: module name "invalid-module-name" is not a valid identifier; use -module-name flag to specify an alternate name
+// INVALID_MODULE_NAME: error: module name 'invalid-module-name' is not a valid identifier; use -module-name flag to specify an alternate name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid.module.name.swift 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_NAME2 %s
-// INVALID_MODULE_NAME2: error: module name "invalid.module.name" is not a valid identifier; use -module-name flag to specify an alternate name
+// INVALID_MODULE_NAME2: error: module name 'invalid.module.name' is not a valid identifier; use -module-name flag to specify an alternate name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid-module-name.swift -module-name still-invalid 2>&1 | %FileCheck -check-prefix=STILL_INVALID %s
-// STILL_INVALID: error: module name "still-invalid" is not a valid identifier{{$}}
+// STILL_INVALID: error: module name 'still-invalid' is not a valid identifier{{$}}
 
 // These should succeed.
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/invalid-module-name.swift > /dev/null

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -2,7 +2,7 @@
 
 // RUN: not %swiftc_driver -emit-silgen -parse-as-library %s -module-name "Swift" 2>&1 | %FileCheck -check-prefix=STDLIB_MODULE %s
 // RUN: %target-swiftc_driver -emit-silgen -parse-as-library %s -module-name "Swift" -parse-stdlib -###
-// STDLIB_MODULE: error: module name "Swift" is reserved for the standard library{{$}}
+// STDLIB_MODULE: error: module name 'Swift' is reserved for the standard library{{$}}
 
 // RUN: not %swiftc_driver -crazy-option-that-does-not-exist %s 2>&1 | %FileCheck -check-prefix=INVALID_OPTION %s
 // RUN: not %swift_driver -crazy-option-that-does-not-exist 2>&1 | %FileCheck -check-prefix=INVALID_OPTION %s
@@ -88,7 +88,7 @@
 // INCREMENTAL_WITHOUT_OFM: swift{{(-frontend|c)?(\.exe)?"?}} -frontend
 
 // RUN: %swiftc_driver -incremental -output-file-map %S/Inputs/empty-ofm.json %s -### 2>&1 | %FileCheck -check-prefix=INCREMENTAL_WITHOUT_OFM_ENTRY %s
-// INCREMENTAL_WITHOUT_OFM_ENTRY: ignoring -incremental; output file map has no master dependencies entry ("swift-dependencies" under "")
+// INCREMENTAL_WITHOUT_OFM_ENTRY: ignoring -incremental; output file map has no master dependencies entry ('swift-dependencies' under '')
 // INCREMENTAL_WITHOUT_OFM_ENTRY: swift{{(-frontend|c)?(\.exe)?"?}} -frontend
 
 // RUN: %swiftc_driver -driver-print-jobs -enforce-exclusivity=checked %s | %FileCheck -check-prefix=EXCLUSIVITY_CHECKED %s

--- a/test/Frontend/invalid-module-name.swift
+++ b/test/Frontend/invalid-module-name.swift
@@ -2,13 +2,13 @@
 // a valid Swift identifier.
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid-module-name.swift 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_NAME %s
-// INVALID_MODULE_NAME: error: module name "invalid-module-name" is not a valid identifier; use -module-name flag to specify an alternate name
+// INVALID_MODULE_NAME: error: module name 'invalid-module-name' is not a valid identifier; use -module-name flag to specify an alternate name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid.module.name.swift 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_NAME2 %s
-// INVALID_MODULE_NAME2: error: module name "invalid.module.name" is not a valid identifier; use -module-name flag to specify an alternate name
+// INVALID_MODULE_NAME2: error: module name 'invalid.module.name' is not a valid identifier; use -module-name flag to specify an alternate name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %S/Inputs/invalid-module-name.swift -module-name still-invalid 2>&1 | %FileCheck -check-prefix=STILL_INVALID %s
-// STILL_INVALID: error: module name "still-invalid" is not a valid identifier{{$}}
+// STILL_INVALID: error: module name 'still-invalid' is not a valid identifier{{$}}
 
 // These should succeed.
 // RUN: %target-swift-frontend -emit-silgen %S/Inputs/invalid-module-name.swift > /dev/null

--- a/test/Frontend/module-alias-invalid-input.swift
+++ b/test/Frontend/module-alias-invalid-input.swift
@@ -1,22 +1,22 @@
 // Tests for invalid module alias format and values.
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias foo=bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS %s
-// INVALID_MODULE_ALIAS: error: invalid module alias "foo"; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name
+// INVALID_MODULE_ALIAS: error: invalid module alias 'foo'; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias Swift=Bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS1 %s
-// INVALID_MODULE_ALIAS1: error: invalid module alias "Swift"; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name
+// INVALID_MODULE_ALIAS1: error: invalid module alias 'Swift'; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar=bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS2 %s
-// INVALID_MODULE_ALIAS2: error: duplicate module alias; the name "bar" is already used for a module alias or an underlying name
+// INVALID_MODULE_ALIAS2: error: duplicate module alias; the name 'bar' is already used for a module alias or an underlying name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar=baz -module-alias baz=cat 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS3 %s
-// INVALID_MODULE_ALIAS3: error: duplicate module alias; the name "baz" is already used for a module alias or an underlying name
+// INVALID_MODULE_ALIAS3: error: duplicate module alias; the name 'baz' is already used for a module alias or an underlying name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS4 %s
-// INVALID_MODULE_ALIAS4: error: invalid module alias format "bar"; make sure to use the format '-module-alias alias_name=underlying_name'
+// INVALID_MODULE_ALIAS4: error: invalid module alias format 'bar'; make sure to use the format '-module-alias alias_name=underlying_name'
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar=c-a.t 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_NAME %s
-// INVALID_MODULE_NAME: error: module name "c-a.t" is not a valid identifier
+// INVALID_MODULE_NAME: error: module name 'c-a.t' is not a valid identifier
 
 // These should succeed.
 // RUN: %target-swift-frontend -emit-silgen %s > /dev/null

--- a/test/ImportResolution/import-command-line.swift
+++ b/test/ImportResolution/import-command-line.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -typecheck %s -enable-source-import -I %S/Inputs -sdk "" -import-module abcde
 
 // RUN: not %target-swift-frontend -typecheck %s -enable-source-import -I %S/Inputs -sdk "" -import-module 3333 2>&1 | %FileCheck -check-prefix=NON-IDENT %s
-// NON-IDENT: error: module name "3333" is not a valid identifier
+// NON-IDENT: error: module name '3333' is not a valid identifier
 
 // RUN: not %target-swift-frontend -typecheck %s -enable-source-import -I %S/Inputs -sdk "" -import-module NON_EXISTENT 2>&1 | %FileCheck -check-prefix=NON-EXISTENT %s
 // NON-EXISTENT: error: no such module 'NON_EXISTENT'

--- a/test/ImportResolution/import-multiple-command-line.swift
+++ b/test/ImportResolution/import-multiple-command-line.swift
@@ -3,7 +3,7 @@
 
 // RUN: not %target-swift-frontend -typecheck %s -enable-source-import -I %S/Inputs -sdk "" -import-module abcde -import-module aeiou -import-module 3333 2>&1 | %FileCheck -check-prefix=NON-IDENT %s
 
-// NON-IDENT: error: module name "3333" is not a valid identifier
+// NON-IDENT: error: module name '3333' is not a valid identifier
 
 var c: C? // expected-error {{cannot find type 'C' in scope}}
 var u: U? // expected-error {{cannot find type 'U' in scope}}

--- a/test/NameLookup/name_lookup2.swift
+++ b/test/NameLookup/name_lookup2.swift
@@ -2,7 +2,7 @@
 
 // -verify-ignore-unknown is for
 // <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: use 'xcrun swiftc' to select the default macOS SDK installed with Xcode
 
 import Swift
 import nonexistentimport  // expected-error {{no such module 'nonexistentimport'}}

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -439,23 +439,23 @@ switch Whatever.Thing {
 }
 
 switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '.Thing'}}
-@unknown case let value: // expected-error {{'@unknown' is only supported for catch-all cases ("case _")}}
+@unknown case let value: // expected-error {{'@unknown' is only supported for catch-all cases ('case _')}}
   _ = value
 }
 
 switch (Whatever.Thing, Whatever.Thing) { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '(_, _)'}}
-@unknown case (_, _): // expected-error {{'@unknown' is only supported for catch-all cases ("case _")}}
+@unknown case (_, _): // expected-error {{'@unknown' is only supported for catch-all cases ('case _')}}
   break
 }
 
 switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '.Thing'}}
-@unknown case is Whatever: // expected-error {{'@unknown' is only supported for catch-all cases ("case _")}}
+@unknown case is Whatever: // expected-error {{'@unknown' is only supported for catch-all cases ('case _')}}
   // expected-warning@-1 {{'is' test is always true}}
   break
 }
 
 switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '.Thing'}}
-@unknown case .Thing: // expected-error {{'@unknown' is only supported for catch-all cases ("case _")}}
+@unknown case .Thing: // expected-error {{'@unknown' is only supported for catch-all cases ('case _')}}
   break
 }
 

--- a/test/SILOptimizer/definite_init_cross_module.swift
+++ b/test/SILOptimizer/definite_init_cross_module.swift
@@ -150,7 +150,7 @@ extension MyGenericPoint {
 
 extension CPoint {
   init(xx: Double, yy: Double) {
-    self.x = xx // expected-error {{'self' used before 'self.init' call or assignment to 'self'}} expected-note {{use "self.init()" to initialize the struct with zero values}} {{5-5=self.init()\n}}
+    self.x = xx // expected-error {{'self' used before 'self.init' call or assignment to 'self'}} expected-note {{use 'self.init()' to initialize the struct with zero values}} {{5-5=self.init()\n}}
     self.y = yy // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
   } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
 
@@ -171,7 +171,7 @@ extension CPoint {
   }
 
   init(other: CPoint, xx: Double) {
-    self.x = xx // expected-error {{'self' used before 'self.init' call or assignment to 'self'}} expected-note {{use "self.init()" to initialize the struct with zero values}} {{5-5=self.init()\n}}
+    self.x = xx // expected-error {{'self' used before 'self.init' call or assignment to 'self'}} expected-note {{use 'self.init()' to initialize the struct with zero values}} {{5-5=self.init()\n}}
     self = other
   }
 

--- a/test/SILOptimizer/definite_init_cross_module_swift4.swift
+++ b/test/SILOptimizer/definite_init_cross_module_swift4.swift
@@ -10,12 +10,12 @@ import OtherModule
 
 extension Point {
   init(xx: Double, yy: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'Point' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'Point' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self.y = yy
   }
 
   init(xx: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'Point' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'Point' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
   } // expected-error {{return from initializer without initializing all stored properties}}
 
   init(xxx: Double, yyy: Double) {
@@ -35,7 +35,7 @@ extension Point {
   }
 
   init(other: Point, xx: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'Point' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'Point' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self = other
   }
 
@@ -47,14 +47,14 @@ extension Point {
 
   init(other: Point, xx: Double, cond: Bool) {
     if cond { self = other }
-    self.x = xx // expected-warning {{initializer for struct 'Point' must use "self.init(...)" or "self = ..." on all paths because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'Point' must use 'self.init(...)' or 'self = ...' on all paths because it is not in module 'OtherModule'}}
     self.y = 0
   }
 }
 
 extension ImmutablePoint {
   init(xx: Double, yy: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'ImmutablePoint' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'ImmutablePoint' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self.y = yy
   }
 
@@ -74,7 +74,7 @@ extension ImmutablePoint {
   }
 
   init(other: ImmutablePoint, xx: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'ImmutablePoint' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'ImmutablePoint' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self = other // expected-error {{immutable value 'self.x' may only be initialized once}}
   }
 
@@ -93,7 +93,7 @@ extension ImmutablePoint {
 
 extension GenericPoint {
   init(xx: T, yy: T) {
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self.y = yy
   }
 
@@ -114,7 +114,7 @@ extension GenericPoint {
   }
 
   init(other: GenericPoint<T>, xx: T) {
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self = other
   }
 
@@ -126,14 +126,14 @@ extension GenericPoint {
 
   init(other: GenericPoint<T>, xx: T, cond: Bool) {
     if cond { self = other }
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use "self.init(...)" or "self = ..." on all paths because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<T>' must use 'self.init(...)' or 'self = ...' on all paths because it is not in module 'OtherModule'}}
     self.y = xx
   }
 }
 
 extension GenericPoint where T == Double {
   init(xx: Double, yy: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self.y = yy
   }
 
@@ -154,7 +154,7 @@ extension GenericPoint where T == Double {
   }
 
   init(other: GenericPoint<Double>, xx: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self = other
   }
 
@@ -166,7 +166,7 @@ extension GenericPoint where T == Double {
 
   init(other: GenericPoint<Double>, xx: Double, cond: Bool) {
     if cond { self = other }
-    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use "self.init(...)" or "self = ..." on all paths because it is not in module 'OtherModule'}}
+    self.x = xx // expected-warning {{initializer for struct 'GenericPoint<Double>' must use 'self.init(...)' or 'self = ...' on all paths because it is not in module 'OtherModule'}}
     self.y = 0
   }
 }
@@ -176,14 +176,14 @@ typealias MyGenericPoint<Q> = GenericPoint<Q>
 extension MyGenericPoint {
   // FIXME: Should preserve type sugar.
   init(myX: T, myY: T) {
-    self.x = myX // expected-warning {{initializer for struct 'GenericPoint<T>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+    self.x = myX // expected-warning {{initializer for struct 'GenericPoint<T>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
     self.y = myY
   }
 }
 
 extension CPoint {
   init(xx: Double, yy: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use "self.init(...)" or "self = ..." because the struct was imported from C}} expected-note {{use "self.init()" to initialize the struct with zero values}} {{5-5=self.init()\n}}
+    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use 'self.init(...)' or 'self = ...' because the struct was imported from C}} expected-note {{use 'self.init()' to initialize the struct with zero values}} {{5-5=self.init()\n}}
     self.y = yy
   }
 
@@ -204,7 +204,7 @@ extension CPoint {
   }
 
   init(other: CPoint, xx: Double) {
-    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use "self.init(...)" or "self = ..." because the struct was imported from C}} expected-note {{use "self.init()" to initialize the struct with zero values}} {{5-5=self.init()\n}}
+    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use 'self.init(...)' or 'self = ...' because the struct was imported from C}} expected-note {{use 'self.init()' to initialize the struct with zero values}} {{5-5=self.init()\n}}
     self = other
   }
 
@@ -216,7 +216,7 @@ extension CPoint {
 
   init(other: CPoint, xx: Double, cond: Bool) {
     if cond { self = other }
-    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use "self.init(...)" or "self = ..." on all paths because the struct was imported from C}}
+    self.x = xx // expected-warning {{initializer for struct 'CPoint' must use 'self.init(...)' or 'self = ...' on all paths because the struct was imported from C}}
     self.y = 0
   }
 }
@@ -224,7 +224,7 @@ extension CPoint {
 
 extension NonnullWrapper {
   init(p: UnsafeMutableRawPointer) {
-    self.ptr = p // expected-warning {{initializer for struct 'NonnullWrapper' must use "self.init(...)" or "self = ..." because the struct was imported from C}}
+    self.ptr = p // expected-warning {{initializer for struct 'NonnullWrapper' must use 'self.init(...)' or 'self = ...' because the struct was imported from C}}
     // No suggestion for "self.init()" because this struct does not support a
     // zeroing initializer.
   }
@@ -265,10 +265,10 @@ extension Empty {
 
   init(other: Empty, cond: Bool) {
     if cond { self = other }
-  } // expected-warning {{initializer for struct 'Empty' must use "self.init(...)" or "self = ..." on all paths because it is not in module 'OtherModule'}}
+  } // expected-warning {{initializer for struct 'Empty' must use 'self.init(...)' or 'self = ...' on all paths because it is not in module 'OtherModule'}}
 
   init(xx: Double) {
-  } // expected-warning {{initializer for struct 'Empty' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+  } // expected-warning {{initializer for struct 'Empty' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
 }
 
 extension GenericEmpty {
@@ -284,8 +284,8 @@ extension GenericEmpty {
 
   init(other: GenericEmpty<T>, cond: Bool) {
     if cond { self = other }
-  } // expected-warning {{initializer for struct 'GenericEmpty<T>' must use "self.init(...)" or "self = ..." on all paths because it is not in module 'OtherModule'}}
+  } // expected-warning {{initializer for struct 'GenericEmpty<T>' must use 'self.init(...)' or 'self = ...' on all paths because it is not in module 'OtherModule'}}
 
   init(xx: Double) {
-  } // expected-warning {{initializer for struct 'GenericEmpty<T>' must use "self.init(...)" or "self = ..." because it is not in module 'OtherModule'}}
+  } // expected-warning {{initializer for struct 'GenericEmpty<T>' must use 'self.init(...)' or 'self = ...' because it is not in module 'OtherModule'}}
 }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -802,11 +802,11 @@ public enum NonExhaustivePayload {
 // case.
 @inlinable
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, for interval: TemporalProxy, flag: Bool) {
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   }
 
-  switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }
@@ -894,11 +894,11 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   } // no-warning
 
   // Test payloaded enums.
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   }
 
-  switch payload { // expected-warning {{switch covers known cases, but 'NonExhaustivePayload' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch payload { // expected-warning {{switch covers known cases, but 'NonExhaustivePayload' may have additional unknown values}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }
@@ -920,7 +920,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   }
 
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   case .b(false): break
   }
@@ -1261,7 +1261,7 @@ public enum SR11672Tests {
       // expected-error@-1 {{switch must be exhaustive}}
       // expected-note@-2 {{add missing case: '.a'}}
       // expected-note@-3 {{add missing case: '.b'}}
-      // expected-note@-4 {{handle unknown values using "@unknown default"}}
+      // expected-note@-4 {{handle unknown values using '@unknown default'}}
     }
   }
 }

--- a/test/Sema/exhaustive_switch_debugger.swift
+++ b/test/Sema/exhaustive_switch_debugger.swift
@@ -13,7 +13,7 @@ public enum NonExhaustivePayload {
 // case.
 @inlinable
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, flag: Bool) {
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   }
 
@@ -73,7 +73,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   }
 
   // Test payloaded enums.
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   }
 
@@ -99,7 +99,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   }
 
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}} expected-note {{handle unknown values using '@unknown default'}} {{none}}
   case .a: break
   case .b(false): break
   }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -506,7 +506,7 @@ class ClassWithConvenienceInit {
   
   convenience init(newY: Int) {
     self.init(newX: 19)
-    x = 67  // expected-error {{'let' property 'x' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    x = 67  // expected-error {{'let' property 'x' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 }
 
@@ -514,7 +514,7 @@ struct StructWithDelegatingInit {
   let x: Int // expected-note {{declared here}}
   
   init(x: Int) { self.x = x }
-  init() { self.init(x: 0); self.x = 22 } // expected-error {{'let' property 'x' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+  init() { self.init(x: 0); self.x = 22 } // expected-error {{'let' property 'x' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
 }
 
 // <rdar://problem/16792027> compiler infinite loops on a really really mutating function

--- a/test/decl/import/import.swift
+++ b/test/decl/import/import.swift
@@ -6,11 +6,11 @@
 
 // -verify-ignore-unknown is for:
 // <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: use 'xcrun swiftc' to select the default macOS SDK installed with Xcode
 // <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: use 'xcrun swiftc' to select the default macOS SDK installed with Xcode
 // <unknown>:0: error: unexpected note produced: did you forget to set an SDK using -sdk or SDKROOT?
-// <unknown>:0: error: unexpected note produced: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
+// <unknown>:0: error: unexpected note produced: use 'xcrun swiftc' to select the default macOS SDK installed with Xcode
 
 import Builtin  // expected-error {{no such module 'Builtin'}}
 

--- a/test/decl/init/constructor-kind.swift
+++ b/test/decl/init/constructor-kind.swift
@@ -34,12 +34,12 @@ class SomeClass : Superclass {
   // Delegating initializer -- let properties are immutable
   convenience init(width: Int) {
     self.init(width: width, height: 20)
-    self.height = Measurement(val: 20) // expected-error {{'let' property 'height' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.height = Measurement(val: 20) // expected-error {{'let' property 'height' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   // Another case
   convenience init(height: Int) {
-    self.width = Measurement(val: 20) // expected-error {{'let' property 'width' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.width = Measurement(val: 20) // expected-error {{'let' property 'width' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
     self.init(width: 10, height: height)
   }
 }
@@ -52,9 +52,9 @@ struct SomeStruct {
   init() {
     self.init()
     self.width = Measurement.self.init(val: width) // expected-error {{cannot convert value of type 'Measurement' to expected argument type 'Int'}}
-    // expected-error@-1 {{'let' property 'width' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    // expected-error@-1 {{'let' property 'width' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
     self.height = Measurement.self.init(val: height) // expected-error {{cannot convert value of type 'Measurement' to expected argument type 'Int'}}
-    // expected-error@-1 {{'let' property 'height' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    // expected-error@-1 {{'let' property 'height' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   // Designated initializer
@@ -67,15 +67,15 @@ struct SomeStruct {
   init(width: Int) {
     self.init()
     self.width = width // expected-error {{cannot assign value of type 'Int' to type 'Measurement'}}
-    // expected-error@-1 {{'let' property 'width' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
-    self.height = Measurement(val: 20) // expected-error {{'let' property 'height' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    // expected-error@-1 {{'let' property 'width' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
+    self.height = Measurement(val: 20) // expected-error {{'let' property 'height' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   // Delegating initializer
   init(height: Int) {
-    self.width = Measurement(val: 10) // expected-error {{'let' property 'width' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.width = Measurement(val: 10) // expected-error {{'let' property 'width' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
     self.height = height // expected-error {{cannot assign value of type 'Int' to type 'Measurement'}}
-    // expected-error@-1 {{'let' property 'height' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    // expected-error@-1 {{'let' property 'height' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
     self.init()
   }
 }

--- a/test/decl/init/resilience-cross-module.swift
+++ b/test/decl/init/resilience-cross-module.swift
@@ -16,7 +16,7 @@ import resilient_protocol
 extension Size {
   init(ww: Int, hh: Int) {
     self.w = ww
-    self.h = hh // expected-error {{'let' property 'h' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.h = hh // expected-error {{'let' property 'h' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   // This is OK

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -11,11 +11,11 @@ public struct Animal {
   public let name: String // expected-note 2 {{declared here}}
 
   @inlinable public init(name: String) {
-    self.name = name // expected-error {{'let' property 'name' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.name = name // expected-error {{'let' property 'name' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   @_transparent public init(cat: String) {
-    self.name = cat // expected-error {{'let' property 'name' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+    self.name = cat // expected-error {{'let' property 'name' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
   }
 
   // This is OK

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -474,8 +474,8 @@ protocol LetThereBeCrash {
 
 extension LetThereBeCrash {
   init() { x = 1; xs = [] }
-  // expected-error@-1 {{'let' property 'x' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
-  // expected-error@-2 {{'let' property 'xs' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+  // expected-error@-1 {{'let' property 'x' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
+  // expected-error@-2 {{'let' property 'xs' may not be initialized directly; use 'self.init(...)' or 'self = ...' instead}}
 }
 
 // SR-11412

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -14,7 +14,7 @@ public func testNonExhaustive(_ value: NonExhaustive) {
   }
 
   switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}}
-  // expected-note@-1 {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-note@-1 {{handle unknown values using '@unknown default'}} {{3-3=@unknown default:\n<#fatalError()#>\n}}
   case .a: break
   case .b: break
   }


### PR DESCRIPTION
Make almost all diagnostic messages use apostrophes around symbols. Most of them already do. This makes all the messages' (except those with file names) formatting consistent.