### PR TITLE
test: avoid windows path separators in test

### DIFF
--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -scan-dependencies %s %S/Inputs/unicode_filёnamё.swift -o %t/deps.json
+// RUN: %target-swift-frontend -scan-dependencies %/s %/S/Inputs/unicode_filёnamё.swift -o %t/deps.json
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s < %t/deps.json
@@ -11,6 +11,6 @@ print(foo())
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "modulePath": "deps.swiftmodule",
 // CHECK-NEXT:      "sourceFiles": [
-// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\}}unicode_filename.swift",
-// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\}}Inputs{{/|\\}}unicode_filёnamё.swift"
+// CHECK-NEXT:        "{{.*}}ScanDependencies/unicode_filename.swift",
+// CHECK-NEXT:        "{{.*}}ScanDependencies/Inputs/unicode_filёnamё.swift"
 // CHECK-NEXT:      ],


### PR DESCRIPTION
Use the POSIX path separators for the test, a subsequent change will add
an explicit test for windows path separators when fixing the JSON
emission.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
