### PR TITLE
[build] Link the Swift resource directory against the headers from a prebuilt clang, if building with one

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -203,16 +203,23 @@ if(SWIFT_BUILD_STATIC_STDLIB)
                              PATTERN "*.h")
 endif()
 
+if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER OR SWIFT_PREBUILT_CLANG)
+  # This will still link against the Swift-forked clang headers if the Swift
+  # toolchain was built with SWIFT_INCLUDE_TOOLS.
+  set(symlink_dir ${clang_headers_location})
+else()
+  set(symlink_dir "../clang/${CLANG_VERSION}")
+endif()
 
 swift_install_symlink_component(clang-resource-dir-symlink
   LINK_NAME clang
-  TARGET ../clang/${CLANG_VERSION}
+  TARGET ${symlink_dir}
   DESTINATION "lib/swift")
 
 if(SWIFT_BUILD_STATIC_STDLIB)
   swift_install_symlink_component(clang-resource-dir-symlink
     LINK_NAME clang
-    TARGET ../clang/${CLANG_VERSION}
+    TARGET ${symlink_dir}
     DESTINATION "lib/swift_static")
 endif()
 


### PR DESCRIPTION
If building the stdlib with a prebuilt clang, link against its headers rather than assuming they are installed in the Swift toolchain. This is particularly useful when building standalone, cross-compiled SDKs, as [I've been patching my Android SDKs to do this for years](https://github.com/buttaface/swift-android-sdk/blob/ab8f0d356c1e28a8b3f3b6a7f3a99e494f0c5f4b/swift-android-5.5.patch#L73).

@llvm-beanz, you set this symlink directory in #5034 years back, would you review?