### PR TITLE
Structural opaque result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ CHANGELOG
 
 _**Note:** This is in reverse chronological order, so newer entries are added to the top._
 
+## Swift Next
+
+* [SE-0328][]:
+
+  Opaque types (expressed with 'some') can now be used in structural positions
+  within a result type, including having multiple opaque types in the same
+  result. For example:
+
+  ```
+  func getSomeDictionary() -> [some Hashable: some Codable] {
+    return [ 1: "One", 2: "Two" ]
+  }
+  ```
 Swift 5.6
 ---------
 
@@ -8761,6 +8774,7 @@ Swift 1.0
 [SE-0316]: <https://github.com/apple/swift-evolution/blob/main/proposals/0316-global-actors.md>
 [SE-0324]: <https://github.com/apple/swift-evolution/blob/main/proposals/0324-c-lang-pointer-arg-conversion.md>
 [SE-0323]: <https://github.com/apple/swift-evolution/blob/main/proposals/0323-async-main-semantics.md>
+[SE-0328]: <https://github.com/apple/swift-evolution/blob/main/proposals/0328-structural-opaque-result-types.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -339,7 +339,8 @@ protected:
   }
 
   void appendBoundGenericArgs(Type type, GenericSignature sig,
-                              bool &isFirstArgList);
+                              bool &isFirstArgList,
+                              const ValueDecl *forDecl = nullptr);
 
   /// Append the bound generics arguments for the given declaration context
   /// based on a complete substitution map.
@@ -349,18 +350,21 @@ protected:
   unsigned appendBoundGenericArgs(DeclContext *dc,
                                   GenericSignature sig,
                                   SubstitutionMap subs,
-                                  bool &isFirstArgList);
+                                  bool &isFirstArgList,
+                                  const ValueDecl *forDecl = nullptr);
   
   /// Append the bound generic arguments as a flat list, disregarding depth.
   void appendFlatGenericArgs(SubstitutionMap subs,
-                             GenericSignature sig);
+                             GenericSignature sig,
+                             const ValueDecl *forDecl = nullptr);
 
   /// Append any retroactive conformances.
   void appendRetroactiveConformances(Type type, GenericSignature sig);
   void appendRetroactiveConformances(SubstitutionMap subMap,
                                      GenericSignature sig,
                                      ModuleDecl *fromModule);
-  void appendImplFunctionType(SILFunctionType *fn, GenericSignature sig);
+  void appendImplFunctionType(SILFunctionType *fn, GenericSignature sig,
+                              const ValueDecl *forDecl = nullptr);
 
   void appendContextOf(const ValueDecl *decl);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2719,8 +2719,8 @@ class OpaqueTypeDecl final :
   /// abstracted underlying types.
   GenericSignature OpaqueInterfaceGenericSignature;
 
-  /// The generic parameter that represents the underlying type.
-  GenericTypeParamType *UnderlyingInterfaceType;
+  /// The underlying type, which will involve the opaque generic parameters.
+  Type UnderlyingInterfaceType;
   
   /// If known, the underlying type and conformances of the opaque type,
   /// expressed as a SubstitutionMap for the opaque interface generic signature.
@@ -2734,7 +2734,7 @@ class OpaqueTypeDecl final :
                  DeclContext *DC,
                  GenericSignature OpaqueInterfaceGenericSignature,
                  ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-                 GenericTypeParamType *UnderlyingInterfaceType);
+                 Type UnderlyingInterfaceType);
 
   unsigned getNumOpaqueReturnTypeReprs() const {
     return NamingDeclAndHasOpaqueReturnTypeRepr.getInt()
@@ -2752,7 +2752,7 @@ public:
       DeclContext *DC,
       GenericSignature OpaqueInterfaceGenericSignature,
       ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-      GenericTypeParamType *UnderlyingInterfaceType);
+      Type UnderlyingInterfaceType);
 
   ValueDecl *getNamingDecl() const {
     return NamingDeclAndHasOpaqueReturnTypeRepr.getPointer();
@@ -2794,10 +2794,7 @@ public:
   }
 
   /// The underlying interface type describing the whole opaque type.
-  ///
-  /// FIXME: Structured opaque types will generalize this to an
-  /// arbitrary type.
-  GenericTypeParamType *getUnderlyingInterfaceType() const {
+  Type getUnderlyingInterfaceType() const {
     return UnderlyingInterfaceType;
   }
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2719,9 +2719,6 @@ class OpaqueTypeDecl final :
   /// abstracted underlying types.
   GenericSignature OpaqueInterfaceGenericSignature;
 
-  /// The underlying type, which will involve the opaque generic parameters.
-  Type UnderlyingInterfaceType;
-  
   /// If known, the underlying type and conformances of the opaque type,
   /// expressed as a SubstitutionMap for the opaque interface generic signature.
   /// This maps types in the interface generic signature to the outer generic
@@ -2733,8 +2730,7 @@ class OpaqueTypeDecl final :
   OpaqueTypeDecl(ValueDecl *NamingDecl, GenericParamList *GenericParams,
                  DeclContext *DC,
                  GenericSignature OpaqueInterfaceGenericSignature,
-                 ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-                 Type UnderlyingInterfaceType);
+                 ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs);
 
   unsigned getNumOpaqueReturnTypeReprs() const {
     return NamingDeclAndHasOpaqueReturnTypeRepr.getInt()
@@ -2751,8 +2747,7 @@ public:
       ValueDecl *NamingDecl, GenericParamList *GenericParams,
       DeclContext *DC,
       GenericSignature OpaqueInterfaceGenericSignature,
-      ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-      Type UnderlyingInterfaceType);
+      ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs);
 
   ValueDecl *getNamingDecl() const {
     return NamingDeclAndHasOpaqueReturnTypeRepr.getPointer();
@@ -2793,11 +2788,8 @@ public:
     };
   }
 
-  /// The underlying interface type describing the whole opaque type.
-  Type getUnderlyingInterfaceType() const {
-    return UnderlyingInterfaceType;
-  }
-  
+  /// The substitutions that map the generic parameters of the opaque type to
+  /// their underlying types, when that information is known.
   Optional<SubstitutionMap> getUnderlyingTypeSubstitutions() const {
     return UnderlyingTypeSubstitutions;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2746,15 +2746,6 @@ class OpaqueTypeDecl final :
     return getNumOpaqueReturnTypeReprs();
   }
 
-  /// Retrieve the buffer containing the opaque return type
-  /// representations that correspond to the opaque generic parameters.
-  ArrayRef<OpaqueReturnTypeRepr *> getOpaqueReturnTypeReprs() const {
-    return {
-      getTrailingObjects<OpaqueReturnTypeRepr *>(),
-      getNumOpaqueReturnTypeReprs()
-    };
-  }
-
 public:
   static OpaqueTypeDecl *get(
       ValueDecl *NamingDecl, GenericParamList *GenericParams,
@@ -2791,6 +2782,15 @@ public:
   /// type declaration.
   TypeArrayView<GenericTypeParamType> getOpaqueGenericParams() const {
     return OpaqueInterfaceGenericSignature.getInnermostGenericParams();
+  }
+
+  /// Retrieve the buffer containing the opaque return type
+  /// representations that correspond to the opaque generic parameters.
+  ArrayRef<OpaqueReturnTypeRepr *> getOpaqueReturnTypeReprs() const {
+    return {
+      getTrailingObjects<OpaqueReturnTypeRepr *>(),
+      getNumOpaqueReturnTypeReprs()
+    };
   }
 
   /// The underlying interface type describing the whole opaque type.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1876,9 +1876,6 @@ ERROR(opaque_type_invalid_constraint,none,
       "and/or a base class", ())
 NOTE(opaque_of_optional_rewrite,none,
       "did you mean to write an optional of an 'opaque' type?", ())
-ERROR(more_than_one_opaque_type,none,
-      "%0 contains multiple 'opaque' types, but only one 'opaque' type is "
-      "supported", (TypeRepr*))
 ERROR(inferred_opaque_type,none,
       "property definition has inferred type %0, involving the 'some' "
       "return type of another declaration", (Type))
@@ -4135,8 +4132,8 @@ ERROR(opaque_type_no_underlying_type_candidates,none,
       "function declares an opaque return type, but has no return statements "
       "in its body from which to infer an underlying type", ())
 ERROR(opaque_type_mismatched_underlying_type_candidates,none,
-      "function declares an opaque return type, but the return statements "
-      "in its body do not have matching underlying types", ())
+      "function declares an opaque return type %0, but the return statements "
+      "in its body do not have matching underlying types", (TypeRepr *))
 NOTE(opaque_type_underlying_type_candidate_here,none,
      "return statement has underlying type %0", (Type))
 ERROR(opaque_type_self_referential_underlying_type,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3003,8 +3003,13 @@ public:
 /// (opaque type)" and "S<T> ---> S<(opaque type)>".
 class UnderlyingToOpaqueExpr : public ImplicitConversionExpr {
 public:
-  UnderlyingToOpaqueExpr(Expr *subExpr, Type ty)
-    : ImplicitConversionExpr(ExprKind::UnderlyingToOpaque, subExpr, ty) {}
+  /// The substitutions to be applied to the opaque type declaration to
+  /// produce the resulting type.
+  const SubstitutionMap substitutions;
+
+  UnderlyingToOpaqueExpr(Expr *subExpr, Type ty, SubstitutionMap substitutions)
+    : ImplicitConversionExpr(ExprKind::UnderlyingToOpaque, subExpr, ty),
+      substitutions(substitutions) {}
   
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::UnderlyingToOpaque;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5601,10 +5601,7 @@ public:
   ///   func foo() -> (some P, some Q)
   ///
   /// then the underlying type of `some P` would be ordinal 0, and `some Q` would be ordinal 1.
-  unsigned getOrdinal() const {
-    // TODO [OPAQUE SUPPORT]: multiple opaque types
-    return 0;
-  }
+  unsigned getOrdinal() const;
   
   static void Profile(llvm::FoldingSetNodeID &ID,
                       OpaqueTypeDecl *OpaqueDecl,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5605,10 +5605,11 @@ public:
   
   static void Profile(llvm::FoldingSetNodeID &ID,
                       OpaqueTypeDecl *OpaqueDecl,
+                      unsigned ordinal,
                       SubstitutionMap Substitutions);
   
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getDecl(), getSubstitutions());
+    Profile(ID, getDecl(), getOrdinal(), getSubstitutions());
   };
   
 private:

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -486,10 +486,6 @@ def enable_experimental_named_opaque_types :
   Flag<["-"], "enable-experimental-named-opaque-types">,
   HelpText<"Enable experimental support for named opaque result types">;
 
-def enable_experimental_structural_opaque_types :
-  Flag<["-"], "enable-experimental-structural-opaque-types">,
-  HelpText<"Enable experimental support for structural opaque result types">;
-
 def enable_explicit_existential_types :
   Flag<["-"], "enable-explicit-existential-types">,
   HelpText<"Enable experimental support for explicit existential types">;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3316,6 +3316,11 @@ public:
                        ArrayRef<ConstraintLocator::PathElement> path,
                        unsigned summaryFlags);
 
+  /// Retrieve a locator for opening the opaque archetype for the given
+  /// opaque type.
+  ConstraintLocator *getOpenOpaqueLocator(
+      ConstraintLocatorBuilder locator, OpaqueTypeDecl *opaqueDecl);
+
   /// Retrive the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags
   ConstraintLocator *

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1518,7 +1518,7 @@ SwiftDeclCollector::constructTypeNode(Type T, TypeInitInfo Info) {
     if (auto OTA = T->getAs<OpaqueTypeArchetypeType>()) {
       if (auto *D = OTA->getDecl()) {
         if (auto SubMap = D->getUnderlyingTypeSubstitutions()) {
-          T = Type(D->getUnderlyingInterfaceType()).
+          T = D->getUnderlyingInterfaceType().
             subst(*SubMap)->getCanonicalType();
         }
       }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4283,7 +4283,7 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl, unsigned ordinal,
   Substitutions = Substitutions.getCanonical();
 
   llvm::FoldingSetNodeID id;
-  Profile(id, Decl, Substitutions);
+  Profile(id, Decl, ordinal, Substitutions);
   
   auto &ctx = Decl->getASTContext();
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4275,9 +4275,7 @@ DependentMemberType *DependentMemberType::get(Type base,
 OpaqueTypeArchetypeType *
 OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl, unsigned ordinal,
                              SubstitutionMap Substitutions) {
-  // TODO [OPAQUE SUPPORT]: multiple opaque types
-  assert(ordinal == 0 && "we only support one 'some' type per composite type");
-  auto opaqueParamType = Decl->getUnderlyingInterfaceType();
+  auto opaqueParamType = Decl->getOpaqueGenericParams()[ordinal];
 
   // TODO: We could attempt to preserve type sugar in the substitution map.
   // Currently archetypes are assumed to be always canonical in many places,

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -265,11 +265,6 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
     auto opaqueDecl = parentModule->lookupOpaqueResultType(mangledName);
     if (!opaqueDecl)
       return Type();
-    // TODO [OPAQUE SUPPORT]: multiple opaque types
-    assert(ordinal == 0 && "not implemented");
-    if (ordinal != 0)
-      return Type();
-    
     SmallVector<Type, 8> allArgs;
     for (auto argSet : args) {
       allArgs.append(argSet.begin(), argSet.end());

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -567,7 +567,7 @@ namespace {
       OS << " naming_decl=";
       printDeclName(OTD->getNamingDecl());
       PrintWithColorRAII(OS, TypeColor) << " opaque_interface="
-        << OTD->getUnderlyingInterfaceType().getString();
+        << OTD->getDeclaredInterfaceType().getString();
       OS << " in "
          << OTD->getOpaqueInterfaceGenericSignature()->getAsString();
       if (auto underlyingSubs = OTD->getUnderlyingTypeSubstitutions()) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -567,7 +567,7 @@ namespace {
       OS << " naming_decl=";
       printDeclName(OTD->getNamingDecl());
       PrintWithColorRAII(OS, TypeColor) << " opaque_interface="
-        << Type(OTD->getUnderlyingInterfaceType()).getString();
+        << OTD->getUnderlyingInterfaceType().getString();
       OS << " in "
          << OTD->getOpaqueInterfaceGenericSignature()->getAsString();
       if (auto underlyingSubs = OTD->getUnderlyingTypeSubstitutions()) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3776,6 +3776,7 @@ namespace {
                                       StringRef label) {
       printArchetypeCommon(T, "opaque_type", label);
       printField("decl", T->getDecl()->getNamingDecl()->printRef());
+      printField("ordinal", T->getOrdinal());
       if (!T->getSubstitutions().empty()) {
         OS << '\n';
         SmallPtrSet<const ProtocolConformance *, 4> Dumped;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7781,14 +7781,12 @@ OpaqueTypeDecl::OpaqueTypeDecl(ValueDecl *NamingDecl,
                                GenericParamList *GenericParams, DeclContext *DC,
                                GenericSignature OpaqueInterfaceGenericSignature,
                                ArrayRef<OpaqueReturnTypeRepr *>
-                                   OpaqueReturnTypeReprs,
-                               Type UnderlyingInterfaceType)
+                                   OpaqueReturnTypeReprs)
     : GenericTypeDecl(DeclKind::OpaqueType, DC, Identifier(), SourceLoc(), {},
                       GenericParams),
       NamingDeclAndHasOpaqueReturnTypeRepr(
         NamingDecl, !OpaqueReturnTypeReprs.empty()),
-      OpaqueInterfaceGenericSignature(OpaqueInterfaceGenericSignature),
-      UnderlyingInterfaceType(UnderlyingInterfaceType) {
+      OpaqueInterfaceGenericSignature(OpaqueInterfaceGenericSignature) {
   // Always implicit.
   setImplicit();
 
@@ -7806,15 +7804,14 @@ OpaqueTypeDecl *OpaqueTypeDecl::get(
       ValueDecl *NamingDecl, GenericParamList *GenericParams,
       DeclContext *DC,
       GenericSignature OpaqueInterfaceGenericSignature,
-      ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-      Type UnderlyingInterfaceType) {
+      ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs) {
   ASTContext &ctx = DC->getASTContext();
   auto size = totalSizeToAlloc<OpaqueReturnTypeRepr *>(
       OpaqueReturnTypeReprs.size());
   auto mem = ctx.Allocate(size, alignof(OpaqueTypeDecl));
   return new (mem) OpaqueTypeDecl(
       NamingDecl, GenericParams, DC, OpaqueInterfaceGenericSignature,
-      OpaqueReturnTypeReprs, UnderlyingInterfaceType);
+      OpaqueReturnTypeReprs);
 }
 
 bool OpaqueTypeDecl::isOpaqueReturnTypeOfFunction(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7782,7 +7782,7 @@ OpaqueTypeDecl::OpaqueTypeDecl(ValueDecl *NamingDecl,
                                GenericSignature OpaqueInterfaceGenericSignature,
                                ArrayRef<OpaqueReturnTypeRepr *>
                                    OpaqueReturnTypeReprs,
-                               GenericTypeParamType *UnderlyingInterfaceType)
+                               Type UnderlyingInterfaceType)
     : GenericTypeDecl(DeclKind::OpaqueType, DC, Identifier(), SourceLoc(), {},
                       GenericParams),
       NamingDeclAndHasOpaqueReturnTypeRepr(
@@ -7807,7 +7807,7 @@ OpaqueTypeDecl *OpaqueTypeDecl::get(
       DeclContext *DC,
       GenericSignature OpaqueInterfaceGenericSignature,
       ArrayRef<OpaqueReturnTypeRepr *> OpaqueReturnTypeReprs,
-      GenericTypeParamType *UnderlyingInterfaceType) {
+      Type UnderlyingInterfaceType) {
   ASTContext &ctx = DC->getASTContext();
   auto size = totalSizeToAlloc<OpaqueReturnTypeRepr *>(
       OpaqueReturnTypeReprs.size());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3781,8 +3781,10 @@ std::string ArchetypeType::getFullName() const {
 void
 OpaqueTypeArchetypeType::Profile(llvm::FoldingSetNodeID &id,
                                  OpaqueTypeDecl *decl,
+                                 unsigned ordinal,
                                  SubstitutionMap subs) {
   id.AddPointer(decl);
+  id.AddInteger(ordinal);
   subs.profile(id);
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3289,6 +3289,10 @@ OpaqueTypeArchetypeType::OpaqueTypeArchetypeType(OpaqueTypeDecl *OpaqueDecl,
 {
 }
 
+unsigned OpaqueTypeArchetypeType::getOrdinal() const {
+  return getInterfaceType()->castTo<GenericTypeParamType>()->getIndex();
+}
+
 SequenceArchetypeType::SequenceArchetypeType(
     const ASTContext &Ctx, GenericEnvironment *GenericEnv, Type InterfaceType,
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -98,9 +98,8 @@ bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
 // TODO [OPAQUE SUPPORT]: We should probably use something like `Type`'s
 // `RecursiveProperties` to track this instead of computing it.
 bool TypeRepr::hasOpaque() {
-  // TODO [OPAQUE SUPPORT]: In the future we will also need to check if `this`
-  // is a `NamedOpaqueReturnTypeRepr`.
-  return findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
+  return isa<NamedOpaqueReturnTypeRepr>(this) ||
+    findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
 }
 
 SourceLoc TypeRepr::findUncheckedAttrLoc() const {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6777,8 +6777,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     
     bool hasOpaqueReturnTy = false;
     if (auto typedPattern = dyn_cast<TypedPattern>(pattern)) {
-      hasOpaqueReturnTy =
-                        isa<OpaqueReturnTypeRepr>(typedPattern->getTypeRepr());
+      hasOpaqueReturnTy = typedPattern->getTypeRepr()->hasOpaque();
     }
     auto sf = CurDeclContext->getParentSourceFile();
     
@@ -7108,7 +7107,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
                               CurDeclContext);
 
   // Let the source file track the opaque return type mapping, if any.
-  if (isa_and_nonnull<OpaqueReturnTypeRepr>(FuncRetTy) &&
+  if (FuncRetTy && FuncRetTy->hasOpaque() &&
       !InInactiveClauseEnvironment) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(FD);
@@ -7984,7 +7983,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   Subscript->getAttrs() = Attributes;
   
   // Let the source file track the opaque return type mapping, if any.
-  if (isa_and_nonnull<OpaqueReturnTypeRepr>(ElementTy.get()) &&
+  if (ElementTy.get() && ElementTy.get()->hasOpaque() &&
       !InInactiveClauseEnvironment) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(Subscript);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2603,7 +2603,7 @@ public:
 /// An AST walker that determines the underlying type of an opaque return decl
 /// from its associated function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
-  using Candidate = std::pair<Expr *, Type>;
+  using Candidate = std::pair<Expr *, SubstitutionMap>;
 
   ASTContext &Ctx;
   AbstractFunctionDecl *Implementation;
@@ -2642,12 +2642,13 @@ public:
     }
 
     // Check whether all of the underlying type candidates match up.
-    // TODO [OPAQUE SUPPORT]: multiple opaque types
-    Type underlyingType = Candidates.front().second;
+    // TODO [OPAQUE SUPPORT]: diagnose multiple opaque types
+    SubstitutionMap underlyingSubs = Candidates.front().second;
+    SubstitutionMap canonicalUnderlyingSubs = underlyingSubs.getCanonical();
     bool mismatch =
         std::any_of(Candidates.begin() + 1, Candidates.end(),
                     [&](Candidate &otherCandidate) {
-                      return !underlyingType->isEqual(otherCandidate.second);
+                      return canonicalUnderlyingSubs != otherCandidate.second.getCanonical();
                     });
     if (mismatch) {
       Implementation->diagnose(
@@ -2655,7 +2656,7 @@ public:
       for (auto candidate : Candidates) {
         Ctx.Diags.diagnose(candidate.first->getLoc(),
                            diag::opaque_type_underlying_type_candidate_here,
-                           candidate.second);
+                           candidate.second.getReplacementTypes()[0]);
       }
       return;
     }
@@ -2664,39 +2665,30 @@ public:
     // in terms of the opaque type itself.
     auto opaqueTypeInContext = Implementation->mapTypeIntoContext(
         OpaqueDecl->getDeclaredInterfaceType());
-    auto isSelfReferencing = underlyingType.findIf([&](Type t) -> bool {
-      return t->isEqual(opaqueTypeInContext);
-    });
-    
-    if (isSelfReferencing) {
-      Ctx.Diags.diagnose(Candidates.front().first->getLoc(),
-                         diag::opaque_type_self_referential_underlying_type,
-                         underlyingType);
-      return;
+    for (auto genericParam : OpaqueDecl->getOpaqueGenericParams()) {
+      auto underlyingType = Type(genericParam).subst(underlyingSubs);
+      auto isSelfReferencing = underlyingType.findIf([&](Type t) -> bool {
+        return t->isEqual(opaqueTypeInContext);
+      });
+
+      if (isSelfReferencing) {
+        Ctx.Diags.diagnose(Candidates.front().first->getLoc(),
+                           diag::opaque_type_self_referential_underlying_type,
+                           underlyingSubs.getReplacementTypes()[0]);
+        return;
+      }
     }
-    
-    // If we have one successful candidate, then save it as the underlying type
-    // of the opaque decl.
-    // Form a substitution map that defines it in terms of the other context
-    // generic parameters.
-    underlyingType = underlyingType->mapTypeOutOfContext();
-    auto underlyingSubs = SubstitutionMap::get(
-      OpaqueDecl->getOpaqueInterfaceGenericSignature(),
-      [&](SubstitutableType *t) -> Type {
-        if (t->isEqual(OpaqueDecl->getUnderlyingInterfaceType())) {
-          return underlyingType;
-        }
-        return Type(t);
-      },
-      LookUpConformanceInModule(OpaqueDecl->getModuleContext()));
-    
-    OpaqueDecl->setUnderlyingTypeSubstitutions(underlyingSubs);
+
+    // If we have one successful candidate, then save it as the underlying
+    // substitutions of the opaque decl.
+    OpaqueDecl->setUnderlyingTypeSubstitutions(
+        underlyingSubs.mapReplacementTypesOutOfContext());
   }
   
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (auto underlyingToOpaque = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
       Candidates.push_back(std::make_pair(underlyingToOpaque->getSubExpr(),
-                                  underlyingToOpaque->getSubExpr()->getType()));
+                                          underlyingToOpaque->substitutions));
       return {false, E};
     }
     return {true, E};

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -544,19 +544,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
     if (auto opaque = var->getOpaqueResultTypeDecl()) {
       init->forEachChildExpr([&](Expr *expr) -> Expr * {
         if (auto coercionExpr = dyn_cast<UnderlyingToOpaqueExpr>(expr)) {
-          auto underlyingType =
-              coercionExpr->getSubExpr()->getType()->mapTypeOutOfContext();
-          auto underlyingSubs = SubstitutionMap::get(
-              opaque->getOpaqueInterfaceGenericSignature(),
-              [&](SubstitutableType *t) -> Type {
-                if (t->isEqual(opaque->getUnderlyingInterfaceType())) {
-                  return underlyingType;
-                }
-                return Type(t);
-              },
-              LookUpConformanceInModule(opaque->getModuleContext()));
-
-          opaque->setUnderlyingTypeSubstitutions(underlyingSubs);
+          opaque->setUnderlyingTypeSubstitutions(
+              coercionExpr->substitutions.mapReplacementTypesOutOfContext());
         }
         return expr;
       });

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -215,13 +215,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     underlyingGenericParamType = interfaceSignature.getGenericParams()[0];
   } else {
     opaqueReprs = collectOpaqueReturnTypeReprs(repr);
-    if (opaqueReprs.size() > 1) {
-      ctx.Diags.diagnose(repr->getLoc(), diag::more_than_one_opaque_type, repr);
-      return nullptr;
-    }
-
-    // TODO [OPAQUE SUPPORT]: right now we only allow one structural 'some' type,
-    // but *very* soon we will allow more than one such type.
     SmallVector<GenericTypeParamType *, 2> genericParamTypes;
     SmallVector<Requirement, 2> requirements;
     for (unsigned i = 0; i < opaqueReprs.size(); ++i) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -296,11 +296,9 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   }
 
   // Create the OpaqueTypeDecl for the result type.
-  auto opaqueDecl = new (ctx)
-      OpaqueTypeDecl(originatingDecl, genericParams, parentDC,
-                     interfaceSignature,
-                     opaqueReprs.empty() ? 0 : opaqueReprs[0],
-                     underlyingGenericParamType);
+  auto opaqueDecl = OpaqueTypeDecl::get(
+      originatingDecl, genericParams, parentDC, interfaceSignature, opaqueReprs,
+      underlyingGenericParamType);
   opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -769,7 +769,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
           return nullptr;
         }
       }();
-      if (resultTypeRepr && !isa<OpaqueReturnTypeRepr>(resultTypeRepr)) {
+      if (resultTypeRepr && !resultTypeRepr->hasOpaque()) {
         const auto resultType =
             resolution.withOptions(TypeResolverContext::FunctionResult)
                 .resolveType(resultTypeRepr);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -178,93 +178,129 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
           ? outerGenericSignature.getGenericParams().back()->getDepth() + 1
           : 0;
 
-  SmallVector<GenericTypeParamType *, 2> genericParamTypes;
-  SmallVector<Requirement, 2> requirements;
-
-  auto opaqueReprs = collectOpaqueReturnTypeReprs(repr);
-  if (opaqueReprs.size() > 1) {
-    ctx.Diags.diagnose(repr->getLoc(), diag::more_than_one_opaque_type, repr);
-    return nullptr;
-  }
-
-  // TODO [OPAQUE SUPPORT]: right now we only allow one structural 'some' type,
-  // but *very* soon we will allow more than one such type.
-  for (unsigned i = 0; i < opaqueReprs.size(); ++i) {
-    auto *currentRepr = opaqueReprs[i];
-
-    // Usually, we resolve the opaque constraint and bail if it isn't a class or
-    // existential type (see below). However, in this case we know we will fail,
-    // so we can bail early and provide a better diagnostic.
-    if (auto *optionalRepr =
-            dyn_cast<OptionalTypeRepr>(currentRepr->getConstraint())) {
-      std::string buf;
-      llvm::raw_string_ostream stream(buf);
-      stream << "(some " << optionalRepr->getBase() << ")?";
-
-      ctx.Diags.diagnose(currentRepr->getLoc(),
-                         diag::opaque_type_invalid_constraint);
-      ctx.Diags
-          .diagnose(currentRepr->getLoc(), diag::opaque_of_optional_rewrite)
-          .fixItReplaceChars(currentRepr->getStartLoc(),
-                             currentRepr->getEndLoc(), stream.str());
-      return nullptr;
-    }
-
-    auto *paramType = GenericTypeParamType::get(/*type sequence*/ false,
-                                                opaqueSignatureDepth, i, ctx);
-    genericParamTypes.push_back(paramType);
-
-    // Try to resolve the constraint repr in the parent decl context. It should
-    // be some kind of existential type. Pass along the error type if resolving
-    // the repr failed.
-    auto constraintType = TypeResolution::forInterface(
-                              dc, TypeResolverContext::GenericRequirement,
-                              // Unbound generics and placeholders are
-                              // meaningless in opaque types.
-                              /*unboundTyOpener*/ nullptr,
-                              /*placeholderHandler*/ nullptr)
-                              .resolveType(currentRepr->getConstraint());
-
-    if (constraintType->hasError())
-      return nullptr;
-
-    // Error out if the constraint type isn't a class or existential type.
-    if (!constraintType->getClassOrBoundGenericClass() &&
-        !constraintType->isExistentialType()) {
-      ctx.Diags.diagnose(currentRepr->getLoc(),
-                         diag::opaque_type_invalid_constraint);
-      return nullptr;
-    }
-
-    if (constraintType->hasArchetype())
-      constraintType = constraintType->mapTypeOutOfContext();
-
-    if (constraintType->getClassOrBoundGenericClass()) {
-      requirements.push_back(
-          Requirement(RequirementKind::Superclass, paramType, constraintType));
-    } else {
-      // In this case, the constraint type is an existential
-      requirements.push_back(
-          Requirement(RequirementKind::Conformance, paramType, constraintType));
-    }
-  }
-
-  auto interfaceSignature = buildGenericSignature(ctx, outerGenericSignature,
-                                                  genericParamTypes,
-                                                  std::move(requirements));
-
-  // Create the OpaqueTypeDecl for the result type.
-  // It has the same parent context and generic environment as the originating
-  // decl.
+  // Determine the context of the opaque type declaration we'll be creating.
   auto parentDC = originatingDecl->getDeclContext();
   auto originatingGenericContext = originatingDecl->getAsGenericContext();
-  GenericParamList *genericParams = originatingGenericContext
-    ? originatingGenericContext->getGenericParams()
-    : nullptr;
+  GenericParamList *genericParams;
+  GenericSignature interfaceSignature;
 
+  // FIXME: The generic parameter that serves as the underlying type of the
+  // opaque result type. This should become unnecessary, once we have fully
+  // implemented structural opaque result types.
+  GenericTypeParamType *underlyingGenericParamType;
+
+  CollectedOpaqueReprs opaqueReprs;
+  if (auto namedOpaque = dyn_cast<NamedOpaqueReturnTypeRepr>(repr)) {
+    // Produce the generic signature for the opaque type.
+    genericParams = namedOpaque->getGenericParams();
+    genericParams->setDepth(opaqueSignatureDepth);
+
+    InferredGenericSignatureRequest request{
+        originatingDC->getParentModule(),
+        outerGenericSignature.getPointer(),
+        genericParams,
+        WhereClauseOwner(originatingDC, genericParams),
+        /*addedRequirements=*/{},
+        /*inferenceSources=*/{},
+        /*allowConcreteGenericParams=*/false};
+
+    interfaceSignature = evaluateOrDefault(
+        ctx.evaluator, request, GenericSignatureWithError())
+          .getPointer();
+    if (!interfaceSignature) {
+      // Already produced an error.
+      return nullptr;
+    }
+
+    underlyingGenericParamType = interfaceSignature.getGenericParams()[0];
+  } else {
+    opaqueReprs = collectOpaqueReturnTypeReprs(repr);
+    if (opaqueReprs.size() > 1) {
+      ctx.Diags.diagnose(repr->getLoc(), diag::more_than_one_opaque_type, repr);
+      return nullptr;
+    }
+
+    // TODO [OPAQUE SUPPORT]: right now we only allow one structural 'some' type,
+    // but *very* soon we will allow more than one such type.
+    SmallVector<GenericTypeParamType *, 2> genericParamTypes;
+    SmallVector<Requirement, 2> requirements;
+    for (unsigned i = 0; i < opaqueReprs.size(); ++i) {
+      auto *currentRepr = opaqueReprs[i];
+
+      // Usually, we resolve the opaque constraint and bail if it isn't a class
+      // or existential type (see below). However, in this case we know we will
+      // fail, so we can bail early and provide a better diagnostic.
+      if (auto *optionalRepr =
+              dyn_cast<OptionalTypeRepr>(currentRepr->getConstraint())) {
+        std::string buf;
+        llvm::raw_string_ostream stream(buf);
+        stream << "(some " << optionalRepr->getBase() << ")?";
+
+        ctx.Diags.diagnose(currentRepr->getLoc(),
+                           diag::opaque_type_invalid_constraint);
+        ctx.Diags
+            .diagnose(currentRepr->getLoc(), diag::opaque_of_optional_rewrite)
+            .fixItReplaceChars(currentRepr->getStartLoc(),
+                               currentRepr->getEndLoc(), stream.str());
+        return nullptr;
+      }
+
+      auto *paramType = GenericTypeParamType::get(/*type sequence*/ false,
+                                                  opaqueSignatureDepth, i, ctx);
+      genericParamTypes.push_back(paramType);
+
+      // Try to resolve the constraint repr in the parent decl context. It
+      // should be some kind of existential type. Pass along the error type if
+      // resolving the repr failed.
+      auto constraintType = TypeResolution::forInterface(
+                                dc, TypeResolverContext::GenericRequirement,
+                                // Unbound generics and placeholders are
+                                // meaningless in opaque types.
+                                /*unboundTyOpener*/ nullptr,
+                                /*placeholderHandler*/ nullptr)
+                                .resolveType(currentRepr->getConstraint());
+
+      if (constraintType->hasError())
+        return nullptr;
+
+      // Error out if the constraint type isn't a class or existential type.
+      if (!constraintType->getClassOrBoundGenericClass() &&
+          !constraintType->isExistentialType()) {
+        ctx.Diags.diagnose(currentRepr->getLoc(),
+                           diag::opaque_type_invalid_constraint);
+        return nullptr;
+      }
+
+      if (constraintType->hasArchetype())
+        constraintType = constraintType->mapTypeOutOfContext();
+
+      if (constraintType->getClassOrBoundGenericClass()) {
+        requirements.push_back(
+            Requirement(RequirementKind::Superclass, paramType,
+                        constraintType));
+      } else {
+        // In this case, the constraint type is an existential
+        requirements.push_back(
+            Requirement(RequirementKind::Conformance, paramType,
+                        constraintType));
+      }
+    }
+
+    interfaceSignature = buildGenericSignature(ctx, outerGenericSignature,
+                                               genericParamTypes,
+                                               std::move(requirements));
+    genericParams = originatingGenericContext
+        ? originatingGenericContext->getGenericParams()
+        : nullptr;
+    underlyingGenericParamType = genericParamTypes[0];
+  }
+
+  // Create the OpaqueTypeDecl for the result type.
   auto opaqueDecl = new (ctx)
       OpaqueTypeDecl(originatingDecl, genericParams, parentDC,
-                     interfaceSignature, opaqueReprs[0], genericParamTypes[0]);
+                     interfaceSignature,
+                     opaqueReprs.empty() ? 0 : opaqueReprs[0],
+                     underlyingGenericParamType);
   opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -183,12 +183,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
   auto originatingGenericContext = originatingDecl->getAsGenericContext();
   GenericParamList *genericParams;
   GenericSignature interfaceSignature;
-
-  // FIXME: The generic parameter that serves as the underlying type of the
-  // opaque result type. This should become unnecessary, once we have fully
-  // implemented structural opaque result types.
-  GenericTypeParamType *underlyingGenericParamType;
-
   CollectedOpaqueReprs opaqueReprs;
   if (auto namedOpaque = dyn_cast<NamedOpaqueReturnTypeRepr>(repr)) {
     // Produce the generic signature for the opaque type.
@@ -211,8 +205,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       // Already produced an error.
       return nullptr;
     }
-
-    underlyingGenericParamType = interfaceSignature.getGenericParams()[0];
   } else {
     opaqueReprs = collectOpaqueReturnTypeReprs(repr);
     SmallVector<GenericTypeParamType *, 2> genericParamTypes;
@@ -285,13 +277,12 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     genericParams = originatingGenericContext
         ? originatingGenericContext->getGenericParams()
         : nullptr;
-    underlyingGenericParamType = genericParamTypes[0];
   }
 
   // Create the OpaqueTypeDecl for the result type.
   auto opaqueDecl = OpaqueTypeDecl::get(
-      originatingDecl, genericParams, parentDC, interfaceSignature, opaqueReprs,
-      underlyingGenericParamType);
+      originatingDecl, genericParams, parentDC, interfaceSignature,
+      opaqueReprs);
   opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2084,9 +2084,47 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
     return resolveExistentialType(existential, options);
   }
 
-  case TypeReprKind::NamedOpaqueReturn:
-    return resolveType(cast<NamedOpaqueReturnTypeRepr>(repr)->getBase(),
-                       options);
+  case TypeReprKind::NamedOpaqueReturn: {
+    // If the named opaque result type is in a valid position, resolution
+    // should happen in the context of an `OpaqueTypeDecl`. This decl is
+    // implicit in the source and is created in such contexts by evaluation of
+    // an `OpaqueResultTypeRequest`.
+    auto opaqueRepr = cast<NamedOpaqueReturnTypeRepr>(repr);
+    if (auto opaqueDecl = dyn_cast<OpaqueTypeDecl>(getDeclContext())) {
+      // Resolve the base type within this context.
+
+      // FIXME: Temporary hack to resolve an identifier type to one of the
+      // generic parameters of the opaque return type. This should be subsumed
+      // be proper name lookup, OF COURSE.
+      if (auto simpleIdent = dyn_cast<SimpleIdentTypeRepr>(
+              opaqueRepr->getBase())) {
+        Identifier name = simpleIdent->getComponentRange().front()
+            ->getNameRef().getBaseIdentifier();
+        if (auto gpDecl = opaqueRepr->getGenericParams()
+                ->lookUpGenericParam(name)) {
+          auto outerGenericSignature = opaqueDecl->getNamingDecl()
+                                           ->getInnermostDeclContext()
+                                           ->getGenericSignatureOfContext();
+
+          SubstitutionMap subs;
+          if (outerGenericSignature)
+            subs = outerGenericSignature->getIdentitySubstitutionMap();
+
+          return OpaqueTypeArchetypeType::get(
+                            opaqueDecl, gpDecl->getIndex(), subs);
+        }
+      }
+
+      return resolveType(opaqueRepr->getBase(), options);
+    }
+
+    // We are not inside an `OpaqueTypeDecl`, so diagnose an error.
+    if (!(options & TypeResolutionFlags::SilenceErrors)) {
+      diagnose(repr->getStartLoc(), diag::unsupported_opaque_type);
+    }
+
+    return ErrorType::get(getASTContext());
+  }
 
   case TypeReprKind::Placeholder: {
     auto &ctx = getASTContext();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3458,7 +3458,7 @@ public:
     auto declContext = MF.getDeclContext(contextID);
     auto interfaceSig = MF.getGenericSignature(interfaceSigID);
     auto interfaceType = MF.getType(interfaceTypeID);
-    
+
     // Check for reentrancy.
     if (declOrOffset.isComplete())
       return cast<OpaqueTypeDecl>(declOrOffset.get());
@@ -3469,7 +3469,7 @@ public:
     auto opaqueDecl = OpaqueTypeDecl::get(
         /*NamingDecl=*/ nullptr, genericParams, declContext,
         interfaceSig, /*OpaqueReturnTypeReprs*/ { },
-        interfaceType->castTo<GenericTypeParamType>());
+        interfaceType);
     declOrOffset = opaqueDecl;
 
     auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3457,7 +3457,6 @@ public:
     
     auto declContext = MF.getDeclContext(contextID);
     auto interfaceSig = MF.getGenericSignature(interfaceSigID);
-    auto interfaceType = MF.getType(interfaceTypeID);
 
     // Check for reentrancy.
     if (declOrOffset.isComplete())
@@ -3468,13 +3467,13 @@ public:
     // Create the decl.
     auto opaqueDecl = OpaqueTypeDecl::get(
         /*NamingDecl=*/ nullptr, genericParams, declContext,
-        interfaceSig, /*OpaqueReturnTypeReprs*/ { },
-        interfaceType);
+        interfaceSig, /*OpaqueReturnTypeReprs*/ { });
     declOrOffset = opaqueDecl;
 
     auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));
     opaqueDecl->setNamingDecl(namingDecl);
 
+    auto interfaceType = MF.getType(interfaceTypeID);
     opaqueDecl->setInterfaceType(MetatypeType::get(interfaceType));
 
     if (auto accessLevel = getActualAccessLevel(rawAccessLevel))

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3464,10 +3464,9 @@ public:
       return cast<OpaqueTypeDecl>(declOrOffset.get());
       
     // Create the decl.
-    auto opaqueDecl = new (ctx)
-        OpaqueTypeDecl(/*NamingDecl*/ nullptr,
-                       /*GenericParams*/ nullptr, declContext, interfaceSig,
-                       /*UnderlyingInterfaceTypeRepr*/ nullptr, interfaceType);
+    auto opaqueDecl = OpaqueTypeDecl::get(
+        /*NamingDecl*/ nullptr, /*GenericParams*/ nullptr, declContext,
+        interfaceSig, /*OpaqueReturnTypeReprs*/ { }, interfaceType);
     declOrOffset = opaqueDecl;
 
     auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 653; // `IsDistributed` bit on SILFunction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 654; // opaque result type orinal
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1083,6 +1083,7 @@ namespace decls_block {
   using OpaqueArchetypeTypeLayout = BCRecordLayout<
     OPAQUE_ARCHETYPE_TYPE,
     DeclIDField,           // the opaque type decl
+    BCVBR<4>,              // the ordinal
     SubstitutionMapIDField // the arguments
   >;
   

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4485,7 +4485,8 @@ public:
     auto substMapID = S.addSubstitutionMapRef(archetypeTy->getSubstitutions());
     unsigned abbrCode = S.DeclTypeAbbrCodes[OpaqueArchetypeTypeLayout::Code];
     OpaqueArchetypeTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                          declID, substMapID);
+                                          declID, archetypeTy->getOrdinal(),
+                                          substMapID);
   }
 
   void visitNestedArchetypeType(const NestedArchetypeType *archetypeTy) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3820,21 +3820,20 @@ public:
     auto contextID = S.addDeclContextRef(opaqueDecl->getDeclContext());
     auto interfaceSigID = S.addGenericSignatureRef(
         opaqueDecl->getOpaqueInterfaceGenericSignature());
-    auto interfaceTypeID =
-      S.addTypeRef(opaqueDecl->getUnderlyingInterfaceType());
+    auto interfaceTypeID = S.addTypeRef(opaqueDecl->getDeclaredInterfaceType());
 
     auto genericSigID = S.addGenericSignatureRef(opaqueDecl->getGenericSignature());
 
-    SubstitutionMapID underlyingTypeID = 0;
+    SubstitutionMapID underlyingSubsID = 0;
     if (auto underlying = opaqueDecl->getUnderlyingTypeSubstitutions())
-      underlyingTypeID = S.addSubstitutionMapRef(*underlying);
+      underlyingSubsID = S.addSubstitutionMapRef(*underlying);
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(opaqueDecl->getFormalAccess());
     unsigned abbrCode = S.DeclTypeAbbrCodes[OpaqueTypeLayout::Code];
     OpaqueTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                  contextID.getOpaqueValue(), namingDeclID,
                                  interfaceSigID, interfaceTypeID, genericSigID,
-                                 underlyingTypeID, rawAccessLevel);
+                                 underlyingSubsID, rawAccessLevel);
     writeGenericParams(opaqueDecl->getGenericParams());
   }
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -28,6 +28,9 @@ extension Int: O, O2 {
   public func baz() {}
 }
 
+@_marker protocol Marker { }
+extension Int: Marker { }
+
 extension String: P {
   // CHECK-LABEL: @"$sSS18opaque_result_typeE3pooQryFQOMQ" = {{.*}}constant <{ {{.*}} }> <{
   // -- header: opaque type context (0x4), generic (0x80), unique (0x40), two entries (0x2_0000)
@@ -132,6 +135,22 @@ func bar(y: C) -> some Q {
 // CHECK-SAME:         @"get_witness_table 18opaque_result_type1PRzAA1QRzlxAaC
 // CHECK-SAME:  }>
 func baz<T: P & Q>(z: T) -> some P & Q {
+  return z
+}
+
+// CHECK-LABEL: @"$s18opaque_result_type4fizz1zQrx_tAA6MarkerRzAA1PRzAA1QRzlFQOMQ" = {{.*}} constant <{ {{.*}} }> <{
+// -- header: opaque type context (0x4), generic (0x80), unique (0x40), three entries (0x3_0000)
+// CHECK-SAME:         <i32 0x3_00c4>
+// -- parent context: anon context for function
+// CHECK-SAME:         @"$s18opaque_result_type4fizz1zQrx_tAA6MarkerRzAA1PRzAA1QRzlFMXX"
+// -- mangled underlying type
+// CHECK-SAME:         @"symbolic x"
+// -- conformance to P
+// CHECK-SAME:         @"get_witness_table 18opaque_result_type6MarkerRzAA1PRzAA1QRzlxAaCHD2_
+// -- conformance to Q
+// CHECK-SAME:         @"get_witness_table 18opaque_result_type6MarkerRzAA1PRzAA1QRzlxAaDHD3_
+// CHECK-SAME:  }>
+func fizz<T: P & Q & Marker>(z: T) -> some P & Q & Marker {
   return z
 }
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -62,7 +62,7 @@ public var globalProp: some O {
   return 0
 }
 
-public class C: P, Q {
+public class C: P, Q, Marker {
   // CHECK-LABEL: @"$s18opaque_result_type1CC3pooQryFQOMQ" = {{.*}} constant <{ {{.*}} }> <{
   // -- header: opaque type context (0x4), generic (0x80), unique (0x40), two entries (0x2_0000)
   // CHECK-SAME:         <i32 0x2_00c4>
@@ -154,6 +154,10 @@ func fizz<T: P & Q & Marker>(z: T) -> some P & Q & Marker {
   return z
 }
 
+func bauble<T: P & Q & Marker, U: Q>(z: T, u: U) -> [(some P & Q & Marker, (some Q)?)] {
+  return [(z, u)]
+}
+
 // Ensure the local type's opaque descriptor gets emitted.
 // CHECK-LABEL: @"$s18opaque_result_type11localOpaqueQryF0D0L_QryFQOMQ" = 
 func localOpaque() -> some P {
@@ -180,7 +184,11 @@ public func useFoo(x: String, y: C) {
   let pqb = pq.qoo()
   pqb.bar()
   pqb.baz()
+
+  let _ = bauble(z: y, u: y)
 }
+
+// CHECK-LABEL: define {{.*}} @"$s18opaque_result_type6bauble1z1uSayQr_QrSgtGx_q_tAA6MarkerRzAA1PRzAA1QRzAaIR_r0_lF"
 
 // CHECK-LABEL: define {{.*}} @"$s18opaque_result_type6useFoo1x1yySS_AA1CCtF"
 // CHECK: [[OPAQUE:%.*]] = call {{.*}} @"$s18opaque_result_type3baz1zQrx_tAA1PRzAA1QRzlFQOMg"

--- a/test/IRGen/opaque_result_type_debug.swift
+++ b/test/IRGen/opaque_result_type_debug.swift
@@ -22,6 +22,12 @@ public struct Foo {
   }
 }
 
+public class C: P { }
+
+public func bar() -> [(some P, (some AnyObject & P)?)] {
+  return [(1, C())]
+}
+
 #else
 
 import opaque_result_type_debug_other
@@ -43,6 +49,12 @@ public func bar<T: P>(genericValue: T) {
 
   let opaqueSubValue = Foo()[]
   use(opaqueSubValue)
+
+  let opaqueArray = bar()
+  let opaqueArrayFirst = opaqueArray[0].0
+  use(opaqueArrayFirst)
+  let opaqueArraySecond = opaqueArray[0].1!
+  use(opaqueArraySecond)
 }
 
 #endif
@@ -56,3 +68,9 @@ public func bar<T: P>(genericValue: T) {
 // CHECK-DAG: {{![0-9]+}} = !DILocalVariable(name: "opaqueValue",{{.*}} type: ![[LET_OPAQUE_TYPE]])
 // CHECK-DAG: {{![0-9]+}} = !DILocalVariable(name: "opaquePropValue",{{.*}} type: ![[LET_OPAQUE_PROP_TYPE]])
 // CHECK-DAG: {{![0-9]+}} = !DILocalVariable(name: "opaqueSubValue",{{.*}} type: ![[LET_OPAQUE_SUB_TYPE]])
+// CHECK-DAG: ![[OPAQUE_ARRAY_FIRST_TYPE:[0-9]+]] = !DICompositeType({{.*}} name: "$s30opaque_result_type_debug_other3barSayQr_QrSgtGyFQOyQo_D"
+// CHECK-DAG: ![[LET_OPAQUE_ARRAY_FIRST_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[OPAQUE_ARRAY_FIRST_TYPE]])
+// CHECK-DAG: {{![0-9]+}} = !DILocalVariable(name: "opaqueArrayFirst",{{.*}} type: ![[LET_OPAQUE_ARRAY_FIRST_TYPE]])
+// CHECK-DAG: ![[OPAQUE_ARRAY_SECOND_TYPE:[0-9]+]] = !DICompositeType({{.*}} name: "$s30opaque_result_type_debug_other3barSayQr_QrSgtGyFQOyQo0_D"
+// CHECK-DAG: ![[LET_OPAQUE_ARRAY_SECOND_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[OPAQUE_ARRAY_SECOND_TYPE]])
+// CHECK-DAG: {{![0-9]+}} = !DILocalVariable(name: "opaqueArraySecond",{{.*}} type: ![[LET_OPAQUE_ARRAY_SECOND_TYPE]])

--- a/test/Serialization/Inputs/OpaqueTypeStructured.swift
+++ b/test/Serialization/Inputs/OpaqueTypeStructured.swift
@@ -1,0 +1,16 @@
+public protocol P { }
+public protocol Q { }
+
+extension Int: P { }
+extension Double: Q { }
+
+public protocol R {
+  associatedtype A
+  func f() -> A
+}
+
+public struct X: R {
+  public func f() -> (some P, [some Q]) {
+    return (1, [3.14159, 2.71828])
+  }
+}

--- a/test/Serialization/opaque_type_structured.swift
+++ b/test/Serialization/opaque_type_structured.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/OpaqueTypeStructured.swift
+// RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print OpaqueTypeStructured -I %t | %FileCheck -check-prefix=AST %s
+import OpaqueTypeStructured
+
+func acceptR<T: R>(_: T) { }
+
+// AST: func f() -> (some P, [some Q])
+
+func passAnX(x: X) {
+  // SIL: $@convention(method) (@in_guaranteed X) -> (@out @_opaqueReturnTypeOf("$s20OpaqueTypeStructured1XV1fQr_SayQrGtyF", 0) __, @owned Array<@_opaqueReturnTypeOf("$s20OpaqueTypeStructured1XV1fQr_SayQrGtyF", 1) __>)
+  acceptR(x)
+  let _: X.A = x.f()
+}
+

--- a/test/Serialization/opaque_type_structured.swift
+++ b/test/Serialization/opaque_type_structured.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/OpaqueTypeStructured.swift
-// RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-frontend -emit-module -disable-availability-checking -o %t -enable-library-evolution %S/Inputs/OpaqueTypeStructured.swift
+// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -I %t %s | %FileCheck -check-prefix=SIL %s
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print OpaqueTypeStructured -I %t | %FileCheck -check-prefix=AST %s
 import OpaqueTypeStructured
 

--- a/test/api-digester/Inputs/cake_baseline/cake.swift
+++ b/test/api-digester/Inputs/cake_baseline/cake.swift
@@ -211,8 +211,8 @@ public class Zoo {
   }
   @inlinable
   @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
-  public func getCurrentAnimalInlinable() -> some Animal {
-    return Cat()
+  public func getCurrentAnimalInlinable() -> [some Animal] {
+    return [Cat()]
   }
 }
 

--- a/test/api-digester/Inputs/cake_current/cake.swift
+++ b/test/api-digester/Inputs/cake_current/cake.swift
@@ -224,8 +224,8 @@ public class Zoo {
   }
   @inlinable
   @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
-  public func getCurrentAnimalInlinable() -> some Animal {
-    return Dog()
+  public func getCurrentAnimalInlinable() -> [some Animal] {
+    return [Dog()]
   }
 }
 

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -50,7 +50,7 @@ cake: Func C7.foo(_:_:) has removed default argument from parameter 1
 cake: Func EscapingFunctionType.addedEscaping(_:) has added @escaping in parameter 0
 cake: Func EscapingFunctionType.removedEscaping(_:) has removed @escaping in parameter 0
 cake: Func Somestruct2.foo1(_:) has parameter 0 type change from cake.C3 to cake.C1
-cake: Func Zoo.getCurrentAnimalInlinable() has return type change from cake.Cat to cake.Dog
+cake: Func Zoo.getCurrentAnimalInlinable() has return type change from [cake.Cat] to [cake.Dog]
 cake: Func ownershipChange(_:_:) has parameter 0 changing from InOut to Default
 cake: Func ownershipChange(_:_:) has parameter 1 changing from Shared to Owned
 cake: Func returnFunctionTypeOwnershipChange() has return type change from (cake.C1) -> () to (__owned cake.C1) -> ()

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -76,7 +76,7 @@ struct Test {
 let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
 
 
-func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{'(some P, some P)' contains multiple 'opaque' types, but only one 'opaque' type is supported}}
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) }
 func asArrayElem() -> [some P] { return [1] }
 
 // Invalid positions

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -2,18 +2,45 @@
 
 // Tests for experimental extensions to opaque return type support.
 
-func f0() -> <T> () { }
-func f1() -> <T, U, V> () { }
-func f2() -> <T: Collection, U: SignedInteger> () { }
-func f4() async -> <T> () { }
+func f0() -> <T> T { return () }
+func f1() -> <T, U, V> T { () }
+// FIXME better diagnostic: expected-error@-1{{generic parameter 'U' could not be inferred}}
+// FIXME better diagnostic: expected-error@-2{{generic parameter 'V' could not be inferred}}
+func f2() -> <T: Collection, U: SignedInteger> T { // expected-note{{required by opaque return type of global function 'f2()'}}
+  () // expected-error{{type '()' cannot conform to 'Collection'}}
+  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
+  // expected-error@-2{{generic parameter 'U' could not be inferred}}
+}
+
+func f4() async -> <T> T { () }
 
 func g0() -> <T> { } // expected-error{{expected type for function result}}
-func g1() -> async <T> () { } // expected-error{{'async' may only occur before '->'}}
-func g2() -> <T> () async { } // expected-error{{'async' may only occur before '->'}}
+func g1() -> async <T> T { () } // expected-error{{'async' may only occur before '->'}}
+func g2() -> <T> T async { () } // expected-error{{'async' may only occur before '->'}}
 
 let x0: <T> Int = 1
 var x1: <T> (Int, Int) = (1, 1)
 var x2: <T> (<U> Int, Int) = (1, 1) // expected-error{{expected type}} expected-error{{cannot convert value of type '(Int, Int)' to specified type 'Int'}}
-for _: <T> Int in [1, 2, 3] { }
+for _: <T> Int in [1, 2, 3] { } // FIXME mention of 'some' is wrong: expected-error{{some' type can only be declared on a single property declaration}}
 
-struct S0 { subscript(i: Int) -> <T> Int { 1 } }
+struct S0 { subscript(i: Int) -> <T> T { 1 } }
+
+protocol P { }
+extension Int: P { }
+
+protocol Q { }
+
+func h0() -> <T: P> T { 5 }
+
+func h1() -> <T: P> T { // expected-note{{opaque return type declared here}}
+  3.14159 // expected-error{{return type of global function 'h1()' requires that 'Double' conform to 'P'}}
+}
+
+func h2() -> <T: P & Q> T { // expected-note{{opaque return type declared here}}
+  3 // expected-error{{return type of global function 'h2()' requires that 'Int' conform to 'Q'}}
+}
+
+func test_h0() {
+  // Make sure we can treat h0 as a P
+  let _: P = h0()
+}

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -12,21 +12,17 @@ class C {}
 class D: P, Q { func paul() {}; func d() {} }
 
 
-// TODO: cases that we should support, but don't yet:
+func asUnwrappedOptionalBase() -> (some P)! { return 1 } // expected-warning{{using '!' is not allowed here; treating this as '?' instead}}
 //
-// WARNING: using '!' is not allowed here; treating this as '?' instead
-// func asUnwrappedOptionalBase() -> (some P)! { return 1 }
+// FIXME: We should be able to support this
+func asHOFRetRet() -> () -> some P { return { 1 } } // expected-error{{cannot convert value of type 'Int' to closure result type 'some P'}}
 //
-// ERROR: generic parameter 'τ_0_0' could not be inferred
-// func asHOFRetRet() -> () -> some P { return { 1 } }
-//
-// ERROR: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
-// func asHOFRetArg() -> (some P) -> () { return { (x: Int) -> () in } }
+func asHOFRetArg() -> (some P) -> () { return { (x: Int) -> () in } } // expected-error{{'some' cannot appear in parameter position in result type '(some P) -> ()'}}
 //
 // ERROR: 'some' types are only implemented for the declared type of properties and subscripts and the return type of functions
 // let x = { () -> some P in return 1 }
 
-func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{only one 'opaque' type is supported}}
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) }
 func asTupleElemBad() -> (P, some Q) { return (1, C()) } // expected-note{{opaque return type declared here}} expected-error{{requires that 'C' conform to 'Q'}}
 
 func asTupleElem() -> (P, some Q) { return (1, 2) }
@@ -96,3 +92,37 @@ typealias Takes<T> = (T) -> Void
 
 // expected-error@+1 {{'some' cannot appear in parameter position in result type 'Takes<some P>' (aka '(some P) -> ()')}}
 func indirectOpaqueParameter() -> Takes<some P> {}
+
+struct X<T, U> { }
+
+struct StructuralMethods {
+  func f1() -> X<(some P)?, [some Q]> {
+    return X<Int?, [String]>()
+  }
+
+  func f2(cond: Bool) -> X<(some P)?, [some Q]> {
+    if cond {
+      return X<Int?, [String]>()
+    } else {
+      return X<Int?, [String]>()
+    }
+  }
+
+  // TODO: Diagnostics here should be more clear about which "some" is the
+  // problem.
+  func f3(cond: Bool) -> X<(some P)?, [some Q]> { // expected-error{{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+    if cond {
+      return X<String?, [String]>() // expected-note{{return statement has underlying type 'String'}}
+    } else {
+      return X<Int?, [String]>() // expected-note{{return statement has underlying type 'Int'}}
+    }
+  }
+
+  func f4(cond: Bool) -> X<(some P)?, [some Q]> { // expected-error{{function declares an opaque return type 'some Q', but the return statements in its body do not have matching underlying types}}
+    if cond {
+      return X<Int?, [String]>() // expected-note{{return statement has underlying type 'String'}}
+    } else {
+      return X<Int?, [Int]>() // expected-note{{return statement has underlying type 'Int'}}
+    }
+  }
+}


### PR DESCRIPTION
Implement the remainder of SE-0328 "Structural opaque result types". This includes:

* Carry the "ordinal" for opaque result types throughout the AST, serialized module files, name mangling, etc.
* Compute substitutions for all opaque generic parameters within the constraint system and use those substitutions consistently
* Generalize the emission of opaque type descriptor metadata to arbitrary requirements
* Eliminate all dependencies on a single underlying generic parameter
* Enable structural opaque result types by default

Implements rdar://51723717

