### PR TITLE
[WIP] Implement -debug-compilation-dir

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1478,7 +1478,7 @@ def use_interface_for_module: Separate<["-", "--"], "use-interface-for-module">,
   MetaVarName<"<name>">;
 
 def debug_compilation_dir : Separate<["-"], "fdebug-compilation-dir">,
-  Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
+  Flags<[FrontendOption]>,
   HelpText<"The compilation directory to embed in the debug info.">;
 
 include "FrontendOptions.td"

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1477,4 +1477,8 @@ def use_interface_for_module: Separate<["-", "--"], "use-interface-for-module">,
   HelpText<"Prefer loading these modules via interface">,
   MetaVarName<"<name>">;
 
+def debug_compilation_dir : Separate<["-"], "fdebug-compilation-dir">,
+  Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
+  HelpText<"The compilation directory to embed in the debug info.">;
+
 include "FrontendOptions.td"

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1817,9 +1817,13 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                                           ResourceDir);
     }
     // TODO: Should we support -fdebug-compilation-dir?
-    llvm::SmallString<256> cwd;
-    llvm::sys::fs::current_path(cwd);
-    Opts.DebugCompilationDir = std::string(cwd.str());
+    if (const Arg *A = Args.getLastArg(OPT_debug_compilation_dir))
+      Opts.DebugCompilationDir = A->getValue();
+    else {
+      llvm::SmallString<256> cwd;
+      llvm::sys::fs::current_path(cwd);
+      Opts.DebugCompilationDir = std::string(cwd.str());
+    }
   }
 
   if (const Arg *A = Args.getLastArg(options::OPT_debug_info_format)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1101,6 +1101,12 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.ExtraArgs.push_back("-fdebug-prefix-map=" + A);
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_debug_compilation_dir)) {
+    StringRef path = A->getValue();
+    Opts.ExtraArgs.insert(Opts.ExtraArgs.begin(),
+                          {"-fdebug-compilation-dir", path.str()});
+  }
+
   if (!workingDirectory.empty()) {
     // Provide a working directory to Clang as well if there are any -Xcc
     // options, in case some of them are search-related. But do it at the
@@ -1818,7 +1824,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     }
     // TODO: Should we support -fdebug-compilation-dir?
     if (const Arg *A = Args.getLastArg(OPT_debug_compilation_dir))
-      Opts.DebugCompilationDir = A->getValue();
+      Opts.DebugCompilationDir = std::string(A->getValue());
     else {
       llvm::SmallString<256> cwd;
       llvm::sys::fs::current_path(cwd);


### PR DESCRIPTION
A draft to implement `-fdebug-compilation-dir` to specify the folder for debug information.