### PR TITLE
Named opaque result types

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2779,6 +2779,16 @@ public:
     return OpaqueInterfaceGenericSignature.getInnermostGenericParams();
   }
 
+  /// Whether the generic parameters of this opaque type declaration were
+  /// explicit, i.e., for named opaque result types.
+  bool hasExplicitGenericParams() const;
+
+  /// When the generic parameters were explicit, returns the generic parameter
+  /// corresponding to the given ordinal.
+  ///
+  /// Otherwise, returns \c nullptr.
+  GenericTypeParamDecl *getExplicitGenericParam(unsigned ordinal) const;
+
   /// Retrieve the buffer containing the opaque return type
   /// representations that correspond to the opaque generic parameters.
   ArrayRef<OpaqueReturnTypeRepr *> getOpaqueReturnTypeReprs() const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -106,6 +106,7 @@ namespace swift {
 
   namespace ast_scope {
   class AbstractPatternEntryScope;
+  class GenericParamScope;
   class PatternEntryDeclScope;
   class PatternEntryInitializerScope;
   } // namespace ast_scope
@@ -1565,6 +1566,7 @@ class PatternBindingEntry {
   friend class PatternBindingInitializer;
   friend class PatternBindingDecl;
   friend class ast_scope::AbstractPatternEntryScope;
+  friend class ast_scope::GenericParamScope;
   friend class ast_scope::PatternEntryDeclScope;
   friend class ast_scope::PatternEntryInitializerScope;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4134,6 +4134,9 @@ ERROR(opaque_type_no_underlying_type_candidates,none,
 ERROR(opaque_type_mismatched_underlying_type_candidates,none,
       "function declares an opaque return type %0, but the return statements "
       "in its body do not have matching underlying types", (TypeRepr *))
+ERROR(opaque_type_mismatched_underlying_type_candidates_named,none,
+      "function declares an opaque return type %0, but the return statements "
+      "in its body do not have matching underlying types", (Identifier))
 NOTE(opaque_type_underlying_type_candidate_here,none,
      "return statement has underlying type %0", (Type))
 ERROR(opaque_type_self_referential_underlying_type,none,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1558,7 +1558,17 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
 
     // If we are generic at this level, emit all of the replacements at
     // this level.
-    if (genericContext->isGeneric()) {
+    bool treatAsGeneric;
+    if (auto opaque = dyn_cast<OpaqueTypeDecl>(decl)) {
+      // For opaque type declarations, the generic parameters of the opaque
+      // type declaration are not part of the mangling, so check whether the
+      // naming declaration has generic parameters.
+      auto namedGenericContext = opaque->getNamingDecl()->getAsGenericContext();
+      treatAsGeneric = namedGenericContext && namedGenericContext->isGeneric();
+    } else {
+      treatAsGeneric = genericContext->isGeneric();
+    }
+    if (treatAsGeneric) {
       auto genericParams = subs.getGenericSignature().getGenericParams();
       unsigned depth = genericParams[currentGenericParamIdx]->getDepth();
       auto replacements = subs.getReplacementTypes();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4338,9 +4338,10 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       case PrintOptions::OpaqueReturnTypePrintingMode::Description:
         return true;
       case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
-        return false;
+        return opaque->getDecl()->hasExplicitGenericParams();
       case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword:
-        return isSimpleUnderPrintOptions(opaque->getExistentialType());
+        return opaque->getDecl()->hasExplicitGenericParams() ||
+            isSimpleUnderPrintOptions(opaque->getExistentialType());
       }
       llvm_unreachable("bad opaque-return-type printing mode");
     }
@@ -5410,11 +5411,28 @@ public:
   }
 
   void visitOpaqueTypeArchetypeType(OpaqueTypeArchetypeType *T) {
+    // Try to print a named opaque type.
+    auto printNamedOpaque = [&] {
+      if (auto genericParam =
+              T->getDecl()->getExplicitGenericParam(T->getOrdinal())) {
+        visit(genericParam->getDeclaredInterfaceType());
+        return true;
+      }
+
+      return false;
+    };
+
     switch (Options.OpaqueReturnTypePrinting) {
     case PrintOptions::OpaqueReturnTypePrintingMode::WithOpaqueKeyword:
+      if (printNamedOpaque())
+        return;
+
       Printer.printKeyword("some", Options, /*Suffix=*/" ");
       LLVM_FALLTHROUGH;
     case PrintOptions::OpaqueReturnTypePrintingMode::WithoutOpaqueKeyword: {
+      if (printNamedOpaque())
+        return;
+
       visit(T->getExistentialType());
       return;
     }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -859,6 +859,13 @@ void AbstractFunctionDeclScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
   ASTScopeImpl *leaf = this;
 
   if (!isa<AccessorDecl>(decl)) {
+    if (auto opaqueRepr = decl->getOpaqueResultTypeRepr()) {
+      if (auto namedOpaque = dyn_cast<NamedOpaqueReturnTypeRepr>(opaqueRepr)) {
+        leaf = scopeCreator.addNestedGenericParamScopesToTree(
+            decl, namedOpaque->getGenericParams(), leaf);
+      }
+    }
+
     leaf = scopeCreator.addNestedGenericParamScopesToTree(
         decl, decl->getGenericParams(), leaf);
 

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -266,6 +266,14 @@ bool GenericTypeOrExtensionScope::areMembersVisibleFromWhereClause() const {
 NullablePtr<const ASTScopeImpl>
 PatternEntryInitializerScope::getLookupParent() const {
   auto parent = getParent().get();
+
+  // Skip generic parameter scopes, which occur here due to named opaque
+  // result types.
+  // FIXME: Proper isa/dyn_cast support would be better than a string
+  // comparison here.
+  while (parent->getClassName() == "GenericParamScope")
+    parent = parent->getLookupParent().get();
+
   ASTScopeAssert(parent->getClassName() == "PatternEntryDeclScope",
                  "PatternEntryInitializerScope in unexpected place");
 

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -161,6 +161,15 @@ SourceRange GenericParamScope::getSourceRangeOfThisASTNode(
     return SourceRange(getLocAfterExtendedNominal(ext), ext->getEndLoc());
   }
 
+  // For a variable, the generic parameter is visible throughout the pattern
+  // binding entry.
+  if (auto var = dyn_cast<VarDecl>(holder)) {
+    if (auto patternBinding = var->getParentPatternBinding()) {
+      unsigned index = patternBinding->getPatternEntryIndexForVarDecl(var);
+      return patternBinding->getPatternList()[index].getSourceRange();
+    }
+  }
+
   // For all other declarations, generic parameters are visible everywhere.
   return holder->getSourceRange();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7829,6 +7829,19 @@ bool OpaqueTypeDecl::isOpaqueReturnTypeOfFunction(
   return false;
 }
 
+bool OpaqueTypeDecl::hasExplicitGenericParams() const {
+  return getExplicitGenericParam(0) != nullptr;
+}
+
+GenericTypeParamDecl *OpaqueTypeDecl::getExplicitGenericParam(
+    unsigned ordinal) const {
+  if (ordinal >= getOpaqueGenericParams().size())
+    return nullptr;
+
+  auto genericParamType = getOpaqueGenericParams()[ordinal];
+  return genericParamType->getDecl();
+}
+
 unsigned OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(
     OpaqueReturnTypeRepr *repr) const {
   assert(NamingDeclAndHasOpaqueReturnTypeRepr.getInt() &&

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -846,7 +846,7 @@ Type ConstraintSystem::openOpaqueType(OpaqueTypeArchetypeType *opaque,
   if (knownReplacements != OpenedTypes.end()) {
     auto param = opaque->getInterfaceType()->castTo<GenericTypeParamType>();
     for (const auto &replacement : knownReplacements->second) {
-      if (replacement.first == param)
+      if (replacement.first->isEqual(param))
         return replacement.second;
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -541,14 +541,23 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   // Bind a property with an opaque return type to the underlying type
   // given by the initializer.
   if (auto var = pattern->getSingleVar()) {
+    SubstitutionMap substitutions;
     if (auto opaque = var->getOpaqueResultTypeDecl()) {
       init->forEachChildExpr([&](Expr *expr) -> Expr * {
         if (auto coercionExpr = dyn_cast<UnderlyingToOpaqueExpr>(expr)) {
-          opaque->setUnderlyingTypeSubstitutions(
-              coercionExpr->substitutions.mapReplacementTypesOutOfContext());
+          auto newSubstitutions =
+              coercionExpr->substitutions.mapReplacementTypesOutOfContext();
+          if (substitutions.empty()) {
+            substitutions = newSubstitutions;
+          } else {
+            assert(substitutions.getCanonical() ==
+                       newSubstitutions.getCanonical());
+          }
         }
         return expr;
       });
+
+      opaque->setUnderlyingTypeSubstitutions(substitutions);
     }
   }
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/opaque_result_type.swift
-// RUN: %target-swift-frontend -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
+// RUN: %target-swift-frontend -enable-experimental-named-opaque-types -enable-implicit-dynamic -disable-availability-checking -emit-ir %t/opaque_result_type.swift | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-NODEBUG %t/opaque_result_type.swift
 
 // rdar://76863553
 // UNSUPPORTED: OS=watchos && CPU=x86_64
@@ -195,6 +195,18 @@ public func useFoo(x: String, y: C) {
 // CHECK: [[CONFORMANCE:%.*]] = call swiftcc i8** @swift_getOpaqueTypeConformance(i8* {{.*}}, %swift.type_descriptor* [[OPAQUE]], [[WORD:i32|i64]] 1)
 // CHECK: [[TYPE:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName{{.*}}({{.*}} @"$s18opaque_result_type3baz1zQrx_tAA1PRzAA1QRzlFQOyAA1CCQo_MD")
 // CHECK: call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** [[CONFORMANCE]], %swift.type* [[TYPE]]
+
+// Make sure we can mangle named opaque result types
+struct Boom<T: P> {
+  var prop1: Int = 5
+  var prop2: <U, V> (U, V) = ("hello", 5)
+}
+
+// CHECK-LABEL: define {{.*}} @"$s18opaque_result_type9gimmeBoomypyF
+// CHECK: call swiftcc void @"$s18opaque_result_type4BoomV5prop15prop2ACyxGSi_AcEQr_QrtvpQOyx_Qo__AcEQr_QrtvpQOyx_Qo0_ttcfcfA0_"
+public func gimmeBoom() -> Any {
+  Boom<String>(prop1: 5)
+}
 
 // CHECK-LABEL: define {{.*}} @"$sSS18opaque_result_type1PAA1AAaBP_AA1OPWT"
 // CHECK: [[OPAQUE:%.*]] = call {{.*}} @"$sSS18opaque_result_typeE3pooQryFQOMg"

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -106,9 +106,13 @@ struct Generic<T: P1 & Equatable> {
   func f() -> <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) {
     return ("hello", value)
   }
+
+  subscript(index: Int) -> <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) {
+    return ("hello", value)
+  }
 }
 
-func testGeneric(gs: Generic<String>, gi: Generic<Int>) {
+func testGeneric(i: Int, gs: Generic<String>, gi: Generic<Int>) {
   let gs1 = gs.f()
   let gs2 = gs.f()
   _ = (gs1 == gs2)
@@ -116,4 +120,6 @@ func testGeneric(gs: Generic<String>, gi: Generic<Int>) {
   let gi1 = gi.f()
   // FIXME: Diagnostic below is correct, but a bit misleading because these are different Us and Vs.
   _ = (gs1 == gi1) // expected-error{{binary operator '==' cannot be applied to operands of type '(U, V)' and '(U, V)'}}
+
+  _ = gs[i]
 }

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -100,7 +100,14 @@ func f4(cond: Bool) -> <T: P1, U where U: Q1> (T, U) {
 func f5(cond: Bool) -> <T: P1, U where U: Q1> (T, U) { }
 // expected-error@-1{{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
 
-struct Generic<T: P1 & Equatable> {
+protocol DefaultInitializable {
+  init()
+}
+
+extension String: DefaultInitializable { }
+extension Int: DefaultInitializable { }
+
+struct Generic<T: P1 & Equatable & DefaultInitializable> {
   var value: T
 
   func f() -> <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) {
@@ -109,6 +116,20 @@ struct Generic<T: P1 & Equatable> {
 
   subscript(index: Int) -> <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) {
     return ("hello", value)
+  }
+
+  var property: <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) {
+    return ("hello", value)
+  }
+
+  var property2: <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) =
+    ("hello", T())
+
+  var property3: <U: Q1, V: P1 where U: Equatable, V: Equatable> (U, V) =
+    ("hello", T()) {
+    didSet {
+      print("here")
+    }
   }
 }
 


### PR DESCRIPTION
Implement support for named opaque result types, e.g.,

```swift
func f() -> <T: Hashable & P, U where U: Q> [T: U] { ... }
```

this mostly involves wiring up name lookup and type resolution so we can find the generic parameters
when they are used.