### PR TITLE
Optimize sequence algorithms to eliminate bounds-checking

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/WriteBackMutableSlice.swift
+++ b/stdlib/private/StdlibCollectionUnittest/WriteBackMutableSlice.swift
@@ -30,8 +30,8 @@ internal func _writeBackMutableSlice<C, Slice_>(
   var newElementIndex = slice.startIndex
   let newElementsEndIndex = slice.endIndex
 
-  while selfElementIndex != selfElementsEndIndex &&
-    newElementIndex != newElementsEndIndex {
+  while selfElementIndex < selfElementsEndIndex &&
+    newElementIndex < newElementsEndIndex {
 
     self_[selfElementIndex] = slice[newElementIndex]
     self_.formIndex(after: &selfElementIndex)

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -127,7 +127,7 @@ extension LazyDropWhileCollection: Collection {
   @inlinable // lazy-performance
   public var startIndex: Index {
     var index = _base.startIndex
-    while index != _base.endIndex && _predicate(_base[index]) {
+    while index < _base.endIndex && _predicate(_base[index]) {
       _base.formIndex(after: &index)
     }
     return index

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -139,7 +139,7 @@ extension LazyFilterCollection: Collection {
   @inlinable // lazy-performance
   public var startIndex: Index {
     var index = _base.startIndex
-    while index != _base.endIndex && !_predicate(_base[index]) {
+    while index < _base.endIndex && !_predicate(_base[index]) {
       _base.formIndex(after: &index)
     }
     return index
@@ -170,7 +170,7 @@ extension LazyFilterCollection: Collection {
     _precondition(index != _base.endIndex, "Can't advance past endIndex")
     repeat {
       _base.formIndex(after: &index)
-    } while index != _base.endIndex && !_predicate(_base[index])
+    } while index < _base.endIndex && !_predicate(_base[index])
     i = index
   }
 

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -228,7 +228,7 @@ extension LazyPrefixWhileCollection: Collection {
       _preconditionFailure("Invalid index passed to index(after:)")
     }
     let nextIndex = _base.index(after: i)
-    guard nextIndex != _base.endIndex && _predicate(_base[nextIndex]) else {
+    guard nextIndex < _base.endIndex && _predicate(_base[nextIndex]) else {
       return Index(endOf: _base)
     }
     return Index(nextIndex)

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -200,7 +200,7 @@ extension _StringGuts {
     startingAt index: Int,
     nextScalar: (Int) -> (Unicode.Scalar, end: Int)
   ) -> Int {
-    _internalInvariant(index != endIndex._encodedOffset)
+    _internalInvariant(index < endIndex._encodedOffset)
     var state = _GraphemeBreakingState()
     var index = index
 
@@ -208,7 +208,7 @@ extension _StringGuts {
       let (scalar1, nextIdx) = nextScalar(index)
       index = nextIdx
 
-      guard index != endIndex._encodedOffset else {
+      guard index < endIndex._encodedOffset else {
         break
       }
 
@@ -228,7 +228,7 @@ extension _StringGuts {
     endingAt index: Int,
     previousScalar: (Int) -> (Unicode.Scalar, start: Int)
   ) -> Int {
-    _internalInvariant(index != startIndex._encodedOffset)
+    _internalInvariant(index > startIndex._encodedOffset)
     var state = _GraphemeBreakingState()
     var index = index
 
@@ -236,7 +236,7 @@ extension _StringGuts {
       let (scalar2, previousIdx) = previousScalar(index)
       index = previousIdx
 
-      guard index != startIndex._encodedOffset else {
+      guard index > startIndex._encodedOffset else {
         break
       }
 
@@ -422,14 +422,14 @@ extension _StringGuts {
   ) -> Bool {
     var emojiIdx = String.Index(_encodedOffset: index)
 
-    guard emojiIdx != startIndex else {
+    guard emojiIdx > startIndex else {
       return false
     }
 
     let scalars = String.UnicodeScalarView(self)
     scalars.formIndex(before: &emojiIdx)
 
-    while emojiIdx != startIndex {
+    while emojiIdx > startIndex {
       scalars.formIndex(before: &emojiIdx)
       let scalar = scalars[emojiIdx]
 
@@ -483,7 +483,7 @@ extension _StringGuts {
   ) -> Bool {
     var riIdx = String.Index(_encodedOffset: index)
 
-    guard riIdx != startIndex else {
+    guard riIdx > startIndex else {
       return false
     }
 
@@ -492,7 +492,7 @@ extension _StringGuts {
     let scalars = String.UnicodeScalarView(self)
     scalars.formIndex(before: &riIdx)
 
-    while riIdx != startIndex {
+    while riIdx > startIndex {
       scalars.formIndex(before: &riIdx)
       let scalar = scalars[riIdx]
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request tweaks several algorithms in the standard library to improve performance optimization, mainly through eliminating extraneous bounds checks by replacing not-equal operators with less-than operators.

These improvements were brought to my attention by @karwa [while discussing the performance roadmap](https://forums.swift.org/t/a-roadmap-for-improving-swift-performance-predictability-arc-improvements-and-ownership-control/54206/38), and have already been implemented in a limited form for [WebURL](https://github.com/karwa/swift-url/blob/e6a46bde02843d58fc4805bb2f84bc331d40ebd3/Sources/WebURL/Util/BidirectionalCollection%2Bsuffix.swift#L33-L68).

However, I am having trouble running local benchmarks to confirm performance improvements. I [asked for assistance](https://forums.swift.org/t/locally-benchmarking-changes-to-swift/54261) on the Swift Forums over a week ago, but have yet to get a reply. I’m opening this pull request as a draft in the hopes that someone may help me with that.
