### PR TITLE
Change task priority propagation rules

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2014,18 +2014,23 @@ enum class JobKind : size_t {
 enum class JobPriority : size_t {
   // This is modelled off of Dispatch.QoS, and the values are directly
   // stolen from there.
-  UserInteractive = 0x21,
-  UserInitiated   = 0x19,
-  Default         = 0x15,
-  Utility         = 0x11,
-  Background      = 0x09,
-  Unspecified     = 0x00,
+  UserInteractive = 0x21, /* UI */
+  UserInitiated   = 0x19, /* IN */
+  Default         = 0x15, /* DEF */
+  Utility         = 0x11, /* UT */
+  Background      = 0x09, /* BG */
+  Unspecified     = 0x00, /* UN */
 };
 
 /// A tri-valued comparator which orders higher priorities first.
 inline int descendingPriorityOrder(JobPriority lhs,
                                    JobPriority rhs) {
   return (lhs == rhs ? 0 : lhs > rhs ? -1 : 1);
+}
+
+inline JobPriority withUserInteractivePriorityDowngrade(JobPriority priority) {
+  return (priority == JobPriority::UserInteractive) ? JobPriority::UserInitiated
+                                                    : priority;
 }
 
 /// Flags for task creation.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2032,8 +2032,9 @@ inline int descendingPriorityOrder(JobPriority lhs,
 class TaskCreateFlags : public FlagSet<size_t> {
 public:
   enum {
-    Priority       = 0,
-    Priority_width = 8,
+    // Priority that user specified while creating the task
+    RequestedPriority = 0,
+    RequestedPriority_width = 8,
 
     Task_IsChildTask                              = 8,
     // bit 9 is unused
@@ -2046,8 +2047,9 @@ public:
   explicit constexpr TaskCreateFlags(size_t bits) : FlagSet(bits) {}
   constexpr TaskCreateFlags() {}
 
-  FLAGSET_DEFINE_FIELD_ACCESSORS(Priority, Priority_width, JobPriority,
-                                 getPriority, setPriority)
+  FLAGSET_DEFINE_FIELD_ACCESSORS(RequestedPriority, RequestedPriority_width,
+                                 JobPriority, getRequestedPriority,
+                                 setRequestedPriority)
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsChildTask,
                                 isChildTask,
                                 setIsChildTask)

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -222,9 +222,9 @@ public:
     void *Storage[14];
 
     /// Initialize this storage during the creation of a task.
-    void initialize(AsyncTask *task);
-    void initializeWithSlab(AsyncTask *task,
-                            void *slab, size_t slabCapacity);
+    void initialize(JobPriority basePri);
+    void initializeWithSlab(JobPriority basePri, void *slab,
+                            size_t slabCapacity);
 
     /// React to the completion of the enclosing task's execution.
     void complete(AsyncTask *task);

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -488,6 +488,12 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority
 swift_task_currentPriority(AsyncTask *task);
 
+/// Returns the base priority of the task. This function does not exist in the
+/// base ABI of this library and must be deployment limited.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+JobPriority
+swift_task_basePriority(AsyncTask *task);
+
 /// Create and add an cancellation record to the task.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 CancellationNotificationStatusRecord*

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -481,6 +481,13 @@ size_t swift_task_getJobFlags(AsyncTask* task);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_isCancelled(AsyncTask* task);
 
+/// Returns the current priority of the task which is >= base priority of the
+/// task. This function does not exist in the base ABI of this library and must
+/// be deployment limited
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+JobPriority
+swift_task_currentPriority(AsyncTask *task);
+
 /// Create and add an cancellation record to the task.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 CancellationNotificationStatusRecord*

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -413,7 +413,7 @@ static void completeTaskWithClosure(SWIFT_ASYNC_CONTEXT AsyncContext *context,
       reinterpret_cast<char *>(context) - sizeof(AsyncContextPrefix));
 
   swift_release((HeapObject *)asyncContextPrefix->closureContext);
-  
+
   // Clean up the rest of the task.
   return completeTaskAndRelease(context, error);
 }
@@ -470,6 +470,13 @@ const void *AsyncTask::getResumeFunctionForLogging() {
   return reinterpret_cast<const void *>(ResumeTask);
 }
 
+JobPriority swift::swift_task_currentPriority(AsyncTask *task)
+{
+  // This is racey but this is to be used in an API is inherently racey anyways.
+  auto oldStatus = task->_private().Status.load(std::memory_order_relaxed);
+  return oldStatus.getStoredPriority();
+}
+
 /// Implementation of task creation.
 SWIFT_CC(swift)
 static AsyncTaskAndContext swift_task_create_commonImpl(
@@ -520,7 +527,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
       // of in a FutureFragment.
       hasAsyncLetResultBuffer = true;
       assert(asyncLet && "Missing async let storage");
-        
+
       jobFlags.task_setIsAsyncLetTask(true);
       jobFlags.task_setIsChildTask(true);
       break;
@@ -591,14 +598,14 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   void *allocation = nullptr;
   if (asyncLet) {
     assert(parent);
-    
+
     // If there isn't enough room in the fixed async let allocation to
     // set up the initial context, then we'll have to allocate more space
     // from the parent.
     if (asyncLet->getSizeOfPreallocatedSpace() < amountToAllocate) {
       hasAsyncLetResultBuffer = false;
     }
-    
+
     // DEPRECATED. This is separated from the above condition because we
     // also have to handle an older async let ABI that did not provide
     // space for the initial slab in the compiler-generated preallocation.
@@ -678,7 +685,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
     auto groupChildFragment = task->groupChildFragment();
     new (groupChildFragment) AsyncTask::GroupChildFragment(group);
   }
-  
+
   // Initialize the future fragment if applicable.
   if (futureResultType) {
     assert(task->isFuture());
@@ -940,7 +947,7 @@ static AsyncTask *swift_continuation_initImpl(ContinuationAsyncContext *context,
   // must happen-after this call.
   context->AwaitSynchronization.store(flags.isPreawaited()
                                         ? ContinuationStatus::Awaited
-                                        : ContinuationStatus::Pending, 
+                                        : ContinuationStatus::Pending,
                                       std::memory_order_relaxed);
 
   AsyncTask *task;

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -488,7 +488,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   TaskCreateFlags taskCreateFlags(rawTaskCreateFlags);
 
   // Propagate task-creation flags to job flags as appropriate.
-  JobFlags jobFlags(JobKind::Task, taskCreateFlags.getPriority());
+  JobFlags jobFlags(JobKind::Task, taskCreateFlags.getCreationPriority());
   jobFlags.task_setIsChildTask(taskCreateFlags.isChildTask());
   if (futureResultType) {
     jobFlags.task_setIsFuture(true);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -297,6 +297,20 @@ extension Task where Success == Never, Failure == Never {
       return TaskPriority(rawValue: UInt8(_getCurrentThreadPriority()))
     }
   }
+
+  /// The current task's base priority.
+  ///
+  /// If you access this property outside of any task, this returns nil
+  @available(SwiftStdlib 9999, *)
+  public static var basePriority: TaskPriority? {
+    withUnsafeCurrentTask { task in
+      // If we are running on behalf of a task, use that task's priority.
+      if let unsafeTask = task {
+         return TaskPriority(rawValue: _taskBasePriority(unsafeTask._task))
+      }
+      return nil
+    }
+  }
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -851,6 +865,9 @@ func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
 @_silgen_name("swift_task_currentPriority")
 internal func _taskCurrentPriority(_ task: Builtin.NativeObject) -> UInt8
+
+@_silgen_name("swift_task_basePriority")
+internal func _taskBasePriority(_ task: Builtin.NativeObject) -> UInt8
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_createNullaryContinuationJob")

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -289,8 +289,8 @@ extension Task where Success == Never, Failure == Never {
   public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.
-      if let task = task {
-        return task.priority
+      if let unsafeTask = task {
+         return TaskPriority(rawValue: _taskCurrentPriority(unsafeTask._task))
       }
 
       // Otherwise, query the system.
@@ -752,8 +752,7 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`
   public var priority: TaskPriority {
-    getJobFlags(_task).priority ?? TaskPriority(
-        rawValue: UInt8(_getCurrentThreadPriority()))
+    TaskPriority(rawValue: _taskCurrentPriority(_task))
   }
 
   /// Cancel the current task.
@@ -849,6 +848,9 @@ func _taskCancel(_ task: Builtin.NativeObject)
 @_silgen_name("swift_task_isCancelled")
 @usableFromInline
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
+
+@_silgen_name("swift_task_currentPriority")
+internal func _taskCurrentPriority(_ task: Builtin.NativeObject) -> UInt8
 
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_task_createNullaryContinuationJob")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -488,7 +488,7 @@ static void swift_taskGroup_initializeImpl(TaskGroup *group, const Metadata *T) 
 // ==== add / attachChild ------------------------------------------------------
 
 void TaskGroup::addChildTask(AsyncTask *child) {
-  SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, group);
+  SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, this);
 
   // The counterpart of this (detachChild) is performed by the group itself,
   // when it offers the completed (child) task's value to a waiting task -

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -411,7 +411,8 @@ void swift::updateNewChildWithParentAndGroupState(AsyncTask *child,
   // Propagate max priority of parent to child task's active status and the Job
   // header
   JobPriority pri = parentStatus.getStoredPriority();
-  newChildTaskStatus = newChildTaskStatus.withNewPriority(pri);
+  newChildTaskStatus =
+      newChildTaskStatus.withNewPriority(withUserInteractivePriorityDowngrade(pri));
   child->Flags.setPriority(pri);
 
   child->_private().Status.store(newChildTaskStatus, std::memory_order_relaxed);

--- a/test/Concurrency/async_task_base_priority.swift
+++ b/test/Concurrency/async_task_base_priority.swift
@@ -1,0 +1,126 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+import Darwin
+import Dispatch
+
+func loopUntil(priority: TaskPriority) async {
+  while (Task.currentPriority != priority) {
+    await Task.sleep(1_000_000_000)
+  }
+}
+
+func print(_ s: String = "") {
+  fputs("\(s)\n", stderr)
+}
+
+func expectedBasePri(priority: TaskPriority) -> TaskPriority {
+  let basePri = Task.basePriority!
+
+  print("Testing basePri matching expected pri - \(basePri) == \(priority)")
+  expectEqual(basePri, priority)
+  return basePri
+}
+
+func expectedCurrentPri(priority: TaskPriority) -> TaskPriority {
+  let curPri = Task.currentPriority
+  print("Testing curPri matching expected pri - \(curPri) == \(priority)")
+  expectEqual(curPri, priority)
+  return curPri
+}
+
+func testNestedTaskPriority(basePri: TaskPriority, curPri: TaskPriority) async {
+    let _ = expectedBasePri(priority: basePri)
+    let _ = expectedCurrentPri(priority: curPri)
+}
+
+@main struct Main {
+  static func main() async {
+
+    let top_level = detach { /* To detach from main actor when running work */
+
+      let tests = TestSuite("Task base priority")
+      if #available(SwiftStdlib 5.1, *) {
+
+        tests.test("Structured concurrency base priority propagation") {
+          let task = Task(priority: .background) {
+            await loopUntil(priority: .default)
+
+            let basePri = expectedBasePri(priority: .background)
+            let curPri = expectedCurrentPri(priority: .default)
+
+            // Structured concurrency via async let, escalated priority of
+            // parent should propagate
+            print("Testing propagation for async let structured concurrency child")
+            async let child = testNestedTaskPriority(basePri: basePri, curPri: curPri)
+            await child
+
+            let dispatchGroup = DispatchGroup()
+            // Structured concurrency via task groups, escalated priority should
+            // propagate
+            await withTaskGroup(of: Void.self, returning: Void.self) { group in
+              dispatchGroup.enter()
+              group.addTask {
+                print("Testing propagation for task group regular child")
+                let _ = await testNestedTaskPriority(basePri: basePri, curPri: curPri)
+                dispatchGroup.leave()
+                return
+              }
+
+              dispatchGroup.enter()
+              group.addTask(priority: .utility) {
+                print("Testing propagation for task group child with specified priority")
+                let _ = await testNestedTaskPriority(basePri: .utility, curPri: curPri)
+                dispatchGroup.leave()
+                return
+              }
+
+              // Wait for child tasks to finish running, don't await since that
+              // will escalate them
+              dispatchGroup.wait()
+            }
+          }
+
+          await task.value // Escalate task BG->DEF
+        }
+
+        tests.test("Unstructured base priority propagation") {
+          let task = Task(priority : .background) {
+            await loopUntil(priority: .default)
+
+            let basePri = expectedBasePri(priority: .background)
+            let _ = expectedCurrentPri(priority: .default)
+
+            let group = DispatchGroup()
+
+            // Create an unstructured task
+            group.enter()
+            let _ = Task {
+              let _ = await testNestedTaskPriority(basePri: basePri, curPri: basePri)
+              group.leave()
+              return
+            }
+
+            // Wait for unstructured task to finish running, don't await it
+            // since that will escalate
+            group.wait()
+          }
+
+          await task.value // Escalate task BG->DEF
+        }
+
+      }
+      await runAllTestsAsync()
+    }
+
+    await top_level.value
+  }
+}

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -140,9 +140,9 @@ static std::pair<AsyncTask*, Context*>
 createTaskWithContext(JobPriority priority, Fn &&fn) {
   auto invoke =
     TaskContinuationFromLambda<Fn, Context>::get(std::move(fn));
-  TaskCreateFlags flags;
-  flags.setPriority(priority);
-  auto pair = swift_task_create_common(flags.getOpaqueValue(),
+  TaskCreateFlags createFlags;
+  createFlags.setRequestedPriority(priority);
+  auto pair = swift_task_create_common(createFlags.getOpaqueValue(),
                                        nullptr,
                                        nullptr,
                                        invoke,


### PR DESCRIPTION
This PR does 4 things:

(a) Makes sure that currentPriority reads from the ActiveTaskStatus's current priority 
(b) Creates the notion of a separate base priority which is tracked in a task. This priority is only set upon creation and doesn't change after.
(b) Adjusts the priority propagation rules for tasks

Rdar: rdar://86100376