### PR TITLE
[CodeComplete] Make SourceKit::CodeCompletion::Completion store a reference to the underlying swift result instead of extending that type

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -1003,8 +1003,7 @@ public:
 class CodeCompletionContext {
   friend class CodeCompletionResultBuilder;
 
-  /// A set of current completion results, not yet delivered to the
-  /// consumer.
+  /// A set of current completion results.
   CodeCompletionResultSink CurrentResults;
 
 public:
@@ -1072,13 +1071,10 @@ public:
   /// Allocate a string owned by the code completion context.
   StringRef copyString(StringRef Str);
 
-  /// Return current code completion results.
-  MutableArrayRef<CodeCompletionResult *> takeResults();
-
   /// Sort code completion results in an implementation-defined order
   /// in place.
-  static void sortCompletionResults(
-      MutableArrayRef<CodeCompletionResult *> Results);
+  static std::vector<CodeCompletionResult *>
+  sortCompletionResults(ArrayRef<CodeCompletionResult *> Results);
 
   CodeCompletionResultSink &getResultSink() {
     return CurrentResults;

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -53,7 +53,7 @@ struct CompletionInstanceResult {
 
 /// The results returned from \c CompletionInstance::codeComplete.
 struct CodeCompleteResult {
-  CodeCompletionResultSink ResultSink;
+  CodeCompletionResultSink &ResultSink;
   SwiftCompletionInfo &Info;
 };
 

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -53,7 +53,7 @@ struct CompletionInstanceResult {
 
 /// The results returned from \c CompletionInstance::codeComplete.
 struct CodeCompleteResult {
-  MutableArrayRef<CodeCompletionResult *> Results;
+  CodeCompletionResultSink ResultSink;
   SwiftCompletionInfo &Info;
 };
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1354,18 +1354,6 @@ void CodeCompletionResultBuilder::finishResult() {
     Sink.Results.push_back(takeResult());
 }
 
-
-MutableArrayRef<CodeCompletionResult *> CodeCompletionContext::takeResults() {
-  // Copy pointers to the results.
-  const size_t Count = CurrentResults.Results.size();
-  CodeCompletionResult **Results =
-      CurrentResults.Allocator->Allocate<CodeCompletionResult *>(Count);
-  std::copy(CurrentResults.Results.begin(), CurrentResults.Results.end(),
-            Results);
-  CurrentResults.Results.clear();
-  return MutableArrayRef<CodeCompletionResult *>(Results, Count);
-}
-
 Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     bool includeLeadingPunctuation) const {
   for (auto i : indices(getChunks())) {
@@ -1451,8 +1439,11 @@ CodeCompletionString::getFirstTextChunk(bool includeLeadingPunctuation) const {
   return StringRef();
 }
 
-void CodeCompletionContext::sortCompletionResults(
-    MutableArrayRef<CodeCompletionResult *> Results) {
+std::vector<CodeCompletionResult *>
+CodeCompletionContext::sortCompletionResults(
+    ArrayRef<CodeCompletionResult *> Results) {
+  std::vector<CodeCompletionResult *> SortedResults(Results.begin(),
+                                                    Results.end());
   struct ResultAndName {
     CodeCompletionResult *result;
     std::string name;
@@ -1460,16 +1451,17 @@ void CodeCompletionContext::sortCompletionResults(
 
   // Caching the name of each field is important to avoid unnecessary calls to
   // CodeCompletionString::getName().
-  std::vector<ResultAndName> nameCache(Results.size());
-  for (unsigned i = 0, n = Results.size(); i < n; ++i) {
-    auto *result = Results[i];
+  std::vector<ResultAndName> nameCache(SortedResults.size());
+  for (unsigned i = 0, n = SortedResults.size(); i < n; ++i) {
+    auto *result = SortedResults[i];
     nameCache[i].result = result;
     llvm::raw_string_ostream OS(nameCache[i].name);
     printCodeCompletionResultFilterName(*result, OS);
     OS.flush();
   }
 
-  // Sort nameCache, and then transform Results to return the pointers in order.
+  // Sort nameCache, and then transform SortedResults to return the pointers in
+  // order.
   std::sort(nameCache.begin(), nameCache.end(),
             [](const ResultAndName &LHS, const ResultAndName &RHS) {
               int Result = StringRef(LHS.name).compare_insensitive(RHS.name);
@@ -1480,8 +1472,9 @@ void CodeCompletionContext::sortCompletionResults(
               return Result < 0;
             });
 
-  llvm::transform(nameCache, Results.begin(),
+  llvm::transform(nameCache, SortedResults.begin(),
                   [](const ResultAndName &entry) { return entry.result; });
+  return SortedResults;
 }
 
 namespace {

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -735,7 +735,8 @@ void swift::ide::CompletionInstance::codeComplete(
                 SwiftCompletionInfo Info{&CI.getASTContext(),
                                          &CI.getInvocation(),
                                          &CompletionContext};
-                DeliverTransformed(ResultType::success({/*Results=*/{}, Info}));
+                CodeCompletionResultSink ResultSink;
+                DeliverTransformed(ResultType::success({ResultSink, Info}));
                 return;
               }
 
@@ -752,7 +753,8 @@ void swift::ide::CompletionInstance::codeComplete(
                 SwiftCompletionInfo Info{&CI.getASTContext(),
                                          &CI.getInvocation(),
                                          &CompletionContext};
-                DeliverTransformed(ResultType::success({/*Results=*/{}, Info}));
+                CodeCompletionResultSink ResultSink;
+                DeliverTransformed(ResultType::success({ResultSink, Info}));
               }
             },
             Callback);

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -709,9 +709,8 @@ void swift::ide::CompletionInstance::codeComplete(
           CancellationFlag->load(std::memory_order_relaxed)) {
         Callback(ResultType::cancelled());
       } else {
-        MutableArrayRef<CodeCompletionResult *> Results = context.takeResults();
         assert(SwiftContext.swiftASTContext);
-        Callback(ResultType::success({Results, SwiftContext}));
+        Callback(ResultType::success({context.getResultSink(), SwiftContext}));
       }
     }
   };

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -178,9 +178,9 @@ public:
       : Completions(Completions) {}
 
   void handleResults(CodeCompletionContext &context) override {
-    MutableArrayRef<CodeCompletionResult *> Results = context.takeResults();
-    CodeCompletionContext::sortCompletionResults(Results);
-    for (auto Result : Results) {
+    auto SortedResults = CodeCompletionContext::sortCompletionResults(
+        context.getResultSink().Results);
+    for (auto Result : SortedResults) {
       std::string InsertableString = toInsertableString(Result);
       if (StringRef(InsertableString).startswith(Completions.Prefix)) {
         llvm::SmallString<128> PrintedResult;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1056,7 +1056,7 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
 }
 
 static void
-printCodeCompletionResultsImpl(MutableArrayRef<CodeCompletionResult *> Results,
+printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
                                llvm::raw_ostream &OS, bool IncludeKeywords,
                                bool IncludeComments, bool IncludeSourceText,
                                bool PrintAnnotatedDescription) {
@@ -1137,8 +1137,8 @@ static int printCodeCompletionResults(
   return printResult<CodeCompleteResult>(
       CancellableResult, [&](CodeCompleteResult &Result) {
         printCodeCompletionResultsImpl(
-            Result.Results, llvm::outs(), IncludeKeywords, IncludeComments,
-            IncludeSourceText, PrintAnnotatedDescription);
+            Result.ResultSink.Results, llvm::outs(), IncludeKeywords,
+            IncludeComments, IncludeSourceText, PrintAnnotatedDescription);
         return 0;
       });
 }
@@ -1514,8 +1514,9 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
           case CancellableResultKind::Success: {
             wasASTContextReused =
                 Result->Info.completionContext->ReusingASTContext;
-            printCodeCompletionResultsImpl(Result->Results, OS, IncludeKeywords,
-                                           IncludeComments, IncludeSourceText,
+            printCodeCompletionResultsImpl(Result->ResultSink.Results, OS,
+                                           IncludeKeywords, IncludeComments,
+                                           IncludeSourceText,
                                            CodeCompletionAnnotateResults);
             break;
           }


### PR DESCRIPTION
Previously, when creating a `SourceKit::CodeCompletion::Completion`, we needed to copy all fields from the underlying `SwiftResult` (aka `swift::ide::CodeCompletionResult`). The arena in which the `SwiftResult` was allocated still needed to be kept alive for the references stored in the `SwiftResult`.

To avoid this unnecessary copy, make `SourceKit::CodeCompletion::Completion` store a reference to the underlying `SwiftResult`.

While making this change, I also noticed that the `innerSink` created by `transformAndForwardResults` did not adopt the sink of the outer results, but was still referencing e.g. strings stored in it. The first commit in this PR makes sure that we retain outer sink from the inner sink.