### PR TITLE
[ShrinkBorrowScope] Fixed assert.

### DIFF
--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -298,7 +298,13 @@ void ShrinkBorrowScope::findBarriers() {
       // At that time, it was checked that this block (along with all that
       // successor's other predecessors) had a terminator over which the borrow
       // scope could be shrunk.  Shrink it now.
-      assert(tryHoistOverInstruction(block->getTerminator()));
+#ifndef NDEBUG
+      bool hoisted = 
+#endif
+      tryHoistOverInstruction(block->getTerminator());
+#ifndef NDEBUG
+      assert(hoisted);
+#endif
     }
     SILInstruction *barrier = nullptr;
     while ((instruction = instruction->getPreviousInstruction())) {

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -copy-propagation -enable-sil-verify-all %s | %FileCheck %s
 
-// REQUIRES: rdar_86809882
-
 import Builtin
 import Swift
 


### PR DESCRIPTION
Previously, it was asserted that hoisting over a terminator succeeded (because it is previously checked that it can be done).  That was erroneously done by putting the call to hoist within an invocation of the assert macro.  The result was that in release builds, the call was not made.  Here, that is fixed by just calling the hoist function and, in debug builds, asserting its return.

rdar://86809882
