### PR TITLE
Revert "Test type_sequence fails on incremental bot"

### DIFF
--- a/test/Constraints/type_sequence.swift
+++ b/test/Constraints/type_sequence.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// REQUIRES: rdar_86744286
-
 struct TupleStruct<First, @_typeSequence Rest> {
   var first: First
   var rest: (Rest...)


### PR DESCRIPTION
I cannot reproduce this locally. Using this to see if it still hits our infrastructure

rdar://86744286