### PR TITLE
Query Equatable/Comparable Conformances to Build Typed Derived ASTs

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -701,7 +701,10 @@ namespace {
       // If this is a member of a nominal type, build a reference to the
       // member with an implied base type.
       if (decl->getDeclContext()->isTypeContext() && isa<FuncDecl>(decl)) {
-        assert(cast<FuncDecl>(decl)->isOperator() && "Must be an operator");
+        assert((cast<FuncDecl>(decl)->isOperator() ||
+               (cast<FuncDecl>(decl)->getAttrs().hasAttribute<ImplementsAttr>() &&
+                cast<FuncDecl>(decl)->getAttrs().getAttribute<ImplementsAttr>()->getMemberName().isOperator()))
+               && "Lookup should only find operators");
 
         auto baseTy = getBaseType(fullType->castTo<FunctionType>());
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1330,7 +1330,10 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
     // Unqualified lookup can find operator names within nominal types.
     auto func = cast<FuncDecl>(value);
-    assert(func->isOperator() && "Lookup should only find operators");
+    assert((func->isOperator() ||
+           (func->getAttrs().hasAttribute<ImplementsAttr>() &&
+            func->getAttrs().getAttribute<ImplementsAttr>()->getMemberName().isOperator()))
+           && "Lookup should only find operators");
 
     OpenedTypeMap replacements;
 

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -160,12 +160,18 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
     SmallVector<ASTNode, 8> statementsInCase;
     for (size_t varIdx = 0; varIdx < lhsPayloadVars.size(); ++varIdx) {
       auto lhsVar = lhsPayloadVars[varIdx];
+      auto lhsTy = ltDecl->mapTypeIntoContext(lhsVar->getInterfaceType());
       auto lhsExpr = new (C) DeclRefExpr(lhsVar, DeclNameLoc(),
-                                         /*implicit*/true);
+                                         /*implicit*/true,
+                                         AccessSemantics::Ordinary,
+                                         lhsTy);
       auto rhsVar = rhsPayloadVars[varIdx];
+      auto rhsTy = ltDecl->mapTypeIntoContext(rhsVar->getInterfaceType());
       auto rhsExpr = new (C) DeclRefExpr(rhsVar, DeclNameLoc(),
-                                         /*Implicit*/true);
-      auto guardStmt = DerivedConformance::returnComparisonIfNotEqualGuard(C, 
+                                         /*Implicit*/true,
+                                         AccessSemantics::Ordinary,
+                                         rhsTy);
+      auto guardStmt = DerivedConformance::returnComparisonIfNotEqualGuard(C, ltDecl,
           lhsExpr, rhsExpr);
       statementsInCase.emplace_back(guardStmt);
     }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -368,19 +368,42 @@ public:
   /// rhs expressions are equal. If not equal, the else block for the guard
   /// returns `guardReturnValue`.
   /// \p C The AST context.
+  /// \p DC The decl context into which these expressions are being emitted
+  ///    e.g. the \c ==(_:_:) FuncDecl.
   /// \p lhsExpr The first expression to compare for equality.
   /// \p rhsExpr The second expression to compare for equality.
   /// \p guardReturnValue The expression to return if the two sides are not
   /// equal
-  static GuardStmt *returnIfNotEqualGuard(ASTContext &C, Expr *lhsExpr,
+  static GuardStmt *returnIfNotEqualGuard(ASTContext &C,
+                                          const DeclContext *DC,
+                                          Expr *lhsExpr,
                                           Expr *rhsExpr,
                                           Expr *guardReturnValue);
-  // return false
-  static GuardStmt *returnFalseIfNotEqualGuard(ASTContext &C, Expr *lhsExpr,
+
+  /// Returns a generated guard statement that checks whether the given lhs and
+  /// rhs expressions are equal. If not equal, the else block for the guard
+  /// returns lhs < rhs.
+  /// \p C The AST context.
+  /// \p DC The decl context into which these expressions are being emitted
+  ///    e.g. the \c ==(_:_:) FuncDecl.
+  /// \p lhsExpr The first expression to compare for equality.
+  /// \p rhsExpr The second expression to compare for equality.
+  static GuardStmt *returnFalseIfNotEqualGuard(ASTContext &C,
+                                               const DeclContext *DC,
+                                               Expr *lhsExpr,
                                                Expr *rhsExpr);
-  // return lhs < rhs
+  /// Returns a generated guard statement that checks whether the given lhs and
+  /// rhs expressions are equal. If not equal, the else block for the guard
+  /// returns lhs < rhs.
+  /// \p C The AST context.
+  /// \p DC The decl context into which these expressions are being emitted
+  ///    e.g. the \c ==(_:_:) FuncDecl.
+  /// \p lhsExpr The first expression to compare for equality.
+  /// \p rhsExpr The second expression to compare for equality.
   static GuardStmt *
-  returnComparisonIfNotEqualGuard(ASTContext &C, Expr *lhsExpr, Expr *rhsExpr);
+  returnComparisonIfNotEqualGuard(ASTContext &C,
+                                  const DeclContext *DC,
+                                  Expr *lhsExpr, Expr *rhsExpr);
 
   /// Returns the ParamDecl for each associated value of the given enum whose
   /// type does not conform to a protocol \p theEnum The enum whose elements and

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar86780149/A.swiftinterface
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar86780149/A.swiftinterface
@@ -1,0 +1,12 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -swift-version 5 -enable-library-evolution
+import Swift
+
+public struct Value {}
+extension Value {
+	public struct State {}
+}
+
+extension Value.State: Swift.Equatable {
+  public static func ==(lhs: Value.State, rhs: Value.State) -> Swift.Bool
+}

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar86780149/B.swiftinterface
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar86780149/B.swiftinterface
@@ -1,0 +1,8 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name B -swift-version 5 -enable-library-evolution
+import Swift
+import A
+
+extension A.Value.State: Swift.Equatable {
+  public static func ==(a: A.Value.State, b: A.Value.State) -> Swift.Bool
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar86780149.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar86780149.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/A.swiftmodule %S/Inputs/rdar86780149/A.swiftinterface
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/B.swiftmodule %S/Inputs/rdar86780149/B.swiftinterface -I %t
+// RUN: %target-swift-frontend -emit-silgen -I %t %s
+
+import A
+import B
+
+struct Foo: Equatable {
+  var x: Value.State
+}


### PR DESCRIPTION
This resolves a case of a semantic ambiguity dredged up in rdar://86780149. The problem there is a library author exported a retroactive conformance of a type to Equatable. That type then gained an Equatable conformance in its originating module, and all clients downstream of them broke. In the Equatable synthesis code, it broke a very particular way where we'd assemble a UDRE that the expression checker wouldn't actually be able to resolve to a singular decl. Because this was implicit AST, it also didn't consider that error a strong enough condition to not make it to codegen.

We already made sure the Equatable/Comparable conformance for the members/payloads of the types entering synthesis were valid. Just use those to construct well-typed AST instead of relying on the expression checker.