### PR TITLE
RequirementMachine: Minimization understands 'relations' among layout requirements

### DIFF
--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -88,9 +88,9 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     switch (step.Kind) {
     case RewriteStep::ApplyRewriteRule: {
       if (!step.isInContext() && !evaluator.isInContext())
-        rulesInEmptyContext.insert(step.RuleID);
+        rulesInEmptyContext.insert(step.getRuleID());
 
-      ++ruleMultiplicity[step.RuleID];
+      ++ruleMultiplicity[step.getRuleID()];
       break;
     }
 
@@ -207,7 +207,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
   for (auto step : Steps) {
     switch (step.Kind) {
     case RewriteStep::ApplyRewriteRule: {
-      if (step.RuleID != ruleID)
+      if (step.getRuleID() != ruleID)
         break;
 
       assert(!sawRule && "Rule appears more than once?");
@@ -262,7 +262,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
 
   for (const auto &step : Steps) {
     if (step.Kind == RewriteStep::ApplyRewriteRule &&
-        step.RuleID == ruleID) {
+        step.getRuleID() == ruleID) {
       foundAny = true;
       break;
     }
@@ -282,7 +282,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
   for (const auto &step : Steps) {
     switch (step.Kind) {
     case RewriteStep::ApplyRewriteRule: {
-      if (step.RuleID != ruleID) {
+      if (step.getRuleID() != ruleID) {
         newSteps.push_back(step);
         break;
       }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -97,6 +97,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::Relation:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
@@ -220,6 +221,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::Relation:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:
@@ -321,6 +323,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
     case RewriteStep::AdjustConcreteType:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
+    case RewriteStep::Relation:
     case RewriteStep::ConcreteConformance:
     case RewriteStep::SuperclassConformance:
     case RewriteStep::ConcreteTypeWitness:

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -137,6 +137,7 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::AdjustConcreteType:
       case RewriteStep::Shift:
       case RewriteStep::Decompose:
+      case RewriteStep::Relation:
       case RewriteStep::ConcreteConformance:
       case RewriteStep::SuperclassConformance:
       case RewriteStep::ConcreteTypeWitness:

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -113,7 +113,7 @@ void RewriteLoop::findProtocolConformanceRules(
     if (!evaluator.isInContext()) {
       switch (step.Kind) {
       case RewriteStep::ApplyRewriteRule: {
-        const auto &rule = system.getRule(step.RuleID);
+        const auto &rule = system.getRule(step.getRuleID());
 
         if (rule.isIdentityConformanceRule())
           break;
@@ -127,7 +127,7 @@ void RewriteLoop::findProtocolConformanceRules(
             // the prefix term is 'X'.
             const auto &term = evaluator.getCurrentTerm();
             MutableTerm prefix(term.begin(), term.begin() + step.StartOffset);
-            result[proto].RulesInContext.emplace_back(prefix, step.RuleID);
+            result[proto].RulesInContext.emplace_back(prefix, step.getRuleID());
           }
         }
 
@@ -262,7 +262,7 @@ MinimalConformances::decomposeTermIntoConformanceRuleLeftHandSides(
   const auto &step = *steps.begin();
 
 #ifndef NDEBUG
-  const auto &rule = System.getRule(step.RuleID);
+  const auto &rule = System.getRule(step.getRuleID());
   assert(rule.isAnyConformanceRule());
   assert(!rule.isIdentityConformanceRule());
 #endif
@@ -277,9 +277,10 @@ MinimalConformances::decomposeTermIntoConformanceRuleLeftHandSides(
     // Build the term U.
     MutableTerm prefix(term.begin(), term.begin() + step.StartOffset);
 
-    decomposeTermIntoConformanceRuleLeftHandSides(prefix, step.RuleID, result);
+    decomposeTermIntoConformanceRuleLeftHandSides(
+        prefix, step.getRuleID(), result);
   } else {
-    result.push_back(step.RuleID);
+    result.push_back(step.getRuleID());
   }
 }
 

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -319,7 +319,7 @@ Optional<unsigned> PropertyMap::addProperty(
   assert(*System.getRule(ruleID).isPropertyRule() == property);
   auto *props = getOrCreateProperties(key);
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
-  return props->addProperty(property, ruleID, Context,
+  return props->addProperty(property, ruleID, System,
                             inducedRules, debug);
 }
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -103,7 +103,7 @@ class PropertyBag {
 
   Optional<unsigned> addProperty(Symbol property,
                                  unsigned ruleID,
-                                 RewriteContext &ctx,
+                                 RewriteSystem &system,
                                  SmallVectorImpl<InducedRule> &inducedRules,
                                  bool debug);
   void copyPropertiesFrom(const PropertyBag *next,

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -87,6 +87,19 @@ struct RewriteStep {
     /// *** Rewrite step kinds introduced by the property map ***
     ///
 
+    /// If not inverted: the top of the primary stack must be a term T.[p1].[p2]
+    /// ending in a pair of property symbols [p1] and [p2], where [p1] < [p2].
+    /// The symbol [p2] is dropped, leaving behind the term T.[p1].
+    ///
+    /// If inverted: the top of the primary stack must be a term T.[p1]
+    /// ending in a property symbol [p1]. The rewrite system must have a
+    /// recorded relation for the pair ([p1], [p2]). The symbol [p2] is added
+    /// to the end of the term, leaving behind the term T.[p1].[p2].
+    ///
+    /// The Arg field stores the result of calling
+    /// RewriteSystem::recordRelation().
+    Relation,
+
     /// If not inverted: the top of the primary stack must be a term ending in
     /// a concrete type symbol [concrete: C] followed by a protocol symbol [P].
     /// These two symbols are combined into a single concrete conformance
@@ -194,6 +207,11 @@ struct RewriteStep {
   static RewriteStep forDecompose(unsigned numSubstitutions, bool inverse) {
     return RewriteStep(Decompose, /*startOffset=*/0, /*endOffset=*/0,
                        /*arg=*/numSubstitutions, inverse);
+  }
+
+  static RewriteStep forRelation(unsigned relationID, bool inverse) {
+    return RewriteStep(Relation, /*startOffset=*/0, /*endOffset=*/0,
+                       /*arg=*/relationID, inverse);
   }
 
   static RewriteStep forConcreteConformance(bool inverse) {
@@ -401,6 +419,9 @@ struct RewritePathEvaluator {
 
   void applyShift(const RewriteStep &step,
                   const RewriteSystem &system);
+
+  void applyRelation(const RewriteStep &step,
+                     const RewriteSystem &system);
 
   void applyDecompose(const RewriteStep &step,
                       const RewriteSystem &system);

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -325,6 +325,17 @@ private:
   //////////////////////////////////////////////////////////////////////////////
 
 public:
+  /// The left hand side is known to be smaller than the right hand side.
+  using Relation = std::pair<Symbol, Symbol>;
+
+private:
+  llvm::DenseMap<Relation, unsigned> RelationMap;
+  std::vector<Relation> Relations;
+
+public:
+  unsigned recordRelation(Symbol lhs, Symbol rhs);
+  Relation getRelation(unsigned index) const;
+
   /// A type witness has a subject type, stored in LHS, which takes the form:
   ///
   /// T.[concrete: C : P].[P:X]

--- a/test/Generics/superclass_and_layout_requirement.swift
+++ b/test/Generics/superclass_and_layout_requirement.swift
@@ -2,8 +2,14 @@
 
 class C {}
 
-// CHECK: superclass_and_layout_requirement.(file).P@
+// CHECK: superclass_and_layout_requirement.(file).P1@
 // CHECK: Requirement signature: <Self where Self.T : C>
-protocol P {
+protocol P1 {
   associatedtype T : C
+}
+
+// CHECK: superclass_and_layout_requirement.(file).P2@
+// CHECK: Requirement signature: <Self where Self.T : C>
+protocol P2 {
+  associatedtype T where T : C, T : AnyObject
 }


### PR DESCRIPTION
A superclass requirement 'T : C' implies a layout requirement 'T : AnyObject' (if the class is @objc) or 'T : _NativeObject'
(if the class is not @objc).

In the latter case, there might already be a 'T : AnyObject' requirement, in which case the type parameter 'T' is subject to two layout requirements:

    T : AnyObject
    T : _NativeObject

The second requirement implies the first however. To encode this in the world of rewrite loops, we the notion of a 'relation'
between property symbols, and a 'Relation' rewrite step.

Here, the relation is that _NativeObject < AnyObject. Once this relation is recorded, the Relation rewrite step will transform

    T.[layout: _NativeObject].[layout: AnyObject]

into

    T.[layout: _NativeObject]

and vice versa.

This rewrite step allows us to construct a rewrite loop which makes the first rewrite rule redundant via the second.