### PR TITLE
SILOptimizer: rename LibswiftPassInvocation -> SwiftPassInvocation

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -368,7 +368,7 @@ class SILInstruction : public llvm::ilist_node<SILInstruction> {
   SILInstructionResultArray getResultsImpl() const;
 
 protected:
-  friend class LibswiftPassInvocation;
+  friend class SwiftPassInvocation;
 
   SILInstruction() {
     NumCreatedInstructions++;

--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -67,19 +67,12 @@ template <typename VectorT = std::vector<SILInstruction *>,
 class SILInstructionWorklist : SILInstructionWorklistBase {
   BlotSetVector<SILInstruction *, VectorT, MapT> worklist;
 
-  /// For invoking Swift instruction passes in Swift.
-  LibswiftPassInvocation *libswiftPassInvocation = nullptr;
-
   void operator=(const SILInstructionWorklist &rhs) = delete;
   SILInstructionWorklist(const SILInstructionWorklist &worklist) = delete;
 
 public:
   SILInstructionWorklist(const char *loggingName = "InstructionWorklist")
       : SILInstructionWorklistBase(loggingName) {}
-
-  void setLibswiftPassInvocation(LibswiftPassInvocation *invocation) {
-    libswiftPassInvocation = invocation;
-  }
 
   /// Returns true if the worklist is empty.
   bool isEmpty() const { return worklist.empty(); }

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -45,7 +45,7 @@ void executePassPipelinePlan(SILModule *SM, const SILPassPipelinePlan &plan,
                              irgen::IRGenModule *IRMod = nullptr);
 
 /// Utility class to invoke Swift passes.
-class LibswiftPassInvocation {
+class SwiftPassInvocation {
   /// Backlink to the pass manager.
   SILPassManager *passManager;
 
@@ -58,12 +58,14 @@ class LibswiftPassInvocation {
   /// All slabs, allocated by the pass.
   SILModule::SlabList allocatedSlabs;
 
+  void endPassRunChecks();
+
 public:
-  LibswiftPassInvocation(SILPassManager *passManager, SILFunction *function,
+  SwiftPassInvocation(SILPassManager *passManager, SILFunction *function,
                          SILCombiner *silCombiner) :
     passManager(passManager), function(function), silCombiner(silCombiner) {}
 
-  LibswiftPassInvocation(SILPassManager *passManager) :
+  SwiftPassInvocation(SILPassManager *passManager) :
     passManager(passManager) {}
 
   SILPassManager *getPassManager() const { return passManager; }
@@ -81,10 +83,16 @@ public:
   void notifyChanges(SILAnalysis::InvalidationKind invalidationKind);
 
   /// Called by the pass manager before the pass starts running.
-  void startPassRun(SILFunction *function);
+  void startFunctionPassRun(SILFunction *function);
+
+  /// Called by the SILCombiner before the instruction pass starts running.
+  void startInstructionPassRun(SILInstruction *inst);
 
   /// Called by the pass manager when the pass has finished.
-  void finishedPassRun();
+  void finishedFunctionPassRun();
+
+  /// Called by the SILCombiner when the instruction pass has finished.
+  void finishedInstructionPassRun();
 };
 
 /// The SIL pass manager.
@@ -126,7 +134,7 @@ class SILPassManager {
   unsigned NumPassesRun = 0;
 
   /// For invoking Swift passes.
-  LibswiftPassInvocation libswiftPassInvocation;
+  SwiftPassInvocation swiftPassInvocation;
 
   /// Change notifications, collected during a bridged pass run.
   SILAnalysis::InvalidationKind changeNotifications =
@@ -201,8 +209,8 @@ public:
   /// pass manager.
   irgen::IRGenModule *getIRGenModule() { return IRMod; }
 
-  LibswiftPassInvocation *getLibswiftPassInvocation() {
-    return &libswiftPassInvocation;
+  SwiftPassInvocation *getSwiftPassInvocation() {
+    return &swiftPassInvocation;
   }
 
   /// Restart the function pass pipeline on the same function
@@ -377,7 +385,7 @@ private:
   void viewCallGraph();
 };
 
-inline void LibswiftPassInvocation::
+inline void SwiftPassInvocation::
 notifyChanges(SILAnalysis::InvalidationKind invalidationKind) {
   passManager->notifyPassChanges(invalidationKind);
 }

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -240,7 +240,7 @@ static void runBridgedFunctionPass(BridgedFunctionPassRunFn &runFunction,
     llvm::errs() << "SILFunction metatype is not registered\n";
     abort();
   }
-  runFunction({{f}, {passManager->getLibswiftPassInvocation()}});
+  runFunction({{f}, {passManager->getSwiftPassInvocation()}});
 }
 
 // Called from initializeSwiftModules().

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -110,7 +110,7 @@ class SILCombiner :
   OwnershipFixupContext ownershipFixupContext;
   
   /// For invoking Swift instruction passes.
-  LibswiftPassInvocation libswiftPassInvocation;
+  SwiftPassInvocation swiftPassInvocation;
 
 public:
   SILCombiner(SILFunctionTransform *parentTransform,
@@ -158,7 +158,7 @@ public:
             [&](SILInstruction *I) { eraseInstFromFunction(*I); }),
         deBlocks(&B.getFunction()),
         ownershipFixupContext(getInstModCallbacks(), deBlocks),
-        libswiftPassInvocation(parentTransform->getPassManager(),
+        swiftPassInvocation(parentTransform->getPassManager(),
                                parentTransform->getFunction(), this) {}
 
   bool runOnFunction(SILFunction &F);


### PR DESCRIPTION
And a few other small related changes:
* remove libswiftPassInvocation from SILInstructionWorklist (because it's not needed)
* replace start/finishPassRun with start/finishFunction/InstructionPassRun

NFC
