### PR TITLE
Fixed typo: desciption -> description

### DIFF
--- a/benchmark/utils/ArgParse.swift
+++ b/benchmark/utils/ArgParse.swift
@@ -79,7 +79,7 @@ class ArgumentParser<U> {
     private var optionalArgsMap = [String : String]()
 
     /// Argument holds the name of the command line parameter, its help
-    /// desciption and a rule that's applied to process it.
+    /// description and a rule that's applied to process it.
     ///
     /// The the rule is typically a value processing closure used to convert it
     /// into given type and storing it in the parsing result.


### PR DESCRIPTION
benchmark/utils/ArgParse.swift

desciption -> description