### PR TITLE
Fixed typo: struct -> enum

### DIFF
--- a/test/decl/protocol/special/coding/Inputs/enum_codable_simple_multi2.swift
+++ b/test/decl/protocol/special/coding/Inputs/enum_codable_simple_multi2.swift
@@ -5,7 +5,7 @@ func foo() {
   let _ = SimpleEnum.encode(to:)
 
   // The synthesized CodingKeys type should not be accessible from outside the
-  // struct.
+  // enum.
   let _ = SimpleEnum.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
   let _ = SimpleEnum.ACodingKeys.self // expected-error {{'ACodingKeys' is inaccessible due to 'private' protection level}}
   let _ = SimpleEnum.BCodingKeys.self // expected-error {{'BCodingKeys' is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
There is a typo in `test/decl/protocol/special/coding/Inputs/enum_codable_simple_multi2.swift`.
`struct` should be `enum`