### PR TITLE
Rename `dealloc_ref [stack]` and enable StackPromotion for OSSA

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -208,6 +208,10 @@ final public class DeallocStackInst : Instruction, UnaryInstruction {
   }
 }
 
+final public class DeallocStackRefInst : Instruction, UnaryInstruction {
+  public var allocRef: AllocRefInst { operand as! AllocRefInst }
+}
+
 final public class CondFailInst : Instruction, UnaryInstruction {
   public override var mayTrap: Bool { true }
 

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -42,6 +42,7 @@ public func registerSILClasses() {
   register(EndAccessInst.self)
   register(EndBorrowInst.self)
   register(DeallocStackInst.self)
+  register(DeallocStackRefInst.self)
   register(CondFailInst.self)
   register(FixLifetimeInst.self)
   register(DebugValueInst.self)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3143,8 +3143,8 @@ optional ``objc`` attribute indicates that the object should be
 allocated using Objective-C's allocation methods (``+allocWithZone:``).
 
 The optional ``stack`` attribute indicates that the object can be allocated
-on the stack instead on the heap. In this case the instruction must have
-balanced with a ``dealloc_ref [stack]`` instruction to mark the end of the
+on the stack instead on the heap. In this case the instruction must be
+balanced with a ``dealloc_stack_ref`` instruction to mark the end of the
 object's lifetime.
 Note that the ``stack`` attribute only specifies that stack allocation is
 possible. The final decision on stack allocation is done during llvm IR
@@ -3381,13 +3381,25 @@ project_box
 
 Given a ``@box T`` reference, produces the address of the value inside the box.
 
+dealloc_stack_ref
+`````````````````
+::
+
+  sil-instruction ::= 'dealloc_stack_ref' sil-operand
+
+  dealloc_stack_ref %0 : $T
+  // $T must be a class type
+  // %0 must be an 'alloc_ref [stack]' instruction
+
+Marks the deallocation of the stack space for an ``alloc_ref [stack]``.
+
 dealloc_ref
 ```````````
 ::
 
-  sil-instruction ::= 'dealloc_ref' ('[' 'stack' ']')? sil-operand
+  sil-instruction ::= 'dealloc_ref' sil-operand
 
-  dealloc_ref [stack] %0 : $T
+  dealloc_ref %0 : $T
   // $T must be a class type
 
 Deallocates an uninitialized class type instance, bypassing the reference

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2005,10 +2005,14 @@ public:
     return insert(new (getModule())
                       DeallocStackInst(getSILDebugLocation(Loc), operand));
   }
-  DeallocRefInst *createDeallocRef(SILLocation Loc, SILValue operand,
-                                   bool canBeOnStack) {
+  DeallocStackRefInst *createDeallocStackRef(SILLocation Loc,
+                                                     SILValue operand) {
+    return insert(new (getModule())
+                    DeallocStackRefInst(getSILDebugLocation(Loc), operand));
+  }
+  DeallocRefInst *createDeallocRef(SILLocation Loc, SILValue operand) {
     return insert(new (getModule()) DeallocRefInst(
-        getSILDebugLocation(Loc), operand, canBeOnStack));
+        getSILDebugLocation(Loc), operand));
   }
   DeallocPartialRefInst *createDeallocPartialRef(SILLocation Loc,
                                                  SILValue operand,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2488,8 +2488,16 @@ SILCloner<ImplClass>::visitDeallocRefInst(DeallocRefInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
       Inst, getBuilder().createDeallocRef(getOpLocation(Inst->getLoc()),
-                                          getOpValue(Inst->getOperand()),
-                                          Inst->canAllocOnStack()));
+                                          getOpValue(Inst->getOperand())));
+}
+
+template<typename ImplClass>
+void
+SILCloner<ImplClass>::visitDeallocStackRefInst(DeallocStackRefInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(
+      Inst, getBuilder().createDeallocStackRef(getOpLocation(Inst->getLoc()),
+                                          getOpValue(Inst->getOperand())));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7619,6 +7619,18 @@ class DeallocStackInst :
       : UnaryInstructionBase(DebugLoc, operand) {}
 };
 
+/// Like DeallocStackInst, but for `alloc_ref [stack]`.
+class DeallocStackRefInst
+    : public UnaryInstructionBase<SILInstructionKind::DeallocStackRefInst,
+                                  DeallocationInst> {
+  friend SILBuilder;
+
+  DeallocStackRefInst(SILDebugLocation DebugLoc, SILValue Operand)
+      : UnaryInstructionBase(DebugLoc, Operand) {}
+public:
+  AllocRefInst *getAllocRef() { return cast<AllocRefInst>(getOperand()); }
+};
+
 /// Deallocate memory for a reference type instance from a destructor or
 /// failure path of a constructor.
 ///
@@ -7632,21 +7644,8 @@ class DeallocRefInst :
                               DeallocationInst> {
   friend SILBuilder;
 
-private:
-  DeallocRefInst(SILDebugLocation DebugLoc, SILValue Operand,
-                 bool canBeOnStack = false)
-      : UnaryInstructionBase(DebugLoc, Operand) {
-    SILNode::Bits.DeallocRefInst.OnStack = canBeOnStack;
-  }
-
-public:
-  bool canAllocOnStack() const {
-    return SILNode::Bits.DeallocRefInst.OnStack;
-  }
-
-  void setStackAllocatable(bool OnStack) {
-    SILNode::Bits.DeallocRefInst.OnStack = OnStack;
-  }
+  DeallocRefInst(SILDebugLocation DebugLoc, SILValue Operand)
+      : UnaryInstructionBase(DebugLoc, Operand) { }
 };
 
 /// Deallocate memory for a reference type instance from a failure path of a

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -218,10 +218,6 @@ protected:
     Length : 32
   );
 
-  SWIFT_INLINE_BITFIELD(DeallocRefInst, DeallocationInst, 1,
-    OnStack : 1
-  );
-
   // Ensure that AllocBoxInst bitfield does not overflow.
   IBWTO_BITFIELD_EMPTY(AllocBoxInst, AllocationInst);
   // Ensure that AllocExistentialBoxInst bitfield does not overflow.

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -808,6 +808,8 @@ ABSTRACT_INST(TermInst, SILInstruction)
 ABSTRACT_INST(DeallocationInst, SILInstruction)
   BRIDGED_NON_VALUE_INST(DeallocStackInst, dealloc_stack,
                  DeallocationInst, MayHaveSideEffects, DoesNotRelease)
+  BRIDGED_NON_VALUE_INST(DeallocStackRefInst, dealloc_stack_ref,
+                 DeallocationInst, MayHaveSideEffects, DoesNotRelease)
   BRIDGED_NON_VALUE_INST(DeallocRefInst, dealloc_ref,
                  DeallocationInst, MayHaveSideEffects, DoesNotRelease)
   NON_VALUE_INST(DeallocPartialRefInst, dealloc_partial_ref,

--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -197,7 +197,8 @@ public:
            (hasUsersBeforeDef || bb != getDefValueParentBlock());
   }
 
-  /// Checks if there is a dealloc_ref inside the value's live range.
+  /// Checks if there is a dealloc_ref or dealloc_stack_ref inside the
+  /// value's live range.
   bool containsDeallocRef(const FrontierImpl &frontier);
 
   /// For debug dumping.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1257,6 +1257,7 @@ public:
   void visitEndCOWMutationInst(EndCOWMutationInst *i);
   void visitIsEscapingClosureInst(IsEscapingClosureInst *i);
   void visitDeallocStackInst(DeallocStackInst *i);
+  void visitDeallocStackRefInst(DeallocStackRefInst *i);
   void visitDeallocBoxInst(DeallocBoxInst *i);
   void visitDeallocRefInst(DeallocRefInst *i);
   void visitDeallocPartialRefInst(DeallocPartialRefInst *i);
@@ -4515,9 +4516,9 @@ void IRGenSILFunction::visitSetDeallocatingInst(SetDeallocatingInst *i) {
     //     ...
     //   set_deallocating %0 // not needed
     //     // code which does not depend on the RC_DEALLOCATING_FLAG flag.
-    //   dealloc_ref %0      // not needed (stems from the inlined deallocator)
+    //   dealloc_ref %0      // stems from the inlined deallocator
     //     ...
-    //   dealloc_ref [stack] %0
+    //   dealloc_stack_ref %0
     SILBasicBlock::iterator Iter(i);
     SILBasicBlock::iterator End = i->getParent()->end();
     for (++Iter; Iter != End; ++Iter) {
@@ -5432,32 +5433,10 @@ void IRGenSILFunction::visitDeallocStackInst(swift::DeallocStackInst *i) {
   allocatedTI.deallocateStack(*this, stackAddr, allocatedType);
 }
 
-void IRGenSILFunction::visitDeallocRefInst(swift::DeallocRefInst *i) {
-  // Lower the operand.
+void IRGenSILFunction::visitDeallocStackRefInst(DeallocStackRefInst *i) {
   Explosion self = getLoweredExplosion(i->getOperand());
   auto selfValue = self.claimNext();
-  auto *ARI = dyn_cast<AllocRefInst>(i->getOperand());
-  if (!i->canAllocOnStack()) {
-    if (ARI && StackAllocs.count(ARI)) {
-      // We can ignore dealloc_refs (without [stack]) for stack allocated
-      // objects.
-      //
-      //   %0 = alloc_ref [stack]
-      //     ...
-      //   dealloc_ref %0     // not needed (stems from the inlined deallocator)
-      //     ...
-      //   dealloc_ref [stack] %0
-      return;
-    }
-
-    auto classType = i->getOperand()->getType();
-    emitClassDeallocation(*this, classType, selfValue);
-    return;
-  }
-  // It's a dealloc_ref [stack]. Even if the alloc_ref did not allocate the
-  // object on the stack, we don't have to deallocate it, because it is
-  // deallocated in the final release.
-  assert(ARI->canAllocOnStack());
+  auto *ARI = i->getAllocRef();
   if (StackAllocs.count(ARI)) {
     if (IGM.IRGen.Opts.EmitStackPromotionChecks) {
       selfValue = Builder.CreateBitCast(selfValue, IGM.RefCountedPtrTy);
@@ -5471,6 +5450,25 @@ void IRGenSILFunction::visitDeallocRefInst(swift::DeallocRefInst *i) {
       Builder.CreateLifetimeEnd(selfValue);
     }
   }
+}
+
+void IRGenSILFunction::visitDeallocRefInst(swift::DeallocRefInst *i) {
+  // Lower the operand.
+  Explosion self = getLoweredExplosion(i->getOperand());
+  auto selfValue = self.claimNext();
+  auto *ARI = dyn_cast<AllocRefInst>(i->getOperand());
+  if (ARI && StackAllocs.count(ARI)) {
+    // We can ignore dealloc_refs for stack allocated objects.
+    //
+    //   %0 = alloc_ref [stack]
+    //     ...
+    //   dealloc_ref %0     // not needed (stems from the inlined deallocator)
+    //     ...
+    //   dealloc_stack_ref %0
+    return;
+  }
+  auto classType = i->getOperand()->getType();
+  emitClassDeallocation(*this, classType, selfValue);
 }
 
 void IRGenSILFunction::visitDeallocPartialRefInst(swift::DeallocPartialRefInst *i) {

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -184,6 +184,10 @@ OPERAND_OWNERSHIP(TrivialUse, UncheckedRefCastAddr)
 OPERAND_OWNERSHIP(TrivialUse, UncheckedTakeEnumDataAddr)
 OPERAND_OWNERSHIP(TrivialUse, UnconditionalCheckedCastAddr)
 
+// The dealloc_stack_ref operand needs to have NonUse ownership because
+// this use comes after the last consuming use (which is usually a dealloc_ref).
+OPERAND_OWNERSHIP(NonUse, DeallocStackRef)
+
 // Use an owned or guaranteed value only for the duration of the operation.
 OPERAND_OWNERSHIP(InstantaneousUse, ExistentialMetatype)
 OPERAND_OWNERSHIP(InstantaneousUse, FixLifetime)

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -371,6 +371,10 @@ namespace {
       return true;
     }
 
+    bool visitDeallocStackRefInst(const DeallocStackRefInst *RHS) {
+      return true;
+    }
+
     bool visitAllocStackInst(const AllocStackInst *RHS) {
       return true;
     }
@@ -1285,13 +1289,8 @@ bool SILInstruction::isAllocatingStack() const {
 }
 
 bool SILInstruction::isDeallocatingStack() const {
-  if (isa<DeallocStackInst>(this))
+  if (isa<DeallocStackInst>(this) || isa<DeallocStackRefInst>(this))
     return true;
-
-  if (auto *DRI = dyn_cast<DeallocRefInst>(this)) {
-    if (DRI->canAllocOnStack())
-      return true;
-  }
 
   if (auto *BI = dyn_cast<BuiltinInst>(this)) {
     if (BI->getBuiltinKind() == BuiltinValueKind::StackDealloc) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2211,9 +2211,10 @@ public:
   void visitDeallocStackInst(DeallocStackInst *DI) {
     *this << getIDAndType(DI->getOperand());
   }
+  void visitDeallocStackRefInst(DeallocStackRefInst *ESRL) {
+    *this << getIDAndType(ESRL->getOperand());
+  }
   void visitDeallocRefInst(DeallocRefInst *DI) {
-    if (DI->canAllocOnStack())
-      *this << "[stack] ";
     *this << getIDAndType(DI->getOperand());
   }
   void visitDeallocPartialRefInst(DeallocPartialRefInst *DPI) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4301,14 +4301,15 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
     ResultVal = B.createDeallocStack(InstLoc, Val);
     break;
-  case SILInstructionKind::DeallocRefInst: {
-    bool OnStack = false;
-    if (parseSILOptional(OnStack, *this, "stack"))
-      return true;
-
+  case SILInstructionKind::DeallocStackRefInst:
     if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
-    ResultVal = B.createDeallocRef(InstLoc, Val, OnStack);
+    ResultVal = B.createDeallocStackRef(InstLoc, Val);
+    break;
+  case SILInstructionKind::DeallocRefInst: {
+    if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+      return true;
+    ResultVal = B.createDeallocRef(InstLoc, Val);
     break;
   }
   case SILInstructionKind::DeallocPartialRefInst: {

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -461,6 +461,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::SwitchValueInst:
   case SILInstructionKind::SwitchEnumInst:
   case SILInstructionKind::DeallocStackInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::AutoreleaseValueInst:
   case SILInstructionKind::BindMemoryInst:
   case SILInstructionKind::RebindMemoryInst:

--- a/lib/SIL/Utils/LoopInfo.cpp
+++ b/lib/SIL/Utils/LoopInfo.cpp
@@ -54,8 +54,8 @@ bool SILLoop::canDuplicate(SILInstruction *I) const {
       if (isa<AllocStackInst>(address) || isa<PartialApplyInst>(address))
         alloc = cast<SingleValueInstruction>(address);
     }
-    if (auto *dealloc = dyn_cast<DeallocRefInst>(I))
-      alloc = dyn_cast<AllocRefInst>(dealloc->getOperand());
+    if (auto *dealloc = dyn_cast<DeallocStackRefInst>(I))
+      alloc = dealloc->getAllocRef();
 
     return alloc && contains(alloc);
   }

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -207,9 +207,9 @@ bool SILValueOwnershipChecker::gatherNonGuaranteedUsers(
   for (auto *op : value->getUses()) {
     auto *user = op->getUser();
 
-    // If this op is a type dependent operand, skip it. It is not interesting
+    // For example, type dependent operands are non-use. It is not interesting
     // from an ownership perspective.
-    if (user->isTypeDependentOperand(*op))
+    if (op->getOperandOwnership() == OperandOwnership::NonUse)
       continue;
 
     // First check if this recursive use is compatible with our values ownership

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2992,11 +2992,9 @@ public:
     auto *cd = DI->getOperand()->getType().getClassOrBoundGenericClass();
     require(cd, "Operand of dealloc_ref must be of class type");
 
-    if (!DI->canAllocOnStack()) {
-      require(!checkResilience(cd, F.getModule().getSwiftModule(),
-                               F.getResilienceExpansion()),
-              "cannot directly deallocate resilient class");
-    }
+    require(!checkResilience(cd, F.getModule().getSwiftModule(),
+                             F.getResilienceExpansion()),
+            "cannot directly deallocate resilient class");
   }
   void checkDeallocPartialRefInst(DeallocPartialRefInst *DPRI) {
     require(DPRI->getInstance()->getType().isObject(),

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -166,7 +166,7 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
 
   // Deallocate the object.
   selfForDealloc = B.createUncheckedRefCast(loc, selfForDealloc, classTy);
-  B.createDeallocRef(loc, selfForDealloc, false);
+  B.createDeallocRef(loc, selfForDealloc);
 
   emitProfilerIncrement(dd->getTypecheckedBody());
 

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2163,6 +2163,7 @@ void EscapeAnalysis::analyzeInstruction(SILInstruction *I,
     case SILInstructionKind::InitExistentialMetatypeInst:
     case SILInstructionKind::OpenExistentialMetatypeInst:
     case SILInstructionKind::ExistentialMetatypeInst:
+    case SILInstructionKind::DeallocStackRefInst:
     case SILInstructionKind::DeallocRefInst:
     case SILInstructionKind::SetDeallocatingInst:
     case SILInstructionKind::FixLifetimeInst:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -616,7 +616,8 @@ bool SILCombiner::eraseApply(FullApplySite FAS, const UserListTy &Users) {
     if (!VLA.computeFrontier(Frontier, ValueLifetimeAnalysis::DontModifyCFG))
       return false;
     // As we are extending the lifetimes of owned parameters, we have to make
-    // sure that no dealloc_ref instructions are within this extended liferange.
+    // sure that no dealloc_ref or dealloc_stack_ref instructions are
+    // within this extended liferange.
     // It could be that the dealloc_ref is deallocating a parameter and then
     // we would have a release after the dealloc.
     if (VLA.containsDeallocRef(Frontier))

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -740,7 +740,7 @@ SILInstruction *SILCombiner::visitAllocRefInst(AllocRefInst *AR) {
     ++UI;
     auto *User = Op->getUser();
     if (!isa<DeallocRefInst>(User) && !isa<SetDeallocatingInst>(User) &&
-        !isa<FixLifetimeInst>(User)) {
+        !isa<FixLifetimeInst>(User) && !isa<DeallocStackRefInst>(User)) {
       HasNonRemovableUses = true;
       break;
     }

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -123,13 +123,11 @@ findDeallocStackInst(AllocStackInst *ASI) {
 /// Return the deallocate ref instructions corresponding to the given
 /// AllocRefInst.
 static llvm::SmallVector<SILInstruction *, 1>
-findDeallocRefInst(AllocRefInst *ARI) {
+findDeallocStackRefInst(AllocRefInst *ARI) {
   llvm::SmallVector<SILInstruction *, 1> DSIs;
   for (auto UI = ARI->use_begin(), E = ARI->use_end(); UI != E; ++UI) {
-    if (auto *D = dyn_cast<DeallocRefInst>(UI->getUser())) {
-      if (D->isDeallocatingStack())
-        DSIs.push_back(D);
-    }
+    if (auto *D = dyn_cast<DeallocStackRefInst>(UI->getUser()))
+      DSIs.push_back(D);
   }
   return DSIs;
 }
@@ -160,6 +158,7 @@ static bool isDeadStoreInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::StrongRetainInst:
   case SILInstructionKind::RetainValueInst:
   case SILInstructionKind::DeallocStackInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::FixLifetimeInst:
@@ -705,7 +704,7 @@ void BlockState::initStoreSetAtEndOfBlock(DSEContext &Ctx) {
     if (auto *ARI = dyn_cast<AllocRefInst>(LocationVault[i].getBase())) {
       if (!ARI->isAllocatingStack())
         continue;
-      for (auto X : findDeallocRefInst(ARI)) {
+      for (auto X : findDeallocStackRefInst(ARI)) {
         SILBasicBlock *DSIBB = X->getParent();
         if (DSIBB != BB)
           continue;

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -126,6 +126,7 @@ bool ObjectOutliner::isValidUseOfObject(SILInstruction *I,
   case SILInstructionKind::DebugValueInst:
   case SILInstructionKind::LoadInst:
   case SILInstructionKind::DeallocRefInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::StrongRetainInst:
   case SILInstructionKind::StrongReleaseInst:
   case SILInstructionKind::FixLifetimeInst:
@@ -491,6 +492,7 @@ bool ObjectOutliner::optimizeObjectAllocation(AllocRefInst *ARI) {
         B.createStrongRelease(User->getLoc(), GVI, B.getDefaultAtomicity());
         LLVM_FALLTHROUGH;
       case SILInstructionKind::DeallocRefInst:
+      case SILInstructionKind::DeallocStackRefInst:
         ToRemove.push_back(User);
         break;
       default:

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -157,6 +157,7 @@ static bool isRLEInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::FixLifetimeInst:
   case SILInstructionKind::EndAccessInst:
   case SILInstructionKind::SetDeallocatingInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::BeginBorrowInst:
   case SILInstructionKind::EndBorrowInst:

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -31,14 +31,14 @@ namespace {
 ///    %x = alloc_ref [stack] $X
 ///      ...
 ///    strong_release %x
-///    dealloc_ref [stack] %x
+///    dealloc_stack_ref %x
 /// with
 ///    %x = alloc_ref [stack] $X
 ///      ...
 ///    set_deallocating %x
 ///    %d = function_ref @dealloc_of_X
 ///    %a = apply %d(%x)
-///    dealloc_ref [stack] %x
+///    dealloc_stack_ref %x
 ///
 /// The optimization is only done for stack promoted objects because they are
 /// known to have no associated objects (which are not explicitly released
@@ -54,7 +54,7 @@ private:
 
   /// Devirtualize releases of array buffers.
   bool devirtualizeReleaseOfObject(SILInstruction *ReleaseInst,
-                                   DeallocRefInst *DeallocInst);
+                                   DeallocStackRefInst *deallocStackInst);
 
   /// Replace the release-instruction \p ReleaseInst with an explicit call to
   /// the deallocating destructor of \p AllocType for \p object.
@@ -79,8 +79,11 @@ void ReleaseDevirtualizer::run() {
 
     for (SILInstruction &I : BB) {
       if (LastRelease) {
-        if (auto *DRI = dyn_cast<DeallocRefInst>(&I)) {
-          Changed |= devirtualizeReleaseOfObject(LastRelease, DRI);
+        // We only do the optimization for stack promoted object, because for
+        // these we know that they don't have associated objects, which are
+        // _not_ released by the deinit method.
+        if (auto *elti = dyn_cast<DeallocStackRefInst>(&I)) {
+          Changed |= devirtualizeReleaseOfObject(LastRelease, elti);
           LastRelease = nullptr;
           continue;
         }
@@ -101,24 +104,12 @@ void ReleaseDevirtualizer::run() {
 
 bool ReleaseDevirtualizer::
 devirtualizeReleaseOfObject(SILInstruction *ReleaseInst,
-                            DeallocRefInst *DeallocInst) {
+                            DeallocStackRefInst *deallocStackInst) {
 
   LLVM_DEBUG(llvm::dbgs() << "  try to devirtualize " << *ReleaseInst);
 
-  // We only do the optimization for stack promoted object, because for these
-  // we know that they don't have associated objects, which are _not_ released
-  // by the deinit method.
-  // This restriction is no problem because only stack promotion result in this
-  // alloc-release-dealloc pattern.
-  if (!DeallocInst->canAllocOnStack())
-    return false;
-
-  // Is the dealloc_ref paired with an alloc_ref?
-  auto *ARI = dyn_cast<AllocRefInst>(DeallocInst->getOperand());
-  if (!ARI)
-    return false;
-
   // Does the last release really release the allocated object?
+  AllocRefInst *ARI = deallocStackInst->getAllocRef();
   SILValue rcRoot = RCIA->getRCIdentityRoot(ReleaseInst->getOperand(0));
   if (rcRoot != ARI)
     return false;

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -55,9 +55,6 @@ private:
 
 void StackPromotion::run() {
   SILFunction *F = getFunction();
-  // FIXME: We should be able to support ownership.
-  if (F->hasOwnership())
-    return;
 
   LLVM_DEBUG(llvm::dbgs() << "** StackPromotion in " << F->getName() << " **\n");
 

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -33,8 +33,8 @@ namespace {
 /// Promotes heap allocated objects to the stack.
 ///
 /// It handles alloc_ref instructions of native swift classes: if promoted,
-/// the [stack] attribute is set in the alloc_ref and a dealloc_ref [stack] is
-/// inserted at the end of the object's lifetime.
+/// the [stack] attribute is set in the alloc_ref and a dealloc_stack_ref
+/// is inserted at the end of the object's lifetime.
 class StackPromotion : public SILFunctionTransform {
 
 public:
@@ -144,10 +144,10 @@ bool StackPromotion::tryPromoteAlloc(AllocRefInst *ARI, EscapeAnalysis *EA,
   // We set the [stack] attribute in the alloc_ref.
   ARI->setStackAllocatable();
 
-  /// And create dealloc_ref [stack] at the end of the object's lifetime.
+  /// And create dealloc_stack_ref at the end of the object's lifetime.
   for (SILInstruction *FrontierInst : Frontier) {
     SILBuilder B(FrontierInst);
-    B.createDeallocRef(ARI->getLoc(), ARI, true);
+    B.createDeallocStackRef(ARI->getLoc(), ARI);
   }
   return true;
 }

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -276,6 +276,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::CheckedCastAddrBranchInst:
   case SILInstructionKind::CheckedCastValueBranchInst:
   case SILInstructionKind::DeallocStackInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::DeallocPartialRefInst:
   case SILInstructionKind::DeallocBoxInst:

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -879,6 +879,7 @@ static bool hasInterestingSideEffect(SILInstruction *I) {
     case swift::SILInstructionKind::RetainValueInst:
     case swift::SILInstructionKind::ReleaseValueInst:
     case swift::SILInstructionKind::StoreInst:
+    case swift::SILInstructionKind::DeallocStackRefInst:
     case swift::SILInstructionKind::DeallocRefInst:
       return false;
     default:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -892,6 +892,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::ExplicitCopyValueInst:
   case SILInstructionKind::DeallocBoxInst:
   case SILInstructionKind::DeallocExistentialBoxInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::DeallocPartialRefInst:
   case SILInstructionKind::DeallocStackInst:

--- a/lib/SILOptimizer/Utils/StackNesting.cpp
+++ b/lib/SILOptimizer/Utils/StackNesting.cpp
@@ -191,7 +191,7 @@ static SILInstruction *createDealloc(SingleValueInstruction *Alloc,
       return B.createDeallocStack(Location, Alloc);
     case SILInstructionKind::AllocRefInst:
       assert(cast<AllocRefInst>(Alloc)->canAllocOnStack());
-      return B.createDeallocRef(Location, Alloc, /*canBeOnStack*/true);
+      return B.createDeallocStackRef(Location, Alloc);
     default:
       llvm_unreachable("unknown stack allocation");
   }

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -345,8 +345,9 @@ bool ValueLifetimeAnalysis::isWithinLifetime(SILInstruction *inst) {
 }
 
 // Searches \p bb backwards from the instruction before \p frontierInst
-// to the beginning of the list and returns true if we find a dealloc_ref
-// /before/ we find \p defValue (the instruction that defines our target value).
+// to the beginning of the list and returns true if we find a dealloc_ref or an
+// dealloc_stack_ref /before/ we find \p defValue (the instruction that
+// defines our target value).
 static bool
 blockContainsDeallocRef(SILBasicBlock *bb,
                         PointerUnion<SILInstruction *, SILArgument *> defValue,
@@ -355,7 +356,7 @@ blockContainsDeallocRef(SILBasicBlock *bb,
   SILBasicBlock::reverse_iterator iter = frontierInst->getReverseIterator();
   for (++iter; iter != End; ++iter) {
     SILInstruction *inst = &*iter;
-    if (isa<DeallocRefInst>(inst))
+    if (isa<DeallocRefInst>(inst) || isa<DeallocStackRefInst>(inst))
       return true;
     // We know that inst is not a nullptr, so if we have a SILArgument, this
     // will always fail as we want.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1663,13 +1663,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
+  case SILInstructionKind::DeallocStackRefInst: {
+    auto Ty = MF->getType(TyID);
+    ResultInst = Builder.createDeallocStackRef(
+        Loc,
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+    break;
+  }
   case SILInstructionKind::DeallocRefInst: {
     auto Ty = MF->getType(TyID);
-    bool OnStack = (bool)Attr;
     ResultInst = Builder.createDeallocRef(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        OnStack);
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
   case SILInstructionKind::DeallocPartialRefInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 654; // opaque result type orinal
+const uint16_t SWIFTMODULE_VERSION_MINOR = 655; // dealloc_stack_ref
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1413,6 +1413,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::UnmanagedAutoreleaseValueInst:
   case SILInstructionKind::SetDeallocatingInst:
   case SILInstructionKind::DeallocStackInst:
+  case SILInstructionKind::DeallocStackRefInst:
   case SILInstructionKind::DeallocRefInst:
   case SILInstructionKind::DeinitExistentialAddrInst:
   case SILInstructionKind::DeinitExistentialValueInst:
@@ -1445,8 +1446,6 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     else if (auto *LI = dyn_cast<Load##Name##Inst>(&SI)) \
       Attr = LI->isTake();
 #include "swift/AST/ReferenceStorage.def"
-    else if (auto *DRI = dyn_cast<DeallocRefInst>(&SI))
-      Attr = (unsigned)DRI->canAllocOnStack();
     else if (auto *RCI = dyn_cast<RefCountingInst>(&SI))
       Attr = RCI->isNonAtomic();
     else if (auto *UOCI = dyn_cast<UncheckedOwnershipConversionInst>(&SI)) {

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -43,7 +43,7 @@ sil @simple_promote : $@convention(thin) () -> () {
 bb0:
   %o1 = alloc_ref [stack] $TestClass
   strong_release %o1 : $TestClass
-  dealloc_ref [stack] %o1 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
 
   %r = tuple()
   return %r : $()
@@ -73,8 +73,8 @@ bb0:
 
   strong_release %o1 : $TestClass
   strong_release %o2 : $TestClass
-  dealloc_ref [stack] %o2 : $TestClass
-  dealloc_ref [stack] %o1 : $TestClass
+  dealloc_stack_ref %o2 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
 
   %r = tuple()
   return %r : $()
@@ -98,7 +98,7 @@ bb0:
   set_deallocating %o1 : $TestClass
   %f = function_ref @not_inlined_destructor :  $@convention(thin) (TestClass) -> ()
   %a = apply %f(%o1) : $@convention(thin) (TestClass) -> ()
-  dealloc_ref [stack] %o1 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
 
   %r = tuple()
   return %r : $()
@@ -120,7 +120,7 @@ bb0:
   %o1 = alloc_ref [stack] $TestClass
   set_deallocating %o1 : $TestClass
   dealloc_ref %o1 : $TestClass
-  dealloc_ref [stack] %o1 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
 
   %r = tuple()
   return %r : $()
@@ -138,7 +138,7 @@ bb0:
   %o1 = alloc_ref [stack] $BigClass
   set_deallocating %o1 : $BigClass
   dealloc_ref %o1 : $BigClass
-  dealloc_ref [stack] %o1 : $BigClass
+  dealloc_stack_ref %o1 : $BigClass
 
   %r = tuple()
   return %r : $()

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -30,7 +30,7 @@ sil @alloc_on_stack : $@convention(thin) () -> () {
 bb0:
   %c = integer_literal $Builtin.Word, 2 // size = 17 + 3(padding) + 2 * 4 = 28
   %o1 = alloc_ref [stack] [tail_elems $Int32 * %c : $Builtin.Word] $TestClass
-  dealloc_ref [stack] %o1 : $TestClass
+  dealloc_stack_ref %o1 : $TestClass
   %r = tuple()
   return %r : $()
 }

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -746,8 +746,8 @@ sil @test_stack_flag : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_ref [stack] $Class1
   %0 = alloc_ref [stack] $Class1
-  // CHECK: dealloc_ref [stack] %0 : $Class1
-  dealloc_ref [stack] %0 : $Class1
+  // CHECK: dealloc_stack_ref %0 : $Class1
+  dealloc_stack_ref  %0 : $Class1
   %2 = tuple ()
   return %2 : $()
 }

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -12,14 +12,14 @@ class X {
 sil [always_inline] @callee_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_ref [stack] $X
-  dealloc_ref [stack] %0 : $X
+  dealloc_stack_ref %0 : $X
   %r = tuple ()
   return %r : $()
 }
 
 // CHECK-LABEL: sil @caller_alloc_ref_stack : $@convention(thin) () -> ()
 // CHECK: [[X:%[0-9]+]] = alloc_ref [stack] $X
-// CHECK: dealloc_ref [stack] [[X]] : $X
+// CHECK: dealloc_stack_ref [[X]] : $X
 sil @caller_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @callee_alloc_ref_stack : $@convention(thin) () -> ()

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -843,7 +843,7 @@ bb3:
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:        store
 // CHECK:        dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_ref [stack] [[REF]]
+// CHECK-NEXT:   dealloc_stack_ref [[REF]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil @wrong_nesting_with_alloc_ref : $(Int) -> () {
@@ -852,7 +852,7 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %1a = project_box %1 : ${ var Int }, 0
   store %0 to %1a : $*Int
-  dealloc_ref [stack] %as1 : $SomeClass
+  dealloc_stack_ref %as1 : $SomeClass
   %3 = load %1a : $*Int
   strong_release %1 : ${ var Int }
   %r = tuple ()

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -878,7 +878,7 @@ bb3:
 // CHECK-NEXT:   [[BOX:%[0-9]+]] = alloc_stack $Int
 // CHECK:        store
 // CHECK:        dealloc_stack [[BOX]]
-// CHECK-NEXT:   dealloc_ref [stack] [[REF]]
+// CHECK-NEXT:   dealloc_stack_ref [[REF]]
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil [ossa] @wrong_nesting_with_alloc_ref : $@convention(thin) (Int) -> () {
@@ -887,7 +887,8 @@ bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %1a = project_box %1 : ${ var Int }, 0
   store %0 to [trivial] %1a : $*Int
-  dealloc_ref [stack] %as1 : $SomeClass
+  dealloc_ref %as1 : $SomeClass
+  dealloc_stack_ref %as1 : $SomeClass
   %3 = load [trivial] %1a : $*Int
   destroy_value %1 : ${ var Int }
   %r = tuple ()

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -101,7 +101,7 @@ bb0(%0 : $Kl):
   store %0 to %21 : $*Kl
   set_deallocating %20 : $NontrivialDestructor
   destroy_addr %21 : $*Kl
-  dealloc_ref [stack] %20 : $NontrivialDestructor
+  dealloc_stack_ref %20 : $NontrivialDestructor
   %r = tuple ()
   return %r : $()
 }
@@ -115,7 +115,7 @@ bb0(%0 : $Kl):
   %21 = ref_element_addr %20 : $NontrivialDestructor, #NontrivialDestructor.p
   store %0 to %21 : $*Kl
   strong_release %20 : $NontrivialDestructor
-  dealloc_ref [stack] %20 : $NontrivialDestructor
+  dealloc_stack_ref %20 : $NontrivialDestructor
   %r = tuple ()
   return %r : $()
 }
@@ -130,7 +130,7 @@ bb0(%0 : $Int):
   store %0 to %21 : $*Int
   set_deallocating %20 : $NontrivialDestructor
   dealloc_ref %20 : $NontrivialDestructor
-  dealloc_ref [stack] %20 : $NontrivialDestructor
+  dealloc_stack_ref %20 : $NontrivialDestructor
   %r = tuple ()
   return %r : $()
 }
@@ -514,7 +514,7 @@ bb0(%0 : $String, %1 : $Int, %2 : $UInt):
   %67 = builtin "destroyArray"<(Int, String)>(%66 : $@thick (Int, String).Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
   fix_lifetime %4 : $_ContiguousArrayStorage<(Int, String)>
   dealloc_ref %4 : $_ContiguousArrayStorage<(Int, String)>
-  dealloc_ref [stack] %4 : $_ContiguousArrayStorage<(Int, String)>
+  dealloc_stack_ref %4 : $_ContiguousArrayStorage<(Int, String)>
   %10 = tuple ()
   return %10 : $()
 }

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -188,7 +188,7 @@ bb0:
   %3 = ref_element_addr %0 : $foo, #foo.a
   store %2 to %3 : $*Int
   %4 = tuple ()
-  dealloc_ref [stack] %0 : $foo
+  dealloc_stack_ref %0 : $foo
   return %4 : $()
 }
 
@@ -198,7 +198,7 @@ bb0:
 // CHECK: bb0
 // CHECK: alloc_ref
 // CHECK: store
-// CHECK: dealloc_ref
+// CHECK: dealloc_stack_ref
 // CHECK: return
 sil hidden @blocking_read_on_local_store_into_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
@@ -209,7 +209,7 @@ bb0:
   store %2 to %3 : $*Int
   %4 = tuple ()
   strong_release %0 : $foo
-  dealloc_ref [stack] %0 : $foo
+  dealloc_stack_ref %0 : $foo
   return %4 : $()
 }
 
@@ -1537,6 +1537,6 @@ bb0:
   store %3 to %4 : $*Int
   set_deallocating %1 : $foo
   dealloc_ref %1 : $foo
-  dealloc_ref [stack] %1 : $foo
+  dealloc_stack_ref %1 : $foo
   return %3 : $Int
 }

--- a/test/SILOptimizer/devirt_release.sil
+++ b/test/SILOptimizer/devirt_release.sil
@@ -15,13 +15,13 @@ class B {
 // CHECK-NOT: strong_release
 // CHECK: [[D:%[0-9]+]] = function_ref @$s4test1BCfD
 // CHECK-NEXT: apply [[D]]([[A]])
-// CHECK-NEXT: dealloc_ref [stack] [[A]]
+// CHECK-NEXT: dealloc_stack_ref [[A]]
 // CHECK: return
 sil @devirtualize_object : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
   strong_release %1 : $B
-  dealloc_ref [stack] %1 : $B
+  dealloc_stack_ref %1 : $B
   %r = tuple ()
   return %r : $()
 }
@@ -80,15 +80,15 @@ bb0(%0 : $B):
 // CHECK-NOT: strong_release
 // CHECK: [[D:%[0-9]+]] = function_ref @$s4test1BCfD
 // CHECK-NEXT: apply [[D]]([[A]])
-// CHECK-NEXT: dealloc_ref [stack] [[A]]
+// CHECK-NEXT: dealloc_stack_ref [[A]]
 // CHECK: return
 sil @dont_crash_with_missing_release : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
   strong_release %1 : $B
-  dealloc_ref [stack] %1 : $B
+  dealloc_stack_ref %1 : $B
   %2 = alloc_ref [stack] $B
-  dealloc_ref [stack] %2 : $B
+  dealloc_stack_ref %2 : $B
   %r = tuple ()
   return %r : $()
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1421,7 +1421,7 @@ sil @check_non_escaping_implicit_destructor_invocation_via_strong_release : $@co
 bb0:
   %0 = alloc_ref [stack] $X
   strong_release %0 : $X
-  dealloc_ref [stack] %0 : $X
+  dealloc_stack_ref %0 : $X
   %3 = tuple ()
   return %3 : $()
 }
@@ -1438,7 +1438,7 @@ sil @check_non_escaping_implicit_destructor_invocation_via_release_value : $@con
 bb0:
   %0 = alloc_ref [stack] $X
   release_value %0 : $X
-  dealloc_ref [stack] %0 : $X
+  dealloc_stack_ref %0 : $X
   %3 = tuple ()
   return %3 : $()
 }
@@ -1455,7 +1455,7 @@ sil @check_escaping_implicit_destructor_invocation_via_strong_release : $@conven
 bb0:
   %0 = alloc_ref [stack] $Z
   strong_release %0 : $Z
-  dealloc_ref [stack] %0 : $Z
+  dealloc_stack_ref %0 : $Z
   %3 = tuple ()
   return %3 : $()
 }
@@ -1472,7 +1472,7 @@ sil @check_escaping_implicit_destructor_invocation_via_release_value : $@convent
 bb0:
   %0 = alloc_ref [stack] $Z
   release_value %0 : $Z
-  dealloc_ref [stack] %0 : $Z
+  dealloc_stack_ref %0 : $Z
   %3 = tuple ()
   return %3 : $()
 }

--- a/test/SILOptimizer/escape_analysis_dead_store.sil
+++ b/test/SILOptimizer/escape_analysis_dead_store.sil
@@ -133,6 +133,6 @@ bb0:
   set_deallocating %0 : $TestArrayContainer
   strong_release %9 : $__ContiguousArrayStorageBase
   dealloc_ref %0 : $TestArrayContainer
-  dealloc_ref [stack] %0 : $TestArrayContainer
+  dealloc_stack_ref %0 : $TestArrayContainer
   return %17 : $Bool
 }

--- a/test/SILOptimizer/escape_analysis_release_hoisting.sil
+++ b/test/SILOptimizer/escape_analysis_release_hoisting.sil
@@ -42,7 +42,7 @@ bb0:
   %12 = init_existential_addr %6 : $*ArrayElementProtocol, $ArrayElementStruct
   store %11 to %12 : $*ArrayElementStruct
   strong_release %0 : $_ContiguousArrayStorage<ArrayElementProtocol>
-  dealloc_ref [stack] %0 : $_ContiguousArrayStorage<ArrayElementProtocol>
+  dealloc_stack_ref %0 : $_ContiguousArrayStorage<ArrayElementProtocol>
   %16 = tuple ()
   return %16 : $()
 }

--- a/test/SILOptimizer/loop_unroll.sil
+++ b/test/SILOptimizer/loop_unroll.sil
@@ -341,9 +341,9 @@ class B {}
 
 // CHECK-LABEL: sil @unroll_with_stack_allocation
 // CHECK: = alloc_ref [stack]
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: = alloc_ref [stack]
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: }
 sil @unroll_with_stack_allocation : $@convention(thin) () -> () {
 bb0:
@@ -361,7 +361,7 @@ bb2:
   %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
   %7 = builtin "cmp_eq_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  dealloc_ref [stack] %a : $B
+  dealloc_stack_ref %a : $B
   cond_br %7, bb4, bb3
 
 bb3:
@@ -375,9 +375,9 @@ bb4:
 // CHECK-LABEL: sil @dont_copy_stack_allocation_with_dealloc_outside_loop
 // CHECK:   = alloc_ref [stack]
 // CHECK: bb2:
-// CHECK:   dealloc_ref [stack]
+// CHECK:   dealloc_stack_ref
 // CHECK: bb3:
-// CHECK:   dealloc_ref [stack]
+// CHECK:   dealloc_stack_ref
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 sil @dont_copy_stack_allocation_with_dealloc_outside_loop : $@convention(thin) () -> () {
@@ -396,11 +396,11 @@ bb1(%4 : $Builtin.Int64):
   cond_br %7, bb3, bb2
 
 bb2:
-  dealloc_ref [stack] %a : $B
+  dealloc_stack_ref %a : $B
   br bb1(%6 : $Builtin.Int64)
 
 bb3:
-  dealloc_ref [stack] %a : $B
+  dealloc_stack_ref %a : $B
   %8 = tuple()
   return %8 : $()
 }

--- a/test/SILOptimizer/loop_unroll_ossa.sil
+++ b/test/SILOptimizer/loop_unroll_ossa.sil
@@ -358,9 +358,9 @@ class B {}
 
 // CHECK-LABEL: sil [ossa] @unroll_with_stack_allocation :
 // CHECK: = alloc_ref [stack]
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: = alloc_ref [stack]
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK-LABEL: } // end sil function 'unroll_with_stack_allocation'
 sil [ossa] @unroll_with_stack_allocation : $@convention(thin) () -> () {
 bb0:
@@ -378,7 +378,8 @@ bb2:
   %5 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %1 : $Builtin.Int64, %3 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %6 = tuple_extract %5 : $(Builtin.Int64, Builtin.Int1), 0
   %7 = builtin "cmp_eq_Int64"(%6 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  dealloc_ref [stack] %a : $B
+  dealloc_ref %a : $B
+  dealloc_stack_ref %a : $B
   cond_br %7, bb4, bb3
 
 bb3:
@@ -392,9 +393,9 @@ bb4:
 // CHECK-LABEL: sil [ossa] @dont_copy_stack_allocation_with_dealloc_outside_loop :
 // CHECK:   = alloc_ref [stack]
 // CHECK: bb2:
-// CHECK:   dealloc_ref [stack]
+// CHECK:   dealloc_stack_ref
 // CHECK: bb3:
-// CHECK:   dealloc_ref [stack]
+// CHECK:   dealloc_stack_ref
 // CHECK-NEXT: tuple
 // CHECK-LABEL: } // end sil function 'dont_copy_stack_allocation_with_dealloc_outside_loop'
 sil [ossa] @dont_copy_stack_allocation_with_dealloc_outside_loop : $@convention(thin) () -> () {
@@ -413,11 +414,13 @@ bb1(%4 : $Builtin.Int64):
   cond_br %7, bb3, bb2
 
 bb2:
-  dealloc_ref [stack] %a : $B
+  dealloc_ref %a : $B
+  dealloc_stack_ref %a : $B
   br bb1(%6 : $Builtin.Int64)
 
 bb3:
-  dealloc_ref [stack] %a : $B
+  dealloc_ref %a : $B
+  dealloc_stack_ref %a : $B
   %8 = tuple()
   return %8 : $()
 }

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -215,7 +215,7 @@ sil hidden_external @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
 // CHECK: function_ref @use 
 // CHECK-NOT: function_ref
 // CHECK: strong_release{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
-// CHECK: dealloc_ref{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
+// CHECK: dealloc_stack_ref{{.*}}C08045E0-2779-11E7-970E-A45E60E99281
 // CHECK: end sil function 'bar' 
 sil @bar : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1267,6 +1267,6 @@ bb0:
   %5 = load %4 : $*Int32
   set_deallocating %1 : $AX
   dealloc_ref %1 : $AX
-  dealloc_ref [stack] %1 : $AX
+  dealloc_stack_ref %1 : $AX
   return %5 : $Int32
 }

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -901,7 +901,8 @@ bb0(%0 : @owned $Klass):
   %5 = load [copy] %4 : $*Klass
   end_borrow %borrow1 : $AX
   set_deallocating %1 : $AX
-  dealloc_ref [stack] %1 : $AX
+  dealloc_ref %1 : $AX
+  dealloc_stack_ref %1 : $AX
   return %5 : $Klass
 }
 

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -1364,7 +1364,8 @@ bb0:
   %5 = load [trivial] %4 : $*Int32
   end_borrow %borrow1 : $AX
   set_deallocating %1 : $AX
-  dealloc_ref [stack] %1 : $AX
+  dealloc_ref %1 : $AX
+  dealloc_stack_ref %1 : $AX
   return %5 : $Int32
 }
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2054,14 +2054,14 @@ bb3:
 
 // CHECK-LABEL: sil @dont_delete_readonly_function_dealloc_ref_simple
 // CHECK:      apply
-// CHECK-NEXT: dealloc_ref
+// CHECK-NEXT: dealloc_stack_ref
 // CHECK:      return
 sil @dont_delete_readonly_function_dealloc_ref_simple : $@convention(thin) () -> () {
 bb0:
   %3 = alloc_ref [stack] $B
   %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
   %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   strong_release %r : $B
   %10 = tuple ()
   return %10 : $()
@@ -2069,9 +2069,9 @@ bb0:
 
 // CHECK-LABEL: sil @dont_delete_readonly_function_dealloc_ref_multibb
 // CHECK:      apply
-// CHECK:      dealloc_ref
+// CHECK:      dealloc_stack_ref
 // CHECK-NEXT: strong_release
-// CHECK:      dealloc_ref
+// CHECK:      dealloc_stack_ref
 // CHECK-NEXT: strong_release
 // CHECK:      return
 sil @dont_delete_readonly_function_dealloc_ref_multibb : $@convention(thin) () -> () {
@@ -2082,12 +2082,12 @@ bb0:
   cond_br undef, bb1, bb2
 
 bb1:
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   strong_release %r : $B
   br bb3
 
 bb2:
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   strong_release %r : $B
   br bb3
 
@@ -2105,7 +2105,7 @@ bb0:
   %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
   %r = apply %f(%3) : $@convention(thin) (@owned B) -> @owned B
   strong_release %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   %10 = tuple ()
   return %10 : $()
 }
@@ -2122,12 +2122,12 @@ bb0:
 
 bb1:
   strong_release %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   br bb3
 
 bb2:
   strong_release %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_stack_ref %3 : $B
   br bb3
 
 bb3:
@@ -3532,7 +3532,7 @@ sil @remove_unused_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
   set_deallocating %1 : $B
-  dealloc_ref [stack] %1 : $B
+  dealloc_stack_ref %1 : $B
   %3 = tuple ()
   return %3 : $()
 }

--- a/test/SILOptimizer/sil_combine_misc_opts.sil
+++ b/test/SILOptimizer/sil_combine_misc_opts.sil
@@ -96,7 +96,7 @@ sil @remove_unused_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $Klass
   set_deallocating %1 : $Klass
-  dealloc_ref [stack] %1 : $Klass
+  dealloc_stack_ref %1 : $Klass
   %3 = tuple ()
   return %3 : $()
 }
@@ -110,7 +110,8 @@ sil [ossa] @remove_unused_alloc_ref_stack_ossa : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $Klass
   set_deallocating %1 : $Klass
-  dealloc_ref [stack] %1 : $Klass
+  dealloc_ref %1 : $Klass
+  dealloc_stack_ref %1 : $Klass
   %3 = tuple ()
   return %3 : $()
 }
@@ -126,7 +127,7 @@ bb0:
   %1 = alloc_ref [stack] $Klass
   set_deallocating %1 : $Klass
   fix_lifetime %1 : $Klass
-  dealloc_ref [stack] %1 : $Klass
+  dealloc_stack_ref %1 : $Klass
   %3 = tuple ()
   return %3 : $()
 }
@@ -142,7 +143,8 @@ bb0:
   %1 = alloc_ref [stack] $Klass
   set_deallocating %1 : $Klass
   fix_lifetime %1 : $Klass
-  dealloc_ref [stack] %1 : $Klass
+  dealloc_ref %1 : $Klass
+  dealloc_stack_ref %1 : $Klass
   %3 = tuple ()
   return %3 : $()
 }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -2383,7 +2383,8 @@ bb0:
   %f = function_ref @readonly_owned : $@convention(thin) (@owned B) -> @owned B
   %3a = copy_value %3 : $B
   %r = apply %f(%3a) : $@convention(thin) (@owned B) -> @owned B
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   destroy_value %r : $B
   %10 = tuple ()
   return %10 : $()
@@ -2391,9 +2392,9 @@ bb0:
 
 // CHECK-LABEL: sil [ossa] @dont_delete_readonly_function_dealloc_ref_multibb :
 // CHECK:      apply
-// CHECK:      dealloc_ref
+// CHECK:      dealloc_stack_ref
 // CHECK-NEXT: destroy_value
-// CHECK:      dealloc_ref
+// CHECK:      dealloc_stack_ref
 // CHECK-NEXT: destroy_value
 // CHECK:      return
 // CHECK: } // end sil function 'dont_delete_readonly_function_dealloc_ref_multibb'
@@ -2406,12 +2407,14 @@ bb0:
   cond_br undef, bb1, bb2
 
 bb1:
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   destroy_value %r : $B
   br bb3
 
 bb2:
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   destroy_value %r : $B
   br bb3
 
@@ -2430,7 +2433,8 @@ bb0:
   %3a = copy_value %3 : $B
   %r = apply %f(%3a) : $@convention(thin) (@owned B) -> @owned B
   destroy_value %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   %10 = tuple ()
   return %10 : $()
 }
@@ -2448,12 +2452,14 @@ bb0:
 
 bb1:
   destroy_value %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   br bb3
 
 bb2:
   destroy_value %r : $B
-  dealloc_ref [stack] %3 : $B
+  dealloc_ref %3 : $B
+  dealloc_stack_ref %3 : $B
   br bb3
 
 bb3:
@@ -3943,7 +3949,8 @@ sil [ossa] @remove_unused_alloc_ref_stack : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
   set_deallocating %1 : $B
-  dealloc_ref [stack] %1 : $B
+  dealloc_ref %1 : $B
+  dealloc_stack_ref %1 : $B
   %3 = tuple ()
   return %3 : $()
 }

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1287,7 +1287,7 @@ bb5:
   br bb6
 
 bb6:
-  dealloc_ref [stack] %a : $Base
+  dealloc_stack_ref %a : $Base
   %r = tuple()
   return %r : $()
 }

--- a/test/SILOptimizer/simplify_cfg_checkcast.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast.sil
@@ -324,7 +324,7 @@ bb5(%2a : @guaranteed $Base):
   br bb6
 
 bb6:
-  dealloc_ref [stack] %a : $Base
+  dealloc_stack_ref %a : $Base
   %r = tuple()
   return %r : $()
 }

--- a/test/SILOptimizer/sink.sil
+++ b/test/SILOptimizer/sink.sil
@@ -191,8 +191,8 @@ sil @takeY : $@convention(thin) (@guaranteed Y) -> ()
 //CHECK-LABEL: sil @dont_sink_stack_allocs
 //CHECK: alloc_ref [stack] $X
 //CHECK: alloc_ref [stack] $Y
-//CHECK: dealloc_ref [stack] %{{[0-9]+}}  : $Y
-//CHECK: dealloc_ref [stack] %{{[0-9]+}}  : $X
+//CHECK: dealloc_stack_ref %{{[0-9]+}}  : $Y
+//CHECK: dealloc_stack_ref %{{[0-9]+}}  : $X
 //CHECK: return
 sil @dont_sink_stack_allocs : $@convention(thin) () -> () {
 bb0:
@@ -204,9 +204,9 @@ bb0:
 
 bb1:
   strong_release %1 : $Y
-  dealloc_ref [stack] %1  : $Y
+  dealloc_stack_ref %1  : $Y
   strong_release %0 : $X
-  dealloc_ref [stack] %0  : $X
+  dealloc_stack_ref %0  : $X
 
   %4 = tuple ()
   return %4 : $()

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -47,7 +47,7 @@ sil @consume_int : $@convention(thin) (Int32) -> ()
 // CHECK-LABEL: sil @simple_promote
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack] [[O]] : $XX
+// CHECK: dealloc_stack_ref [[O]] : $XX
 // CHECK: return
 sil @simple_promote : $@convention(thin) () -> Int32 {
 bb0:
@@ -99,8 +99,8 @@ bb2:
 // CHECK: [[X:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: [[Y:%[0-9]+]] = alloc_ref [stack] $YY
 // CHECK: apply
-// CHECK: dealloc_ref [stack] [[Y]] : $YY
-// CHECK: dealloc_ref [stack] [[X]] : $XX
+// CHECK: dealloc_stack_ref [[Y]] : $YY
+// CHECK: dealloc_stack_ref [[X]] : $XX
 // CHECK: return
 sil @promote_nested : $@convention(thin) () -> () {
 bb0:
@@ -121,7 +121,7 @@ bb0:
 // CHECK-NEXT: unreachable
 // CHECK: bb2:
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack] [[O]] : $XX
+// CHECK: dealloc_stack_ref [[O]] : $XX
 // CHECK: return
 sil @promote_with_unreachable_block : $@convention(thin) () -> Int32 {
 bb0:
@@ -162,10 +162,10 @@ bb1:
 // CHECK:        [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK:      bb2:
 // CHECK:        strong_release
-// CHECK-NEXT:   dealloc_ref [stack] [[O]] : $XX
+// CHECK-NEXT:   dealloc_stack_ref [[O]] : $XX
 // CHECK:      bb3:
 // CHECK-NEXT:   strong_release
-// CHECK-NEXT:   dealloc_ref [stack] [[O]] : $XX
+// CHECK-NEXT:   dealloc_stack_ref [[O]] : $XX
 // CHECK: return
 sil @promote_in_loop_with_if : $@convention(thin) () -> Int32 {
 bb0:
@@ -225,7 +225,7 @@ bb2:
 // CHECK-NOT: dealloc_ref
 // CHECK: bb2:
 // CHECK:   apply
-// CHECK:   dealloc_ref [stack] [[Y]] : $YY
+// CHECK:   dealloc_stack_ref [[Y]] : $YY
 // CHECK:   return
 sil @dont_promote_use_of_container_outside_loop : $@convention(thin) () -> () {
 bb0:
@@ -268,7 +268,7 @@ bb2:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: {{^}}bb2:
 // CHECK-NEXT: strong_release
-// CHECK-NEXT: dealloc_ref [stack] [[O]] : $XX
+// CHECK-NEXT: dealloc_stack_ref [[O]] : $XX
 // CHECK-NEXT: return
 sil @promote_with_use_in_loop : $@convention(thin) () -> Int32 {
 bb0:
@@ -293,7 +293,7 @@ bb2:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: {{^}}bb4:
 // CHECK-NEXT: strong_release
-// CHECK-NEXT: dealloc_ref [stack] [[O]] : $XX
+// CHECK-NEXT: dealloc_stack_ref [[O]] : $XX
 // CHECK-NEXT: return
 sil @promote_with_use_in_multi_block_backedge_loop : $@convention(thin) () -> Int32 {
 bb0:
@@ -324,7 +324,7 @@ bb4:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: {{^}}bb5:
 // CHECK-NEXT: dealloc_stack
-// CHECK-NEXT: dealloc_ref [stack] [[O]] : $XX
+// CHECK-NEXT: dealloc_stack_ref [[O]] : $XX
 // CHECK-NEXT: return
 sil @promote_with_other_stack_allocs : $@convention(thin) () -> Int32 {
 bb0:
@@ -361,7 +361,7 @@ bb5:
 // CHECK: {{^}}bb2:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] $XX
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack] [[O]] : $XX
+// CHECK: dealloc_stack_ref [[O]] : $XX
 // CHECK: dealloc_stack
 // CHECK: return
 sil @promote_and_fix_stack_nesting1 : $@convention(thin) () -> Int32 {
@@ -388,7 +388,7 @@ bb2:
 // CHECK-NEXT: alloc_ref [stack] $XX
 // CHECK: {{^}}bb3:
 // CHECK: strong_release
-// CHECK-NEXT: dealloc_ref [stack]
+// CHECK-NEXT: dealloc_stack_ref
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: return
 sil @promote_and_fix_stack_nesting2 : $@convention(thin) () -> Int32 {
@@ -419,7 +419,7 @@ bb3:
 // CHECK: {{^}}bb2:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] [tail_elems{{.*}}] $XX
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: dealloc_stack
 // CHECK: return
 sil @promote_and_fix_stack_nesting3 : $@convention(thin) () -> Int32 {
@@ -447,7 +447,7 @@ bb2:
 // CHECK: {{^}}bb2:
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] [tail_elems{{.*}}] $XX
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: dealloc_stack
 // CHECK: return
 sil @promote_and_fix_stack_nesting4 : $@convention(thin) () -> Int32 {
@@ -475,7 +475,7 @@ bb2:
 // CHECK: {{^}}bb2({{.*}}):
 // CHECK: [[O:%[0-9]+]] = alloc_ref [stack] [tail_elems{{.*}}] $XX
 // CHECK: strong_release
-// CHECK: dealloc_ref [stack]
+// CHECK: dealloc_stack_ref
 // CHECK: dealloc_stack
 // CHECK: return
 sil @promote_and_fix_stack_nesting5 : $@convention(thin) (Builtin.Word) -> Int32 {
@@ -505,7 +505,7 @@ bb2(%i : $Builtin.Word):
 // CHECK: tuple_extract [[A]]
 // CHECK: [[TAF:%[0-9]+]] = function_ref @take_array
 // CHECK: apply [[TAF]]
-// CHECK: dealloc_ref [stack] [[B]]
+// CHECK: dealloc_stack_ref [[B]]
 // CHECK: return
 sil @promote_array : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
@@ -586,7 +586,7 @@ bb0(%0 : $Array<Int>):
 // CHECK: [[AV:%.*]] = tuple_extract [[A]]{{.*}}, 0
 // CHECK: tuple_extract [[A]]
 // CHECK: store [[AV]] to [[ARR]]
-// CHECK: dealloc_ref [stack] [[B]]
+// CHECK: dealloc_stack_ref [[B]]
 // CHECK: return
 
 sil @promote_array_withUnsafeMutableBufferPointer_use : $@convention(thin) (Int, @owned @callee_owned (@inout Int) -> (@out (), @error Error)) -> () {
@@ -693,7 +693,7 @@ bb0(%0 : $Int):
 // CHECK: [[AV:%.*]] = tuple_extract [[A]]{{.*}}, 0
 // CHECK: tuple_extract [[A]]
 // CHECK: store [[AV]] to [[ARR]]
-// CHECK: dealloc_ref [stack] [[B]]
+// CHECK: dealloc_stack_ref [[B]]
 // CHECK: return
 
 sil @promote_array_withUnsafeMutableBufferPointer_capture : $@convention(thin) (Int, @owned Array<Int>) -> () {
@@ -745,13 +745,13 @@ bb0(%0 : $Int, %another: $Array<Int>):
 
 // CHECK-LABEL: sil @promote_with_unreachable_block_nest_bug
 // CHECK: bb3:
-// CHECK: dealloc_ref [stack] %{{.*}}
+// CHECK: dealloc_stack_ref %{{.*}}
 // CHECK: bb4:
 // CHECK: br bb5
 // CHECK: bb5:
-// CHECK: dealloc_ref [stack] %{{.*}}
+// CHECK: dealloc_stack_ref %{{.*}}
 // CHECK: bb6:
-// CHECK: dealloc_ref [stack] %{{.*}}
+// CHECK: dealloc_stack_ref %{{.*}}
 // CHECK: bb11:
 // CHECK: alloc_ref [stack] $XX
 // CHECK: return

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -678,8 +678,8 @@ sil [transparent] [serialized] @test_stack_flag : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_ref [stack] $Class1
   %0 = alloc_ref [stack] $Class1
-  // CHECK: dealloc_ref [stack] %0 : $Class1
-  dealloc_ref [stack] %0 : $Class1
+  // CHECK: dealloc_stack_ref %0 : $Class1
+  dealloc_stack_ref %0 : $Class1
   %2 = tuple ()
   return %2 : $()
 }

--- a/utils/vim/syntax/sil.vim
+++ b/utils/vim/syntax/sil.vim
@@ -86,7 +86,7 @@ syn keyword swiftKeyword break case continue default do else for if in static sw
 syn keyword swiftKeyword sil internal thunk skipwhite
 syn keyword swiftKeyword public hidden private shared public_external hidden_external skipwhite
 syn keyword swiftKeyword getter setter allocator initializer enumelt destroyer globalaccessor objc skipwhite
-syn keyword swiftKeyword alloc_global alloc_stack alloc_ref alloc_ref_dynamic alloc_box alloc_existential_box dealloc_stack dealloc_box dealloc_existential_box dealloc_ref dealloc_partial_ref skipwhite
+syn keyword swiftKeyword alloc_global alloc_stack alloc_ref alloc_ref_dynamic alloc_box alloc_existential_box dealloc_stack dealloc_stack_ref dealloc_box dealloc_existential_box dealloc_ref dealloc_partial_ref skipwhite
 syn keyword swiftKeyword debug_value debug_value_addr skipwhite
 syn keyword swiftKeyword load load_unowned store assign mark_uninitialized mark_function_escape copy_addr destroy_addr index_addr index_raw_pointer bind_memory to skipwhite
 syn keyword swiftKeyword strong_retain strong_release strong_retain_unowned ref_to_unowned unowned_to_ref unowned_retain unowned_release load_weak store_unowned store_weak fix_lifetime autorelease_value set_deallocating is_unique is_escaping_closure skipwhite


### PR DESCRIPTION
The blocker for enabling StackPromotion for OSSA was that the ownership of `dealloc_ref [stack]` was wrong. It should have `NonUse` ownership, because it's just an end-of-lifetime marker for an `alloc_ref [stack]`.

Also, the instruction syntax `dealloc_ref [stack]` is very confusing, because it does not do anything like a deallocation.
It's renamed to `dealloc_stack_ref `, which better describes its purpose.

Renaming means: removed the `[stack]` flag from `dealloc_ref` and introduced a new instruction `dealloc_stack_ref ` (with correct operand ownership of `NonUse`)