### PR TITLE
Concurrency: avoid unnecessary dependency on LLVMSupport

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -36,9 +36,7 @@
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Actor.h"
 #include "swift/Basic/ListMerger.h"
-#ifndef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
-#include "llvm/Config/config.h"
-#else
+#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
 // All platforms where we care about back deployment have a known
 // configurations.
 #define HAVE_PTHREAD_H 1
@@ -72,7 +70,7 @@
 #include <sys/syscall.h>
 #endif
 
-#if HAVE_PTHREAD_H
+#if defined(_POSIX_THREADS)
 #include <pthread.h>
 
 // Only use __has_include since HAVE_PTHREAD_NP_H is not provided.


### PR DESCRIPTION
We do not have the `llvm/Config/config.h` header available in the forked
LLVMSupport library in our standard library packaging.  This removes
that dependency by using the standard macro `_POSIX_THREADS` to detect
if we should use pthreads.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
