### PR TITLE
DependencyScan: properly escape `\` in JSON strings

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -332,6 +332,19 @@ static void discoverCrosssImportOverlayDependencies(
                 allModules.end(), action);
 }
 
+namespace {
+std::string quote(StringRef unquoted) {
+  llvm::SmallString<128> buffer;
+  llvm::raw_svector_ostream os(buffer);
+  for (const auto ch : unquoted) {
+    if (ch == '\\')
+      os << '\\';
+    os << ch;
+  }
+  return buffer.str().str();
+}
+}
+
 /// Write a single JSON field.
 template <typename T>
 void writeJSONSingleField(llvm::raw_ostream &out, StringRef fieldName,
@@ -342,14 +355,14 @@ void writeJSONSingleField(llvm::raw_ostream &out, StringRef fieldName,
 void writeJSONValue(llvm::raw_ostream &out, StringRef value,
                     unsigned indentLevel) {
   out << "\"";
-  out << value;
+  out << quote(value);
   out << "\"";
 }
 
 void writeJSONValue(llvm::raw_ostream &out, swiftscan_string_ref_t value,
                     unsigned indentLevel) {
   out << "\"";
-  out << get_C_string(value);
+  out << quote(get_C_string(value));
   out << "\"";
 }
 
@@ -615,7 +628,7 @@ static void writeJSON(llvm::raw_ostream &out,
           const auto &arg =
               get_C_string(swiftTextualDeps->command_line->strings[i]);
           out.indent(6 * 2);
-          out << "\"" << arg << "\"";
+          out << "\"" << quote(arg) << "\"";
           if (i != count - 1)
             out << ",";
           out << "\n";
@@ -630,7 +643,7 @@ static void writeJSON(llvm::raw_ostream &out,
           const auto &candidate = get_C_string(
               swiftTextualDeps->compiled_module_candidates->strings[i]);
           out.indent(6 * 2);
-          out << "\"" << candidate << "\"";
+          out << "\"" << quote(candidate) << "\"";
           if (i != count - 1)
             out << ",";
           out << "\n";
@@ -654,7 +667,7 @@ static void writeJSON(llvm::raw_ostream &out,
           const auto &arg =
               get_C_string(swiftTextualDeps->extra_pcm_args->strings[i]);
           out.indent(6 * 2);
-          out << "\"" << arg << "\"";
+          out << "\"" << quote(arg) << "\"";
           if (i != count - 1)
             out << ",";
           out << "\n";

--- a/test/ScanDependencies/escaped.swift
+++ b/test/ScanDependencies/escaped.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies %s -I %S\\Inputs -o - | %FileCheck %s
+
+// We want to explicitly use the Windows path separator
+// REQUIRES: OS=windows-msvc
+
+import A
+
+// CHECK:        "modulePath": "escaped.swiftmodule",
+// CHECK-NEXT:   "sourceFiles": [
+// CHECK-NEXT:      "{{.*}}\\test\\ScanDependencies\\escaped.swift"
+// CHECK-NEXT:   ],


### PR DESCRIPTION
The Windows uses `\` as a path separator, which is not permitted within
a JSON string without escaping.  This corrects the encoding of the path
separator in the emitted dependency information.  This issue was found
through the swift-driver test suite.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
