### PR TITLE
Disable Flaky Compiler Crasher Test

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
@@ -1,4 +1,6 @@
 // RUN: %target-build-swift %s
+// Every so often, this test causes the linker to crash!
+// REQUIRES: rdar86041709
 
 // SR-13933: Fix "multiple consuming users" ownership error caused by
 // `VJPCloner::visitApply` related to `@differentiable`-function-typed callees.


### PR DESCRIPTION
This test appears to cause the linker to crash every so often.

rdar://86041709