### PR TITLE
[ConstraintSystem] New "stable" disjunction selection algorithm

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5033,6 +5033,9 @@ private:
   ///
   /// \returns The selected disjunction.
   Constraint *selectDisjunction();
+  /// Select the best possible disjunction for solver to attempt
+  /// based on the given list.
+  Constraint *selectBestDisjunction(ArrayRef<Constraint *> disjunctions);
 
   /// Pick a conjunction from the InactiveConstraints list.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2251,6 +2251,7 @@ public:
   friend class SplitterStep;
   friend class ComponentStep;
   friend class TypeVariableStep;
+  friend class DisjunctionStep;
   friend class ConjunctionStep;
   friend class ConjunctionElement;
   friend class RequirementFailure;
@@ -2401,6 +2402,10 @@ private:
   /// The set of remembered disjunction choices used to reach
   /// the current constraint system.
   llvm::MapVector<ConstraintLocator *, unsigned> DisjunctionChoices;
+
+  /// The stack of all disjunctions selected during current path in order.
+  /// This stack is managed by the \c DisjunctionStep.
+  llvm::SmallVector<Constraint *, 4> SelectedDisjunctions;
 
   /// A map from applied disjunction constraints to the corresponding
   /// argument function type.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10401,6 +10401,24 @@ retry_after_fail:
           }
         }
 
+        // Disabled overloads need special handling depending mode.
+        if (constraint->isDisabled()) {
+          // In diagnostic mode, invalidate previous common result type if
+          // current overload choice has a fix to make sure that we produce
+          // the best diagnostics possible.
+          if (shouldAttemptFixes()) {
+            if (constraint->getFix())
+              commonResultType = ErrorType::get(getASTContext());
+            return true;
+          }
+
+          // In performance mode, let's skip the disabled overload choice
+          // and continue - this would make sure that common result type
+          // could be found if one exists among the overloads the solver
+          // is actually going to attempt.
+          return false;
+        }
+
         // Determine the type that this choice will have.
         Type choiceType = getEffectiveOverloadType(
             constraint->getLocator(), choice, /*allowMembers=*/true,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10428,6 +10428,34 @@ retry_after_fail:
           return true;
         }
 
+        // This is the situation where a property has the same name
+        // as a method e.g.
+        //
+        // protocol P {
+        //   var test: String { get }
+        // }
+        //
+        // extension P {
+        //   var test: String { get { return "" } }
+        // }
+        //
+        // struct S : P {
+        //  func test() -> Int { 42 }
+        // }
+        //
+        // var s = S()
+        // s.test() <- disjunction would have two choices here, one
+        //             for the property from `P` and one for the method of `S`.
+        //
+        // In cases like this, let's exclude property overload from common
+        // result determination because it cannot be applied.
+        //
+        // Note that such overloads cannot be disabled, because they still
+        // have to be checked in diagnostic mode and there is (currently)
+        // no way to re-enable them for diagnostics.
+        if (!choiceType->lookThroughAllOptionalTypes()->is<FunctionType>())
+          return true;
+
         // If types lined up exactly, let's favor this overload choice.
         if (Type(argFnType)->isEqual(choiceType))
           constraint->setFavored();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2190,8 +2190,15 @@ ConstraintSystem::selectBestDisjunction(ArrayRef<Constraint *> disjunctions) {
         unsigned firstFavored = first->countFavoredNestedConstraints();
         unsigned secondFavored = second->countFavoredNestedConstraints();
 
-        if (!isOperatorDisjunction(first) || !isOperatorDisjunction(second))
+        if (!isOperatorDisjunction(first) || !isOperatorDisjunction(second)) {
+          // If one of the sides has favored overloads, let's prefer it
+          // since it's a strong enough signal that there is something
+          // known about the arguments associated with the call.
+          if (firstFavored == 0 || secondFavored == 0)
+            return firstFavored > secondFavored;
+
           return firstActive < secondActive;
+        }
 
         if (firstFavored == secondFavored) {
           // Look for additional choices that are "favored"

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1662,8 +1662,9 @@ ConstraintSystem::filterDisjunction(
 // right-hand side of a conversion constraint, since having a concrete
 // type that we're converting to can make it possible to split the
 // constraint system into multiple ones.
-static Constraint *selectBestBindingDisjunction(
-    ConstraintSystem &cs, SmallVectorImpl<Constraint *> &disjunctions) {
+static Constraint *
+selectBestBindingDisjunction(ConstraintSystem &cs,
+                             ArrayRef<Constraint *> disjunctions) {
 
   if (disjunctions.empty())
     return nullptr;
@@ -2169,6 +2170,13 @@ Constraint *ConstraintSystem::selectDisjunction() {
   collectDisjunctions(disjunctions);
   if (disjunctions.empty())
     return nullptr;
+
+  return selectBestDisjunction(disjunctions);
+}
+
+Constraint *
+ConstraintSystem::selectBestDisjunction(ArrayRef<Constraint *> disjunctions) {
+  assert(!disjunctions.empty());
 
   if (auto *disjunction = selectBestBindingDisjunction(*this, disjunctions))
     return disjunction;

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -653,6 +653,7 @@ public:
     assert(Disjunction->getKind() == ConstraintKind::Disjunction);
     pruneOverloadSet(Disjunction);
     ++cs.solverState->NumDisjunctions;
+    cs.SelectedDisjunctions.push_back(Disjunction);
   }
 
   ~DisjunctionStep() override {
@@ -663,6 +664,8 @@ public:
     // Re-enable previously disabled overload choices.
     for (auto *choice : DisabledChoices)
       choice->setEnabled();
+
+    CS.SelectedDisjunctions.pop_back();
   }
 
   StepResult resume(bool prevFailed) override;

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -448,8 +448,8 @@ struct Struct123: Equatable {
 }
 func testBestSolutionFilter() {
   let a = Struct123();
-  let b = [Struct123]().first(where: { $0 == a && 1 + 90 * 5 / 8 == 45 * -10 })?.structMem != .#^BEST_SOLUTION_FILTER?xfail=rdar73282163^#
-  let c = min(10.3, 10 / 10.4) < 6 / 7 ? true : Optional(a)?.structMem != .#^BEST_SOLUTION_FILTER2?check=BEST_SOLUTION_FILTER;xfail=rdar73282163^#
+  let b = [Struct123]().first(where: { $0 == a && 1 + 90 * 5 / 8 == 45 * -10 })?.structMem != .#^BEST_SOLUTION_FILTER^#
+  min(10.3, 10 / 10.4) < 6 / 7 ? true : Optional(a)?.structMem != .#^BEST_SOLUTION_FILTER2?check=BEST_SOLUTION_FILTER^#
 }
 
 // BEST_SOLUTION_FILTER: Begin completions

--- a/validation-test/Sema/type_checker_perf/fast/mixed_double_and_float_operators.swift
+++ b/validation-test/Sema/type_checker_perf/fast/mixed_double_and_float_operators.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink
+// REQUIRES: OS=macosx,tools-release,no_asan
+
+import Foundation
+
+var r: Float  = 0
+var x: Double = 0
+var y: Double = 0
+
+let _ = (1.0 - 1.0 / (1.0 + exp(-5.0 * (r - 0.05)/0.01))) * Float(x) + Float(y)

--- a/validation-test/Sema/type_checker_perf/fast/property_and_methods_with_same_name.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/property_and_methods_with_same_name.swift.gyb
@@ -1,0 +1,30 @@
+// RUN: %scale-test --begin 1 --end 10  --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+func test(_: [A]) {}
+
+class A {}
+
+protocol P {
+  var arr: Int { get }
+}
+
+extension P {
+  var arr: Int { get { return 42 } }
+}
+
+class S : P {
+  func arr() -> [A] { [] }
+  func arr(_: Int = 42) -> [A] { [] }
+}
+
+// There is a clash between `arr` property and `arr` methods
+// returning `[A]` which shouldn't prevent "common result"
+// determination.
+func run_test(s: S) {
+  test(s.arr() +
+       %for i in range(0, N):
+       s.arr() +
+       %end
+       s.arr())
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar23682605.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23682605.swift
@@ -14,7 +14,6 @@ func memoize<T: Hashable, U>( body: @escaping ((T)->U, T)->U ) -> (T)->U {
 }
 
 let fibonacci = memoize {
-  // expected-error@-1 {{reasonable time}}
   fibonacci, n in
   n < 2 ? Double(n) : fibonacci(n - 1) + fibonacci(n - 2)
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46713933_literal_arg.swift
@@ -8,5 +8,4 @@ func wrap<T: ExpressibleByStringLiteral>(_ key: String, _ value: T) -> T { retur
 
 func wrapped() -> Int {
   return wrap("1", 1) + wrap("1", 1) + wrap("1", 1) + wrap("1", 1) + wrap("1", 1) + wrap("1", 1)
-  // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}
 }

--- a/validation-test/Sema/type_checker_perf/fast/sr10130.swift
+++ b/validation-test/Sema/type_checker_perf/fast/sr10130.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+import Foundation
+
+let itemsPerRow = 10
+let size: CGFloat = 20
+let margin: CGFloat = 10
+
+let _ = (0..<100).map { (row: CGFloat($0 / itemsPerRow), col: CGFloat($0 % itemsPerRow)) }
+                 .map {
+                        CGRect(x: $0.col * (size + margin) + margin,
+                               y: $0.row * (size + margin) + margin,
+                               width: size,
+                               height: size)
+                 }


### PR DESCRIPTION
 Prelude.

 The core idea behind `shrink` is simple - reduce overload sets via
  a bottom-up walk'n'solve that would utilize previously discovered
  solutions along the way. This helps in some circumstances but requires
  rollbacks and AST modification (if choices produced by previous steps
  fail to produce solutions higher up). For some expressions, especially
  ones with multiple generic overload sets, `shrink` is actively harmful
  because it would never be able to produce useful results.

  The Algorithm.

  These changes integrate core idea of local information propagation
  from `shrink` into the disjunction selection algorithm itself.

  The algorithm itself is as follows - at the beginning use existing
  selection algorithm (based on favoring, active choices, etc.) to
  select the first disjunction to attempt, and push it to the stack
  of "selected" disjunctions; next time solver requests a disjunction,
  use the last selected one to pick the closest disjunction to it in
  the AST order preferring parents over children.

  For example:

  ```
           +
         /   \
       *     Float(<some variable e.g. `r` = 10))
     /  \
   exp   Float(1.0)
    |
   2.0
  ```

  If solver starts by picking `Float(r)` first, it would then
  attempt `+`, `exp` in that order. If it did pick `Float(1.0)`
  then, the sequence is `*`, `+` and finally `exp`.

  Since the main idea here to is keep everything as local as possible
  along a given path, that means special handling for closures and tuples:

  - Closures: if last disjunction is a call with a trailing closure argument,
    and such argument is resolved (constraint are generate for the body) -
    use selection algorithm to peek next disjunction from the body of the
    closure, and solve everything inside before moving to the next member
    in the chain (if any). This helps with linked member expressions e.g.
    `.map { ... }.filter { ... }.reduce { ... }`;

  - Tuples: The idea here is to keep solving local to a current element
    until it runs out of disjunction, and then use selection algorithm to
    peek from the pool of disjunctions associated with other elements of
    the tuple.

Resolves: SR-10130
Resolves: rdar://48992848
Resolves: rdar://23682605
Resolves: rdar://46713933

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
