### PR TITLE
🍒 [5.5] Add Initializers' AFPs

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1196,9 +1196,12 @@ public:
     return entity;
   }
 
-  static LinkEntity forAsyncFunctionPointer(AbstractFunctionDecl *decl) {
+  static LinkEntity forAsyncFunctionPointer(SILDeclRef declRef) {
     LinkEntity entity;
-    entity.setForDecl(Kind::AsyncFunctionPointerAST, decl);
+    entity.setForDecl(Kind::AsyncFunctionPointerAST,
+                      declRef.getAbstractFunctionDecl());
+    entity.SecondaryPointer =
+        reinterpret_cast<void *>(static_cast<uintptr_t>(declRef.kind));
     return entity;
   }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -462,7 +462,10 @@ std::string LinkEntity::mangleAsString() const {
 
   case Kind::AsyncFunctionPointerAST: {
     std::string Result;
-    Result = SILDeclRef(const_cast<ValueDecl *>(getDecl())).mangle();
+    Result = SILDeclRef(const_cast<ValueDecl *>(getDecl()),
+                        static_cast<SILDeclRef::Kind>(
+                            reinterpret_cast<uintptr_t>(SecondaryPointer)))
+                 .mangle();
     Result.append("Tu");
     return Result;
   }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -426,15 +426,14 @@ void TBDGenVisitor::addSymbol(SILDeclRef declRef) {
   addSymbol(declRef.mangle(), SymbolSource::forSILDeclRef(declRef));
 }
 
-void TBDGenVisitor::addAsyncFunctionPointerSymbol(AbstractFunctionDecl *AFD) {
-  auto declRef = SILDeclRef(AFD);
+void TBDGenVisitor::addAsyncFunctionPointerSymbol(SILDeclRef declRef) {
   auto silLinkage = effectiveLinkageForClassMember(
     declRef.getLinkage(ForDefinition),
     declRef.getSubclassScope());
   if (Opts.PublicSymbolsOnly && silLinkage != SILLinkage::Public)
     return;
 
-  auto entity = LinkEntity::forAsyncFunctionPointer(AFD);
+  auto entity = LinkEntity::forAsyncFunctionPointer(declRef);
   auto linkage =
       LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
   addSymbol(linkage.getName(), SymbolSource::forSILDeclRef(declRef));
@@ -753,7 +752,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   visitDefaultArguments(AFD, AFD->getParameters());
 
   if (AFD->hasAsync()) {
-    addAsyncFunctionPointerSymbol(AFD);
+    addAsyncFunctionPointerSymbol(SILDeclRef(AFD));
   }
 }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -999,6 +999,10 @@ void TBDGenVisitor::visitConstructorDecl(ConstructorDecl *CD) {
     // default ValueDecl handling gives the allocating one, so we have to
     // manually include the non-allocating one.
     addSymbol(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+    if (CD->hasAsync()) {
+      addAsyncFunctionPointerSymbol(
+          SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+    }
     if (auto parentClass = CD->getParent()->getSelfClassDecl()) {
       if (parentClass->isObjC() || CD->isObjC())
         recorder.addObjCMethod(parentClass, SILDeclRef(CD));

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -122,7 +122,7 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
                  SymbolKind kind = SymbolKind::GlobalSymbol);
 
   void addSymbol(SILDeclRef declRef);
-  void addAsyncFunctionPointerSymbol(AbstractFunctionDecl *AFD);
+  void addAsyncFunctionPointerSymbol(SILDeclRef declRef);
 
   void addSymbol(LinkEntity entity);
 

--- a/test/TBD/rdar82045176.swift
+++ b/test/TBD/rdar82045176.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %s -emit-module -module-name thing -emit-tbd -enable-testing -Xfrontend -disable-availability-checking -Xfrontend -validate-tbd-against-ir=all
+
+class Test {
+  init() async { }
+}


### PR DESCRIPTION
**Description:** Previously, the AFPs for initializers were omitted from TBDs. That resulted in a mismatch between the symbols exported from the IR module and the symbols listed in the TBD file. Here that is fixed by adding those symbols to the TBD file. -- This also causes Swift to crash on Linux builds where these assertions are enabled in toolchain builds, causing issues to our Linux adopters.
**Risk:** Low
**Review by:** @DougGregor @nate-chandler 
**Testing:** verified manually on reproducer project provided in SR-15659 (reproduced on 5.5.2, and confirmed Swift with this fix (main) does not exhibit the issue)
**Original PR:** https://github.com/apple/swift/pull/38918 by @nate-chandler
**Radar:** https://bugs.swift.org/browse/SR-15659 rdar://86945821 and rdar://82045176 