### PR TITLE
Eliminate the notion of a "bound signature" for opaque type archetypes.

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -107,12 +107,10 @@ private:
   /// This is only useful when lazily populating a generic environment.
   Optional<Type> getMappingIfPresent(GenericParamKey key) const;
 
-  /// Get the "raw" generic signature, without substituting into opaque
-  /// type's signature.
-  GenericSignature getRawGenericSignature() const;
-
 public:
-  GenericSignature getGenericSignature() const;
+  GenericSignature getGenericSignature() const {
+    return SignatureAndKind.getPointer();
+  }
 
   Kind getKind() const { return SignatureAndKind.getInt(); }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5578,12 +5578,6 @@ public:
   /// Retrieve the set of substitutions applied to the opaque type.
   SubstitutionMap getSubstitutions() const;
 
-  /// Get the generic signature used to build out this archetype. This is
-  /// equivalent to the OpaqueTypeDecl's interface generic signature, with
-  /// all of the generic parameters aside from the opaque type's interface
-  /// type same-type-constrained to their substitutions for this type.
-  GenericSignature getBoundSignature() const;
-  
   /// Get a generic environment that has this opaque archetype bound within it.
   GenericEnvironment *getGenericEnvironment() const;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4592,7 +4592,7 @@ GenericEnvironment *GenericEnvironment::forOpaqueType(
   size_t bytes = totalSizeToAlloc<OpaqueTypeDecl *, SubstitutionMap, Type>(
       1, 1, numGenericParams);
   void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment), arena);
-  auto env = new (mem) GenericEnvironment(GenericSignature(), opaque, subs);
+  auto env = new (mem) GenericEnvironment(signature, opaque, subs);
   return env;
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3314,7 +3314,8 @@ void ASTMangler::appendAnyProtocolConformance(
                                                      conformance.getAbstract());
     appendDependentProtocolConformance(path, genericSig);
   } else if (auto opaqueType = conformingType->getAs<OpaqueTypeArchetypeType>()) {
-    GenericSignature opaqueSignature = opaqueType->getBoundSignature();
+    GenericSignature opaqueSignature =
+        opaqueType->getDecl()->getOpaqueInterfaceGenericSignature();
     ConformanceAccessPath conformanceAccessPath =
         opaqueSignature->getConformanceAccessPath(
           opaqueType->getInterfaceType(),

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3320,10 +3320,6 @@ GenericEnvironment *OpaqueTypeArchetypeType::getGenericEnvironment() const {
   return Environment;
 }
 
-GenericSignature OpaqueTypeArchetypeType::getBoundSignature() const {
-  return getGenericEnvironment()->getGenericSignature();
-}
-
 OpaqueTypeDecl *OpaqueTypeArchetypeType::getDecl() const {
   return Environment->getOpaqueTypeDecl();
 }


### PR DESCRIPTION
The refactoring that moved the substitution of the outer environment
into an opaque type archeptype into the generic environment eliminated
the need for the bound signature entirely, so remove it.
