### PR TITLE
Ensure `SWIFT_DARWIN_PLATFORMS` is defined when loading stdlib options

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -2,6 +2,7 @@ include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/modules/SwiftUtils.cmake)
 precondition(SWIFT_HOST_VARIANT_SDK)
+precondition(SWIFT_DARWIN_PLATFORMS)
 
 if("${SWIFT_HOST_VARIANT_SDK}" MATCHES "CYGWIN")
   set(SWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING_default FALSE)


### PR DESCRIPTION
This was missed when working on #40723 and will prevent
`SWIFT_STDLIB_HAS_ASL` having a wrong default.