### PR TITLE
Always Import FieldDecls from Records

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9866,13 +9866,21 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   llvm::SmallVector<Decl *, 16> members;
   for (const clang::Decl *m : clangRecord->decls()) {
     auto nd = dyn_cast<clang::NamedDecl>(m);
+    if (!nd)
+      continue;
+
     // Currently, we don't import unnamed bitfields.
     if (isa<clang::FieldDecl>(m) &&
         cast<clang::FieldDecl>(m)->isUnnamedBitfield())
       continue;
 
-    if (nd && nd == nd->getCanonicalDecl() &&
-        nd->getDeclContext() == clangRecord &&
+    // Make sure we always pull in record fields. Everything else had better
+    // be canonical. Note that this check mostly catches nested C++ types since
+    // we import nested C struct types by C's usual convention of chucking them
+    // into the global namespace.
+    const bool isCanonicalInContext =
+        (isa<clang::FieldDecl>(nd) || nd == nd->getCanonicalDecl());
+    if (isCanonicalInContext && nd->getDeclContext() == clangRecord &&
         isVisibleClangEntry(nd))
       insertMembersAndAlternates(nd, members);
   }

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -11,9 +11,9 @@ protocol HasReturn42 {
 // CHECK: [[OUT:%.*]] = call i32 @{{_ZN18ConformsToProtocol8return42Ev|"\?return42@ConformsToProtocol@@QEAAHXZ"}}(%struct.ConformsToProtocol*
 // CHECK: ret i32 [[OUT]]
 
-// CHECK: define {{.*}}%swift.metadata_response @"$sSo18ConformsToProtocolVMa"(i64 [[ARG:%.*]])
+// CHECK: define {{.*}}%swift.metadata_response @"$sSo18ConformsToProtocolVMa"({{i64|i32}} [[ARG:%.*]])
 // CHECK: load %swift.type*, %swift.type** @"$sSo18ConformsToProtocolVML"
-// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata(i64 [[ARG]], %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* bitcast (<{ i8**, i64, <{ i32, i32, i32, i32, i32, i32, i32, i32 }>* }>* @"$sSo18ConformsToProtocolVMf" to %swift.full_type*), i32 0, i32 1))
+// CHECK: call swiftcc %swift.metadata_response @swift_getForeignTypeMetadata({{i64|i32}} [[ARG]]
 // CHECK: ret %swift.metadata_response
 
 extension ConformsToProtocol : HasReturn42 {}

--- a/test/Interop/Cxx/templates/class-template-instantiation.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation.swift
@@ -18,7 +18,8 @@ TemplatesTestSuite.test("with-swift-type") {
   expectEqual(wrappedMagicNumber.getValuePlusArg(8), 21)
 }
 
-TemplatesTestSuite.test("with-c++-type-calling-method-on-arg") {
+TemplatesTestSuite.test("with-c++-type-calling-method-on-arg")
+  .skip(.watchOSSimulatorAny("rdar://problem/87262809")).code {
   let i1 = IntWrapper(value: 42)
   let i2 = IntWrapper(value: 12)
   var wrappedMagicNumber = MagicWrapper<IntWrapper>(t: i1)

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -4,7 +4,7 @@ import ClassTemplateInstantiationErrors
 
 // CHECK-LABEL: define {{.*}}void @"$s4main23instantiateValidMembersyyF"()
 // CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
-// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted* {{.*}}, {{i32|i64|\[1 x i32\]|\%struct\.IntWrapper\* byval\(\%struct\.IntWrapper\)}}
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted*
 // CHECK: ret void
 
 // CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*


### PR DESCRIPTION
When we switched this path over to use lazy member loading, a
subsequent commit introduced a check that members were canonical. In
certain extremely twisty scenarios involving multiple modular frameworks
pulling in non-modular headers, this check can fail which results in us
silently dropping these members on the floor.

It's ultimately correct to only pull in the canonical members, but real-world
examples of "system" frameworks evading modularity diagnostics exist so this
is strictly a regression.

Drop the canonicity check for FieldDecls.

rdar://86740970