### PR TITLE
[SwiftSyntax] Avoid linking clangAST in SwiftSyntaxParserLib build

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -570,6 +570,10 @@ static bool isMainActor(Type type) {
 
 void swift::printClangDeclName(const clang::NamedDecl *ND,
                                llvm::raw_ostream &os) {
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return; // not needed for the parser library.
+#endif
+
   ND->getNameForDiagnostic(os, ND->getASTContext().getPrintingPolicy(), false);
 }
 


### PR DESCRIPTION
`printClangDeclName` introduced another use of the clang AST in `swiftAST`, remove it by returning early if we are only building the parser library.