### PR TITLE
[WIP, experimental] Provide interfaces to catch C++ exceptions and translate them to Swift errors

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -151,6 +151,8 @@ WARNING(warn_implicit_concurrency_import_failed,none,
         "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())
 WARNING(warn_implicit_string_processing_import_failed,none,
         "unable to perform implicit import of \"_StringProcessing\" module: no such module found", ())
+WARNING(warn_implicit_exception_handling_import_failed,none,
+        "unable to perform implicit import of \"_ExceptionHandling\" module: no such module found", ())
 
 ERROR(error_module_name_required,none, "-module-name is required", ())
 ERROR(error_bad_module_name,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -147,6 +147,9 @@ namespace swift {
     /// Enable experimental string processing
     bool EnableExperimentalStringProcessing = false;
 
+    /// Enable experimental exception handling
+    bool EnableExperimentalExceptionHandling = false;
+
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -370,6 +370,10 @@ public:
   /// imported.
   bool shouldImportSwiftStringProcessing() const;
 
+  /// Whether the Swift Exception Handling support library should be implicitly
+  /// imported.
+  bool shouldImportSwiftExceptionHandling() const;
+
   /// Performs input setup common to these tools:
   /// sil-opt, sil-func-extractor, sil-llvm-gen, and sil-nm.
   /// Return value includes the buffer so caller can keep it alive.
@@ -557,6 +561,14 @@ public:
   /// Whether the Swift String Processing support library can be imported
   /// i.e. if it can be found.
   bool canImportSwiftStringProcessing() const;
+
+  /// Verify that if an implicit import of the `ExceptionHandling` module if
+  /// expected, it can actually be imported. Emit a warning, otherwise.
+  void verifyImplicitExceptionHandlingImport();
+
+  /// Whether the Swift Exception Handling support library can be imported
+  /// i.e. if it can be found.
+  bool canImportSwiftExceptionHandling() const;
 
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
   /// \returns the primary SourceFile, or nullptr if there is no primary input;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -606,6 +606,11 @@ def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
   HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;
 
+def enable_experimental_exception_handling :
+  Flag<["-"], "enable-experimental-exception-handling">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable Objective-C/C++ exception handling (experimental feature)">;
+
 def experimental_emit_module_separately:
   Flag<["-"], "experimental-emit-module-separately">,
   Flags<[NoInteractiveOption, HelpHidden]>,

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -28,6 +28,8 @@ constexpr static const StringLiteral SWIFT_CONCURRENCY_NAME = "_Concurrency";
 constexpr static const StringLiteral SWIFT_DISTRIBUTED_NAME = "_Distributed";
 /// The name of the StringProcessing module, which supports that extension.
 constexpr static const StringLiteral SWIFT_STRING_PROCESSING_NAME = "_StringProcessing";
+/// The name of the ExceptionHandling module, which supports that extension.
+constexpr static const StringLiteral SWIFT_EXCEPTION_HANDLING_NAME = "_ExceptionHandling";
 /// The name of the SwiftShims module, which contains private stdlib decls.
 constexpr static const StringLiteral SWIFT_SHIMS_NAME = "SwiftShims";
 /// The name of the Builtin module, which contains Builtin functions.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5373,7 +5373,8 @@ void ProtocolDecl::computeKnownProtocolKind() const {
       !module->getName().is("Foundation") &&
       !module->getName().is("_Differentiation") &&
       !module->getName().is("_Concurrency") &&
-      !module->getName().is("_Distributed")) {
+      !module->getName().is("_Distributed") &&
+      !module->getName().is("_ExceptionHandling")) {
     const_cast<ProtocolDecl *>(this)->Bits.ProtocolDecl.KnownProtocol = 1;
     return;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -489,6 +489,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalStringProcessing |=
       Args.hasArg(OPT_enable_experimental_string_processing);
 
+  // Experimental exception handling (automatic if C++ interop is enabled)
+  Opts.EnableExperimentalExceptionHandling |=
+      Args.hasArg(OPT_enable_experimental_exception_handling)
+      || Args.hasArg(OPT_enable_experimental_cxx_interop);
+
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
   Opts.CheckAPIAvailabilityOnly |=

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -109,6 +109,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stubs)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
+  add_subdirectory(ExceptionHandling)
 
   if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
     add_subdirectory(Differentiation)

--- a/stdlib/public/ExceptionHandling/CMakeLists.txt
+++ b/stdlib/public/ExceptionHandling/CMakeLists.txt
@@ -1,0 +1,49 @@
+#===--- CMakeLists.txt - Concurrency support library ---------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2019 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+set(swift_exception_handling_link_libraries
+  swiftCore)
+
+set(swift_exception_handling_c_compile_flags)
+if(SWIFT_COMPILER_IS_MSVC_LIKE)
+  list(APPEND swift_exception_handling_c_compile_flags
+    /EHa
+    /GR)
+else()
+  list(APPEND swift_exception_handling_c_compile_flags
+    -fexceptions
+    -frtti)
+endif()
+
+add_swift_target_library(swift_ExceptionHandling ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  ExceptionHandling.cpp
+  ExceptionHandling.mm
+  ExceptionHandling.swift
+
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_OPENBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_MODULE_DEPENDS_WINDOWS CRT
+
+  LINK_LIBRARIES ${swift_exception_handling_link_libraries}
+
+  C_COMPILE_FLAGS
+    -Dswift_ExceptionHandling_EXPORTS
+    ${swift_exception_handling_c_compile_flags}
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -parse-stdlib
+
+  INSTALL_IN_COMPONENT stdlib
+)

--- a/stdlib/public/ExceptionHandling/ExceptionHandling.cpp
+++ b/stdlib/public/ExceptionHandling/ExceptionHandling.cpp
@@ -1,0 +1,370 @@
+//===--- ExceptionHandling.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ExceptionHandling.h"
+
+#include <cstring>
+#include <memory>
+
+#if __has_include(<cxxabi.h>)
+#include <cxxabi.h>
+#endif
+
+#if defined(_MSC_VER)
+#include <ehdata.h>
+#endif
+
+#include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/Portability.h"
+#include "../runtime/ImageInspection.h"
+
+// NOTE: swift_slowDealloc() calls free() (or on Apple, an equivalent function)
+// when alignment is small, so it should be okay to treat malloc()-allocated
+// C strings as safe to pass to swift_slowDealloc().
+
+std::exception_ptr *swift::_swift_exceptionPointerCopyCurrent(void) {
+  if (auto ep = std::current_exception()) {
+    return _swift_exceptionPointerCopy(&ep);
+  }
+  return nullptr;
+}
+
+std::exception_ptr *
+swift::_swift_exceptionPointerCopy(const std::exception_ptr *ep) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return nullptr;
+  }
+
+  // Avoid using operator new() here because the exception might be
+  // related to an operator new() failure. Use good ol' slowAlloc and
+  // placement new instead.
+  auto result = reinterpret_cast<std::exception_ptr *>(
+    swift_slowAlloc(sizeof(std::exception_ptr),
+                    alignof(std::exception_ptr) - 1)
+  );
+  if (result) {
+    new (result) std::exception_ptr(*ep);
+  }
+
+  return result;
+}
+
+void swift::_swift_exceptionPointerDelete(std::exception_ptr *ep) {
+  // As with _swift_exceptionPointerCopyCurrent(), avoid using delete here.
+  // Directly call the destructor and then deallocate the exception pointer
+  // manually.
+  if (!ep) {
+    return;
+  }
+
+  ep->~exception_ptr();
+  swift_slowDealloc(ep, sizeof(std::exception_ptr),
+                    alignof(std::exception_ptr) - 1);
+}
+
+bool swift::_swift_exceptionPointerIsNil(const std::exception_ptr *ep) {
+  return (!ep || !*ep);
+}
+
+#pragma mark - Converting to other exception types
+
+#if defined(_WIN32)
+bool swift::_swift_exceptionPointerGetThrownExceptionRecord(
+  const std::exception_ptr *ep, EXCEPTION_RECORD *outER) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return false;
+  }
+
+  try {
+    std::rethrow_exception(*ep);
+  } catch (const EXCEPTION_RECORD& exceptionRecord) {
+    *outER = exceptionRecord;
+    return true;
+  } catch (...) {
+    // Not a Windows structured exception.
+  }
+
+  return false;
+}
+#endif
+
+#pragma mark - Stringifying exceptions
+
+namespace swift {
+/// Get the mangled name of the specified exception's type, if possible.
+///
+/// \param ep A pointer to a previously-thrown exception.
+///
+/// \returns The mangled name of the thrown exception's type, or \c nullptr if
+///   it could not be determined. The caller should not free the resulting
+///   pointer. It is owned by the system.
+static const char *
+_swift_exceptionPointerGetMangledTypeName(const std::exception_ptr *ep);
+
+/// Create a demangled copy of the specified mangled type name.
+///
+/// \param mangledName The type name to demangle.
+///
+/// \returns A demangled copy of \a mangledName, or \c nullptr if it could not
+///   be demangled. The caller is responsible for freeing the resulting pointer
+///   with \c swift_slowDealloc() or \c free().
+static char *
+_swift_exceptionPointerCopyDemangledTypeName(const char *mangledName);
+
+#if SWIFT_OBJC_INTEROP
+/// Copy the description (from \c -description or \c -debugDescription) of a
+/// previously-thrown Objective-C object.
+///
+/// \param obj A previously-thrown Objective-C object (as returned from
+///   \c _swift_exceptionPointerGetThrownObjectiveCObject().)
+/// \param debug Whether to use \c -debugDescription instead of \c -description.
+///
+/// \returns A null-terminated C string containing a description of the
+///   thrown object. The caller is responsible for freeing this string with
+///   \c swift_slowDealloc() when done with it. If no description was available,
+///   returns \c nullptr.
+///
+/// \note This function is implemented in ExceptionHandling.mm.
+extern char *
+_swift_exceptionPointerCopyObjectiveCExceptionDescription(id obj, bool debug);
+#endif
+}
+
+static const char *
+swift::_swift_exceptionPointerGetMangledTypeName(const std::exception_ptr *ep) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return nullptr;
+  }
+
+#if __has_include(<cxxabi.h>)
+  // Let the C++ ABI figure out the type for all non-Objective-C exceptions.
+  if (auto typeInfo = __cxxabiv1::__cxa_current_exception_type()) {
+    return typeInfo->name();
+  }
+
+#elif defined(_MSC_VER)
+  // Under the MSVC++ ABI, std::exception_ptr is secretly just a
+  // std::shared_ptr<EXCEPTION_RECORD>. EHExceptionRecord is a layout-compatible
+  // type that is used in the STL implementation and comes with macros for
+  // discovering the underlying exception's mangled/decorated type name.
+  //
+  // For more information about std::exception_ptr as implemented by MSVC++,
+  // see: https://github.com/microsoft/STL/blob/main/stl/src/excptptr.cpp
+  auto *er = reinterpret_cast<const std::shared_ptr<EHExceptionRecord> *>(ep);
+  if (PER_IS_MSVC_PURE_OR_NATIVE_EH(er)) {
+    if (auto throwInfo = PER_PTHROW(er)) {
+      if (THROW_COUNT(*throwInfo) > 0) {
+        if (auto type = THROW_PCT(*throwInfo, 0)) {
+          return CT_NAME(*type);
+        }
+      }
+    }
+  }
+
+#else
+  // Unsupported by this EH ABI, but we might still be able to get the
+  // type name if the exception is a std::exception or of a subclass thereof.
+  try {
+    std::rethrow_exception(*ep);
+  } catch (const std::exception& e) {
+    return typeid(e).name();
+  } catch (...) {
+    // The exception was of some other type and this ABI does not allow us to
+    // inspect any further. Stop.
+  }
+#endif
+
+  return nullptr;
+}
+
+static char *
+swift::_swift_exceptionPointerCopyDemangledTypeName(const char *mangledName) {
+  if (!mangledName) {
+    return nullptr;
+  }
+
+#if __has_include(<cxxabi.h>)
+  int status = 0;
+  return abi::__cxa_demangle(mangledName, nullptr, nullptr, &status);
+
+#elif defined(_MSC_VER)
+  return _swift_withWin32DbgHelpLibrary([=] (bool isInitialized) -> char * {
+    if (!isInitialized) {
+      return nullptr;
+    }
+
+    // std::type_info::raw_name() has a leading period that interferes with
+    // demangling. Strip it off if found.
+    if (mangledName[0] == '.') {
+      mangledName += 1;
+    }
+
+    // Allocate some space for the demangled type name.
+    static const constexpr size_t MAX_DEMANGLED_NAME_SIZE = 1024;
+    auto demangledName = reinterpret_cast<char *>(
+      swift_slowAlloc(MAX_DEMANGLED_NAME_SIZE), 0);
+    if (demangledName) {
+
+      // Call into DbgHelp to perform the demangling. These flags should give us
+      // the correct demangling of a mangled C++ type name.
+      DWORD undecorateFlags = UNDNAME_NAME_ONLY | UNDNAME_NO_ARGUMENTS;
+  #if !defined(_WIN64)
+      undecorateFlags |= UNDNAME_32_BIT_DECODE;
+  #endif
+      if (UnDecorateSymbolName(mangledName, demangledName,
+                               MAX_DEMANGLED_NAME_SIZE, undecorateFlags)) {
+        return demangledName;
+      }
+
+      // Don't leak the allocated buffer if demangling failed.
+      swift_slowDealloc(demangledName, 0);
+    }
+
+    return nullptr;
+  });
+#else
+  // Unsupported on this platform.
+  return nullptr;
+#endif
+}
+
+char *swift::_swift_exceptionPointerCopyTypeName(const std::exception_ptr *ep) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return nullptr;
+  }
+
+#if SWIFT_OBJC_INTEROP
+  if (id obj = _swift_exceptionPointerGetThrownObjectiveCObject(ep)) {
+    return strdup(object_getClassName(obj));
+  }
+#endif
+
+#if defined(_WIN32)
+  EXCEPTION_RECORD exceptionRecord;
+  if (_swift_exceptionPointerGetThrownExceptionRecord(ep, &exceptionRecord)) {
+    // std::type_info::name() is demangled by default on Windows.
+    return typeid(EXCEPTION_RECORD).name();
+  }
+#endif
+
+  if (auto typeName = _swift_exceptionPointerGetMangledTypeName(ep)) {
+    auto result = _swift_exceptionPointerCopyDemangledTypeName(typeName);
+    if (!result) {
+      // Couldn't demangle the type name. Use the mangled name instead.
+      result = strdup(typeName);
+    }
+    return result;
+  }
+
+  return nullptr;
+}
+
+char *
+swift::_swift_exceptionPointerCopyDescription(const std::exception_ptr *ep,
+                                              bool debug) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return nullptr;
+  }
+
+#if SWIFT_OBJC_INTEROP
+  if (id obj = _swift_exceptionPointerGetThrownObjectiveCObject(ep)) {
+    return _swift_exceptionPointerCopyObjectiveCExceptionDescription(obj,
+                                                                     debug);
+  }
+#endif
+
+#if defined(_WIN32)
+  EXCEPTION_RECORD exceptionRecord;
+  if (_swift_exceptionPointerGetThrownExceptionRecord(ep, &exceptionRecord)) {
+    // TODO: OS-supplied descriptions of specific exception codes, if possible.
+    char *result = nullptr;
+    swift_asprintf(&result, "An error (exception code %u) occurred.",
+                   exceptionRecord.ExceptionCode);
+    return result;
+  }
+#endif
+
+  try {
+    std::rethrow_exception(*ep);
+  } catch (const std::exception& e) {
+    if (auto what = e.what()) {
+      return strdup(what);
+    }
+  } catch (...) {
+    // Not an exception we understand, so not something we can describe.
+  }
+
+  return nullptr;
+}
+
+#pragma mark - Catching exceptions in Swift
+
+namespace swift {
+/// Call out to a Swift function that might throw an exception while leaving a
+/// breadcrumb in any resultant stack traces.
+///
+/// This function serves two purposes:
+///
+/// 1. It adds a "noisy" symbol to stack traces in crash logs that can be
+///    useful in diagnosing issues; and
+///
+/// 2. It works around an apparent clang bug rdar://87360634 where functions
+///    marked __attribute__((swiftcall)) do not generate correct exception
+///    handling metadata (even if they are implemented in C++.)
+SWIFT_NOINLINE SWIFT_DISABLE_TAIL_CALLS extern "C" void
+__SWIFT_IS_CALLING_A_FUNCTION_THAT_MAY_THROW_EXCEPTIONS__(
+  SWIFT_CC(swift) void (* body)(
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT void **outError),
+  void *bodyContext,
+  void **outError);
+
+void __SWIFT_IS_CALLING_A_FUNCTION_THAT_MAY_THROW_EXCEPTIONS__(
+  SWIFT_CC(swift) void (* body)(
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT void **outError),
+  void *bodyContext,
+  void **outError) {
+  (* body)(bodyContext, outError);
+}
+}
+
+SWIFT_CC(swift) void swift::_swift_withUnsafeExceptionHandling(
+  SWIFT_CC(swift) void (* body)(
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT void **outError),
+  void *bodyContext,
+  SWIFT_CONTEXT void *context,
+  SWIFT_ERROR_RESULT void **outError) {
+
+#if defined(_WIN32)
+  auto oldSEHTranslator = _set_se_translator([] (unsigned int u,
+                                                 _EXCEPTION_POINTERS *pExp) {
+    throw (* pExp->ExceptionRecord);
+  });
+#endif
+
+  try {
+    // Invoke the closure. Any thrown Swift error will be placed in
+    // *outError and the caller will detect it and rethrow it.
+    __SWIFT_IS_CALLING_A_FUNCTION_THAT_MAY_THROW_EXCEPTIONS__(body, bodyContext,
+                                                              outError);
+
+  } catch (...) {
+    *outError = swift::swift_caughtException_copyCurrent();
+  }
+
+#if defined(_WIN32)
+  _set_se_translator(oldSEHTranslator);
+#endif
+}
+

--- a/stdlib/public/ExceptionHandling/ExceptionHandling.h
+++ b/stdlib/public/ExceptionHandling/ExceptionHandling.h
@@ -1,0 +1,186 @@
+//===--- ExceptionHandling.h - C++ and Objective-C exception handling -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __SWIFT_RUNTIME_EXCEPTIONHANDLING_H__
+#define __SWIFT_RUNTIME_EXCEPTIONHANDLING_H__
+
+#include "swift/Runtime/Config.h"
+
+#include <exception>
+#if SWIFT_OBJC_INTEROP
+#include <objc/runtime.h>
+#endif
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+// NOTE: Most of the functions in this header are not exported since they are
+// only used by ExceptionHandling.swift and are not needed outside this module.
+
+extern "C" {
+namespace swift {
+
+/// Create a copy of the current top-level C++ or Objective-C exception (as from
+/// \c std::current_exception()) suitable for use with Swift runtime and
+/// standard library functions.
+///
+/// \returns A pointer to a new \c std::exception_ptr structure. The caller is
+///   responsible for deleting this pointer with
+///   \c _swift_exceptionPointerDelete() when done with it. If there is no
+///   current exception, returns \c nullptr.
+std::exception_ptr *_swift_exceptionPointerCopyCurrent(void);
+
+/// Create a copy of an existing C++ exception pointer suitable for use with
+/// Swift runtime and standard library functions.
+///
+/// \param ep A pointer to a previously-thrown exception.
+///
+/// \returns A pointer to a new \c std::exception_ptr structure. The caller is
+///   responsible for deleting this pointer with
+///   \c _swift_exceptionPointerDelete() when done with it. If the exception
+///   pointer is equal to \c nullptr, returns \c nullptr.
+std::exception_ptr *_swift_exceptionPointerCopy(const std::exception_ptr *ep);
+
+/// Delete an instance of \c std::exception_ptr.
+///
+/// \param ep A pointer to an instance of \c std::exception_ptr that was created
+///   with \c _swift_exceptionPointerCopyCurrent().
+void _swift_exceptionPointerDelete(std::exception_ptr *ep);
+
+#pragma mark - Converting to other exception types
+
+/// Check if an instance of \c std::exception_ptr is equal to \c nullptr.
+///
+/// \param ep A pointer to a previously-thrown exception.
+///
+/// \returns Whether or not \a ep is equal to \c nullptr.
+bool _swift_exceptionPointerIsNil(const std::exception_ptr *ep);
+
+#if SWIFT_OBJC_INTEROP
+/// Get the Objective-C object (possibly an instance of \c NSException)
+/// represented by the specified C++ exception pointer.
+///
+/// \param ep A pointer to a previously-thrown exception.
+///
+/// \returns The thrown Objective-C object, or \c nil if the thrown exception
+///   was not an Objective-C object.
+id
+_swift_exceptionPointerGetThrownObjectiveCObject(const std::exception_ptr *ep);
+#endif
+
+#if defined(_WIN32)
+/// Get the Windows structured exception code represented by the specified C++
+/// exception pointer.
+///
+/// \param ep A pointer to a previously-thrown exception.
+/// \param outER On successful return, the Windows structured exception
+///   record that was thrown. On failure, unspecified.
+///
+/// \returns Whether or not \a ep represents a Windows structured exception.
+///
+/// The (proposed) Swift runtime convention for handling Windows structured
+/// exceptions is to install a translator function before an exception might be
+/// thrown, then to rethrow the \c EXCEPTION_RECORD structure from within that
+/// function. If a Windows structured exception is thrown via another mechanism,
+/// this function will not be able to detect it.
+///
+/// \sa _set_se_translator()
+/// \sa https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/set-se-translator
+bool
+_swift_exceptionPointerGetThrownExceptionRecord(const std::exception_ptr *ep,
+                                                EXCEPTION_RECORD *outER);
+#endif
+
+#pragma mark - Stringifying exceptions
+
+/// Get a description of a C++ exception pointer's underlying exception type.
+///
+/// \param ep A pointer to a previously-thrown exception.
+///
+/// \returns A null-terminated C string containing a description of the
+///   exception's type (such as \c "NSException" or \c "std::exception". The
+///   caller is responsible for freeing this string with \c swift_slowDealloc()
+///   when done with it. If no type information was available, returns
+///   \c nullptr.
+///
+/// The resulting string may or may not be demangled depending on the
+/// capabilities of the current system.
+char *_swift_exceptionPointerCopyTypeName(const std::exception_ptr *ep);
+
+/// Get a description of a C++ exception pointer.
+///
+/// \param ep A pointer to a previously-thrown exception.
+/// \param debug Whether or not to copy a debug description containing more
+///   information (when available.) The format of an exception's debug
+///   description is subject to change.
+///
+/// \returns A null-terminated C string containing a description of the
+///   exception. The caller is responsible for freeing this string with
+///   \c swift_slowDealloc() when done with it. If no description was available,
+///   returns \c nullptr.
+char *_swift_exceptionPointerCopyDescription(const std::exception_ptr *ep,
+                                             bool debug);
+
+#pragma mark - Catching exceptions in Swift
+
+/// Create a \c CaughtException instance from the current thrown-and-caught
+/// exception.
+///
+/// \returns A pointer to a newly-allocated instance of \c CaughtException that
+///   can be assigned to the \c swift_error_result -annotated parameter of a C
+///   function that uses the Swift calling convention. If there is no current
+///   exception, this function returns \c nullptr.
+///
+/// This function is used by the Swift runtime and standard library to convert a
+/// caught exception to an \c Error. C++ callers outside the runtime or standard
+/// library might also call it with the following signature:
+///
+/// \code
+/// namespace swift {
+///   extern "C" void *_Nullable swift_caughtException_copyCurrent(void);
+/// }
+/// \endcode
+///
+/// Swift callers should prefer \c CaughtException.current.
+///
+/// \warning Swift support for exception handling is experimental. It remains
+///   undefined behavior to throw an exception through a Swift stack frame.
+SWIFT_EXPORT_FROM(swift_ExceptionHandling)
+void *swift_caughtException_copyCurrent(void);
+
+/// Invoke a Swift function or closure in a context that can catch Objective-C
+/// and C++ exceptions.
+///
+/// \param body A Swift function or closure to invoke.
+/// \param bodyContext The context pointer for \a body.
+/// \param context The context pointer for the function. Ignored.
+/// \param outError The Swift error pointer for errors thrown from \a body.
+///
+/// \throws Whatever Swift error is thrown by \a body. Exceptions are thrown as
+///   instances of the Swift \c CaughtException type.
+///
+/// \warning Swift support for exception handling is experimental. It remains
+///   undefined behavior to throw an exception through a Swift stack frame.
+SWIFT_CC(swift) void _swift_withUnsafeExceptionHandling(
+  SWIFT_CC(swift) void (* body)(
+    SWIFT_CONTEXT void *context,
+    SWIFT_ERROR_RESULT void **outError),
+  void *bodyContext,
+  SWIFT_CONTEXT void *context,
+  SWIFT_ERROR_RESULT void **outError);
+
+}
+}
+
+#endif

--- a/stdlib/public/ExceptionHandling/ExceptionHandling.mm
+++ b/stdlib/public/ExceptionHandling/ExceptionHandling.mm
@@ -1,0 +1,67 @@
+//===--- ExceptionHandling.mm ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "ExceptionHandling.h"
+
+#if SWIFT_OBJC_INTEROP
+#import <Foundation/Foundation.h>
+
+#include "swift/Runtime/HeapObject.h"
+
+id swift::_swift_exceptionPointerGetThrownObjectiveCObject(
+  const std::exception_ptr *ep) {
+  if (_swift_exceptionPointerIsNil(ep)) {
+    return nil;
+  }
+  
+  try {
+    std::rethrow_exception(*ep);
+  } catch (id obj) {
+    return obj;
+  } catch (...) {
+    return nil;
+  }
+}
+
+namespace swift {
+extern char *
+_swift_exceptionPointerCopyObjectiveCExceptionDescription(id obj, bool debug);
+}
+
+char *
+swift::_swift_exceptionPointerCopyObjectiveCExceptionDescription(id obj,
+                                                                 bool debug) {
+  id objcDesc;
+  if (debug) {
+    objcDesc = [obj debugDescription];
+  } else {
+    objcDesc = [obj description];
+  }
+  if (objcDesc) {
+    auto szDesc = [objcDesc maximumLengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    if (auto utf8Desc = reinterpret_cast<char *>(swift_slowAlloc(szDesc, 0))) {
+      auto didCopy = [objcDesc getCString:utf8Desc
+                                maxLength:szDesc
+                                 encoding:NSUTF8StringEncoding];
+      if (didCopy) {
+        return utf8Desc;
+
+      } else {
+        // Failed to copy the string as UTF-8, so clean up the heap allocation.
+        swift_slowDealloc(utf8Desc, szDesc, 0);
+      }
+    }
+  }
+
+  return nullptr;
+}
+#endif

--- a/stdlib/public/ExceptionHandling/ExceptionHandling.swift
+++ b/stdlib/public/ExceptionHandling/ExceptionHandling.swift
@@ -1,0 +1,334 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+#if os(Windows)
+import WinSDK
+#endif
+
+/// A class representing a C++ `std::exception_ptr` instance.
+///
+/// Instances of this class manage the lifetime of a `std::exception_ptr` value,
+/// primarily on behalf of instances of `CaughtException`.
+///
+/// - Bug: In the future once C++ interop is fully defined and available, this
+///   type should be replaced with direct uses of `std::exception_ptr`.
+fileprivate final class _ExceptionPointer: RawRepresentable {
+  public typealias RawValue = UnsafeMutableRawPointer /* std::exception_ptr * */
+
+  public var rawValue: UnsafeMutableRawPointer
+
+  @_silgen_name("_swift_exceptionPointerCopy")
+  private static func __copy(_ ep: UnsafeRawPointer) -> UnsafeMutableRawPointer?
+
+  /// Initialize an instance of this class with a pointer to a C++ exception
+  /// pointer (that is, a value of type `const std::exception_ptr *`.)
+  ///
+  /// - Parameters:
+  ///   - rawValue: A pointer to an exception pointer. The exception pointer is
+  ///     copied and the caller retains ownership of `rawValue`.
+  ///
+  /// If `rawValue` represents a `nil` exception, this initializer returns `nil`.
+  public init?(rawValue: UnsafeRawPointer) {
+    guard let ep = Self.__copy(rawValue) else {
+      return nil
+    }
+    self.rawValue = ep
+  }
+
+  /// Initialize an instance of this class with a pointer to a C++ exception
+  /// pointer (that is, a value of type `const std::exception_ptr *`.)
+  ///
+  /// - Parameters:
+  ///   - rawValue: A pointer to an exception pointer. The exception pointer is
+  ///     copied and the caller retains ownership of `rawValue`.
+  ///
+  /// If `rawValue` represents a `nil` exception, this initializer returns `nil`.
+  public convenience init?(rawValue: UnsafeMutableRawPointer) {
+    self.init(rawValue: UnsafeRawPointer(rawValue))
+  }
+
+  @_silgen_name("_swift_exceptionPointerIsNil")
+  private static func __isNil(_ ep: UnsafeRawPointer) -> Bool
+
+  /// Initialize an instance of this class with a mutable pointer to a C++
+  /// exception pointer (that is, a value of type `std::exception_ptr *`) and
+  /// take ownership of it.
+  ///
+  /// - Parameters:
+  ///   - rawValue: A mutable pointer to an exception pointer. The exception
+  ///     pointer is _not_ copied and the resulting `_ExceptionPointer` instance
+  ///     takes ownership of it.
+  ///
+  /// If `rawValue` represents a `nil` exception, this initializer returns `nil`.
+  public init?(rawValueNoCopy rawValue: UnsafeMutableRawPointer) {
+    if Self.__isNil(rawValue) {
+      return nil
+    }
+    self.rawValue = rawValue
+  }
+
+  @_silgen_name("_swift_exceptionPointerDelete")
+  private static func __delete(_ ep: UnsafeMutableRawPointer)
+
+  deinit {
+    Self.__delete(rawValue)
+  }
+
+  // MARK: -
+
+  @_silgen_name("_swift_exceptionPointerCopyCurrent")
+  private static func __copyCurrent() -> UnsafeMutableRawPointer?
+
+  /// The exception that is currently caught, if any.
+  ///
+  /// If the current code is executing within a C++ `catch` or Objective-C
+  /// `@catch` clause, the value of this property equals the exception that
+  /// has been caught. Otherwise, the value of this property is `nil`.
+  ///
+  /// Put in terms of C++: if the value returned by `std::current_exception()`
+  /// is equal to `nullptr`, then the value of this property is `nil`.
+  static var current: Self? {
+    return __copyCurrent().flatMap(Self.init(rawValueNoCopy:))
+  }
+}
+
+// MARK: -
+
+/// An error representing a previously-caught C++ or Objective-C exception.
+///
+/// - Warning: Swift support for exception handling is experimental. It remains
+///     undefined behavior to throw an exception through a Swift stack frame.
+@available(macOS 9999.0, iOS 9999.0, watchOS 9999.0, tvOS 9999.0, *)
+public struct CaughtException: Error {
+  private let _ep: _ExceptionPointer
+
+  /// Initialize an instance of this type with a preexisting instance of
+  /// `_ExceptionPointer`.
+  ///
+  /// - Parameters:
+  ///   - ep: An existing exception pointer object.
+  fileprivate init(_ ep: _ExceptionPointer) {
+    _ep = ep
+  }
+
+  /// Initialize an instance of this type with a pointer to a C++ exception
+  /// pointer (that is, a value of type `const std::exception_ptr *`.)
+  ///
+  /// - Parameters:
+  ///   - ep: A pointer to an exception pointer. The exception pointer is copied
+  ///     and the caller retains ownership of `ep`.
+  ///
+  /// If `ep` represents a `nil` exception, this initializer returns `nil`. If
+  /// `ep` is not a valid pointer to a C++ exception pointer, the result is
+  /// undefined.
+  public init?(exceptionPointer ep: UnsafeRawPointer) {
+    guard let ep = _ExceptionPointer(rawValue: ep) else {
+      return nil
+    }
+    self.init(ep)
+  }
+
+  /// Initialize an instance of this type with a pointer to a C++ exception
+  /// pointer (that is, a value of type `const std::exception_ptr *`.)
+  ///
+  /// - Parameters:
+  ///   - ep: A pointer to an exception pointer. The exception pointer is copied
+  ///     and the caller retains ownership of `ep`.
+  ///
+  /// If `ep` represents a `nil` exception, this initializer returns `nil`. If
+  /// `ep` is not a valid pointer to a C++ exception pointer, the result is
+  /// undefined.
+  public init?(exceptionPointer ep: UnsafeMutableRawPointer) {
+    self.init(exceptionPointer: UnsafeRawPointer(ep))
+  }
+
+  /// The exception that is currently caught, if any.
+  ///
+  /// If the current code is executing within a C++ `catch` or Objective-C
+  /// `@catch` clause, the value of this property equals the exception that
+  /// has been caught. Otherwise, the value of this property is `nil`.
+  public static var current: Self? {
+    return _ExceptionPointer.current.map(Self.init)
+  }
+}
+
+// MARK: - Exception inspection
+
+@available(macOS 9999.0, iOS 9999.0, watchOS 9999.0, tvOS 9999.0, *)
+extension CaughtException: CustomStringConvertible,
+                           CustomDebugStringConvertible {
+  @_silgen_name("_swift_exceptionPointerCopyTypeName")
+  private static func __copyTypeName(
+    _ ep: UnsafeRawPointer
+  ) -> UnsafePointer<CChar>?
+
+  private static func __typeName(_ ep: UnsafeRawPointer) -> String? {
+    let utf8 = __copyTypeName(ep)
+    defer {
+      utf8?.deallocate()
+    }
+
+    return utf8.flatMap(String.init(validatingUTF8:))
+  }
+
+  @_silgen_name("_swift_exceptionPointerCopyDescription")
+  private static func __copyDescription(
+    _ ep: UnsafeRawPointer,
+    debug: Bool
+  ) -> UnsafePointer<CChar>?
+
+  private static func __description(
+    _ ep: UnsafeRawPointer,
+    debug: Bool
+  ) -> String? {
+    let utf8 = __copyDescription(ep, debug: debug)
+    defer {
+      utf8?.deallocate()
+    }
+
+    return utf8.flatMap(String.init(validatingUTF8:))
+  }
+
+  public var description: String {
+    return Self.__description(_ep.rawValue, debug: false)
+      ?? "An unknown exception occurred."
+  }
+
+  public var debugDescription: String {
+    let description = Self.__description(_ep.rawValue, debug: true)
+    let typeName = Self.__typeName(_ep.rawValue)
+
+    switch (description, typeName) {
+    case (.some(let description), .some(let typeName)):
+      return "An exception of type \(typeName) occurred: \(description)"
+    case (.some(let description), _):
+      return "An exception occurred: \(description)"
+    case (_, .some(let typeName)):
+      return "An exception of type \(typeName) occurred."
+    default:
+      return "An unknown exception occurred."
+    }
+  }
+}
+
+// MARK: -
+
+@available(macOS 9999.0, iOS 9999.0, watchOS 9999.0, tvOS 9999.0, *)
+extension CaughtException {
+#if _runtime(_ObjC)
+  @_silgen_name("_swift_exceptionPointerGetThrownObjectiveCObject")
+  private static func __getThrownObjectiveCObject(
+    _ ep: UnsafeRawPointer
+  ) -> Unmanaged<AnyObject>?
+
+  /// The Objective-C object that was thrown, if any.
+  ///
+  /// If the represented exception is not an Objective-C object, the value of
+  /// this property is `nil`.
+  ///
+  /// - Note: Objective-C allows throwing objects of any class, not just
+  ///     instances of `NSException`.
+  public var thrownObjectiveCObject: Any? {
+    // Note: Swift expects C functions to return at +1 normally but this
+    // C function returns at +0, so Unmanaged is used to manually correct
+    // the refcounting.
+    return Self.__getThrownObjectiveCObject(_ep.rawValue)?
+      .takeUnretainedValue()
+  }
+#endif
+
+#if os(Windows)
+  @_silgen_name("_swift_exceptionPointerGetThrownExceptionRecord")
+  private static func __getThrownExceptionRecord(
+    _ ep: UnsafeRawPointer,
+    _ outER: UnsafeMutablePointer<EXCEPTION_RECORD>
+  ) -> Bool
+
+  /// The Windows structured exception code that was thrown, if any.
+  ///
+  /// If the represented exception is not a Windows structured exception, the
+  /// value of this property is `nil`.
+  public var thrownExceptionRecord: EXCEPTION_RECORD? {
+    return withUnsafeTemporaryAllocation(
+      of: EXCEPTION_RECORD.self,
+      capacity: 1
+    ) { er in
+      if Self.__getThrownExceptionRecord(_ep.rawValue, er.baseAddress!) {
+        return er.baseAddress!.move()
+      }
+      return nil
+    }
+  }
+#endif
+}
+
+// MARK: - Catching exceptions in Swift
+
+/// Create a `CaughtException` instance from the current thrown-and-caught
+/// exception.
+///
+/// - Returns: A pointer to a newly-allocated instance of `CaughtException` that
+///   can be assigned to the `swift_error_result`-annotated parameter of a C
+///   function that uses the Swift calling convention. If there is no current
+///   exception, this function returns `nil`.
+///
+/// This function is used by the Swift runtime and standard library to convert a
+/// caught exception to an `Error`. C++ callers outside the runtime or standard
+/// library might also call it with the following signature:
+///
+/// ```c++
+/// namespace swift {
+///   extern "C" void *_Nullable swift_caughtException_copyCurrent(void);
+/// }
+/// ```
+///
+/// Swift callers should prefer `CaughtException.current`.
+///
+/// - Warning: Swift support for exception handling is experimental. It remains
+///   undefined behavior to throw an exception through a Swift stack frame.
+@available(macOS 9999.0, iOS 9999.0, watchOS 9999.0, tvOS 9999.0, *)
+@_cdecl("swift_caughtException_copyCurrent")
+@usableFromInline internal func
+swift_caughtException_copyCurrent_DoNotCall() -> UnsafeMutableRawPointer? {
+  return CaughtException.current.map { exception in
+    Unmanaged.passRetained(exception as AnyObject).toOpaque()
+  }
+}
+
+@_silgen_name("_swift_withUnsafeExceptionHandling")
+private func __withUnsafeExceptionHandling(_ body: () throws -> Void) throws
+
+/// Invoke a closure in a context that can catch Objective-C and C++ exceptions.
+///
+/// - Parameters:
+///   - body: A closure to invoke.
+///
+/// - Returns: Whatever is returned by `body`.
+///
+/// - Throws: Whatever is thrown by `body`. Any Objective-C exception or C++
+///   exception is thrown as an instance of `CaughtException`. Thrown Swift
+///   errors are rethrown as-is.
+///
+/// - Warning: Swift support for exception handling is experimental. It remains
+///   undefined behavior to throw an exception through a Swift stack frame.
+@available(macOS 9999.0, iOS 9999.0, watchOS 9999.0, tvOS 9999.0, *)
+public func withUnsafeExceptionHandling<R>(_ body: () throws -> R) throws -> R {
+  return try withUnsafeTemporaryAllocation(of: R.self, capacity: 1) { result in
+    try __withUnsafeExceptionHandling {
+      result.baseAddress!.initialize(to: try body())
+    }
+
+    return result.baseAddress!.move()
+  }
+}

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -109,6 +109,12 @@
 #define SWIFT_WEAK_IMPORT
 #endif
 
+#if (__has_attribute(disable_tail_calls))
+#define SWIFT_DISABLE_TAIL_CALLS __attribute__((disable_tail_calls))
+#else
+#define SWIFT_DISABLE_TAIL_CALLS
+#endif
+
 // Define the appropriate attributes for sharing symbols across
 // image (executable / shared-library) boundaries.
 //
@@ -196,6 +202,11 @@
 #define SWIFT_IMAGE_EXPORTS_swift_Differentiation 1
 #else
 #define SWIFT_IMAGE_EXPORTS_swift_Differentiation 0
+#endif
+#if defined(swift_ExceptionHandling_EXPORTS)
+#define SWIFT_IMAGE_EXPORTS_swift_ExceptionHandling 1
+#else
+#define SWIFT_IMAGE_EXPORTS_swift_ExceptionHandling 0
 #endif
 
 #define SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)                          \


### PR DESCRIPTION
**⚠️ This PR is experimental only! I am not planning to merge it at this time.**

<!-- What's in this pull request? -->
This PR introduces a new `Error` type, `CaughtException`, that represents arbitrary C++ and Objective-C exceptions. It does so by wrapping instances of `std::exception_ptr` and providing runtime functions to access their various properties.

It also exposes a function, `withUnsafeExceptionHandling(_:)`, that ostensibly catches exceptions thrown from within a function that may or may not be a Swift closure. If the function is in fact a C++ function, it should just work. If it's a Swift function, you're still in the land of Undefined Behaviour.

This change creates a new module _Cxx, akin to _Concurrency, to house the new code since it needs different compile-time settings than the rest of the stdlib. Whether or not we want to ship such a module is still an open question.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
