### PR TITLE
SE-0340: `noasync` availability kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 ## Swift 5.7
 
+* [SE-0340][]:
+
+  It is now possible to make declarations unavailable from use in asynchronous
+  contexts with the `@available(*, noasync)` attribute.
+
+  This is to protect the consumers of an API against undefined behavior that can
+  occur when the API uses thread-local storage, or encourages using thread-local
+  storage, across suspension points, or protect developers against holding locks
+  across suspension points which may lead to undefined behavior, priority
+  inversions, or deadlocks.
+
 * [SE-0343][]:
 
 Top-level scripts support asynchronous calls.
@@ -9083,6 +9094,7 @@ Swift 1.0
 [SE-0341]: <https://github.com/apple/swift-evolution/blob/main/proposals/0341-opaque-parameters.md>
 [SE-0336]: <https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md>
 [SE-0343]: <https://github.com/apple/swift-evolution/blob/main/proposals/0343-top-level-concurrency.md>
+[SE-0340]: <https://github.com/apple/swift-evolution/blob/main/proposals/0340-swift-noasync.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -614,6 +614,8 @@ enum class PlatformAgnosticAvailabilityKind {
   PackageDescriptionVersionSpecific,
   /// The declaration is unavailable for other reasons.
   Unavailable,
+  /// The declaration is unavailable from asynchronous contexts
+  NoAsync,
 };
 
 /// Defines the @available attribute.
@@ -701,6 +703,9 @@ public:
 
   /// Whether this is an unconditionally deprecated entity.
   bool isUnconditionallyDeprecated() const;
+
+  /// Whether this is a noasync attribute.
+  bool isNoAsync() const;
 
   /// Returns the platform-agnostic availability.
   PlatformAgnosticAvailabilityKind getPlatformAgnosticAvailability() const {
@@ -2260,6 +2265,11 @@ public:
   /// Returns the first @available attribute that indicates
   /// a declaration will be deprecated in the future, or null otherwise.
   const AvailableAttr *getSoftDeprecated(const ASTContext &ctx) const;
+
+  /// Returns the first @available attribute that indicates
+  /// a declaration is unavailable from asynchronous contexts, or null
+  /// otherwise.
+  const AvailableAttr *getNoAsync(const ASTContext &ctx) const;
 
   SWIFT_DEBUG_DUMPER(dump(const Decl *D = nullptr));
   void print(ASTPrinter &Printer, const PrintOptions &Options,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1497,9 +1497,8 @@ ERROR(attr_unsupported_on_target, none,
 // availability
 ERROR(attr_availability_platform,none,
       "expected platform name or '*' for '%0' attribute", (StringRef))
-ERROR(attr_availability_unavailable_deprecated,none,
-      "'%0' attribute cannot be both unconditionally 'unavailable' and "
-      "'deprecated'", (StringRef))
+ERROR(attr_availability_multiple_kinds ,none,
+      "'%0' attribute cannot be both '%1' and '%2'", (StringRef, StringRef, StringRef))
 
 WARNING(attr_availability_invalid_duplicate,none,
         "'%0' argument has already been specified", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4848,8 +4848,8 @@ ERROR(async_named_decl_must_be_available_from_async,none,
         "asynchronous %0 %1 must be available from asynchronous contexts",
         (DescriptiveDeclKind, DeclName))
 ERROR(async_unavailable_decl,none,
-      "%0 %1 is unavailable from asynchronous contexts%select{|; %3}2",
-      (DescriptiveDeclKind, DeclBaseName, bool, StringRef))
+      "%0 %1 is unavailable from asynchronous contexts%select{|; %2}2",
+      (DescriptiveDeclKind, DeclBaseName, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -301,6 +301,9 @@ struct PrintOptions {
   /// Whether to print generic requirements in a where clause.
   bool PrintGenericRequirements = true;
 
+  /// Suppress emitting @available(*, noasync)
+  bool SuppressNoAsyncAvailabilityAttr = false;
+
   /// How to print opaque return types.
   enum class OpaqueReturnTypePrintingMode {
     /// 'some P1 & P2'.

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -76,6 +76,7 @@ LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes, 0, "Primary associated types", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3015,6 +3015,18 @@ suppressingFeatureUnavailableFromAsync(PrintOptions &options,
   options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
+static bool usesFeatureNoAsyncAvailability(Decl *decl) {
+   return decl->getAttrs().getNoAsync(decl->getASTContext()) != nullptr;
+}
+
+static void
+suppressingFeatureNoAsyncAvailability(PrintOptions &options,
+                                      llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<PrintOptions> orignalOptions(options);
+  options.SuppressNoAsyncAvailabilityAttr = true;
+  action();
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -190,7 +190,7 @@ DeclAttributes::findMostSpecificActivePlatform(const ASTContext &ctx) const{
       continue;
 
     // We have an attribute that is active for the platform, but
-    // is it more specific than our curent best?
+    // is it more specific than our current best?
     if (!bestAttr || inheritsAvailabilityFromPlatform(avAttr->Platform,
                                                       bestAttr->Platform)) {
       bestAttr = avAttr;
@@ -356,6 +356,48 @@ DeclAttributes::getSoftDeprecated(const ASTContext &ctx) const {
   return conditional;
 }
 
+const AvailableAttr *DeclAttributes::getNoAsync(const ASTContext &ctx) const {
+  const AvailableAttr *bestAttr = nullptr;
+  for (const DeclAttribute *attr : *this) {
+    if (const AvailableAttr *avAttr = dyn_cast<AvailableAttr>(attr)) {
+      if (avAttr->isInvalid())
+        continue;
+
+      if (avAttr->getPlatformAgnosticAvailability() ==
+          PlatformAgnosticAvailabilityKind::NoAsync) {
+        // An API may only be unavailable on specific platforms.
+        // If it doesn't have a platform associated with it, then it's
+        // unavailable for all platforms, so we should include it. If it does
+        // have a platform and we are not that platform, then it doesn't apply
+        // to us.
+        const bool isGoodForPlatform =
+            (avAttr->hasPlatform() && avAttr->isActivePlatform(ctx)) ||
+            !avAttr->hasPlatform();
+
+        if (!isGoodForPlatform)
+          continue;
+
+        if (!bestAttr) {
+          // If there is no best attr selected
+          // and the attr either has an active platform, or doesn't have one at
+          // all, select it.
+          bestAttr = avAttr;
+        } else if (bestAttr && avAttr->hasPlatform() &&
+                   bestAttr->hasPlatform() &&
+                   inheritsAvailabilityFromPlatform(avAttr->Platform,
+                                                    bestAttr->Platform)) {
+          // if they both have a viable platform, use the better one
+          bestAttr = avAttr;
+        } else if (avAttr->hasPlatform() && !bestAttr->hasPlatform()) {
+          // Use the one more specific
+          bestAttr = avAttr;
+        }
+      }
+    }
+  }
+  return bestAttr;
+}
+
 void DeclAttributes::dump(const Decl *D) const {
   StreamPrinter P(llvm::errs());
   PrintOptions PO = PrintOptions::printDeclarations();
@@ -394,6 +436,7 @@ static bool isShortAvailable(const DeclAttribute *DA) {
   case PlatformAgnosticAvailabilityKind::Deprecated:
   case PlatformAgnosticAvailabilityKind::Unavailable:
   case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+  case PlatformAgnosticAvailabilityKind::NoAsync:
     return false;
   case PlatformAgnosticAvailabilityKind::None:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
@@ -771,6 +814,8 @@ static void printAvailableAttr(const AvailableAttr *Attr, ASTPrinter &Printer,
     Printer << ", unavailable";
   else if (Attr->isUnconditionallyDeprecated())
     Printer << ", deprecated";
+  else if (Attr->isNoAsync())
+    Printer << ", noasync";
 
   if (Attr->Introduced)
     Printer << ", introduced: " << Attr->Introduced.getValue().getAsString();
@@ -974,6 +1019,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_Available: {
     auto Attr = cast<AvailableAttr>(this);
+    if (Options.SuppressNoAsyncAvailabilityAttr && Attr->isNoAsync())
+      return false;
     if (!Options.PrintSPIs && Attr->IsSPI) {
       assert(Attr->hasPlatform());
       assert(Attr->Introduced.hasValue());
@@ -1705,6 +1752,7 @@ bool AvailableAttr::isUnconditionallyUnavailable() const {
   case PlatformAgnosticAvailabilityKind::Deprecated:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
   case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::NoAsync:
     return false;
 
   case PlatformAgnosticAvailabilityKind::Unavailable:
@@ -1722,6 +1770,7 @@ bool AvailableAttr::isUnconditionallyDeprecated() const {
   case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
   case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
   case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
+  case PlatformAgnosticAvailabilityKind::NoAsync:
     return false;
 
   case PlatformAgnosticAvailabilityKind::Deprecated:
@@ -1729,6 +1778,10 @@ bool AvailableAttr::isUnconditionallyDeprecated() const {
   }
 
   llvm_unreachable("Unhandled PlatformAgnosticAvailabilityKind in switch.");
+}
+
+bool AvailableAttr::isNoAsync() const {
+  return PlatformAgnostic == PlatformAgnosticAvailabilityKind::NoAsync;
 }
 
 llvm::VersionTuple AvailableAttr::getActiveVersion(const ASTContext &ctx) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7533,9 +7533,10 @@ AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
     // rename parameter, falling back to the first with a rename. Note that
     // `getAttrs` is in reverse source order, so the last attribute is the
     // first in source
-    if (!attr->Rename.empty() && (attr->Platform == PlatformKind::none ||
-                                  !avAttr))
+    if (!attr->Rename.empty() &&
+        (attr->Platform == PlatformKind::none || !avAttr) && !attr->isNoAsync()) {
       avAttr = attr;
+    }
   }
 
   auto *renamedDecl = evaluateOrDefault(

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4361,6 +4361,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   bool isImplicit;
   bool isUnavailable;
   bool isDeprecated;
+  bool isNoAsync;
   bool isPackageDescriptionVersionSpecific;
   bool isSPI;
   DEF_VER_TUPLE_PIECES(Introduced);
@@ -4371,7 +4372,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
 
   // Decode the record, pulling the version tuple information.
   serialization::decls_block::AvailableDeclAttrLayout::readRecord(
-      scratch, isImplicit, isUnavailable, isDeprecated,
+      scratch, isImplicit, isUnavailable, isDeprecated, isNoAsync,
       isPackageDescriptionVersionSpecific, isSPI, LIST_VER_TUPLE_PIECES(Introduced),
       LIST_VER_TUPLE_PIECES(Deprecated), LIST_VER_TUPLE_PIECES(Obsoleted),
       platform, renameDeclID, messageSize, renameSize);
@@ -4394,6 +4395,8 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
     platformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
   else if (isDeprecated)
     platformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
+  else if (isNoAsync)
+    platformAgnostic = PlatformAgnosticAvailabilityKind::NoAsync;
   else if (((PlatformKind)platform) == PlatformKind::none &&
            (!Introduced.empty() || !Deprecated.empty() || !Obsoleted.empty()))
     platformAgnostic =

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 678; // remove shared_external linkage
+const uint16_t SWIFTMODULE_VERSION_MINOR = 679; // NoAsync
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1916,6 +1916,7 @@ namespace decls_block {
     BCFixed<1>, // implicit flag
     BCFixed<1>, // is unconditionally unavailable?
     BCFixed<1>, // is unconditionally deprecated?
+    BCFixed<1>, // is unavailable from async?
     BCFixed<1>, // is this PackageDescription version-specific kind?
     BCFixed<1>, // is SPI?
     BC_AVAIL_TUPLE, // Introduced

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2580,6 +2580,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isImplicit(),
           theAttr->isUnconditionallyUnavailable(),
           theAttr->isUnconditionallyDeprecated(),
+          theAttr->isNoAsync(),
           theAttr->isPackageDescriptionVersionSpecific(),
           theAttr->IsSPI,
           LIST_VER_TUPLE_PIECES(Introduced),

--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -31,6 +31,7 @@ StringRef getDomain(const AvailableAttr &AvAttr) {
     case PlatformAgnosticAvailabilityKind::Deprecated:
     case PlatformAgnosticAvailabilityKind::Unavailable:
     case PlatformAgnosticAvailabilityKind::None:
+    case PlatformAgnosticAvailabilityKind::NoAsync:
       break;
   }
 

--- a/test/Concurrency/Inputs/UnavailableFunction.swift
+++ b/test/Concurrency/Inputs/UnavailableFunction.swift
@@ -1,2 +1,5 @@
 @_unavailableFromAsync
 public func unavailableFunction() { }
+
+@available(*, noasync)
+public func noasyncFunction() { }

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -64,11 +64,13 @@ func makeAsyncClosuresSynchronously(bop: inout Bop) -> (() async -> Void) {
     bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
     bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
     unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
+    noasyncFunction() // expected-error@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
     // Can use them from synchronous closures
     _ = { Bop() }()
     _ = { bop.foo() }()
     _ = { bop.muppet() }()
+    _ = { noasyncFunction() }()
 
     // Unavailable global function
     foo()         // expected-warning{{'foo' is unavailable from asynchronous contexts}}
@@ -87,6 +89,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
   bop.foo()     // expected-warning@:7{{'foo' is unavailable from asynchronous contexts}}
   bop.muppet()  // expected-warning@:7{{'muppet' is unavailable from asynchronous contexts}}
   unavailableFunction() // expected-warning@:3{{'unavailableFunction' is unavailable from asynchronous contexts}}
+  noasyncFunction() // expected-error@:3{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
   // Unavailable global function
   foo()         // expected-warning{{'foo' is unavailable from asynchronous contexts}}
@@ -101,6 +104,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
     bop.foo()
     bop.muppet()
     unavailableFunction()
+    noasyncFunction()
 
     _ = { () async -> Void in
       // Check Unavailable things inside of a nested async closure
@@ -109,6 +113,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
       bop.muppet()    // expected-warning@:11{{'muppet' is unavailable from asynchronous contexts}}
       _ = Bop()       // expected-warning@:11{{'init' is unavailable from asynchronous contexts; Use Bop(a: Int) instead}}
       unavailableFunction() // expected-warning@:7{{'unavailableFunction' is unavailable from asynchronous contexts}}
+      noasyncFunction() // expected-error@:7{{'noasyncFunction' is unavailable from asynchronous contexts}}
     }
   }
 
@@ -118,6 +123,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
     bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
     bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
     unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
+    noasyncFunction() // expected-error@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
     _ = {
       foo()

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -185,4 +185,13 @@ public func multipleSuppressible<T>(value: T) async {}
 @_unavailableFromAsync(message: "Test")
 public func unavailableFromAsyncFunc() { }
 
+// CHECK:      #if compiler(>=5.3) && $NoAsyncAvailability
+// CHECK-NEXT: @available(*, noasync, message: "Test")
+// CHECK-NEXT: public func noAsyncFunc()
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func noAsyncFunc()
+// CHECK-NEXT: #endif
+@available(*, noasync, message: "Test")
+public func noAsyncFunc() { }
+
 // CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -149,7 +149,7 @@ let _: Int
 @available(*, renamed: "a(:b:)") // expected-error{{'renamed' argument of 'available' attribute must be an operator, identifier, or full function name, optionally prefixed by a type name}}
 let _: Int
 
-@available(*, deprecated, unavailable, message: "message") // expected-error{{'available' attribute cannot be both unconditionally 'unavailable' and 'deprecated'}}
+@available(*, deprecated, unavailable, message: "message") // expected-error{{'available' attribute cannot be both 'unavailable' and 'deprecated'}}
 struct BadUnconditionalAvailability { };
 
 @available(*, unavailable, message="oh no you don't") // expected-error {{'=' has been replaced with ':' in attribute arguments}} {{35-36=: }}

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -12,20 +12,20 @@ func messageNoAsync() { }
 @available(*, noasync, renamed: "asyncReplacement()")
 func renamedNoAsync(_ completion: @escaping (Int) -> Void) -> Void { }
 
-@available(macOS 11, *)
+@available(macOS 11, iOS 13, watchOS 6, *)
 func asyncReplacement() async -> Int { }
 
 @available(*, noasync, renamed: "IOActor.readString()")
 func readStringFromIO() -> String {}
 
-@available(macOS 11, *)
+@available(macOS 11, iOS 13, watchOS 6, *)
 actor IOActor {
     func readString() -> String {
         return readStringFromIO()
     }
 }
 
-@available(macOS 11, *)
+@available(macOS 11, iOS 13, watchOS 6, *)
 func asyncFunc() async {
     // expected-error@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts}}
     basicNoAsync()
@@ -40,11 +40,13 @@ func asyncFunc() async {
     let _ = readStringFromIO()
 }
 
-// expected-error@+2{{asynchronous global function 'unavailableAsyncFunc()' must be available from asynchronous contexts}}
+// expected-error@+3{{asynchronous global function 'unavailableAsyncFunc()' must be available from asynchronous contexts}}
+@available(macOS 11, iOS 13, watchOS 6, *)
 @available(*, noasync)
 func unavailableAsyncFunc() async {
 }
 
+@available(macOS 11, iOS 13, watchOS 6, *)
 protocol BadSyncable {
     // expected-error@+2{{asynchronous property 'isSyncd' must be available from asynchronous contexts}}
     @available(*, noasync)

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -1,0 +1,41 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: concurrency
+
+
+@available(*, noasync)
+func basicNoAsync() { }
+
+@available(*, noasync, message: "a message from the author")
+func messageNoAsync() { }
+
+@available(*, noasync, renamed: "asyncReplacement()")
+func renamedNoAsync(_ completion: @escaping (Int) -> Void) -> Void { }
+
+@available(macOS 11, *)
+func asyncReplacement() async -> Int { }
+
+@available(*, noasync, renamed: "IOActor.readString()")
+func readStringFromIO() -> String {}
+
+@available(macOS 11, *)
+actor IOActor {
+    func readString() -> String {
+        return readStringFromIO()
+    }
+}
+
+@available(macOS 11, *)
+func asyncFunc() async {
+    // expected-error@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts}}
+    basicNoAsync()
+
+    // expected-error@+1{{global function 'messageNoAsync' is unavailable from asynchronous contexts; a message from the author}}
+    messageNoAsync()
+
+    // expected-error@+1{{global function 'renamedNoAsync' is unavailable from asynchronous contexts}}{{5-19=asyncReplacement}}
+    renamedNoAsync() { _ in }
+
+    // expected-error@+1{{global function 'readStringFromIO' is unavailable from asynchronous contexts}}{{13-29=IOActor.readString}}
+    let _ = readStringFromIO()
+}

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -39,3 +39,24 @@ func asyncFunc() async {
     // expected-error@+1{{global function 'readStringFromIO' is unavailable from asynchronous contexts}}{{13-29=IOActor.readString}}
     let _ = readStringFromIO()
 }
+
+// expected-error@+2{{asynchronous global function 'unavailableAsyncFunc()' must be available from asynchronous contexts}}
+@available(*, noasync)
+func unavailableAsyncFunc() async {
+}
+
+protocol BadSyncable {
+    // expected-error@+2{{asynchronous property 'isSyncd' must be available from asynchronous contexts}}
+    @available(*, noasync)
+    var isSyncd: Bool { get async }
+
+    // expected-error@+2{{asynchronous instance method 'sync' must be available from asynchronous contexts}}
+    @available(*, noasync)
+    func sync(_ str: String) async
+}
+
+class TestClass {
+    // expected-error@+2{{'@available' attribute cannot be applied to this declaration}}
+    @available(*, noasync)
+    deinit { }
+}


### PR DESCRIPTION
Add `noasync` availability kind to the `@available` attribute. This is moving the checking from the `@_unavailableFromAsync` attribute over to availability checking. There are additional features here including handling unavailability on different platforms, a message, and renaming function calls.

This implements [SE-0340 Swift noasync](https://github.com/apple/swift-evolution/blob/main/proposals/0340-swift-noasync.md).