### PR TITLE
[5.6] Always Import FieldDecls from Records

### DIFF
--- a/test/Interop/Cxx/templates/class-template-instantiation.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation.swift
@@ -18,7 +18,8 @@ TemplatesTestSuite.test("with-swift-type") {
   expectEqual(wrappedMagicNumber.getValuePlusArg(8), 21)
 }
 
-TemplatesTestSuite.test("with-c++-type-calling-method-on-arg") {
+TemplatesTestSuite.test("with-c++-type-calling-method-on-arg")
+  .skip(.watchOSSimulatorAny("rdar://problem/87262809")).code {
   let i1 = IntWrapper(value: 42)
   let i2 = IntWrapper(value: 12)
   var wrappedMagicNumber = MagicWrapper<IntWrapper>(t: i1)

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -4,7 +4,7 @@ import ClassTemplateInstantiationErrors
 
 // CHECK-LABEL: define {{.*}}void @"$s4main23instantiateValidMembersyyF"()
 // CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
-// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted* {{.*}}, {{i32|i64|\[1 x i32\]|\%struct\.IntWrapper\* byval\(\%struct\.IntWrapper\)}}
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted*
 // CHECK: ret void
 
 // CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*


### PR DESCRIPTION
Cherry picked from #40760 

------

When we switched this path over to use lazy member loading, a
subsequent commit introduced a check that members were canonical. In
certain extremely twisty scenarios involving multiple modular frameworks
pulling in non-modular headers, this check can fail which results in us
silently dropping these members on the floor.

It's ultimately correct to only pull in the canonical members, but real-world
examples of "system" frameworks evading modularity diagnostics exist so this
is strictly a regression.

Drop the canonicity check for FieldDecls.

rdar://86740970