### PR TITLE
Assert child count in mangleDependentGenericConformanceRequirement

### DIFF
--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -965,6 +965,7 @@ ManglingError Remangler::mangleDependentAssociatedTypeRef(Node *node,
 ManglingError
 Remangler::mangleDependentGenericConformanceRequirement(Node *node,
                                                         unsigned depth) {
+  DEMANGLER_ASSERT(node->getNumChildren() == 2, node);
   Node *ProtoOrClass = node->getChild(1);
   if (ProtoOrClass->getFirstChild()->getKind() == Node::Kind::Protocol) {
     RETURN_IF_ERROR(manglePureProtocol(ProtoOrClass, depth + 1));


### PR DESCRIPTION
From LLDB, we've seen crash instances where `mangleDependentGenericConformanceRequirement` segfaults when reading `node->getChild(1)`.

This change introduces a `DEMANGLER_ASSERT` that verifies the input node has two children, which the surrounding code implicitly assumes.

rdar://78025198