### PR TITLE
Fix emitting bodies of local functions declared in unreachable code into SIL

### DIFF
--- a/test/SILGen/local_declared_in_unreachable_code.swift
+++ b/test/SILGen/local_declared_in_unreachable_code.swift
@@ -1,0 +1,54 @@
+// RUN: %target-swift-emit-silgen  -parse-as-library %s | %FileCheck %s
+
+// Check that we don't crash when referencing a local function that is 
+// declared in unreachable code, for example after a return statement.
+
+// CHECK-LABEL: sil hidden [ossa] @$s34local_declared_in_unreachable_code11globalFunc1SiyF : $@convention(thin) () -> Int {
+func globalFunc1() -> Int {
+    let i = localFunc()
+
+    // CHECK-LABEL: sil private [ossa] @$s34local_declared_in_unreachable_code11globalFunc1SiyF0A4FuncL_SiyF : $@convention(thin) () -> Int {
+    func localFunc() -> Int {
+        return 42
+    }
+
+    return i
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s34local_declared_in_unreachable_code11globalFunc2SiyF : $@convention(thin) () -> Int {
+func globalFunc2() -> Int {
+    let i = localFunc()
+    return i
+
+    // Declaration after return statement
+    // CHECK-LABEL: sil private [ossa] @$s34local_declared_in_unreachable_code11globalFunc2SiyF0A4FuncL_SiyF : $@convention(thin) () -> Int {
+    func localFunc() -> Int {
+        return 42
+    }
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s34local_declared_in_unreachable_code11globalFunc3SiyF : $@convention(thin) () -> Int {
+@inlinable
+func globalFunc3() -> Int {
+    let i = localFunc()
+
+    // CHECK-LABEL: sil shared [serializable] [ossa] @$s34local_declared_in_unreachable_code11globalFunc3SiyF0A4FuncL_SiyF : $@convention(thin) () -> Int {
+    func localFunc() -> Int {
+        return 42
+    }
+
+    return i
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s34local_declared_in_unreachable_code11globalFunc4SiyF : $@convention(thin) () -> Int {
+@inlinable
+func globalFunc4() -> Int {
+    let i = localFunc()
+    return i
+
+    // Declaration after return statement
+    // CHECK-LABEL: sil shared [serializable] [ossa] @$s34local_declared_in_unreachable_code11globalFunc4SiyF0A4FuncL_SiyF : $@convention(thin) () -> Int {
+    func localFunc() -> Int {
+        return 42
+    }
+}


### PR DESCRIPTION
Resolves: SR-15507

Previously, `StmtEmitter::visitBraceStmt` would stop looking any further as soon as it reached an unreachable point in the code. As a result, bodies of local functions that were declared in unreachable code would not be emitted into SIL, even when the local function was used in reachable code. This resulted in undefined symbols or the assertion failure described in SR-15507.

Now, it will continue scanning unreachable code, and will still visit local functions declared there, so that their bodies make it into SIL; of course, making sure that we don't visit nodes that are _not_ interesting when they are in unreachable code, and that we still emit a diagnostic about unreachability only once.