### PR TITLE
[move-function] Implement support for checking in defers

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -108,6 +108,7 @@ enum class FunctionSigSpecializationParamKind : unsigned {
   ClosureProp = 5,
   BoxToValue = 6,
   BoxToStack = 7,
+  InOutToOut = 8,
 
   // Option Set Flags use bits 6-31. This gives us 26 bits to use for option
   // flags.
@@ -144,6 +145,7 @@ enum class SpecializationPass : uint8_t {
   CapturePropagation,
   FunctionSignatureOpts,
   GenericSpecializer,
+  MoveDiagnosticInOutToOut,
 };
 
 static inline char encodeSpecializationPass(SpecializationPass Pass) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -128,6 +128,14 @@ public:
                          ArrayRef<SILValue> entryArgs,
                          bool replaceOriginalFunctionInPlace = false);
 
+  /// The same as clone function body, except the caller can provide a callback
+  /// that allows for an entry arg to be assigned to a custom old argument. This
+  /// is useful if one re-arranges parameters when converting from inout to out.
+  void
+  cloneFunctionBody(SILFunction *F, SILBasicBlock *clonedEntryBB,
+                    ArrayRef<SILValue> entryArgs,
+                    llvm::function_ref<SILValue(SILValue)> entryArgToOldArgMap);
+
   /// MARK: Callback utilities used from CRTP extensions during cloning.
   /// These should only be called from within an instruction cloning visitor.
 
@@ -602,6 +610,29 @@ void SILCloner<ImplClass>::cloneFunctionBody(SILFunction *F,
   assert(entryArgs.size() == F->getArguments().size());
   for (unsigned i = 0, e = entryArgs.size(); i != e; ++i)
     ValueMap[F->getArgument(i)] = entryArgs[i];
+
+  BBMap.insert(std::make_pair(&*F->begin(), clonedEntryBB));
+
+  Builder.setInsertionPoint(clonedEntryBB);
+
+  // This will layout all newly cloned blocks immediate after clonedEntryBB.
+  visitBlocksDepthFirst(&*F->begin());
+
+  commonFixUp(F);
+}
+
+template <typename ImplClass>
+void SILCloner<ImplClass>::cloneFunctionBody(
+    SILFunction *F, SILBasicBlock *clonedEntryBB, ArrayRef<SILValue> entryArgs,
+    llvm::function_ref<SILValue(SILValue)> entryArgIndexToOldArgIndex) {
+  assert(F != clonedEntryBB->getParent() && "Must clone into a new function.");
+  assert(BBMap.empty() && "This API does not allow clients to map blocks.");
+  assert(ValueMap.empty() && "Stale ValueMap.");
+
+  assert(entryArgs.size() == F->getArguments().size());
+  for (unsigned i = 0, e = entryArgs.size(); i != e; ++i) {
+    ValueMap[entryArgIndexToOldArgIndex(entryArgs[i])] = entryArgs[i];
+  }
 
   BBMap.insert(std::make_pair(&*F->begin(), clonedEntryBB));
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1056,6 +1056,19 @@ public:
   /// generic.
   SubstitutionMap getForwardingSubstitutionMap();
 
+  /// Returns true if this SILFunction must be a defer statement.
+  ///
+  /// NOTE: This may return false for defer statements that have been
+  /// deserialized without a DeclContext. This means that this is guaranteed to
+  /// be correct for SILFunctions in Raw SIL that were not deserialized as
+  /// canonical. Thus one can use it for diagnostics.
+  bool isDefer() const {
+    if (auto *dc = getDeclContext())
+      if (auto *decl = dyn_cast_or_null<FuncDecl>(dc->getAsDecl()))
+        return decl->isDeferBody();
+    return false;
+  }
+
   //===--------------------------------------------------------------------===//
   // Block List Access
   //===--------------------------------------------------------------------===//

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -62,20 +62,24 @@ class FunctionSignatureSpecializationMangler : public SpecializationMangler {
   using ArgumentModifierIntBase = uint16_t;
   enum class ArgumentModifier : ArgumentModifierIntBase {
     // Option Space 4 bits (i.e. 16 options).
-    Unmodified=0,
-    ConstantProp=1,
-    ClosureProp=2,
-    BoxToValue=3,
-    BoxToStack=4,
-    First_Option=0, Last_Option=31,
+    Unmodified = 0,
+    ConstantProp = 1,
+    ClosureProp = 2,
+    BoxToValue = 3,
+    BoxToStack = 4,
+    InOutToOut = 5,
+
+    First_Option = 0,
+    Last_Option = 31,
 
     // Option Set Space. 12 bits (i.e. 12 option).
-    Dead=32,
-    OwnedToGuaranteed=64,
-    SROA=128,
-    GuaranteedToOwned=256,
-    ExistentialToGeneric=512,
-    First_OptionSetEntry=32, LastOptionSetEntry=32768,
+    Dead = 32,
+    OwnedToGuaranteed = 64,
+    SROA = 128,
+    GuaranteedToOwned = 256,
+    ExistentialToGeneric = 512,
+    First_OptionSetEntry = 32,
+    LastOptionSetEntry = 32768,
   };
 
   using ArgInfo = std::pair<ArgumentModifierIntBase,
@@ -102,6 +106,7 @@ public:
   void setArgumentSROA(unsigned OrigArgIdx);
   void setArgumentBoxToValue(unsigned OrigArgIdx);
   void setArgumentBoxToStack(unsigned OrigArgIdx);
+  void setArgumentInOutToOut(unsigned OrigArgIdx);
   void setReturnValueOwnedToUnowned();
 
   std::string mangle();

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2950,6 +2950,11 @@ NodePointer Demangler::demangleFuncSpecParam(Node::Kind Kind) {
       return addChild(Param, createNode(
                 Node::Kind::FunctionSignatureSpecializationParamKind,
                 unsigned(FunctionSigSpecializationParamKind::BoxToStack)));
+    case 'r':
+      return addChild(
+          Param,
+          createNode(Node::Kind::FunctionSignatureSpecializationParamKind,
+                     unsigned(FunctionSigSpecializationParamKind::InOutToOut)));
     default:
       return nullptr;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1017,6 +1017,7 @@ void NodePrinter::printFunctionSigSpecializationParams(NodePointer Node,
     switch (K) {
     case FunctionSigSpecializationParamKind::BoxToValue:
     case FunctionSigSpecializationParamKind::BoxToStack:
+    case FunctionSigSpecializationParamKind::InOutToOut:
       print(Node->getChild(Idx++), depth + 1);
       break;
     case FunctionSigSpecializationParamKind::ConstantPropFunction:
@@ -1586,6 +1587,9 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
       return nullptr;
     case FunctionSigSpecializationParamKind::BoxToStack:
       Printer << "Stack Promoted from Box";
+      return nullptr;
+    case FunctionSigSpecializationParamKind::InOutToOut:
+      Printer << "InOut Converted to Out";
       return nullptr;
     case FunctionSigSpecializationParamKind::ConstantPropFunction:
       Printer << "Constant Propagated Function";

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -645,6 +645,11 @@ private:
         if (!result)
           return nullptr;
         param->addChild(result, Factory);
+      } else if (Mangled.nextIf("r_")) {
+        auto result = FUNCSIGSPEC_CREATE_PARAM_KIND(InOutToOut);
+        if (!result)
+          return nullptr;
+        param->addChild(result, Factory);
       } else {
         // Otherwise handle option sets.
         unsigned Value = 0;

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1407,6 +1407,9 @@ Remangler::mangleFunctionSignatureSpecializationParam(Node *node,
     case FunctionSigSpecializationParamKind::BoxToStack:
       Buffer << 's';
       break;
+    case FunctionSigSpecializationParamKind::InOutToOut:
+      Buffer << 'r';
+      break;
     case FunctionSigSpecializationParamKind::SROA:
       Buffer << 'x';
       break;

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -196,14 +196,15 @@ namespace {
 
 struct UseState {
   SILValue address;
-  SmallVector<MarkUnresolvedMoveAddrInst *, 8> markMoves;
-  SmallPtrSet<SILInstruction *, 8> seenMarkMoves;
-  SmallSetVector<SILInstruction *, 8> inits;
-  SmallSetVector<SILInstruction *, 8> livenessUses;
-  SmallBlotSetVector<DestroyAddrInst *, 8> destroys;
-  llvm::SmallDenseMap<SILInstruction *, unsigned, 8> destroyToIndexMap;
-  SmallBlotSetVector<SILInstruction *, 8> reinits;
-  llvm::SmallDenseMap<SILInstruction *, unsigned, 8> reinitToIndexMap;
+  SmallVector<MarkUnresolvedMoveAddrInst *, 1> markMoves;
+  SmallPtrSet<SILInstruction *, 1> seenMarkMoves;
+  SmallSetVector<SILInstruction *, 2> inits;
+  SmallSetVector<SILInstruction *, 4> livenessUses;
+  SmallBlotSetVector<DestroyAddrInst *, 4> destroys;
+  llvm::SmallDenseMap<SILInstruction *, unsigned, 4> destroyToIndexMap;
+  SmallBlotSetVector<SILInstruction *, 4> reinits;
+  llvm::SmallDenseMap<SILInstruction *, unsigned, 4> reinitToIndexMap;
+  SmallBlotSetVector<Operand *, 2> partialApplyOperands;
 
   void insertMarkUnresolvedMoveAddr(MarkUnresolvedMoveAddrInst *inst) {
     if (!seenMarkMoves.insert(inst).second)

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -109,6 +109,12 @@ void FunctionSignatureSpecializationMangler::setArgumentBoxToStack(
       ArgumentModifierIntBase(ArgumentModifier::BoxToStack);
 }
 
+void FunctionSignatureSpecializationMangler::setArgumentInOutToOut(
+    unsigned OrigArgIdx) {
+  OrigArgs[OrigArgIdx].first =
+      ArgumentModifierIntBase(ArgumentModifier::InOutToOut);
+}
+
 void
 FunctionSignatureSpecializationMangler::
 setReturnValueOwnedToUnowned() {
@@ -221,6 +227,11 @@ void FunctionSignatureSpecializationMangler::mangleArgument(
 
   if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::BoxToStack)) {
     ArgOpBuffer << 's';
+    return;
+  }
+
+  if (ArgMod == ArgumentModifierIntBase(ArgumentModifier::InOutToOut)) {
+    ArgOpBuffer << 'r';
     return;
   }
 

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -136,6 +136,13 @@ public func errorLoopMultipleMove(_ x: __owned Klass) -> () { // expected-error 
     }
 }
 
+public func errorLoopMultipleMove1(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
+    for _ in 0..<1024 {
+        let _ = _move(x) // expected-note {{move here}}
+                         // expected-note @-1 {{cyclic move here. move will occur multiple times in the loop}}
+    }
+}
+
 public func errorLoopMoveOfParameter(_ x: __owned Klass) -> () { // expected-error {{'x' used after being moved}}
     let _ = _move(x) // expected-note {{move here}}
     for _ in 0..<1024 {


### PR DESCRIPTION
This is an initial version of the code needed to handle reinitializing a variable in a defer. There is a bunch of boiler plate since:

1. I had to reimplement some new data flow analyses on the defer itself.
2. I had to teach the rest of the code how to use the summarized information from the defer when it was performing normal data flow on the caller.
3. I had to implement a cloner that converted the inout_aliasable arguments from the defer to our parameters since we will be passing in the moved argument uninitialized in the caller and otherwise memory lifetime invariants are broken.

I am doing some initial testing here and I am going to add more tests once this gets in tree.