### PR TITLE
Gardening: remove trailing whitespaces in libswift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -15,7 +15,7 @@ import SIL
 
 struct AliasAnalysis {
   let bridged: BridgedAliasAnalysis
-  
+
   func mayRead(_ inst: Instruction, fromAddress: Value) -> Bool {
     switch AliasAnalysis_getMemBehavior(bridged, inst.bridged, fromAddress.bridged) {
       case MayReadBehavior, MayReadWriteBehavior, MayHaveSideEffectsBehavior:

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -23,7 +23,7 @@ public struct CalleeAnalysis {
 
 public struct FunctionArray : RandomAccessCollection, CustomReflectable {
   fileprivate let bridged: BridgedCalleeList
-  
+
   public var startIndex: Int { 0 }
   public var endIndex: Int { BridgedFunctionArray_size(bridged) }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyGlobalValue.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyGlobalValue.swift
@@ -31,7 +31,7 @@ let simplifyGlobalValuePass = InstructionPass<GlobalValueInst>(
     users.removeAll()
   }
 })
-  
+
 /// Returns true if reference counting and debug_value users of a global_value
 /// can be deleted.
 private func checkUsers(of val: Value, users: inout StackList<Instruction>) -> Bool {

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyStrongRetainRelease.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyStrongRetainRelease.swift
@@ -44,7 +44,7 @@ let simplifyStrongRetainPass = InstructionPass<StrongRetainInst>(
     }
   }
 })
-  
+
 let simplifyStrongReleasePass = InstructionPass<StrongReleaseInst>(
   name: "simplify-strong_release", {
   (release: StrongReleaseInst, context: PassContext) in
@@ -65,7 +65,7 @@ let simplifyStrongReleasePass = InstructionPass<StrongReleaseInst>(
     }
   }
 })
-  
+
 /// Returns true if \p value is something where reference counting instructions
 /// don't have any effect.
 private func isNotReferenceCounted(value: Value, context: PassContext) -> Bool {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
@@ -21,16 +21,16 @@ public typealias BridgedInstructionPassCtxt =
 struct PassContext {
 
   fileprivate let passContext: BridgedPassContext
-  
+
   var isSwift51RuntimeAvailable: Bool {
     PassContext_isSwift51RuntimeAvailable(passContext) != 0
   }
-  
+
   var aliasAnalysis: AliasAnalysis {
     let bridgedAA = PassContext_getAliasAnalysis(passContext)
     return AliasAnalysis(bridged: bridgedAA)
   }
-  
+
   var calleeAnalysis: CalleeAnalysis {
     let bridgeCA = PassContext_getCalleeAnalysis(passContext)
     return CalleeAnalysis(bridged: bridgeCA)
@@ -52,7 +52,7 @@ struct PassContext {
           }
         }
     }
-  
+
     if instruction is FullApplySite {
       PassContext_notifyChanges(passContext, callsChanged)
     }

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -31,13 +31,13 @@ final public class BasicBlock : ListNode, CustomStringConvertible {
   public var reverseInstructions: ReverseList<Instruction> {
     ReverseList(startAt: SILBasicBlock_lastInst(bridged).instruction)
   }
-  
+
   public var terminator: TermInst {
     SILBasicBlock_lastInst(bridged).instruction as! TermInst
   }
 
   public var successors: SuccessorArray { terminator.successors }
-  
+
   public var predecessors: PredecessorList {
     PredecessorList(startAt: SILBasicBlock_getFirstPred(bridged))
   }
@@ -60,7 +60,7 @@ final public class BasicBlock : ListNode, CustomStringConvertible {
     }
     fatalError()
   }
-  
+
   public var label: String { "bb\(index)" }
 
   var bridged: BridgedBasicBlock { BridgedBasicBlock(obj: SwiftObject(self)) }
@@ -82,20 +82,20 @@ public struct ArgumentArray : RandomAccessCollection {
 
 public struct SuccessorArray : RandomAccessCollection, CustomReflectable {
   private let succArray: BridgedArrayRef
-  
+
   init(succArray: BridgedArrayRef) {
     self.succArray = succArray
   }
-  
+
   public var startIndex: Int { return 0 }
   public var endIndex: Int { return Int(succArray.numElements) }
-  
+
   public subscript(_ index: Int) -> BasicBlock {
     precondition(index >= 0 && index < endIndex)
     let s = BridgedSuccessor(succ: succArray.data + index &* BridgedSuccessorSize);
     return SILSuccessor_getTargetBlock(s).block
   }
-  
+
   public var customMirror: Mirror {
     let c: [Mirror.Child] = map { (label: nil, value: $0.label) }
     return Mirror(self, children: c)
@@ -104,7 +104,7 @@ public struct SuccessorArray : RandomAccessCollection, CustomReflectable {
 
 public struct PredecessorList : Sequence, IteratorProtocol, CustomReflectable {
   private var currentSucc: OptionalBridgedSuccessor
-  
+
   public init(startAt: OptionalBridgedSuccessor) { currentSucc = startAt }
 
   public mutating func next() -> BasicBlock? {

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -60,7 +60,7 @@ public struct Builder {
       return cf.getAs(CondFailInst.self)
     }
   }
-  
+
   public func createIntegerLiteral(_ value: Int, type: Type) -> IntegerLiteralInst {
     notifyInstructionsChanged()
     let literal = SILBuilder_createIntegerLiteral(


### PR DESCRIPTION
This is a trivial change, which it made sense to put into a separate commit, as it clearly wasn't relevant to the rest of the recent changes in this area.