### PR TITLE
[move-function] Make sure we error if code reinitializes a var's fields separately instead of the var all at once.

### DIFF
--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -631,3 +631,40 @@ extension MiscTests {
     }
 }
 
+//////////////////////////////////
+// Multiple Captures from Defer //
+//////////////////////////////////
+
+func multipleCapture1<T : P>(_ k: T) -> () {
+    let kType = type(of: k)
+    var k2 = k
+    var k3 = k
+    let _ = _move(k2)
+    let _ = _move(k3)
+    var k4 = k
+    k4 = k
+    defer {
+        k2 = kType.getP()
+        print(k4)
+        k3 = kType.getP()
+    }
+    print("foo bar")
+}
+
+func multipleCapture2<T : P>(_ k: T) -> () {
+    let kType = type(of: k)
+    var k2 = k // expected-error {{'k2' used after being moved}}
+    k2 = k
+    var k3 = k
+    let _ = _move(k2) // expected-note {{move here}}
+    let _ = _move(k3)
+    var k4 = k
+    k4 = k
+    defer {
+        print(k2) // expected-note {{use here}}
+        print(k4)
+        k3 = kType.getP()
+    }
+    print("foo bar")
+}
+

--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -668,3 +668,25 @@ func multipleCapture2<T : P>(_ k: T) -> () {
     print("foo bar")
 }
 
+//////////////////////
+// Reinit in pieces //
+//////////////////////
+
+// These tests exercise the diagnostic to see how we error if we re-initialize a
+// var in pieces. Eventually we should teach either this diagnostic pass how to
+// handle this or teach DI how to combine the initializations into one large
+// reinit.
+struct ProtPair<T : P> {
+    var lhs: T
+    var rhs: T
+}
+
+func reinitInPieces1<T : P>(_ k: ProtPair<T>) {
+    let selfType = type(of: k.lhs)
+    var k2 = k
+    k2 = k
+
+    let _ = _move(k2) // expected-error {{_move applied to value that the compiler does not support checking}}
+    k2.lhs = selfType.getP()
+    k2.rhs = selfType.getP()
+}

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -710,3 +710,24 @@ func multipleCapture2(_ k: Klass) -> () {
     print("foo bar")
 }
 
+//////////////////////
+// Reinit in pieces //
+//////////////////////
+
+// These tests exercise the diagnostic to see how we error if we re-initialize a
+// var in pieces. Eventually we should teach either this diagnostic pass how to
+// handle this or teach DI how to combine the initializations into one large
+// reinit.
+struct KlassPair {
+    var lhs: Klass
+    var rhs: Klass
+}
+
+func reinitInPieces1(_ k: KlassPair) {
+    var k2 = k
+    k2 = k
+
+    let _ = _move(k2) // expected-error {{_move applied to value that the compiler does not support checking}}
+    k2.lhs = Klass()
+    k2.rhs = Klass()
+}

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -674,3 +674,39 @@ extension KlassWrapper {
         print("foo bar")
     }
 }
+
+//////////////////////////////////
+// Multiple Captures from Defer //
+//////////////////////////////////
+
+func multipleCapture1(_ k: Klass) -> () {
+    var k2 = k
+    var k3 = k
+    let _ = _move(k2)
+    let _ = _move(k3)
+    var k4 = k
+    k4 = k
+    defer {
+        k2 = Klass()
+        print(k4)
+        k3 = Klass()
+    }
+    print("foo bar")
+}
+
+func multipleCapture2(_ k: Klass) -> () {
+    var k2 = k // expected-error {{'k2' used after being moved}}
+    k2 = k
+    var k3 = k
+    let _ = _move(k2) // expected-note {{move here}}
+    let _ = _move(k3)
+    var k4 = k
+    k4 = k
+    defer {
+        print(k2) // expected-note {{use here}}
+        print(k4)
+        k3 = Klass()
+    }
+    print("foo bar")
+}
+


### PR DESCRIPTION
In the future, we should be able to handle this. For now though we are not sensitive to fields, so it makes sense to just error.

I also added some other tests in an additional commit that exercises the code that ensures we handle defer that capture multiple vars correctly.