### PR TITLE
Ensure that we set opaque type substitutions on local variables.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -538,29 +538,6 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   PBD->setPattern(patternNumber, pattern, initContext);
   PBD->setInit(patternNumber, init);
 
-  // Bind a property with an opaque return type to the underlying type
-  // given by the initializer.
-  if (auto var = pattern->getSingleVar()) {
-    SubstitutionMap substitutions;
-    if (auto opaque = var->getOpaqueResultTypeDecl()) {
-      init->forEachChildExpr([&](Expr *expr) -> Expr * {
-        if (auto coercionExpr = dyn_cast<UnderlyingToOpaqueExpr>(expr)) {
-          auto newSubstitutions =
-              coercionExpr->substitutions.mapReplacementTypesOutOfContext();
-          if (substitutions.empty()) {
-            substitutions = newSubstitutions;
-          } else {
-            assert(substitutions.getCanonical() ==
-                       newSubstitutions.getCanonical());
-          }
-        }
-        return expr;
-      });
-
-      opaque->setUnderlyingTypeSubstitutions(substitutions);
-    }
-  }
-
   if (hadError)
     PBD->setInvalid();
 

--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -253,3 +253,25 @@ public enum EnumWithTupleWithOpaqueField {
   case a(Int)
   case b((OpaqueProps, String))
 }
+
+// rdar://86800325 - Make sure we don't crash on result builders.
+@resultBuilder
+struct Builder {
+  static func buildBlock(_: Any...) -> Int { 5 }
+}
+
+protocol P2 {
+  associatedtype A: P2
+
+  @Builder var builder: A { get }
+}
+
+extension Int: P2 {
+  var builder: some P2 { 5 }
+}
+
+struct UseBuilder: P2 {
+  var builder: some P2 {
+    let extractedExpr: some P2 = 5
+  }
+}


### PR DESCRIPTION
We were never setting these opaque type substitutions, but code
generation was silently failing. Now we assert, so move the code into
the proper common location so we always set opaque type substitutions
on properties.

Fixes rdar://86800325.
