### PR TITLE
SILGen: Continue emitting local decls after hitting a return.

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -296,11 +296,27 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
     SGF.LocalAuxiliaryDecls.clear();
   }
 
+  bool didDiagnoseUnreachableElements = false;
   for (auto &ESD : S->getElements()) {
     
-    if (auto D = ESD.dyn_cast<Decl*>())
+    if (auto D = ESD.dyn_cast<Decl*>()) {
       if (isa<IfConfigDecl>(D))
         continue;
+
+      // Hoisted declarations are emitted at the top level by emitSourceFile().
+      if (D->isHoisted())
+        continue;
+
+      // PatternBindingBecls represent local variable bindings that execute
+      // as part of the function's execution.
+      if (!isa<PatternBindingDecl>(D)) {
+        // Other decls define entities that may be used by the program, such as
+        // local function declarations. So handle them here, before checking for
+        // reachability, and then continue looping.
+        SGF.visit(D);
+        continue;
+      }
+    }
     
     // If we ever reach an unreachable point, stop emitting statements and issue
     // an unreachable code diagnostic.
@@ -350,6 +366,10 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
           continue;
       }
       
+      if (didDiagnoseUnreachableElements)
+        continue;
+      didDiagnoseUnreachableElements = true;
+      
       if (StmtType != UnknownStmtType) {
         diagnose(getASTContext(), ESD.getStartLoc(),
                  diag::unreachable_code_after_stmt, StmtType);
@@ -376,7 +396,7 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
           }
         }
       }
-      return;
+      continue;
     }
 
     // Process children.
@@ -395,11 +415,11 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
     } else {
       auto *D = ESD.get<Decl*>();
 
-      // Hoisted declarations are emitted at the top level by emitSourceFile().
-      if (D->isHoisted())
-        continue;
+      // Only PatternBindingDecls should be emitted here.
+      // Other decls were handled above.
+      auto PBD = cast<PatternBindingDecl>(D);
 
-      SGF.visit(D);
+      SGF.visit(PBD);
     }
   }
 }

--- a/test/SILGen/local_decl_after_unreachable.swift
+++ b/test/SILGen/local_decl_after_unreachable.swift
@@ -1,0 +1,16 @@
+
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}3foo{{.*}}F : {{.*}} {
+func foo() {
+    return bar(Baz())
+
+    struct Baz {
+        // CHECK-LABEL: sil {{.*}} @{{.*}}3foo{{.*}}3Baz{{.*}}C : {{.*}} {
+        init() {}
+    }
+
+    // CHECK-LABEL: sil {{.*}} @{{.*}}3foo{{.*}}3bar{{.*}}F : {{.*}} {
+    func bar(_: Any) {}
+
+}


### PR DESCRIPTION
Instead of short-circuiting out of emitBlockStmt if the SIL insertion point
has become unreachable (because, for instance, all paths through the function
have returned), iterate through the remaining elements and process
non-PatternBindingDecl declarations, to ensure that local functions and types
get emitted. Fixes rdar://87039628.