### PR TITLE
[SIL] Added borrow scopes to alloc_boxes.

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -285,6 +285,10 @@ SILBuilder::emitDestroyAddr(SILLocation Loc, SILValue Operand) {
     if (isa<DeallocStackInst>(Inst))
       continue;
 
+    // end_borrow insts also don't affect take-ability
+    if (isa<EndBorrowInst>(Inst))
+      continue;
+
     // An end_access of the same address may be able to be rewritten as a
     // [deinit] access.
     if (auto endAccess = dyn_cast<EndAccessInst>(Inst)) {

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -57,6 +57,9 @@ static void lifetimeExtendAddressOnlyRValueSubValues(
            "addresses must be address only.");
     auto boxTy = SILBoxType::get(v->getType().getASTType());
     SILValue box = SGF.B.createAllocBox(loc, boxTy);
+    if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
+      box = SGF.B.createBeginBorrow(loc, box, /*isLexical=*/true);
+    }
     SILValue addr = SGF.B.createProjectBox(loc, box, 0);
     SGF.B.createCopyAddr(loc, v, addr, IsTake, IsInitialization);
 

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1040,6 +1040,7 @@ public:
   ALWAYS_NON_ESCAPING_INST(Load)
   ALWAYS_NON_ESCAPING_INST(StrongRelease)
   ALWAYS_NON_ESCAPING_INST(DestroyValue)
+  ALWAYS_NON_ESCAPING_INST(EndBorrow)
 #undef ALWAYS_NON_ESCAPING_INST
 
   bool visitDeallocBoxInst(DeallocBoxInst *dbi) {
@@ -1213,7 +1214,8 @@ static bool findEscapeOrMutationUses(Operand *op,
   // we want to be more conservative around non-top level copies (i.e. a copy
   // derived from a projection like instruction). In fact such a thing may not
   // even make any sense!
-  if (isa<CopyValueInst>(user) || isa<MarkUninitializedInst>(user)) {
+  if (isa<CopyValueInst>(user) || isa<MarkUninitializedInst>(user) ||
+      isa<BeginBorrowInst>(user)) {
     bool foundSomeMutations = false;
     for (auto *use : cast<SingleValueInstruction>(user)->getUses()) {
       foundSomeMutations |= findEscapeOrMutationUses(use, state);

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -102,10 +102,14 @@ public:
   /// with the memory info.
   SingleValueInstruction *getUninitializedValue() const {
     if (IsBox) {
+      SILValue inst = MemoryInst;
+      if (auto *bbi = MemoryInst->getSingleUserOfType<BeginBorrowInst>()) {
+        inst = bbi;
+      }
       // TODO: consider just storing the ProjectBoxInst in this case.
-      auto *pbi = MemoryInst->getSingleUserOfType<ProjectBoxInst>();
-      assert(pbi);
-      return pbi;
+      SingleValueInstruction *svi = inst->getSingleUserOfType<ProjectBoxInst>();
+      assert(svi);
+      return svi;
     }
     return MemoryInst;
   }

--- a/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInvalidEscapingCaptures.cpp
@@ -157,7 +157,11 @@ const ParamDecl *getParamDeclFromOperand(SILValue value) {
 
 bool isUseOfSelfInInitializer(Operand *oper) {
   if (auto *PBI = dyn_cast<ProjectBoxInst>(oper->get())) {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(PBI->getOperand())) {
+    SILValue value = PBI->getOperand();
+    if (auto *bbi = dyn_cast<BeginBorrowInst>(value)) {
+      value = bbi->getOperand();
+    }
+    if (auto *MUI = dyn_cast<MarkUninitializedInst>(value)) {
       switch (MUI->getMarkUninitializedKind()) {
       case MarkUninitializedInst::Kind::Var:
         return false;

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -172,7 +172,8 @@ static bool getFinalReleases(SILValue Box,
 
     // If we have a copy value or a mark_uninitialized, add its uses to the work
     // list and continue.
-    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User) ||
+        isa<BeginBorrowInst>(User)) {
       llvm::copy(cast<SingleValueInstruction>(User)->getUses(),
                  std::back_inserter(Worklist));
       continue;
@@ -385,12 +386,14 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
     // Projections are fine as well.
     if (isa<StrongRetainInst>(User) || isa<StrongReleaseInst>(User) ||
         isa<ProjectBoxInst>(User) || isa<DestroyValueInst>(User) ||
-        (!inAppliedFunction && isa<DeallocBoxInst>(User)))
+        (!inAppliedFunction && isa<DeallocBoxInst>(User)) ||
+        isa<EndBorrowInst>(User))
       continue;
 
     // If our user instruction is a copy_value or a mark_uninitialized, visit
     // the users recursively.
-    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User) ||
+        isa<BeginBorrowInst>(User)) {
       llvm::copy(cast<SingleValueInstruction>(User)->getUses(),
                  std::back_inserter(Worklist));
       continue;
@@ -502,10 +505,12 @@ static void replaceProjectBoxUsers(SILValue HeapBox, SILValue StackBox) {
       continue;
     }
 
-    auto *CVI = dyn_cast<CopyValueInst>(Op->getUser());
-    if (!CVI)
-      continue;
-    llvm::copy(CVI->getUses(), std::back_inserter(Worklist));
+    auto *User = Op->getUser();
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User) ||
+        isa<BeginBorrowInst>(User)) {
+      llvm::copy(cast<SingleValueInstruction>(User)->getUses(),
+                 std::back_inserter(Worklist));
+    }
   }
 }
 
@@ -578,8 +583,9 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   while (!Worklist.empty()) {
     auto *User = Worklist.pop_back_val();
 
-    // Look through any mark_uninitialized, copy_values.
-    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User)) {
+    // Look through any mark_uninitialized, copy_values, begin_borrow.
+    if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User) ||
+        isa<BeginBorrowInst>(User)) {
       auto Inst = cast<SingleValueInstruction>(User);
       llvm::transform(Inst->getUses(), std::back_inserter(Worklist),
                       [](Operand *Op) -> SILInstruction * {
@@ -592,7 +598,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
 
     assert(isa<StrongReleaseInst>(User) || isa<StrongRetainInst>(User) ||
            isa<DeallocBoxInst>(User) || isa<ProjectBoxInst>(User) ||
-           isa<DestroyValueInst>(User));
+           isa<DestroyValueInst>(User) || isa<EndBorrowInst>(User));
 
     User->eraseFromParent();
   }
@@ -934,6 +940,7 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
     assert((isa<SingleValueInstruction>(Box) && isa<AllocBoxInst>(Box) ||
             isa<CopyValueInst>(Box) ||
             isa<MarkUninitializedInst>(Box) ||
+            isa<BeginBorrowInst>(Box) ||
             isa<SILFunctionArgument>(Box)) &&
            "Expected either an alloc box or a copy of an alloc box or a "
            "function argument");

--- a/test/SILGen/access_marker_gen.swift
+++ b/test/SILGen/access_marker_gen.swift
@@ -12,7 +12,8 @@ public struct S {
 // CHECK: bb0(%0 : @guaranteed $Optional<AnyObject>):
 // CHECK: [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
 // CHECK: [[MARKED_BOX:%.*]] = mark_uninitialized [var] [[BOX]] : ${ var S }
-// CHECK: [[ADDR:%.*]] = project_box [[MARKED_BOX]] : ${ var S }, 0
+// CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK: [[ADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var S }, 0
 // CHECK: cond_br %{{.*}}, bb1, bb2
 // CHECK: bb1:
 // CHECK: [[ACCESS1:%.*]] = begin_access [modify] [unknown] [[ADDR]] : $*S
@@ -45,7 +46,8 @@ func takeS(_ s: S) {}
 // CHECK-LABEL: sil [ossa] @$s17access_marker_gen14modifyAndReadSyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK: %[[BOX:.*]] = alloc_box ${ var S }, var, name "s"
-// CHECK: %[[ADDRS:.*]] = project_box %[[BOX]] : ${ var S }, 0
+// CHECK: %[[BOX_LIFETIME:[^,]+]] = begin_borrow [lexical] %[[BOX]]
+// CHECK: %[[ADDRS:.*]] = project_box %[[BOX_LIFETIME]] : ${ var S }, 0
 // CHECK: %[[ACCESS1:.*]] = begin_access [modify] [unknown] %[[ADDRS]] : $*S
 // CHECK: %[[ADDRI:.*]] = struct_element_addr %[[ACCESS1]] : $*S, #S.i
 // CHECK: assign %{{.*}} to %[[ADDRI]] : $*Int

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -166,7 +166,8 @@ func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   var v = v
   // CHECK: bb0([[DEST:%[0-9]+]] : $*Unloadable, [[VARG:%[0-9]+]] : $*Unloadable):
   // CHECK: [[VBOX:%.*]] = alloc_box ${ var Unloadable }
-  // CHECK: [[PBOX:%[0-9]+]] = project_box [[VBOX]]
+  // CHECK: [[V_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VBOX]]
+  // CHECK: [[PBOX:%[0-9]+]] = project_box [[V_LIFETIME]]
   // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*Unloadable
   dest = v
   // CHECK: [[READBOX:%.*]] = begin_access [read] [unknown] [[PBOX]] :
@@ -211,7 +212,8 @@ func address_only_var() -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable):
   var x = some_address_only_function_1()
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Unloadable }
-  // CHECK: [[XPB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XPB:%.*]] = project_box [[XBOX_LIFETIME]]
   // CHECK: apply {{%.*}}([[XPB]])
   return x
   // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XPB]] :

--- a/test/SILGen/auto_generated_super_init_call.swift
+++ b/test/SILGen/auto_generated_super_init_call.swift
@@ -50,6 +50,7 @@ class SomeDerivedClass : Parent {
 // CHECK-NEXT: [[SELFAGAIN:%.*]] = unchecked_ref_cast [[PARENT]]
 // CHECK-NEXT: store [[SELFAGAIN]] to [init] [[SELF]]
 // CHECK-NEXT: [[SELFLOAD:%.*]] = load [copy] [[SELF]]
+// CHECK-NEXT: end_borrow
 // CHECK-NEXT: destroy_value
 // CHECK-NEXT: return [[SELFLOAD]]
   }

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -18,7 +18,8 @@ func useD(_ d: D) {}
 // CHECK-LABEL: sil hidden [ossa] @$s6borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}} : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var C }, var, name "c"
-// CHECK:   [[PB_BOX:%.*]] = project_box [[BOX]]
+// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[PB_BOX:%.*]] = project_box [[BOX_LIFETIME]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PB_BOX]] : $*C
 // CHECK:   [[CLASS:%.*]] = load [copy] [[ACCESS]]
 // CHECK:   [[BORROWED_CLASS:%.*]] = begin_borrow [[CLASS]]
@@ -29,6 +30,7 @@ func useD(_ d: D) {}
 // CHECK:   destroy_value [[CLASS]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$s6borrow4useD{{.*}} : $@convention(thin) (@guaranteed D) -> ()
 // CHECK:   apply [[FUNC]]([[LOADED_VALUE]])
+// CHECK:   end_borrow [[BOX_LIFETIME]]
 // CHECK:   destroy_value [[BOX]]
 // CHECK: } // end sil function '$s6borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}}'
 func lvalueBorrowShouldBeAtEndOfFormalAccessScope() {

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -82,7 +82,8 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK-LABEL: sil hidden [ossa] @$s18boxed_existentials23test_property_of_lvalueySSs5Error_pF :
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $Error):
 // CHECK:         [[VAR:%.*]] = alloc_box ${ var Error }
-// CHECK:         [[PVAR:%.*]] = project_box [[VAR]]
+// CHECK:         [[VAR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+// CHECK:         [[PVAR:%.*]] = project_box [[VAR_LIFETIME]]
 // CHECK:         [[ARG_COPY:%.*]] = copy_value [[ARG]] : $Error
 // CHECK:         store [[ARG_COPY]] to [init] [[PVAR]]
 // CHECK:         [[ACCESS:%.*]] = begin_access [read] [unknown] [[PVAR]] : $*Error
@@ -98,6 +99,7 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[RESULT:%.*]] = apply [[METHOD]]<[[VALUE_TYPE]]>([[BORROW]])
 // CHECK:         destroy_addr [[COPY]]
 // CHECK:         dealloc_stack [[COPY]]
+// CHECK:         end_borrow [[VAR_LIFETIME]]
 // CHECK:         destroy_value [[VAR]]
 // CHECK-NOT:         destroy_value [[ARG]]
 // CHECK:         return [[RESULT]]
@@ -131,9 +133,11 @@ func test_open_existential_semantics(_ guaranteed: Error,
                                      _ immediate: Error) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
-  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   // GUARANTEED: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
-  // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
+  // GUARANTEED: [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // GUARANTEED: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
 
   // CHECK-NOT: copy_value [[ARG0]]
   // CHECK: [[VALUE:%.*]] = open_existential_box [[ARG0]]
@@ -200,7 +204,8 @@ func test_open_existential_semantics(_ guaranteed: Error,
 func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
   var immediate = immediate
   // CHECK:       [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var Error }
-  // CHECK:       [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
+  // CHECK:       [[IMMEDIATE_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK:       [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   if true {
     // CHECK-NOT: copy_value [[GUAR]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[GUAR:%.*]]

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -37,12 +37,14 @@ func class_bound_generic<T : ClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound> { var τ_0_0 } <T>
-  // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK:   [[X1:%.*]] = load [copy] [[READ]]
+  // CHECK:   end_borrow [[X_LIFETIME]]
   // CHECK:   destroy_value [[X_ADDR]]
   // CHECK:   return [[X1]]
 }
@@ -52,7 +54,8 @@ func class_bound_generic_2<T : ClassBound & NotClassBound>(x: T) -> T {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $T):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ClassBound, τ_0_0 : NotClassBound> { var τ_0_0 } <T>
-  // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
@@ -66,7 +69,8 @@ func class_bound_protocol(x: ClassBound) -> ClassBound {
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $ClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound }
-  // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
@@ -81,7 +85,8 @@ func class_bound_protocol_composition(x: ClassBound & NotClassBound)
   var x = x
   // CHECK: bb0([[X:%.*]] : @guaranteed $ClassBound & NotClassBound):
   // CHECK:   [[X_ADDR:%.*]] = alloc_box ${ var ClassBound & NotClassBound }
-  // CHECK:   [[PB:%.*]] = project_box [[X_ADDR]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_ADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
   // CHECK:   store [[X_COPY]] to [init] [[PB]]
   return x
@@ -126,7 +131,8 @@ func class_bound_method(x: ClassBound) {
   var x = x
   x.classBoundMethod()
   // CHECK: [[XBOX:%.*]] = alloc_box ${ var ClassBound }, var, name "x"
-  // CHECK: [[XBOX_PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XBOX_PB:%.*]] = project_box [[XLIFETIME]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[XBOX_PB]]
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*ClassBound
@@ -135,6 +141,7 @@ func class_bound_method(x: ClassBound) {
   // CHECK: [[METHOD:%.*]] = witness_method $[[OPENED]], #ClassBound.classBoundMethod :
   // CHECK: apply [[METHOD]]<[[OPENED]]>([[PROJ]])
   // CHECK: destroy_value [[PROJ]]
+  // CHECK: end_borrow [[XLIFETIME]]
   // CHECK: destroy_value [[XBOX]]
 }
 // CHECK: } // end sil function '$ss18class_bound_method1xys10ClassBound_p_tF'

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -33,8 +33,9 @@ func read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
+  // CHECK:   [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
   // SEMANTIC ARC TODO: This is incorrect. We need to do the project_box on the copy.
-  // CHECK:   [[PROJECT:%.*]] = project_box [[XBOX]]
+  // CHECK:   [[PROJECT:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   store [[X]] to [trivial] [[PROJECT]]
 
   func cap() -> Int {
@@ -42,12 +43,10 @@ func read_only_capture(_ x: Int) -> Int {
   }
 
   return cap()
-  // CHECK:   [[XBOX_BORROW:%.*]] = begin_borrow [[XBOX]]
   // SEMANTIC ARC TODO: See above. This needs to happen on the copy_valued box.
   // CHECK:   mark_function_escape [[PROJECT]]
   // CHECK:   [[CAP:%[0-9]+]] = function_ref @[[CAP_NAME:\$s8closures17read_only_capture.*]] : $@convention(thin) (@guaranteed { var Int }) -> Int
-  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XBOX_BORROW]])
-  // CHECK:   end_borrow [[XBOX_BORROW]]
+  // CHECK:   [[RET:%[0-9]+]] = apply [[CAP]]([[XLIFETIME]])
   // CHECK:   destroy_value [[XBOX]]
   // CHECK:   return [[RET]]
 }
@@ -67,14 +66,14 @@ func write_to_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
+  // CHECK:   [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[XLIFETIME]]
   // CHECK:   store [[X]] to [trivial] [[XBOX_PB]]
   // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
+  // CHECK:   [[X2LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[X2BOX]]
+  // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2LIFETIME]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*Int
   // CHECK:   copy_addr [[ACCESS]] to [initialization] [[X2BOX_PB]]
-  // CHECK:   [[X2BOX_BORROW:%.*]] = begin_borrow [[X2BOX]]
-  // SEMANTIC ARC TODO: This next mark_function_escape should be on a projection from X2BOX_BORROW.
   // CHECK:   mark_function_escape [[X2BOX_PB]]
   var x2 = x
 
@@ -84,10 +83,7 @@ func write_to_capture(_ x: Int) -> Int {
 
   scribble()
   // CHECK:   [[SCRIB:%[0-9]+]] = function_ref @[[SCRIB_NAME:\$s8closures16write_to_capture.*]] : $@convention(thin) (@guaranteed { var Int }) -> ()
-  // CHECK:   apply [[SCRIB]]([[X2BOX_BORROW]])
-  // SEMANTIC ARC TODO: This should load from X2BOX_BORROW project. There is an
-  // issue here where after a copy_value, we need to reassign a projection in
-  // some way.
+  // CHECK:   apply [[SCRIB]]([[X2LIFETIME]])
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[X2BOX_PB]] : $*Int
   // CHECK:   [[RET:%[0-9]+]] = load [trivial] [[ACCESS]]
   // CHECK:   destroy_value [[X2BOX]]
@@ -126,14 +122,15 @@ func capture_local_func(_ x: Int) -> () -> () -> Int {
   // CHECK: bb0([[ARG:%.*]] : $Int):
   var x = x
   // CHECK:   [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]]
+  // CHECK:   [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK:   [[XBOX_PB:%[0-9]+]] = project_box [[XLIFETIME]]
   // CHECK:   store [[ARG]] to [trivial] [[XBOX_PB]]
 
   func aleph() -> Int { return x }
 
   func beth() -> () -> Int { return aleph }
   // CHECK: [[BETH_REF:%.*]] = function_ref @[[BETH_NAME:\$s8closures18capture_local_funcySiycycSiF4bethL_SiycyF]] : $@convention(thin) (@guaranteed { var Int }) -> @owned @callee_guaranteed () -> Int
-  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XLIFETIME]]
   // SEMANTIC ARC TODO: This is incorrect. This should be a project_box from XBOX_COPY.
   // CHECK: mark_function_escape [[XBOX_PB]]
   // CHECK: [[BETH_CLOSURE:%[0-9]+]] = partial_apply [callee_guaranteed] [[BETH_REF]]([[XBOX_COPY]])
@@ -163,7 +160,8 @@ func anon_read_only_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[PB:%[0-9]+]] = project_box [[XLIFETIME]]
 
   return ({ x })()
   // -- func expression
@@ -185,7 +183,8 @@ func small_closure_capture(_ x: Int) -> Int {
   var x = x
   // CHECK: bb0([[X:%[0-9]+]] : $Int):
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
 
   return { x }()
   // -- func expression
@@ -207,11 +206,12 @@ func small_closure_capture(_ x: Int) -> Int {
 func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   var x = x
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
+  // CHEKC: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
 
   return { x + $0 }
   // -- func expression
   // CHECK: [[ANON:%[0-9]+]] = function_ref @[[CLOSURE_NAME:\$s8closures35small_closure_capture_with_argument.*]] : $@convention(thin) (Int, @guaranteed { var Int }) -> Int
-  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XBOX]]
+  // CHECK: [[XBOX_COPY:%.*]] = copy_value [[XLIFETIME]]
   // CHECK: [[ANON_CLOSURE_APP:%[0-9]+]] = partial_apply [callee_guaranteed] [[ANON]]([[XBOX_COPY]])
   // -- return
   // CHECK: destroy_value [[XBOX]]
@@ -244,7 +244,8 @@ func uncaptured_locals(_ x: Int) -> (Int, Int) {
   // -- locals without captures are stack-allocated
   // CHECK: bb0([[XARG:%[0-9]+]] : $Int):
   // CHECK:   [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[PB:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   store [[XARG]] to [trivial] [[PB]]
 
   var y = zero
@@ -318,7 +319,8 @@ class SelfCapturedInInit : Base {
   // First create our initial value for self.
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SelfCapturedInInit }, let, name "self"
   // CHECK:   [[UNINIT_SELF:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[UNINIT_SELF]]
+  // CHECK:   [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   store [[SELF]] to [init] [[PB_SELF_BOX]]
   //
   // Then perform the super init sequence.
@@ -660,7 +662,8 @@ class SuperSub : SuperBase {
 // -- We enter with an assumed strong +1.
 // CHECK:  bb0([[SELF:%.*]] : @guaranteed $UnownedSelfNestedCapture):
 // CHECK:         [[OUTER_SELF_CAPTURE:%.*]] = alloc_box ${ var @sil_unowned UnownedSelfNestedCapture }
-// CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_CAPTURE]]
+// CHECK:         [[OUTER_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[OUTER_SELF_CAPTURE]]
+// CHECK:         [[PB:%.*]] = project_box [[OUTER_SELF_LIFETIME]]
 // -- strong +2
 // CHECK:         [[SELF_COPY:%.*]] = copy_value [[SELF]]
 // CHECK:         [[UNOWNED_SELF:%.*]] = ref_to_unowned [[SELF_COPY]] :

--- a/test/SILGen/complete_object_init.swift
+++ b/test/SILGen/complete_object_init.swift
@@ -7,11 +7,13 @@ class A {
 // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick A.Type):
 // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var A }
 // CHECK:   [[UNINIT_SELF:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var A }
-// CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF]]
+// CHECK:   [[UNINIT_SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_SELF]]
+// CHECK:   [[PB:%.*]] = project_box [[UNINIT_SELF_LIFETIME]]
 // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick A.Type, #A.init!allocator
 // CHECK:   [[INIT_RESULT:%[0-9]+]] = apply [[INIT]]({{%[^,]*}}, [[SELF_META]])
 // CHECK:   assign [[INIT_RESULT]] to [[PB]] : $*A
 // CHECK:   [[RESULT:%[0-9]+]] = load [copy] [[PB]] : $*A
+// CHECK:   end_borrow [[UNINIT_SELF_LIFETIME]]
 // CHECK:   destroy_value [[UNINIT_SELF]] : ${ var A }
 // CHECK:   return [[RESULT]] : $A
   convenience init() {

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -9,9 +9,11 @@ func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes014init_var_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[X:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[PBX:%.*]] = project_box [[X]]
+// CHECK:   [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK:   [[PBX:%.*]] = project_box [[XLIFETIME]]
 // CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[PBY:%.*]] = project_box [[Y]]
+// CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
+// CHECK:   [[PBY:%.*]] = project_box [[YLIFETIME]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
 // CHECK:   copy_addr [[READ]] to [initialization] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
@@ -38,7 +40,8 @@ func init_var_from_computed_lvalue() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes021assign_computed_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[Y:%.*]] = alloc_box
-// CHECK:   [[PBY:%.*]] = project_box [[Y]]
+// CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
+// CHECK:   [[PBY:%.*]] = project_box [[YLIFETIME]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]
 // CHECK:   [[Y_VAL:%.*]] = load [trivial] [[READ]]
 // CHECK:   [[SETTER:%.*]] = function_ref @$s21copy_lvalue_peepholes8computedBi64_vs

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -33,27 +33,34 @@ func tuple_patterns() {
   var (a, b) : (Int, Float)
   // CHECK: [[ABOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[ABOX]]
-  // CHECK: [[PBA:%.*]] = project_box [[AADDR]]
+  // CHECK: [[A_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[AADDR]]
+  // CHECK: [[PBA:%.*]] = project_box [[A_LIFETIME]]
   // CHECK: [[BBOX:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[BBOX]]
-  // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
+  // CHECK: [[B_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BADDR]]
+  // CHECK: [[PBB:%.*]] = project_box [[B_LIFETIME]]
 
   var (c, d) = (a, b)
   // CHECK: [[CADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
+  // CHECK: [[C_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[CADDR]]
+  // CHECK: [[PBC:%.*]] = project_box [[C_LIFETIME]]
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
+  // CHECK: [[D_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[DADDR]]
+  // CHECK: [[PBD:%.*]] = project_box [[D_LIFETIME]]
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [initialization] [[PBC]]
   // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
   // CHECK: copy_addr [[READB]] to [initialization] [[PBD]]
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
+  // CHECK: [[E_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[EADDR]]
+  // CHECK: [[PBE:%.*]] = project_box [[E_LIFETIME]]
   // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[PBF:%.*]] = project_box [[FADDR]]
+  // CHECK: [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[FADDR]]
+  // CHECK: [[PBF:%.*]] = project_box [[F_LIFETIME]]
   // CHECK: [[GADDR:%[0-9]+]] = alloc_box ${ var () }
   // CHECK: [[HADDR:%[0-9]+]] = alloc_box ${ var Double }
-  // CHECK: [[PBH:%.*]] = project_box [[HADDR]]
+  // CHECK: [[H_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[HADDR]]
+  // CHECK: [[PBH:%.*]] = project_box [[H_LIFETIME]]
   // CHECK: [[EFGH:%[0-9]+]] = apply
   // CHECK: ([[E:%[0-9]+]], [[F:%[0-9]+]], [[H:%[0-9]+]]) = destructure_tuple
   // CHECK: store [[E]] to [trivial] [[PBE]]
@@ -62,7 +69,8 @@ func tuple_patterns() {
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
+  // CHECK: [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IADDR]]
+  // CHECK: [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [initialization] [[PBI]]
@@ -72,9 +80,11 @@ func tuple_patterns() {
   var (i,_) = (a, b)
 
   // CHECK: [[JADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBJ:%.*]] = project_box [[JADDR]]
+  // CHECK: [[J_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[JADDR]]
+  // CHECK: [[PBJ:%.*]] = project_box [[J_LIFETIME]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[KADDR:%[0-9]+]] = alloc_box ${ var () }
+  // CHECK: [[K_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[KADDR]]
   // CHECK-NOT: alloc_box ${ var Double }
   // CHECK: [[J_K_:%[0-9]+]] = apply
   // CHECK: ([[J:%[0-9]+]], [[K:%[0-9]+]], {{%[0-9]+}}) = destructure_tuple
@@ -85,10 +95,12 @@ func tuple_patterns() {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls16simple_arguments{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+// CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
 // CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
+// CHECK-NEXT: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
+// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y_LIFETIME]]
 // CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
   var x = x
@@ -106,7 +118,8 @@ func tuple_argument(x: (Int, Float, ())) {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls14inout_argument{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Int, %1 : $Int):
 // CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
+// CHECK: [[X_LOCAL_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_LOCAL]]
+// CHECK: [[PBX:%.*]] = project_box [[X_LOCAL_LIFETIME]]
 func inout_argument(x: inout Int, y: Int) {
   var y = y
   x = y
@@ -130,7 +143,8 @@ func store_to_global(x: Int) {
   var x = x
   global = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBX:%.*]] = project_box [[XADDR]]
+  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @$s5decls6globalSivau
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()
   // CHECK: [[ADDR:%[0-9]+]] = pointer_to_address [[PTR]]

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -30,7 +30,8 @@ struct D {
 // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1DV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin D.Type) -> D
 // CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
-// CHECK: [[PB_THIS:%.*]] = project_box [[THIS]]
+// CHECK: [[THISLIFE:%[^,]+]] = begin_borrow [lexical] [[THIS]]
+// CHECK: [[PB_THIS:%.*]] = project_box [[THISLIFE]]
 // CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
 // CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
 // CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1DV1iSivpfi
@@ -71,7 +72,8 @@ class F : E { }
 // CHECK: bb0([[ORIGSELF:%[0-9]+]] : @owned $F)
 // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var F }
 // CHECK-NEXT: [[SELF:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-// CHECK-NEXT: [[PB:%.*]] = project_box [[SELF]]
+// CHECK-NEXT: [[SELFLIFE:%[^,]+]] = begin_borrow [lexical] [[SELF]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[SELFLIFE]]
 // CHECK-NEXT: store [[ORIGSELF]] to [init] [[PB]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [take] [[PB]] : $*F
 // CHECK-NEXT: [[E:%[0-9]]] = upcast [[SELFP]] : $F to $E
@@ -81,6 +83,7 @@ class F : E { }
 // CHECK-NEXT: [[ESELFW:%[0-9]+]] = unchecked_ref_cast [[ESELF]] : $E to $F
 // CHECK-NEXT: store [[ESELFW]] to [init] [[PB]] : $*F
 // CHECK-NEXT: [[SELFP:%[0-9]+]] = load [copy] [[PB]] : $*F
+// CHECK-NEXT: end_borrow [[SELFLIFE]]
 // CHECK-NEXT: destroy_value [[SELF]] : ${ var F }
 // CHECK-NEXT: return [[SELFP]] : $F
 

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -51,7 +51,8 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK: [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
+  // CHECK: [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJBOX]]
+  // CHECK-NEXT: [[PBOBJ:%[0-9]+]] = project_box [[OBJLIFETIME]]
   // CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK: store [[ARG_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
@@ -61,6 +62,7 @@ func direct_to_static_method(_ obj: AnyObject) {
   // CHECK-NEXT: [[OPENMETA:%[0-9]+]] = open_existential_metatype [[OBJMETA]] : $@thick AnyObject.Type to $@thick (@opened([[UUID:".*"]]) AnyObject).Type
   // CHECK-NEXT: [[METHOD:%[0-9]+]] = objc_method [[OPENMETA]] : $@thick (@opened([[UUID]]) AnyObject).Type, #X.staticF!foreign : (X.Type) -> () -> (), $@convention(objc_method) (@thick (@opened([[UUID]]) AnyObject).Type) -> ()
   // CHECK: apply [[METHOD]]([[OPENMETA]]) : $@convention(objc_method) (@thick (@opened([[UUID]]) AnyObject).Type) -> ()
+  // CHECK: end_borrow [[OBJLIFETIME]]
   // CHECK: destroy_value [[OBJBOX]]
   type(of: obj).staticF!()
 }
@@ -71,11 +73,13 @@ func opt_to_class(_ obj: AnyObject) {
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $AnyObject):
   var obj = obj
   // CHECK:   [[EXISTBOX:%[0-9]+]] = alloc_box ${ var AnyObject } 
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTBOX]]
+  // CHECK:   [[EXISTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[EXISTBOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[EXISTLIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[PBOBJ]]
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-  // CHECK:   [[PBOPT:%.*]] = project_box [[OPTBOX]]
+  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPTBOX]]
+  // CHECK:   [[PBOPT:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[EXISTVAL:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJ_SELF:%[0-9]*]] = open_existential_ref [[EXISTVAL]]
@@ -105,7 +109,9 @@ func opt_to_class(_ obj: AnyObject) {
 
   // Exit
   // CHECK:   destroy_value [[OBJ_SELF]] : $@opened({{".*"}}) AnyObject
+  // CHECK:   end_borrow [[OPTLIFETIME]]
   // CHECK:   destroy_value [[OPTBOX]] : ${ var Optional<@callee_guaranteed () -> ()> }
+  // CHECK:   end_borrow [[EXISTLIFETIME]]
   // CHECK:   destroy_value [[EXISTBOX]] : ${ var AnyObject }
   // CHECK:   [[RESULT:%[0-9]+]] = tuple ()
   // CHECK:   return [[RESULT]] : $()
@@ -122,11 +128,13 @@ func opt_to_static_method(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJBOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJBOX]]
+  // CHECK:   [[OBJLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJBOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJLIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[OPTBOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-  // CHECK:   [[PBO:%.*]] = project_box [[OPTBOX]]
+  // CHECK:   [[OPTLIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPTBOX]]
+  // CHECK:   [[PBO:%.*]] = project_box [[OPTLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJCOPY:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[OBJMETA:%[0-9]+]] = existential_metatype $@thick AnyObject.Type, [[OBJCOPY]] : $AnyObject
@@ -142,11 +150,13 @@ func opt_to_property(_ obj: AnyObject) {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   project_box [[INT_BOX]]
+  // CHECK:   [[INT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT_BOX]]
+  // CHECK:   project_box [[INT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -171,11 +181,13 @@ func opt_to_property(_ obj: AnyObject) {
 // GUARANTEED-LABEL: sil hidden [ossa] @$s14dynamic_lookup15opt_to_property{{[_0-9a-zA-Z]*}}F
   // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   project_box [[INT_BOX]]
+  // GUARANTEED:   [[INT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT_BOX]]
+  // GUARANTEED:   project_box [[INT_LIFETIME]]
   // GUARANTEED:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // GUARANTEED:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // GUARANTEED:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -200,11 +212,13 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   alloc_box ${ var Int }
   // CHECK:   project_box
@@ -234,11 +248,13 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
 // GUARANTEED-LABEL: sil hidden [ossa] @$s14dynamic_lookup19direct_to_subscript{{[_0-9a-zA-Z]*}}F
   // GUARANTEED: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // GUARANTEED:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // GUARANTEED:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // GUARANTEED:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // GUARANTEED:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
+  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // GUARANTEED:   store [[I]] to [trivial] [[PBI]] : $*Int
   // GUARANTEED:   alloc_box ${ var Int }
   // GUARANTEED:   project_box
@@ -268,11 +284,13 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   var i = i
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
+  // CHECK:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
@@ -301,12 +319,14 @@ func downcast(_ obj: AnyObject) -> X {
   var obj = obj
   // CHECK: bb0([[OBJ:%[0-9]+]] : @guaranteed $AnyObject):
   // CHECK:   [[OBJ_BOX:%[0-9]+]] = alloc_box ${ var AnyObject }
-  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_BOX]]
+  // CHECK:   [[OBJ_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OBJ_BOX]]
+  // CHECK:   [[PBOBJ:%[0-9]+]] = project_box [[OBJ_LIFETIME]]
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[X:%[0-9]+]] = unconditional_checked_cast [[OBJ]] : $AnyObject to X
+  // CHECK:   end_borrow [[OBJ_LIFETIME]]
   // CHECK:   destroy_value [[OBJ_BOX]] : ${ var AnyObject }
   // CHECK:   return [[X]] : $X
   return obj as! X

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -246,8 +246,9 @@ class Z {
     // so that IRGen can recover metadata.
 
     // CHECK:      [[WEAK_SELF:%.*]] = alloc_box ${ var @sil_weak Optional<Z> }
+    // CHECK:      [[WEAK_SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[WEAK_SELF]]
     // CHECK:      [[FN:%.*]] = function_ref @$s12dynamic_self1ZC23testDynamicSelfCaptures1xACXDSi_tFyycfU1_ : $@convention(thin) (@guaranteed { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
-    // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF]] : ${ var @sil_weak Optional<Z> }
+    // CHECK:      [[WEAK_SELF_COPY:%.*]] = copy_value [[WEAK_SELF_LIFETIME]] : ${ var @sil_weak Optional<Z> }
     // CHECK-NEXT: [[DYNAMIC_SELF:%.*]] = metatype $@thick @dynamic_self Z.Type
     // CHECK:      partial_apply [callee_guaranteed] [[FN]]([[WEAK_SELF_COPY]], [[DYNAMIC_SELF]]) : $@convention(thin) (@guaranteed { var @sil_weak Optional<Z> }, @thick @dynamic_self Z.Type) -> ()
     let fn3 = {

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -119,7 +119,8 @@ public enum MyResilientEnum {
   // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience15MyResilientEnumOACycfC : $@convention(method) (@thin MyResilientEnum.Type) -> @out MyResilientEnum
   // CHECK:       [[SELF_BOX:%.*]] = alloc_box ${ var MyResilientEnum }, var, name "self"
   // CHECK:       [[SELF_TMP:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var MyResilientEnum }
-  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_TMP]] : ${ var MyResilientEnum }, 0
+  // CHECK:       [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[SELF_TMP]]
+  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]] : ${ var MyResilientEnum }, 0
   // CHECK:       [[NEW_SELF:%.*]] = enum $MyResilientEnum, #MyResilientEnum.loki!enumelt
   // CHECK:       [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*MyResilientEnum
   // CHECK:       assign [[NEW_SELF]] to [[ACCESS]] : $*MyResilientEnum
@@ -147,7 +148,8 @@ public enum MoreHorses {
   // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience10MoreHorsesOACycfC : $@convention(method) (@thin MoreHorses.Type) -> @out MoreHorses
   // CHECK:       [[SELF_BOX:%.*]] = alloc_box ${ var MoreHorses }, var, name "self"
   // CHECK:       [[SELF_TMP:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var MoreHorses }
-  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_TMP]] : ${ var MoreHorses }, 0
+  // CHECK:       [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[SELF_TMP]]
+  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]] : ${ var MoreHorses }, 0
   // CHECK:       [[BUILTIN_INT:%.*]] = integer_literal $Builtin.IntLiteral, 0
   // CHECK:       [[INT_METATYPE:%.*]] = metatype $@thin Int.Type
   // CHECK:       [[INT_CTOR:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -695,7 +695,8 @@ class BaseThrowingInit : HasThrowingInit {
 // CHECK: sil hidden [ossa] @$s6errors16BaseThrowingInit{{.*}}c : $@convention(method) (Int, Int, @owned BaseThrowingInit) -> (@owned BaseThrowingInit, @error Error)
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var BaseThrowingInit }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
-// CHECK:      [[PB:%.*]] = project_box [[MARKED_BOX]]
+// CHECK:      [[BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK:      [[PB:%.*]] = project_box [[BOX_LIFETIME]]
 //   Initialize subField.
 // CHECK:      [[T0:%.*]] = load_borrow [[PB]]
 // CHECK-NEXT: [[T1:%.*]] = ref_element_addr [[T0]] : $BaseThrowingInit, #BaseThrowingInit.subField
@@ -864,7 +865,8 @@ func testOptionalTryThatNeverThrows() {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors18testOptionalTryVaryyF
 // CHECK-NEXT: bb0:
 // CHECK-NEXT: [[BOX:%.+]] = alloc_box ${ var Optional<Cat> }
-// CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
+// CHECK-NEXT: [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK: [[FN:%.+]] = function_ref @$s6errors10make_a_catAA3CatCyKF
 // CHECK-NEXT: try_apply [[FN]]() : $@convention(thin) () -> (@owned Cat, @error Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
 // CHECK: [[SUCCESS]]([[VALUE:%.+]] : @owned $Cat)
@@ -872,6 +874,7 @@ func testOptionalTryThatNeverThrows() {
 // CHECK-NEXT: store [[CAT_ENUM]] to [init] [[PB]] : $*Optional<Cat>
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
+// CHECK-NEXT: end_borrow [[LIFETIME]]
 // CHECK-NEXT: destroy_value [[BOX]] : ${ var Optional<Cat> }
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
 // CHECK-NEXT: return [[VOID]] : $()
@@ -911,7 +914,8 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors29testOptionalTryAddressOnlyVar{{.*}}F
 // CHECK: bb0(%0 : $*T):
 // CHECK: [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
-// CHECK-NEXT: [[PB:%.*]] = project_box [[BOX]]
+// CHECK: [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT: [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK: [[FN:%.+]] = function_ref @$s6errors11dont_return{{.*}}F
 // CHECK-NEXT: try_apply [[FN]]<T>([[BOX_DATA]], %0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @error Error), normal [[SUCCESS:[^ ]+]], error [[CLEANUPS:[^ ]+]],
@@ -919,6 +923,7 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT: inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT: br [[DONE:[^ ]+]],
 // CHECK: [[DONE]]:
+// CHECK-NEXT: end_borrow [[LIFETIME]]
 // CHECK-NEXT: destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NOT: destroy_addr %0 : $*T
 // CHECK-NEXT: [[VOID:%.+]] = tuple ()
@@ -975,10 +980,12 @@ func testOptionalTryNeverFails() {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors28testOptionalTryNeverFailsVaryyF
 // CHECK: bb0:
 // CHECK-NEXT:   [[BOX:%.+]] = alloc_box ${ var Optional<()> }
-// CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
+// CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT:   [[VALUE:%.+]] = tuple ()
 // CHECK-NEXT:   [[ENUM:%.+]] = enum $Optional<()>, #Optional.some!enumelt, [[VALUE]]
 // CHECK-NEXT:   store [[ENUM]] to [trivial] [[PB]] :
+// CHECK-NEXT:   end_borrow [[LIFETIME]]
 // CHECK-NEXT:   destroy_value [[BOX]] : ${ var Optional<()> }
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()
@@ -1006,10 +1013,12 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors39testOptionalTryNeverFailsAddressOnlyVar{{.*}}F
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[BOX:%.+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>
-// CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
+// CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
+// CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT:   copy_addr %0 to [initialization] [[BOX_DATA]] : $*T
 // CHECK-NEXT:   inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK-NEXT:   end_borrow [[LIFETIME]]
 // CHECK-NEXT:   destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()

--- a/test/SILGen/existential_metatypes.swift
+++ b/test/SILGen/existential_metatypes.swift
@@ -65,7 +65,8 @@ func existentialMetatypeUpcast2(_ x: (P & Q).Type) -> P.Type {
 // CHECK-LABEL: sil hidden [ossa] @$s21existential_metatypes0A19MetatypeVarPropertyAA5ValueVyF : $@convention(thin) () -> Value
 func existentialMetatypeVarProperty() -> Value {
   // CHECK:      [[BOX:%.*]] = alloc_box ${ var @thick P.Type }
-  // CHECK:      [[ADDR:%.*]] = project_box [[BOX]] : ${ var @thick P.Type }, 0
+  // CHECK:      [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK:      [[ADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var @thick P.Type }, 0
   // CHECK:      [[T0:%.*]] = metatype $@thick S.Type
   // CHECK:      [[T1:%.*]] = init_existential_metatype [[T0]]
   // CHECK:      store [[T1]] to [trivial] [[ADDR]] :

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -392,7 +392,8 @@ func tuple() -> (Int, Float) { return (1, 1.0) }
 func tuple_element(_ x: (Int, Float)) {
   var x = x
   // CHECK: [[XADDR:%.*]] = alloc_box ${ var (Int, Float) }
-  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK: [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
 
   int(x.0)
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
@@ -427,15 +428,20 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   var z = z
   // CHECK: bb0({{.*}}):
   // CHECK: [[AB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[PBA:%.*]] = project_box [[AB]]
+  // CHECK: [[AL:%[0-9]+]] = begin_borrow [lexical] [[AB]]
+  // CHECK: [[PBA:%.*]] = project_box [[AL]]
   // CHECK: [[BB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[PBB:%.*]] = project_box [[BB]]
+  // CHECK: [[BL:%[0-9]+]] = begin_borrow [lexical] [[BB]]
+  // CHECK: [[PBB:%.*]] = project_box [[BL]]
   // CHECK: [[XB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBX:%.*]] = project_box [[XB]]
+  // CHECK: [[XL:%[0-9]+]] = begin_borrow [lexical] [[XB]]
+  // CHECK: [[PBX:%.*]] = project_box [[XL]]
   // CHECK: [[YB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBY:%.*]] = project_box [[YB]]
+  // CHECK: [[YL:%[0-9]+]] = begin_borrow [lexical] [[YB]]
+  // CHECK: [[PBY:%.*]] = project_box [[YL]]
   // CHECK: [[ZB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PBZ:%.*]] = project_box [[ZB]]
+  // CHECK: [[ZL:%[0-9]+]] = begin_borrow [lexical] [[ZB]]
+  // CHECK: [[PBZ:%.*]] = project_box [[ZL]]
 
   return a
     ? x

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -52,7 +52,8 @@ struct Box<T> {
 // CHECK-LABEL: sil hidden [ossa] @$s10extensions3BoxV1tACyxGx_tcfC : $@convention(method) <T> (@in T, @thin Box<T>.Type) -> @out Box<T>
 // CHECK:      [[SELF_BOX:%.*]] = alloc_box $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[UNINIT_SELF_BOX:%.*]] = mark_uninitialized [rootself] [[SELF_BOX]]
-// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
+// CHECK-NEXT: [[UNINIT_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_SELF_BOX]]
+// CHECK-NEXT: [[SELF_ADDR:%.*]] = project_box [[UNINIT_SELF_BOX_LIFETIME]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK:      [[RESULT:%.*]] = struct_element_addr [[SELF_ADDR]] : $*Box<T>, #Box.t
 // CHECK:      [[INIT:%.*]] = function_ref @$s10extensions3BoxV1txSgvpfi : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
 // CHECK-NEXT: apply [[INIT]]<T>([[RESULT]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
@@ -67,6 +68,7 @@ struct Box<T> {
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
 // CHECK-NEXT: copy_addr [[SELF_ADDR]] to [initialization] %0 : $*Box<T>
 // CHECK-NEXT: destroy_addr %1 : $*T
+// CHECK-NEXT: end_borrow [[UNINIT_SELF_BOX_LIFETIME]]
 // CHECK-NEXT: destroy_value [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]] : $()

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -53,7 +53,8 @@ protocol GenericCollection : Collection {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach13trivialStructyySaySiGF : $@convention(thin) (@guaranteed Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<Int>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
@@ -65,6 +66,7 @@ protocol GenericCollection : Collection {
 // CHECK:   br [[LOOP_DEST]]
 //
 // CHECK: [[NONE_BB]]:
+// CHECK:   end_borrow [[ITERATOR_LIFETIME]]
 // CHECK:   destroy_value [[ITERATOR_BOX]]
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()
@@ -105,7 +107,8 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach26trivialStructContinueBreakyySaySiGF : $@convention(thin) (@guaranteed Array<Int>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<Int>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<Int>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<Int>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
@@ -145,6 +148,7 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   br [[CONT_BLOCK]]
 //
 // CHECK: [[CONT_BLOCK]]
+// CHECK:   end_borrow [[ITERATOR_LIFETIME]]
 // CHECK:   destroy_value [[ITERATOR_BOX]] : ${ var IndexingIterator<Array<Int>> }
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()
@@ -205,7 +209,8 @@ func existentialBreak(_ xx: [P]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach24existentialContinueBreakyySayAA1P_pGF : $@convention(thin) (@guaranteed Array<P>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<P>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var IndexingIterator<Array<P>> }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<P>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
@@ -254,6 +259,7 @@ func existentialBreak(_ xx: [P]) {
 //
 // CHECK: [[CONT_BLOCK]]
 // CHECK:   dealloc_stack [[ELT_STACK]]
+// CHECK:   end_borrow [[ITERATOR_LIFETIME]]
 // CHECK:   destroy_value [[ITERATOR_BOX]] : ${ var IndexingIterator<Array<P>> }
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()
@@ -365,7 +371,8 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach26genericStructContinueBreakyySayAA07GenericC0VyxGGlF : $@convention(thin) <T> (@guaranteed Array<GenericStruct<T>>) -> () {
 // CHECK: bb0([[ARRAY:%.*]] : @guaranteed $Array<GenericStruct<T>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0> { var IndexingIterator<Array<GenericStruct<τ_0_0>>> } <T>, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<GenericStruct<T>>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
@@ -414,6 +421,7 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 //
 // CHECK: [[CONT_BLOCK]]
 // CHECK:   dealloc_stack [[ELT_STACK]]
+// CHECK:   end_borrow [[ITERATOR_LIFETIME]]
 // CHECK:   destroy_value [[ITERATOR_BOX]]
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()
@@ -473,7 +481,8 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach30genericCollectionContinueBreakyyxSlRzlF : $@convention(thin) <T where T : Collection> (@in_guaranteed T) -> () {
 // CHECK: bb0([[COLLECTION:%.*]] : $*T):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Collection> { var τ_0_0.Iterator } <T>, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $T, #Sequence.makeIterator :
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<T>([[PROJECT_ITERATOR_BOX]], [[COLLECTION_COPY:%.*]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<T.Element>
@@ -520,6 +529,7 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 //
 // CHECK: [[CONT_BLOCK]]
 // CHECK:   dealloc_stack [[ELT_STACK]]
+// CHECK:   end_borrow [[ITERATOR_LIFETIME]]
 // CHECK:   destroy_value [[ITERATOR_BOX]]
 // CHECK:   [[FUNC_END_FUNC:%.*]] = function_ref @funcEnd : $@convention(thin) () -> ()
 // CHECK:   apply [[FUNC_END_FUNC]]()

--- a/test/SILGen/foreach_async.swift
+++ b/test/SILGen/foreach_async.swift
@@ -74,7 +74,8 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async13trivialStructyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> () {
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:
@@ -108,7 +109,8 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async21trivialStructContinueyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> () {
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:
@@ -169,7 +171,8 @@ func trivialStructBreak(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK-LABEL: sil hidden [ossa] @$s13foreach_async26trivialStructContinueBreakyyAA17AsyncLazySequenceVySaySiGGYaF : $@convention(thin) @async (@guaranteed AsyncLazySequence<Array<Int>>) -> ()
 // CHECK: bb0([[SOURCE:%.*]] : @guaranteed $AsyncLazySequence<Array<Int>>):
 // CHECK:   [[ITERATOR_BOX:%.*]] = alloc_box ${ var AsyncLazySequence<Array<Int>>.Iterator }, var, name "$x$generator"
-// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_BOX]]
+// CHECK:   [[ITERATOR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ITERATOR_BOX]]
+// CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 
 // CHECK: [[LOOP_DEST]]:

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -196,7 +196,8 @@ class VeryErrorProne : ErrorProne {
 // CHECK:    bb0([[ARG1:%.*]] : @owned $Optional<AnyObject>, [[ARG2:%.*]] : @owned $VeryErrorProne):
 // CHECK:      [[BOX:%.*]] = alloc_box ${ var VeryErrorProne }
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
-// CHECK:      [[PB:%.*]] = project_box [[MARKED_BOX]]
+// CHECK:      [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_BOX]]
+// CHECK:      [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK:      [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
 // CHECK:      store [[ARG2]] to [init] [[PB]]
 // CHECK:      [[T0:%.*]] = load [take] [[PB]]

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -103,11 +103,14 @@ func calls(_ i:Int, j:Int, k:Int) {
   var k = k
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
   // CHECK: [[IBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[IADDR:%.*]] = project_box [[IBOX]]
+  // CHECK: [[ILIFETIME:%[^,]+]] = begin_borrow [lexical] [[IBOX]]
+  // CHECK: [[IADDR:%.*]] = project_box [[ILIFETIME]]
   // CHECK: [[JBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[JADDR:%.*]] = project_box [[JBOX]]
+  // CHECK: [[JLIFETIME:%[^,]+]] = begin_borrow [lexical] [[JBOX]]
+  // CHECK: [[JADDR:%.*]] = project_box [[JLIFETIME]]
   // CHECK: [[KBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
+  // CHECK: [[KLIFETIME:%[^,]+]] = begin_borrow [lexical] [[KBOX]]
+  // CHECK: [[KADDR:%.*]] = project_box [[KLIFETIME]]
 
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
@@ -138,7 +141,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Curry 'self' onto method argument lists dispatched using class_method.
 
   // CHECK: [[CBOX:%[0-9]+]] = alloc_box ${ var SomeClass }
-  // CHECK: [[CADDR:%.*]] = project_box [[CBOX]]
+  // CHECK: [[CLIFETIME:%[^,]+]] = begin_borrow [lexical] [[CBOX]]
+  // CHECK: [[CADDR:%.*]] = project_box [[CLIFETIME]]
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeClass.Type
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]
@@ -229,7 +233,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- onto protocol type methods dispatched using protocol_method.
 
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var SomeProtocol }
-  // CHECK: [[PADDR:%.*]] = project_box [[PBOX]]
+  // CHECK: [[PLIFETIME:%[^,]+]] = begin_borrow [lexical] [[PBOX]]
+  // CHECK: [[PADDR:%.*]] = project_box [[PLIFETIME]]
   var p : SomeProtocol = ConformsToSomeProtocol()
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PADDR]]
@@ -261,7 +266,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // -- Use an apply or partial_apply instruction to bind type parameters of a generic.
 
   // CHECK: [[GBOX:%[0-9]+]] = alloc_box ${ var SomeGeneric<Builtin.Int64> }
-  // CHECK: [[GADDR:%.*]] = project_box [[GBOX]]
+  // CHECK: [[GLIFETIME:%[^,]+]] = begin_borrow [lexical] [[GBOX]]
+  // CHECK: [[GADDR:%.*]] = project_box [[GLIFETIME]]
   // CHECK: [[META:%[0-9]+]] = metatype $@thick SomeGeneric<Builtin.Int64>.Type
   // CHECK: [[CTOR_GEN:%[0-9]+]] = function_ref @$s9functions11SomeGenericC{{[_0-9a-zA-Z]*}}fC : $@convention(method) <τ_0_0> (@thick SomeGeneric<τ_0_0>.Type) -> @owned SomeGeneric<τ_0_0>
   // CHECK: apply [[CTOR_GEN]]<Builtin.Int64>([[META]])
@@ -308,7 +314,8 @@ func calls(_ i:Int, j:Int, k:Int) {
   // "thick" function values when stored, returned, or passed as arguments.
 
   // CHECK: [[FBOX:%[0-9]+]] = alloc_box ${ var @callee_guaranteed (Builtin.Int64, Builtin.Int64) -> Builtin.Int64 }
-  // CHECK: [[FADDR:%.*]] = project_box [[FBOX]]
+  // CHECK: [[FLIFETIME:%[^,]+]] = begin_borrow [lexical] [[FBOX]]
+  // CHECK: [[FADDR:%.*]] = project_box [[FLIFETIME]]
   // CHECK: [[FUNC_THIN:%[0-9]+]] = function_ref @$s9functions19standalone_function{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> Builtin.Int64
   // CHECK: [[FUNC_THICK:%[0-9]+]] = thin_to_thick_function [[FUNC_THIN]]
   // CHECK: store [[FUNC_THICK]] to [init] [[FADDR]]

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -11,10 +11,13 @@ struct S {}
 // CHECK-LABEL: sil hidden [ossa] @$s26guaranteed_closure_context0A9_capturesyyF
 func guaranteed_captures() {
   // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box ${ var S }
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_TRIVIAL_BOX]]
   var mutableTrivial = S()
   // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box ${ var C }
+  // CHECK: [[MUTABLE_RETAINABLE_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_RETAINABLE_BOX]]
   var mutableRetainable = C()
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX:%.*]] = alloc_box ${ var P }
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_ADDRESS_ONLY_BOX]]
   var mutableAddressOnly: P = C()
 
   // CHECK: [[IMMUTABLE_TRIVIAL:%.*]] = apply {{.*}} -> S
@@ -30,38 +33,34 @@ func guaranteed_captures() {
          immutableTrivial, immutableRetainable, immutableAddressOnly))
   }
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
-  // CHECK:     [[B_MUTABLE_TRIVIAL_BOX:%.*]] = begin_borrow [[MUTABLE_TRIVIAL_BOX]] : ${ var S }
-  // CHECK:     [[B_MUTABLE_RETAINABLE_BOX:%.*]] = begin_borrow [[MUTABLE_RETAINABLE_BOX]] : ${ var C }
-  // CHECK:     [[B_MUTABLE_ADDRESS_ONLY_BOX:%.*]] = begin_borrow [[MUTABLE_ADDRESS_ONLY_BOX]] : ${ var P }
-
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@\$s26guaranteed_closure_context0A9_capturesyyF17captureEverythingL_yyF]]
-  // CHECK: apply [[FN]]([[B_MUTABLE_TRIVIAL_BOX]], [[B_MUTABLE_RETAINABLE_BOX]], [[B_MUTABLE_ADDRESS_ONLY_BOX]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE]], [[IMMUTABLE_ADDRESS_ONLY]])
+  // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_LIFETIME]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE]], [[IMMUTABLE_ADDRESS_ONLY]])
   captureEverything()
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
   // -- partial_apply still takes ownership of its arguments.
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME]]
-  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX]]
-  // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX]]
-  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
+  // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[B_IMMUTABLE_RETAINABLE]]
   // CHECK: [[IMMUTABLE_ADDRESS:%.*]] = alloc_stack $P
   // CHECK: [[CLOSURE:%.*]] = partial_apply {{.*}}([[MUTABLE_TRIVIAL_BOX_COPY]], [[MUTABLE_RETAINABLE_BOX_COPY]], [[MUTABLE_ADDRESS_ONLY_BOX_COPY]], [[IMMUTABLE_TRIVIAL]], [[IMMUTABLE_RETAINABLE_COPY]], [[IMMUTABLE_ADDRESS]])
   // CHECK: [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
   // CHECK: apply {{.*}}[[CONVERT]]
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX]]
-  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
   escape(captureEverything)

--- a/test/SILGen/guaranteed_self.swift
+++ b/test/SILGen/guaranteed_self.swift
@@ -342,7 +342,8 @@ class D: C {
   // CHECK:       bb0([[SELF:%.*]] : @owned $D):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var D }
   // CHECK-NEXT:    [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK-NEXT:    [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK-NEXT:    [[LIFETIME:%.+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK-NEXT:    [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK-NEXT:    store [[SELF]] to [init] [[PB]]
   // CHECK-NOT:     [[PB]]
   // CHECK:         [[SELF1:%.*]] = load [take] [[PB]]
@@ -357,6 +358,7 @@ class D: C {
   // CHECK-NOT:     [[SELF2]]
   // CHECK-NOT:     [[SUPER2]]
   // CHECK:         [[SELF_FINAL:%.*]] = load [copy] [[PB]]
+  // CHECK-NEXT:    end_borrow [[LIFETIME]]
   // CHECK-NEXT:    destroy_value [[MARKED_SELF_BOX]]
   // CHECK-NEXT:    return [[SELF_FINAL]]
   required init() {
@@ -462,7 +464,8 @@ class LetFieldClass {
   // CHECK-NEXT: end_borrow [[REBORROWED_KRAKEN]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
-  // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: [[KRAKEN_ADDR:%.*]] = ref_element_addr [[CLS]] : $LetFieldClass, #LetFieldClass.letk
   // CHECK-NEXT: [[KRAKEN:%.*]] = load [copy] [[KRAKEN_ADDR]]
   // CHECK-NEXT: store [[KRAKEN]] to [init] [[PB]]
@@ -472,6 +475,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_COPY]]
+  // CHECK-NEXT: end_borrow [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: tuple
   // CHECK-NEXT: return
@@ -505,7 +509,8 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[BORROWED_KRAKEN]])
   // CHECK-NEXT: [[KRAKEN_BOX:%.*]] = alloc_box ${ var Kraken }
-  // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[KRAKEN_LIFETIME:%.+]] = begin_borrow [lexical] [[KRAKEN_BOX]]
+  // CHECK-NEXT: [[PB:%.*]] = project_box [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: [[KRAKEN_GETTER_FUN:%.*]] = class_method [[CLS]] : $LetFieldClass, #LetFieldClass.vark!getter : (LetFieldClass) -> () -> Kraken, $@convention(method) (@guaranteed LetFieldClass) -> @owned Kraken
   // CHECK-NEXT: [[KRAKEN2:%.*]] = apply [[KRAKEN_GETTER_FUN]]([[CLS]])
   // CHECK-NEXT: store [[KRAKEN2]] to [init] [[PB]]
@@ -515,6 +520,7 @@ class LetFieldClass {
   // CHECK: [[DESTROY_SHIP_FUN:%.*]] = function_ref @$s15guaranteed_self11destroyShipyyAA6KrakenCF : $@convention(thin) (@guaranteed Kraken) -> ()
   // CHECK-NEXT: apply [[DESTROY_SHIP_FUN]]([[KRAKEN_COPY]])
   // CHECK-NEXT: destroy_value [[KRAKEN_COPY]]
+  // CHECK-NEXT: end_borrow [[KRAKEN_LIFETIME]]
   // CHECK-NEXT: destroy_value [[KRAKEN_BOX]]
   // CHECK-NEXT: end_borrow [[BORROWED_KRAKEN]]
   // CHECK-NEXT: destroy_value [[KRAKEN]]

--- a/test/SILGen/if_expr.swift
+++ b/test/SILGen/if_expr.swift
@@ -33,10 +33,12 @@ func consumeAddressOnly(_: AddressOnly) {}
 func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK: bb0([[RET:%.*]] : $*AddressOnly, {{.*}}):
   // CHECK: [[a:%[0-9]+]] = alloc_box ${ var AddressOnly }, var, name "a"
-  // CHECK: [[PBa:%.*]] = project_box [[a]]
+  // CHECK: [[a_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[a]]
+  // CHECK: [[PBa:%.*]] = project_box [[a_LIFETIME]]
   var a : AddressOnly = A()
   // CHECK: [[b:%[0-9]+]] = alloc_box ${ var AddressOnly }, var, name "b"
-  // CHECK: [[PBb:%.*]] = project_box [[b]]
+  // CHECK: [[b_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[b]]
+  // CHECK: [[PBb:%.*]] = project_box [[b_LIFETIME]]
   var b : AddressOnly = B()
 
   // CHECK:   cond_br {{%.*}}, [[TRUE:bb[0-9]+]], [[FALSE:bb[0-9]+]]

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -175,7 +175,8 @@ func if_multi() {
   // CHECK:   [[BORROWED_A:%.*]] = begin_borrow [lexical] [[A]]
   // CHECK:   debug_value [[BORROWED_A]] : $String, let, name "a"
   // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
-  // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
+  // CHECK:   [[B_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[B]]
+  // CHECK:   [[PB:%[0-9]+]] = project_box [[B_LIFETIME]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt: [[IF_BODY:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
 
   // CHECK: [[IF_EXIT1a]]:
@@ -187,6 +188,7 @@ func if_multi() {
   if let a = foo(), var b = bar() {
     // CHECK:   store [[BVAL]] to [init] [[PB]] : $*String
     // CHECK:   debug_value {{.*}} : $String, let, name "c"
+    // CHECK:   end_borrow [[B_LIFETIME]]
     // CHECK:   destroy_value [[B]]
     // CHECK:   destroy_value [[A]]
     // CHECK:   br [[IF_DONE]]
@@ -207,7 +209,8 @@ func if_multi_else() {
   // CHECK:   [[BORROWED_A:%.*]] = begin_borrow [lexical] [[A]]
   // CHECK:   debug_value [[BORROWED_A]] : $String, let, name "a"
   // CHECK:   [[B:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
-  // CHECK:   [[PB:%[0-9]+]] = project_box [[B]]
+  // CHECK:   [[B_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[B]]
+  // CHECK:   [[PB:%[0-9]+]] = project_box [[B_LIFETIME]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt: [[IF_BODY:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
   
     // CHECK: [[IF_EXIT1a]]:
@@ -219,6 +222,7 @@ func if_multi_else() {
   if let a = foo(), var b = bar() {
     // CHECK:   store [[BVAL]] to [init] [[PB]] : $*String
     // CHECK:   debug_value {{.*}} : $String, let, name "c"
+    // CHECK:   end_borrow [[B_LIFETIME]]
     // CHECK:   destroy_value [[B]]
     // CHECK:   destroy_value [[A]]
     // CHECK:   br [[IF_DONE:bb[0-9]+]]
@@ -244,7 +248,8 @@ func if_multi_where() {
   // CHECK:   [[BORROWED_A:%.*]] = begin_borrow [lexical] [[A]]
   // CHECK:   debug_value [[BORROWED_A]] : $String, let, name "a"
   // CHECK:   [[BBOX:%[0-9]+]] = alloc_box ${ var String }, var, name "b"
-  // CHECK:   [[PB:%[0-9]+]] = project_box [[BBOX]]
+  // CHECK:   [[BBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BBOX]]
+  // CHECK:   [[PB:%[0-9]+]] = project_box [[BBOX_LIFETIME]]
   // CHECK:   switch_enum {{.*}}, case #Optional.some!enumelt: [[CHECK_WHERE:bb.*]], case #Optional.none!enumelt: [[IF_EXIT1a:bb[0-9]+]]
   // CHECK: [[IF_EXIT1a]]:
   // CHECK:   dealloc_box {{.*}} ${ var String }
@@ -256,12 +261,14 @@ func if_multi_where() {
   // CHECK:   cond_br {{.*}}, [[IF_BODY:bb[0-9]+]], [[IF_EXIT3:bb[0-9]+]]
   if let a = foo(), var b = bar(), a == b {
     // CHECK: [[IF_BODY]]:
+    // CHECK:   end_borrow [[BBOX_LIFETIME]]
     // CHECK:   destroy_value [[BBOX]]
     // CHECK:   destroy_value [[A]]
     // CHECK:   br [[DONE]]
     let c = a
   }
   // CHECK: [[IF_EXIT3]]:
+  // CHECK:   end_borrow [[BBOX_LIFETIME]]
   // CHECK:   destroy_value [[BBOX]]
   // CHECK:   destroy_value [[A]]
   // CHECK:   br [[DONE]]

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -8,7 +8,8 @@ func foo(f f: (() -> ())!) {
 // CHECK: sil hidden [ossa] @{{.*}}foo{{.*}} : $@convention(thin) (@guaranteed Optional<@callee_guaranteed () -> ()>) -> () {
 // CHECK: bb0([[T0:%.*]] : @guaranteed $Optional<@callee_guaranteed () -> ()>):
 // CHECK:   [[F:%.*]] = alloc_box ${ var Optional<@callee_guaranteed () -> ()> }
-// CHECK:   [[PF:%.*]] = project_box [[F]]
+// CHECK:   [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[F]]
+// CHECK:   [[PF:%.*]] = project_box [[F_LIFETIME]]
 // CHECK:   [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK:   store [[T0_COPY]] to [init] [[PF]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PF]] : $*Optional<@callee_guaranteed () -> ()>
@@ -26,6 +27,7 @@ func foo(f f: (() -> ())!) {
 // CHECK:   end_borrow [[B]]
 // CHECK:   br bb2
 // CHECK: bb2(
+// CHECK:   end_borrow [[F_LIFETIME]]
 // CHECK:   destroy_value [[F]]
 // CHECK:   return
 // CHECK: bb3:

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -9,7 +9,8 @@ struct S {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
     // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
     // CHECK-NEXT:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK-NEXT:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
     
     // CHECK-NEXT:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_CTOR:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -19,6 +20,7 @@ struct S {
     self.init(x: X())
     // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[PB]] : $*S
     // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*S
+    // CHECK-NEXT:   end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT:   destroy_value [[MARKED_SELF_BOX]] : ${ var S }
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
@@ -36,7 +38,8 @@ enum E {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
     // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
     // CHECK:   [[MARKED_E_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[E_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_BOX]]
+    // CHECK:   [[E_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_E_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[E_LIFETIME]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[E_DELEG_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -46,6 +49,7 @@ enum E {
     // CHECK:   assign [[S:%[0-9]+]] to [[PB]] : $*E
     // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*E
     self.init(x: X())
+    // CHECK:   end_borrow [[E_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_E_BOX]] : ${ var E }
     // CHECK:   return [[E_BOX1:%[0-9]+]] : $E
   }
@@ -60,7 +64,8 @@ struct S2 {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -73,6 +78,7 @@ struct S2 {
     // CHECK:   assign [[SELF_BOX1]] to [[PB]] : $*S2
     // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[PB]] : $*S2
     self.init(t: X())
+    // CHECK:   end_borrow [[SELF_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var S2 }
     // CHECK:   return [[SELF_BOX4]] : $S2
   }
@@ -90,12 +96,14 @@ class C1 {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[SELF_META:%[0-9]+]] : $@thick C1.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C1 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
 
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick C1.Type, #C1.init!allocator
     // CHECK:   [[SELFP:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_META]])
     // CHECK:   assign [[SELFP]] to [[PB]]
     // CHECK:   [[SELFP:%[0-9]+]] = load [copy] [[PB]] : $*C1
+    // CHECK:   end_borrow [[SELF_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var C1 }
     // CHECK:   return [[SELFP]] : $C1
     self.init(x1: x, x2: x)
@@ -112,11 +120,13 @@ class C1 {
     // CHECK: bb0([[X:%[0-9]+]] : $X, [[SELF_META:%[0-9]+]] : $@thick C2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var C2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB_SELF:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB_SELF:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:   [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick C2.Type, #C2.init!allocator
     // CHECK:   [[REPLACE_SELF:%[0-9]+]] = apply [[DELEG_INIT]]([[X]], [[X]], [[SELF_META]])
     // CHECK:   assign [[REPLACE_SELF]] to [[PB_SELF]] : $*C2
     // CHECK:   [[VAR_15:%[0-9]+]] = load [copy] [[PB_SELF]] : $*C2
+    // CHECK:   end_borrow [[SELF_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var C2 }
     // CHECK:   return [[VAR_15]] : $C2
     self.init(x1: x, x2: x)

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -233,7 +233,8 @@ struct WeirdPropertyTest {
 func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
   // CHECK: [[VBOX:%[0-9]+]] = alloc_box ${ var WeirdPropertyTest }
-  // CHECK: [[PB:%.*]] = project_box [[VBOX]]
+  // CHECK: [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[VLIFETIME]]
   // CHECK: store %0 to [trivial] [[PB]]
 
   // The setter isn't mutating, so we need to load the box.
@@ -465,11 +466,13 @@ struct LetPropertyStruct {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testLetPropertyAccessOnLValueBase
 // CHECK: bb0(%0 : $LetPropertyStruct):
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
-// CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
+// CHECK:  [[ALIFETIME:%[^,]+]] = begin_borrow [lexical] [[ABOX]]
+// CHECK:  [[A:%[0-9]+]] = project_box [[ALIFETIME]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[A]]
 // CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[READ]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
+// CHECK:   end_borrow [[ALIFETIME]]
 // CHECK:   destroy_value [[ABOX]] : ${ var LetPropertyStruct }
 // CHECK:   return [[PROP]] : $Int
 func testLetPropertyAccessOnLValueBase(_ a : LetPropertyStruct) -> Int {

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -57,7 +57,8 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss026dynamicMetatypeFromGenericB0ys1CCms0dB0VyACGF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var GenericMetatype<C> }
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
+// CHECK:         [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX_LIFETIME]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*GenericMetatype<C>
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[READ]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
@@ -94,7 +95,8 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss024dynamicMetatypeToGenericB0yys1CCmF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var @thick C.Type }
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
+// CHECK:         [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX_LIFETIME]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*@thick C.Type
 // CHECK:         [[META:%.*]] = load [trivial] [[READ]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -20,7 +20,8 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: bb0([[STR:%[0-9]+]] : @owned $String,
 // CHECK-RAW: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var ErrorDomain }
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
-// CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
+// CHECK-RAW: [[SELF_BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+// CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[SELF_BOX_LIFETIME]]
 // CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [lexical] [[STR]]
 // CHECK-RAW: [[COPIED_STR:%.*]] = copy_value [[BORROWED_STR]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -394,7 +394,8 @@ class Hoozit : Gizmo {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
   // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
   // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK: [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
   // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]
   // CHECK: [[CAST_BORROWED_GIZMO:%.*]] = unchecked_ref_cast [[BORROWED_GIZMO]] : $Gizmo to $Hoozit

--- a/test/SILGen/objc_dealloc.swift
+++ b/test/SILGen/objc_dealloc.swift
@@ -20,7 +20,8 @@ class SwiftGizmo : Gizmo {
   override init() {
     // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SwiftGizmo }, let, name "self"
     // CHECK:   [[SELF_UNINIT:%.*]] = mark_uninitialized [derivedselfonly] [[SELF_BOX]] : ${ var SwiftGizmo }
-    // CHECK:   [[SELF_ADDR:%.*]] = project_box [[SELF_UNINIT]]
+    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF_UNINIT]]
+    // CHECK:   [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK-NOT: ref_element_addr
     // CHECK:   [[SELF:%.*]] = load [take] [[SELF_ADDR]]
     // CHECK-NEXT:   [[UPCAST_SELF:%.*]] = upcast [[SELF]] : $SwiftGizmo to $Gizmo

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -25,7 +25,8 @@ extension Hive {
   // CHECK: bb0([[QUEEN:%.*]] : @owned $Bee, [[META:%.*]] : $@thick Hive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[MU]] : ${ var Hive }, 0
+  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
   // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [lexical] [[QUEEN]]
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
@@ -46,13 +47,14 @@ extension Hive {
   // CHECK: bb0([[QUEEN:%.*]] : @owned $Bee, [[META:%.*]] : $@thick Hive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
   // CHECK-NEXT:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK-NEXT:   [[PB_BOX:%.*]] = project_box [[MU]] : ${ var Hive }, 0
+  // CHECK-NEXT:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK-NEXT:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
   // CHECK-NEXT:   [[BORROWED_QUEEN:%.*]] = begin_borrow [lexical] [[QUEEN]]
   // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
   // CHECK:   [[OPT_COPIED_BORROWED_QUEEN:%.*]] = enum $Optional<Bee>, #Optional.some!enumelt, [[COPIED_BORROWED_QUEEN]]
-  // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.foreign : (Hive.Type) -> (Bee?) throws -> Hive, $@convention(objc_method) (Optional<Bee>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive> // user: %25
+  // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.foreign : (Hive.Type) -> (Bee?) throws -> Hive, $@convention(objc_method) (Optional<Bee>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
   // CHECK:   [[ERROR_PTR_STACK:%.*]] = alloc_stack $AutoreleasingUnsafeMutablePointer<Optional<NSError>>
   // CHECK:   [[ERROR_PTR:%.*]] = load [trivial] [[ERROR_PTR_STACK]]
   // CHECK:   [[OPT_ERROR_PTR:%.*]] = enum $Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, #Optional.some!enumelt, [[ERROR_PTR]]
@@ -93,7 +95,8 @@ class SubHive : Hive {
   // CHECK: bb0([[METATYPE:%.*]] : $@thick SubHive.Type):
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var SubHive }, let, name "self"
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var SubHive }
-  // CHECK:   [[PB_BOX:%.*]] = project_box [[MU]] : ${ var SubHive }, 0
+  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
+  // CHECK:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var SubHive }, 0
   // CHECK:   [[UP_METATYPE:%.*]] = upcast [[METATYPE]]
   // CHECK:   [[OBJC_METATYPE:%.*]] = thick_to_objc_metatype [[UP_METATYPE]]
   // CHECK:   [[QUEEN:%.*]] = unchecked_ref_cast {{.*}} : $Bee to $Optional<Bee>

--- a/test/SILGen/objc_init_ref_delegation.swift
+++ b/test/SILGen/objc_init_ref_delegation.swift
@@ -8,12 +8,14 @@ extension Gizmo {
     // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF_META:%[0-9]+]] : $@thick Gizmo.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Gizmo }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[MARKED_SELF_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX_LIFETIME]]
     // CHECK:   [[SELF_OBJC_META:%.*]] = thick_to_objc_metatype [[SELF_META]]
     // CHECK:   [[ORIG_SELF:%.*]] = alloc_ref_dynamic [objc] [[SELF_OBJC_META]]
     // CHECK:   [[INIT_DELEG:%[0-9]+]] = objc_method [[ORIG_SELF]] : $Gizmo, #Gizmo.init!initializer.foreign : (Gizmo.Type) -> (Int) -> Gizmo?, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF_RET:%[0-9]+]] = apply [[INIT_DELEG]]([[I]], [[ORIG_SELF]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
     // CHECK:   [[SELF4:%.*]] = load [copy] [[PB_BOX]]
+    // CHECK:   end_borrow [[MARKED_SELF_BOX_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]]
     // CHECK:   return [[SELF4]] : $Gizmo
     self.init(bellsOn:i)

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -33,7 +33,8 @@ func test5(_ g: Gizmo) {
   Gizmo.inspect(g)
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
   // CHECK:   [[CLASS:%.*]] = metatype $@objc_metatype Gizmo.Type
@@ -43,6 +44,7 @@ func test5(_ g: Gizmo) {
   // CHECK:   [[METHOD:%.*]] = objc_method [[CLASS]] : {{.*}}, #Gizmo.inspect!foreign
   // CHECK:   apply [[METHOD]]([[G]], [[CLASS]])
   // CHECK:   destroy_value [[G]]
+  // CHECK:   end_borrow [[GIZMO_BOX_LIFETIME]]
   // CHECK:   destroy_value [[GIZMO_BOX]]
   // CHECK-NOT:   destroy_value [[ARG]]
 }
@@ -55,7 +57,8 @@ func test6(_ g: Gizmo) {
   Gizmo.consume(g)
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
   // CHECK:   [[CLASS:%.*]] = metatype $@objc_metatype Gizmo.Type
@@ -65,6 +68,7 @@ func test6(_ g: Gizmo) {
   // CHECK:   [[METHOD:%.*]] = objc_method [[CLASS]] : {{.*}}, #Gizmo.consume!foreign
   // CHECK:   apply [[METHOD]]([[G]], [[CLASS]])
   // CHECK-NOT:  destroy_value [[G]]
+  // CHECK:   end_borrow [[GIZMO_BOX_LIFETIME]]
   // CHECK:   destroy_value [[GIZMO_BOX]]
   // CHECK-NOT:  destroy_value [[G]]
   // CHECK-NOT:   destroy_value [[ARG]]
@@ -79,7 +83,8 @@ func test7(_ g: Gizmo) {
   g.fork()
   // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:   [[GIZMO_BOX:%.*]] = alloc_box ${ var Gizmo }
-  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[GIZMO_BOX]]
+  // CHECK:   [[GIZMO_BOX_PB:%.*]] = project_box [[GIZMO_BOX_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   store [[ARG_COPY]] to [init] [[GIZMO_BOX_PB]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[GIZMO_BOX_PB]] : $*Gizmo
@@ -87,6 +92,7 @@ func test7(_ g: Gizmo) {
   // CHECK:   [[METHOD:%.*]] = objc_method [[G]] : {{.*}}, #Gizmo.fork!foreign
   // CHECK:   apply [[METHOD]]([[G]])
   // CHECK-NOT:  destroy_value [[G]]
+  // CHECK:   end_borrow [[GIZMO_BOX_LIFETIME]]
   // CHECK:   destroy_value [[GIZMO_BOX]]
   // CHECK-NOT:  destroy_value [[G]]
   // CHECK-NOT:   destroy_value [[ARG]]

--- a/test/SILGen/objc_protocols.swift
+++ b/test/SILGen/objc_protocols.swift
@@ -239,7 +239,8 @@ extension InformallyFunging: NSFunging { }
 func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializable {
   // CHECK: bb0([[META:%[0-9]+]] : $@thick Initializable.Type, [[I:%[0-9]+]] : $Int):
   // CHECK:   [[I2_BOX:%[0-9]+]] = alloc_box ${ var Initializable }
-  // CHECK:   [[PB:%.*]] = project_box [[I2_BOX]]
+  // CHECK:   [[I2_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[I2_BOX]]
+  // CHECK:   [[PB:%.*]] = project_box [[I2_LIFETIME]]
   // CHECK:   [[ARCHETYPE_META:%[0-9]+]] = open_existential_metatype [[META]] : $@thick Initializable.Type to $@thick (@opened([[N:".*"]]) Initializable).Type
   // CHECK:   [[ARCHETYPE_META_OBJC:%[0-9]+]] = thick_to_objc_metatype [[ARCHETYPE_META]] : $@thick (@opened([[N]]) Initializable).Type to $@objc_metatype (@opened([[N]]) Initializable).Type
   // CHECK:   [[I2_ALLOC:%[0-9]+]] = alloc_ref_dynamic [objc] [[ARCHETYPE_META_OBJC]] : $@objc_metatype (@opened([[N]]) Initializable).Type, $@opened([[N]]) Initializable
@@ -249,6 +250,7 @@ func testInitializableExistential(_ im: Initializable.Type, i: Int) -> Initializ
   // CHECK:   store [[I2_EXIST_CONTAINER]] to [init] [[PB]] : $*Initializable
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*Initializable
   // CHECK:   [[I2:%[0-9]+]] = load [copy] [[READ]] : $*Initializable
+  // CHECK:   end_borrow [[I2_LIFETIME]]
   // CHECK:   destroy_value [[I2_BOX]] : ${ var Initializable }
   // CHECK:   return [[I2]] : $Initializable
   var i2 = im.init(int: i)

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -362,7 +362,8 @@ class Hoozit : Gizmo {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
   // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
   // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK: [[PB_BOX:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
   // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]
   // CHECK: [[CAST_BORROWED_GIZMO:%.*]] = unchecked_ref_cast [[BORROWED_GIZMO]] : $Gizmo to $Hoozit

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -16,7 +16,8 @@ public struct DidSetWillSetTests {
 
     // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
     // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
-    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
+    // CHECK:        [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF]]
+    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
     // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
     // CHECK-NEXT:   assign %0 to [[P1]]
@@ -238,7 +239,8 @@ func local_observing_property(_ arg: Int) {
   // Alloc and initialize the property to the argument value.
   // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[BOX]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: store [[ARG]] to [trivial] [[PB]]
 }
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -7,7 +7,8 @@ class B : A {}
 // CHECK-LABEL: sil hidden [ossa] @$s4main3fooyyAA1ACSgF : $@convention(thin) (@guaranteed Optional<A>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : @guaranteed $Optional<A>):
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
 //   Check whether the temporary holds a value.
 // CHECK:      [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:      switch_enum [[ARG_COPY]] : $Optional<A>, case #Optional.some!enumelt: [[IS_PRESENT:bb[0-9]+]], case #Optional.none!enumelt: [[NOT_PRESENT:bb[0-9]+]]
@@ -35,6 +36,7 @@ class B : A {}
 //
 //   Finish.
 // CHECK:    [[RETURN_BB]]:
+// CHECK-NEXT: end_borrow [[X_LIFETIME]]
 // CHECK-NEXT: destroy_value [[X]]
 // CHECK-NOT: destroy_value [[ARG]]
 // CHECK-NEXT: tuple
@@ -51,7 +53,8 @@ func foo(_ y : A?) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main3baryyAA1ACSgSgSgSgF : $@convention(thin) (@guaranteed Optional<Optional<Optional<Optional<A>>>>) -> () {
 // CHECK:    bb0([[ARG:%.*]] : @guaranteed $Optional<Optional<Optional<Optional<A>>>>):
 // CHECK:      [[X:%.*]] = alloc_box ${ var Optional<Optional<Optional<B>>> }, var, name "x"
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
 // -- Check for some(...)
 // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: switch_enum [[ARG_COPY]] : ${{.*}}, case #Optional.some!enumelt: [[P:bb[0-9]+]], case #Optional.none!enumelt: [[NIL_DEPTH_1:bb[0-9]+]]
@@ -110,6 +113,7 @@ func foo(_ y : A?) {
 // CHECK-NEXT: enum $Optional<Optional<Optional<B>>>, #Optional.some!enumelt,
 // CHECK:      br [[DONE_DEPTH2:bb[0-9]+]]
 // CHECK:    [[DONE_DEPTH2]]
+// CHECK-NEXT: end_borrow [[X_LIFETIME]]
 // CHECK-NEXT: destroy_value [[X]]
 // CHECK-NOT: destroy_value %0
 // CHECK:      return
@@ -136,7 +140,8 @@ func bar(_ y : A????) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main3bazyyyXlSgF : $@convention(thin) (@guaranteed Optional<AnyObject>) -> () {
 // CHECK:       bb0([[ARG:%.*]] : @guaranteed $Optional<AnyObject>):
 // CHECK:         [[X:%.*]] = alloc_box ${ var Optional<B> }, var, name "x"
-// CHECK-NEXT:    [[PB:%.*]] = project_box [[X]]
+// CHECK:         [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT:    [[PB:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:         switch_enum [[ARG_COPY]]
 // CHECK:       bb1([[VAL:%.*]] : @owned $AnyObject):
@@ -196,8 +201,10 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK: bb0(%0 : $Optional<Int>):
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
 // CHECK-NEXT: [[X:%.*]] = alloc_box ${ var Optional<Int> }, var, name "x"
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+// CHECK-NEXT: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT: store %0 to [trivial] [[PB]] : $*Optional<Int>
+// CHECK-NEXT: end_borrow [[X_LIFETIME]]
 // CHECK-NEXT: destroy_value [[X]] : ${ var Optional<Int> }
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a

--- a/test/SILGen/optional.swift
+++ b/test/SILGen/optional.swift
@@ -32,11 +32,13 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testAddrOnlyCallResult{{.*}} :
 // CHECK:    bb0([[T0:%.*]] : @guaranteed $Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>>):
 // CHECK: [[F:%.*]] = alloc_box $<τ_0_0> { var Optional<@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>> } <T>, var, name "f"
-// CHECK-NEXT: [[PBF:%.*]] = project_box [[F]]
+// CHECK: [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[F]]
+// CHECK-NEXT: [[PBF:%.*]] = project_box [[F_LIFETIME]]
 // CHECK: [[T0_COPY:%.*]] = copy_value [[T0]]
 // CHECK: store [[T0_COPY]] to [init] [[PBF]]
 // CHECK-NEXT: [[X:%.*]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <T>, var, name "x"
-// CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+// CHECK-NEXT: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
 // CHECK-NEXT: [[TEMP:%.*]] = init_enum_data_addr [[PBX]]
 // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBF]]
 //   Check whether 'f' holds a value.
@@ -56,7 +58,9 @@ func testAddrOnlyCallResult<T>(_ f: (() -> T)?) {
 // CHECK-NEXT: br bb2
 //   Continuation block.
 // CHECK:    bb2
+// CHECK-NEXT: end_borrow [[X_LIFETIME]]
 // CHECK-NEXT: destroy_value [[X]]
+// CHECK-NEXT: end_borrow [[F_LIFETIME]]
 // CHECK-NEXT: destroy_value [[F]]
 // CHECK-NOT: destroy_value %0
 // CHECK-NEXT: [[T0:%.*]] = tuple ()

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -174,7 +174,8 @@ func stringToPointer(_ s: String) {
 func inoutToPointer() {
   var int = 0
   // CHECK: [[INT:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[INT]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   takesMutablePointer(&int)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]
@@ -226,7 +227,8 @@ func takesPlusZeroOptionalPointer(_ x: AutoreleasingUnsafeMutablePointer<C?>) {}
 func classInoutToPointer() {
   var c = C()
   // CHECK: [[VAR:%.*]] = alloc_box ${ var C }
-  // CHECK: [[PB:%.*]] = project_box [[VAR]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VAR]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   takesPlusOnePointer(&c)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]
@@ -236,8 +238,9 @@ func classInoutToPointer() {
   // CHECK: apply [[TAKES_PLUS_ONE]]
 
   takesPlusZeroPointer(&c)
+  // CHECK: [[WRITE2:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[WRITEBACK:%.*]] = alloc_stack $@sil_unmanaged C
-  // CHECK: [[OWNED:%.*]] = load_borrow [[PB]]
+  // CHECK: [[OWNED:%.*]] = load_borrow [[WRITE2]]
   // CHECK: [[UNOWNED:%.*]] = ref_to_unmanaged [[OWNED]]
   // CHECK: store [[UNOWNED]] to [trivial] [[WRITEBACK]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITEBACK]]
@@ -248,7 +251,7 @@ func classInoutToPointer() {
   // CHECK: [[UNOWNED_OUT:%.*]] = load [trivial] [[WRITEBACK]]
   // CHECK: [[OWNED_OUT:%.*]] = unmanaged_to_ref [[UNOWNED_OUT]]
   // CHECK: [[OWNED_OUT_COPY:%.*]] = copy_value [[OWNED_OUT]]
-  // CHECK: assign [[OWNED_OUT_COPY]] to [[PB]]
+  // CHECK: assign [[OWNED_OUT_COPY]] to [[WRITE2]]
 
   var cq: C? = C()
   takesPlusZeroOptionalPointer(&cq)
@@ -277,7 +280,8 @@ func functionInoutToPointer() {
 // CHECK-LABEL: sil hidden [ossa] @$s18pointer_conversion20inoutPointerOrderingyyF
 func inoutPointerOrdering() {
   // CHECK: [[ARRAY_BOX:%.*]] = alloc_box ${ var Array<Int> }
-  // CHECK: [[ARRAY:%.*]] = project_box [[ARRAY_BOX]] :
+  // CHECK: [[ARRAY_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ARRAY_BOX]]
+  // CHECK: [[ARRAY:%.*]] = project_box [[ARRAY_LIFETIME]] :
   // CHECK: store {{.*}} to [init] [[ARRAY]]
   var array = [Int]()
 

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -13,7 +13,8 @@ func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
   // CHECK: [[MARKED_BOX:%[0-9]+]] = mark_uninitialized [var] [[BOX]]
-  // CHECK: [[XADDR:%.*]] = project_box [[MARKED_BOX]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_BOX]]
+  // CHECK: [[XADDR:%.*]] = project_box [[LIFETIME]]
   x.1 = c
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[XADDR]]
   // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
@@ -343,7 +344,8 @@ func inout_arg(_ x: inout Int) {}
 func physical_inout(_ x: Int) {
   var x = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   inout_arg(&x)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @$s10properties9inout_arg{{[_0-9a-zA-Z]*}}F
@@ -369,7 +371,8 @@ func val_subscript_set(_ v: Val, i: Int, x: Float) {
   var v = v
   v[i] = x
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
-  // CHECK: [[PB:%.*]] = project_box [[VADDR]]
+  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[VADDR]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[SUBSCRIPT_SET_METHOD:%[0-9]+]] = function_ref @$s10properties3ValV{{[_0-9a-zA-Z]*}}is
   // CHECK: apply [[SUBSCRIPT_SET_METHOD]]([[X]], [[I]], [[WRITE]])
@@ -665,7 +668,8 @@ class r19254812Derived: r19254812Base{
 // Accessing the "pi" property should not copy_value/release self.
 // CHECK-LABEL: sil hidden [ossa] @$s10properties16r19254812DerivedC{{[_0-9a-zA-Z]*}}fc
 // CHECK: [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself]
-// CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+// CHECK: [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+// CHECK: [[PB_BOX:%.*]] = project_box [[LIFETIME]]
 
 // Initialization of the pi field: no copy_values/releases.
 // CHECK:  [[SELF:%[0-9]+]] = load_borrow [[PB_BOX]] : $*r19254812Derived
@@ -777,7 +781,8 @@ struct MutatingGetterStruct {
 
   // CHECK-LABEL: sil hidden [ossa] @$s10properties20MutatingGetterStructV4test
   // CHECK: [[X:%.*]] = alloc_box ${ var MutatingGetterStruct }, var, name "x"
-  // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
+  // CHECK: [[LIFETIME:%.*]] = begin_borrow [lexical] [[X]]
+  // CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: apply {{%.*}}([[WRITE]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -33,7 +33,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -75,7 +76,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -102,7 +104,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -33,7 +33,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -77,7 +78,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -106,7 +108,8 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/property_abstraction.swift
+++ b/test/SILGen/property_abstraction.swift
@@ -38,7 +38,8 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK-LABEL: sil hidden [ossa] @$s20property_abstraction6inOutF{{[_0-9a-zA-Z]*}}F : 
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Foo<Int, Int>):
 // CHECK:   [[XBOX:%.*]] = alloc_box ${ var Foo<Int, Int> }, var, name "x"
-// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX]] : ${ var Foo<Int, Int> }, 0
+// CHECK:   [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+// CHECK:   [[XBOX_PB:%.*]] = project_box [[XBOX_LIFETIME]] : ${ var Foo<Int, Int> }, 0
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK:   store [[ARG_COPY]] to [init] [[XBOX_PB]]
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[XBOX_PB]] : $*Foo<Int, Int>
@@ -56,6 +57,7 @@ func inOutFunc(_ f: inout ((Int) -> Int)) { }
 // CHECK:   [[F_ORIG:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_FN]]([[F_SUBST_OUT]])
 // CHECK:   [[F_CONV:%.*]] = convert_function [[F_ORIG]]
 // CHECK:   assign [[F_CONV]] to [[F_ADDR]]
+// CHECK:   end_borrow [[XBOX_LIFETIME]]
 // CHECK:   destroy_value [[XBOX]]
 // CHECK: } // end sil function '$s20property_abstraction6inOutF{{[_0-9a-zA-Z]*}}F'
 func inOutF(_ x: Foo<Int, Int>) {

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -17,13 +17,14 @@ func testLocalWrapper() {
   @Wrapper var value: Int
   // CHECK: [[A:%.*]] = alloc_box ${ var Wrapper<Int> }, var, name "_value"
   // CHECK: [[W:%.*]] = mark_uninitialized [var] [[A]] : ${ var Wrapper<Int> }
-  // CHECK: [[P:%.*]] = project_box [[W]] : ${ var Wrapper<Int> }
+  // CHECK: [[L:%[^,]+]] = begin_borrow [lexical] [[W]]
+  // CHECK: [[P:%.*]] = project_box [[L]] : ${ var Wrapper<Int> }
 
   value = 10
   // CHECK: [[I:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[IPA:%.*]] = partial_apply [callee_guaranteed] [[I]]() : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[S:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_Sivs : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
-  // CHECK-NEXT: [[C:%.*]] = copy_value [[W]] : ${ var Wrapper<Int> }
+  // CHECK-NEXT: [[C:%.*]] = copy_value [[L]] : ${ var Wrapper<Int> }
   // CHECK-NOT: mark_function_escape
   // CHECK-NEXT: [[SPA:%.*]] = partial_apply [callee_guaranteed] [[S]]([[C]]) : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
   // CHECK-NEXT: assign_by_wrapper {{%.*}} : $Int to [[P]] : $*Wrapper<Int>, init [[IPA]] : $@callee_guaranteed (Int) -> Wrapper<Int>, set [[SPA]] : $@callee_guaranteed (Int) -> ()

--- a/test/SILGen/protocol_class_refinement.swift
+++ b/test/SILGen/protocol_class_refinement.swift
@@ -29,7 +29,8 @@ class Base {}
 func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
   var x = x
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : ObjectUID> { var τ_0_0 } <T>
-  // CHECK: [[PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
   // -- call x.uid()
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]
@@ -83,7 +84,8 @@ func getObjectUID<T: ObjectUID>(x: T) -> (Int, Int, Int, Int) {
 func getBaseObjectUID<T: UID>(x: T) -> (Int, Int, Int) where T: Base {
   var x = x
   // CHECK: [[XBOX:%.*]] = alloc_box $<τ_0_0 where τ_0_0 : Base, τ_0_0 : UID> { var τ_0_0 } <T>
-  // CHECK: [[PB:%.*]] = project_box [[XBOX]]
+  // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
   // -- call x.uid()
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]] : $*T
   // CHECK: [[X:%.*]] = load [copy] [[READ]]

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -100,7 +100,8 @@ func inout_func(_ n: inout Int) {}
 // CHECK: bb0([[M:%[0-9]+]] : $MetaHolder, [[DD:%[0-9]+]] : $@thick D.Type, [[D:%[0-9]+]] : @guaranteed $D):
 func testD(_ m: MetaHolder, dd: D.Type, d: D) {
   // CHECK: [[D2:%[0-9]+]] = alloc_box ${ var D }
-  // CHECK: [[RESULT:%.*]] = project_box [[D2]]
+  // CHECK: [[D2L:%[0-9]+]] = begin_borrow [lexical] [[D2]]
+  // CHECK: [[RESULT:%.*]] = project_box [[D2L]]
   // CHECK: [[MATERIALIZED_BORROWED_D:%[0-9]+]] = alloc_stack $D
   // CHECK: store_borrow [[D]] to [[MATERIALIZED_BORROWED_D]]
   // CHECK: [[FN:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE11returnsSelf{{[_0-9a-zA-Z]*}}F
@@ -526,7 +527,8 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
 // CHECK: bb0([[P:%[0-9]+]] : $*P1):
 func testExistentials2(_ p1: P1) {
   // CHECK: [[P1A:%[0-9]+]] = alloc_box ${ var P1 }
-  // CHECK: [[PB:%.*]] = project_box [[P1A]]
+  // CHECK: [[P1AL:%[0-9]+]] = begin_borrow [lexical] [[P1A]]
+  // CHECK: [[PB:%.*]] = project_box [[P1AL]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*P1 to $*@opened([[UUID:".*"]]) P1
   // CHECK: [[FN:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE11returnsSelf{{[_0-9a-zA-Z]*}}F
   // CHECK: [[P1AINIT:%[0-9]+]] = init_existential_addr [[PB]] : $*P1, $@opened([[UUID2:".*"]]) P1
@@ -555,7 +557,8 @@ func testExistentialsGetters(_ p1: P1) {
 func testExistentialSetters(_ p1: P1, b: Bool) {
   var p1 = p1
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var P1 }
-  // CHECK: [[PBP:%[0-9]+]] = project_box [[PBOX]]
+  // CHECK: [[PLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[PBOX]]
+  // CHECK: [[PBP:%[0-9]+]] = project_box [[PLIFETIME]]
   // CHECK-NEXT: copy_addr [[P]] to [initialization] [[PBP]] : $*P1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBP]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr mutable_access [[WRITE]] : $*P1 to $*@opened([[UUID:".*"]]) P1
@@ -588,7 +591,8 @@ struct HasAP1 {
 func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   var hasAP1 = hasAP1
   // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box ${ var HasAP1 }
-  // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_BOX]]
+  // CHECK: [[HASP1_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[HASP1_BOX]]
+  // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_LIFETIME]]
   // CHECK-NEXT: copy_addr [[HASP1]] to [initialization] [[PBHASP1]] : $*HasAP1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBHASP1]]
   // CHECK: [[P1_COPY:%[0-9]+]] = alloc_stack $P1
@@ -613,7 +617,8 @@ func test_open_existential_semantics_opaque(_ guaranteed: P1,
                                             immediate: P1) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var P1 }
-  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
   // CHECK: [[VALUE:%.*]] = open_existential_addr immutable_access %0
   // CHECK: [[METHOD:%.*]] = function_ref
   // CHECK: apply [[METHOD]]<{{.*}}>([[VALUE]])
@@ -655,7 +660,8 @@ func test_open_existential_semantics_class(_ guaranteed: CP1,
                                            immediate: CP1) {
   var immediate = immediate
   // CHECK: [[IMMEDIATE_BOX:%.*]] = alloc_box ${ var CP1 }
-  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_BOX]]
+  // CHECK: [[IMMEDIATE_LIFETIME:%.*]] = begin_borrow [lexical] [[IMMEDIATE_BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[IMMEDIATE_LIFETIME]]
 
   // CHECK-NOT: copy_value [[ARG0]]
   // CHECK: [[VALUE:%.*]] = open_existential_ref [[ARG0]]
@@ -695,7 +701,8 @@ extension InitRequirement {
   init(d: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_BOX_LIFETIME]]
     // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -707,6 +714,7 @@ extension InitRequirement {
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
+    // CHECK-NEXT: end_borrow [[SELF_BOX_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
     // CHECK:      return
     self.init(c: d)
@@ -717,7 +725,8 @@ extension InitRequirement {
   init(d2: D) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
@@ -728,6 +737,7 @@ extension InitRequirement {
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
     // CHECK: } // end sil function '$s19protocol_extensions15InitRequirementPAAE2d2xAA1DC_tcfC'
     self.init(d: d2)
@@ -738,7 +748,8 @@ extension InitRequirement {
   init(c2: C) {
     // CHECK:      [[SELF_BOX:%.*]] = alloc_box
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
+    // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[SELF_TYPE:%.*]] = metatype $@thick Self.Type
@@ -752,6 +763,7 @@ extension InitRequirement {
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
     // CHECK:      return
     self = Self(c: c2)
@@ -820,7 +832,8 @@ extension ProtoDelegatesToObjC where Self : ObjCInitClass {
   init(string: String) {
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : ObjCInitClass, τ_0_0 : ProtoDelegatesToObjC> { var τ_0_0 } <Self>
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+    // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
     // CHECK:   [[SELF_META_C:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick ObjCInitClass.Type
     // CHECK:   [[OBJC_INIT:%[0-9]+]] = class_method [[SELF_META_C]] : $@thick ObjCInitClass.Type, #ObjCInitClass.init!allocator
     // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[OBJC_INIT]]([[SELF_META_C]])
@@ -844,7 +857,8 @@ extension ProtoDelegatesToRequired where Self : RequiredInitClass {
   init(string: String) {
   // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : RequiredInitClass, τ_0_0 : ProtoDelegatesToRequired> { var τ_0_0 } <Self>
   // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:   [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:   [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:   [[SELF_META_AS_CLASS_META:%[0-9]+]] = upcast [[SELF_META]] : $@thick Self.Type to $@thick RequiredInitClass.Type
   // CHECK:   [[INIT:%[0-9]+]] = class_method [[SELF_META_AS_CLASS_META]] : $@thick RequiredInitClass.Type, #RequiredInitClass.init!allocator : (RequiredInitClass.Type) -> () -> RequiredInitClass, $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass
   // CHECK:   [[SELF_RESULT:%[0-9]+]] = apply [[INIT]]([[SELF_META_AS_CLASS_META]]) : $@convention(method) (@thick RequiredInitClass.Type) -> @owned RequiredInitClass

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -14,11 +14,13 @@ func optionalMethodGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<@callee_guaranteed (Int) -> ()> }
-  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
+  // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<@callee_guaranteed (Int) -> ()>
@@ -32,11 +34,13 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
+  // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
@@ -50,11 +54,13 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   var t = t
   // CHECK: bb0([[T:%[0-9]+]] : @guaranteed $T):
   // CHECK:   [[TBOX:%[0-9]+]] = alloc_box $<τ_0_0 where τ_0_0 : P1> { var τ_0_0 } <T>
-  // CHECK:   [[PT:%[0-9]+]] = project_box [[TBOX]]
+  // CHECK:   [[TLIFETIME:%[^,]+]] = begin_borrow [lexical] [[TBOX]]
+  // CHECK:   [[PT:%[0-9]+]] = project_box [[TLIFETIME]]
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   project_box [[OPT_BOX]]
+  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
+  // CHECK:   project_box [[OPT_LIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 5

--- a/test/SILGen/reabstract_lvalue.swift
+++ b/test/SILGen/reabstract_lvalue.swift
@@ -14,7 +14,8 @@ func transform(_ i: Int) -> Double {
 // CHECK-LABEL: sil hidden [ossa] @$s17reabstract_lvalue0A13FunctionInOutyyF : $@convention(thin) () -> ()
 func reabstractFunctionInOut() {
   // CHECK: [[BOX:%.*]] = alloc_box ${ var @callee_guaranteed (Int) -> Double }
-  // CHECK: [[PB:%.*]] = project_box [[BOX]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
   // CHECK: [[ARG:%.*]] = function_ref @$s17reabstract_lvalue9transformySdSiF
   // CHECK: [[THICK_ARG:%.*]] = thin_to_thick_function [[ARG]]
   // CHECK: store [[THICK_ARG:%.*]] to [init] [[PB]]

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -527,10 +527,12 @@ func defer_mutable(_ x: Int) {
   var x = x
   // expected-warning@-1 {{variable 'x' was never mutated; consider changing to 'let' constant}}
   // CHECK: [[BOX:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: project_box [[BOX]]
-  // CHECK-NOT: [[BOX]]
+  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK-NEXT: project_box [[LIFETIME]]
+  // CHECK-NOT: [[LIFETIME]]
   // CHECK: function_ref @$s10statements13defer_mutableyySiF6$deferL_yyF : $@convention(thin) (@inout_aliasable Int) -> ()
-  // CHECK-NOT: [[BOX]]
+  // CHECK-NOT: [[LIFETIME]]
+  // CHECK: end_borrow [[LIFETIME]]
   // CHECK: destroy_value [[BOX]]
   defer { _ = x } // expected-warning {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
 }

--- a/test/SILGen/stored_property_init_reabstraction.swift
+++ b/test/SILGen/stored_property_init_reabstraction.swift
@@ -25,7 +25,8 @@ struct Struct<T> {
 
 // CHECK-LABEL: sil hidden [ossa] @$s34stored_property_init_reabstraction6StructVyACySiGSicSiRszlufC : $@convention(method) (Int, @thin Struct<Int>.Type) -> @owned Struct<Int> {
 // CHECK: [[SELF_BOX:%.*]] = mark_uninitialized [rootself] {{%.*}} : ${ var Struct<Int> }
-// CHECK: [[SELF:%.*]] = project_box [[SELF_BOX]] : ${ var Struct<Int> }, 0
+// CHECK: [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF_BOX]]
+// CHECK: [[SELF:%.*]] = project_box [[SELF_LIFETIME]] : ${ var Struct<Int> }, 0
 // CHECK: [[ADDR:%.*]] = struct_element_addr [[SELF]] : $*Struct<Int>, #Struct.fn
 // CHECK: [[INIT:%.*]] = function_ref @$s34stored_property_init_reabstraction6StructV2fnyxcSgvpfi : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>
 // CHECK: [[VALUE:%.*]] = apply [[INIT]]<Int>() : $@convention(thin) <τ_0_0> () -> @owned Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>>

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -132,12 +132,14 @@ func methodCalls(
   // CHECK: store_borrow [[PAYLOAD]] to [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") Base<Int> & P, #P.protocolSelfReturn : <Self where Self : P> (Self) -> () -> Self, [[PAYLOAD]] : $@opened("{{.*}}") Base<Int> & P : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_box
-  // CHECK: [[RESULT_BUF:%.*]] = project_box [[RESULT_BOX]]
+  // CHECK: [[RESULT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[RESULT_BOX]]
+  // CHECK: [[RESULT_BUF:%.*]] = project_box [[RESULT_LIFETIME]]
   // CHECK: apply [[METHOD]]<@opened("{{.*}}") Base<Int> & P>([[RESULT_BUF]], [[SELF_BOX]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
   // CHECK: dealloc_stack [[SELF_BOX]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: [[RESULT_REF:%.*]] = load [take] [[RESULT_BUF]] : $*@opened("{{.*}}") Base<Int> & P
   // CHECK: [[RESULT:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") Base<Int> & P : $@opened("{{.*}}") Base<Int> & P, $Base<Int> & P
   // CHECK: destroy_value [[RESULT]] : $Base<Int> & P
+  // CHECK: end_borrow [[RESULT_LIFETIME]]
   // CHECK: dealloc_box [[RESULT_BOX]]
   let _: Base<Int> & P = baseAndP.protocolSelfReturn()
 
@@ -153,11 +155,13 @@ func methodCalls(
   // CHECK: [[METATYPE:%.*]] = open_existential_metatype %1 : $@thick (Base<Int> & P).Type to $@thick (@opened("{{.*}}") (Base<Int> & P)).Type
   // CHECK: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") (Base<Int> & P), #P.protocolSelfReturn : <Self where Self : P> (Self.Type) -> () -> Self, [[METATYPE]] : $@thick (@opened("{{.*}}") (Base<Int> & P)).Type : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[RESULT_BOX:%.*]] = alloc_box
+  // CHECK: [[RESULT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[RESULT_BOX]]
   // CHECK: [[RESULT_BUF:%.*]] = project_box
   // CHECK: apply [[METHOD]]<@opened("{{.*}}") (Base<Int> & P)>([[RESULT_BUF]], [[METATYPE]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@thick τ_0_0.Type) -> @out τ_0_0
   // CHECK: [[RESULT_REF:%.*]] = load [take] [[RESULT_BUF]] : $*@opened("{{.*}}") (Base<Int> & P)
   // CHECK: [[RESULT_VALUE:%.*]] = init_existential_ref [[RESULT_REF]] : $@opened("{{.*}}") (Base<Int> & P) : $@opened("{{.*}}") (Base<Int> & P), $Base<Int> & P
   // CHECK: destroy_value [[RESULT_VALUE]]
+  // CHECK: end_borrow [[RESULT_LIFETIME]]
   // CHECK: dealloc_box [[RESULT_BOX]]
   let _: Base<Int> & P = baseAndPType.protocolSelfReturn()
 

--- a/test/SILGen/super_init_refcounting.swift
+++ b/test/SILGen/super_init_refcounting.swift
@@ -11,7 +11,8 @@ class Bar: Foo {
   // CHECK: bb0([[INPUT_SELF:%.*]] : @owned $Bar):
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Bar }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         store [[INPUT_SELF]] to [init] [[PB_SELF_BOX]]
   // CHECK:         [[ORIG_SELF:%.*]] = load [take] [[PB_SELF_BOX]]
   // CHECK-NOT:     copy_value [[ORIG_SELF]]
@@ -30,7 +31,8 @@ extension Foo {
   // CHECK-LABEL: sil hidden [ossa] @$s22super_init_refcounting3FooC{{[_0-9a-zA-Z]*}}fC
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Foo }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] =  mark_uninitialized [delegatingself] [[SELF_BOX]]
-  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         [[SELF_INIT:%.*]] = class_method
   // CHECK:         [[NEW_SELF:%.*]] = apply [[SELF_INIT]](%1)
   // CHECK:         assign [[NEW_SELF]] to [[PB_SELF_BOX]]
@@ -74,7 +76,8 @@ class Good: Foo {
   // CHECK-LABEL: sil hidden [ossa] @$s22super_init_refcounting4GoodC{{[_0-9a-zA-Z]*}}fc
   // CHECK:         [[SELF_BOX:%.*]] = alloc_box ${ var Good }
   // CHECK:         [[MARKED_SELF_BOX:%.*]] = mark_uninitialized [derivedself] [[SELF_BOX]]
-  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK:         [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK:         [[PB_SELF_BOX:%.*]] = project_box [[SELF_LIFETIME]]
   // CHECK:         store %0 to [init] [[PB_SELF_BOX]]
   // CHECK:         [[SELF_OBJ:%.*]] = load_borrow [[PB_SELF_BOX]]
   // CHECK:         [[X_ADDR:%.*]] = ref_element_addr [[SELF_OBJ]] : $Good, #Good.x

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -139,9 +139,11 @@ func test5() {
   case (var n, foo()):
     // Check that the var is boxed and unboxed and the final value is the one that falls through into the next case
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "n"
-    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX]] : ${ var Int }, 0
+    // CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX_LIFETIME]] : ${ var Int }, 0
     // CHECK:   function_ref @$s18switch_fallthrough1ayyF
     // CHECK:   [[N:%.*]] = load [trivial] [[N_BOX]] : $*Int
+    // CHECK:   end_borrow [[BOX_LIFETIME]]
     // CHECK:   destroy_value [[BOX]] : ${ var Int }
     // CHECK:   br [[CASE2:bb[0-9]+]]([[N]] : $Int)
     a()

--- a/test/SILGen/switch_multiple_entry_address_only.swift
+++ b/test/SILGen/switch_multiple_entry_address_only.swift
@@ -93,7 +93,8 @@ func multipleLabelsVar(e: E) {
   // CHECK:      bb3:
   // CHECK-NEXT: debug_value [[X_PHI]] : $*Any, var, name "x"
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
-  // CHECK-NEXT: [[BOX_PAYLOAD:%.*]] = project_box [[ANY_BOX]] : ${ var Any }, 0
+  // CHECK-NEXT: [[ANY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ANY_BOX]]
+  // CHECK-NEXT: [[BOX_PAYLOAD:%.*]] = project_box [[ANY_BOX_LIFETIME]] : ${ var Any }, 0
   // CHECK-NEXT: copy_addr [take] [[X_PHI]] to [initialization] [[BOX_PAYLOAD]]
   // CHECK-NEXT: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX_PAYLOAD]]
   // CHECK-NEXT: [[ANY_STACK:%.*]] = alloc_stack $Any
@@ -103,6 +104,7 @@ func multipleLabelsVar(e: E) {
   // CHECK-NEXT: apply [[FN]]([[ANY_STACK]]
   // CHECK-NEXT: destroy_addr [[ANY_STACK]]
   // CHECK-NEXT: dealloc_stack [[ANY_STACK]]
+  // CHECK-NEXT: end_borrow [[ANY_BOX_LIFETIME]]
   // CHECK-NEXT: destroy_value [[ANY_BOX]]
   // CHECK-NEXT: br bb5
 

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -47,12 +47,14 @@ func test_var_1() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK-NOT: br bb
   case var x:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
+  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
     a(x: x)
   }
@@ -65,7 +67,8 @@ func test_var_2() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -76,12 +79,14 @@ func test_var_2() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
+  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -91,16 +96,19 @@ func test_var_2() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b(x: y)
   case var z:
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1c1xySi_tF
+  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   br [[CONT]]
     c(x: z)
@@ -116,7 +124,8 @@ func test_var_3() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -126,15 +135,18 @@ func test_var_3() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var2aa1xySi_Sit_tF
+  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
 
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -147,14 +159,17 @@ func test_var_3() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
+  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     a(x: y)
     b(x: z)
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
+  // CHECK:   [[WLIFETIME:%[^,]+]] = begin_borrow [lexical] [[WADDR]]
+  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var5ansed1xSbSi_tF
@@ -167,13 +182,16 @@ func test_var_3() {
   // CHECK:   br [[CONT]]
     bb(x: w)
   // CHECK: [[NO_CASE3]]:
+  // CHECK:   end_borrow [[WLIFETIME]]
   // CHECK:   destroy_value [[WADDR]]
   case var v:
   // CHECK:   [[VADDR:%.*]] = alloc_box ${ var (Int, Int) } 
-  // CHECK:   [[V:%.*]] = project_box [[VADDR]]
+  // CHECK:   [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VADDR]]
+  // CHECK:   [[V:%.*]] = project_box [[VLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[V]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var2cc1xySi_Sit_tF
+  // CHECK:   end_borrow [[VLIFETIME]]
   // CHECK:   destroy_value [[VADDR]]
   // CHECK:   br [[CONT]]
     cc(x: v)
@@ -204,7 +222,8 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_X]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*X
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.+]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
@@ -213,6 +232,7 @@ func test_var_4(p p: P) {
   case (is X, var x) where runced(x: x):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
+  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
@@ -235,7 +255,8 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_Y]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*Y
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%.+]] = begin_borrow [lexical] [[YADDR]]
+  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
@@ -247,6 +268,7 @@ func test_var_4(p p: P) {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*P
@@ -255,6 +277,7 @@ func test_var_4(p p: P) {
     b(x: y)
 
   // CHECK: [[NO_CASE2]]:
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   br [[NEXT:bb[0-9]+]]
@@ -264,7 +287,8 @@ func test_var_4(p p: P) {
 
   // CHECK: [[NEXT]]:
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var (P, Int) }
-  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%.+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 1
   // CHECK:   function_ref @$s10switch_var5ansed1xSbSi_tF
@@ -274,6 +298,7 @@ func test_var_4(p p: P) {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 1
   // CHECK:   function_ref @$s10switch_var1c1xySi_tF
+  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK-NEXT: destroy_addr [[PAIR]]
   // CHECK-NEXT: dealloc_stack [[PAIR]]
@@ -281,15 +306,18 @@ func test_var_4(p p: P) {
     c(x: z.1)
 
   // CHECK: [[DFLT_NO_CASE3]]:
+  // CHECK-NEXT:   end_borrow [[ZLIFETIME]]
   // CHECK-NEXT:   destroy_value [[ZADDR]]
   // CHECK-NOT: destroy_addr
   case (_, var w):
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(P, Int), 0
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
+  // CHECK:   [[WLIFETIME:%.+]] = begin_borrow [lexical] [[WADDR]]
+  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1d1xySi_tF
+  // CHECK:   end_borrow [[WLIFETIME]]
   // CHECK:   destroy_value [[WADDR]]
   // CHECK-NEXT:   destroy_addr [[PAIR_0]] : $*P
   // CHECK-NEXT:   dealloc_stack [[PAIR]]
@@ -306,7 +334,8 @@ func test_var_5() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
+  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
+  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
   // CHECK: [[CASE1]]:
@@ -314,18 +343,24 @@ func test_var_5() {
     a()
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[Y:%[0-9]+]] = project_box [[YADDR]]
+  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
+  // CHECK:   [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
   // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZADDR]]
+  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
   // CHECK: [[CASE2]]:
+  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b()
   // CHECK: [[NO_CASE2]]:
+  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
+  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
   case (_, _) where runced():
@@ -346,39 +381,49 @@ func test_var_return() {
   switch (foo(), bar()) {
   case var x where runced():
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
+    // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
+    // CHECK: [[X:%[0-9]+]] = project_box [[XLIFETIME]]
     // CHECK: function_ref @$s10switch_var1ayyF
+    // CHECK: end_borrow [[XLIFETIME]]
     // CHECK: destroy_value [[XADDR]]
     // CHECK: br [[EPILOG:bb[0-9]+]]
     a()
     return
   // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[Y:%[0-9]+]] = project_box [[YADDR]]
+  // CHECK: [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
+  // CHECK: [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
   // CHECK: [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[Z:%[0-9]+]] = project_box [[ZADDR]]
+  // CHECK: [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
+  // CHECK: [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
   case (var y, var z) where funged():
     // CHECK: function_ref @$s10switch_var1byyF
+    // CHECK: end_borrow [[ZLIFETIME]]
     // CHECK: destroy_value [[ZADDR]]
+    // CHECK: end_borrow [[YLIFETIME]]
     // CHECK: destroy_value [[YADDR]]
     // CHECK: br [[EPILOG]]
     b()
     return
   case var w where ansed():
     // CHECK: [[WADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[W:%[0-9]+]] = project_box [[WADDR]]
+    // CHECK: [[WLIFETIME:%[^,]+]] = begin_borrow [lexical] [[WADDR]]
+    // CHECK: [[W:%[0-9]+]] = project_box [[WLIFETIME]]
     // CHECK: function_ref @$s10switch_var1cyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
+    // CHECK: end_borrow [[WLIFETIME]]
     // CHECK: destroy_value [[WADDR]]
     // CHECK: br [[EPILOG]]
     c()
     return
   case var v:
     // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[V:%[0-9]+]] = project_box [[VADDR]]
+    // CHECK: [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VADDR]]
+    // CHECK: [[V:%[0-9]+]] = project_box [[VLIFETIME]]
     // CHECK: function_ref @$s10switch_var1dyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
+    // CHECK: end_borrow [[VLIFETIME]]
     // CHECK: destroy_value [[VADDR]]
     // CHECK: br [[EPILOG]]
     d()
@@ -464,7 +509,8 @@ func test_mixed_let_var() {
 
   // First pattern.
   // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }, var, name "x"
-  // CHECK:   [[PBOX:%.*]] = project_box [[BOX]]
+  // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+  // CHECK:   [[PBOX:%.*]] = project_box [[LIFETIME]]
   // CHECK:   [[VAL_COPY:%.*]] = copy_value [[BORROWED_VAL]]
   // CHECK:   store [[VAL_COPY]] to [init] [[PBOX]]
   // CHECK:   cond_br {{.*}}, [[CASE1:bb[0-9]+]], [[NOCASE1:bb[0-9]+]]
@@ -474,6 +520,7 @@ func test_mixed_let_var() {
   // CHECK:   [[X:%.*]] = load [copy] [[READ]]
   // CHECK:   [[A:%.*]] = function_ref @$s10switch_var1a1xySS_tF
   // CHECK:   apply [[A]]([[X]])
+  // CHECK:   end_borrow [[LIFETIME]]
   // CHECK:   destroy_value [[BOX]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -25,9 +25,11 @@ func make_xy() -> (x: Int, y: P) { return (make_int(), make_p()) }
 // CHECK-LABEL: sil hidden [ossa] @$s6tuples17testShuffleOpaqueyyF
 func testShuffleOpaque() {
   // CHECK: [[X:%.*]] = alloc_box ${ var P }
-  // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
+  // CHECK: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
   // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $P
 
   // CHECK:      [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
@@ -38,7 +40,8 @@ func testShuffleOpaque() {
   var (x,y) : (y:P, x:Int) = make_xy()
 
   // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: P, x: Int) }
-  // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
+  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[PAIR]]
+  // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR_LIFETIME]]
   // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $P
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
@@ -67,9 +70,11 @@ func testShuffleOpaque() {
 // CHECK-LABEL: testShuffleTuple
 func testShuffleTuple() {
   // CHECK: [[X:%.*]] = alloc_box ${ var P }
-  // CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
+  // CHECK: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples8make_intSiyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()
@@ -83,7 +88,8 @@ func testShuffleTuple() {
   var (x,y) : (y:P, x:Int) = (x: make_int(), y: make_p())
 
   // CHECK-NEXT: [[PAIR:%.*]] = alloc_box ${ var (y: P, x: Int) }
-  // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR]]
+  // CHECK-NEXT: [[PAIR_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[PAIR]]
+  // CHECK-NEXT: [[PBPAIR:%.*]] = project_box [[PAIR_LIFETIME]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples8make_intSiyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -28,7 +28,8 @@ struct S {
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
     // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
+    // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
+    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XLIFETIME]]
     // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
     // CHECK: [[X:%.*]] = load [trivial] [[READ]] : $*Int
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[THIS]] : $*S

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -44,11 +44,13 @@ func test0(c c: C) {
   var a: A
   // CHECK:   [[A1:%.*]] = alloc_box ${ var A }, var, name "a"
   // CHECK:   [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
-  // CHECK:   [[PBA:%.*]] = project_box [[MARKED_A1]]
+  // CHECK:   [[MARKED_A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_A1]]
+  // CHECK:   [[PBA:%.*]] = project_box [[MARKED_A1_LIFETIME]]
 
   unowned var x = c
   // CHECK:   [[X:%.*]] = alloc_box ${ var @sil_unowned C }
-  // CHECK:   [[PBX:%.*]] = project_box [[X]]
+  // CHECK:   [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+  // CHECK:   [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
   // CHECK:   [[T2:%.*]] = ref_to_unowned [[ARG_COPY]] : $C  to $@sil_unowned C
   // CHECK:   [[T2_COPY:%.*]] = copy_value [[T2]] : $@sil_unowned C
@@ -75,7 +77,9 @@ func test0(c c: C) {
   // CHECK:   [[T4_COPY:%.*]] = copy_value [[T4]] : $@sil_unowned C  
   // CHECK:   assign [[T4_COPY]] to [[XP]] : $*@sil_unowned C
   // CHECK:   destroy_value [[T3]] : $C
+  // CHECK:   end_borrow [[X_LIFETIME]]
   // CHECK:   destroy_value [[X]]
+  // CHECK:   end_borrow [[MARKED_A1_LIFETIME]]
   // CHECK:   destroy_value [[MARKED_A1]]
 }
 // CHECK: } // end sil function '$s7unowned5test01cyAA1CC_tF'
@@ -87,7 +91,8 @@ func testunowned_local() -> C {
 
   // CHECK: [[BORROWED_C:%.*]] = begin_borrow [lexical] [[C]]
   // CHECK: [[UC:%.*]] = alloc_box ${ var @sil_unowned C }, let, name "uc"
-  // CHECK: [[PB_UC:%.*]] = project_box [[UC]]
+  // CHECK: [[UC_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UC]]
+  // CHECK: [[PB_UC:%.*]] = project_box [[UC_LIFETIME]]
   // CHECK: [[C_COPY:%.*]] = copy_value [[BORROWED_C]]
   // CHECK: [[tmp1:%.*]] = ref_to_unowned [[C_COPY]] : $C to $@sil_unowned C
   // CHECK: [[tmp1_copy:%.*]] = copy_value [[tmp1]]
@@ -100,6 +105,7 @@ func testunowned_local() -> C {
   // CHECK: end_borrow [[tmp2]]
   return uc
 
+  // CHECK: end_borrow [[UC_LIFETIME]]
   // CHECK: destroy_value [[UC]]
   // CHECK: destroy_value [[C]]
   // CHECK: return [[tmp3]]

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -29,7 +29,8 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK: bb0([[INPUT_ELEMENT:%.*]] : @guaranteed $Element,
   // CHECK:   [[BOX:%.*]] = alloc_box
   // CHECK:   [[UNINIT_BOX:%.*]] = mark_uninitialized [rootself] [[BOX]]
-  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX]]
+  // CHECK:   [[UNINIT_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_BOX]]
+  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX_LIFETIME]]
   // CHECK:   [[COPY_INPUT_ELEMENT:%.*]] = copy_value [[INPUT_ELEMENT]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_UNINIT_BOX]]
   // CHECK:   [[STRUCT_ACCESS:%.*]] = struct_element_addr [[ACCESS]]
@@ -38,6 +39,7 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK:   destroy_value [[COPY_INPUT_ELEMENT]]
   // CHECK:   end_access [[ACCESS]]
   // CHECK:   [[RESULT:%.*]] = load [trivial] [[PROJECT_UNINIT_BOX]]
+  // CHECK:   end_borrow [[UNINIT_BOX_LIFETIME]]
   // CHECK:   destroy_value [[UNINIT_BOX]]
   // CHECK:   return [[RESULT]]
   // CHECK: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'
@@ -70,7 +72,8 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s11unsafevalue11UnsafeValueV20withGuaranteeingBase4base_qd_0_qd___qd_0_xXEtr0_lF :
   // CHECK: bb0([[RESULT:%.*]] : $*Result, [[BASE:%.*]] : $*Base, [[CLOSURE:%.*]] : $@noescape @callee_guaranteed {{.*}}, [[UNSAFE_VALUE:%.*]] : $UnsafeValue<Element>):
   // CHECK:  [[COPY_BOX:%.*]] = alloc_box
-  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX]]
+  // CHECK:  [[COPY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[COPY_BOX]]
+  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX_LIFETIME]]
   // CHECK:  store [[UNSAFE_VALUE]] to [trivial] [[COPY_PROJ]]
   // CHECK:  [[VALUE_ADDR:%.*]] = begin_access [read] [unknown] [[COPY_PROJ]]
   // CHECK:  [[STR_VALUE_ADDR:%.*]] = struct_element_addr [[VALUE_ADDR]]
@@ -81,6 +84,7 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK:  end_access [[VALUE_ADDR]]
   // CHECK:  apply [[CLOSURE]]([[RESULT]], [[GUARANTEED_REF_DEP_ON_BASE]])
   // CHECK:  end_borrow [[GUARANTEED_REF]]
+  // CHECK:  end_borrow [[COPY_BOX_LIFETIME]]
   // CHECK:  destroy_value [[COPY_BOX]]
   // CHECK: } // end sil function '$s11unsafevalue11UnsafeValueV20withGuaranteeingBase4base_qd_0_qd___qd_0_xXEtr0_lF'
   //

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -16,16 +16,19 @@ func test0(c c: C) {
   var c = c
 // CHECK:    bb0(%0 : @guaranteed $C):
 // CHECK:      [[C:%.*]] = alloc_box ${ var C }
-// CHECK-NEXT: [[PBC:%.*]] = project_box [[C]]
+// CHECK:      [[C_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[C]]
+// CHECK-NEXT: [[PBC:%.*]] = project_box [[C_LIFETIME]]
 
   var a: A
 // CHECK:      [[A1:%.*]] = alloc_box ${ var A }
 // CHECK:      [[MARKED_A1:%.*]] = mark_uninitialized [var] [[A1]]
-// CHECK-NEXT: [[PBA:%.*]] = project_box [[MARKED_A1]]
+// CHECK:      [[A1_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_A1]]
+// CHECK-NEXT: [[PBA:%.*]] = project_box [[A1_LIFETIME]]
 
   weak var x = c
 // CHECK:      [[X:%.*]] = alloc_box ${ var @sil_weak Optional<C> }, var, name "x"
-// CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
+// CHECK:      [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
+// CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
 //   Implicit conversion
 // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] [[PBC]]
 // CHECK-NEXT: [[TMP:%.*]] = load [copy] [[READ]] : $*C
@@ -71,13 +74,15 @@ class CC {
   // CHECK:  bb0([[SELF:%.*]] : @owned $CC):
   // CHECK:    [[UNINIT_SELF:%.*]] = mark_uninitialized [rootself] [[SELF]] : $CC
   // CHECK:    [[FOO:%.*]] = alloc_box ${ var Optional<CC> }, var, name "foo"
-  // CHECK:    [[PB:%.*]] = project_box [[FOO]]
+  // CHECK:    [[FOO_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[FOO]]
+  // CHECK:    [[PB:%.*]] = project_box [[FOO_LIFETIME]]
   // CHECK:    [[BORROWED_UNINIT_SELF:%.*]] = begin_borrow [[UNINIT_SELF]]
   // CHECK:    [[X:%.*]] = ref_element_addr [[BORROWED_UNINIT_SELF]] : $CC, #CC.x
   // CHECK:    [[READ:%.*]] = begin_access [read] [dynamic] [[X]] : $*@sil_weak Optional<CC>
   // CHECK:    [[VALUE:%.*]] = load_weak [[READ]] : $*@sil_weak Optional<CC>
   // CHECK:    store [[VALUE]] to [init] [[PB]] : $*Optional<CC>
   // CHECK:    end_borrow [[BORROWED_UNINIT_SELF]]
+  // CHECK:    end_borrow [[FOO_LIFETIME]]
   // CHECK:    destroy_value [[FOO]]
   // CHECK: } // end sil function '$s4weak2CCC{{[_0-9a-zA-Z]*}}fc'
   init() {

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -53,13 +53,15 @@ struct StructOfInt {
 // CHECK: bb0(%0 : $@thin StructOfInt.Type):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var StructOfInt }, var, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var StructOfInt }
-// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var StructOfInt }, 0
+// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var StructOfInt }, 0
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]] : $*StructOfInt
 // CHECK:   [[ADR:%.*]] = struct_element_addr [[ACCESS]] : $*StructOfInt, #StructOfInt.i
 // CHECK:   assign %{{.*}} to [[ADR]] : $*Int
 // CHECK:   end_access [[ACCESS]] : $*StructOfInt
 // CHECK-NOT: begin_access
 // CHECK:   [[VAL:%.*]] = load [trivial] [[PROJ]] : $*StructOfInt
+// CHECK:   end_borrow [[UNINIT_LIFETIME]]
 // CHECK:   destroy_value [[UNINIT]] : ${ var StructOfInt }
 // CHECK:   return [[VAL]] : $StructOfInt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify11StructOfIntVACycfC'
@@ -105,7 +107,8 @@ class SubHasInt : SuperHasInt {
 // CHECK: bb0(%0 : @owned $SubHasInt):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
-// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var SubHasInt }, 0
+// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var SubHasInt }, 0
 // CHECK-NOT: begin_access
 // CHECK:   store %0 to [init] [[PROJ]] : $*SubHasInt
 // CHECK-NOT: begin_access
@@ -124,6 +127,7 @@ class SubHasInt : SuperHasInt {
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
 // CHECK:   [[VAL:%.*]] = load [copy] [[PROJ]] : $*SubHasInt
+// CHECK:   end_borrow [[UNINIT_LIFETIME]]
 // CHECK:   destroy_value [[UNINIT]] : ${ var SubHasInt }
 // CHECK:   return [[VAL]] : $SubHasInt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify9SubHasIntCACycfc'
@@ -132,7 +136,8 @@ class SubHasInt : SuperHasInt {
 // CHECK: bb0(%0 : $Int, %1 : @owned $SubHasInt):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
-// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var SubHasInt }, 0
+// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var SubHasInt }, 0
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
 // CHECK-NOT: begin_access
@@ -151,6 +156,7 @@ class SubHasInt : SuperHasInt {
 // CHECK-NOT: begin_access
 // CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
 // CHECK:   [[VAL:%.*]] = load [copy] [[PROJ]] : $*SubHasInt
+// CHECK:   end_borrow [[UNINIT_LIFETIME]]
 // CHECK:   destroy_value [[UNINIT]] : ${ var SubHasInt }
 // CHECK:   return [[VAL]] : $SubHasInt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify9SubHasIntC1xACSi_tcfc'
@@ -215,12 +221,13 @@ func testCaptureLocal() -> ()->() {
 }
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify16testCaptureLocalyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 // CHECK: bb0:
-// CHECK:   alloc_box ${ var Int }, var, name "x"
-// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "x"
+// CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
 // CHECK:   store %{{.*}} to [trivial] [[ACCESS]]
 // CHECK:   end_access
-// CHECK:   [[CAPTURE:%.*]] = copy_value %0 : ${ var Int }
+// CHECK:   [[CAPTURE:%.*]] = copy_value [[LIFETIME]] : ${ var Int }
 // CHECK:   partial_apply [callee_guaranteed] %{{.*}}([[CAPTURE]]) : $@convention(thin) (@guaranteed { var Int }) -> ()
 // CHECK:   begin_access [read] [unknown] [[PROJ]]
 // CHECK:   [[VAL:%.*]] = load [trivial]
@@ -597,7 +604,7 @@ struct DelegatingInit {
 // CHECK-NOT: begin_access
 // CHECK:   load [trivial] [[BOX]] : $*DelegatingInit
 // CHECK:   destroy_value
-// CHECK:   return %10 : $DelegatingInit
+// CHECK:   return {{%[^,]+}} : $DelegatingInit
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify14DelegatingInitV1iACSi_tcfC'
 
 // --- addressor.

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -4,27 +4,28 @@
 
 // CHECK: sil hidden [ossa] @$s4null19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> Int {
 // CHECK: bb0:
-// CHECK:   %0 = alloc_box ${ var Int }, var, name "x", loc {{.*}}:32:7, scope 3
-// CHECK:   %1 = project_box %0 : ${ var Int }, 0, loc {{.*}}:32:7, scope 3
-// CHECK:   %2 = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:32:11, scope 3
-// CHECK:   %3 = metatype $@thin Int.Type, loc {{.*}}:32:11, scope 3
-// CHECK:   %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
-// CHECK:   %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
-// CHECK:   store %5 to [trivial] %1 : $*Int, loc {{.*}}:32:11, scope 3
-// CHECK:   %7 = copy_value %0 : ${ var Int }, loc {{.*}}:33:11, scope 3
-// CHECK:   %8 = project_box %7 : ${ var Int }, 0, loc {{.*}}:33:11, scope 3
-// CHECK:   mark_function_escape %1 : $*Int, loc {{.*}}:33:11, scope 3
-// CHECK:   %10 = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
-// CHECK:   %11 = load [trivial] %8 : $*Int, loc {{.*}}:33:11, scope 3
-// CHECK:   destroy_value %7 : ${ var Int }, loc {{.*}}:33:11, scope 3
-// CHECK:   %13 = partial_apply [callee_guaranteed] %10(%11) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] %13
-// CHECK:   debug_value [[BORROW]] : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 3
-// CHECK:   %16 = copy_value [[BORROW]] : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
+// CHECK:   [[BOX:%[^,]+]] = alloc_box ${ var Int }, var, name "x", loc {{.*}}:33:7, scope 3
+// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
+// CHECK:   [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]] : ${ var Int }, 0, loc {{.*}}:33:7, scope 3
+// CHECK:   [[ONE:%[^,]+]] = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:33:11, scope 3
+// CHECK:   [[THIN_INT_TYPE:%[^,]+]] = metatype $@thin Int.Type, loc {{.*}}:33:11, scope 3
+// CHECK:   [[INTEGER_LITERAL:%[^,]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:33:11, scope 3
+// CHECK:   [[ONE_INT:%[^,]+]] = apply [[INTEGER_LITERAL]]([[ONE]], [[THIN_INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:33:11, scope 3
+// CHECK:   store [[ONE_INT]] to [trivial] [[BOX_ADDR]] : $*Int, loc {{.*}}:33:11, scope 3
+// CHECK:   [[BOX_COPY:%[^,]+]] = copy_value [[BOX_LIFETIME]] : ${ var Int }, loc {{.*}}:34:11, scope 3
+// CHECK:   [[BOX_COPY_ADDR:%[^,]+]] = project_box [[BOX_COPY]] : ${ var Int }, 0, loc {{.*}}:34:11, scope 3
+// CHECK:   mark_function_escape [[BOX_ADDR]] : $*Int, loc {{.*}}:34:11, scope 3
+// CHECK:   [[SPECIALIZED_F:%[^,]+]] = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:34:11, scope 3
+// CHECK:   [[REGISTER_11:%[^,]+]] = load [trivial] [[BOX_COPY_ADDR]] : $*Int, loc {{.*}}:34:11, scope 3
+// CHECK:   destroy_value [[BOX_COPY]] : ${ var Int }, loc {{.*}}:34:11, scope 3
+// CHECK:   [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[SPECIALIZED_F]]([[REGISTER_11]]) : $@convention(thin) (Int) -> Int, loc {{.*}}:34:11, scope 3
+// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [[CLOSURE]]
+// CHECK:   debug_value [[BORROW]] : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:34:7, scope 3
+// CHECK:   [[CLOSURE_COPY:%[^,]+]] = copy_value [[BORROW]] : $@callee_guaranteed () -> Int, loc {{.*}}:35:10, scope 3
 // There used to be an end_borrow here. We leave an emptyline here to preserve line numbers.
-// CHECK:   destroy_value %13 : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 3
-// CHECK:   destroy_value %0 : ${ var Int }, loc {{.*}}:35:1, scope 3
-// CHECK:   return %16 : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3
+// CHECK:   destroy_value [[CLOSURE]] : $@callee_guaranteed () -> Int, loc {{.*}}:36:1, scope 3
+// CHECK:   destroy_value [[BOX]] : ${ var Int }, loc {{.*}}:36:1, scope 3
+// CHECK:   return [[CLOSURE_COPY]] : $@callee_guaranteed () -> Int, loc {{.*}}:35:3, scope 3
 // CHECK: }
 
 


### PR DESCRIPTION
Because AllocBoxToStack is not able to transform every alloc_box into an alloc_stack, it's necessary to add begin_borrow [lexical] to every alloc_box in order to provide lexical scopes for those alloc_boxes which will not be transformed into alloc_stacks.
    
Now that alloc_boxes whose lifetimes are lexical are emitted with begin_borrow [lexical]/end_borrow, AllocBoxToStack needs to be able to see through those new borrow scopes in order to continue stack promoting the same boxes that it was able to before those lexical scopes were emitted.
