### PR TITLE
RequirementMachine: Two more fixes for -requirement-machine-protocol-signatures=verify

### DIFF
--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -304,7 +304,6 @@ void PropertyMap::clear() {
 
   Trie.clear();
   Entries.clear();
-  ConcreteTypeInDomainMap.clear();
 }
 
 /// Build the property map from all rules of the form T.[p] => T, where
@@ -374,10 +373,6 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
 
   // Now, check for conflicts between superclass and concrete type rules.
   checkConcreteTypeRequirements(inducedRules);
-
-  // We collect terms with fully concrete types so that we can re-use them
-  // to tie off recursion in the next step.
-  computeConcreteTypeInDomainMap();
 
   // Now, we merge concrete type rules with conformance rules, by adding
   // relations between associated type members of type parameters with

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -340,7 +340,11 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
     if (rule.isSimplified())
       continue;
 
-    if (rule.isPermanent())
+    // Identity conformances ([P].[P] => [P]) are permanent rules, but we
+    // keep them around to ensure that concrete conformance introduction
+    // works in the case where the protocol's Self type is itself subject
+    // to a superclass or concrete type requirement.
+    if (rule.isPermanent() && !rule.isIdentityConformanceRule())
       continue;
 
     // Collect all rules of the form T.[p] => T where T is canonical.

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -117,7 +117,7 @@ public:
     return Superclass.hasValue();
   }
 
-  Type getSuperclassBound() const {
+  CanType getSuperclassBound() const {
     return Superclass->getSuperclass();
   }
 
@@ -130,7 +130,7 @@ public:
     return ConcreteType.hasValue();
   }
 
-  Type getConcreteType() const {
+  CanType getConcreteType() const {
     return ConcreteType->getConcreteType();
   }
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -165,9 +165,6 @@ class PropertyMap {
   std::vector<PropertyBag *> Entries;
   Trie<PropertyBag *, MatchKind::Longest> Trie;
 
-  using ConcreteTypeInDomain = std::pair<CanType, ArrayRef<const ProtocolDecl *>>;
-  llvm::DenseMap<ConcreteTypeInDomain, Term> ConcreteTypeInDomainMap;
-
   // Building the property map introduces new induced rules, which
   // runs another round of Knuth-Bendix completion, which rebuilds the
   // property map again.
@@ -235,7 +232,6 @@ private:
   void checkConcreteTypeRequirements(
                    SmallVectorImpl<InducedRule> &inducedRules);
 
-  void computeConcreteTypeInDomainMap();
   void concretizeNestedTypesFromConcreteParents(
                    SmallVectorImpl<InducedRule> &inducedRules);
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -1003,6 +1003,7 @@ void RuleBuilder::collectRulesFromReferencedProtocols() {
       llvm::dbgs() << "protocol " << proto->getName() << " {\n";
     }
 
+    // Add the identity conformance rule [P].[P] => [P].
     MutableTerm lhs;
     lhs.add(Symbol::forProtocol(proto, Context));
     lhs.add(Symbol::forProtocol(proto, Context));

--- a/test/Generics/circular_protocol_superclass.swift
+++ b/test/Generics/circular_protocol_superclass.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: circular_protocol_superclass.(file).A@
+// CHECK-NEXT: Requirement signature: <Self where Self : a>
+protocol A : a {
+  associatedtype e : a
+}
+
+class a : A {
+  typealias e = a
+}

--- a/test/Generics/rdar79564324.swift
+++ b/test/Generics/rdar79564324.swift
@@ -38,6 +38,7 @@ public func test<T : P>(_ t: T) where T == T.A {
 // CHECK-NEXT: Rewrite loops: {
 // CHECK:      }
 // CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P] => { conforms_to: [P] }
 // CHECK-NEXT:   [P:A] => { conforms_to: [P] }
 // CHECK-NEXT:   τ_0_1 => { conforms_to: [P] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P] }

--- a/test/Generics/unify_nested_types_4.swift
+++ b/test/Generics/unify_nested_types_4.swift
@@ -37,20 +37,28 @@ struct G<T : P1 & P2> {}
 // we solve this by merging the repeated types with T.A or T.B:
 //
 // T.A.A => T.A
-// T.A.B => T.B
 // T.B.A => T.B
-// T.B.B => T.A
 // ...
 
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P1&P2:A].[concrete: S1 : P1] => τ_0_0.[P1&P2:A]
 // CHECK: - τ_0_0.[P1&P2:A].[P1:A] => τ_0_0.[P1&P2:A]
-// CHECK: - τ_0_0.[P1&P2:A].[P1:B] => τ_0_0.[P1&P2:B]
+// CHECK: - τ_0_0.[P1&P2:A].[P1:B].[concrete: S2] => τ_0_0.[P1&P2:A].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:B].[concrete: S2 : P1] => τ_0_0.[P1&P2:B]
 // CHECK: - τ_0_0.[P1&P2:B].[P1:A] => τ_0_0.[P1&P2:B]
-// CHECK: - τ_0_0.[P1&P2:B].[P1:B] => τ_0_0.[P1&P2:A]
+// CHECK: - τ_0_0.[P1&P2:B].[P1:B].[concrete: S1] => τ_0_0.[P1&P2:B].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:A].[P1:B].[concrete: S2 : P1] => τ_0_0.[P1&P2:A].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:A].[P1:B].[P1:A] => τ_0_0.[P1&P2:A].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:A].[P1:B].[P1:B] => τ_0_0.[P1&P2:A]
+// CHECK: - τ_0_0.[P1&P2:B].[P1:B].[concrete: S1 : P1] => τ_0_0.[P1&P2:B].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:B].[P1:B].[P1:A] => τ_0_0.[P1&P2:B].[P1:B]
+// CHECK: - τ_0_0.[P1&P2:B].[P1:B].[P1:B] => τ_0_0.[P1&P2:B]
 // CHECK: }
 // CHECK-LABEL: Property map: {
 // CHECK: τ_0_0.[P1&P2:A] => { conforms_to: [P1] concrete_type: [concrete: S1] }
 // CHECK: τ_0_0.[P1&P2:B] => { conforms_to: [P1] concrete_type: [concrete: S2] }
+// CHECK: τ_0_0.[P1&P2:A].[P1:B] => { conforms_to: [P1] concrete_type: [concrete: S2] }
+// CHECK: τ_0_0.[P1&P2:B].[P1:B] => { conforms_to: [P1] concrete_type: [concrete: S1] }
 // CHECK: }
 // CHECK: }

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -26,6 +26,6 @@ extension P where Self : Derived {
 // CHECK-NEXT: Rewrite loops: {
 // CHECK:      }
 // CHECK-NEXT: Property map: {
-// CHECK-NEXT:   [P] => { layout: _NativeClass superclass: [superclass: Base] }
+// CHECK-NEXT:   [P] => { conforms_to: [P] layout: _NativeClass superclass: [superclass: Base] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P] layout: _NativeClass superclass: [superclass: Derived] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -44,6 +44,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT: Rewrite loops: {
 // CHECK:      }
 // CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1] => { conforms_to: [P1] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -48,6 +48,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT: Rewrite loops: {
 // CHECK:      }
 // CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1] => { conforms_to: [P1] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -47,6 +47,9 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT: Rewrite loops: {
 // CHECK:      }
 // CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1] => { conforms_to: [P1] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
+// CHECK-NEXT:   [Q] => { conforms_to: [Q] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<τ_0_0> with <[P1:A1]>] }
 // CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0> with <[P2:A2]>] }


### PR DESCRIPTION
Only three test failures remain with this flag enabled:
- Generics/concrete_conformances_in_protocol.swift
- Generics/requirement_inference.swift
- Generics/sr12531.swift