### PR TITLE
test: add a local lit configuration for Interop

### DIFF
--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -1,0 +1,14 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+def get_target_os():
+    import re
+    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
+    return run_os
+
+if get_target_os() in ['windows-msvc']:
+    config.substitutions.insert(0, ('%target-abi', 'WIN'))
+else:
+    # FIXME(compnerd) do all the targets we currently support use SysV ABI?
+    config.substitutions.insert(0, ('%target-abi', 'SYSV'))
+


### PR DESCRIPTION
This adds a local lit configuration for simplifying matching against
different ABIs.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
