### PR TITLE
[NFC] Removing unused ctx variable

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8035,7 +8035,6 @@ namespace {
         // Note that in this mode `ClosuresToTypeCheck` acts
         // as a stack because multi-statement closures could
         // have other multi-statement closures in the body.
-        auto &ctx = closure->getASTContext();
         if (cs.participatesInInference(closure)) {
           hadError |= cs.applySolutionToBody(
               solution, closure, Rewriter.dc,


### PR DESCRIPTION
Cleaning up build warning for unused `ctx` variable in CSApply.cpp.