### PR TITLE
[Demangler] Remove no-op case of DEMANGLER_ASSERT

### DIFF
--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -40,7 +40,7 @@
       swift::Demangle::failAssert(__FILE__, __LINE__, node, #expr);            \
   } while (0)
 
-#endif // !defined(NDEBUG) && !SWIFT_RUNTIME
+#endif // SWIFT_RUNTIME || defined(NDEBUG)
 
 namespace swift {
 namespace Demangle {

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -22,22 +22,22 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/NamespaceMacros.h"
 
-#if !defined(NDEBUG) && !SWIFT_RUNTIME
-
-// Except in the runtime, DEMANGLER_ASSERT() works like assert()
-#define DEMANGLER_ASSERT(expr, node)                                           \
-  do {                                                                         \
-    if (!(expr))                                                               \
-      swift::Demangle::failAssert(__FILE__, __LINE__, node, #expr);            \
-  } while (0)
-
-#else
+#if SWIFT_RUNTIME || defined(NDEBUG)
 
 // In the runtime and non-asserts builds, DEMANGLER_ASSERT() returns an error
 #define DEMANGLER_ASSERT(expr, node)                                           \
   do {                                                                         \
     if (!(expr))                                                               \
       return ManglingError(ManglingError::AssertionFailed, (node), __LINE__);  \
+  } while (0)
+
+#else
+
+// Except in the runtime, assert builds cause DEMANGLER_ASSERT() to assert()
+#define DEMANGLER_ASSERT(expr, node)                                           \
+  do {                                                                         \
+    if (!(expr))                                                               \
+      swift::Demangle::failAssert(__FILE__, __LINE__, node, #expr);            \
   } while (0)
 
 #endif // !defined(NDEBUG) && !SWIFT_RUNTIME

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -22,18 +22,9 @@
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/NamespaceMacros.h"
 
-#if SWIFT_RUNTIME
+#if !defined(NDEBUG) && !SWIFT_RUNTIME
 
-// In the runtime, DEMANGLER_ASSERT() returns an error
-#define DEMANGLER_ASSERT(expr, node)                                           \
-  do {                                                                         \
-    if (!(expr))                                                               \
-      return ManglingError(ManglingError::AssertionFailed, (node), __LINE__);  \
-  } while (0)
-
-#elif !defined(NDEBUG)
-
-// If NDEBUG is not defined, DEMANGLER_ASSERT() works like assert()
+// Except in the runtime, DEMANGLER_ASSERT() works like assert()
 #define DEMANGLER_ASSERT(expr, node)                                           \
   do {                                                                         \
     if (!(expr))                                                               \
@@ -42,10 +33,14 @@
 
 #else
 
-// Otherwise, DEMANGLER_ASSERT() does nothing
-#define DEMANGLER_ASSERT(expr, node)
+// In the runtime and non-asserts builds, DEMANGLER_ASSERT() returns an error
+#define DEMANGLER_ASSERT(expr, node)                                           \
+  do {                                                                         \
+    if (!(expr))                                                               \
+      return ManglingError(ManglingError::AssertionFailed, (node), __LINE__);  \
+  } while (0)
 
-#endif // SWIFT_RUNTIME
+#endif // !defined(NDEBUG) && !SWIFT_RUNTIME
 
 namespace swift {
 namespace Demangle {


### PR DESCRIPTION
Change the configuration logic around `DEMANGLER_ASSERT` to remove the no-op definition.

Currently, `DEMANGLER_ASSERT` has three cases/modes:

1. When building for the Swift runtime, a failed assert results in an error value being returned.
2. Outside of the Swift runtime, a failed assert works like a regular assert – i.e. its behavior depends on whether it's an asserts build or not.
3. The assert does nothing. This happens for non-runtime, non-assert builds.

This changes the macro to have only two cases, by eliminating the no-op case. Now, `DEMANGLER_ASSERT` will either result in a real assert, or return an error value. The same runtime/asserts build logic is kept, the difference is that the third case now behaves like the first case.

This is motivated by lldb, which embeds the swift compiler. Like the runtime, and unlike the compiler, lldb needs the soft-failure behavior of returning error values. A crash in the embedded swift compiler will bring down lldb with it.