### PR TITLE
Tolerate missing Sendable conformances on superclasses.

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -851,8 +851,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
 
     // Look up the inherited conformance.
     ModuleDecl *module = entry->getDeclContext()->getParentModule();
-    auto inheritedConformance = module->lookupConformance(superclassTy,
-                                                          protocol);
+    auto inheritedConformance = module->lookupConformance(
+        superclassTy, protocol, /*allowMissing=*/true);
 
     // Form the inherited conformance.
     entry->Conformance =

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1287,7 +1287,8 @@ LookupConformanceInModuleRequest::evaluate(
     auto superclassTy = type->getSuperclassForDecl(conformingClass);
 
     // Compute the conformance for the inherited type.
-    auto inheritedConformance = mod->lookupConformance(superclassTy, protocol);
+    auto inheritedConformance = mod->lookupConformance(
+        superclassTy, protocol, /*allowMissing=*/true);
     assert(inheritedConformance &&
            "We already found the inherited conformance");
 

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -145,3 +145,8 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
     }
   }
 }
+
+// rdar://86653457 - Crash due to missing Sendable conformances.
+class Klass<Output: Sendable>: Sendable {}
+final class SubKlass: Klass<[S]> {}
+public struct S {}


### PR DESCRIPTION
Fixes the crash in rdar://86653457
