### PR TITLE
[move-function] Fix _move SILGen test to match current codegen.

### DIFF
--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -7,11 +7,12 @@ import Swift
 
 class Klass {}
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyAA5KlassCADF : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyAA5KlassCADnF : $@convention(thin) (@owned Klass) -> @owned Klass {
 // CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = alloc_stack $Klass
-// CHECK-NEXT: [[ARC_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[ARC_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: [[INPUT_ADDR:%.*]] = alloc_stack $Klass
 // CHECK-NEXT: store [[ARC_COPY]] to [init] [[INPUT_ADDR]]
 // CHECK-NEXT: // function_ref _move<A>(_:)
@@ -20,26 +21,31 @@ class Klass {}
 // CHECK-NEXT: dealloc_stack [[INPUT_ADDR]]
 // CHECK-NEXT: [[RELOADED_VALUE:%.*]] = load [take] [[RESULT_ADDR]]
 // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RELOADED_VALUE]]
-// CHECK: } // end sil function '$s8moveonly7useMoveyAA5KlassCADF'
+// CHECK: } // end sil function '$s8moveonly7useMoveyAA5KlassCADnF'
 
-// CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyAA5KlassCADF : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
+// CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyAA5KlassCADnF : $@convention(thin) (@owned Klass) -> @owned Klass {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
-// CHECK-SIL-NEXT: [allows_diagnostics] move_value
+// CHECK-SIL-NEXT: move_value
 // CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: return
-// CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADF'
-func useMove(_ k: Klass) -> Klass {
+// CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADnF'
+func useMove(_ k: __owned Klass) -> Klass {
     _move(k)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyxxRlzClF : $@convention(thin) <T where T : AnyObject> (@guaranteed T) -> @owned T {
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyxxnRlzClF : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned T {
 // CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
 // CHECK-NEXT: debug_value
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = alloc_stack $T
-// CHECK-NEXT: [[ARC_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT: [[ARC_COPY:%.*]] = copy_value [[BORROWED_ARG]]
 // CHECK-NEXT: [[INPUT_ADDR:%.*]] = alloc_stack $T
 // CHECK-NEXT: store [[ARC_COPY]] to [init] [[INPUT_ADDR]]
 // CHECK-NEXT: // function_ref _move<A>(_:)
@@ -48,17 +54,21 @@ func useMove(_ k: Klass) -> Klass {
 // CHECK-NEXT: dealloc_stack [[INPUT_ADDR]]
 // CHECK-NEXT: [[RELOADED_VALUE:%.*]] = load [take] [[RESULT_ADDR]]
 // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RELOADED_VALUE]]
-// CHECK: } // end sil function '$s8moveonly7useMoveyxxRlzClF'
+// CHECK: } // end sil function '$s8moveonly7useMoveyxxnRlzClF'
 
-// CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyxxRlzClF : $@convention(thin) <T where T : AnyObject> (@guaranteed T) -> @owned T {
+// CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyxxnRlzClF : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned T {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
-// CHECK-SIL-NEXT: [allows_diagnostics] move_value
+// CHECK-SIL-NEXT: move_value
 // CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: return
-// CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxRlzClF'
-func useMove<T : AnyObject>(_ k: T) -> T {
+// CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxnRlzClF'
+func useMove<T : AnyObject>(_ k: __owned T) -> T {
     _move(k)
 }


### PR DESCRIPTION
I re-enabled this test since I thought that the only issue was not having an optimized stdlib. In reality the underlying codegen and changed slightly due to intervening things I enabled. This just updates the test to match current codegen.