### PR TITLE
Revert "Re-enable a test requiring an optimized stdlib to ensure we pattern match."

### DIFF
--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-silgen -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck %s
 // RUN: %target-swift-emit-sil -module-name moveonly -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module -enable-experimental-move-only | %FileCheck -check-prefix=CHECK-SIL %s
 
-// REQUIRES: optimized_stdlib
+// REQUIRES: rdar84780237
 
 import Swift
 


### PR DESCRIPTION
Reverts apple/swift#40005

This seems to be failing on Windows and Linux builders