### PR TITLE
[AST] scan `@_exported import` modules of source files for display decls

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/RawComment.h"
 #include "swift/Basic/BasicSourceInfo.h"
+#include "swift/Basic/Debug.h"
 
 #include "llvm/ADT/PointerIntPair.h"
 
@@ -307,6 +308,9 @@ public:
   virtual StringRef getExportedModuleName() const {
     return getParentModule()->getRealName().str();
   }
+
+  SWIFT_DEBUG_DUMPER(dumpDisplayDecls());
+  SWIFT_DEBUG_DUMPER(dumpTopLevelDecls());
 
   /// Traverse the decls within this file.
   ///

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -26,6 +26,7 @@
 #include "swift/AST/Type.h"
 #include "swift/Basic/BasicSourceInfo.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/Basic/Debug.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceLoc.h"
@@ -855,6 +856,9 @@ public:
   /// \c SerializeOptionsForDebugging hack. Once this information can be
   /// transferred from module files to the dSYMs, remove this.
   bool isExternallyConsumed() const;
+
+  SWIFT_DEBUG_DUMPER(dumpDisplayDecls());
+  SWIFT_DEBUG_DUMPER(dumpTopLevelDecls());
 
   SourceRange getSourceRange() const { return SourceRange(); }
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -393,6 +393,8 @@ protected:
 public:
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
+  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results) const override;
+
   virtual void
   getOperatorDecls(SmallVectorImpl<OperatorDecl *> &results) const override;
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -288,6 +288,10 @@ public:
 
   ~SourceFile();
 
+  bool hasImports() const {
+    return Imports.hasValue();
+  }
+
   /// Retrieve an immutable view of the source file's imports.
   ArrayRef<AttributedImport<ImportedModule>> getImports() const {
     return *Imports;
@@ -392,8 +396,6 @@ protected:
 
 public:
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
-
-  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results) const override;
 
   virtual void
   getOperatorDecls(SmallVectorImpl<OperatorDecl *> &results) const override;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -788,6 +788,24 @@ void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
   FORWARD(getTopLevelDecls, (Results));
 }
 
+void ModuleDecl::dumpDisplayDecls() const {
+  SmallVector<Decl *, 32> Decls;
+  getDisplayDecls(Decls);
+  for (auto *D : Decls) {
+    D->dump(llvm::errs());
+    llvm::errs() << "\n";
+  }
+}
+
+void ModuleDecl::dumpTopLevelDecls() const {
+  SmallVector<Decl *, 32> Decls;
+  getTopLevelDecls(Decls);
+  for (auto *D : Decls) {
+    D->dump(llvm::errs());
+    llvm::errs() << "\n";
+  }
+}
+
 void ModuleDecl::getExportedPrespecializations(
     SmallVectorImpl<Decl *> &Results) const {
   FORWARD(getExportedPrespecializations, (Results));
@@ -3060,6 +3078,22 @@ void FileUnit::getTopLevelDeclsWhereAttributesMatch(
       return !matchAttributes(D->getAttrs());
     });
   Results.erase(newEnd, Results.end());
+}
+
+void FileUnit::dumpDisplayDecls() const {
+  SmallVector<Decl *, 32> Decls;
+  getDisplayDecls(Decls);
+  for (auto *D : Decls) {
+    D->dump(llvm::errs());
+  }
+}
+
+void FileUnit::dumpTopLevelDecls() const {
+  SmallVector<Decl *, 32> Decls;
+  getTopLevelDecls(Decls);
+  for (auto *D : Decls) {
+    D->dump(llvm::errs());
+  }
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const FileUnit *file) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -822,6 +822,17 @@ void SourceFile::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
   Results.append(decls.begin(), decls.end());
 }
 
+void SourceFile::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
+  if (Imports.hasValue()) {
+    for (auto import : *Imports) {
+      if (import.options.contains(ImportFlags::Exported)) {
+        import.module.importedModule->getDisplayDecls(Results);
+      }
+    }
+  }
+  getTopLevelDecls(Results);
+}
+
 void ModuleDecl::getOperatorDecls(
     SmallVectorImpl<OperatorDecl *> &results) const {
   // For a parsed module, we can check the source cache on the module rather

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER
 
 // REQUIRES: objc_interop
 
@@ -10,6 +11,9 @@ import Foundation
 
 public enum SwiftEnum {}
 
+// HEADER:       "precise": "c:@testVariable"
+
+// CHECK:        "precise": "s:17EmitWhileBuilding9SwiftEnumO",
 // CHECK:        "declarationFragments": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:           "kind": "keyword",

--- a/test/SymbolGraph/ClangImporter/Inputs/EmitWhileBuilding/Extra.swift
+++ b/test/SymbolGraph/ClangImporter/Inputs/EmitWhileBuilding/Extra.swift
@@ -1,0 +1,1 @@
+public struct SomeStruct {}


### PR DESCRIPTION
Resolves rdar://85230067

When collecting decls for SourceFile modules, decls from `@_exported import` modules (including those added with `-import-underlying-module`) are not collected. This causes SymbolGraphGen to miss Clang symbols when building in `-emit-module` mode. This PR adds an override for `SourceFile::getDisplayDecls` (called indirectly by SymbolGraphGen) that also collects symbols from these exported modules.