### PR TITLE
AST: Remove legacy GSB-based GenericSignature query implementation

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -95,7 +95,6 @@ namespace swift {
   class TypeVariableType;
   class TupleType;
   class FunctionType;
-  class GenericSignatureBuilder;
   class ArchetypeType;
   class Identifier;
   class InheritedNameSet;
@@ -1225,14 +1224,6 @@ public:
   /// Increments \c NumTypoCorrections then checks this against the limit in
   /// the language options.
   bool shouldPerformTypoCorrection();
-  
-private:
-  /// Register the given generic signature builder to be used as the canonical
-  /// generic signature builder for the given signature, if we don't already
-  /// have one.
-  void registerGenericSignatureBuilder(GenericSignature sig,
-                                       GenericSignatureBuilder &&builder);
-  friend class GenericSignatureBuilder;
 
 private:
   friend class IntrinsicInfo;
@@ -1240,11 +1231,6 @@ private:
   llvm::LLVMContext &getIntrinsicScratchContext() const;
 
 public:
-  /// Retrieve or create the stored generic signature builder for the given
-  /// canonical generic signature and module.
-  GenericSignatureBuilder *getOrCreateGenericSignatureBuilder(
-                                                     CanGenericSignature sig);
-
   rewriting::RewriteContext &getRewriteContext();
 
   /// This is a hack to break cycles. Don't introduce new callers of this

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -30,7 +30,6 @@
 
 namespace swift {
 
-class GenericSignatureBuilder;
 class ProtocolConformanceRef;
 class ProtocolType;
 class SubstitutionMap;
@@ -84,7 +83,6 @@ private:
   ConformanceAccessPath(ArrayRef<Entry> path) : path(path) {}
 
   friend class GenericSignatureImpl;
-  friend class GenericSignatureBuilder;
   friend class rewriting::RequirementMachine;
 
 public:
@@ -338,9 +336,6 @@ public:
   
   ASTContext &getASTContext() const;
 
-  /// Retrieve the generic signature builder for the given generic signature.
-  GenericSignatureBuilder *getGenericSignatureBuilder() const;
-
   /// Retrieve the requirement machine for the given generic signature.
   rewriting::RequirementMachine *getRequirementMachine() const;
 
@@ -385,8 +380,6 @@ public:
   ///
   /// The type parameters must be known to not be concrete within the context.
   bool areSameTypeParameterInContext(Type type1, Type type2) const;
-  bool areSameTypeParameterInContext(Type type1, Type type2,
-                                     GenericSignatureBuilder &builder) const;
 
   /// Determine if \c sig can prove \c requirement, meaning that it can deduce
   /// T: Foo or T == U (etc.) with the information it knows. This includes
@@ -396,8 +389,6 @@ public:
       Requirement requirement, bool allowMissing = false) const;
 
   bool isCanonicalTypeInContext(Type type) const;
-  bool isCanonicalTypeInContext(Type type,
-                                GenericSignatureBuilder &builder) const;
 
   /// Retrieve the conformance access path used to extract the conformance of
   /// interface \c type to the given \c protocol.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -477,10 +477,6 @@ namespace swift {
     ASTVerifierOverrideKind ASTVerifierOverride =
         ASTVerifierOverrideKind::NoOverride;
 
-    /// Whether the new experimental generics implementation is enabled.
-    RequirementMachineMode EnableRequirementMachine =
-        RequirementMachineMode::Enabled;
-
     /// Enables merged associated type support, which might go away.
     bool RequirementMachineMergedAssociatedTypes = true;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -616,10 +616,6 @@ def no_emit_module_separately:
   Flags<[NoInteractiveOption, HelpHidden]>,
   HelpText<"Force using merge-module as the incremental build mode (new Driver only)">;
 
-def requirement_machine_EQ : Joined<["-"], "requirement-machine=">,
-  Flags<[FrontendOption, ModuleInterfaceOption]>,
-  HelpText<"Control usage of experimental generics implementation: 'on', 'off', or 'verify'">;
-
 def requirement_machine_protocol_signatures_EQ : Joined<["-"], "requirement-machine-protocol-signatures=">,
   Flags<[FrontendOption]>,
   HelpText<"Control usage of experimental protocol requirement signature minimization: 'on', 'off', or 'verify'">;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -24,8 +24,6 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/STLExtras.h"
-#include "GenericSignatureBuilder.h"
-#include "GenericSignatureBuilderImpl.h"
 #include "RequirementMachine/RequirementMachine.h"
 #include <functional>
 
@@ -182,17 +180,6 @@ ArrayRef<Requirement> GenericSignature::getRequirements() const {
       : getPointer()->getRequirements();
 }
 
-GenericSignatureBuilder *
-GenericSignatureImpl::getGenericSignatureBuilder() const {
-  // The generic signature builder is associated with the canonical signature.
-  if (!isCanonical())
-    return getCanonicalSignature()->getGenericSignatureBuilder();
-
-  // generic signature builders are stored on the ASTContext.
-  return getASTContext().getOrCreateGenericSignatureBuilder(
-                                             CanGenericSignature(this));
-}
-
 rewriting::RequirementMachine *
 GenericSignatureImpl::getRequirementMachine() const {
   if (Machine)
@@ -290,156 +277,8 @@ GenericSignature::LocalRequirements
 GenericSignatureImpl::getLocalRequirements(Type depType) const {
   assert(depType->isTypeParameter() && "Expected a type parameter here");
 
-  auto computeViaGSB = [&]() {
-    GenericSignature::LocalRequirements result;
-
-    auto &builder = *getGenericSignatureBuilder();
-
-    auto resolved =
-      builder.maybeResolveEquivalenceClass(
-                                    depType,
-                                    ArchetypeResolutionKind::CompleteWellFormed,
-                                    /*wantExactPotentialArchetype=*/false);
-    if (!resolved) {
-      result.concreteType = ErrorType::get(depType);
-      return result;
-    }
-
-    if (auto concreteType = resolved.getAsConcreteType()) {
-      result.concreteType = concreteType;
-      return result;
-    }
-
-    auto *equivClass = resolved.getEquivalenceClass(builder);
-
-    auto genericParams = getGenericParams();
-    result.anchor = equivClass->getAnchor(builder, genericParams);
-
-    if (equivClass->concreteType) {
-      result.concreteType = equivClass->concreteType;
-      return result;
-    }
-
-    result.superclass = equivClass->superclass;
-
-    for (const auto &conforms : equivClass->conformsTo) {
-      auto proto = conforms.first;
-
-      if (!equivClass->isConformanceSatisfiedBySuperclass(proto))
-        result.protos.push_back(proto);
-    }
-
-    result.layout = equivClass->layout;
-
-    return result;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getLocalRequirements(depType, getGenericParams());
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    auto typesEqual = [&](Type lhs, Type rhs, bool canonical) {
-      if (!lhs || !rhs)
-        return !lhs == !rhs;
-      if (lhs->isEqual(rhs))
-        return true;
-
-      if (canonical)
-        return false;
-
-      if (getCanonicalTypeInContext(lhs) ==
-          getCanonicalTypeInContext(rhs))
-        return true;
-
-      return false;
-    };
-
-    auto compare = [&]() {
-      // If the types are concrete, we don't care about the rest.
-      if (gsbResult.concreteType || rqmResult.concreteType) {
-        if (!typesEqual(gsbResult.concreteType,
-                        rqmResult.concreteType,
-                        false))
-          return false;
-
-        return true;
-      }
-
-      if (!typesEqual(gsbResult.anchor,
-                      rqmResult.anchor,
-                      true))
-        return false;
-
-      if (gsbResult.layout != rqmResult.layout)
-        return false;
-
-      auto lhsProtos = gsbResult.protos;
-      ProtocolType::canonicalizeProtocols(lhsProtos);
-      auto rhsProtos = rqmResult.protos;
-      ProtocolType::canonicalizeProtocols(rhsProtos);
-
-      if (lhsProtos != rhsProtos)
-        return false;
-
-      if (!typesEqual(gsbResult.superclass,
-                      rqmResult.superclass,
-                      false))
-        return false;
-
-      return true;
-    };
-
-    auto dumpReqs = [&](const GenericSignature::LocalRequirements &reqs) {
-      if (reqs.anchor) {
-        llvm::errs() << "- Anchor: " << reqs.anchor << "\n";
-        reqs.anchor.dump(llvm::errs());
-      }
-      if (reqs.concreteType) {
-        llvm::errs() << "- Concrete type: " << reqs.concreteType << "\n";
-        reqs.concreteType.dump(llvm::errs());
-      }
-      if (reqs.superclass) {
-        llvm::errs() << "- Superclass: " << reqs.superclass << "\n";
-        reqs.superclass.dump(llvm::errs());
-      }
-      if (reqs.layout) {
-        llvm::errs() << "- Layout: " << reqs.layout << "\n";
-      }
-      for (const auto *proto : reqs.protos) {
-        llvm::errs() << "- Conforms to: " << proto->getName() << "\n";
-      }
-    };
-
-    if (!compare()) {
-      llvm::errs() << "RequirementMachine::getLocalRequirements() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; depType.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says:\n";
-      dumpReqs(gsbResult);
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says:\n";
-      dumpReqs(rqmResult);
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getLocalRequirements(
+      depType, getGenericParams());
 }
 
 ASTContext &GenericSignatureImpl::getASTContext() const {
@@ -467,54 +306,7 @@ bool GenericSignatureImpl::requiresClass(Type type) const {
   assert(type->isTypeParameter() &&
          "Only type parameters can have superclass requirements");
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                                    type,
-                                    ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return false;
-
-    // If this type was mapped to a concrete type, then there is no
-    // requirement.
-    if (equivClass->concreteType) return false;
-
-    // If there is a layout constraint, it might be a class.
-    if (equivClass->layout && equivClass->layout->isClass()) return true;
-
-    return false;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->requiresClass(type);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::requiresClass() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->requiresClass(type);
 }
 
 /// Determine the superclass bound on the given dependent type.
@@ -522,64 +314,8 @@ Type GenericSignatureImpl::getSuperclassBound(Type type) const {
   assert(type->isTypeParameter() &&
          "Only type parameters can have superclass requirements");
 
-  auto computeViaGSB = [&]() -> Type {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-    builder.resolveEquivalenceClass(
-                                  type,
-                                  ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return nullptr;
-
-    // If this type was mapped to a concrete type, then there is no
-    // requirement.
-    if (equivClass->concreteType) return nullptr;
-
-    // Retrieve the superclass bound.
-    return equivClass->superclass;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getSuperclassBound(type, getGenericParams());
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    auto check = [&]() {
-      if (!gsbResult || !rqmResult)
-        return !gsbResult == !rqmResult;
-      return gsbResult->isEqual(rqmResult);
-    };
-
-    if (!check()) {
-      llvm::errs() << "RequirementMachine::getSuperclassBound() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      if (gsbResult)
-        gsbResult.dump(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      if (rqmResult)
-        rqmResult.dump(llvm::errs());
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getSuperclassBound(
+      type, getGenericParams());
 }
 
 /// Determine the set of protocols to which the given type parameter is
@@ -588,170 +324,21 @@ GenericSignature::RequiredProtocols
 GenericSignatureImpl::getRequiredProtocols(Type type) const {
   assert(type->isTypeParameter() && "Expected a type parameter");
 
-  auto computeViaGSB = [&]() -> GenericSignature::RequiredProtocols {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                                    type,
-                                    ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return { };
-
-    // If this type parameter was mapped to a concrete type, then there
-    // are no requirements.
-    if (equivClass->concreteType) return { };
-
-    // Retrieve the protocols to which this type conforms.
-    GenericSignature::RequiredProtocols result;
-    for (const auto &conforms : equivClass->conformsTo)
-      result.push_back(conforms.first);
-
-    // Canonicalize the resulting set of protocols.
-    ProtocolType::canonicalizeProtocols(result);
-
-    return result;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getRequiredProtocols(type);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::getRequiredProtocols() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: ";
-      for (auto *otherProto : gsbResult)
-        llvm::errs() << " " << otherProto->getName();
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says: ";
-      for (auto *otherProto : rqmResult)
-        llvm::errs() << " " << otherProto->getName();
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getRequiredProtocols(type);
 }
 
 bool GenericSignatureImpl::requiresProtocol(Type type,
                                             ProtocolDecl *proto) const {
   assert(type->isTypeParameter() && "Expected a type parameter");
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                                    type,
-                                    ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return false;
-
-    // FIXME: Optionally deal with concrete conformances here
-    // or have a separate method do that additionally?
-    //
-    // If this type parameter was mapped to a concrete type, then there
-    // are no requirements.
-    if (equivClass->concreteType) return false;
-
-    // Check whether the representative conforms to this protocol.
-    return equivClass->conformsTo.count(proto) > 0;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->requiresProtocol(type, proto);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::requiresProtocol() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "Protocol: "; proto->dumpRef(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->requiresProtocol(type, proto);
 }
 
 /// Determine whether the given dependent type is equal to a concrete type.
 bool GenericSignatureImpl::isConcreteType(Type type) const {
   assert(type->isTypeParameter() && "Expected a type parameter");
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                                    type,
-                                    ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return false;
-
-    return bool(equivClass->concreteType);
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->isConcreteType(type);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::isConcreteType() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->isConcreteType(type);
 }
 
 /// Return the concrete type that the given type parameter is constrained to,
@@ -760,111 +347,14 @@ bool GenericSignatureImpl::isConcreteType(Type type) const {
 Type GenericSignatureImpl::getConcreteType(Type type) const {
   assert(type->isTypeParameter() && "Expected a type parameter");
 
-  auto computeViaGSB = [&]() -> Type {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-    builder.resolveEquivalenceClass(
-                                  type,
-                                  ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return nullptr;
-
-    return equivClass->concreteType;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getConcreteType(type, getGenericParams());
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    auto check = [&]() {
-      if (!gsbResult || !rqmResult)
-        return !gsbResult == !rqmResult;
-      if (gsbResult->isEqual(rqmResult))
-        return true;
-
-      return (getCanonicalTypeInContext(gsbResult)
-              == getCanonicalTypeInContext(rqmResult));
-    };
-
-    if (!check()) {
-      llvm::errs() << "RequirementMachine::getConcreteType() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      if (gsbResult)
-        gsbResult.dump(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      if (rqmResult)
-        rqmResult.dump(llvm::errs());
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getConcreteType(type, getGenericParams());
 }
 
 LayoutConstraint GenericSignatureImpl::getLayoutConstraint(Type type) const {
   assert(type->isTypeParameter() &&
          "Only type parameters can have layout constraints");
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                                    type,
-                                    ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return LayoutConstraint();
-
-    return equivClass->layout;
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getLayoutConstraint(type);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::getLayoutConstraint() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getLayoutConstraint(type);
 }
 
 bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
@@ -875,71 +365,7 @@ bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
   if (type1.getPointer() == type2.getPointer())
     return true;
 
-  auto computeViaGSB = [&]() {
-    return areSameTypeParameterInContext(type1, type2,
-                                         *getGenericSignatureBuilder());
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->areSameTypeParameterInContext(type1, type2);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      auto firstConcreteType = getConcreteType(type1);
-      auto secondConcreteType = getConcreteType(type2);
-      if (!firstConcreteType->isEqual(secondConcreteType)) {
-        llvm::errs() << "RequirementMachine::areSameTypeParameterInContext() is broken\n";
-        llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-        llvm::errs() << "First dependent type: "; type1.dump(llvm::errs());
-        llvm::errs() << "Second dependent type: "; type2.dump(llvm::errs());
-        llvm::errs() << "\n";
-        llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-        llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-        getRequirementMachine()->dump(llvm::errs());
-        abort();
-      }
-    }
-
-    return rqmResult;
-  }
-  }
-}
-
-bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
-                                                         Type type2,
-                                                         GenericSignatureBuilder &builder) const {
-  assert(type1->isTypeParameter());
-  assert(type2->isTypeParameter());
-
-  if (type1.getPointer() == type2.getPointer())
-    return true;
-
-  auto equivClass1 =
-    builder.resolveEquivalenceClass(
-                             type1,
-                             ArchetypeResolutionKind::CompleteWellFormed);
-  assert(equivClass1 && "not a valid dependent type of this signature?");
-
-  auto equivClass2 =
-    builder.resolveEquivalenceClass(
-                             type2,
-                             ArchetypeResolutionKind::CompleteWellFormed);
-  assert(equivClass2 && "not a valid dependent type of this signature?");
-
-  return equivClass1 == equivClass2;
+  return getRequirementMachine()->areSameTypeParameterInContext(type1, type2);
 }
 
 bool GenericSignatureImpl::isRequirementSatisfied(
@@ -1016,70 +442,7 @@ bool GenericSignatureImpl::isCanonicalTypeInContext(Type type) const {
   if (!type->hasTypeParameter())
     return true;
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    return isCanonicalTypeInContext(type, builder);
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->isCanonicalTypeInContext(type);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::isCanonicalTypeInContext() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
-}
-
-bool GenericSignatureImpl::isCanonicalTypeInContext(
-    Type type, GenericSignatureBuilder &builder) const {
-  // If the type isn't independently canonical, it's certainly not canonical
-  // in this context.
-  if (!type->isCanonical())
-    return false;
-
-  // All the contextual canonicality rules apply to type parameters, so if the
-  // type doesn't involve any type parameters, it's already canonical.
-  if (!type->hasTypeParameter())
-    return true;
-
-  // Look for non-canonical type parameters.
-  return !type.findIf([&](Type component) -> bool {
-    if (!component->isTypeParameter()) return false;
-
-    auto equivClass =
-      builder.resolveEquivalenceClass(
-                               Type(component),
-                               ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass) return false;
-
-    return (equivClass->concreteType ||
-            !component->isEqual(equivClass->getAnchor(builder,
-                                                      getGenericParams())));
-  });
+  return getRequirementMachine()->isCanonicalTypeInContext(type);
 }
 
 CanType GenericSignature::getCanonicalTypeInContext(Type type) const {
@@ -1099,44 +462,8 @@ CanType GenericSignatureImpl::getCanonicalTypeInContext(Type type) const {
   if (!type->hasTypeParameter())
     return CanType(type);
 
-  auto computeViaGSB = [&]() {
-    auto &builder = *getGenericSignatureBuilder();
-    return builder.getCanonicalTypeInContext(type, { })->getCanonicalType();
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getCanonicalTypeInContext(type, { })->getCanonicalType();
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::getCanonicalTypeInContext() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
-      gsbResult.dump(llvm::errs());
-      llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
-      rqmResult.dump(llvm::errs());
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getCanonicalTypeInContext(
+      type, { })->getCanonicalType();
 }
 
 ArrayRef<CanTypeWrapper<GenericTypeParamType>>
@@ -1150,129 +477,14 @@ CanGenericSignature::getGenericParams() const {
 ConformanceAccessPath
 GenericSignatureImpl::getConformanceAccessPath(Type type,
                                                ProtocolDecl *protocol) const {
-  auto computeViaGSB = [&]() {
-    return getGenericSignatureBuilder()->getConformanceAccessPath(
-        type, protocol, this);
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->getConformanceAccessPath(type, protocol);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    auto compare = [&]() {
-      if (gsbResult.size() != rqmResult.size())
-        return false;
-
-      auto *begin1 = gsbResult.begin();
-      auto *end1 = gsbResult.end();
-      auto *begin2 = rqmResult.begin();
-      auto *end2 = rqmResult.end();
-
-      while (begin1 < end1) {
-        assert(begin2 < end2);
-
-        if (!begin1->first->isEqual(begin2->first))
-          return false;
-        if (begin1->second != begin2->second)
-          return false;
-
-        ++begin1;
-        ++begin2;
-      }
-
-      return true;
-    };
-
-    if (!compare()) {
-      llvm::errs() << "RequirementMachine::getConformanceAccessPath() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "Protocol: "; protocol->dumpRef(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: ";
-      gsbResult.print(llvm::errs());
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says: ";
-      rqmResult.print(llvm::errs());
-      llvm::errs() << "\n\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->getConformanceAccessPath(type, protocol);
 }
 
 TypeDecl *
 GenericSignatureImpl::lookupNestedType(Type type, Identifier name) const {
   assert(type->isTypeParameter());
 
-  auto computeViaGSB = [&]() -> TypeDecl * {
-    auto *builder = getGenericSignatureBuilder();
-    auto equivClass =
-      builder->resolveEquivalenceClass(
-                                  type,
-                                  ArchetypeResolutionKind::CompleteWellFormed);
-    if (!equivClass)
-      return nullptr;
-
-    return equivClass->lookupNestedType(*builder, name);
-  };
-
-  auto computeViaRQM = [&]() {
-    auto *machine = getRequirementMachine();
-    return machine->lookupNestedType(type, name);
-  };
-
-  auto &ctx = getASTContext();
-  switch (ctx.LangOpts.EnableRequirementMachine) {
-  case RequirementMachineMode::Disabled:
-    return computeViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return computeViaRQM();
-
-  case RequirementMachineMode::Verify: {
-    auto rqmResult = computeViaRQM();
-    auto gsbResult = computeViaGSB();
-
-    if (gsbResult != rqmResult) {
-      llvm::errs() << "RequirementMachine::lookupNestedType() is broken\n";
-      llvm::errs() << "Generic signature: " << GenericSignature(this) << "\n";
-      llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
-      llvm::errs() << "GenericSignatureBuilder says: ";
-      if (gsbResult)
-        gsbResult->dumpRef(llvm::errs());
-      else
-        llvm::errs() << "<nullptr>";
-      llvm::errs() << "\n";
-      llvm::errs() << "RequirementMachine says: ";
-      if (rqmResult)
-        rqmResult->dumpRef(llvm::errs());
-      else
-        llvm::errs() << "<nullptr>";
-      llvm::errs() << "\n";
-      getRequirementMachine()->dump(llvm::errs());
-      abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  return getRequirementMachine()->lookupNestedType(type, name);
 }
 
 unsigned GenericParamKey::findIndexIn(

--- a/lib/AST/GenericSignatureBuilder.h
+++ b/lib/AST/GenericSignatureBuilder.h
@@ -788,22 +788,6 @@ public:
   Type getCanonicalTypeInContext(Type type,
                             TypeArrayView<GenericTypeParamType> genericParams);
 
-  /// Retrieve the conformance access path used to extract the conformance of
-  /// interface \c type to the given \c protocol.
-  ///
-  /// \param type The interface type whose conformance access path is to be
-  /// queried.
-  /// \param protocol A protocol to which \c type conforms.
-  ///
-  /// \returns the conformance access path that starts at a requirement of
-  /// this generic signature and ends at the conformance that makes \c type
-  /// conform to \c protocol.
-  ///
-  /// \seealso ConformanceAccessPath
-  ConformanceAccessPath getConformanceAccessPath(Type type,
-                                                 ProtocolDecl *protocol,
-                                                 GenericSignature sig);
-
   /// Dump all of the requirements, both specified and inferred. It cannot be
   /// statically proven that this doesn't modify the GSB.
   SWIFT_DEBUG_HELPER(void dump());

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -854,20 +854,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableSubstSILFunctionTypes =
       Args.hasArg(OPT_disable_subst_sil_function_types);
 
-  if (auto A = Args.getLastArg(OPT_requirement_machine_EQ)) {
-    auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(A->getValue())
-        .Case("off", RequirementMachineMode::Disabled)
-        .Case("on", RequirementMachineMode::Enabled)
-        .Case("verify", RequirementMachineMode::Verify)
-        .Default(None);
-
-    if (value)
-      Opts.EnableRequirementMachine = *value;
-    else
-      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
-                     A->getAsString(Args), A->getValue());
-  }
-
   if (auto A = Args.getLastArg(OPT_requirement_machine_protocol_signatures_EQ)) {
     auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(A->getValue())
         .Case("off", RequirementMachineMode::Disabled)

--- a/test/Generics/ambiguous_protocol_inheritance.swift
+++ b/test/Generics/ambiguous_protocol_inheritance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify
+// RUN: %target-typecheck-verify-swift
 
 protocol Base { // expected-note {{'Base' previously declared here}}
 // expected-note@-1 {{found this candidate}}

--- a/test/Generics/associated_type_order.swift
+++ b/test/Generics/associated_type_order.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=on | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol P1 {
   associatedtype B

--- a/test/Generics/concrete_type_property_of_suffix.swift
+++ b/test/Generics/concrete_type_property_of_suffix.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify
+// RUN: %target-typecheck-verify-swift
 
 protocol P {
   associatedtype T where T == U?

--- a/test/Generics/conditional_requirement_inference.swift
+++ b/test/Generics/conditional_requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on
-// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine=on %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 
 // Valid example

--- a/test/Generics/generic_objc_superclass.swift
+++ b/test/Generics/generic_objc_superclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Generics/gsb_canonical_type_bug_1.swift
+++ b/test/Generics/gsb_canonical_type_bug_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=on | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // The GSB computes an incorrect canonical type here, which caused a SILGen assert.
 

--- a/test/Generics/gsb_canonical_type_bug_2.swift
+++ b/test/Generics/gsb_canonical_type_bug_2.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=on | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -requirement-machine=off | %FileCheck %s --check-prefix=CHECK-GSB
-// RUN: not --crash %target-swift-emit-silgen %s -requirement-machine=verify
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 protocol P1 {
   associatedtype A
@@ -23,4 +21,3 @@ extension P2 {
 }
 
 // CHECK-LABEL:     sil hidden [ossa] @$s24gsb_canonical_type_bug_22P2PAAE3fooyyqd___1AQztAA2P1Rd__AA2P3Rd__1BAaHPQyd__Rsd__AeaGPQyd__AFRSlF : $@convention(method) <Self where Self : P2><T where T : P1, T : P3, T == T.B, Self.A == T.A> (@in_guaranteed T, @in_guaranteed Self.A, @in_guaranteed Self) -> ()
-// CHECK-GSB-LABEL: sil hidden [ossa] @$s24gsb_canonical_type_bug_22P2PAAE3fooyyqd___1AAA2P1PQyd__tAaFRd__AA2P3Rd__1BAaIPQyd__Rsd__AhERtzlF : $@convention(method) <Self where Self : P2><T where T : P1, T : P3, T == T.B, Self.A == T.A> (@in_guaranteed T, @in_guaranteed T.A, @in_guaranteed Self) -> ()

--- a/test/Generics/gsb_canonical_type_bug_3.swift
+++ b/test/Generics/gsb_canonical_type_bug_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=on | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 // The GSB computes an incorrect canonical type for bar() which causes
 // SILGen to assert.

--- a/test/Generics/member_type_of_superclass_bound.swift
+++ b/test/Generics/member_type_of_superclass_bound.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=verify
+// RUN: %target-swift-emit-silgen %s
 
 // The substituted type of SS.x.x is computed by taking the type of S.x,
 // which is T.T in the generic signature <T where T : P>, and then

--- a/test/Generics/rdar79564324.swift
+++ b/test/Generics/rdar79564324.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/rdar79564324_other.swift -emit-module-path %t/rdar79564324_other.swiftmodule -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -emit-silgen %s -I %t -requirement-machine=on
+// RUN: %target-swift-frontend -emit-module %S/Inputs/rdar79564324_other.swift -emit-module-path %t/rdar79564324_other.swiftmodule -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -I %t
 
 import rdar79564324_other
 

--- a/test/Generics/recursive_conformances.swift
+++ b/test/Generics/recursive_conformances.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify
+// RUN: %target-typecheck-verify-swift
 
 // Make sure the requirement machine can compute a confluent
 // completion in examples where we merge two associated types

--- a/test/Generics/unify_associated_types.swift
+++ b/test/Generics/unify_associated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_concrete_types_2.swift
+++ b/test/Generics/unify_concrete_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_nested_types_1.swift
+++ b/test/Generics/unify_nested_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_2.swift
+++ b/test/Generics/unify_nested_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_3.swift
+++ b/test/Generics/unify_nested_types_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_4.swift
+++ b/test/Generics/unify_nested_types_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A : P1

--- a/test/Generics/unify_nested_types_5.swift
+++ b/test/Generics/unify_nested_types_5.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify
+// RUN: %target-typecheck-verify-swift
 
 protocol P {
   associatedtype A : P

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 class Base {}
 class Derived : Base {

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.

--- a/test/IRGen/retroactive_conformance_path.swift
+++ b/test/IRGen/retroactive_conformance_path.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -module-name=test %s -o %t/a.out -requirement-machine=verify
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64 || CPU=x86_64

--- a/test/IRGen/retroactive_conformance_path_2.swift
+++ b/test/IRGen/retroactive_conformance_path_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -g -primary-file %s -requirement-machine=verify
+// RUN: %target-swift-frontend -emit-ir -g -primary-file %s
 
 public struct TestType<T: Error> { }
 

--- a/test/SILGen/mangle_conformance_access_path.swift
+++ b/test/SILGen/mangle_conformance_access_path.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/mangle_conformance_access_path_helper.swift -emit-module-path %t/mangle_conformance_access_path_helper.swiftmodule
-// RUN: %target-swift-frontend -emit-silgen %s -I %t -requirement-machine=verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -I %t | %FileCheck %s
 
 import mangle_conformance_access_path_helper
 

--- a/test/SILGen/sil_verifier_method_self_type.swift
+++ b/test/SILGen/sil_verifier_method_self_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=verify
+// RUN: %target-swift-emit-silgen %s
 
 public class C<Key, Value> {
   public func method() -> Value { fatalError() }

--- a/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
+++ b/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine=verify | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 enum E<T : P> {
   case a(T.X)

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -requirement-machine=verify
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -458,11 +458,6 @@ static llvm::cl::opt<bool>
                        llvm::cl::desc("Ignore [always_inline] attribute."),
                        llvm::cl::init(false));
 
-static llvm::cl::opt<std::string> EnableRequirementMachine(
-    "requirement-machine",
-    llvm::cl::desc("Control usage of experimental generics implementation: "
-                   "'on', 'off', or 'verify'."));
-
 static void runCommandLineSelectedPasses(SILModule *Module,
                                          irgen::IRGenModule *IRGenMod) {
   const SILOptions &opts = Module->getOptions();
@@ -581,23 +576,6 @@ int main(int argc, char **argv) {
 
   Invocation.getDiagnosticOptions().VerifyMode =
       VerifyMode ? DiagnosticOptions::Verify : DiagnosticOptions::NoVerify;
-
-  if (EnableRequirementMachine.size()) {
-    auto value = llvm::StringSwitch<Optional<RequirementMachineMode>>(
-        EnableRequirementMachine)
-      .Case("off", RequirementMachineMode::Disabled)
-      .Case("on", RequirementMachineMode::Enabled)
-      .Case("verify", RequirementMachineMode::Verify)
-      .Default(None);
-
-    if (value)
-      Invocation.getLangOptions().EnableRequirementMachine = *value;
-    else {
-      fprintf(stderr, "Invalid value for -requirement-machine flag: %s\n",
-              EnableRequirementMachine.c_str());
-      exit(-1);
-    }
-  }
 
   // Setup the SIL Options.
   SILOptions &SILOpts = Invocation.getSILOptions();

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-frontend %s -emit-silgen -requirement-machine=off
+// RUN: %target-swift-frontend %s -emit-silgen
 
 // rdar://80395274 tracks getting this to pass with the requirement machine.
+// XFAIL: *
 
 import StdlibUnittest
 


### PR DESCRIPTION
The RequirementMachine-based queries seem to work well these days, and in fact, we're not even testing the old implementation anymore. Only a handful of tests pass `-requirement-machine=off` or `-requirement-machine=verify`. There are of course countless bugs in the old implementation, and a few tests will already fail with it I imagine. The old code will remain in the `release/5.6` branch, but I'm going to rip it out on `main` since it has outlived its purpose.