### PR TITLE
[AutoDiff] Move differentiable curry thunk bug reproducer to an XFAIL test.

### DIFF
--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -requirement-machine=off -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s
 
 // Test differentiation transform diagnostics.
 
@@ -773,27 +773,31 @@ public func fragileDifferentiable(_ x: Float) -> Float {
   implicitlyDifferentiableFromFragile(x)
 }
 
+
+// FIXME(rdar://87429620): Differentiable curry thunk RequirementMachine error.
+#if false
 // TF-1208: Test curry thunk differentiation regression.
-public struct TF_1208_Struct<Scalar> {
+public struct SR_14228_Struct<Scalar> {
   var x: Scalar
 }
-extension TF_1208_Struct: Differentiable where Scalar: Differentiable {
+extension SR_14228_Struct: Differentiable where Scalar: Differentiable {
   @differentiable(reverse)
   public static func id(x: Self) -> Self {
     return x
   }
 }
 @differentiable(reverse, wrt: x)
-public func TF_1208<Scalar: Differentiable>(
-  _ x: TF_1208_Struct<Scalar>,
-  // NOTE(TF-1208): This diagnostic is unexpected because `TF_1208_Struct.id` is marked `@differentiable`.
-  // expected-error @+3 2 {{function is not differentiable}}
-  // expected-note @+2 {{differentiated functions in '@inlinable' functions must be marked '@differentiable' or have a public '@derivative'; this is not possible with a closure, make a top-level function instead}}
-  // expected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
-  reduction: @differentiable(reverse) (TF_1208_Struct<Scalar>) -> TF_1208_Struct<Scalar> = TF_1208_Struct.id
-) -> TF_1208_Struct<Scalar> {
+public func SR_14228<Scalar: Differentiable>(
+  _ x: SR_14228_Struct<Scalar>,
+  // NOTE(TF-1208): This diagnostic is unexpected because `SR_14228_Struct.id` is marked `@differentiable`.
+  // xpected-error @+3 2 {{function is not differentiable}}
+  // xpected-note @+2 {{differentiated functions in '@inlinable' functions must be marked '@differentiable' or have a public '@derivative'; this is not possible with a closure, make a top-level function instead}}
+  // xpected-note @+1 {{opaque non-'@differentiable' function is not differentiable}}
+  reduction: @differentiable(reverse) (SR_14228_Struct<Scalar>) -> SR_14228_Struct<Scalar> = SR_14228_Struct.id
+) -> SR_14228_Struct<Scalar> {
   reduction(x)
 }
+#endif
 
 //===----------------------------------------------------------------------===//
 // Coroutines (SIL function yields, `begin_apply`) (not yet supported)

--- a/test/AutoDiff/compiler_crashers/rdar87429620-differentiable-curry-thunk-reqmachine.swift
+++ b/test/AutoDiff/compiler_crashers/rdar87429620-differentiable-curry-thunk-reqmachine.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// XFAIL: *
+
+// rdar://87429620 (Differentiable curry thunk RequirementMachine error)
+
+import _Differentiation
+
+public struct SR_14228_Struct<Scalar> {
+  var x: Scalar
+}
+
+extension SR_14228_Struct: Differentiable where Scalar: Differentiable {
+  @differentiable(reverse)
+  public static func id(x: Self) -> Self {
+    return x
+  }
+}
+
+@differentiable(reverse, wrt: x)
+public func SR_14228<Scalar: Differentiable>(
+  _ x: SR_14228_Struct<Scalar>,
+  reduction: @differentiable(reverse) (SR_14228_Struct<Scalar>) -> SR_14228_Struct<Scalar> = SR_14228_Struct.id
+) -> SR_14228_Struct<Scalar> {
+  reduction(x)
+}
+
+// Invalid type parameter in getCanonicalTypeInContext()
+// Original type: τ_0_0.TangentVector
+// Simplified term: τ_0_0.[Differentiable:TangentVector]
+// Longest valid prefix: τ_0_0
+// Prefix type: τ_0_0
+//
+// Requirement machine for <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 == τ_0_1, τ_0_2 == τ_0_3>
+// Rewrite system: {
+// - τ_0_1 => τ_0_0 [explicit]
+// - τ_0_3 => τ_0_2 [explicit]
+// }
+// Rewrite loops: {
+// }
+// Property map: {
+// }
+// Conformance access paths: {
+// }


### PR DESCRIPTION
Due to rdar://87429620, test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift is still using `-requirement-machine=off`. This patch moves the reproducer to a standalone XFAIL test, and removes `-requirement-machine=off` from differentiation_diagnostics.swift.
