### PR TITLE
Ensure Debug Help library calls on Windows are made in as thread-safe a manner as possible by wrapping them in a scoped lock.

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -85,10 +85,13 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
   // providing failure status instead of just returning the original string like
   // swift demangle.
 #if defined(_WIN32)
-  static StaticMutex mutex;
-
   char szUndName[1024];
-  DWORD dwResult = mutex.withLock([&syminfo, &szUndName]() {
+  DWORD dwResult;
+  dwResult = _swift_withWin32DbgHelpLibrary([&] (bool isInitialized) -> DWORD {
+    if (!isInitialized) {
+      return 0;
+    }
+
     DWORD dwFlags = UNDNAME_COMPLETE;
 #if !defined(_WIN64)
     dwFlags |= UNDNAME_32_BIT_DECODE;
@@ -98,7 +101,7 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
                                 sizeof(szUndName), dwFlags);
   });
 
-  if (dwResult == TRUE) {
+  if (dwResult) {
     symbolName += szUndName;
     return true;
   }

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -23,6 +23,8 @@
 #include <DbgHelp.h>
 #endif
 
+#include "swift/Runtime/Mutex.h"
+
 using namespace swift;
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
@@ -38,36 +40,52 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolAddress = dli_saddr;
   return 1;
 #elif defined(_WIN32)
-  static const constexpr size_t kSymbolMaxNameLen = 1024;
-  static bool bInitialized = false;
+  return _swift_withWin32DbgHelpLibrary([&] (bool isInitialized) {
+    static const constexpr size_t kSymbolMaxNameLen = 1024;
 
-  if (bInitialized == false) {
-    if (SymInitialize(GetCurrentProcess(), /*UserSearchPath=*/NULL,
-                      /*fInvadeProcess=*/TRUE) == FALSE)
+    if (!isInitialized) {
       return 0;
-    bInitialized = true;
-  }
+    }
 
-  char buffer[sizeof(SYMBOL_INFO) + kSymbolMaxNameLen];
-  PSYMBOL_INFO pSymbol = reinterpret_cast<PSYMBOL_INFO>(buffer);
-  pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-  pSymbol->MaxNameLen = kSymbolMaxNameLen;
+    char buffer[sizeof(SYMBOL_INFO) + kSymbolMaxNameLen];
+    PSYMBOL_INFO pSymbol = reinterpret_cast<PSYMBOL_INFO>(buffer);
+    pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    pSymbol->MaxNameLen = kSymbolMaxNameLen;
 
-  DWORD64 dwDisplacement = 0;
+    DWORD64 dwDisplacement = 0;
 
-  if (SymFromAddr(GetCurrentProcess(), reinterpret_cast<const DWORD64>(address),
-                  &dwDisplacement, pSymbol) == FALSE)
-    return 0;
+    if (SymFromAddr(GetCurrentProcess(),
+                    reinterpret_cast<const DWORD64>(address),
+                    &dwDisplacement, pSymbol) == FALSE) {
+      return 0;
+    }
 
-  info->fileName = NULL;
-  info->baseAddress = reinterpret_cast<void *>(pSymbol->ModBase);
-  info->symbolName.reset(_strdup(pSymbol->Name));
-  info->symbolAddress = reinterpret_cast<void *>(pSymbol->Address);
+    info->fileName = NULL;
+    info->baseAddress = reinterpret_cast<void *>(pSymbol->ModBase);
+    info->symbolName.reset(_strdup(pSymbol->Name));
+    info->symbolAddress = reinterpret_cast<void *>(pSymbol->Address);
 
-  return 1;
+    return 1;
+  });
 #else
   return 0;
 #endif // defined(__CYGWIN__) || defined(_WIN32)
 }
+
+#if defined(_WIN32)
+static StaticMutex mutex;
+static bool isDbgHelpInitialized = false;
+
+void swift::_swift_withWin32DbgHelpLibrary(
+  const std::function<void(bool /* isInitialized */)>& body) {
+  mutex.withLock([&body] () {
+    if (!isDbgHelpInitialized) {
+      SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+      isDbgHelpInitialized = SymInitialize(GetCurrentProcess(), nullptr, true);
+    }
+    body(isDbgHelpInitialized);
+  });
+}
+#endif
 
 #endif // !defined(__ELF__) && !defined(__MACH__)


### PR DESCRIPTION
Ensure Debug Help library calls on Windows are made in as thread-safe a manner as possible by wrapping them in a scoped lock.

<!-- What's in this pull request? -->
According to the [Win32 documentation](https://docs.microsoft.com/en-us/windows/win32/debug/about-dbghelp), the functions in the Debug Help library (DbgHelp.lib) are **not** thread-safe. That means that calling them across threads may blow up the process.

While we don't have a mechanism to control the use of this library outside the runtime/stdlib, we can at least ensure that all uses of it within the runtime/stdlib are thread-safe. We do so by exposing a new C++ runtime function, `swift::withDebugHelpLibrary()`, that callers can invoke. This function acquires a lock and ensures `SymInitialize()` has been called and has succeeded before any work is done that relies on the library.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
