### PR TITLE
Remove APPLYSITE obfuscation.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -38,8 +38,10 @@ class FullApplySite;
 
 struct ApplySiteKind {
   enum innerty : std::underlying_type<SILInstructionKind>::type {
-#define APPLYSITE_INST(ID, PARENT) ID = unsigned(SILInstructionKind::ID),
-#include "swift/SIL/SILNodes.def"
+    ApplyInst = unsigned(SILInstructionKind::ApplyInst),
+    PartialApplyInst = unsigned(SILInstructionKind::PartialApplyInst),
+    TryApplyInst = unsigned(SILInstructionKind::TryApplyInst),
+    BeginApplyInst = unsigned(SILInstructionKind::BeginApplyInst),
   } value;
 
   explicit ApplySiteKind(SILInstructionKind kind) {
@@ -60,10 +62,14 @@ struct ApplySiteKind {
 private:
   static Optional<innerty> fromNodeKindHelper(SILInstructionKind kind) {
     switch (kind) {
-#define APPLYSITE_INST(ID, PARENT)                                             \
-  case SILInstructionKind::ID:                                                 \
-    return ApplySiteKind::ID;
-#include "swift/SIL/SILNodes.def"
+    case SILInstructionKind::ApplyInst:
+      return ApplySiteKind::ApplyInst;
+    case SILInstructionKind::PartialApplyInst:
+      return ApplySiteKind::PartialApplyInst;
+    case SILInstructionKind::TryApplyInst:
+      return ApplySiteKind::TryApplyInst;
+    case SILInstructionKind::BeginApplyInst:
+      return ApplySiteKind::BeginApplyInst;
     default:
       return None;
     }
@@ -497,8 +503,9 @@ public:
 
 struct FullApplySiteKind {
   enum innerty : std::underlying_type<SILInstructionKind>::type {
-#define FULLAPPLYSITE_INST(ID, PARENT) ID = unsigned(SILInstructionKind::ID),
-#include "swift/SIL/SILNodes.def"
+    ApplyInst = unsigned(SILInstructionKind::ApplyInst),
+    TryApplyInst = unsigned(SILInstructionKind::TryApplyInst),
+    BeginApplyInst = unsigned(SILInstructionKind::BeginApplyInst),
   } value;
 
   explicit FullApplySiteKind(SILInstructionKind kind) {
@@ -519,10 +526,12 @@ struct FullApplySiteKind {
 private:
   static Optional<innerty> fromNodeKindHelper(SILInstructionKind kind) {
     switch (kind) {
-#define FULLAPPLYSITE_INST(ID, PARENT)                                         \
-  case SILInstructionKind::ID:                                                 \
-    return FullApplySiteKind::ID;
-#include "swift/SIL/SILNodes.def"
+    case SILInstructionKind::ApplyInst:
+      return FullApplySiteKind::ApplyInst;
+    case SILInstructionKind::TryApplyInst:
+      return FullApplySiteKind::TryApplyInst;
+    case SILInstructionKind::BeginApplyInst:
+      return FullApplySiteKind::BeginApplyInst;
     default:
       return None;
     }

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,14 +16,12 @@
 /// supports changing how macros expand by #defining an auxillary variable
 /// before including SILNodes.def as summarized in the chart below:
 ///
-/// | #define            | Operation                                               |
-/// |--------------------+---------------------------------------------------------|
-/// | N/A                | Visit single value insts as insts                       |
-/// | VALUE              | Visit single value insts as values                      |
-/// | ABSTRACT_VALUE     | Visit abstract single value insts as values             |
-/// | APPLYSITE_INST     | Visit full and partial apply site insts as apply sites. |
-/// | FULLAPPLYSITE_INST | Visit full apply site insts as apply sites.             |
-/// | DYNAMICCAST_INST   | Visit dynamic casts as dynamic casts.                   |
+/// | #define            | Operation                                           |
+/// |--------------------+-----------------------------------------------------|
+/// | N/A                | Visit single value insts as insts                   |
+/// | VALUE              | Visit single value insts as values                  |
+/// | ABSTRACT_VALUE     | Visit abstract single value insts as values         |
+/// | DYNAMICCAST_INST   | Visit dynamic casts as dynamic casts.               |
 ///
 /// We describe the triggering variables below:
 ///
@@ -37,29 +35,7 @@
 ///     If defined this will cause ABSTRACT_SINGLE_VALUE_INST to expand to
 ///     ABSTRACT_VALUE INSTEAD OF ABSTRACT_INST.
 ///
-/// 3. FULLAPPLYSITE_INST(ID, PARENT).
-///
-///   If defined this will cause:
-///
-///       * FULLAPPLYSITE_SINGLE_VALUE_INST,
-///       * FULLAPPLYSITE_MULTIPLE_VALUE_INST,
-///       * FULLAPPLYSITE_TERMINATOR_INST,
-///
-///   To expand to FULLAPPLYSITE_INST(ID, PARENT) instead of SINGLE_VALUE_INST,
-///   MULTIPLE_VALUE_INST, or TERMINATOR_INST.
-///
-/// 4. APPLYSITE_INST(ID, PARENT)
-///
-///   If defined this will cause:
-///
-///         * APPLYSITE_SINGLE_VALUE_INST
-///         * APPLYSITE_MULTIPLE_VALUE_INST
-///         * APPLYSITE_TERMINATOR_INST
-///
-///   to expand to APPLYSITE_INST(ID, PARENT) instead of delegating to
-///   SINGLE_VALUE_INST.
-///
-/// 5. DYNAMICCAST_INST(ID, PARENT)
+/// 3. DYNAMICCAST_INST(ID, PARENT)
 ///
 ///   If defined this will cause:
 ///
@@ -71,12 +47,6 @@
 ///   SINGLE_VALUE_INST, TERMINATOR, or NON_VALUE_INST
 ///
 //===----------------------------------------------------------------------===//
-
-#ifdef APPLYSITE_INST
-#ifdef FULLAPPLYSITE_INST
-#error "Can not query for apply site and full apply site in one include"
-#endif
-#endif
 
 /// NODE(ID, PARENT)
 ///
@@ -121,36 +91,6 @@
 #endif
 #endif
 
-/// APPLYSITE_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR,
-///                             MAYRELEASE)
-///
-///   A SINGLE_VALUE_INST that is a partial or full apply site. ID is a member
-///   of ApplySiteKind.
-#ifndef APPLYSITE_SINGLE_VALUE_INST
-#ifdef APPLYSITE_INST
-#define APPLYSITE_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_INST(ID, PARENT)
-#else
-#define APPLYSITE_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  BRIDGED_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-#endif
-
-/// FULLAPPLYSITE_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR,
-///                                 MAYRELEASE)
-///
-///   A SINGLE_VALUE_INST that is a full apply site. ID is a member of
-///   FullApplySiteKind and ApplySiteKind.
-#ifndef FULLAPPLYSITE_SINGLE_VALUE_INST
-#ifdef FULLAPPLYSITE_INST
-#define FULLAPPLYSITE_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  FULLAPPLYSITE_INST(ID, PARENT)
-#else
-#define FULLAPPLYSITE_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-#endif
-
 /// MULTIPLE_VALUE_INST(Id, TextualName, Parent, MemBehavior, MayRelease)
 ///
 ///   A concrete subclass of MultipleValueInstruction. ID is a member of
@@ -159,36 +99,6 @@
 #ifndef MULTIPLE_VALUE_INST
 #define MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-
-/// APPLYSITE_MULTIPLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR,
-///                               MAYRELEASE)
-///
-///   A MULTIPLE_VALUE_INST that is additionally either a partial or full apply
-///   site. ID is a member of ApplySiteKind.
-#ifndef APPLYSITE_MULTIPLE_VALUE_INST
-#ifdef APPLYSITE_INST
-#define APPLYSITE_MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_INST(ID, PARENT)
-#else
-#define APPLYSITE_MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-#endif
-
-/// FULLAPPLYSITE_MULTIPLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR,
-///                                   MAYRELEASE)
-///
-///   A MULTIPLE_VALUE_INST that is additionally a full apply site. ID is a
-///   member of FullApplySiteKind and ApplySiteKind.
-#ifndef FULLAPPLYSITE_MULTIPLE_VALUE_INST
-#ifdef FULLAPPLYSITE_INST
-#define FULLAPPLYSITE_MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  FULLAPPLYSITE_INST(ID, PARENT)
-#else
-#define FULLAPPLYSITE_MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_MULTIPLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
 #endif
 
 /// MULTIPLE_VALUE_INST_RESULT(ID, PARENT)
@@ -283,34 +193,6 @@
 #else
 #define DYNAMICCAST_TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   TERMINATOR(ID, TEXTUAL_NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-#endif
-
-/// APPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-///
-/// ID is a member of ApplySiteKind, TerminatorKind, and ApplySiteKind and name
-/// of a subclass of TermInst.
-#ifndef APPLYSITE_TERMINATOR_INST
-#ifdef APPLYSITE_INST
-#define APPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_INST(ID, NAME)
-#else
-#define APPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  TERMINATOR(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-#endif
-#endif
-
-/// FULLAPPLYSITE_TERMINATOR(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
-///
-/// ID is a member of FullApplySiteKind, TerminatorKind, and ApplySiteKind and
-/// name of a subclass of TermInst.
-#ifndef FULLAPPLYSITE_TERMINATOR_INST
-#ifdef FULLAPPLYSITE_INST
-#define FULLAPPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  FULLAPPLYSITE_INST(ID, PARENT)
-#else
-#define FULLAPPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
-  APPLYSITE_TERMINATOR_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 #endif
 #endif
 
@@ -640,12 +522,12 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
 
   // Function Application
-  FULLAPPLYSITE_SINGLE_VALUE_INST(ApplyInst, apply,
-                                  SingleValueInstruction, MayHaveSideEffects, MayRelease)
+  BRIDGED_SINGLE_VALUE_INST(ApplyInst, apply,
+                    SingleValueInstruction, MayHaveSideEffects, MayRelease)
   BRIDGED_SINGLE_VALUE_INST(BuiltinInst, builtin,
                     SingleValueInstruction, MayHaveSideEffects, MayRelease)
-  APPLYSITE_SINGLE_VALUE_INST(PartialApplyInst, partial_apply,
-                              SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
+  BRIDGED_SINGLE_VALUE_INST(PartialApplyInst, partial_apply,
+                    SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
 
   // Metatypes
   SINGLE_VALUE_INST(MetatypeInst, metatype,
@@ -780,8 +662,8 @@ ABSTRACT_INST(TermInst, SILInstruction)
              TermInst, MayHaveSideEffects, MayRelease)
   TERMINATOR(UnwindInst, unwind,
              TermInst, None, DoesNotRelease)
-  FULLAPPLYSITE_TERMINATOR_INST(TryApplyInst, try_apply,
-                                TermInst, MayHaveSideEffects, MayRelease)
+  TERMINATOR(TryApplyInst, try_apply,
+             TermInst, MayHaveSideEffects, MayRelease)
   TERMINATOR(BranchInst, br,
              TermInst, None, DoesNotRelease)
   TERMINATOR(CondBranchInst, cond_br,
@@ -923,8 +805,8 @@ BRIDGED_NON_VALUE_INST(CondFailInst, cond_fail,
 NODE_RANGE(NonValueInstruction, UnreachableInst, CondFailInst)
 
 ABSTRACT_INST(MultipleValueInstruction, SILInstruction)
-FULLAPPLYSITE_MULTIPLE_VALUE_INST(BeginApplyInst, begin_apply,
-                                  MultipleValueInstruction, MayHaveSideEffects, MayRelease)
+MULTIPLE_VALUE_INST(BeginApplyInst, begin_apply,
+                    MultipleValueInstruction, MayHaveSideEffects, MayRelease)
                                   
 // begin_cow_mutation is defined to have side effects, because it has
 // dependencies with instructions which retain the buffer operand. This prevents
@@ -952,19 +834,13 @@ NODE_RANGE(SILNode, SILPhiArgument, DestructureTupleInst)
 #undef ABSTRACT_VALUE
 #undef ABSTRACT_NODE
 #undef ABSTRACT_VALUE_AND_INST
-#undef FULLAPPLYSITE_TERMINATOR_INST
-#undef APPLYSITE_TERMINATOR_INST
 #undef DYNAMICCAST_TERMINATOR
 #undef TERMINATOR
 #undef NON_VALUE_INST
 #undef BRIDGED_NON_VALUE_INST
 #undef DYNAMICCAST_NON_VALUE_INST
 #undef MULTIPLE_VALUE_INST_RESULT
-#undef FULLAPPLYSITE_MULTIPLE_VALUE_INST
-#undef APPLYSITE_MULTIPLE_VALUE_INST
 #undef MULTIPLE_VALUE_INST
-#undef FULLAPPLYSITE_SINGLE_VALUE_INST
-#undef APPLYSITE_SINGLE_VALUE_INST
 #undef DYNAMICCAST_SINGLE_VALUE_INST
 #undef DYNAMICCAST_INST
 #undef SINGLE_VALUE_INST
@@ -974,5 +850,3 @@ NODE_RANGE(SILNode, SILPhiArgument, DestructureTupleInst)
 #undef ARGUMENT
 #undef VALUE
 #undef NODE
-#undef APPLYSITE_INST
-#undef FULLAPPLYSITE_INST

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -637,8 +637,10 @@ private:
   void visitCopyValueInst(CopyValueInst *Inst);
   void visitProjectBoxInst(ProjectBoxInst *Inst);
   void checkNoPromotedBoxInApply(ApplySite Apply);
-#define APPLYSITE_INST(Name, Parent) void visit##Name(Name *Inst);
-#include "swift/SIL/SILNodes.def"
+  void visitApplyInst(ApplyInst *Inst);
+  void visitBeginApplyInst(BeginApplyInst *Inst);
+  void visitPartialApplyInst(PartialApplyInst *Inst);
+  void visitTryApplyInst(TryApplyInst *Inst);
 };
 } // end anonymous namespace
 


### PR DESCRIPTION
These macros make ApplySite.h and SILNodes.def unreadable. Getting rid
of them will save me (and I'm sure others) a lot of time when working with ApplySite.

Best practice dictates that the ApplySite abstraction be modeled in
one place. The macros serve no purpose other than obfuscation.
