### PR TITLE
[update-checkout] Fetch if the local branch/tag doesn't exist

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -156,6 +156,18 @@ def update_single_repository(pool_args):
             if checkout_target:
                 shell.run(['git', 'status', '--porcelain', '-uno'],
                           echo=False)
+
+                # Some of the projects switch branches/tags when they
+                # are updated. Local checkout might not have that tag/branch
+                # fetched yet, so let's attempt to fetch before attempting
+                # checkout.
+                try:
+                    shell.run(['git', 'rev-parse', '--verify', checkout_target])
+                except Exception:
+                    shell.run(["git", "fetch", "--recurse-submodules=yes",
+                               "--tags"],
+                              echo=True)
+
                 try:
                     shell.run(['git', 'checkout', checkout_target], echo=True)
                 except Exception as originalException:


### PR DESCRIPTION
Dependencies are usually updated to a different branch/tag name
when new versions get new released, but local checkout might not
have that fetched yet, so if initial checkout fails, let's fetch
before attempting to checkout.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
