### PR TITLE
IRGen: Use the 'right' async context index in the dynamic replacement prolog

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2848,7 +2848,7 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
     unsigned argIdx = 0;
     for (auto arg : forwardedArgs) {
       // Replace the context argument.
-      if (argIdx == asyncContextIndex)
+      if (argIdx == asyncFnPtr.getSignature().getAsyncContextIndex())
         arguments.push_back(Builder.CreateBitOrPointerCast(
             calleeContextBuffer.getAddress(), IGM.SwiftContextPtrTy));
       else

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -23,3 +23,10 @@ internal func _replacement_number() async -> Int {
 public func calls_number() async -> Int {
   await number()
 }
+
+// CHECK-LABEL: define swifttailcc void @"$s25async_dynamic_replacement32indirectReturnDynamicReplaceableSi_S6ityYaKF"(<{ %TSi, %TSi, %TSi, %TSi, %TSi, %TSi, %TSi }>* {{.*}}%0, %swift.context* swiftasync %1)
+// CHECK: forward_to_replaced:
+// CHECK: musttail call swifttailcc void {{.*}}(<{ %TSi, %TSi, %TSi, %TSi, %TSi, %TSi, %TSi }>* noalias nocapture %0, %swift.context* swiftasync {{.*}})
+public dynamic func indirectReturnDynamicReplaceable() async throws -> (Int, Int, Int, Int, Int, Int, Int) {
+    return (0, 0, 0, 0, 0, 0, 0)
+}

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -24,7 +24,7 @@ public func calls_number() async -> Int {
   await number()
 }
 
-// CHECK-LABEL: define swifttailcc void @"$s25async_dynamic_replacement32indirectReturnDynamicReplaceableSi_S6ityYaKF"(<{ %TSi, %TSi, %TSi, %TSi, %TSi, %TSi, %TSi }>* {{.*}}%0, %swift.context* swiftasync %1)
+// CHECK-LABEL: define {{.*}}swifttailcc void @"$s25async_dynamic_replacement32indirectReturnDynamicReplaceableSi_S6ityYaKF"(<{ %TSi, %TSi, %TSi, %TSi, %TSi, %TSi, %TSi }>* {{.*}}%0, %swift.context* swiftasync %1)
 // CHECK: forward_to_replaced:
 // CHECK: musttail call swifttailcc void {{.*}}(<{ %TSi, %TSi, %TSi, %TSi, %TSi, %TSi, %TSi }>* noalias nocapture %0, %swift.context* swiftasync {{.*}})
 public dynamic func indirectReturnDynamicReplaceable() async throws -> (Int, Int, Int, Int, Int, Int, Int) {


### PR DESCRIPTION
The right index is the index derived for calling a function
(Signature::forAsyncEntry) rather then for receiving the results
(Signature::forAsyncAwait(); the resume fn signature).

rdar://86863272