### PR TITLE
[5.6] Add requires optimized stdlib to two tests

### DIFF
--- a/test/stdlib/LifetimeManagement.swift
+++ b/test/stdlib/LifetimeManagement.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift
 
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 
 import StdlibUnittest
 

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -5,6 +5,7 @@
 // test to fail only when optimizations are enabled.
 
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 
 import Swift
 import StdlibUnittest


### PR DESCRIPTION
We do this on main. This should fix the stdlib no optimization bot for 5.6.