### PR TITLE
[CMake] Fix condition of cmake_dependent_option macro for BOOTSTRAPPING_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ How to build the swift compiler modules. Possible values are
                    `SWIFT_NATIVE_SWIFT_TOOLS_PATH` (non-Darwin only)
     CROSSCOMPILE-WITH-HOSTLIBS:    build with a bootstrapping-with-hostlibs compiled
                                    compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
-]=]  OFF "NOT CMAKE_GENERATOR STREQUAL \"Xcode\"" OFF)
+]=]  OFF "NOT XCODE" OFF)
 
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING


### PR DESCRIPTION
<!-- What's in this pull request? -->
Trying to build with `--xcode`, more specifically `SKIP_XCODE_VERSION_CHECK=1 ./swift/utils/build-script --xcode --debug --debug-swift --skip-build-benchmarks  --swift-darwin-supported-archs "$(uname -m)" --sccache  --skip-ios --skip-tvos --skip-watchos` and was getting an error: 
```sh
    /bin/sh -c ${BUILD_DIR}/Xcode-DebugAssert/swift-macosx-arm64/tools/driver/Swift.build/Debug/swift-frontend-bootstrapping0.build/Script-86289F9744663899789BE6CE.sh
${BUILD_DIR}/Xcode-DebugAssert/swift-macosx-arm64/tools/driver/Swift.build/Debug/swift-frontend-bootstrapping0.build/Script-86289F9744663899789BE6CE.sh: line 4: cd: ${BUILD_DIR}/Xcode-DebugAssert/swift-macosx-arm64/bootstrapping0/bin: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```
All the logs were printing 
`--   Bootstrapping:  BOOTSTRAPPING-WITH-HOSTLIBS`

After looking into the documentation found that Full Condition Syntax is only supported after 3.22. 
My version is 3.21.1, so after this change build is fine. 

I think it makes sense to make this change because this is basically the same thing and since minimum required version of cmake on the [documentation](https://github.com/apple/swift/blob/main/docs/HowToGuides/GettingStarted.md#spot-check-dependencies) is 3.19.6 this should work out of the box for all versions from that on. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
