### PR TITLE
AST: Implement ProtocolConformance::subst() for BuiltinProtocolConformances [5.6]

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1165,8 +1165,33 @@ ProtocolConformance::subst(TypeSubstitutionFn subs,
                                    const_cast<ProtocolConformance *>(this),
                                    subMap);
   }
+  case ProtocolConformanceKind::Builtin: {
+    auto origType = getType();
+    if (!origType->hasTypeParameter() &&
+        !origType->hasArchetype())
+      return const_cast<ProtocolConformance *>(this);
+
+    auto substType = origType.subst(subs, conformances, options);
+
+    // We do an exact pointer equality check because subst() can
+    // change sugar.
+    if (substType.getPointer() == origType.getPointer())
+      return const_cast<ProtocolConformance *>(this);
+
+    SmallVector<Requirement, 2> requirements;
+    for (auto req : getConditionalRequirements()) {
+      requirements.push_back(*req.subst(subs, conformances, options));
+    }
+
+    auto kind = cast<BuiltinProtocolConformance>(this)
+        ->getBuiltinConformanceKind();
+
+    return substType->getASTContext()
+        .getBuiltinConformance(substType,
+                               getProtocol(), getGenericSignature(),
+                               requirements, kind);
+  }
   case ProtocolConformanceKind::Self:
-  case ProtocolConformanceKind::Builtin:
     return const_cast<ProtocolConformance*>(this);
   case ProtocolConformanceKind::Inherited: {
     // Substitute the base.

--- a/validation-test/compiler_crashers_2_fixed/sr15628.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15628.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+protocol P {
+  associatedtype A: Sendable
+}
+
+struct S<T>: P {
+  typealias A = ()
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-15628 / rdar://problem/87094438