### PR TITLE
[SwiftSyntax] Remove another link dependency from swiftAST to clangAST when building the parser lib

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -831,6 +831,10 @@ std::string ASTMangler::mangleOpaqueTypeDecl(const OpaqueTypeDecl *decl) {
 }
 
 std::string ASTMangler::mangleOpaqueTypeDecl(const ValueDecl *decl) {
+#if SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  return std::string(); // not needed for the parser library.
+#endif
+
   OptimizeProtocolNames = false;
 
   beginMangling();


### PR DESCRIPTION
Remove another link dependency from swiftAST to clangAST when building the parser lib.