### PR TITLE
Support bootstrapping with Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,7 @@ set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     option only affects the tools that run on the host (the compiler), and has
     no effect on the target libraries (the standard library and the runtime).")
 
-# NOTE: We do not currently support building the swift compiler modules with the Xcode generator.
-cmake_dependent_option(BOOTSTRAPPING_MODE [=[
+option(BOOTSTRAPPING_MODE [=[
 How to build the swift compiler modules. Possible values are
     OFF:           build without swift modules
     HOSTTOOLS:     build with a pre-installed toolchain
@@ -204,7 +203,7 @@ How to build the swift compiler modules. Possible values are
                    `SWIFT_NATIVE_SWIFT_TOOLS_PATH` (non-Darwin only)
     CROSSCOMPILE-WITH-HOSTLIBS:    build with a bootstrapping-with-hostlibs compiled
                                    compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
-]=]  OFF "NOT XCODE" OFF)
+]=] OFF)
 
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
@@ -1110,8 +1109,6 @@ if(SWIFT_INCLUDE_TOOLS)
   # SwiftCompilerSources must come before "tools".
   # It adds swift module names to the global property "swift_compiler_modules"
   # which is used in add_swift_host_tool for the lldb workaround.
-  #
-  # NOTE: We do not currently support SwiftCompilerSources with the Xcode generator.
   add_subdirectory(SwiftCompilerSources)
 
   # Always include this after including stdlib/!

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -89,8 +89,7 @@ function(add_swift_compiler_modules_library name)
   set(sdk_option "")
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
-    set(deployment_version "10.15") # TODO: once #38675 lands, replace this with
-#   set(deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+    set(deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
     set(sdk_option "-sdk" "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
     if(${BOOTSTRAPPING_MODE} STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
       # Let the cross-compiled compile don't pick up the compiled stdlib by providing
@@ -158,6 +157,15 @@ function(add_swift_compiler_modules_library name)
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
+
+  # Xcode does not compile libraries that contain only object files.
+  # Therefore, it fails to create the static library. As a workaround,
+  # we add a dummy script phase to the target.
+  if (XCODE)
+    add_custom_command(TARGET ${name} POST_BUILD 
+      COMMAND ""
+      COMMENT "Dummy script phase to force building this target")
+  endif()
 endfunction()
 
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
   swift_create_post_build_symlink(swift-frontend-bootstrapping0
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/bin")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/${CMAKE_CFG_INTDIR}/bin")
 
   # Bootstrapping - level 1
 
@@ -37,7 +37,7 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
   swift_create_post_build_symlink(swift-frontend-bootstrapping1
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/bin")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/${CMAKE_CFG_INTDIR}/bin")
 endif()
 
 add_swift_host_tool(swift-frontend


### PR DESCRIPTION
A `/${CMAKE_CFG_INTDIR}` was missing in a path. With Ninja, this does not matter because then it is always "". But with Xcode, it is "Debug", "Release", etc.. This causes SR-15705, which is also the error mentioned in #40833.

Edit: fixed the other problems too (see comments), now it fully works.