### PR TITLE
[SourceKit] Don't force 'raw' PCM objects in SourceKit's compiler invocations

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -708,16 +708,9 @@ importer::getNormalInvocationArguments(
     invocationArgStrs.push_back("-fmodules-validate-system-headers");
   }
 
-  if (importerOpts.DetailedPreprocessingRecord) {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-Xclang", "-detailed-preprocessing-record",
-      "-Xclang", "-fmodule-format=raw",
-    });
-  } else {
-    invocationArgStrs.insert(invocationArgStrs.end(), {
-      "-Xclang", "-fmodule-format=obj",
-    });
-  }
+  invocationArgStrs.insert(invocationArgStrs.end(), {
+    "-Xclang", "-fmodule-format=obj",
+  });
 
   // Enable API notes alongside headers/in frameworks.
   invocationArgStrs.push_back("-fapinotes-modules");

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -329,7 +329,6 @@ bool ide::initCompilerInvocation(
   }
 
   ClangImporterOptions &ImporterOpts = Invocation.getClangImporterOptions();
-  ImporterOpts.DetailedPreprocessingRecord = true;
 
   assert(!Invocation.getModuleName().empty());
 


### PR DESCRIPTION
This change would allow SourceKit to use explicit modules that have been built by the build system. Explicit modules are in `object` format and looks like this [commit](https://github.com/apple/swift/commit/7c92a8e55510d60be5ae2ffc06669e0274d45bc0#diff-b58f1bfd56bbb3fb79cd40f3c38792977886ebbbefd0367a01ac6bead234c3f4) added support for object files in SourceKit.

I still need to test this change (am having trouble getting the toolchain to build) but would like to get feedback on this in the meantime.

CC @DavidGoldman @akyrtzi 