### PR TITLE
Make Objective-C interoperability configurable in the runtime

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -48,6 +48,24 @@
 #include "llvm/Support/Casting.h"
 
 namespace swift {
+
+template <typename Runtime> struct TargetGenericMetadataInstantiationCache;
+template <typename Runtime> struct TargetAnyClassMetadata;
+template <typename Runtime> struct TargetAnyClassMetadataObjCInterop;
+template <typename Runtime, typename TargetAnyClassMetadataVariant>
+struct TargetClassMetadata;
+template <typename Runtime> struct TargetStructMetadata;
+template <typename Runtime> struct TargetOpaqueMetadata;
+template <typename Runtime> struct TargetValueMetadata;
+template <typename Runtime> struct TargetForeignClassMetadata;
+template <typename Runtime> struct TargetContextDescriptor;
+template <typename Runtime> class TargetTypeContextDescriptor;
+template <typename Runtime> class TargetClassDescriptor;
+template <typename Runtime> class TargetValueTypeDescriptor;
+template <typename Runtime> class TargetEnumDescriptor;
+template <typename Runtime> class TargetStructDescriptor;
+template <typename Runtime> struct TargetGenericMetadataPattern;
+
 template <unsigned PointerSize>
 struct RuntimeTarget;
 
@@ -90,6 +108,18 @@ struct InProcess {
   using StoredSize = size_t;
   using StoredPointerDifference = ptrdiff_t;
 
+#ifdef SWIFT_OBJC_INTEROP
+  static constexpr bool ObjCInterop = true;
+  template <typename T>
+  using TargetAnyClassMetadata = TargetAnyClassMetadataObjCInterop<T>;
+#else
+  static constexpr bool ObjCInterop = false;
+  template <typename T>
+  using TargetAnyClassMetadata = TargetAnyClassMetadata<T>;
+#endif
+  template <typename T>
+  using TargetClassMetadata = TargetClassMetadata<T, TargetAnyClassMetadata<T>>;
+
   static_assert(sizeof(StoredSize) == sizeof(StoredPointerDifference),
                 "target uses differently-sized size_t and ptrdiff_t");
   
@@ -120,14 +150,44 @@ struct ExternalPointer {
   StoredPointer PointerValue;
 };
 
-/// An external process's runtime target, which may be a different architecture.
+template <typename Runtime> struct WithObjCInterop {
+  using StoredPointer = typename Runtime::StoredPointer;
+  using StoredSignedPointer = typename Runtime::StoredSignedPointer;
+  using StoredSize = typename Runtime::StoredSize;
+  using StoredPointerDifference = typename Runtime::StoredPointerDifference;
+  static constexpr size_t PointerSize = Runtime::PointerSize;
+  static constexpr bool ObjCInterop = true;
+  template <typename T>
+  using TargetAnyClassMetadata = TargetAnyClassMetadataObjCInterop<T>;
+};
+
+template <typename Runtime> struct NoObjCInterop {
+  using StoredPointer = typename Runtime::StoredPointer;
+  using StoredSignedPointer = typename Runtime::StoredSignedPointer;
+  using StoredSize = typename Runtime::StoredSize;
+  using StoredPointerDifference = typename Runtime::StoredPointerDifference;
+  static constexpr size_t PointerSize = Runtime::PointerSize;
+  static constexpr bool ObjCInterop = false;
+  template <typename T>
+  using TargetAnyClassMetadata = TargetAnyClassMetadata<T>;
+};
+
+/// An external process's runtime target, which may be a different architecture,
+/// and may or may not have Objective-C interoperability.
 template <typename Runtime>
 struct External {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;
   using StoredPointerDifference = typename Runtime::StoredPointerDifference;
+  template <typename T>
+  using TargetAnyClassMetadata =
+      typename Runtime::template TargetAnyClassMetadata<T>;
+  template <typename T>
+  using TargetClassMetadata = TargetClassMetadata<T, TargetAnyClassMetadata<T>>;
+
   static constexpr size_t PointerSize = Runtime::PointerSize;
+  static constexpr bool ObjCInterop = Runtime::ObjCInterop;
   const StoredPointer PointerValue;
   
   template <typename T>
@@ -478,21 +538,6 @@ namespace {
   };
 }
 
-template <typename Runtime> struct TargetGenericMetadataInstantiationCache;
-template <typename Runtime> struct TargetAnyClassMetadata;
-template <typename Runtime> struct TargetClassMetadata;
-template <typename Runtime> struct TargetStructMetadata;
-template <typename Runtime> struct TargetOpaqueMetadata;
-template <typename Runtime> struct TargetValueMetadata;
-template <typename Runtime> struct TargetForeignClassMetadata;
-template <typename Runtime> struct TargetContextDescriptor;
-template <typename Runtime> class TargetTypeContextDescriptor;
-template <typename Runtime> class TargetClassDescriptor;
-template <typename Runtime> class TargetValueTypeDescriptor;
-template <typename Runtime> class TargetEnumDescriptor;
-template <typename Runtime> class TargetStructDescriptor;
-template <typename Runtime> struct TargetGenericMetadataPattern;
-
 using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
 
 // FIXME: https://bugs.swift.org/browse/SR-1155
@@ -540,7 +585,7 @@ struct TargetMetadata {
 
 #if SWIFT_OBJC_INTEROP
 protected:
-  constexpr TargetMetadata(TargetAnyClassMetadata<Runtime> *isa)
+  constexpr TargetMetadata(TargetAnyClassMetadataObjCInterop<Runtime> *isa)
     : Kind(reinterpret_cast<StoredPointer>(isa)) {}
 #endif
 
@@ -684,12 +729,23 @@ public:
   getTypeContextDescriptor() const {
     switch (getKind()) {
     case MetadataKind::Class: {
-      const auto cls = static_cast<const TargetClassMetadata<Runtime> *>(this);
-      if (!cls->isTypeMetadata())
-        return nullptr;
-      if (cls->isArtificialSubclass())
-        return nullptr;
-      return cls->getDescription();
+      if (Runtime::ObjCInterop) {
+        const auto cls = static_cast<const TargetClassMetadata<
+            Runtime, TargetAnyClassMetadataObjCInterop<Runtime>> *>(this);
+        if (!cls->isTypeMetadata())
+          return nullptr;
+        if (cls->isArtificialSubclass())
+          return nullptr;
+        return cls->getDescription();
+      } else {
+        const auto cls = static_cast<const TargetClassMetadata<
+            Runtime, TargetAnyClassMetadata<Runtime>> *>(this);
+        if (!cls->isTypeMetadata())
+          return nullptr;
+        if (cls->isArtificialSubclass())
+          return nullptr;
+        return cls->getDescription();
+      }
     }
     case MetadataKind::Struct:
     case MetadataKind::Enum:
@@ -706,7 +762,8 @@ public:
 
   /// Get the class object for this type if it has one, or return null if the
   /// type is not a class (or not a class with a class object).
-  const TargetClassMetadata<Runtime> *getClassObject() const;
+  const typename Runtime::template TargetClassMetadata<Runtime> *
+  getClassObject() const;
 
   /// Retrieve the generic arguments of this type, if it has any.
   ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *
@@ -740,8 +797,9 @@ public:
   typename std::enable_if<std::is_same<R, InProcess>::value, Class>::type
   getObjCClassObject() const {
     return reinterpret_cast<Class>(
-      const_cast<TargetClassMetadata<InProcess>*>(
-        getClassObject()));
+        const_cast<TargetClassMetadata<
+            InProcess, TargetAnyClassMetadataObjCInterop<InProcess>> *>(
+            getClassObject()));
   }
 #endif
 
@@ -777,7 +835,9 @@ template <typename Runtime>
 struct TargetHeapMetadataHeaderPrefix {
   /// Destroy the object, returning the allocated size of the object
   /// or 0 if the object shouldn't be deallocated.
-  TargetSignedPointer<Runtime, HeapObjectDestroyer *__ptrauth_swift_heap_object_destructor> destroy;
+  TargetSignedPointer<Runtime, HeapObjectDestroyer *
+                                   __ptrauth_swift_heap_object_destructor>
+      destroy;
 };
 using HeapMetadataHeaderPrefix =
   TargetHeapMetadataHeaderPrefix<InProcess>;
@@ -810,7 +870,7 @@ struct TargetHeapMetadata : TargetMetadata<Runtime> {
   constexpr TargetHeapMetadata(MetadataKind kind)
     : TargetMetadata<Runtime>(kind) {}
 #if SWIFT_OBJC_INTEROP
-  constexpr TargetHeapMetadata(TargetAnyClassMetadata<Runtime> *isa)
+  constexpr TargetHeapMetadata(TargetAnyClassMetadataObjCInterop<Runtime> *isa)
     : TargetMetadata<Runtime>(isa) {}
 #endif
 };
@@ -949,6 +1009,8 @@ struct TargetClassMetadataBounds : TargetMetadataBounds<Runtime> {
 
   using TargetMetadataBounds<Runtime>::NegativeSizeInWords;
   using TargetMetadataBounds<Runtime>::PositiveSizeInWords;
+  using TargetClassMetadata =
+      typename Runtime::template TargetClassMetadata<Runtime>;
 
   /// The offset from the address point of the metadata to the immediate
   /// members.
@@ -961,10 +1023,13 @@ struct TargetClassMetadataBounds : TargetMetadataBounds<Runtime> {
     : TargetMetadataBounds<Runtime>{negativeSizeInWords, positiveSizeInWords},
       ImmediateMembersOffset(immediateMembersOffset) {}
 
+  template <typename T>
+    using TargetClassMetadataT = typename Runtime::template TargetClassMetadata<T>;
+
   /// Return the basic bounds of all Swift class metadata.
   /// The immediate members offset will not be meaningful.
   static constexpr TargetClassMetadataBounds<Runtime> forSwiftRootClass() {
-    using Metadata = FullMetadata<TargetClassMetadata<Runtime>>;
+    using Metadata = FullMetadata<TargetClassMetadataT<Runtime>>;
     return forAddressPointAndSize(sizeof(typename Metadata::HeaderType),
                                   sizeof(Metadata));
   }
@@ -1007,39 +1072,67 @@ template <typename Runtime>
 struct TargetAnyClassMetadata : public TargetHeapMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSize = typename Runtime::StoredSize;
+  using TargetClassMetadata =
+      typename Runtime::template TargetClassMetadata<Runtime>;
 
-#if SWIFT_OBJC_INTEROP
-  constexpr TargetAnyClassMetadata(TargetAnyClassMetadata<Runtime> *isa,
-                                   TargetClassMetadata<Runtime> *superclass)
-    : TargetHeapMetadata<Runtime>(isa),
-      Superclass(superclass),
-      CacheData{nullptr, nullptr},
-      Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
-#endif
+protected:
+  constexpr TargetAnyClassMetadata(
+      TargetAnyClassMetadataObjCInterop<Runtime> *isa,
+      TargetClassMetadata *superclass)
+      : TargetHeapMetadata<Runtime>(isa), Superclass(superclass) {}
 
-  constexpr TargetAnyClassMetadata(TargetClassMetadata<Runtime> *superclass)
-    : TargetHeapMetadata<Runtime>(MetadataKind::Class),
-      Superclass(superclass)
-#if SWIFT_OBJC_INTEROP
-      , CacheData{nullptr, nullptr},
-      Data(SWIFT_CLASS_IS_SWIFT_MASK)
-#endif
-      {}
-
-#if SWIFT_OBJC_INTEROP
-  // Allow setting the metadata kind to a class ISA on class metadata.
-  using TargetMetadata<Runtime>::getClassISA;
-  using TargetMetadata<Runtime>::setClassISA;
-#endif
+public:
+  constexpr TargetAnyClassMetadata(TargetClassMetadata *superclass)
+      : TargetHeapMetadata<Runtime>(MetadataKind::Class),
+        Superclass(superclass) {}
 
   // Note that ObjC classes do not have a metadata header.
 
   /// The metadata for the superclass.  This is null for the root class.
-  TargetSignedPointer<Runtime, const TargetClassMetadata<Runtime> *
+  TargetSignedPointer<Runtime, const TargetClassMetadata *
                                    __ptrauth_swift_objc_superclass>
       Superclass;
 
+  /// Is this object a valid swift type metadata?  That is, can it be
+  /// safely downcast to ClassMetadata?
+  bool isTypeMetadata() const {
+    return true;
+  }
+  /// A different perspective on the same bit.
+  bool isPureObjC() const {
+    return !isTypeMetadata();
+  }
+};
+
 #if SWIFT_OBJC_INTEROP
+/// This is the class metadata object for all classes (Swift and ObjC) in a
+/// runtime that has Objective-C interoperability.
+template <typename Runtime>
+struct TargetAnyClassMetadataObjCInterop
+    : public TargetAnyClassMetadata<Runtime> {
+  using StoredPointer = typename Runtime::StoredPointer;
+  using StoredSize = typename Runtime::StoredSize;
+
+  using TargetClassMetadataObjCInterop =
+      TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
+
+  constexpr TargetAnyClassMetadataObjCInterop(
+      TargetAnyClassMetadataObjCInterop<Runtime> *isa,
+      TargetClassMetadataObjCInterop *superclass)
+      : TargetAnyClassMetadata<Runtime>(isa, superclass),
+        CacheData{nullptr, nullptr},
+        Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
+
+  constexpr TargetAnyClassMetadataObjCInterop(
+      TargetClassMetadataObjCInterop *superclass)
+      : TargetAnyClassMetadata<Runtime>(superclass), CacheData{nullptr,
+                                                               nullptr},
+        Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
+
+  // Allow setting the metadata kind to a class ISA on class metadata.
+  using TargetMetadata<Runtime>::getClassISA;
+  using TargetMetadata<Runtime>::setClassISA;
+
   /// The cache data is used for certain dynamic lookups; it is owned
   /// by the runtime and generally needs to interoperate with
   /// Objective-C's use.
@@ -1052,26 +1145,29 @@ struct TargetAnyClassMetadata : public TargetHeapMetadata<Runtime> {
   StoredSize Data;
   
   static constexpr StoredPointer offsetToData() {
-    return offsetof(TargetAnyClassMetadata, Data);
+    return offsetof(TargetAnyClassMetadataObjCInterop, Data);
   }
-#endif
 
   /// Is this object a valid swift type metadata?  That is, can it be
   /// safely downcast to ClassMetadata?
   bool isTypeMetadata() const {
-#if SWIFT_OBJC_INTEROP
     return (Data & SWIFT_CLASS_IS_SWIFT_MASK);
-#else
-    return true;
-#endif
   }
   /// A different perspective on the same bit
   bool isPureObjC() const {
     return !isTypeMetadata();
   }
 };
+
+using AnyClassMetadata =
+  TargetAnyClassMetadataObjCInterop<InProcess>;
+
+#else
+
 using AnyClassMetadata =
   TargetAnyClassMetadata<InProcess>;
+
+#endif
 
 using ClassIVarDestroyer =
   SWIFT_CC(swift) void(SWIFT_CONTEXT HeapObject *);
@@ -1082,23 +1178,28 @@ using ClassIVarDestroyer =
 ///
 /// Note that the layout of this type is compatible with the layout of
 /// an Objective-C class.
-template <typename Runtime>
-struct TargetClassMetadata : public TargetAnyClassMetadata<Runtime> {
+///
+/// If the Runtime supports Objective-C interoperability, this class inherits
+/// from TargetAnyClassMetadataObjCInterop, otherwise it inherits from
+/// TargetAnyClassMetadata.
+template <typename Runtime, typename TargetAnyClassMetadataVariant>
+struct TargetClassMetadata : public TargetAnyClassMetadataVariant {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSize = typename Runtime::StoredSize;
 
   TargetClassMetadata() = default;
-  constexpr TargetClassMetadata(const TargetAnyClassMetadata<Runtime> &base,
-             ClassFlags flags,
-             ClassIVarDestroyer *ivarDestroyer,
-             StoredPointer size, StoredPointer addressPoint,
-             StoredPointer alignMask,
-             StoredPointer classSize, StoredPointer classAddressPoint)
-    : TargetAnyClassMetadata<Runtime>(base),
-      Flags(flags), InstanceAddressPoint(addressPoint),
-      InstanceSize(size), InstanceAlignMask(alignMask),
-      Reserved(0), ClassSize(classSize), ClassAddressPoint(classAddressPoint),
-      Description(nullptr), IVarDestroyer(ivarDestroyer) {}
+  constexpr TargetClassMetadata(const TargetAnyClassMetadataVariant &base,
+                                ClassFlags flags,
+                                ClassIVarDestroyer *ivarDestroyer,
+                                StoredPointer size, StoredPointer addressPoint,
+                                StoredPointer alignMask,
+                                StoredPointer classSize,
+                                StoredPointer classAddressPoint)
+      : TargetAnyClassMetadataVariant(base), Flags(flags),
+        InstanceAddressPoint(addressPoint), InstanceSize(size),
+        InstanceAlignMask(alignMask), Reserved(0), ClassSize(classSize),
+        ClassAddressPoint(classAddressPoint), Description(nullptr),
+        IVarDestroyer(ivarDestroyer) {}
 
   // The remaining fields are valid only when isTypeMetadata().
   // The Objective-C runtime knows the offsets to some of these fields.
@@ -1150,7 +1251,7 @@ public:
   //   - class variables (if we choose to support these)
   //   - "tabulated" virtual methods
 
-  using TargetAnyClassMetadata<Runtime>::isTypeMetadata;
+  using TargetAnyClassMetadataVariant::isTypeMetadata;
 
   ConstTargetMetadataPointer<Runtime, TargetClassDescriptor>
   getDescription() const {
@@ -1350,7 +1451,18 @@ public:
     return metadata->getKind() == MetadataKind::Class;
   }
 };
-using ClassMetadata = TargetClassMetadata<InProcess>;
+#if SWIFT_OBJC_INTEROP
+using ClassMetadata =
+    TargetClassMetadata<InProcess,
+                        TargetAnyClassMetadataObjCInterop<InProcess>>;
+#else
+using ClassMetadata =
+    TargetClassMetadata<InProcess, TargetAnyClassMetadata<InProcess>>;
+#endif
+
+template <typename Runtime>
+using TargetClassMetadataObjCInterOp =
+    TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
 
 /// The structure of class metadata that's compatible with dispatch objects.
 /// This includes Swift heap metadata, followed by the vtable entries that
@@ -1398,7 +1510,7 @@ using HeapLocalVariableMetadata
 /// Swift-compiled.
 template <typename Runtime>
 struct TargetObjCClassWrapperMetadata : public TargetMetadata<Runtime> {
-  ConstTargetMetadataPointer<Runtime, TargetClassMetadata> Class;
+  ConstTargetMetadataPointer<Runtime, TargetClassMetadataObjCInterOp> Class;
 
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::ObjCClassWrapper;
@@ -2489,6 +2601,9 @@ public:
 /// A reference to a type.
 template <typename Runtime>
 struct TargetTypeReference {
+  template <typename T>
+  using TargetClassMetadata = typename T::template TargetClassMetadata<T>;
+
   union {
     /// A direct reference to a TypeContextDescriptor or ProtocolDescriptor.
     RelativeDirectPointer<TargetContextDescriptor<Runtime>>
@@ -2502,7 +2617,7 @@ struct TargetTypeReference {
     /// An indirect reference to an Objective-C class.
     RelativeDirectPointer<
         ConstTargetMetadataPointer<Runtime, TargetClassMetadata>>
-      IndirectObjCClass;
+        IndirectObjCClass;
 
     /// A direct reference to an Objective-C class name.
     RelativeDirectPointer<const char>
@@ -2529,11 +2644,11 @@ struct TargetTypeReference {
 #if SWIFT_OBJC_INTEROP
   /// If this type reference is one of the kinds that supports ObjC
   /// references,
-  const TargetClassMetadata<Runtime> *
+  const TargetClassMetadataObjCInterOp<Runtime> *
   getObjCClass(TypeReferenceKind kind) const;
 #endif
 
-  const TargetClassMetadata<Runtime> * const *
+  const TargetClassMetadataObjCInterOp<Runtime> * const *
   getIndirectObjCClass(TypeReferenceKind kind) const {
     assert(kind == TypeReferenceKind::IndirectObjCClass);
     return IndirectObjCClass.get();
@@ -2615,10 +2730,11 @@ public:
     return TypeRef.getDirectObjCClassName(getTypeKind());
   }
 
-  const TargetClassMetadata<Runtime> * const *getIndirectObjCClass() const {
+  const TargetClassMetadataObjCInterOp<Runtime> *const *
+  getIndirectObjCClass() const {
     return TypeRef.getIndirectObjCClass(getTypeKind());
   }
-  
+
   const TargetContextDescriptor<Runtime> *getTypeDescriptor() const {
     return TypeRef.getTypeDescriptor(getTypeKind());
   }

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -649,13 +649,24 @@ static RemoteASTContextImpl *createImpl(ASTContext &ctx,
                                       std::shared_ptr<MemoryReader> &&reader) {
   auto &target = ctx.LangOpts.Target;
   assert(target.isArch32Bit() || target.isArch64Bit());
+  bool objcInterop = ctx.LangOpts.EnableObjCInterop;
 
   if (target.isArch32Bit()) {
-    using Target = External<RuntimeTarget<4>>;
-    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    if (objcInterop) {
+      using Target = External<WithObjCInterop<RuntimeTarget<4>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    } else {
+      using Target = External<NoObjCInterop<RuntimeTarget<4>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    }
   } else {
-    using Target = External<RuntimeTarget<8>>;
-    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    if (objcInterop) {
+      using Target = External<WithObjCInterop<RuntimeTarget<8>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    } else {
+      using Target = External<NoObjCInterop<RuntimeTarget<8>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    }
   }
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -36,7 +36,11 @@ using namespace swift;
 using namespace swift::reflection;
 using namespace swift::remote;
 
-using Runtime = External<RuntimeTarget<sizeof(uintptr_t)>>;
+#if SWIFT_OBJC_INTEROP
+using Runtime = External<WithObjCInterop<RuntimeTarget<sizeof(uintptr_t)>>>;
+#else
+using Runtime = External<NoObjCInterOp<RuntimeTarget<sizeof(uintptr_t)>>>;
+#endif
 using NativeReflectionContext = swift::reflection::ReflectionContext<Runtime>;
 
 struct SwiftReflectionContext {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -487,9 +487,9 @@ public:
     return c;
 #endif
   }
-  
-  template<> inline const ClassMetadata *
-  Metadata::getClassObject() const {
+
+  template <>
+  inline const ClassMetadata *Metadata::getClassObject() const {
     switch (getKind()) {
     case MetadataKind::Class: {
       // Native Swift class metadata is also the class object.

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -611,14 +611,25 @@ static ReflectionContextHolder makeReflectionContextForObjectFiles(
   uint8_t pointerSize;
   Reader->queryDataLayout(DataLayoutQueryType::DLQ_GetPointerSize,
                           nullptr, &pointerSize);
-  
   switch (pointerSize) {
   case 4:
-    return makeReflectionContextForMetadataReader<External<RuntimeTarget<4>>>
-                                                            (std::move(Reader));
+    return makeReflectionContextForMetadataReader<
+    // FIXME: This could be configurable.
+#if SWIFT_OBJC_INTEROP
+        External<WithObjCInterop<RuntimeTarget<4>>>
+#else
+        External<NoObjCInterop<RuntimeTarget<4>>>
+#endif
+        >(std::move(Reader));
   case 8:
-    return makeReflectionContextForMetadataReader<External<RuntimeTarget<8>>>
-                                                            (std::move(Reader));
+    return makeReflectionContextForMetadataReader<
+    // FIXME: This could be configurable.
+#if SWIFT_OBJC_INTEROP
+        External<WithObjCInterop<RuntimeTarget<8>>>
+#else
+        External<NoObjCInterop<RuntimeTarget<8>>>
+#endif
+        >(std::move(Reader));
   default:
     fputs("unsupported word size in object file\n", stderr);
     abort();


### PR DESCRIPTION
In order to be able to debug, for example, a Linux process from a macOS host, we need to be able to initialize a ReflectionContext without Objective-C interoperability. This patch turns ObjCInterOp into another template trait, so it's possible to instantiate a non-ObjC MetadataReader on a system built with ObjC-interop (but not vice versa).

Posting this early to get feedback on my amateurish C++ templating.

rdar://87179578