### PR TITLE
[TypeChecker] NFC: Add a slow perf test related to operator `>=`

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/operator_chain_with_hetergeneous_arguments.swift
+++ b/validation-test/Sema/type_checker_perf/slow/operator_chain_with_hetergeneous_arguments.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+// TODO(performance): This should be converted in a scale test once performance issue is fixed
+func test(bytes: Int, length: UInt32) {
+  // left-hand side of `>=` is `Int` and right-hand side is a chain of `UInt32` inferred from `length`
+  _ = bytes >= 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + length
+  // expected-error@-1 {{reasonable time}}
+}


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
