### PR TITLE
Refactor OSLogOptimization utility functions into a separate file

### DIFF
--- a/include/swift/SILOptimizer/Utils/CompileTimeInterpolationUtils.h
+++ b/include/swift/SILOptimizer/Utils/CompileTimeInterpolationUtils.h
@@ -1,0 +1,46 @@
+//===--- CompileTimeInterpolationUtils.h ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Utilities for the compile-time string interpolation approach used by the
+// OSLogOptimization pass.
+
+#ifndef SWIFT_SILOPTIMIZER_COMPILE_TIME_INTERPOLATION_H
+#define SWIFT_SILOPTIMIZER_COMPILE_TIME_INTERPOLATION_H
+
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILConstants.h"
+#include "swift/SILOptimizer/Utils/ConstExpr.h"
+
+namespace swift {
+
+/// Decide if the given instruction (which could possibly be a call) should
+/// be constant evaluated.
+///
+/// \returns true iff the given instruction is not a call or if it is, it calls
+/// a known constant-evaluable function such as string append etc., or calls
+/// a function annotate as "constant_evaluable".
+bool shouldAttemptEvaluation(SILInstruction *inst);
+
+/// Skip or evaluate the given instruction based on the evaluation policy and
+/// handle errors. The policy is to evaluate all non-apply instructions as well
+/// as apply instructions that are marked as "constant_evaluable".
+std::pair<Optional<SILBasicBlock::iterator>, Optional<SymbolicValue>>
+evaluateOrSkip(ConstExprStepEvaluator &stepEval, SILBasicBlock::iterator instI);
+
+/// Given a vector of SILValues \p worklist, compute the set of transitive
+/// users of these values (excluding the worklist values) by following the
+/// use-def chain starting at value. Note that this function does not follow
+/// use-def chains though branches.
+void getTransitiveUsers(SILInstructionResultArray values,
+                        SmallVectorImpl<SILInstruction *> &users);
+} // end namespace swift
+#endif

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -76,11 +76,12 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/OptimizationMode.h"
-#include "swift/AST/SemanticAttrs.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -93,10 +94,10 @@
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/SIL/BasicBlockBits.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/CompileTimeInterpolationUtils.h"
 #include "swift/SILOptimizer/Utils/ConstExpr.h"
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
@@ -243,38 +244,6 @@ static bool isIntegerOrBoolType(SILType silType, ASTContext &astContext) {
   }
   NominalTypeDecl *nominalDecl = silType.getNominalOrBoundGenericNominal();
   return nominalDecl && isStdlibIntegerOrBoolDecl(nominalDecl, astContext);
-}
-
-/// Decide if the given instruction (which could possibly be a call) should
-/// be constant evaluated.
-///
-/// \returns true iff the given instruction is not a call or if it is, it calls
-/// a known constant-evaluable function such as string append etc., or calls
-/// a function annotate as "constant_evaluable".
-static bool shouldAttemptEvaluation(SILInstruction *inst) {
-  auto *apply = dyn_cast<ApplyInst>(inst);
-  if (!apply)
-    return true;
-  SILFunction *calleeFun = apply->getCalleeFunction();
-  if (!calleeFun)
-    return false;
-  return isConstantEvaluable(calleeFun);
-}
-
-/// Skip or evaluate the given instruction based on the evaluation policy and
-/// handle errors. The policy is to evaluate all non-apply instructions as well
-/// as apply instructions that are marked as "constant_evaluable".
-static std::pair<Optional<SILBasicBlock::iterator>, Optional<SymbolicValue>>
-evaluateOrSkip(ConstExprStepEvaluator &stepEval,
-               SILBasicBlock::iterator instI) {
-  SILInstruction *inst = &(*instI);
-
-  // Note that skipping a call conservatively approximates its effects on the
-  // interpreter state.
-  if (shouldAttemptEvaluation(inst)) {
-    return stepEval.tryEvaluateOrElseMakeEffectsNonConstant(instI);
-  }
-  return stepEval.skipByMakingEffectsNonConstant(instI);
 }
 
 /// Return true iff the given value is a stdlib Int or Bool and it not a direct
@@ -818,31 +787,6 @@ static SILValue emitCodeForSymbolicValue(SymbolicValue symVal,
   }
 }
 
-/// Given a SILValue \p value, compute the set of transitive users of the value
-/// (excluding value itself) by following the use-def chain starting at value.
-/// Note that this function does not follow use-def chains though branches.
-static void getTransitiveUsers(SILValue value,
-                               SmallVectorImpl<SILInstruction *> &users) {
-  // Collect the instructions that are data dependent on the value using a
-  // fix point iteration.
-  SmallPtrSet<SILInstruction *, 16> visitedUsers;
-  SmallVector<SILValue, 16> worklist;
-  worklist.push_back(value);
-
-  while (!worklist.empty()) {
-    SILValue currVal = worklist.pop_back_val();
-    for (Operand *use : currVal->getUses()) {
-      SILInstruction *user = use->getUser();
-      if (visitedUsers.count(user))
-        continue;
-      visitedUsers.insert(user);
-      llvm::copy(user->getResults(), std::back_inserter(worklist));
-    }
-  }
-  // At this point, visitedUsers have all the transitive, data-dependent uses.
-  users.append(visitedUsers.begin(), visitedUsers.end());
-}
-
 /// Collect the end points of the instructions that are data dependent on \c
 /// value. A instruction is data dependent on \c value if its result may
 /// transitively depends on \c value. Note that data dependencies through
@@ -853,7 +797,7 @@ static void getTransitiveUsers(SILValue value,
 /// \param endUsers buffer for storing the found end points of the data
 /// dependence chain.
 static void
-getEndPointsOfDataDependentChain(SILValue value, SILFunction *fun,
+getEndPointsOfDataDependentChain(SingleValueInstruction *value, SILFunction *fun,
                                  SmallVectorImpl<SILInstruction *> &endUsers) {
   assert(!value->getType().isAddress());
 

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(swiftSILOptimizer PRIVATE
   CanonicalizeBorrowScope.cpp
   CastOptimizer.cpp
   CheckedCastBrJumpThreading.cpp
+  CompileTimeInterpolationUtils.cpp
   ConstantFolding.cpp
   ConstExpr.cpp
   Devirtualize.cpp

--- a/lib/SILOptimizer/Utils/CompileTimeInterpolationUtils.cpp
+++ b/lib/SILOptimizer/Utils/CompileTimeInterpolationUtils.cpp
@@ -1,0 +1,60 @@
+//===--- CompileTimeInterpolationUtils.cpp -------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/CompileTimeInterpolationUtils.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/SIL/SILFunction.h"
+
+using namespace swift;
+
+bool swift::shouldAttemptEvaluation(SILInstruction *inst) {
+  auto *apply = dyn_cast<ApplyInst>(inst);
+  if (!apply)
+    return true;
+  SILFunction *calleeFun = apply->getCalleeFunction();
+  if (!calleeFun)
+    return false;
+  return isConstantEvaluable(calleeFun);
+}
+
+std::pair<Optional<SILBasicBlock::iterator>, Optional<SymbolicValue>>
+swift::evaluateOrSkip(ConstExprStepEvaluator &stepEval,
+                      SILBasicBlock::iterator instI) {
+  SILInstruction *inst = &(*instI);
+
+  // Note that skipping a call conservatively approximates its effects on the
+  // interpreter state.
+  if (shouldAttemptEvaluation(inst)) {
+    return stepEval.tryEvaluateOrElseMakeEffectsNonConstant(instI);
+  }
+  return stepEval.skipByMakingEffectsNonConstant(instI);
+}
+
+void swift::getTransitiveUsers(SILInstructionResultArray values,
+                               SmallVectorImpl<SILInstruction *> &users) {
+  // Collect the instructions that are data dependent on the value using a
+  // fix point iteration.
+  SmallPtrSet<SILInstruction *, 16> visited;
+  SmallVector<SILValue, 16> worklist;
+  llvm::copy(values, std::back_inserter(worklist));
+  while (!worklist.empty()) {
+    SILValue currVal = worklist.pop_back_val();
+    for (Operand *use : currVal->getUses()) {
+      SILInstruction *user = use->getUser();
+      if (visited.count(user))
+        continue;
+      visited.insert(user);
+      llvm::copy(user->getResults(), std::back_inserter(worklist));
+    }
+  }
+  users.append(visited.begin(), visited.end());
+}


### PR DESCRIPTION
This PR refactors some of the utility functions used by the OSLogOptimization SIL pass so that they may be used by other parts of the compiler.

Namely, this factors out:
`shouldAttemptEvaluation` - checks whether or not an instruction should be evaluated
`evaluateOrSkip` - evaluates viable instructions, skips others
`getTransitiveUsers` - computes the transitive users of a list of SILValues to get all data dependent instructions