### PR TITLE
[Distributed] A couple of improvements to `HeterogeneousBuffer` and test-cases

### DIFF
--- a/stdlib/public/Distributed/HeterogeneousBuffer.swift
+++ b/stdlib/public/Distributed/HeterogeneousBuffer.swift
@@ -73,11 +73,20 @@ struct HeterogeneousBuffer: Sequence {
         return nil
       }
 
-      func nextOffset<T>(_: T.Type) -> Int {
-        return MemoryLayout<T>.nextAlignedOffset(offset)
+      func alignedOffsetAndSize<T>(_: T.Type) -> (offset: Int, size: Int) {
+        return (MemoryLayout<T>.nextAlignedOffset(offset), MemoryLayout<T>.size)
       }
-      offset = _openExistential(hbuf.types[i], do: nextOffset)
-      i += 1
+
+      // Retrieve aligned offset and element size info
+      let info = _openExistential(hbuf.types[i], do: alignedOffsetAndSize)
+      // Adjust current offset
+      offset = info.offset
+
+      defer {
+        // Advance offset by the size of the current element
+        offset += info.size
+        i += 1
+      }
 
       return hbuf.buffer.advanced(by: offset)
     }

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -116,12 +116,13 @@ struct FakeActorSystem: DistributedActorSystem {
 struct FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
+  var substitutions: [Any.Type] = []
   var arguments: [Any] = []
   var returnType: Any.Type? = nil
   var errorType: Any.Type? = nil
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {
-    fatalError("NOT IMPLEMENTED: \(#function)")
+    substitutions.append(type)
   }
   mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws {
     arguments.append(argument)
@@ -137,7 +138,7 @@ struct FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvo
   // === Receiving / decoding -------------------------------------------------
 
   func decodeGenericSubstitutions() throws -> [Any.Type] {
-    []
+    return substitutions
   }
 
   var argumentIndex: Int = 0

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -50,8 +50,8 @@ distributed actor Greeter {
     .init(q: "question", a: 42, b: 1, c: 2.0, d: "Lorum ipsum")
   }
 
-  distributed func echo(name: String) -> String {
-    return "Echo: \(name)"
+  distributed func echo(name: String, age: Int) -> String {
+    return "Echo: name: \(name), age: \(age)"
   }
 
   distributed func enumResult() -> E {
@@ -156,7 +156,7 @@ struct FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvo
     }
 
     print("  > decode argument: \(argument)")
-    pointer.pointee = argument
+    pointer.initialize(to: argument)
     argumentIndex += 1
   }
 
@@ -190,8 +190,7 @@ let helloName = "$s4main7GreeterC5helloSSyFTE"
 let answerName = "$s4main7GreeterC6answerSiyFTE"
 let largeResultName = "$s4main7GreeterC11largeResultAA11LargeStructVyFTE"
 let enumResultName = "$s4main7GreeterC10enumResultAA1EOyFTE"
-
-let echoName = "$s4main7GreeterC4echo4nameS2S_tFTE"
+let echoName = "$s4main7GreeterC4echo4name3ageS2S_SitFTE"
 
 func test() async throws {
   let system = FakeActorSystem()
@@ -243,6 +242,7 @@ func test() async throws {
 
   var echoInvocation = system.makeInvocationEncoder()
   try echoInvocation.recordArgument("Caplin")
+  try echoInvocation.recordArgument(42)
   try echoInvocation.doneRecording()
   try await system.executeDistributedTarget(
       on: local,
@@ -250,7 +250,7 @@ func test() async throws {
       invocationDecoder: &echoInvocation,
       handler: FakeResultHandler()
   )
-  // CHECK: RETURN: Echo: Caplin
+  // CHECK: RETURN: Echo: name: Caplin, age: 42
 
   print("done")
   // CHECK-NEXT: done


### PR DESCRIPTION
- Fix iterator to advance the offset by appropriate number of bytes
- Add support of encoding/decoding substitutions in `FakeInvocation`
- Adjust `echo` test to use two arguments instead of one

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
