### PR TITLE
[Distributed] NFC: Disable remote call test on 32-bit watchOS

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -4,7 +4,9 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
-// REQUIRES: rdar87568630
+
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
