### PR TITLE
ASTMangler: Respect @_originallyDefinedIn in mangleOpaqueTypeDecl() [5.6]

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -831,9 +831,11 @@ std::string ASTMangler::mangleOpaqueTypeDecl(const OpaqueTypeDecl *decl) {
 }
 
 std::string ASTMangler::mangleOpaqueTypeDecl(const ValueDecl *decl) {
-  DWARFMangling = true;
   OptimizeProtocolNames = false;
-  return mangleDeclAsUSR(decl, MANGLING_PREFIX_STR);
+
+  beginMangling();
+  appendEntity(decl);
+  return finalize();
 }
 
 std::string ASTMangler::mangleGenericSignature(const GenericSignature sig) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2939,7 +2939,9 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
 
 OpaqueTypeDecl *ValueDecl::getOpaqueResultTypeDecl() const {
   if (getOpaqueResultTypeRepr() == nullptr) {
-    if (isa<ModuleDecl>(this))
+    if (!isa<VarDecl>(this) &&
+        !isa<FuncDecl>(this) &&
+        !isa<SubscriptDecl>(this))
       return nullptr;
     auto file = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
     // Don't look up when the decl is from source, otherwise a cycle will happen.

--- a/test/ModuleInterface/Inputs/CoreVegetable.swift
+++ b/test/ModuleInterface/Inputs/CoreVegetable.swift
@@ -1,0 +1,5 @@
+@available(macOS 10.8, *)
+@_originallyDefinedIn(module: "CoreSoup", macOS 10.10)
+public struct Vegetable {
+  public init() {}
+}

--- a/test/ModuleInterface/originally-defined-attr-opaque-result.swift
+++ b/test/ModuleInterface/originally-defined-attr-opaque-result.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/CoreVegetable.swiftinterface %S/Inputs/CoreVegetable.swift -disable-availability-checking -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/CoreChef.swiftinterface -module-name CoreChef %s -I %t -disable-availability-checking -enable-library-evolution -swift-version 5 -DLIB
+
+// RUN: %FileCheck %s < %t/CoreChef.swiftinterface
+
+// REQUIRES: OS=macosx
+import CoreVegetable
+
+public protocol Soup {}
+
+public struct VegetableSoup : Soup {}
+
+public protocol Chef {
+  associatedtype Food
+
+  func cookSoup(_: Vegetable) -> Food
+}
+
+public struct SoupChef : Chef {
+  public func cookSoup(_: Vegetable) -> some Soup { VegetableSoup() }
+}
+
+// CHECK-LABEL: public typealias Food = @_opaqueReturnTypeOf("$s8CoreChef04SoupB0V04cookC0yQr0aC09VegetableVF", 0) __


### PR DESCRIPTION
mangleOpaqueTypeDecl() used to enable DWARFMangling, which
ignores @_originallyDefinedIn, which would in turn break module
interfaces.

Fixes rdar://problem/86480663.