### PR TITLE
Add a -reflection-metadata-for-debugger-only flag that emits reflection metadata but does not link them from runtime data structures

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -87,6 +87,13 @@ enum class SwiftAsyncFramePointerKind : unsigned {
    Never,  // Don't emit Swift async extended frame info.
 };
 
+enum class ReflectionMetadataMode : unsigned {
+  None,         ///< Don't emit reflection metadata at all.
+  DebuggerOnly, ///< Emit reflection metadata for the debugger, don't link them
+                ///  into runtime metadata and don't force them to stay alive.
+  Runtime,      ///< Make reflection metadata fully available.
+};
+
 using clang::PointerAuthSchema;
 
 struct PointerAuthOptions : clang::PointerAuthOptions {
@@ -295,7 +302,7 @@ public:
   unsigned ValueNames : 1;
 
   /// Emit nominal type field metadata.
-  unsigned EnableReflectionMetadata : 1;
+  ReflectionMetadataMode ReflectionMetadata : 2;
 
   /// Emit names of struct stored properties and enum cases.
   unsigned EnableReflectionNames : 1;
@@ -419,7 +426,7 @@ public:
         LLVMLTOKind(IRGenLLVMLTOKind::None),
         SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Auto),
         HasValueNamesSetting(false),
-        ValueNames(false), EnableReflectionMetadata(true),
+        ValueNames(false), ReflectionMetadata(ReflectionMetadataMode::Runtime),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),
         ForcePublicLinkage(false), LazyInitializeClassMetadata(false),
         LazyInitializeProtocolConformances(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -455,6 +455,9 @@ def enable_anonymous_context_mangled_names :
 def disable_reflection_metadata : Flag<["-"], "disable-reflection-metadata">,
   HelpText<"Disable emission of reflection metadata for nominal types">;
 
+def reflection_metadata_for_debugger_only : Flag<["-"], "reflection-metadata-for-debugger-only">,
+  HelpText<"Emit reflection metadata for debugger only, don't make them available at runtime">;
+
 def disable_reflection_names : Flag<["-"], "disable-reflection-names">,
   HelpText<"Disable emission of names of stored properties and enum cases in"
            "reflection metadata">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2043,8 +2043,13 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   }
 
   if (Args.hasArg(OPT_disable_reflection_metadata)) {
-    Opts.EnableReflectionMetadata = false;
+    Opts.ReflectionMetadata = ReflectionMetadataMode::None;
     Opts.EnableReflectionNames = false;
+  }
+
+  if (Args.hasArg(OPT_reflection_metadata_for_debugger_only)) {
+    Opts.ReflectionMetadata = ReflectionMetadataMode::DebuggerOnly;
+    Opts.EnableReflectionNames = true;
   }
 
   if (Args.hasArg(OPT_enable_anonymous_context_mangled_names))

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1488,11 +1488,12 @@ namespace {
     void maybeAddResilientSuperclass() { }
 
     void addReflectionFieldDescriptor() {
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata) {
+      if (IGM.IRGen.Opts.ReflectionMetadata !=
+          ReflectionMetadataMode::Runtime) {
         B.addInt32(0);
         return;
       }
-    
+
       IGM.IRGen.noteUseOfFieldDescriptor(getType());
 
       B.addRelativeAddress(IGM.getAddrOfReflectionFieldDescriptor(
@@ -1566,7 +1567,8 @@ namespace {
     void maybeAddResilientSuperclass() { }
 
     void addReflectionFieldDescriptor() {
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata) {
+      if (IGM.IRGen.Opts.ReflectionMetadata !=
+          ReflectionMetadataMode::Runtime) {
         B.addInt32(0);
         return;
       }
@@ -1723,7 +1725,8 @@ namespace {
     void addReflectionFieldDescriptor() {
       // Classes are always reflectable, unless reflection is disabled or this
       // is a foreign class.
-      if (!IGM.IRGen.Opts.EnableReflectionMetadata ||
+      if ((IGM.IRGen.Opts.ReflectionMetadata !=
+           ReflectionMetadataMode::Runtime) ||
           getType()->isForeign()) {
         B.addInt32(0);
         return;

--- a/test/IRGen/reflection-metadata-for-debugger-only.swift
+++ b/test/IRGen/reflection-metadata-for-debugger-only.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name main %s -emit-ir | %FileCheck %s --check-prefix=CHECK-REFL
+// RUN: %target-swift-frontend -module-name main %s -emit-ir -reflection-metadata-for-debugger-only | %FileCheck %s --check-prefix=CHECK-REFLDEBUG
+// RUN: %target-swift-frontend -module-name main %s -emit-ir -disable-reflection-metadata | %FileCheck %s --check-prefix=CHECK-NOREFL
+
+public class Generic<T> {
+  public func m1(t: T) -> T { return t }
+  public func m2(t: T) -> T { return t }
+}
+
+protocol MyProtocol {
+  associatedtype T
+  func foo() -> T
+}
+
+public struct MyStruct<T>: MyProtocol {
+  func foo() -> T { fatalError() }
+}
+
+// CHECK-REFL: @"$s4main8MyStructVyxGAA0B8ProtocolAAMA"
+// CHECK-REFL: @"$s4main7GenericCMn" = {{.*}} @"$s4main7GenericCMF" {{.*}}
+// CHECK-REFL: @"$s4main7GenericCMF" =
+// CHECK-REFL: @"$s4main10MyProtocol_pMF" =
+// CHECK-REFL: @"$s4main8MyStructVMn" = {{.*}} @"$s4main8MyStructVMF" {{.*}}
+// CHECK-REFL: @"$s4main8MyStructVMF" =
+
+// CHECK-REFLDEBUG-NOT: @"$s4main8MyStructVyxGAA0B8ProtocolAAMA"
+// CHECK-REFLDEBUG: @"$s4main7GenericCMn" =
+// CHECK-REFLDEBUG-NOT: @"$s4main7GenericCMF"
+// CHECK-REFLDEBUG-SAME: , align 4
+// CHECK-REFLDEBUG: @"$s4main7GenericCMF" =
+// CHECK-REFLDEBUG: @"$s4main10MyProtocol_pMF" =
+// CHECK-REFLDEBUG: @"$s4main8MyStructVMn" =
+// CHECK-REFLDEBUG-NOT: @"$s4main8MyStructVMF"
+// CHECK-REFLDEBUG-SAME: , align 4
+// CHECK-REFLDEBUG: @"$s4main8MyStructVMF" =
+
+// CHECK-NOREFL-NOT: @"$s4main8MyStructVyxGAA0B8ProtocolAAMA"
+// CHECK-NOREFL-NOT: @"$s4main10MyProtocol_pMF"
+// CHECK-NOREFL-NOT: @"$s4main7GenericCMF"
+// CHECK-NOREFL-NOT: @"$s4main8MyStructVMF"


### PR DESCRIPTION
Currently, the compiler can avoid emitting reflection metadata with -disable-reflection-metadata flag. The interesting goal of this is that this reduces binary size, as the reflection record (field names, etc.) are not present. Unfortunately, this also basically breaks all debugging. This PR introduces a "middle option" -- the compiler emits the reflection metadata that is consumed by the compiler, but those records are not linked/referenced from the runtime metadata records, therefore they can be captured as a separate build step, and then stripped by the linker (they are unreferenced by anything). That's that this new -reflection-metadata-for-debugger-only flag does.