### PR TITLE
[5.6] ABI checker: check validity of extended nominals before continue

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1906,10 +1906,11 @@ void SwiftDeclCollector::lookupVisibleDecls(ArrayRef<ModuleDecl *> Modules) {
   for (auto *D: KnownDecls) {
     if (auto *Ext = dyn_cast<ExtensionDecl>(D)) {
       if (HandledExtensions.find(Ext) == HandledExtensions.end()) {
-        auto *NTD = Ext->getExtendedNominal();
-        // Check if the extension is from other modules.
-        if (!llvm::is_contained(Modules, NTD->getModuleContext())) {
-          ExtensionMap[NTD].push_back(Ext);
+        if (auto *NTD = Ext->getExtendedNominal()) {
+          // Check if the extension is from other modules.
+          if (!llvm::is_contained(Modules, NTD->getModuleContext())) {
+            ExtensionMap[NTD].push_back(Ext);
+          }
         }
       }
     }


### PR DESCRIPTION
Radar: rdar://87150470
Description: Fix an ABI checker crash on invalid code due to missing extended type pointer from an extension declaration.
Risk: Low
Testing: PR testing
Original PR: https://github.com/apple/swift/pull/40785
Reviewer: @xymus 