### PR TITLE
stubs: avoid reaching up-tree, prefer inclusion options

### DIFF
--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -13,7 +13,7 @@
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Portability.h"
-#include "../SwiftShims/AssertionReporting.h"
+#include "SwiftShims/AssertionReporting.h"
 #include <cstdarg>
 #include <cstdint>
 #include <stdio.h>

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -20,7 +20,7 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Debug.h"
 #include <TargetConditionals.h>
-#include "../SwiftShims/FoundationShims.h"
+#include "SwiftShims/FoundationShims.h"
 
 struct os_system_version_s {
     unsigned int major;

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -26,7 +26,7 @@ set(LLVM_OPTIONAL_SOURCES
 
 set(swift_stubs_c_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
-list(APPEND swift_stubs_c_compile_flags -I${SWIFT_SOURCE_DIR}/include)
+list(APPEND swift_stubs_c_compile_flags -I${SWIFT_SOURCE_DIR}/include -I${SWIFT_SOURCE_DIR}/stdlib/public)
 
 add_swift_target_library(swiftStdlibStubs
                   OBJECT_LIBRARY

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -20,7 +20,7 @@
 
 #if SWIFT_OBJC_INTEROP
 #import <CoreFoundation/CoreFoundation.h>
-#include "../SwiftShims/CoreFoundationShims.h"
+#include "SwiftShims/CoreFoundationShims.h"
 #import <objc/runtime.h>
 #include "swift/Runtime/Once.h"
 #include <dlfcn.h>

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -16,8 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../SwiftShims/GlobalObjects.h"
-#include "../SwiftShims/Random.h"
+#include "SwiftShims/GlobalObjects.h"
+#include "SwiftShims/Random.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/EnvironmentVariables.h"

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -29,7 +29,7 @@
 
 #include <type_traits>
 
-#include "../SwiftShims/LibcShims.h"
+#include "SwiftShims/LibcShims.h"
 
 #if defined(_WIN32)
 static void __attribute__((__constructor__))

--- a/stdlib/public/stubs/MathStubs.cpp
+++ b/stdlib/public/stubs/MathStubs.cpp
@@ -16,7 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../SwiftShims/Visibility.h"
+#include "SwiftShims/Visibility.h"
 
 #include <climits>
 #include <cstdlib>

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -39,7 +39,7 @@
 
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Mutex.h"
-#include "../SwiftShims/Random.h"
+#include "SwiftShims/Random.h"
 
 #include <algorithm> // required for std::min
 

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -72,9 +72,9 @@
 #include "swift/Runtime/SwiftDtoa.h"
 #include "swift/Basic/Lazy.h"
 
-#include "../SwiftShims/LibcShims.h"
-#include "../SwiftShims/RuntimeShims.h"
-#include "../SwiftShims/RuntimeStubs.h"
+#include "SwiftShims/LibcShims.h"
+#include "SwiftShims/RuntimeShims.h"
+#include "SwiftShims/RuntimeStubs.h"
 
 #include "llvm/ADT/StringExtras.h"
 

--- a/stdlib/public/stubs/ThreadLocalStorage.cpp
+++ b/stdlib/public/stubs/ThreadLocalStorage.cpp
@@ -12,7 +12,7 @@
 
 #include <cstring>
 
-#include "../SwiftShims/ThreadLocalStorage.h"
+#include "SwiftShims/ThreadLocalStorage.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/ThreadLocalStorage.h"

--- a/stdlib/public/stubs/Unicode/Apple/NormalizationData.h
+++ b/stdlib/public/stubs/Unicode/Apple/NormalizationData.h
@@ -16,7 +16,7 @@
 #ifndef NORMALIZATION_DATA_H
 #define NORMALIZATION_DATA_H
 
-#include "../SwiftShims/SwiftStdint.h"
+#include "SwiftShims/SwiftStdint.h"
 
 static const __swift_uint16_t _swift_stdlib_normData_data[66] = {
   0x4, 0x358, 0xA0, 0x50, 0x6C0, 0x44, 0x80, 0x48, 0x720, 0x3, 0x733, 0x88, 0xC8, 0x3C, 0xD0, 0xF0,

--- a/stdlib/public/stubs/Unicode/Apple/ScalarPropsData.h
+++ b/stdlib/public/stubs/Unicode/Apple/ScalarPropsData.h
@@ -16,7 +16,7 @@
 #ifndef SCALAR_PROP_DATA_H
 #define SCALAR_PROP_DATA_H
 
-#include "../SwiftShims/SwiftStdint.h"
+#include "SwiftShims/SwiftStdint.h"
 
 #define BIN_PROPS_COUNT 4874
 

--- a/stdlib/public/stubs/Unicode/Common/GraphemeData.h
+++ b/stdlib/public/stubs/Unicode/Common/GraphemeData.h
@@ -16,7 +16,7 @@
 #ifndef GRAPHEME_DATA_H
 #define GRAPHEME_DATA_H
 
-#include "../SwiftShims/SwiftStdint.h"
+#include "SwiftShims/SwiftStdint.h"
 
 #define GRAPHEME_BREAK_DATA_COUNT 621
 

--- a/stdlib/public/stubs/Unicode/Common/NormalizationData.h
+++ b/stdlib/public/stubs/Unicode/Common/NormalizationData.h
@@ -16,7 +16,7 @@
 #ifndef NORMALIZATION_DATA_H
 #define NORMALIZATION_DATA_H
 
-#include "../SwiftShims/SwiftStdint.h"
+#include "SwiftShims/SwiftStdint.h"
 
 static const __swift_uint16_t _swift_stdlib_normData_data[66] = {
   0x110, 0x70, 0x3B0, 0x8, 0x750, 0x78, 0x6C4, 0x410, 0x6E0, 0x60, 0x734, 0x784,

--- a/stdlib/public/stubs/Unicode/Common/ScalarPropsData.h
+++ b/stdlib/public/stubs/Unicode/Common/ScalarPropsData.h
@@ -16,7 +16,7 @@
 #ifndef SCALAR_PROP_DATA_H
 #define SCALAR_PROP_DATA_H
 
-#include "../SwiftShims/SwiftStdint.h"
+#include "SwiftShims/SwiftStdint.h"
 
 #define BIN_PROPS_COUNT 4855
 

--- a/stdlib/public/stubs/Unicode/UnicodeData.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeData.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "../SwiftShims/UnicodeData.h"
+#include "SwiftShims/UnicodeData.h"
 #include <limits>
 
 // Every 4 byte chunks of data that we need to hash (in this case only ever

--- a/stdlib/public/stubs/Unicode/UnicodeGrapheme.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeGrapheme.cpp
@@ -15,7 +15,7 @@
 #else
 #include "swift/Runtime/Debug.h"
 #endif
-#include "../SwiftShims/UnicodeData.h"
+#include "SwiftShims/UnicodeData.h"
 #include <limits>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL

--- a/stdlib/public/stubs/Unicode/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeNormalization.cpp
@@ -22,7 +22,7 @@
 #include "swift/Runtime/Debug.h"
 #endif
 
-#include "../SwiftShims/UnicodeData.h"
+#include "SwiftShims/UnicodeData.h"
 #include <limits>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL

--- a/stdlib/public/stubs/Unicode/UnicodeScalarProps.cpp
+++ b/stdlib/public/stubs/Unicode/UnicodeScalarProps.cpp
@@ -22,7 +22,7 @@
 #include "swift/Runtime/Debug.h"
 #endif
 
-#include "../SwiftShims/UnicodeData.h"
+#include "SwiftShims/UnicodeData.h"
 #include <limits>
 
 SWIFT_RUNTIME_STDLIB_INTERNAL


### PR DESCRIPTION
This removes the explicit tree structure reference in the stubs to
locate the shims.  Instead, it expects that the `SwiftShims` directory
will be added to the header search path.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
