### PR TITLE
Don't build arm64e slices of the back-deployed libswift_Concurrency.dylib

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -25,6 +25,10 @@ include(AddSwiftStdlib)
 list(REMOVE_ITEM SWIFT_SDK_IOS_ARCHITECTURES "armv7" "armv7s")
 list(REMOVE_ITEM SWIFT_SDK_IOS_SIMULATOR_ARCHITECTURES "i386")
 
+# Don't build the libraries for arm64e; it's not a stable ABI.
+list(REMOVE_ITEM SWIFT_SDK_IOS_ARCHITECTURES "arm64e")
+list(REMOVE_ITEM SWIFT_SDK_OSX_ARCHITECTURES "arm64e")
+
 # The back-deployed library can only be shared.
 list(APPEND SWIFT_STDLIB_LIBRARY_BUILD_TYPES SHARED)
 


### PR DESCRIPTION
The arm64e ABI is not stable, so there is no reason to build or ship
arm64e slices of the back-deployed libswift_Concurrency.dylib. Moreover,
these slices interact poorly with bitcode_strip tool, resulting in
a shared library that iOS will refuse to load in certain circumstances.

Fixes rdar://85752735 / FB9780976.

Thank you to Jay Muthialu and Keith Smiley for helping debug this issue!
