### PR TITLE
Remove constexpr-if from runtime

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -881,7 +881,7 @@ private:
     auto *newElements = ElementStorage::allocate(newCapacity);
 
     if (elements) {
-      if constexpr (std::is_trivially_copyable<ElemTy>::value) {
+      if (std::is_trivially_copyable<ElemTy>::value) {
         memcpy(newElements->data(), elements->data(),
                elementCount * sizeof(ElemTy));
       } else {


### PR DESCRIPTION
constexpr-if is a C++17 feature. Swift is C++14, so this results in a
lot of warnings. Clang is smart enough that the constant propagation
will elide the unused side of the branch anyway. Since we're doing a
template check on a type, we should always have enough information at
compile to elide. We would need a constexpr/std::enable_if-level
approach if the API's were different to tell clang not to look at one
side of the branch. That's not the case here so we can let the optimizer
do it's thing and let clang look at both sides.