### PR TITLE
[cxx-interop] Fix linker errors when using std-vector.

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -40,6 +40,7 @@ public:
         isa<clang::VarDecl>(DRE->getDecl())) {
       callback(DRE->getDecl());
     }
+
     return true;
   }
 
@@ -56,6 +57,17 @@ public:
     callback(CXXCE->getConstructor());
     return true;
   }
+
+  bool VisitVarDecl(clang::VarDecl *VD) {
+    if (auto cxxRecord = VD->getType()->getAsCXXRecordDecl())
+      if (auto dtor = cxxRecord->getDestructor())
+        callback(dtor);
+
+    return true;
+  }
+
+  bool shouldVisitTemplateInstantiations() const { return true; }
+  bool shouldVisitImplicitCode() const { return true; }
 };
 
 // If any (re)declaration of `decl` contains executable code, returns that
@@ -65,6 +77,11 @@ public:
 // the initializer of the variable.
 clang::Decl *getDeclWithExecutableCode(clang::Decl *decl) {
   if (auto fd = dyn_cast<clang::FunctionDecl>(decl)) {
+    // If this is a potentially not-yet-instanciated template, we might
+    // still have a body.
+    if (fd->getTemplateInstantiationPattern())
+      return fd;
+
     const clang::FunctionDecl *definition;
     if (fd->hasBody(definition)) {
       return const_cast<clang::FunctionDecl *>(definition);
@@ -100,7 +117,7 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
   SmallVector<const clang::Decl *, 8> stack;
   stack.push_back(decl);
 
-  ClangDeclFinder refFinder([&](const clang::Decl *D) {
+  auto callback = [&](const clang::Decl *D) {
     for (auto *DC = D->getDeclContext();; DC = DC->getParent()) {
       // Check that this is not a local declaration inside a function.
       if (DC->isFunctionOrMethod()) {
@@ -117,14 +134,46 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
     if (!GlobalClangDecls.insert(D->getCanonicalDecl()).second) {
       return;
     }
+
     stack.push_back(D);
-  });
+  };
+
+  ClangDeclFinder refFinder(callback);
 
   while (!stack.empty()) {
     auto *next = const_cast<clang::Decl *>(stack.pop_back_val());
+
+    // If a function calls another method in a class template specialization, we
+    // need to instantiate that other function. Do that here.
+    if (auto *fn = dyn_cast<clang::FunctionDecl>(next)) {
+      // Make sure that this method is part of a class template specialization.
+      if (fn->getTemplateInstantiationPattern())
+        Context.getClangModuleLoader()
+            ->getClangSema()
+            .InstantiateFunctionDefinition(fn->getLocation(), fn);
+    }
+
     if (clang::Decl *executableDecl = getDeclWithExecutableCode(next)) {
         refFinder.TraverseDecl(executableDecl);
         next = executableDecl;
+    }
+
+    // Unfortunately, implicitly defined CXXDestructorDecls don't have a real
+    // body, so we need to traverse these manually.
+    if (auto *dtor = dyn_cast<clang::CXXDestructorDecl>(next)) {
+      auto cxxRecord = dtor->getParent();
+
+      for (auto field : cxxRecord->fields()) {
+        if (auto fieldCxxRecord = field->getType()->getAsCXXRecordDecl())
+          if (auto *fieldDtor = fieldCxxRecord->getDestructor())
+            callback(fieldDtor);
+      }
+
+      for (auto base : cxxRecord->bases()) {
+        if (auto baseCxxRecord = base.getType()->getAsCXXRecordDecl())
+          if (auto *baseDtor = baseCxxRecord->getDestructor())
+            callback(baseDtor);
+      }
     }
 
     if (auto var = dyn_cast<clang::VarDecl>(next))
@@ -133,15 +182,7 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
     if (isa<clang::FieldDecl>(next)) {
       continue;
     }
-    // If a method calls another method in a class template specialization, we
-    // need to instantiate that other method. Do that here.
-    if (auto *method = dyn_cast<clang::CXXMethodDecl>(next)) {
-      // Make sure that this method is part of a class template specialization.
-      if (method->getTemplateInstantiationPattern())
-        Context.getClangModuleLoader()
-            ->getClangSema()
-            .InstantiateFunctionDefinition(method->getLocation(), method);
-    }
+
     ClangCodeGen->HandleTopLevelDecl(clang::DeclGroupRef(next));
   }
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -468,6 +468,10 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
 
   if (ObjCInterop)
     this->addLinkLibrary(LinkLibrary("objc", LibraryKind::Library));
+
+  // Automatically with libc++ when possible.
+  if (Context.LangOpts.EnableCXXInterop && Context.LangOpts.Target.isOSDarwin())
+    this->addLinkLibrary(LinkLibrary("c++", LibraryKind::Library));
   
   // FIXME: It'd be better to have the driver invocation or build system that
   // executes the linker introduce these compatibility libraries, since at

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -81,12 +81,7 @@ static clang::CXXDestructorDecl *getCXXDestructor(SILType type) {
       dyn_cast<clang::CXXRecordDecl>(structDecl->getClangDecl());
   if (!cxxRecordDecl)
     return nullptr;
-  for (auto member : cxxRecordDecl->methods()) {
-    if (auto dest = dyn_cast<clang::CXXDestructorDecl>(member)) {
-      return dest;
-    }
-  }
-  return nullptr;
+  return cxxRecordDecl->getDestructor();
 }
 
 namespace {

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -1,0 +1,3 @@
+module StdVector {
+  header "std-vector.h"
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -1,0 +1,10 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H
+
+#include <vector>
+
+using Vector = std::vector<int>;
+
+inline Vector initVector() { return {}; }
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,0 +1,61 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -lc++)
+//
+// REQUIRES: executable_test
+//
+// Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
+// REQUIRES: OS=macosx
+
+import StdlibUnittest
+import StdVector
+import std.vector
+
+var StdVectorTestSuite = TestSuite("StdVector")
+
+extension Vector : RandomAccessCollection {
+  public var startIndex: Int { 0 }
+  public var endIndex: Int { size() }
+}
+
+StdVectorTestSuite.test("init") {
+    let v = Vector()
+    expectEqual(v.size(), 0)
+    expectTrue(v.empty())
+}
+
+StdVectorTestSuite.test("push back") {
+    var v = Vector()
+    var _42: CInt = 42
+    v.push_back(&_42)
+    expectEqual(v.size(), 1)
+    expectFalse(v.empty())
+    expectEqual(v[0], 42)
+}
+
+func fill(vector v: inout Vector) {
+    var _1: CInt = 1, _2: CInt = 2, _3: CInt = 3
+    v.push_back(&_1)
+    v.push_back(&_2)
+    v.push_back(&_3)
+}
+
+StdVectorTestSuite.test("for loop") {
+    var v = Vector()
+    fill(vector: &v)
+
+    var count: CInt = 1
+    for e in v {
+        expectEqual(e, count)
+        count += 1
+    }
+    expectEqual(count, 4)
+}
+
+StdVectorTestSuite.test("map") {
+    var v = Vector()
+    fill(vector: &v)
+
+    let a = v.map { $0 + 5 }
+    expectEqual(a, [6, 7, 8])
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -lc++)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/templates/Inputs/define-referenced-inline.h
+++ b/test/Interop/Cxx/templates/Inputs/define-referenced-inline.h
@@ -1,0 +1,56 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFINE_REFERENCED_INLINE_TYPES_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFINE_REFERENCED_INLINE_TYPES_H
+
+template <class T>
+inline void inlineFn1(T) { }
+
+template <class T>
+inline void inlineFn2(T) { }
+
+inline void inlineFn3() { }
+
+template<class T>
+struct HasInlineDtor {
+  inline ~HasInlineDtor() { inlineFn1(T()); }
+};
+
+template<class T>
+struct CtorCallsInlineFn {
+  CtorCallsInlineFn(T x) { inlineFn2(x); }
+};
+
+template<class T>
+struct HasInlineStaticMember {
+  inline static void member() { inlineFn3(); }
+};
+
+template<class T>
+struct ChildWithInlineCtorDtor1 {
+  inline ChildWithInlineCtorDtor1() { HasInlineStaticMember<T>::member(); }
+  inline ~ChildWithInlineCtorDtor1() { HasInlineStaticMember<T>::member(); }
+};
+
+template<class T>
+struct ChildWithInlineCtorDtor2 {
+  inline ChildWithInlineCtorDtor2() { HasInlineStaticMember<T>::member(); }
+  inline ~ChildWithInlineCtorDtor2() { HasInlineStaticMember<T>::member(); }
+};
+
+template<class T>
+struct ParentWithChildWithInlineCtorDtor : ChildWithInlineCtorDtor1<T> {};
+
+template<class T>
+struct HolderWithChildWithInlineCtorDtor {
+  ChildWithInlineCtorDtor2<T> x;
+};
+
+template<class T>
+struct DtorCallsInlineMethod {
+  inline void unique_name() {}
+
+  ~DtorCallsInlineMethod() {
+    unique_name();
+  }
+};
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFINE_REFERENCED_INLINE_TYPES_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -127,3 +127,8 @@ module TemplateTypeParameterNotInSignature {
   header "template-type-parameter-not-in-signature.h"
   requires cplusplus
 }
+
+module DefineReferencedInline {
+  header "define-referenced-inline.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/define-referenced-inline.swift
+++ b/test/Interop/Cxx/templates/define-referenced-inline.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-exceptions)
+//
+// REQUIRES: executable_test
+//
+// Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
+// REQUIRES: OS=macosx
+
+import DefineReferencedInline
+import StdlibUnittest
+
+var TemplatesTestSuite = TestSuite("TemplatesTestSuite")
+
+TemplatesTestSuite.test("tests") {
+  let a = CtorCallsInlineFn<CInt>(0)
+  let b = HasInlineDtor<CInt>()
+  let c = ParentWithChildWithInlineCtorDtor<CInt>()
+  let d = HolderWithChildWithInlineCtorDtor<CInt>()
+  let e = DtorCallsInlineMethod<CInt>()
+}
+
+runAllTests()


### PR DESCRIPTION
Adds tests for using std-vector and some other interesting types.

This patch fixes four mis conceptions that the compiler was previously making:
1. Implicit destructors have no side effects. (Yes, this means we were not cleaning up some objects.)
2. Implicit destructors have bodies. (Technically they do, but the body doesn't include CallExprs that they make when lowered to IR.)
3. Functions other than methods can be uninstantiated templates. 
4. Uninstantiated templates may have executable code. (I.e., we can never take the fast path.)