### PR TITLE
[SE-327] Remove redundant global-actor isolation.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3538,6 +3538,14 @@ public:
   /// Whether this nominal type qualifies as any actor (plain or distributed).
   bool isAnyActor() const;
 
+  /// Whether this nominal type corresponds to a language-level value type
+  /// (i.e., structs and enums), meaning that a shallow copy is created when
+  /// reassigning an instance member of the type. That is in contrast with
+  /// reference types like classes and actors, where such mutations are
+  /// reflected for all instance holders. A protocol is not considered a
+  /// value type, even though their conformers might be a value type.
+  bool isValueType() const;
+
   /// Return the range of semantics attributes attached to this NominalTypeDecl.
   auto getSemanticsAttrs() const
       -> decltype(getAttrs().getSemanticsAttrs()) {
@@ -5237,6 +5245,10 @@ public:
 
   /// Is this an "async let" property?
   bool isAsyncLet() const;
+
+  /// Is this a stored property that will _not_ trigger any user-defined code
+  /// upon any kind of access?
+  bool isOrdinaryStoredProperty() const;
 
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3538,14 +3538,6 @@ public:
   /// Whether this nominal type qualifies as any actor (plain or distributed).
   bool isAnyActor() const;
 
-  /// Whether this nominal type corresponds to a language-level value type
-  /// (i.e., structs and enums), meaning that a shallow copy is created when
-  /// reassigning an instance member of the type. That is in contrast with
-  /// reference types like classes and actors, where such mutations are
-  /// reflected for all instance holders. A protocol is not considered a
-  /// value type, even though their conformers might be a value type.
-  bool isValueType() const;
-
   /// Return the range of semantics attributes attached to this NominalTypeDecl.
   auto getSemanticsAttrs() const
       -> decltype(getAttrs().getSemanticsAttrs()) {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4573,6 +4573,9 @@ ERROR(distributed_actor_remote_func_implemented_manually,none,
 ERROR(nonisolated_distributed_actor_storage,none,
       "'nonisolated' can not be applied to distributed actor stored properties",
       ())
+ERROR(nonisolated_storage_value_type,none,
+      "'nonisolated' is redundant on %0's stored properties",
+      (DescriptiveDeclKind))
 ERROR(distributed_actor_func_nonisolated, none,
       "cannot declare method %0 as both 'nonisolated' and 'distributed'",
       (DeclName))
@@ -4773,6 +4776,9 @@ ERROR(global_actor_on_actor_class,none,
       "actor %0 cannot have a global actor", (Identifier))
 ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
+ERROR(global_actor_on_storage_of_value_type,none,
+      "stored property %0 within %1 cannot have a global actor",
+      (DeclName, DescriptiveDeclKind))
 ERROR(global_actor_non_unsafe_init,none,
       "global actor attribute %0 argument can only be '(unsafe)'", (Type))
 ERROR(global_actor_non_final_class,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4286,10 +4286,6 @@ bool NominalTypeDecl::isAnyActor() const {
   return isActor() || isDistributedActor();
 }
 
-bool NominalTypeDecl::isValueType() const {
-  return isa<StructDecl>(this) || isa<EnumDecl>(this);
-}
-
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,
                                  Identifier name, SourceLoc nameLoc,
                                  ArrayRef<InheritedEntry> inherited,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4286,6 +4286,10 @@ bool NominalTypeDecl::isAnyActor() const {
   return isActor() || isDistributedActor();
 }
 
+bool NominalTypeDecl::isValueType() const {
+  return isa<StructDecl>(this) || isa<EnumDecl>(this);
+}
+
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,
                                  Identifier name, SourceLoc nameLoc,
                                  ArrayRef<InheritedEntry> inherited,
@@ -6278,6 +6282,16 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
 
 bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>();
+}
+
+bool VarDecl::isOrdinaryStoredProperty() const {
+  // we assume if it hasAttachedPropertyWrapper, it has no storage.
+  //
+  // also, we don't expect someone to call this on a local property, so for
+  // efficiency we don't check if it's not async-let. feel free to promote
+  // the assert into a full-fledged part of the condition if needed.
+  assert(!isAsyncLet());
+  return hasStorage() && !hasObservers();
 }
 
 void ParamDecl::setSpecifier(Specifier specifier) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5629,8 +5629,8 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
           return;
         }
 
-        // 'nonisolated' is redundant for the stored properties of a value type.
-        if (nominal->isValueType() && !var->isStatic() &&
+        // 'nonisolated' is redundant for the stored properties of a struct.
+        if (isa<StructDecl>(nominal) && !var->isStatic() &&
             var->isOrdinaryStoredProperty()) {
           diagnoseAndRemoveAttr(attr, diag::nonisolated_storage_value_type,
                                 nominal->getDescriptiveKind())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5630,8 +5630,10 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
         }
 
         // 'nonisolated' is redundant for the stored properties of a struct.
-        if (isa<StructDecl>(nominal) && !var->isStatic() &&
-            var->isOrdinaryStoredProperty()) {
+        if (isa<StructDecl>(nominal) &&
+            !var->isStatic() &&
+            var->isOrdinaryStoredProperty() &&
+            !isWrappedValueOfPropWrapper(var)) {
           diagnoseAndRemoveAttr(attr, diag::nonisolated_storage_value_type,
                                 nominal->getDescriptiveKind())
             .warnUntilSwiftVersion(6);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -359,7 +359,7 @@ GlobalActorAttributeRequest::evaluate(
       // ... and not if it's the instance storage of a struct
       if (!var->isStatic() && var->isOrdinaryStoredProperty()) {
         if (auto *nominal = var->getDeclContext()->getSelfNominalTypeDecl()) {
-          if (isa<StructDecl>(nominal)) {
+          if (isa<StructDecl>(nominal) && !isWrappedValueOfPropWrapper(var)) {
 
             var->diagnose(diag::global_actor_on_storage_of_value_type,
                           var->getName(), nominal->getDescriptiveKind())
@@ -3631,7 +3631,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
         if (!var->isStatic() && var->isOrdinaryStoredProperty())
           if (auto *varDC = var->getDeclContext())
             if (auto *nominal = varDC->getSelfNominalTypeDecl())
-              if (isa<StructDecl>(nominal))
+              if (isa<StructDecl>(nominal) && !isWrappedValueOfPropWrapper(var))
                 return ActorIsolation::forUnspecified();
 
       auto typeExpr = TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3627,12 +3627,14 @@ ActorIsolation ActorIsolationRequest::evaluate(
     case ActorIsolation::GlobalActorUnsafe:
     case ActorIsolation::GlobalActor: {
       // Stored properties of a struct don't need global-actor isolation.
-      if (auto *var = dyn_cast<VarDecl>(value))
-        if (!var->isStatic() && var->isOrdinaryStoredProperty())
-          if (auto *varDC = var->getDeclContext())
-            if (auto *nominal = varDC->getSelfNominalTypeDecl())
-              if (isa<StructDecl>(nominal) && !isWrappedValueOfPropWrapper(var))
-                return ActorIsolation::forUnspecified();
+      if (ctx.isSwiftVersionAtLeast(6))
+        if (auto *var = dyn_cast<VarDecl>(value))
+          if (!var->isStatic() && var->isOrdinaryStoredProperty())
+            if (auto *varDC = var->getDeclContext())
+              if (auto *nominal = varDC->getSelfNominalTypeDecl())
+                if (isa<StructDecl>(nominal) &&
+                    !isWrappedValueOfPropWrapper(var))
+                  return ActorIsolation::forUnspecified();
 
       auto typeExpr = TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);
       auto attr = CustomAttr::create(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -360,11 +360,15 @@ GlobalActorAttributeRequest::evaluate(
       if (!var->isStatic() && var->isOrdinaryStoredProperty()) {
         if (auto *nominal = var->getDeclContext()->getSelfNominalTypeDecl()) {
           if (nominal->isValueType()) {
+
             var->diagnose(diag::global_actor_on_storage_of_value_type,
                           var->getName(), nominal->getDescriptiveKind())
               .highlight(globalActorAttr->getRangeWithAt())
               .warnUntilSwiftVersion(6);
-            return None;
+
+            // In Swift 6, once the diag above is an error, it is disallowed.
+            if (var->getASTContext().isSwiftVersionAtLeast(6))
+              return None;
           }
         }
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -356,10 +356,10 @@ GlobalActorAttributeRequest::evaluate(
         return None;
       }
 
-      // ... and not if it's the instance storage of a value type
+      // ... and not if it's the instance storage of a struct
       if (!var->isStatic() && var->isOrdinaryStoredProperty()) {
         if (auto *nominal = var->getDeclContext()->getSelfNominalTypeDecl()) {
-          if (nominal->isValueType()) {
+          if (isa<StructDecl>(nominal)) {
 
             var->diagnose(diag::global_actor_on_storage_of_value_type,
                           var->getName(), nominal->getDescriptiveKind())
@@ -3626,12 +3626,12 @@ ActorIsolation ActorIsolationRequest::evaluate(
 
     case ActorIsolation::GlobalActorUnsafe:
     case ActorIsolation::GlobalActor: {
-      // Stored properties of a value type don't need global-actor isolation.
+      // Stored properties of a struct don't need global-actor isolation.
       if (auto *var = dyn_cast<VarDecl>(value))
         if (!var->isStatic() && var->isOrdinaryStoredProperty())
           if (auto *varDC = var->getDeclContext())
             if (auto *nominal = varDC->getSelfNominalTypeDecl())
-              if (nominal->isValueType())
+              if (isa<StructDecl>(nominal))
                 return ActorIsolation::forUnspecified();
 
       auto typeExpr = TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -799,3 +799,14 @@ Expr *swift::buildPropertyWrapperInitCall(
 
   return initializer;
 }
+
+bool swift::isWrappedValueOfPropWrapper(VarDecl *var) {
+  if (!var->isStatic())
+    if (auto *dc = var->getDeclContext())
+      if (auto *nominal = dc->getSelfNominalTypeDecl())
+        if (nominal->getAttrs().hasAttribute<PropertyWrapperAttr>())
+          if (var->getName() == var->getASTContext().Id_wrappedValue)
+            return true;
+
+  return false;
+}

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1276,6 +1276,10 @@ Expr *buildPropertyWrapperInitCall(
     PropertyWrapperInitKind initKind,
     llvm::function_ref<void(ApplyExpr *)> callback = [](ApplyExpr *) {});
 
+/// Check if this var is the \c wrappedValue property belonging to
+/// a property wrapper type declaration.
+bool isWrappedValueOfPropWrapper(VarDecl *var);
+
 /// Whether an overriding declaration requires the 'override' keyword.
 enum class OverrideRequiresKeyword {
   /// The keyword is never required.

--- a/test/Concurrency/Inputs/dynamically_replaceable.swift
+++ b/test/Concurrency/Inputs/dynamically_replaceable.swift
@@ -1,2 +1,0 @@
-@MainActor
-public dynamic func dynamicOnMainActor() { }

--- a/test/Concurrency/Inputs/other_global_actor_inference.swift
+++ b/test/Concurrency/Inputs/other_global_actor_inference.swift
@@ -1,0 +1,15 @@
+
+// dynamically_replaceable
+@MainActor
+public dynamic func dynamicOnMainActor() { }
+
+// property wrapper + main actor
+@propertyWrapper
+public struct IntWrapper {
+
+  public init(wrappedValue: Int) {
+    self.wrappedValue = wrappedValue
+  }
+
+  @MainActor public var wrappedValue: Int
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -46,7 +46,7 @@ actor MySuperActor {
   }
 }
 
-class Point { // expected-note 3{{class 'Point' does not conform to the 'Sendable' protocol}}
+class Point { // expected-note 5{{class 'Point' does not conform to the 'Sendable' protocol}}
   var x : Int = 0
   var y : Int = 0
 }
@@ -111,14 +111,11 @@ func checkAsyncPropertyAccess() async {
 
 /// ------------------------------------------------------------------
 /// -- Value types do not need isolation on their stored properties --
-
-@available(SwiftStdlib 5.1, *)
 protocol MainCounter {
   @MainActor var counter: Int { get set }
   @MainActor var ticker: Int { get set }
 }
 
-@available(SwiftStdlib 5.1, *)
 struct InferredFromConformance: MainCounter {
   var counter = 0
   var ticker: Int {
@@ -128,7 +125,6 @@ struct InferredFromConformance: MainCounter {
 }
 
 @MainActor
-@available(SwiftStdlib 5.1, *)
 struct InferredFromContext {
   var point = Point()
   var polygon: [Point] {
@@ -144,23 +140,16 @@ struct InferredFromContext {
   static var stuff: [Int] = []
 }
 
-@available(SwiftStdlib 5.1, *)
 func checkIsolationValueType(_ formance: InferredFromConformance,
                              _ ext: InferredFromContext,
                              _ anno: NoGlobalActorValueType) async {
-  // these do not need an await, since it's a value type
-  _ = ext.point
-  _ = formance.counter
-  _ = anno.point
+  // these still do need an await in Swift 5
+  _ = await ext.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to main actor-isolated property 'point' cannot cross actor boundary}}
+  _ = await formance.counter
+  _ = await anno.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
   _ = anno.counter
 
-  // make sure it's just a warning if someone was awaiting on it previously
-  _ = await ext.point // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = await formance.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = await anno.point  // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = await anno.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
-
-  // these do need await, regardless of reference or value type
+  // these will always need an await
   _ = await (formance as MainCounter).counter
   _ = await ext[1]
   _ = await formance.ticker
@@ -170,7 +159,6 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 }
 
 // check for instance members that do not need global-actor protection
-@available(SwiftStdlib 5.1, *)
 struct NoGlobalActorValueType {
   @SomeGlobalActor var point: Point // expected-warning {{stored property 'point' within struct cannot have a global actor; this is an error in Swift 6}}
 

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,0 +1,78 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-concurrency -swift-version 6
+// REQUIRES: concurrency
+
+final class ImmutablePoint: Sendable {
+  let x : Int = 0
+  let y : Int = 0
+}
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+/// ------------------------------------------------------------------
+/// -- Value types do not need isolation on their stored properties --
+protocol MainCounter {
+  @MainActor var counter: Int { get set }
+  @MainActor var ticker: Int { get set }
+}
+
+struct InferredFromConformance: MainCounter {
+  var counter = 0
+  var ticker: Int {
+    get { 1 }
+    set {}
+  }
+}
+
+@MainActor
+struct InferredFromContext {
+  var point = ImmutablePoint()
+  var polygon: [ImmutablePoint] {
+    get { [] }
+  }
+
+  nonisolated let flag: Bool = false // expected-error {{'nonisolated' is redundant on struct's stored properties}}{{3-15=}}
+
+  subscript(_ i: Int) -> Int { return i }
+
+  static var stuff: [Int] = []
+}
+
+func checkIsolationValueType(_ formance: InferredFromConformance,
+                             _ ext: InferredFromContext,
+                             _ anno: NoGlobalActorValueType) async {
+  // these do not need an await, since it's a value type
+  _ = ext.point
+  _ = formance.counter
+  _ = anno.point
+  _ = anno.counter
+
+  // make sure it's just a warning if someone was awaiting on it previously
+  _ = await ext.point // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await formance.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await anno.point  // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = await anno.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
+
+  // these do need await, regardless of reference or value type
+  _ = await (formance as MainCounter).counter
+  _ = await ext[1]
+  _ = await formance.ticker
+  _ = await ext.polygon
+  _ = await InferredFromContext.stuff
+  _ = await NoGlobalActorValueType.polygon
+}
+
+// check for instance members that do not need global-actor protection
+struct NoGlobalActorValueType {
+  @SomeGlobalActor var point: ImmutablePoint // expected-error {{stored property 'point' within struct cannot have a global actor}}
+
+  @MainActor let counter: Int // expected-error {{stored property 'counter' within struct cannot have a global actor}}
+
+  @MainActor static var polygon: [ImmutablePoint] = []
+}
+
+/// -----------------------------------------------------------------

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/dynamically_replaceable.swiftmodule -module-name dynamically_replaceable -warn-concurrency %S/Inputs/dynamically_replaceable.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
 // RUN: %target-typecheck-verify-swift -I %t -disable-availability-checking
 // REQUIRES: concurrency
-import dynamically_replaceable
+import other_global_actor_inference
 
 actor SomeActor { }
 
@@ -30,6 +30,14 @@ struct GenericGlobalActor<T> {
 }
 @MainActor class Copper {}
 @MainActor func iron() {}
+
+struct Carbon {
+  @IntWrapper var atomicWeight: Int
+
+  func getWeight() -> Int {
+    return atomicWeight
+  }
+}
 
 // ----------------------------------------------------------------------
 // Check that @MainActor(blah) doesn't work

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -263,6 +263,22 @@ func barSync() {
 }
 
 // ----------------------------------------------------------------------
+// Property observers
+// ----------------------------------------------------------------------
+
+@OtherGlobalActor
+struct Observed {
+  var thing: Int = 0 { // expected-note {{property declared here}}
+    didSet {}
+    willSet {}
+  }
+}
+
+func checkObserved(_ o: Observed) { // expected-note {{add '@OtherGlobalActor' to make global function 'checkObserved' part of global actor 'OtherGlobalActor'}}
+  _ = o.thing // expected-error {{property 'thing' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
+}
+
+// ----------------------------------------------------------------------
 // Property wrappers
 // ----------------------------------------------------------------------
 
@@ -318,13 +334,13 @@ actor WrapperActor<Wrapped: Sendable> {
 
 struct HasWrapperOnActor {
   @WrapperOnActor var synced: Int = 0
-  // expected-note@-1 3{{property declared here}}
+  // expected-note@-1 2{{property declared here}}
 
-  // expected-note@+1 3{{to make instance method 'testErrors()'}}
+  // expected-note@+1 2{{to make instance method 'testErrors()'}}
   func testErrors() {
     _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
     _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
-    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
+    _ = _synced
   }
 
   @MainActor mutating func testOnMain() {
@@ -483,7 +499,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 struct HasWrapperOnUnsafeActor {
   @WrapperOnUnsafeActor var synced: Int = 0
-  // expected-note@-1 3{{property declared here}}
+  // expected-note@-1 2{{property declared here}}
 
   func testUnsafeOkay() {
     _ = synced
@@ -494,7 +510,7 @@ struct HasWrapperOnUnsafeActor {
   nonisolated func testErrors() {
     _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from}}
     _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from}}
-    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from}}
+    _ = _synced
   }
 
   @MainActor mutating func testOnMain() {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -299,7 +299,7 @@ struct WrapperOnActor<Wrapped: Sendable> {
     stored = wrappedValue
   }
 
-  @MainActor var wrappedValue: Wrapped { // expected-note {{property declared here}}
+  @MainActor var wrappedValue: Wrapped {
     get { }
     set { }
   }
@@ -315,7 +315,7 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
   
-  public var wrappedValue: Wrapped // expected-note {{property declared here}}
+  public var wrappedValue: Wrapped
 
   public var accessCount: Int
 
@@ -352,36 +352,15 @@ actor WrapperActor<Wrapped: Sendable> {
   }
 }
 
-struct HasMainActorWrappedProp {
-  @WrapperOnMainActor var thing: Int = 1 // expected-note {{property declared here}}
-
-  var plainStorage: Int
-
-  var computedProp: Int { 0 } // expected-note {{property declared here}}
-
-  nonisolated func testErrors() {
-    _ = thing // expected-error {{property 'thing' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
-    _ = _thing.wrappedValue // expected-error {{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
-
-    _ = _thing
-    _ = _thing.accessCount
-
-    _ = plainStorage
-
-    _ = computedProp // expected-error {{property 'computedProp' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
-  }
-}
-
 struct HasWrapperOnActor {
   @WrapperOnActor var synced: Int = 0
-  // expected-note@-1 2{{property declared here}}
+  // expected-note@-1 3{{property declared here}}
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
     _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
     _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
-    _ = _synced
-    _ = _synced.wrappedValue // expected-error{{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
   }
 
   @MainActor mutating func testOnMain() {
@@ -540,7 +519,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 struct HasWrapperOnUnsafeActor {
   @WrapperOnUnsafeActor var synced: Int = 0
-  // expected-note@-1 2{{property declared here}}
+  // expected-note@-1 3{{property declared here}}
 
   func testUnsafeOkay() {
     _ = synced
@@ -551,7 +530,7 @@ struct HasWrapperOnUnsafeActor {
   nonisolated func testErrors() {
     _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from}}
     _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from}}
-    _ = _synced
+    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from a non-isolated synchronous context}}
   }
 
   @MainActor mutating func testOnMain() {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -1,0 +1,127 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 6 -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
+// RUN: %target-typecheck-verify-swift -swift-version 6 -I %t -disable-availability-checking
+// REQUIRES: concurrency
+import other_global_actor_inference
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+@globalActor
+struct OtherGlobalActor {
+  static let shared = SomeActor()
+}
+
+
+// MARK: Property Wrappers
+
+@propertyWrapper
+actor WrapperActor<Wrapped: Sendable> {
+  var storage: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    storage = wrappedValue
+  }
+
+  nonisolated var wrappedValue: Wrapped {
+    get { }
+    set { }
+  }
+
+  nonisolated var projectedValue: Wrapped {
+    get { }
+    set { }
+  }
+}
+
+@propertyWrapper
+@OtherGlobalActor
+struct WrapperOnActor<Wrapped: Sendable> {
+  private var stored: Wrapped
+
+  nonisolated init(wrappedValue: Wrapped) {
+    stored = wrappedValue
+  }
+
+  @MainActor var wrappedValue: Wrapped { // expected-note {{property declared here}}
+    get { }
+    set { }
+  }
+
+  @SomeGlobalActor var projectedValue: Wrapped {
+    get {  }
+    set { }
+  }
+}
+
+@MainActor
+@propertyWrapper
+public struct WrapperOnMainActor<Wrapped> {
+  // Make sure inference of @MainActor on wrappedValue doesn't crash.
+
+  public var wrappedValue: Wrapped // expected-note {{property declared here}}
+
+  public var accessCount: Int
+
+  nonisolated public init(wrappedValue: Wrapped) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct HasMainActorWrappedProp {
+  @WrapperOnMainActor var thing: Int = 1 // expected-note {{property declared here}}
+
+  var plainStorage: Int
+
+  var computedProp: Int { 0 } // expected-note {{property declared here}}
+
+  nonisolated func testErrors() {
+    _ = thing // expected-error {{property 'thing' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+    _ = _thing.wrappedValue // expected-error {{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+
+    _ = _thing
+    _ = _thing.accessCount
+
+    _ = plainStorage
+
+    _ = computedProp // expected-error {{property 'computedProp' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+  }
+}
+
+struct HasWrapperOnActor {
+  @WrapperOnActor var synced: Int = 0
+  // expected-note@-1 2{{property declared here}}
+
+  // expected-note@+1 3{{to make instance method 'testErrors()'}}
+  func testErrors() {
+    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+    _ = _synced
+    _ = _synced.wrappedValue // expected-error{{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+  }
+
+  @MainActor mutating func testOnMain() {
+    _ = synced
+    synced = 17
+  }
+
+  @WrapperActor var actorSynced: Int = 0
+
+  func testActorSynced() {
+    _ = actorSynced
+    _ = $actorSynced
+    _ = _actorSynced
+  }
+}
+
+struct Carbon {
+  @IntWrapper var atomicWeight: Int // expected-note {{property declared here}}
+
+  nonisolated func getWeight() -> Int {
+    return atomicWeight // expected-error {{property 'atomicWeight' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+  }
+}

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -602,8 +602,11 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
+    // CHECK:       [[PREV_AGAIN:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [trivial] [[ELEM_ADDR]] : $*Float
     // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[PREV_AGAIN]] : $Optional<Builtin.Executor>
     // CHECK: } // end sil function '$s4test9ContainerV10getOrCrashSfyYaFZ'
     static func getOrCrash() async -> Float {
         return await this!.iso
@@ -628,8 +631,11 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
+    // CHECK:       [[PREV_AGAIN:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [copy] [[ELEM_ADDR]] : $*CatBox
     // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[PREV_AGAIN]] : $Optional<Builtin.Executor>
     // CHECK: } // end sil function '$s4test9ContainerV13getRefOrCrashAA6CatBoxCyYaFZ'
     static func getRefOrCrash() async -> CatBox {
         return await this!.isoRef

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -602,10 +602,8 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
-    // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [trivial] [[ELEM_ADDR]] : $*Float
-    // CHECK:       hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-    // CHECK:       hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
     // CHECK: } // end sil function '$s4test9ContainerV10getOrCrashSfyYaFZ'
     static func getOrCrash() async -> Float {
         return await this!.iso
@@ -630,10 +628,8 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
-    // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [copy] [[ELEM_ADDR]] : $*CatBox
-    // CHECK:       hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-    // CHECK:       hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
     // CHECK: } // end sil function '$s4test9ContainerV13getRefOrCrashAA6CatBoxCyYaFZ'
     static func getRefOrCrash() async -> CatBox {
         return await this!.isoRef
@@ -705,5 +701,3 @@ class Polar {
 func accessStaticIsolated() async -> Int {
   return await Polar.temperature
 }
-
-

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -590,10 +590,9 @@ struct Container {
     // CHECK:     hop_to_executor {{%[0-9]+}} : $MainActor
     // CHECK:     = apply [[ADDRESS_ACCESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
     // CHECK:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-    // CHECK:    [[MAIN:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MainActor
-    // CHECK:    hop_to_executor [[MAIN]] : $MainActor
-    // CHECK:    [[ACCESS:%[0-9]+]] = begin_access [read] [dynamic] {{%[0-9]+}} : $*Optional<Container>
-    // CHECK:    switch_enum_addr [[ACCESS]] : $*Optional<Container>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[CRASH_BB:bb[0-9]+]]
+    // CHECK:     hop_to_executor {{%.*}} : $MainActor
+    // CHECK:     [[ACCESS:%[0-9]+]] = begin_access [read] [dynamic] {{%[0-9]+}} : $*Optional<Container>
+    // CHECK:     switch_enum_addr [[ACCESS]] : $*Optional<Container>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[CRASH_BB:bb[0-9]+]]
     //
     // CHECK: [[CRASH_BB]]:
     // CHECK-NOT:   hop_to_executor [[GENERIC_EXEC]]
@@ -602,11 +601,10 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
-    // CHECK:       [[PREV_AGAIN:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
     // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [trivial] [[ELEM_ADDR]] : $*Float
-    // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
-    // CHECK:       hop_to_executor [[PREV_AGAIN]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
+    // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
     // CHECK: } // end sil function '$s4test9ContainerV10getOrCrashSfyYaFZ'
     static func getOrCrash() async -> Float {
         return await this!.iso
@@ -620,8 +618,7 @@ struct Container {
     // CHECK:     hop_to_executor {{%[0-9]+}} : $MainActor
     // CHECK:     = apply [[ADDRESS_ACCESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
     // CHECK:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-    // CHECK:    [[MAIN:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MainActor
-    // CHECK:    hop_to_executor [[MAIN]] : $MainActor
+    // CHECK:    hop_to_executor {{%.*}} : $MainActor
     // CHECK:    [[ACCESS:%[0-9]+]] = begin_access [read] [dynamic] {{%[0-9]+}} : $*Optional<Container>
     // CHECK:    switch_enum_addr [[ACCESS]] : $*Optional<Container>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[CRASH_BB:bb[0-9]+]]
     //
@@ -631,11 +628,10 @@ struct Container {
     // CHECK: [[SOME_BB]]:
     // CHECK:       [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[ACCESS]] : $*Optional<Container>, #Optional.some!enumelt
     // CHECK:       [[ELEM_ADDR:%[0-9]+]] = struct_element_addr [[DATA_ADDR]] : $*Container, #Container.iso
-    // CHECK:       [[PREV_AGAIN:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
     // CHECK:       hop_to_executor {{%[0-9]+}} : $Cat
     // CHECK:       {{%[0-9]+}} = load [copy] [[ELEM_ADDR]] : $*CatBox
-    // CHECK:       hop_to_executor [[PREV]] : $Optional<Builtin.Executor>
-    // CHECK:       hop_to_executor [[PREV_AGAIN]] : $Optional<Builtin.Executor>
+    // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
+    // CHECK:       hop_to_executor [[GENERIC_EXEC]] :
     // CHECK: } // end sil function '$s4test9ContainerV13getRefOrCrashAA6CatBoxCyYaFZ'
     static func getRefOrCrash() async -> CatBox {
         return await this!.isoRef

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -67,7 +67,7 @@ struct OtherGlobalActor {
 }
 
 @GA1 struct X {
-  @GA1 var member: Int
+  @GA1 var member: Int // expected-warning {{stored property 'member' within struct cannot have a global actor; this is an error in Swift 6}}
 }
 
 struct Y {

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -1,0 +1,53 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+class Visibility: ObservableObject { // expected-note {{class 'Visibility' does not conform to the 'Sendable' protocol}}
+    @Published var yes = false // some nonsense
+}
+
+struct CoffeeTrackerView: View { // expected-note{{consider making struct 'CoffeeTrackerView' conform to the 'Sendable' protocol}}
+    @ObservedObject var showDrinkList: Visibility = Visibility()
+
+    var storage: Visibility = Visibility()
+
+    var body: some View {
+        VStack {
+          Button(action: {}) {
+            Image(self.showDrinkList.yes ? "add-coffee" : "add-tea")
+                    .renderingMode(.template)
+            }
+        }
+    }
+}
+
+@MainActor
+func fromMainActor() async {
+  let view = CoffeeTrackerView()
+  _ = view.body
+  _ = view.showDrinkList
+  _ = view.storage
+}
+
+
+func fromConcurrencyAware() async {
+  // expected-note@+3 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@+1 {{non-sendable type 'CoffeeTrackerView' returned by call to main actor-isolated function cannot cross actor boundary}}
+  let view = CoffeeTrackerView()
+
+  // expected-note@+3 {{property access is 'async'}}
+  // expected-warning@+2 {{non-sendable type 'some View' in implicitly asynchronous access to main actor-isolated property 'body' cannot cross actor boundary}}
+  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+  _ = view.body
+
+  // expected-note@+3 {{property access is 'async'}}
+  // expected-warning@+2 {{non-sendable type 'Visibility' in implicitly asynchronous access to main actor-isolated property 'showDrinkList' cannot cross actor boundary}}
+  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+  _ = view.showDrinkList
+
+  _ = view.storage
+}

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-class Visibility: ObservableObject { // expected-note {{class 'Visibility' does not conform to the 'Sendable' protocol}}
+class Visibility: ObservableObject { // expected-note 2{{class 'Visibility' does not conform to the 'Sendable' protocol}}
     @Published var yes = false // some nonsense
 }
 
@@ -49,5 +49,5 @@ func fromConcurrencyAware() async {
   // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
   _ = view.showDrinkList
 
-  _ = view.storage
+  _ = await view.storage // expected-warning {{non-sendable type 'Visibility' in implicitly asynchronous access to main actor-isolated property 'storage' cannot cross actor boundary}}
 }


### PR DESCRIPTION
As part of SE-327, global-actor isolation applied to
the instance-stored properties of a value type do
not require any isolation, since there is no way to
create a race on access to that storage.

https://github.com/apple/swift-evolution/blob/main/proposals/0327-actor-initializers.md#removing-redundant-isolation

This change turns global-actor annotations on such
properties into an error in Swift 6+, and a warning
in Swift 5 and earlier.

In addition, inference for global-actor isolation
no longer applies global-actor isolation to such
properties. Since this latter change only results
in warnings in existing Swift 5 code, about a now
superflous 'await', this change will happen in
Swift 5+.

Fixes rdar://87568381