### PR TITLE
[stdlib] Make Range.init(_: ClosedRange<Bound>) inlinable

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -315,6 +315,8 @@ extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
   /// For example, passing a closed range with an upper bound of `Int.max`
   /// triggers a runtime error, because the resulting half-open range would
   /// require an upper bound of `Int.max + 1`, which is not representable as
+  /// an `Int`.
+  @inlinable // trivial-implementation
   public init(_ other: ClosedRange<Bound>) {
     let upperBound = other.upperBound.advanced(by: 1)
     self.init(_uncheckedBounds: (lower: other.lowerBound, upper: upperBound))


### PR DESCRIPTION
Currently, a simple `Range.init(_: ClosedRange<Bound>)`-calling function such as:

```swift
func makeSingleElementRange(n: Int) -> Range<Int> {
    return Range(n...n)
}
```

will perform unspecialised generic calls under optimisation because `Range.init(_: ClosedRange<Bound>)` is not inlinable:

```
output.makeSingleElementRange(n: Swift.Int) -> Swift.Range<Swift.Int>:
        sub     rsp, 40
        mov     qword ptr [rsp + 8], rdi
        mov     qword ptr [rsp + 16], rdi
        call    (lazy protocol witness table accessor for type Swift.Int and conformance Swift.Int : Swift.SignedInteger in Swift)
        mov     rcx, rax
        mov     rsi, qword ptr [rip + ($sSiN)@GOTPCREL]
        mov     rdx, qword ptr [rip + ($sSiSxsWP)@GOTPCREL]
        lea     rax, [rsp + 24]
        lea     rdi, [rsp + 8]
        call    ($sSnsSxRzSZ6StrideRpzrlEySnyxGSNyxGcfC)@PLT
        mov     rax, qword ptr [rsp + 24]
        mov     rdx, qword ptr [rsp + 32]
        add     rsp, 40
        ret
```

Mark the `init` as inlinable so these functions can be properly optimised.

Also add a missing line of documentation.