### PR TITLE
[docs] Sccache bug has been fixed

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -128,8 +128,6 @@ Double-check that running `pwd` prints a path ending with `swift`.
 
 ### macOS
 
-⚠️ Since version 0.2.14, `sccache` no longer caches compile commands issued by `build-script` because of [sccache PR 898](https://github.com/mozilla/sccache/pull/898), since `build-script` adds the `-arch x86_64` argument twice. The instructions below may install `sccache` 0.2.14 or newer. You may want to instead download and install an older release from their [Releases page](https://github.com/mozilla/sccache/releases) until this issue is resolved.
-
 1. Install [Xcode 13 beta 4][Xcode] or newer:
    The required version of Xcode changes frequently and is often a beta release.
    Check this document or the host information on <https://ci.swift.org> for the


### PR DESCRIPTION
<!-- What's in this pull request? -->
In v2.15.0, the target duplication problem has supposedly been addressed. I have not verified it's actually fixed because I haven't built Swift from source yet. Here is the sequence of events surrounding the fix:

- [Dec 11, 2020] The following PR, which is currently linked in `GettingStarted.md`, is merged and creates the bug:
  - https://github.com/mozilla/sccache/pull/898
- [Feb 18, 2021] The first PR is mentioned in a second PR to [mozilla/sccache](https://github.com/mozilla/sccache):
  - https://github.com/mozilla/sccache/pull/959
- [Mar 10, 2021] The second PR is rejected because the following comment shows it's already been fixed:
  - https://github.com/mozilla/sccache/pull/959#issuecomment-795091725
- [Jul 27, 2021] @mcc-devel recognizes the fix and makes the following PR:
  - https://github.com/apple/swift/pull/38659
- [Sep 5, 2021] @xwu states that the PR must be rebased. After that, no further action is taken and the warning in `GettingStarted.md` remains.
  - https://github.com/apple/swift/pull/38659#issuecomment-913215257

---

I have one question though: the commit goes to the file `gcc.rs`, yet (based on my limited and likely flawed understanding) Clang is often used for Swift instead of GCC. Does that mean the patch fixes builds using GCC, but Clang builds are still broken? For reference, I plan to use Xcode instead of Ninja to build the Swift compiler from source, and am still reading the beginner documentation on how to do it.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
