### PR TITLE
[docs] Add "currency type" to the lexicon

### DIFF
--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -137,7 +137,7 @@ the AST level. See also [witness table](#witness-table).
 An edge in a control flow graph where the destination has multiple predecessors
 and the source has multiple successors.
 
-## currency
+## currency type
 
 Aa type that's meant to be commonly passed around and stored, like `Array`, as opposed to a type that's useful for temporary/internal purposes but which you wouldn't normally use in an external interface, like `ArraySlice`. Having broad agreement about the currency type you use for a particular kind of data (e.g. using `Array` to pass around sequential collections) generally makes the whole ecosystem better by reducing artificial barriers to passing data from one system to another, and it gives algorithm writers an obvious target to ensure they optimize for. That's where the analogy to currency comes from: agreeing on a currency type improves the flow of information in a program in some of the same ways that agreeing on a currency improves the flow of trade in an economy.
 

--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -137,6 +137,10 @@ the AST level. See also [witness table](#witness-table).
 An edge in a control flow graph where the destination has multiple predecessors
 and the source has multiple successors.
 
+## currency
+
+Aa type that's meant to be commonly passed around and stored, like `Array`, as opposed to a type that's useful for temporary/internal purposes but which you wouldn't normally use in an external interface, like `ArraySlice`. Having broad agreement about the currency type you use for a particular kind of data (e.g. using `Array` to pass around sequential collections) generally makes the whole ecosystem better by reducing artificial barriers to passing data from one system to another, and it gives algorithm writers an obvious target to ensure they optimize for. That's where the analogy to currency comes from: agreeing on a currency type improves the flow of information in a program in some of the same ways that agreeing on a currency improves the flow of trade in an economy.
+
 ## customization point
 
 Informal term for a protocol requirement that has a default implementation,

--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -139,7 +139,16 @@ and the source has multiple successors.
 
 ## currency type
 
-Aa type that's meant to be commonly passed around and stored, like `Array`, as opposed to a type that's useful for temporary/internal purposes but which you wouldn't normally use in an external interface, like `ArraySlice`. Having broad agreement about the currency type you use for a particular kind of data (e.g. using `Array` to pass around sequential collections) generally makes the whole ecosystem better by reducing artificial barriers to passing data from one system to another, and it gives algorithm writers an obvious target to ensure they optimize for. That's where the analogy to currency comes from: agreeing on a currency type improves the flow of information in a program in some of the same ways that agreeing on a currency improves the flow of trade in an economy.
+A type that's meant to be commonly passed around and stored, like `Array`, as
+opposed to a type that's useful for temporary/internal purposes but which you
+wouldn't normally use in an external interface, like `ArraySlice`. Having broad
+agreement about the currency type you use for a particular kind of data (e.g.
+using `Array` to pass around sequential collections) generally makes the whole
+ecosystem better by reducing artificial barriers to passing data from one system 
+to another, and it gives algorithm writers an obvious target to ensure they
+optimize for. That's where the analogy to currency comes from: agreeing on a
+currency type improves the flow of information in a program in some of the same
+ways that agreeing on a currency improves the flow of trade in an economy.
 
 ## customization point
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ documentation, please create a thread on the Swift forums under the
     Describes the design of the optimizer pipeline.
   - [HighLevelSILOptimizations.rst](/docs/HighLevelSILOptimizations.rst):
     Describes how the optimizer understands the semantics of high-level
-    operations on [currency](/docs/Lexicon.md#currency) data types and optimizes accordingly.
+    operations on [currency](/docs/Lexicon.md#currency-types) data types and optimizes accordingly.
     Includes a thorough discussion of the `@_semantics` attribute.
 
 ### SourceKit subsystems

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ documentation, please create a thread on the Swift forums under the
     Describes the design of the optimizer pipeline.
   - [HighLevelSILOptimizations.rst](/docs/HighLevelSILOptimizations.rst):
     Describes how the optimizer understands the semantics of high-level
-    operations on built-in data types and optimizes accordingly.
+    operations on [currency](/docs/Lexicon.md#currency) data types and optimizes accordingly.
     Includes a thorough discussion of the `@_semantics` attribute.
 
 ### SourceKit subsystems

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,8 @@ documentation, please create a thread on the Swift forums under the
     Describes the design of the optimizer pipeline.
   - [HighLevelSILOptimizations.rst](/docs/HighLevelSILOptimizations.rst):
     Describes how the optimizer understands the semantics of high-level
-    operations on [currency](/docs/Lexicon.md#currency-types) data types and optimizes accordingly.
+    operations on [currency](/docs/Lexicon.md#currency-type) data types and 
+    optimizes accordingly.
     Includes a thorough discussion of the `@_semantics` attribute.
 
 ### SourceKit subsystems

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ documentation, please create a thread on the Swift forums under the
     Describes the design of the optimizer pipeline.
   - [HighLevelSILOptimizations.rst](/docs/HighLevelSILOptimizations.rst):
     Describes how the optimizer understands the semantics of high-level
-    operations on currency data types and optimizes accordingly.
+    operations on built-in data types and optimizes accordingly.
     Includes a thorough discussion of the `@_semantics` attribute.
 
 ### SourceKit subsystems


### PR DESCRIPTION
<!-- What's in this pull request? -->
I don't understand why it says "currency", which means money. There might be some Swift data type for money, but I haven't heard of it yet. Also, the explanation misses that the entire document just covers built-in Swift types. Did you mean "concurrency"?

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
