### PR TITLE
[Concurrency] Disable flaky test

### DIFF
--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -15,7 +15,7 @@
 // UNSUPPORTED: OS=watchos
 
 // rdar://86825277
-// UNSUPPORTED: CPU=arm64e
+// UNSUPPORTED: CPU=arm64, CPU=arm64e
 
 #if false
 func fib(_ n: Int) -> Int {

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -17,7 +17,6 @@
 // rdar://86825277
 // UNSUPPORTED: CPU=arm64, CPU=arm64e
 
-#if false
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1
@@ -67,7 +66,6 @@ func runFibonacci(_ n: Int) async {
     await runFibonacci(10)
   }
 }
-#endif
 
 // CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global 'racyCounter'

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -17,7 +17,7 @@
 // rdar://86825277
 // UNSUPPORTED: CPU=arm64e
 
-#if 0
+#if false
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -17,6 +17,7 @@
 // rdar://86825277
 // UNSUPPORTED: CPU=arm64e
 
+#if 0
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1
@@ -66,6 +67,7 @@ func runFibonacci(_ n: Int) async {
     await runFibonacci(10)
   }
 }
+#endif
 
 // CHECK: ThreadSanitizer: Swift access race
 // CHECK: Location is global 'racyCounter'

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -15,6 +15,7 @@
 // UNSUPPORTED: OS=watchos
 
 // rdar://86825277
+// SR-15805
 // UNSUPPORTED: CPU=arm64 || CPU=arm64e
 
 func fib(_ n: Int) -> Int {

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -15,7 +15,7 @@
 // UNSUPPORTED: OS=watchos
 
 // rdar://86825277
-// UNSUPPORTED: CPU=arm64, CPU=arm64e
+// UNSUPPORTED: CPU=arm64 || CPU=arm64e
 
 func fib(_ n: Int) -> Int {
   var first = 0


### PR DESCRIPTION
The tests "racy_async_let_fibonacci.swift" fails when building the Swift compiler from source using the following command:
```bash
utils/build-script --skip-build-benchmarks \
  --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
  --sccache --release-debuginfo --swift-disable-dead-stripping --test
```

But it doesn't fail when removing the `--test` flag, then running the following after the build (from `GettingStarted.md`):
```bash
# Rebuild all test dependencies and run all tests under test/.
utils/run-test --lit ../llvm-project/llvm/utils/lit/lit.py \
  ../build/Ninja-RelWithDebInfoAssert/swift-macosx-$(uname -m)/test-macosx-$(uname -m)
```

I don't know whether this is a flaky test, and I certainly don't know how to disable the test if it is flaky. Could someone please help me with this?

For reference, the failure happened on macOS arm64 when using Ninja instead of Xcode.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
