### PR TITLE
Revert "[AST] scan `@_exported import` modules of source files for display decls"

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -16,7 +16,6 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/RawComment.h"
 #include "swift/Basic/BasicSourceInfo.h"
-#include "swift/Basic/Debug.h"
 
 #include "llvm/ADT/PointerIntPair.h"
 
@@ -308,9 +307,6 @@ public:
   virtual StringRef getExportedModuleName() const {
     return getParentModule()->getRealName().str();
   }
-
-  SWIFT_DEBUG_DUMPER(dumpDisplayDecls());
-  SWIFT_DEBUG_DUMPER(dumpTopLevelDecls());
 
   /// Traverse the decls within this file.
   ///

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -26,7 +26,6 @@
 #include "swift/AST/Type.h"
 #include "swift/Basic/BasicSourceInfo.h"
 #include "swift/Basic/Compiler.h"
-#include "swift/Basic/Debug.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceLoc.h"
@@ -856,9 +855,6 @@ public:
   /// \c SerializeOptionsForDebugging hack. Once this information can be
   /// transferred from module files to the dSYMs, remove this.
   bool isExternallyConsumed() const;
-
-  SWIFT_DEBUG_DUMPER(dumpDisplayDecls());
-  SWIFT_DEBUG_DUMPER(dumpTopLevelDecls());
 
   SourceRange getSourceRange() const { return SourceRange(); }
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -288,10 +288,6 @@ public:
 
   ~SourceFile();
 
-  bool hasImports() const {
-    return Imports.hasValue();
-  }
-
   /// Retrieve an immutable view of the source file's imports.
   ArrayRef<AttributedImport<ImportedModule>> getImports() const {
     return *Imports;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -780,46 +780,12 @@ void SourceFile::lookupObjCMethods(
   results.append(known->second.begin(), known->second.end());
 }
 
-static void collectParsedExportedImports(const ModuleDecl *M, SmallPtrSetImpl<ModuleDecl *> &Imports) {
-  for (const FileUnit *file : M->getFiles()) {
-    if (const SourceFile *source = dyn_cast<SourceFile>(file)) {
-      if (source->hasImports()) {
-        for (auto import : source->getImports()) {
-          if (import.options.contains(ImportFlags::Exported)) {
-            if (!Imports.contains(import.module.importedModule)) {
-              Imports.insert(import.module.importedModule);
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 void ModuleDecl::getLocalTypeDecls(SmallVectorImpl<TypeDecl*> &Results) const {
   FORWARD(getLocalTypeDecls, (Results));
 }
 
 void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
   FORWARD(getTopLevelDecls, (Results));
-}
-
-void ModuleDecl::dumpDisplayDecls() const {
-  SmallVector<Decl *, 32> Decls;
-  getDisplayDecls(Decls);
-  for (auto *D : Decls) {
-    D->dump(llvm::errs());
-    llvm::errs() << "\n";
-  }
-}
-
-void ModuleDecl::dumpTopLevelDecls() const {
-  SmallVector<Decl *, 32> Decls;
-  getTopLevelDecls(Decls);
-  for (auto *D : Decls) {
-    D->dump(llvm::errs());
-    llvm::errs() << "\n";
-  }
 }
 
 void ModuleDecl::getExportedPrespecializations(
@@ -942,23 +908,8 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
 }
 
 void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
-  if (isParsedModule(this)) {
-    SmallPtrSet<ModuleDecl *, 4> Modules;
-    collectParsedExportedImports(this, Modules);
-    for (const ModuleDecl *import : Modules) {
-      import->getDisplayDecls(Results);
-    }
-  }
   // FIXME: Should this do extra access control filtering?
   FORWARD(getDisplayDecls, (Results));
-
-#ifndef NDEBUG
-  llvm::DenseSet<Decl *> visited;
-  for (auto *D : Results) {
-    auto inserted = visited.insert(D).second;
-    assert(inserted && "there should be no duplicate decls");
-  }
-#endif
 }
 
 ProtocolConformanceRef
@@ -3109,22 +3060,6 @@ void FileUnit::getTopLevelDeclsWhereAttributesMatch(
       return !matchAttributes(D->getAttrs());
     });
   Results.erase(newEnd, Results.end());
-}
-
-void FileUnit::dumpDisplayDecls() const {
-  SmallVector<Decl *, 32> Decls;
-  getDisplayDecls(Decls);
-  for (auto *D : Decls) {
-    D->dump(llvm::errs());
-  }
-}
-
-void FileUnit::dumpTopLevelDecls() const {
-  SmallVector<Decl *, 32> Decls;
-  getTopLevelDecls(Decls);
-  for (auto *D : Decls) {
-    D->dump(llvm::errs());
-  }
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const FileUnit *file) {

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
 // RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
-// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER
 
 // REQUIRES: objc_interop
 
@@ -11,9 +10,6 @@ import Foundation
 
 public enum SwiftEnum {}
 
-// HEADER:       "precise": "c:@testVariable"
-
-// CHECK:        "precise": "s:17EmitWhileBuilding9SwiftEnumO",
 // CHECK:        "declarationFragments": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:           "kind": "keyword",

--- a/test/SymbolGraph/ClangImporter/Inputs/EmitWhileBuilding/Extra.swift
+++ b/test/SymbolGraph/ClangImporter/Inputs/EmitWhileBuilding/Extra.swift
@@ -1,1 +1,0 @@
-public struct SomeStruct {}


### PR DESCRIPTION
Reverts apple/swift#40810

Release: https://ci.swift.org/view/Source%20Compatibility/job/swift-main-source-compat-suite/6379/
Debug: https://ci.swift.org/view/Source%20Compatibility/job/swift-main-source-compat-suite-debug/4420/

```
========================================
Failures:
  FAIL: fluent, 4.2, 270b6f, Swift Package
  FAIL: grpc-swift, 5.0, a45db1, Swift Package
  FAIL: async-http-client, 5.0, a72c5a, Swift Package
  FAIL: swift-nio-http2, 5.0, 492a77, Swift Package
  FAIL: swift-nio-extras, 5.0, 66f9a5, Swift Package
  FAIL: swift-nio-extras, 4.2, 0dbd54, Swift Package
  FAIL: swift-nio-ssl, 5.0, 6363cd, Swift Package
  FAIL: swift-nio-ssh, 5.0, 09778e, Swift Package
  FAIL: swift-nio-transport-services, 5.0, e7f527, Swift Package
  FAIL: swift-cluster-membership, 5.0, 0fd434, Swift Package
  FAIL: vapor_console, 4.2, 5b9796, Swift Package
  FAIL: vapor_core, 4.2, 08a576, Swift Package
  FAIL: vapor_database-kit, 4.2, 3a17db, Swift Package
  FAIL: vapor_multipart, 4.2, e57007, Swift Package
  FAIL: vapor_routing, 4.2, 3219e3, Swift Package
  FAIL: vapor_service, 4.2, 281a70, Swift Package
  FAIL: vapor_template-kit, 4.2, db35b1, Swift Package
  FAIL: vapor_url-encoded-form, 4.2, cbfe7e, Swift Package
  FAIL: vapor_validation, 4.2, 156f8a, Swift Package
  FAIL: mqtt-nio, 5.0, 17794a, Swift Package
========================================
Action Summary:
     Passed: 313
     Failed: 20
    XFailed: 20
    UPassed: 0
      Total: 353
```