### PR TITLE
Remove JVP functions from public API

### DIFF
--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
@@ -373,18 +373,18 @@ public func gradient<T, U, R: FloatingPoint>(
   return pullback(at: x, y, of: f)(1)
 }
 
-public func derivative<T: FloatingPoint, R>(
-  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
-) -> R.TangentVector where T.TangentVector == T {
-  return differential(at: x, of: f)(1)
-}
+//public func derivative<T: FloatingPoint, R>(
+//  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
+//) -> R.TangentVector where T.TangentVector == T {
+//  return differential(at: x, of: f)(1)
+//}
 
-public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: ${Self}<T>, _ y: ${Self}<U>,
-  of f: @differentiable(reverse) (${Self}<T>, ${Self}<U>) -> R
-) -> R.TangentVector where T.TangentVector == T, U.TangentVector == U {
-  return differential(at: x, y, of: f)(1, 1)
-}
+//public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+//  at x: ${Self}<T>, _ y: ${Self}<U>,
+//  of f: @differentiable(reverse) (${Self}<T>, ${Self}<U>) -> R
+//) -> R.TangentVector where T.TangentVector == T, U.TangentVector == U {
+//  return differential(at: x, y, of: f)(1, 1)
+//}
 
 public func valueWithGradient<T, R: FloatingPoint>(
   at x: T, of f: @differentiable(reverse) (T) -> ${Self}<R>
@@ -393,11 +393,11 @@ public func valueWithGradient<T, R: FloatingPoint>(
   return (y, pullback(1))
 }
 
-public func valueWithDerivative<T: FloatingPoint, R>(
-  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
-) -> (value: R, derivative: R.TangentVector) {
-  let (y, differential) = valueWithDifferential(at: x, of: f)
-  return (y, differential(1))
-}
+//public func valueWithDerivative<T: FloatingPoint, R>(
+//  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
+//) -> (value: R, derivative: R.TangentVector) {
+//  let (y, differential) = valueWithDifferential(at: x, of: f)
+//  return (y, differential(1))
+//}
 
 % end

--- a/stdlib/public/Differentiation/AnyDifferentiable.swift
+++ b/stdlib/public/Differentiation/AnyDifferentiable.swift
@@ -85,15 +85,15 @@ public struct AnyDifferentiable: Differentiable {
     return (AnyDifferentiable(base), { v in v.base as! T.TangentVector })
   }
 
-  @inlinable
-  @derivative(of: init)
-  internal static func _jvpInit<T: Differentiable>(
-    _ base: T
-  ) -> (
-    value: AnyDifferentiable, differential: (T.TangentVector) -> AnyDerivative
-  ) {
-    return (AnyDifferentiable(base), { dbase in AnyDerivative(dbase) })
-  }
+//  @inlinable
+//  @derivative(of: init)
+//  internal static func _jvpInit<T: Differentiable>(
+//    _ base: T
+//  ) -> (
+//    value: AnyDifferentiable, differential: (T.TangentVector) -> AnyDerivative
+//  ) {
+//    return (AnyDifferentiable(base), { dbase in AnyDerivative(dbase) })
+//  }
 
   public typealias TangentVector = AnyDerivative
 
@@ -268,14 +268,14 @@ public struct AnyDerivative: Differentiable & AdditiveArithmetic {
     return (AnyDerivative(base), { v in v.base as! T.TangentVector })
   }
 
-  @inlinable
-  @derivative(of: init)
-  internal static func _jvpInit<T>(
-    _ base: T
-  ) -> (value: AnyDerivative, differential: (T.TangentVector) -> AnyDerivative)
-  where T: Differentiable, T.TangentVector == T {
-    return (AnyDerivative(base), { dbase in AnyDerivative(dbase) })
-  }
+//  @inlinable
+//  @derivative(of: init)
+//  internal static func _jvpInit<T>(
+//    _ base: T
+//  ) -> (value: AnyDerivative, differential: (T.TangentVector) -> AnyDerivative)
+//  where T: Differentiable, T.TangentVector == T {
+//    return (AnyDerivative(base), { dbase in AnyDerivative(dbase) })
+//  }
 
   public typealias TangentVector = AnyDerivative
 
@@ -320,16 +320,16 @@ public struct AnyDerivative: Differentiable & AdditiveArithmetic {
     return (lhs + rhs, { v in (v, v) })
   }
 
-  @derivative(of: +)
-  @inlinable
-  internal static func _jvpAdd(
-    lhs: AnyDerivative, rhs: AnyDerivative
-  ) -> (
-    value: AnyDerivative,
-    differential: (AnyDerivative, AnyDerivative) -> (AnyDerivative)
-  ) {
-    return (lhs + rhs, { (dlhs, drhs) in dlhs + drhs })
-  }
+//  @derivative(of: +)
+//  @inlinable
+//  internal static func _jvpAdd(
+//    lhs: AnyDerivative, rhs: AnyDerivative
+//  ) -> (
+//    value: AnyDerivative,
+//    differential: (AnyDerivative, AnyDerivative) -> (AnyDerivative)
+//  ) {
+//    return (lhs + rhs, { (dlhs, drhs) in dlhs + drhs })
+//  }
 
   @inlinable
   public static func - (
@@ -349,16 +349,16 @@ public struct AnyDerivative: Differentiable & AdditiveArithmetic {
     return (lhs - rhs, { v in (v, .zero - v) })
   }
 
-  @derivative(of: -)
-  @inlinable
-  internal static func _jvpSubtract(
-    lhs: AnyDerivative, rhs: AnyDerivative
-  ) -> (
-    value: AnyDerivative,
-    differential: (AnyDerivative, AnyDerivative) -> AnyDerivative
-  ) {
-    return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
-  }
+//  @derivative(of: -)
+//  @inlinable
+//  internal static func _jvpSubtract(
+//    lhs: AnyDerivative, rhs: AnyDerivative
+//  ) -> (
+//    value: AnyDerivative,
+//    differential: (AnyDerivative, AnyDerivative) -> AnyDerivative
+//  ) {
+//    return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
+//  }
 
   // `Differentiable` requirements.
   @inlinable

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -42,13 +42,13 @@ where Element: Differentiable {
     return (base, { $0 })
   }
 
-  @usableFromInline
-  @derivative(of: base)
-  func _jvpBase() -> (
-    value: [Element], differential: (Array<Element>.TangentVector) -> TangentVector
-  ) {
-    return (base, { $0 })
-  }
+//  @usableFromInline
+//  @derivative(of: base)
+//  func _jvpBase() -> (
+//    value: [Element], differential: (Array<Element>.TangentVector) -> TangentVector
+//  ) {
+//    return (base, { $0 })
+//  }
 
   /// Creates a differentiable view of the given array.
   public init(_ base: [Element]) { self._base = base }
@@ -61,13 +61,13 @@ where Element: Differentiable {
     return (Array.DifferentiableView(base), { $0 })
   }
 
-  @usableFromInline
-  @derivative(of: init(_:))
-  static func _jvpInit(_ base: [Element]) -> (
-    value: Array.DifferentiableView, differential: (TangentVector) -> TangentVector
-  ) {
-    return (Array.DifferentiableView(base), { $0 })
-  }
+//  @usableFromInline
+//  @derivative(of: init(_:))
+//  static func _jvpInit(_ base: [Element]) -> (
+//    value: Array.DifferentiableView, differential: (TangentVector) -> TangentVector
+//  ) {
+//    return (Array.DifferentiableView(base), { $0 })
+//  }
 
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
@@ -202,16 +202,16 @@ extension Array where Element: Differentiable {
     return (self[index], pullback)
   }
 
-  @usableFromInline
-  @derivative(of: subscript)
-  func _jvpSubscript(index: Int) -> (
-    value: Element, differential: (TangentVector) -> Element.TangentVector
-  ) {
-    func differential(_ v: TangentVector) -> Element.TangentVector {
-      return v[index]
-    }
-    return (self[index], differential)
-  }
+//  @usableFromInline
+//  @derivative(of: subscript)
+//  func _jvpSubscript(index: Int) -> (
+//    value: Element, differential: (TangentVector) -> Element.TangentVector
+//  ) {
+//    func differential(_ v: TangentVector) -> Element.TangentVector {
+//      return v[index]
+//    }
+//    return (self[index], differential)
+//  }
 
   @usableFromInline
   @derivative(of: +)
@@ -236,22 +236,22 @@ extension Array where Element: Differentiable {
     return (lhs + rhs, pullback)
   }
 
-  @usableFromInline
-  @derivative(of: +)
-  static func _jvpConcatenate(_ lhs: Self, _ rhs: Self) -> (
-    value: Self,
-    differential: (TangentVector, TangentVector) -> TangentVector
-  ) {
-    func differential(_ l: TangentVector, _ r: TangentVector) -> TangentVector {
-      precondition(
-        l.base.count == lhs.count && r.base.count == rhs.count, """
-          Tangent vectors with invalid count; expected to equal the \
-          operand counts \(lhs.count) and \(rhs.count)
-          """)
-      return .init(l.base + r.base)
-    }
-    return (lhs + rhs, differential)
-  }
+//  @usableFromInline
+//  @derivative(of: +)
+//  static func _jvpConcatenate(_ lhs: Self, _ rhs: Self) -> (
+//    value: Self,
+//    differential: (TangentVector, TangentVector) -> TangentVector
+//  ) {
+//    func differential(_ l: TangentVector, _ r: TangentVector) -> TangentVector {
+//      precondition(
+//        l.base.count == lhs.count && r.base.count == rhs.count, """
+//          Tangent vectors with invalid count; expected to equal the \
+//          operand counts \(lhs.count) and \(rhs.count)
+//          """)
+//      return .init(l.base + r.base)
+//    }
+//    return (lhs + rhs, differential)
+//  }
 }
 
 
@@ -269,15 +269,15 @@ extension Array where Element: Differentiable {
     })
   }
 
-  @usableFromInline
-  @derivative(of: append)
-  mutating func _jvpAppend(_ element: Element) -> (
-    value: Void,
-    differential: (inout TangentVector, Element.TangentVector) -> Void
-  ) {
-    append(element)
-    return ((), { $0.base.append($1) })
-  }
+//  @usableFromInline
+//  @derivative(of: append)
+//  mutating func _jvpAppend(_ element: Element) -> (
+//    value: Void,
+//    differential: (inout TangentVector, Element.TangentVector) -> Void
+//  ) {
+//    append(element)
+//    return ((), { $0.base.append($1) })
+//  }
 }
 
 extension Array where Element: Differentiable {
@@ -297,14 +297,14 @@ extension Array where Element: Differentiable {
     })
   }
 
-  @usableFromInline
-  @derivative(of: +=)
-  static func _jvpAppend(_ lhs: inout Self, _ rhs: Self) -> (
-    value: Void, differential: (inout TangentVector, TangentVector) -> Void
-  ) {
-    lhs += rhs
-    return ((), { $0.base += $1.base })
-  }
+//  @usableFromInline
+//  @derivative(of: +=)
+//  static func _jvpAppend(_ lhs: inout Self, _ rhs: Self) -> (
+//    value: Void, differential: (inout TangentVector, TangentVector) -> Void
+//  ) {
+//    lhs += rhs
+//    return ((), { $0.base += $1.base })
+//  }
 }
 
 extension Array where Element: Differentiable {
@@ -321,16 +321,16 @@ extension Array where Element: Differentiable {
     )
   }
 
-  @usableFromInline
-  @derivative(of: init(repeating:count:))
-  static func _jvpInit(repeating repeatedValue: Element, count: Int) -> (
-    value: Self, differential: (Element.TangentVector) -> TangentVector
-  ) {
-    (
-      value: Self(repeating: repeatedValue, count: count),
-      differential: { v in TangentVector(.init(repeating: v, count: count)) }
-    )
-  }
+//  @usableFromInline
+//  @derivative(of: init(repeating:count:))
+//  static func _jvpInit(repeating repeatedValue: Element, count: Int) -> (
+//    value: Self, differential: (Element.TangentVector) -> TangentVector
+//  ) {
+//    (
+//      value: Self(repeating: repeatedValue, count: count),
+//      differential: { v in TangentVector(.init(repeating: v, count: count)) }
+//    )
+//  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -367,26 +367,26 @@ extension Array where Element: Differentiable {
     return (value: values, pullback: pullback)
   }
 
-  @inlinable
-  @derivative(of: differentiableMap)
-  internal func _jvpDifferentiableMap<Result: Differentiable>(
-    _ body: @differentiable(reverse) (Element) -> Result
-  ) -> (
-    value: [Result],
-    differential: (Array.TangentVector) -> Array<Result>.TangentVector
-  ) {
-    var values: [Result] = []
-    var differentials: [(Element.TangentVector) -> Result.TangentVector] = []
-    for x in self {
-      let (y, df) = valueWithDifferential(at: x, of: body)
-      values.append(y)
-      differentials.append(df)
-    }
-    func differential(_ tans: Array.TangentVector) -> Array<Result>.TangentVector {
-      .init(zip(tans.base, differentials).map { tan, df in df(tan) })
-    }
-    return (value: values, differential: differential)
-  }
+//  @inlinable
+//  @derivative(of: differentiableMap)
+//  internal func _jvpDifferentiableMap<Result: Differentiable>(
+//    _ body: @differentiable(reverse) (Element) -> Result
+//  ) -> (
+//    value: [Result],
+//    differential: (Array.TangentVector) -> Array<Result>.TangentVector
+//  ) {
+//    var values: [Result] = []
+//    var differentials: [(Element.TangentVector) -> Result.TangentVector] = []
+//    for x in self {
+//      let (y, df) = valueWithDifferential(at: x, of: body)
+//      values.append(y)
+//      differentials.append(df)
+//    }
+//    func differential(_ tans: Array.TangentVector) -> Array<Result>.TangentVector {
+//      .init(zip(tans.base, differentials).map { tan, df in df(tan) })
+//    }
+//    return (value: values, differential: differential)
+//  }
 }
 
 extension Array where Element: Differentiable {
@@ -437,32 +437,32 @@ extension Array where Element: Differentiable {
     )
   }
 
-  @inlinable
-  @derivative(of: differentiableReduce, wrt: (self, initialResult))
-  func _jvpDifferentiableReduce<Result: Differentiable>(
-    _ initialResult: Result,
-    _ nextPartialResult: @differentiable(reverse) (Result, Element) -> Result
-  ) -> (value: Result,
-        differential: (Array.TangentVector, Result.TangentVector)
-          -> Result.TangentVector) {
-    var differentials:
-      [(Result.TangentVector, Element.TangentVector) -> Result.TangentVector]
-        = []
-    let count = self.count
-    differentials.reserveCapacity(count)
-    var result = initialResult
-    for element in self {
-      let (y, df) =
-        valueWithDifferential(at: result, element, of: nextPartialResult)
-      result = y
-      differentials.append(df)
-    }
-    return (value: result, differential: { dSelf, dInitial in
-      var dResult = dInitial
-      for (dElement, df) in zip(dSelf.base, differentials) {
-        dResult = df(dResult, dElement)
-      }
-      return dResult
-    })
-  }
+//  @inlinable
+//  @derivative(of: differentiableReduce, wrt: (self, initialResult))
+//  func _jvpDifferentiableReduce<Result: Differentiable>(
+//    _ initialResult: Result,
+//    _ nextPartialResult: @differentiable(reverse) (Result, Element) -> Result
+//  ) -> (value: Result,
+//        differential: (Array.TangentVector, Result.TangentVector)
+//          -> Result.TangentVector) {
+//    var differentials:
+//      [(Result.TangentVector, Element.TangentVector) -> Result.TangentVector]
+//        = []
+//    let count = self.count
+//    differentials.reserveCapacity(count)
+//    var result = initialResult
+//    for element in self {
+//      let (y, df) =
+//        valueWithDifferential(at: result, element, of: nextPartialResult)
+//      result = y
+//      differentials.append(df)
+//    }
+//    return (value: result, differential: { dSelf, dInitial in
+//      var dResult = dInitial
+//      for (dElement, df) in zip(dSelf.base, differentials) {
+//        dResult = df(dResult, dElement)
+//      }
+//      return dResult
+//    })
+//  }
 }

--- a/stdlib/public/Differentiation/DifferentialOperators.swift
+++ b/stdlib/public/Differentiation/DifferentialOperators.swift
@@ -18,29 +18,29 @@ import Swift
 
 // Value with differential
 
-@inlinable
-public func valueWithDifferential<T, R>(
-  at x: T, of f: @differentiable(reverse) (T) -> R
-) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
-  return Builtin.applyDerivative_jvp(f, x)
-}
-
-@inlinable
-public func valueWithDifferential<T, U, R>(
-  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
-) -> (value: R,
-      differential: (T.TangentVector, U.TangentVector) -> R.TangentVector) {
-  return Builtin.applyDerivative_jvp_arity2(f, x, y)
-}
-
-@inlinable
-public func valueWithDifferential<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
-) -> (value: R,
-      differential: (T.TangentVector, U.TangentVector, V.TangentVector)
-        -> (R.TangentVector)) {
-  return Builtin.applyDerivative_jvp_arity3(f, x, y, z)
-}
+//@inlinable
+//public func valueWithDifferential<T, R>(
+//  at x: T, of f: @differentiable(reverse) (T) -> R
+//) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
+//  return Builtin.applyDerivative_jvp(f, x)
+//}
+//
+//@inlinable
+//public func valueWithDifferential<T, U, R>(
+//  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
+//) -> (value: R,
+//      differential: (T.TangentVector, U.TangentVector) -> R.TangentVector) {
+//  return Builtin.applyDerivative_jvp_arity2(f, x, y)
+//}
+//
+//@inlinable
+//public func valueWithDifferential<T, U, V, R>(
+//  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
+//) -> (value: R,
+//      differential: (T.TangentVector, U.TangentVector, V.TangentVector)
+//        -> (R.TangentVector)) {
+//  return Builtin.applyDerivative_jvp_arity3(f, x, y, z)
+//}
 
 // Value with pullback
 
@@ -70,26 +70,26 @@ public func valueWithPullback<T, U, V, R>(
 
 // Differential
 
-@inlinable
-public func differential<T, R>(
-  at x: T, of f: @differentiable(reverse) (T) -> R
-) -> (T.TangentVector) -> R.TangentVector {
-  return valueWithDifferential(at: x, of: f).1
-}
-
-@inlinable
-public func differential<T, U, R>(
-  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
-) -> (T.TangentVector, U.TangentVector) -> R.TangentVector {
-  return valueWithDifferential(at: x, y, of: f).1
-}
-
-@inlinable
-public func differential<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
-) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
-  return valueWithDifferential(at: x, y, z, of: f).1
-}
+//@inlinable
+//public func differential<T, R>(
+//  at x: T, of f: @differentiable(reverse) (T) -> R
+//) -> (T.TangentVector) -> R.TangentVector {
+//  return valueWithDifferential(at: x, of: f).1
+//}
+//
+//@inlinable
+//public func differential<T, U, R>(
+//  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
+//) -> (T.TangentVector, U.TangentVector) -> R.TangentVector {
+//  return valueWithDifferential(at: x, y, of: f).1
+//}
+//
+//@inlinable
+//public func differential<T, U, V, R>(
+//  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
+//) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
+//  return valueWithDifferential(at: x, y, z, of: f).1
+//}
 
 
 // Pullback
@@ -118,32 +118,32 @@ public func pullback<T, U, V, R>(
 
 // Derivative
 
-@inlinable
-public func derivative<T: FloatingPoint, R>(
-  at x: T, of f: @differentiable(reverse) (T) -> R
-) ->  R.TangentVector
-  where T.TangentVector == T {
-  return differential(at: x, of: f)(T(1))
-}
-
-@inlinable
-public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
-) -> R.TangentVector
-  where T.TangentVector == T,
-        U.TangentVector == U {
-  return differential(at: x, y, of: f)(T(1), U(1))
-}
-
-@inlinable
-public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
-  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
-) -> R.TangentVector
-  where T.TangentVector == T,
-        U.TangentVector == U,
-        V.TangentVector == V {
-  return differential(at: x, y, z, of: f)(T(1), U(1), V(1))
-}
+//@inlinable
+//public func derivative<T: FloatingPoint, R>(
+//  at x: T, of f: @differentiable(reverse) (T) -> R
+//) ->  R.TangentVector
+//  where T.TangentVector == T {
+//  return differential(at: x, of: f)(T(1))
+//}
+//
+//@inlinable
+//public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+//  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
+//) -> R.TangentVector
+//  where T.TangentVector == T,
+//        U.TangentVector == U {
+//  return differential(at: x, y, of: f)(T(1), U(1))
+//}
+//
+//@inlinable
+//public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+//  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
+//) -> R.TangentVector
+//  where T.TangentVector == T,
+//        U.TangentVector == U,
+//        V.TangentVector == V {
+//  return differential(at: x, y, z, of: f)(T(1), U(1), V(1))
+//}
 
 // Gradient
 
@@ -173,36 +173,36 @@ public func gradient<T, U, V, R>(
 
 // Value with derivative
 
-@inlinable
-public func valueWithDerivative<T: FloatingPoint, R>(
-  at x: T, of f: @escaping @differentiable(reverse) (T) -> R
-) -> (value: R, derivative: R.TangentVector)
-  where T.TangentVector == T {
-  let (y, differential) = valueWithDifferential(at: x, of: f)
-  return (y, differential(T(1)))
-}
-
-@inlinable
-public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: T, _ y: U, of f: @escaping @differentiable(reverse) (T, U) -> R
-) -> (value: R, derivative: R.TangentVector)
-  where T.TangentVector == T,
-        U.TangentVector == U {
-  let (y, differential) = valueWithDifferential(at: x, y, of: f)
-  return (y, differential(T(1), U(1)))
-}
-
-@inlinable
-public func valueWithDerivative<
-  T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
-  at x: T, _ y: U, _ z: V, of f: @escaping @differentiable(reverse) (T, U, V) -> R
-) -> (value: R, derivative: R.TangentVector)
-  where T.TangentVector == T,
-        U.TangentVector == U,
-        V.TangentVector == V {
-  let (y, differential) = valueWithDifferential(at: x, y, z, of: f)
-  return (y, differential(T(1), U(1), V(1)))
-}
+//@inlinable
+//public func valueWithDerivative<T: FloatingPoint, R>(
+//  at x: T, of f: @escaping @differentiable(reverse) (T) -> R
+//) -> (value: R, derivative: R.TangentVector)
+//  where T.TangentVector == T {
+//  let (y, differential) = valueWithDifferential(at: x, of: f)
+//  return (y, differential(T(1)))
+//}
+//
+//@inlinable
+//public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
+//  at x: T, _ y: U, of f: @escaping @differentiable(reverse) (T, U) -> R
+//) -> (value: R, derivative: R.TangentVector)
+//  where T.TangentVector == T,
+//        U.TangentVector == U {
+//  let (y, differential) = valueWithDifferential(at: x, y, of: f)
+//  return (y, differential(T(1), U(1)))
+//}
+//
+//@inlinable
+//public func valueWithDerivative<
+//  T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+//  at x: T, _ y: U, _ z: V, of f: @escaping @differentiable(reverse) (T, U, V) -> R
+//) -> (value: R, derivative: R.TangentVector)
+//  where T.TangentVector == T,
+//        U.TangentVector == U,
+//        V.TangentVector == V {
+//  let (y, differential) = valueWithDifferential(at: x, y, z, of: f)
+//  return (y, differential(T(1), U(1), V(1)))
+//}
 
 // Value with gradient
 
@@ -236,32 +236,32 @@ public func valueWithGradient<T, U, V, R>(
 
 // Derivative (curried)
 
-@inlinable 
-public func derivative<T: FloatingPoint, R>(
-  of f: @escaping @differentiable(reverse) (T) -> R
-) -> (T) -> R.TangentVector
-  where T.TangentVector == T {
-  return { x in derivative(at: x, of: f) }
-}
-
-@inlinable 
-public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
-  of f: @escaping @differentiable(reverse) (T, U) -> R
-) -> (T, U) -> R.TangentVector
-  where T.TangentVector == T,
-        U.TangentVector == U {
-  return { (x, y) in derivative(at: x, y, of: f) }
-}
-
-@inlinable
-public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
-  of f: @escaping @differentiable(reverse) (T, U, V) -> R
-) -> (T, U, V) -> R.TangentVector
-  where T.TangentVector == T,
-        U.TangentVector == U,
-        V.TangentVector == V {
-  return { (x, y, z) in derivative(at: x, y, z, of: f) }
-}
+//@inlinable
+//public func derivative<T: FloatingPoint, R>(
+//  of f: @escaping @differentiable(reverse) (T) -> R
+//) -> (T) -> R.TangentVector
+//  where T.TangentVector == T {
+//  return { x in derivative(at: x, of: f) }
+//}
+//
+//@inlinable
+//public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
+//  of f: @escaping @differentiable(reverse) (T, U) -> R
+//) -> (T, U) -> R.TangentVector
+//  where T.TangentVector == T,
+//        U.TangentVector == U {
+//  return { (x, y) in derivative(at: x, y, of: f) }
+//}
+//
+//@inlinable
+//public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
+//  of f: @escaping @differentiable(reverse) (T, U, V) -> R
+//) -> (T, U, V) -> R.TangentVector
+//  where T.TangentVector == T,
+//        U.TangentVector == U,
+//        V.TangentVector == V {
+//  return { (x, y, z) in derivative(at: x, y, z, of: f) }
+//}
 
 // Gradient (curried)
 

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -62,13 +62,13 @@ extension ${Self} {
     return (-x, { v in -v })
   }
 
-  @usableFromInline
-  @_transparent
-  @derivative(of: -)
-  static func _jvpNegate(x: ${Self})
-  -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
-    return (-x, { dx in -dx })
-  }
+//  @usableFromInline
+//  @_transparent
+//  @derivative(of: -)
+//  static func _jvpNegate(x: ${Self})
+//  -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
+//    return (-x, { dx in -dx })
+//  }
 }
 
 /// Derivatives of standard binary operators.

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -55,15 +55,15 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: subscript(_:))
-  internal func _jvpSubscript(index: Int)
-    -> (value: Scalar, differential: (TangentVector) -> Scalar.TangentVector)
-  {
-    return (self[index], { v in
-      return .init(v[index])
-    })
-  }
+//  @inlinable
+//  @derivative(of: subscript(_:))
+//  internal func _jvpSubscript(index: Int)
+//    -> (value: Scalar, differential: (TangentVector) -> Scalar.TangentVector)
+//  {
+//    return (self[index], { v in
+//      return .init(v[index])
+//    })
+//  }
 
   @inlinable
   @derivative(of: subscript(_:).set)
@@ -100,17 +100,17 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: +)
-  static func _jvpAdd(lhs: Self, rhs: Self)
-    -> (
-      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
-    )
-  {
-    return (lhs + rhs, { ltan, rtan in
-      return ltan + rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: +)
+//  static func _jvpAdd(lhs: Self, rhs: Self)
+//    -> (
+//      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
+//    )
+//  {
+//    return (lhs + rhs, { ltan, rtan in
+//      return ltan + rtan
+//    })
+//  }
 
   @inlinable
   @derivative(of: -)
@@ -124,17 +124,17 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: -)
-  static func _jvpSubtract(lhs: Self, rhs: Self)
-    -> (
-      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
-    )
-  {
-    return (lhs - rhs, { ltan, rtan in
-      return ltan - rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: -)
+//  static func _jvpSubtract(lhs: Self, rhs: Self)
+//    -> (
+//      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
+//    )
+//  {
+//    return (lhs - rhs, { ltan, rtan in
+//      return ltan - rtan
+//    })
+//  }
 
   @inlinable
   @derivative(of: -)
@@ -146,15 +146,15 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: -)
-  static func _jvpNegate(rhs: Self)
-    -> (value: Self, differential: (TangentVector) -> (TangentVector))
-  {
-    return (-rhs, { v in
-      return -v
-    })
-  }
+//  @inlinable
+//  @derivative(of: -)
+//  static func _jvpNegate(rhs: Self)
+//    -> (value: Self, differential: (TangentVector) -> (TangentVector))
+//  {
+//    return (-rhs, { v in
+//      return -v
+//    })
+//  }
 }
 
 extension SIMD
@@ -175,17 +175,17 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: *)
-  static func _jvpMultiply(lhs: Self, rhs: Self)
-    -> (
-      value: Self,  differential: (TangentVector, TangentVector) -> TangentVector
-    )
-  {
-    return (lhs * rhs, { ltan, rtan in
-      return lhs * rtan + ltan * rhs
-    })
-  }
+//  @inlinable
+//  @derivative(of: *)
+//  static func _jvpMultiply(lhs: Self, rhs: Self)
+//    -> (
+//      value: Self,  differential: (TangentVector, TangentVector) -> TangentVector
+//    )
+//  {
+//    return (lhs * rhs, { ltan, rtan in
+//      return lhs * rtan + ltan * rhs
+//    })
+//  }
 
   @inlinable
   @derivative(of: /)
@@ -199,17 +199,17 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: /)
-  static func _jvpDivide(lhs: Self, rhs: Self)
-    -> (
-      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
-    )
-  {
-    return ( lhs / rhs, { ltan, rtan in
-      (ltan * rhs - lhs * rtan) / (rhs * rhs)
-    })
-  }
+//  @inlinable
+//  @derivative(of: /)
+//  static func _jvpDivide(lhs: Self, rhs: Self)
+//    -> (
+//      value: Self, differential: (TangentVector, TangentVector) -> TangentVector
+//    )
+//  {
+//    return ( lhs / rhs, { ltan, rtan in
+//      (ltan * rhs - lhs * rtan) / (rhs * rhs)
+//    })
+//  }
 }
 
 extension SIMD
@@ -231,16 +231,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: +)
-  static func _jvpAdd(lhs: Scalar, rhs: Self) -> (
-    value: Self,
-    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
-  ) {
-    return (lhs + rhs, { ltan, rtan in
-      return ltan + rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: +)
+//  static func _jvpAdd(lhs: Scalar, rhs: Self) -> (
+//    value: Self,
+//    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
+//  ) {
+//    return (lhs + rhs, { ltan, rtan in
+//      return ltan + rtan
+//    })
+//  }
 
   @inlinable
   @derivative(of: -)
@@ -253,16 +253,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: -)
-  static func _jvpSubtract(lhs: Scalar, rhs: Self) -> (
-    value: Self,
-    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
-  ) {
-    return (lhs - rhs, { ltan, rtan in
-      return ltan - rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: -)
+//  static func _jvpSubtract(lhs: Scalar, rhs: Self) -> (
+//    value: Self,
+//    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
+//  ) {
+//    return (lhs - rhs, { ltan, rtan in
+//      return ltan - rtan
+//    })
+//  }
 
   @inlinable
   @derivative(of: +)
@@ -275,16 +275,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: +)
-  static func _jvpAdd(lhs: Self, rhs: Scalar) -> (
-    value: Self,
-    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
-  ) {
-    return (lhs + rhs, { ltan, rtan in
-      return ltan + rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: +)
+//  static func _jvpAdd(lhs: Self, rhs: Scalar) -> (
+//    value: Self,
+//    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
+//  ) {
+//    return (lhs + rhs, { ltan, rtan in
+//      return ltan + rtan
+//    })
+//  }
 
   @inlinable
   @derivative(of: -)
@@ -297,16 +297,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: -)
-  static func _jvpSubtract(lhs: Self, rhs: Scalar) -> (
-    value: Self,
-    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
-  ) {
-    return (lhs - rhs, { ltan, rtan in
-      return ltan - rtan
-    })
-  }
+//  @inlinable
+//  @derivative(of: -)
+//  static func _jvpSubtract(lhs: Self, rhs: Scalar) -> (
+//    value: Self,
+//    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
+//  ) {
+//    return (lhs - rhs, { ltan, rtan in
+//      return ltan - rtan
+//    })
+//  }
 }
 
 extension SIMD
@@ -327,16 +327,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: *)
-  static func _jvpMultiply(lhs: Self, rhs: Scalar) -> (
-    value: Self,
-    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
-  ) {
-    return (lhs * rhs, { ltan, rtan in
-      return lhs * rtan + ltan * rhs
-    })
-  }
+//  @inlinable
+//  @derivative(of: *)
+//  static func _jvpMultiply(lhs: Self, rhs: Scalar) -> (
+//    value: Self,
+//    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
+//  ) {
+//    return (lhs * rhs, { ltan, rtan in
+//      return lhs * rtan + ltan * rhs
+//    })
+//  }
 
   @inlinable
   @derivative(of: /)
@@ -349,16 +349,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: /)
-  static func _jvpDivide(lhs: Self, rhs: Scalar) -> (
-    value: Self,
-    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
-  ) {
-    return (lhs / rhs, { ltan, rtan in
-      (ltan * rhs - lhs * rtan) / (rhs * rhs)
-    })
-  }
+//  @inlinable
+//  @derivative(of: /)
+//  static func _jvpDivide(lhs: Self, rhs: Scalar) -> (
+//    value: Self,
+//    differential: (TangentVector, Scalar.TangentVector) -> TangentVector
+//  ) {
+//    return (lhs / rhs, { ltan, rtan in
+//      (ltan * rhs - lhs * rtan) / (rhs * rhs)
+//    })
+//  }
 
   @inlinable
   @derivative(of: *)
@@ -371,16 +371,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: *)
-  static func _jvpMultiply(lhs: Scalar, rhs: Self) -> (
-    value: Self,
-    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
-  ) {
-    return (lhs * rhs, { ltan, rtan in
-      return lhs * rtan + ltan * rhs
-    })
-  }
+//  @inlinable
+//  @derivative(of: *)
+//  static func _jvpMultiply(lhs: Scalar, rhs: Self) -> (
+//    value: Self,
+//    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
+//  ) {
+//    return (lhs * rhs, { ltan, rtan in
+//      return lhs * rtan + ltan * rhs
+//    })
+//  }
 
   @inlinable
   @derivative(of: /)
@@ -393,16 +393,16 @@ where
     })
   }
 
-  @inlinable
-  @derivative(of: /)
-  static func _jvpDivide(lhs: Scalar, rhs: Self) -> (
-    value: Self,
-    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
-  ) {
-    return (lhs / rhs, { ltan, rtan in
-      (ltan * rhs - lhs * rtan) / (rhs * rhs)
-    })
-  }
+//  @inlinable
+//  @derivative(of: /)
+//  static func _jvpDivide(lhs: Scalar, rhs: Self) -> (
+//    value: Self,
+//    differential: (Scalar.TangentVector, TangentVector) -> TangentVector
+//  ) {
+//    return (lhs / rhs, { ltan, rtan in
+//      (ltan * rhs - lhs * rtan) / (rhs * rhs)
+//    })
+//  }
 }
 
 // FIXME(TF-1103): Derivative registration does not yet support
@@ -449,6 +449,7 @@ where
     return (Self(repeating: value), { v in v.sum() })
   }
 
+  // Leaving this because compiler crashes if commented out.
   @inlinable
   @derivative(of: init(repeating:))
   static func _jvpInit(repeating value: Scalar)

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -26,15 +26,15 @@ import Swift
 #error("Unsupported platform")
 #endif
 
-@usableFromInline
-@derivative(of: fma)
-func _jvpFma<T: FloatingPoint & Differentiable> (
-  _ x: T,
-  _ y: T,
-  _ z: T
-) -> (value: T, differential: (T, T, T) -> T) where T == T.TangentVector {
-  return (fma(x, y, z), { (dx, dy, dz) in dx * y + dy * x + dz })
-}
+//@usableFromInline
+//@derivative(of: fma)
+//func _jvpFma<T: FloatingPoint & Differentiable> (
+//  _ x: T,
+//  _ y: T,
+//  _ z: T
+//) -> (value: T, differential: (T, T, T) -> T) where T == T.TangentVector {
+//  return (fma(x, y, z), { (dx, dy, dz) in dx * y + dy * x + dz })
+//}
 
 @usableFromInline
 @derivative(of: fma)
@@ -46,17 +46,17 @@ func _vjpFma<T: FloatingPoint & Differentiable> (
   return (fma(x, y, z), { v in (v * y, v * x, v) })
 }
 
-@usableFromInline
-@derivative(of: remainder)
-func _jvpRemainder<T: FloatingPoint & Differentiable> (
-  _ x: T,
-  _ y: T
-) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
-  fatalError("""
-    Unimplemented JVP for 'remainder(_:)'. \
-    https://bugs.swift.org/browse/TF-1108 tracks this issue
-    """)
-}
+//@usableFromInline
+//@derivative(of: remainder)
+//func _jvpRemainder<T: FloatingPoint & Differentiable> (
+//  _ x: T,
+//  _ y: T
+//) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
+//  fatalError("""
+//    Unimplemented JVP for 'remainder(_:)'. \
+//    https://bugs.swift.org/browse/TF-1108 tracks this issue
+//    """)
+//}
 
 @usableFromInline
 @derivative(of: remainder)
@@ -67,17 +67,17 @@ func _vjpRemainder<T: FloatingPoint & Differentiable> (
   return (remainder(x, y), { v in (v, -v * ((x / y).rounded(.toNearestOrEven))) })
 }
 
-@usableFromInline
-@derivative(of: fmod)
-func _jvpFmod<T: FloatingPoint & Differentiable> (
-  _ x: T,
-  _ y: T
-) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
-  fatalError("""
-    Unimplemented JVP for 'fmod(_:)'. \
-    https://bugs.swift.org/browse/TF-1108 tracks this issue
-    """)
-}
+//@usableFromInline
+//@derivative(of: fmod)
+//func _jvpFmod<T: FloatingPoint & Differentiable> (
+//  _ x: T,
+//  _ y: T
+//) -> (value: T, differential: (T, T) -> T) where T == T.TangentVector {
+//  fatalError("""
+//    Unimplemented JVP for 'fmod(_:)'. \
+//    https://bugs.swift.org/browse/TF-1108 tracks this issue
+//    """)
+//}
 
 @usableFromInline
 @derivative(of: fmod)
@@ -88,7 +88,7 @@ func _vjpFmod<T: FloatingPoint & Differentiable> (
   return (fmod(x, y), { v in (v, -v * ((x / y).rounded(.towardZero))) })
 }
 
-%for derivative_kind in ['jvp', 'vjp']:
+%for derivative_kind in ['vjp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 @usableFromInline
 @derivative(of: sqrt)
@@ -130,10 +130,10 @@ func _${derivative_kind}Trunc<T: FloatingPoint & Differentiable> (
 ) -> (value: T, ${linear_map_kind}: (T) -> T) where T == T.TangentVector {
   return (trunc(x), { v in 0 })
 }
-%end # for derivative_kind in ['jvp', 'vjp']:
+%end # for derivative_kind in ['vjp']:
 
 // Unary functions
-%for derivative_kind in ['jvp', 'vjp']:
+%for derivative_kind in ['vjp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
@@ -273,7 +273,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 #endif
 %    end # if T == 'Float80':
 %  end # for T in ['Float', 'Double', 'Float80']:
-%end # for derivative_kind in ['jvp', 'vjp']:
+%end # for derivative_kind in ['vjp']:
 
 // Binary functions
 %for T in ['Float', 'Float80']:
@@ -289,14 +289,14 @@ func _vjpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, pullback: (${T}) -> (${T}, $
   ) })
 }
 
-@inlinable
-@derivative(of: pow)
-func _jvpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, differential: (${T}, ${T}) -> ${T}) {
-  let value = pow(x, y)
-  return (value, { (dx, dy) in
-    dx * y * pow(x, y - 1) + dy * value * log(x.isLessThanOrEqualTo(0) ? ${T}(1) : x)
-  })
-}
+//@inlinable
+//@derivative(of: pow)
+//func _jvpPow(_ x: ${T}, _ y: ${T}) -> (value: ${T}, differential: (${T}, ${T}) -> ${T}) {
+//  let value = pow(x, y)
+//  return (value, { (dx, dy) in
+//    dx * y * pow(x, y - 1) + dy * value * log(x.isLessThanOrEqualTo(0) ? ${T}(1) : x)
+//  })
+//}
 %  if T == 'Float80':
 #endif
 %  end # if T == 'Float80':

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -38,24 +38,24 @@ FloatingPointDerivativeTests.test("${Self}.+") {
   expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), of: +))
   expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10)))
 
-  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), of: +))
-  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10), ${Self}(10)))
+//  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), of: +))
+//  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.-") {
   expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), of: -))
   expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), of: -)(${Self}(10)))
 
-  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), of: -))
-  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), of: -)(${Self}(5), ${Self}(10)))
+//  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), of: -))
+//  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), of: -)(${Self}(5), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.*") {
   expectEqual((5, 4), gradient(at: ${Self}(4), ${Self}(5), of: *))
   expectEqual((50, 40), pullback(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10)))
 
-  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), of: *))
-  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
+//  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), of: *))
+//  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}./") {
@@ -70,8 +70,8 @@ FloatingPointDerivativeTests.test("${Self}./") {
     expectEqualWithTolerance(-1.6, dy)
   }
 
-  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), of: /))
-  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
+//  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), of: /))
+//  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -62,19 +62,19 @@ where T == T.TangentVector {
   expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: ulps)
 }
 
-func checkDerivative<T: BinaryFloatingPoint & Differentiable>(
-  _ f: @differentiable(reverse) (T, T) -> T,
-  _ x: T,
-  _ y: T,
-  ulps: T = 192)
-where T == T.TangentVector {
-  let eps = T(0.01)
-  let deriv = derivative(at: x, y, of: f)
-  let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
-  expectEqualWithTolerance(TestLiteralType(dfdx + dfdy), deriv, ulps: ulps)
-}
+//func checkDerivative<T: BinaryFloatingPoint & Differentiable>(
+//  _ f: @differentiable(reverse) (T, T) -> T,
+//  _ x: T,
+//  _ y: T,
+//  ulps: T = 192)
+//where T == T.TangentVector {
+//  let eps = T(0.01)
+//  let deriv = derivative(at: x, y, of: f)
+//  let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
+//  expectEqualWithTolerance(TestLiteralType(dfdx + dfdy), deriv, ulps: ulps)
+//}
 
-%for op in ['derivative', 'gradient']:
+%for op in ['gradient']:
 %for T in ['Float', 'Float80']:
 
 %if T == 'Float80':
@@ -206,6 +206,6 @@ DerivativeTests.test("${op}_${T}") {
 %end
 
 %end # for T in ['Float', 'Float80']:
-%end # for op in ['derivative', 'gradient']:
+%end # for op in ['gradient']:
 
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_array.swift
+++ b/test/AutoDiff/validation-test/forward_mode_array.swift
@@ -4,114 +4,114 @@
 import StdlibUnittest
 import DifferentiationUnittest
 
-var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
-
-//===----------------------------------------------------------------------===//
-// Array methods from ArrayDifferentiation.swift
-//===----------------------------------------------------------------------===//
-
-typealias FloatArrayTan = Array<Float>.TangentVector
-
-ForwardModeTests.test("Array.+") {
-  func sumFirstThreeConcatenating(_ a: [Float], _ b: [Float]) -> Float {
-    let c = a + b
-    return c[0] + c[1] + c[2]
-  }
-
-  expectEqual(3, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([1, 1])))
-  expectEqual(0, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 1]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 0]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([1, 1])))
-  expectEqual(2, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([0, 1])))
-
-  expectEqual(
-    3,
-    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 1]), .init([1, 1])))
-  expectEqual(
-    3,
-    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 0]), .init([0, 0])))
-
-  expectEqual(
-    3,
-    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([1, 1, 1, 1])))
-  expectEqual(
-    0,
-    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([0, 0, 0, 1])))
-}
-
-ForwardModeTests.test("Array.init(repeating:count:)") {
-  @differentiable(reverse)
-  func repeating(_ x: Float) -> [Float] {
-    Array(repeating: x, count: 10)
-  }
-  expectEqual(Float(10), derivative(at: .zero) { x in
-    repeating(x).differentiableReduce(0, {$0 + $1})
-  })
-  expectEqual(Float(20), differential(at: .zero, of: { x in
-    repeating(x).differentiableReduce(0, {$0 + $1})
-  })(2))
-}
-
-ForwardModeTests.test("Array.DifferentiableView.init") {
-  @differentiable(reverse)
-  func constructView(_ x: [Float]) -> Array<Float>.DifferentiableView {
-    return Array<Float>.DifferentiableView(x)
-  }
-
-  let forward = differential(at: [5, 6, 7, 8], of: constructView)
-  expectEqual(
-    FloatArrayTan([1, 2, 3, 4]),
-    forward(FloatArrayTan([1, 2, 3, 4])))
-}
-
-ForwardModeTests.test("Array.DifferentiableView.base") {
-  @differentiable(reverse)
-  func accessBase(_ x: Array<Float>.DifferentiableView) -> [Float] {
-    return x.base
-  }
-
-  let forward = differential(
-    at: Array<Float>.DifferentiableView([5, 6, 7, 8]),
-    of: accessBase)
-  expectEqual(
-    FloatArrayTan([1, 2, 3, 4]),
-    forward(FloatArrayTan([1, 2, 3, 4])))
-}
-
-ForwardModeTests.test("Array.differentiableMap") {
-  let x: [Float] = [1, 2, 3]
-  let tan = Array<Float>.TangentVector([1, 1, 1])
-
-  func multiplyMap(_ a: [Float]) -> [Float] {
-    return a.differentiableMap({ x in 3 * x })
-  }
-  expectEqual([3, 3, 3], differential(at: x, of: multiplyMap)(tan))
-
-  func squareMap(_ a: [Float]) -> [Float] {
-    return a.differentiableMap({ x in x * x })
-  }
-  expectEqual([2, 4, 6], differential(at: x, of: squareMap)(tan))
-}
-
-ForwardModeTests.test("Array.differentiableReduce") {
-  let x: [Float] = [1, 2, 3]
-  let tan = Array<Float>.TangentVector([1, 1, 1])
-
-  func sumReduce(_ a: [Float]) -> Float {
-    return a.differentiableReduce(0, { $0 + $1 })
-  }
-  expectEqual(1 + 1 + 1, differential(at: x, of: sumReduce)(tan))
-
-  func productReduce(_ a: [Float]) -> Float {
-    return a.differentiableReduce(1, { $0 * $1 })
-  }
-  expectEqual(x[1] * x[2] + x[0] * x[2] + x[0] * x[1], differential(at: x, of: productReduce)(tan))
-
-  func sumOfSquaresReduce(_ a: [Float]) -> Float {
-    return a.differentiableReduce(0, { $0 + $1 * $1 })
-  }
-  expectEqual(2 * x[0] + 2 * x[1] + 2 * x[2], differential(at: x, of: sumOfSquaresReduce)(tan))
-}
-
-runAllTests()
+//var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
+//
+////===----------------------------------------------------------------------===//
+//// Array methods from ArrayDifferentiation.swift
+////===----------------------------------------------------------------------===//
+//
+//typealias FloatArrayTan = Array<Float>.TangentVector
+//
+//ForwardModeTests.test("Array.+") {
+//  func sumFirstThreeConcatenating(_ a: [Float], _ b: [Float]) -> Float {
+//    let c = a + b
+//    return c[0] + c[1] + c[2]
+//  }
+//
+//  expectEqual(3, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([1, 1])))
+//  expectEqual(0, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([0, 1])))
+//  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 1]), .init([0, 1])))
+//  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 0]), .init([0, 1])))
+//  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([1, 1])))
+//  expectEqual(2, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([0, 1])))
+//
+//  expectEqual(
+//    3,
+//    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 1]), .init([1, 1])))
+//  expectEqual(
+//    3,
+//    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 0]), .init([0, 0])))
+//
+//  expectEqual(
+//    3,
+//    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([1, 1, 1, 1])))
+//  expectEqual(
+//    0,
+//    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([0, 0, 0, 1])))
+//}
+//
+//ForwardModeTests.test("Array.init(repeating:count:)") {
+//  @differentiable(reverse)
+//  func repeating(_ x: Float) -> [Float] {
+//    Array(repeating: x, count: 10)
+//  }
+//  expectEqual(Float(10), derivative(at: .zero) { x in
+//    repeating(x).differentiableReduce(0, {$0 + $1})
+//  })
+//  expectEqual(Float(20), differential(at: .zero, of: { x in
+//    repeating(x).differentiableReduce(0, {$0 + $1})
+//  })(2))
+//}
+//
+//ForwardModeTests.test("Array.DifferentiableView.init") {
+//  @differentiable(reverse)
+//  func constructView(_ x: [Float]) -> Array<Float>.DifferentiableView {
+//    return Array<Float>.DifferentiableView(x)
+//  }
+//
+//  let forward = differential(at: [5, 6, 7, 8], of: constructView)
+//  expectEqual(
+//    FloatArrayTan([1, 2, 3, 4]),
+//    forward(FloatArrayTan([1, 2, 3, 4])))
+//}
+//
+//ForwardModeTests.test("Array.DifferentiableView.base") {
+//  @differentiable(reverse)
+//  func accessBase(_ x: Array<Float>.DifferentiableView) -> [Float] {
+//    return x.base
+//  }
+//
+//  let forward = differential(
+//    at: Array<Float>.DifferentiableView([5, 6, 7, 8]),
+//    of: accessBase)
+//  expectEqual(
+//    FloatArrayTan([1, 2, 3, 4]),
+//    forward(FloatArrayTan([1, 2, 3, 4])))
+//}
+//
+//ForwardModeTests.test("Array.differentiableMap") {
+//  let x: [Float] = [1, 2, 3]
+//  let tan = Array<Float>.TangentVector([1, 1, 1])
+//
+//  func multiplyMap(_ a: [Float]) -> [Float] {
+//    return a.differentiableMap({ x in 3 * x })
+//  }
+//  expectEqual([3, 3, 3], differential(at: x, of: multiplyMap)(tan))
+//
+//  func squareMap(_ a: [Float]) -> [Float] {
+//    return a.differentiableMap({ x in x * x })
+//  }
+//  expectEqual([2, 4, 6], differential(at: x, of: squareMap)(tan))
+//}
+//
+//ForwardModeTests.test("Array.differentiableReduce") {
+//  let x: [Float] = [1, 2, 3]
+//  let tan = Array<Float>.TangentVector([1, 1, 1])
+//
+//  func sumReduce(_ a: [Float]) -> Float {
+//    return a.differentiableReduce(0, { $0 + $1 })
+//  }
+//  expectEqual(1 + 1 + 1, differential(at: x, of: sumReduce)(tan))
+//
+//  func productReduce(_ a: [Float]) -> Float {
+//    return a.differentiableReduce(1, { $0 * $1 })
+//  }
+//  expectEqual(x[1] * x[2] + x[0] * x[2] + x[0] * x[1], differential(at: x, of: productReduce)(tan))
+//
+//  func sumOfSquaresReduce(_ a: [Float]) -> Float {
+//    return a.differentiableReduce(0, { $0 + $1 * $1 })
+//  }
+//  expectEqual(2 * x[0] + 2 * x[1] + 2 * x[2], differential(at: x, of: sumOfSquaresReduce)(tan))
+//}
+//
+//runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_inout.swift
+++ b/test/AutoDiff/validation-test/forward_mode_inout.swift
@@ -4,158 +4,158 @@
 import StdlibUnittest
 import DifferentiationUnittest
 
-var ForwardModeInoutTests = TestSuite("ForwardModeInoutDifferentiation")
-
-//===----------------------------------------------------------------------===//
-// Inout tests.
-//===----------------------------------------------------------------------===//
-
-import DifferentiationUnittest
-import StdlibUnittest
-
-ForwardModeInoutTests.test("Float.+=") {
-  func mutatingAddWrapper(_ x: Float, _ y: Float) -> Float {
-    var result: Float = x
-    result += y
-    return result
-  }
-  expectEqual(20, differential(at: 4, 5, of: mutatingAddWrapper)(10, 10))
-}
-
-ForwardModeInoutTests.test("Float.-=") {
-  func mutatingSubtractWrapper(_ x: Float, _ y: Float) -> Float {
-    var result: Float = x
-    result -= y
-    return result
-  }
-  expectEqual(0, differential(at: 4, 5, of: mutatingSubtractWrapper)(10, 10))
-  expectEqual(10, differential(at: 4, 5, of: mutatingSubtractWrapper)(20, 10))
-}
-
-ForwardModeInoutTests.test("Float.*=") {
-  func mutatingMultiplyWrapper(_ x: Float, _ y: Float) -> Float {
-    var result: Float = x
-    result *= y
-    return result
-  }
-  expectEqual(22, differential(at: 4, 5, of: mutatingMultiplyWrapper)(2, 3))
-}
-
-ForwardModeInoutTests.test("Float./=") {
-  func mutatingDivideWrapper(_ x: Float, _ y: Float) -> Float {
-    var result: Float = x
-    result /= y
-    return result
-  }
-  expectEqual(-1, differential(at: 2, 3, of: mutatingDivideWrapper)(3, 9))
-}
-
-// Simplest possible `inout` parameter differentiation.
-ForwardModeInoutTests.test("InoutIdentity") {
-  // Semantically, an empty function with an `inout` parameter is an identity
-  // function.
-  func inoutIdentity(_ x: inout Float) {}
-
-  func identity(_ x: Float) -> Float {
-    var result = x
-    inoutIdentity(&result)
-    return result
-  }
-  expectEqual(1, derivative(at: 10, of: identity))
-  expectEqual(10, differential(at: 10, of: identity)(10))
-
-  func inoutIdentityGeneric<T: Differentiable>(_ x: inout T) {}
-
-  func identityGeneric<T: Differentiable>(_ x: T) -> T {
-    var result: T = x
-    inoutIdentityGeneric(&result)
-    return result
-  }
-  expectEqual(1, derivative(at: 10.0, of: identityGeneric))
-  expectEqual(10, differential(at: 10.0, of: identityGeneric)(10))
-}
-
-ForwardModeInoutTests.test("MultipleInoutParams") {
-  func swap<T: Differentiable>(_ x: inout T, _ y: inout T) {
-    let z = x
-    x = y
-    y = z
-  }
-
-  func first<T: Differentiable>(_ x: T, _ y: T) -> T {
-    var p1 = x
-    var p2 = y
-    swap(&p1, &p2)
-    return p2
-  }
-  expectEqual(1, differential(at: 1, 1, of: first)(1, 2))
-
-  func second<T: Differentiable>(_ x: T, _ y: T) -> T {
-    var p1 = x
-    var p2 = y
-    swap(&p1, &p2)
-    return p1
-  }
-  expectEqual(2, differential(at: 1, 1, of: second)(1, 2))
-}
-
-ForwardModeInoutTests.test("StructMutatingMethod") {
-  struct Mut: Differentiable {
-    var x: Float
-
-    mutating func add(_ y: Float) {
-      self.x += y
-    }
-
-    mutating func addMut(_ m: Mut) {
-      self.x += m.x
-    }
-  }
-
-  func identity(_ y: Float) -> Float {
-    var mut = Mut(x: 0.0)
-    mut.add(y)
-    return mut.x
-  }
-  expectEqual(1, derivative(at: 1, of: identity))
-
-  func identity2(_ y: Float) -> Float {
-    var mut = Mut(x: 0.0)
-    let mut2 = Mut(x: y)
-    mut.addMut(mut2)
-    return mut.x
-  }
-  expectEqual(1, derivative(at: 1, of: identity2))
-
-  func double(_ y: Float) -> Float {
-    var mut = Mut(x: y)
-    mut.add(y)
-    return mut.x
-  }
-  expectEqual(2, derivative(at: 1, of: double))
-
-  func double2(_ y: Float) -> Float {
-    var mut = Mut(x: y)
-    let mut2 = Mut(x: y)
-    mut.addMut(mut2)
-    return mut.x
-  }
-  expectEqual(2, derivative(at: 1, of: double2))
-
-  func square(_ y: Float) -> Float {
-    var mut = Mut(x: 0.0)
-    mut.add(y * y)
-    return mut.x
-  }
-  expectEqual(6, derivative(at: 3, of: square))
-
-  func square2(_ y: Float) -> Float {
-    var mut = Mut(x: 0.0)
-    let mut2 = Mut(x: y * y)
-    mut.addMut(mut2)
-    return mut.x
-  }
-  expectEqual(6, derivative(at: 3, of: square2))
-}
-
-runAllTests()
+//var ForwardModeInoutTests = TestSuite("ForwardModeInoutDifferentiation")
+//
+////===----------------------------------------------------------------------===//
+//// Inout tests.
+////===----------------------------------------------------------------------===//
+//
+//import DifferentiationUnittest
+//import StdlibUnittest
+//
+//ForwardModeInoutTests.test("Float.+=") {
+//  func mutatingAddWrapper(_ x: Float, _ y: Float) -> Float {
+//    var result: Float = x
+//    result += y
+//    return result
+//  }
+//  expectEqual(20, differential(at: 4, 5, of: mutatingAddWrapper)(10, 10))
+//}
+//
+//ForwardModeInoutTests.test("Float.-=") {
+//  func mutatingSubtractWrapper(_ x: Float, _ y: Float) -> Float {
+//    var result: Float = x
+//    result -= y
+//    return result
+//  }
+//  expectEqual(0, differential(at: 4, 5, of: mutatingSubtractWrapper)(10, 10))
+//  expectEqual(10, differential(at: 4, 5, of: mutatingSubtractWrapper)(20, 10))
+//}
+//
+//ForwardModeInoutTests.test("Float.*=") {
+//  func mutatingMultiplyWrapper(_ x: Float, _ y: Float) -> Float {
+//    var result: Float = x
+//    result *= y
+//    return result
+//  }
+//  expectEqual(22, differential(at: 4, 5, of: mutatingMultiplyWrapper)(2, 3))
+//}
+//
+//ForwardModeInoutTests.test("Float./=") {
+//  func mutatingDivideWrapper(_ x: Float, _ y: Float) -> Float {
+//    var result: Float = x
+//    result /= y
+//    return result
+//  }
+//  expectEqual(-1, differential(at: 2, 3, of: mutatingDivideWrapper)(3, 9))
+//}
+//
+//// Simplest possible `inout` parameter differentiation.
+//ForwardModeInoutTests.test("InoutIdentity") {
+//  // Semantically, an empty function with an `inout` parameter is an identity
+//  // function.
+//  func inoutIdentity(_ x: inout Float) {}
+//
+//  func identity(_ x: Float) -> Float {
+//    var result = x
+//    inoutIdentity(&result)
+//    return result
+//  }
+//  expectEqual(1, derivative(at: 10, of: identity))
+//  expectEqual(10, differential(at: 10, of: identity)(10))
+//
+//  func inoutIdentityGeneric<T: Differentiable>(_ x: inout T) {}
+//
+//  func identityGeneric<T: Differentiable>(_ x: T) -> T {
+//    var result: T = x
+//    inoutIdentityGeneric(&result)
+//    return result
+//  }
+//  expectEqual(1, derivative(at: 10.0, of: identityGeneric))
+//  expectEqual(10, differential(at: 10.0, of: identityGeneric)(10))
+//}
+//
+//ForwardModeInoutTests.test("MultipleInoutParams") {
+//  func swap<T: Differentiable>(_ x: inout T, _ y: inout T) {
+//    let z = x
+//    x = y
+//    y = z
+//  }
+//
+//  func first<T: Differentiable>(_ x: T, _ y: T) -> T {
+//    var p1 = x
+//    var p2 = y
+//    swap(&p1, &p2)
+//    return p2
+//  }
+//  expectEqual(1, differential(at: 1, 1, of: first)(1, 2))
+//
+//  func second<T: Differentiable>(_ x: T, _ y: T) -> T {
+//    var p1 = x
+//    var p2 = y
+//    swap(&p1, &p2)
+//    return p1
+//  }
+//  expectEqual(2, differential(at: 1, 1, of: second)(1, 2))
+//}
+//
+//ForwardModeInoutTests.test("StructMutatingMethod") {
+//  struct Mut: Differentiable {
+//    var x: Float
+//
+//    mutating func add(_ y: Float) {
+//      self.x += y
+//    }
+//
+//    mutating func addMut(_ m: Mut) {
+//      self.x += m.x
+//    }
+//  }
+//
+//  func identity(_ y: Float) -> Float {
+//    var mut = Mut(x: 0.0)
+//    mut.add(y)
+//    return mut.x
+//  }
+//  expectEqual(1, derivative(at: 1, of: identity))
+//
+//  func identity2(_ y: Float) -> Float {
+//    var mut = Mut(x: 0.0)
+//    let mut2 = Mut(x: y)
+//    mut.addMut(mut2)
+//    return mut.x
+//  }
+//  expectEqual(1, derivative(at: 1, of: identity2))
+//
+//  func double(_ y: Float) -> Float {
+//    var mut = Mut(x: y)
+//    mut.add(y)
+//    return mut.x
+//  }
+//  expectEqual(2, derivative(at: 1, of: double))
+//
+//  func double2(_ y: Float) -> Float {
+//    var mut = Mut(x: y)
+//    let mut2 = Mut(x: y)
+//    mut.addMut(mut2)
+//    return mut.x
+//  }
+//  expectEqual(2, derivative(at: 1, of: double2))
+//
+//  func square(_ y: Float) -> Float {
+//    var mut = Mut(x: 0.0)
+//    mut.add(y * y)
+//    return mut.x
+//  }
+//  expectEqual(6, derivative(at: 3, of: square))
+//
+//  func square2(_ y: Float) -> Float {
+//    var mut = Mut(x: 0.0)
+//    let mut2 = Mut(x: y * y)
+//    mut.addMut(mut2)
+//    return mut.x
+//  }
+//  expectEqual(6, derivative(at: 3, of: square2))
+//}
+//
+//runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_simd.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simd.swift
@@ -4,246 +4,246 @@
 import StdlibUnittest
 import DifferentiationUnittest
 
-var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
-
-//===----------------------------------------------------------------------===//
-// SIMD methods from SIMDDifferentiation.swift.gyb
-// Tests replicate reverse mode tests from test/AutoDiff/stdlib/simd.swift
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("init(repeating:)") {
-  func foo1(x: Float) -> SIMD4<Float> {
-    return SIMD4<Float>(repeating: 2 * x)
-  }
-  let (val1, df1) = valueWithDifferential(at: 5, of: foo1)
-  expectEqual(SIMD4<Float>(10, 10, 10, 10), val1)
-  expectEqual(SIMD4<Float>(6, 6, 6, 6), df1(3))
-}
-
-ForwardModeTests.test("Identity") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-
-  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
-    return x
-  }
-  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
-  expectEqual(a, val1)
-  expectEqual(g, df1(.init(g)))
-}
-
-ForwardModeTests.test("Negate") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-
-  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
-    return -x
-  }
-  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
-  expectEqual(-a, val1)
-  expectEqual(-g, df1(.init(g)))
-}
-
-ForwardModeTests.test("subscript") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-
-  func foo1(x: SIMD4<Float>) -> Float {
-    return x[3]
-  }
-
-  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
-  expectEqual(4, val1)
-  expectEqual(4, df1(a))
-}
-
-ForwardModeTests.test("Addition") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-
-  // SIMD + SIMD
-  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
-    return x + y
-  }
-  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
-  expectEqual(SIMD4<Float>(2, 4, 6, 8), val1)
-  expectEqual(a + g, df1(a, g))
-
-  // SIMD + Scalar
-  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return x + y
-  }
-  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
-  expectEqual(SIMD4<Float>(6, 7, 8, 9), val2)
-  expectEqual(g + 1, df2(g, 1))
-
-  // Scalar + SIMD
-  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return y + x
-  }
-  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
-  expectEqual(SIMD4<Float>(6, 7, 8, 9), val3)
-  expectEqual(2 + g, df3(g, 2))
-}
-
-ForwardModeTests.test("Subtraction") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-
-  // SIMD - SIMD
-  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
-    return x - y
-  }
-  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
-  expectEqual(SIMD4<Float>(0, 0, 0, 0), val1)
-  expectEqual(g - a, df1(g, a))
-
-  // SIMD - Scalar
-  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return x - y
-  }
-  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
-  expectEqual(SIMD4<Float>(-4, -3, -2, -1), val2)
-  expectEqual(g - 1, df2(g, 1))
-
-  // Scalar - SIMD
-  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return y - x
-  }
-  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
-  expectEqual(SIMD4<Float>(4, 3, 2, 1), val3)
-  expectEqual(2 - g, df3(g, 2))
-}
-
-ForwardModeTests.test("Multiplication") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let a2 = SIMD4<Float>(4, 3, 2, 1)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-  let g2 = SIMD4<Float>(0, 2, 1, 3)
-
-  // SIMD * SIMD
-  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
-    return x * y
-  }
-  let (val1, df1) = valueWithDifferential(at: a, a2, of: foo1)
-  expectEqual(a * a2, val1)
-  expectEqual(a * g2 + g * a2, df1(g, g2))
-
-  // SIMD * Scalar
-  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return x * y
-  }
-  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
-  expectEqual(a * 5, val2)
-  expectEqual(a * 2 + g * 5, df2(g, 2))
-
-  // Scalar * SIMD
-  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return y * x
-  }
-  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
-  expectEqual(a * 5, val3)
-  expectEqual(a * 3 + g * 5, df3(g, 3))
-}
-
-ForwardModeTests.test("Division") {
-  let a = SIMD4<Float>(1, 2, 3, 4)
-  let g = SIMD4<Float>(1, 1, 1, 1)
-
-  // SIMD / SIMD
-  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
-    return x / y
-  }
-  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
-  expectEqual(a / a, val1)
-  expectEqual((g * a - a * g) / (a * a)/* == 0 */, df1(g, g))
-
-  // SIMD / Scalar
-  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
-    return x / y
-  }
-  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
-  expectEqual(a / 5, val2)
-  expectEqual((g * 5 - a * 2) / (5 * 5), df2(g, 2))
-
-  // Scalar / SIMD
-  func foo3(x: Float, y: SIMD4<Float>) -> SIMD4<Float> {
-    return x / y
-  }
-  let (val3, df3) = valueWithDifferential(at: 5, a, of: foo3)
-  expectEqual(5 / a, val3)
-  expectEqual((3 * a - 5 * g) / (a * a), df3(3, g))
-}
-
-ForwardModeTests.test("Generics") {
-  let a = SIMD3<Double>(1, 2, 3)
-  let g = SIMD3<Double>(1, 1, 1)
-
-  // FIXME(SR-13210): Fix forward-mode SIL verification error.
-  /*
-  func testInit<Scalar, SIMDType: SIMD>(x: Scalar) -> SIMDType
-    where SIMDType.Scalar == Scalar,
-          SIMDType : Differentiable,
-          Scalar : BinaryFloatingPoint & Differentiable,
-          SIMDType.TangentVector == SIMDType,
-          Scalar.TangentVector == Scalar {
-    return SIMDType.init(repeating: x)
-  }
-  func simd3Init(x: Double) -> SIMD3<Double> { testInit(x: x) }
-  let (val1, df1) = valueWithDifferential(at: 10, of: simd3Init)
-  expectEqual(SIMD3<Double>(10, 10, 10), val1)
-  expectEqual(SIMD3<Double>(5, 5, 5), df1(5))
-  */
-
-  // SIMDType + SIMDType
-  func testAddition<Scalar, SIMDType: SIMD>(lhs: SIMDType, rhs: SIMDType)
-    -> SIMDType
-    where SIMDType.Scalar == Scalar,
-          SIMDType : Differentiable,
-          SIMDType.TangentVector : SIMD,
-          Scalar : BinaryFloatingPoint,
-          SIMDType.TangentVector.Scalar : BinaryFloatingPoint {
-    return lhs + rhs
-  }
-  func simd3Add(lhs: SIMD3<Double>, rhs: SIMD3<Double>) -> SIMD3<Double> {
-    return testAddition(lhs: lhs, rhs: rhs)
-  }
-  let (val2, df2) = valueWithDifferential(at: a, a, of: simd3Add)
-  expectEqual(SIMD3<Double>(2, 4, 6), val2)
-  expectEqual(g + a, df2(g, a))
-
-  // Scalar - SIMDType
-  func testSubtraction<Scalar, SIMDType: SIMD>(lhs: Scalar, rhs: SIMDType)
-    -> SIMDType
-    where SIMDType.Scalar == Scalar,
-          SIMDType : Differentiable,
-          Scalar : BinaryFloatingPoint & Differentiable,
-          SIMDType.TangentVector == SIMDType,
-          Scalar.TangentVector == Scalar {
-    return lhs - rhs
-  }
-  func simd3Subtract(lhs: Double, rhs: SIMD3<Double>) -> SIMD3<Double> {
-    return testSubtraction(lhs: lhs, rhs: rhs)
-  }
-  let (val3, df3) = valueWithDifferential(at: 5, a, of: simd3Subtract)
-  expectEqual(SIMD3<Double>(4, 3, 2), val3)
-  expectEqual(2 - g, df3(2, g))
-
-  // SIMDType * Scalar
-  func testMultipication<Scalar, SIMDType: SIMD>(lhs: SIMDType, rhs: Scalar)
-    -> SIMDType
-    where SIMDType.Scalar == Scalar,
-      SIMDType : Differentiable,
-      Scalar : BinaryFloatingPoint & Differentiable,
-      SIMDType.TangentVector == SIMDType,
-      Scalar.TangentVector == Scalar {
-    return lhs * rhs
-  }
-  func simd3Multiply(lhs: SIMD3<Double>, rhs: Double) -> SIMD3<Double> {
-    return testMultipication(lhs: lhs, rhs: rhs)
-  }
-  let (val4, df4) = valueWithDifferential(at: a, 5, of: simd3Multiply)
-  expectEqual(SIMD3<Double>(5, 10, 15), val4)
-  expectEqual(a * 3 + g * 5 , df4(g, 3))
-}
-
-runAllTests()
+//var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
+//
+////===----------------------------------------------------------------------===//
+//// SIMD methods from SIMDDifferentiation.swift.gyb
+//// Tests replicate reverse mode tests from test/AutoDiff/stdlib/simd.swift
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("init(repeating:)") {
+//  func foo1(x: Float) -> SIMD4<Float> {
+//    return SIMD4<Float>(repeating: 2 * x)
+//  }
+//  let (val1, df1) = valueWithDifferential(at: 5, of: foo1)
+//  expectEqual(SIMD4<Float>(10, 10, 10, 10), val1)
+//  expectEqual(SIMD4<Float>(6, 6, 6, 6), df1(3))
+//}
+//
+//ForwardModeTests.test("Identity") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//
+//  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
+//    return x
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
+//  expectEqual(a, val1)
+//  expectEqual(g, df1(.init(g)))
+//}
+//
+//ForwardModeTests.test("Negate") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//
+//  func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
+//    return -x
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
+//  expectEqual(-a, val1)
+//  expectEqual(-g, df1(.init(g)))
+//}
+//
+//ForwardModeTests.test("subscript") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//
+//  func foo1(x: SIMD4<Float>) -> Float {
+//    return x[3]
+//  }
+//
+//  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
+//  expectEqual(4, val1)
+//  expectEqual(4, df1(a))
+//}
+//
+//ForwardModeTests.test("Addition") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//
+//  // SIMD + SIMD
+//  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
+//    return x + y
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
+//  expectEqual(SIMD4<Float>(2, 4, 6, 8), val1)
+//  expectEqual(a + g, df1(a, g))
+//
+//  // SIMD + Scalar
+//  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return x + y
+//  }
+//  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
+//  expectEqual(SIMD4<Float>(6, 7, 8, 9), val2)
+//  expectEqual(g + 1, df2(g, 1))
+//
+//  // Scalar + SIMD
+//  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return y + x
+//  }
+//  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
+//  expectEqual(SIMD4<Float>(6, 7, 8, 9), val3)
+//  expectEqual(2 + g, df3(g, 2))
+//}
+//
+//ForwardModeTests.test("Subtraction") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//
+//  // SIMD - SIMD
+//  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
+//    return x - y
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
+//  expectEqual(SIMD4<Float>(0, 0, 0, 0), val1)
+//  expectEqual(g - a, df1(g, a))
+//
+//  // SIMD - Scalar
+//  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return x - y
+//  }
+//  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
+//  expectEqual(SIMD4<Float>(-4, -3, -2, -1), val2)
+//  expectEqual(g - 1, df2(g, 1))
+//
+//  // Scalar - SIMD
+//  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return y - x
+//  }
+//  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
+//  expectEqual(SIMD4<Float>(4, 3, 2, 1), val3)
+//  expectEqual(2 - g, df3(g, 2))
+//}
+//
+//ForwardModeTests.test("Multiplication") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let a2 = SIMD4<Float>(4, 3, 2, 1)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//  let g2 = SIMD4<Float>(0, 2, 1, 3)
+//
+//  // SIMD * SIMD
+//  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
+//    return x * y
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, a2, of: foo1)
+//  expectEqual(a * a2, val1)
+//  expectEqual(a * g2 + g * a2, df1(g, g2))
+//
+//  // SIMD * Scalar
+//  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return x * y
+//  }
+//  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
+//  expectEqual(a * 5, val2)
+//  expectEqual(a * 2 + g * 5, df2(g, 2))
+//
+//  // Scalar * SIMD
+//  func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return y * x
+//  }
+//  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
+//  expectEqual(a * 5, val3)
+//  expectEqual(a * 3 + g * 5, df3(g, 3))
+//}
+//
+//ForwardModeTests.test("Division") {
+//  let a = SIMD4<Float>(1, 2, 3, 4)
+//  let g = SIMD4<Float>(1, 1, 1, 1)
+//
+//  // SIMD / SIMD
+//  func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
+//    return x / y
+//  }
+//  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
+//  expectEqual(a / a, val1)
+//  expectEqual((g * a - a * g) / (a * a)/* == 0 */, df1(g, g))
+//
+//  // SIMD / Scalar
+//  func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
+//    return x / y
+//  }
+//  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
+//  expectEqual(a / 5, val2)
+//  expectEqual((g * 5 - a * 2) / (5 * 5), df2(g, 2))
+//
+//  // Scalar / SIMD
+//  func foo3(x: Float, y: SIMD4<Float>) -> SIMD4<Float> {
+//    return x / y
+//  }
+//  let (val3, df3) = valueWithDifferential(at: 5, a, of: foo3)
+//  expectEqual(5 / a, val3)
+//  expectEqual((3 * a - 5 * g) / (a * a), df3(3, g))
+//}
+//
+//ForwardModeTests.test("Generics") {
+//  let a = SIMD3<Double>(1, 2, 3)
+//  let g = SIMD3<Double>(1, 1, 1)
+//
+//  // FIXME(SR-13210): Fix forward-mode SIL verification error.
+//  /*
+//  func testInit<Scalar, SIMDType: SIMD>(x: Scalar) -> SIMDType
+//    where SIMDType.Scalar == Scalar,
+//          SIMDType : Differentiable,
+//          Scalar : BinaryFloatingPoint & Differentiable,
+//          SIMDType.TangentVector == SIMDType,
+//          Scalar.TangentVector == Scalar {
+//    return SIMDType.init(repeating: x)
+//  }
+//  func simd3Init(x: Double) -> SIMD3<Double> { testInit(x: x) }
+//  let (val1, df1) = valueWithDifferential(at: 10, of: simd3Init)
+//  expectEqual(SIMD3<Double>(10, 10, 10), val1)
+//  expectEqual(SIMD3<Double>(5, 5, 5), df1(5))
+//  */
+//
+//  // SIMDType + SIMDType
+//  func testAddition<Scalar, SIMDType: SIMD>(lhs: SIMDType, rhs: SIMDType)
+//    -> SIMDType
+//    where SIMDType.Scalar == Scalar,
+//          SIMDType : Differentiable,
+//          SIMDType.TangentVector : SIMD,
+//          Scalar : BinaryFloatingPoint,
+//          SIMDType.TangentVector.Scalar : BinaryFloatingPoint {
+//    return lhs + rhs
+//  }
+//  func simd3Add(lhs: SIMD3<Double>, rhs: SIMD3<Double>) -> SIMD3<Double> {
+//    return testAddition(lhs: lhs, rhs: rhs)
+//  }
+//  let (val2, df2) = valueWithDifferential(at: a, a, of: simd3Add)
+//  expectEqual(SIMD3<Double>(2, 4, 6), val2)
+//  expectEqual(g + a, df2(g, a))
+//
+//  // Scalar - SIMDType
+//  func testSubtraction<Scalar, SIMDType: SIMD>(lhs: Scalar, rhs: SIMDType)
+//    -> SIMDType
+//    where SIMDType.Scalar == Scalar,
+//          SIMDType : Differentiable,
+//          Scalar : BinaryFloatingPoint & Differentiable,
+//          SIMDType.TangentVector == SIMDType,
+//          Scalar.TangentVector == Scalar {
+//    return lhs - rhs
+//  }
+//  func simd3Subtract(lhs: Double, rhs: SIMD3<Double>) -> SIMD3<Double> {
+//    return testSubtraction(lhs: lhs, rhs: rhs)
+//  }
+//  let (val3, df3) = valueWithDifferential(at: 5, a, of: simd3Subtract)
+//  expectEqual(SIMD3<Double>(4, 3, 2), val3)
+//  expectEqual(2 - g, df3(2, g))
+//
+//  // SIMDType * Scalar
+//  func testMultipication<Scalar, SIMDType: SIMD>(lhs: SIMDType, rhs: Scalar)
+//    -> SIMDType
+//    where SIMDType.Scalar == Scalar,
+//      SIMDType : Differentiable,
+//      Scalar : BinaryFloatingPoint & Differentiable,
+//      SIMDType.TangentVector == SIMDType,
+//      Scalar.TangentVector == Scalar {
+//    return lhs * rhs
+//  }
+//  func simd3Multiply(lhs: SIMD3<Double>, rhs: Double) -> SIMD3<Double> {
+//    return testMultipication(lhs: lhs, rhs: rhs)
+//  }
+//  let (val4, df4) = valueWithDifferential(at: a, 5, of: simd3Multiply)
+//  expectEqual(SIMD3<Double>(5, 10, 15), val4)
+//  expectEqual(a * 3 + g * 5 , df4(g, 3))
+//}
+//
+//runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_simple.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simple.swift
@@ -4,1400 +4,1400 @@
 import StdlibUnittest
 import DifferentiationUnittest
 
-var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
-
-//===----------------------------------------------------------------------===//
-// Basic tests.
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("Identity") {
-  func func_to_diff(x: Float) -> Float {
-    return x
-  }
-  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
-  expectEqual(4, y)
-  expectEqual(1, differential(1))
-}
-
-ForwardModeTests.test("Unary") {
-  func func_to_diff(x: Float) -> Float {
-    return x * x
-  }
-  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
-  expectEqual(16, y)
-  expectEqual(8, differential(1))
-}
-
-ForwardModeTests.test("Binary") {
-  func func_to_diff(x: Float, y: Float) -> Float {
-    return x * y
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
-  expectEqual(20, y)
-  expectEqual(9, differential(1, 1))
-}
-
-ForwardModeTests.test("BinaryWithLets") {
-  func func_to_diff(x: Float, y: Float) -> Float {
-    let a = x + y
-    let b = a
-    return b * -y
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
-  expectEqual(-45, y)
-  expectEqual(-19, differential(1, 1))
-}
-
-ForwardModeTests.test("SubsetParametersDiff") {
-  func func_to_diff1(x: Int, y: Float, z: Int) -> Float {
-    return y
-  }
-  let (y1, differential1) = valueWithDifferential(at: 5) { y in
-    func_to_diff1(x: 0, y: y, z: 0)
-  }
-  expectEqual(5, y1)
-  expectEqual(1, differential1(1))
-
-  func func_to_diff2(x: Float, y: Int, z: Int) -> Float {
-    return 2 * x
-  }
-  let (y2, differential2) = valueWithDifferential(at: 6) { x in
-    func_to_diff2(x: x, y: 0, z: 0)
-  }
-  expectEqual(12, y2)
-  expectEqual(2, differential2(1))
-
-  func func_to_diff3(x: Int, y: Int, z: Float) -> Float {
-    return 3 * z
-  }
-  let (y3, differential3) = valueWithDifferential(at: 7) { z in
-    func_to_diff3(x: 0, y: 0, z: z)
-  }
-  expectEqual(21, y3)
-  expectEqual(3, differential3(1))
-}
-
-//===----------------------------------------------------------------------===//
-// Functions with variables
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("UnaryWithVars") {
-  func unary(x: Float) -> Float {
-    var a = x
-    a = x
-    var b = a + 2
-    b = b - 1
-    let c: Float = 3
-    var d = a + b + c - 1
-    d = d + d
-    return d
-  }
-
-  let (y, differential) = valueWithDifferential(at: 4, of: unary)
-  expectEqual(22, y)
-  expectEqual(4, differential(1))
-}
-
-//===----------------------------------------------------------------------===//
-// Functions with basic struct
-//===----------------------------------------------------------------------===//
-
-struct A: Differentiable & AdditiveArithmetic {
-  var x: Float
-}
-
-ForwardModeTests.test("StructInit") {
-  func structInit(x: Float) -> A {
-    return A(x: 2 * x)
-  }
-
-  let (y, differential) = valueWithDifferential(at: 4, of: structInit)
-  expectEqual(A(x: 8), y)
-  expectEqual(A(x: 2), differential(1))
-}
-
-ForwardModeTests.test("StructExtract") {
-  func structExtract(x: A) -> Float {
-    return 2 * x.x
-  }
-
-  let (y, differential) = valueWithDifferential(
-    at: A(x: 4),
-    of: structExtract)
-  expectEqual(8, y)
-  expectEqual(2, differential(A(x: 1)))
-}
-
-ForwardModeTests.test("LocalStructVariable") {
-  func structExtract(x: A) -> A {
-    let a = A(x: 2 * x.x) // 2x
-    var b = A(x: a.x + 2) // 2x + 2
-    b = A(x: b.x + a.x) // 2x + 2 + 2x = 4x + 2
-    return b
-  }
-
-  let (y, differential) = valueWithDifferential(
-    at: A(x: 4),
-    of: structExtract)
-  expectEqual(A(x: 18), y)
-  expectEqual(A(x: 4), differential(A(x: 1)))
-}
-
-//===----------------------------------------------------------------------===//
-// Functions with methods
-//===----------------------------------------------------------------------===//
-
-extension A {
-  func noParamMethodA() -> A {
-    return A(x: 2 * x)
-  }
-
-  func noParamMethodx() -> Float {
-    return 2 * x
-  }
-
-  static func *(lhs: A, rhs: A) -> A {
-    return A(x: lhs.x * rhs.x)
-  }
-
-  func complexBinaryMethod(u: A, v: Float) -> A {
-    var b: A = u * A(x: 2)  // A(x: u * 2)
-    b.x = b.x * v        // A(x: u * 2 * v)
-    let c = b.x + 1      // u * 2 * v + 1
-
-    // A(x: u * 2 * v + 1 + u * 2 * v) = A(x: x * (4uv + 1))
-    return A(x: x * (c + b.x))
-  }
-}
-
-ForwardModeTests.test("noParamMethodA") {
-  let (y, differential) = valueWithDifferential(at: A(x: 4)) { x in
-    x.noParamMethodA()
-  }
-  expectEqual(A(x: 8), y)
-  expectEqual(A(x: 2), differential(A(x: 1)))
-}
-
-ForwardModeTests.test("noParamMethodx") {
-  let (y, differential) = valueWithDifferential(at: A(x: 4)) { x in
-    x.noParamMethodx()
-  }
-  expectEqual(8, y)
-  expectEqual(2, differential(A(x: 1)))
-}
-
-ForwardModeTests.test("complexBinaryMethod") {
-  let (y, differential) = valueWithDifferential(at: A(x: 4), A(x: 5), 3) {
-    (x, y, z) in
-    // derivative = A(x: 4uv + 4xv + 4ux + 1) = 4*5*3 + 4*4*3 + 4*5*4 + 1 = 189
-    x.complexBinaryMethod(u: y, v: z)
-  }
-  expectEqual(A(x: 244), y)
-  expectEqual(A(x: 189), differential(A(x: 1), A(x: 1), 1))
-}
-
-//===----------------------------------------------------------------------===//
-// Tracked struct
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.testWithLeakChecking("TrackedIdentity") {
-  func identity(x: Tracked<Float>) -> Tracked<Float> {
-    return x
-  }
-  let (y, differential) = valueWithDifferential(at: 4, of: identity)
-  expectEqual(4, y)
-  expectEqual(1, differential(1))
-}
-
-ForwardModeTests.testWithLeakChecking("TrackedAddition") {
-  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
-    return x + y
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
-  expectEqual(9, y)
-  expectEqual(2, differential(1, 1))
-}
-
-ForwardModeTests.testWithLeakChecking("TrackedDivision") {
-  func divide(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
-    return x / y
-  }
-  let (y, differential) = valueWithDifferential(at: 10, 5, of: divide)
-  expectEqual(2, y)
-  expectEqual(-0.2, differential(1, 1))
-}
-
-ForwardModeTests.testWithLeakChecking("TrackedMultipleMultiplication") {
-  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
-    return x * y * x
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
-  expectEqual(80, y)
-  // 2yx+xx
-  expectEqual(56, differential(1, 1))
-}
-
-ForwardModeTests.testWithLeakChecking("TrackedWithLets") {
-  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
-    let a = x + y
-    let b = a * a // (x+y)^2
-    let c = b / x + y // (x+y)^2/x+y
-    return c
-  }
-  // (3x^2+2xy-y^2)/x^2+1
-  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
-  expectEqual(25.25, y)
-  expectEqual(4.9375, differential(1, 1))
-}
-
-//===----------------------------------------------------------------------===//
-// Tuples
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("TupleLet") {
-  do {
-    func tupleLet(_ x: Float) -> Float {
-      let tuple = (2 * x, x)
-      return tuple.0
-    }
-    let (value, derivative) = valueWithDerivative(at: 4, of: tupleLet)
-    expectEqual(8, value)
-    expectEqual(2, derivative)
-  }
-}
-
-ForwardModeTests.test("TupleVar") {
-  do {
-    func tupleVar(_ x: Float) -> Float {
-      var tuple = (2 * x, x)
-      return tuple.0
-    }
-    let (value, derivative) = valueWithDerivative(at: 4, of: tupleVar)
-    expectEqual(8, value)
-    expectEqual(2, derivative)
-  }
-
-  do {
-    // TF-964: Test tuple with non-tuple-typed adjoint value.
-    func TF_964(_ x: Float) -> Float {
-      var tuple = (2 * x, 1)
-      return tuple.0
-    }
-    let (value, derivative) = valueWithDerivative(at: 4, of: TF_964)
-    expectEqual(8, value)
-    expectEqual(2, derivative)
-  }
-}
-
-ForwardModeTests.test("TupleMutation") {
-  func foo(_ x: Float) -> Float {
-    var tuple = (x, x)
-    tuple.0 = tuple.0 * x
-    return x * tuple.0
-  }
-  expectEqual(27, derivative(at: 3, of: foo))
-
-  func fifthPower(_ x: Float) -> Float {
-    var tuple = (x, x)
-    tuple.0 = tuple.0 * x
-    tuple.1 = tuple.0 * x
-    return tuple.0 * tuple.1
-  }
-  expectEqual(405, derivative(at: 3, of: fifthPower))
-
-  func nested(_ x: Float) -> Float {
-    var tuple = ((x, x), x)
-    tuple.0.0 = tuple.0.0 * x
-    tuple.0.1 = tuple.0.0 * x
-    return tuple.0.0 * tuple.0.1
-  }
-  expectEqual(405, derivative(at: 3, of: nested))
-
-  func generic<T: Differentiable & AdditiveArithmetic>(_ x: T) -> T {
-    var tuple = (x, x)
-    return tuple.0
-  }
-  expectEqual(1, derivative(at: 3.0, of: generic))
-
-  // FIXME(TF-1033): Fix forward-mode ownership error for tuple with non-active
-  // initial values.
-  /*
-  func genericInitialNonactive<T: Differentiable & AdditiveArithmetic>(
-    _ x: T
-  ) -> T {
-    var tuple = (T.zero, T.zero)
-    tuple.0 = x
-    tuple.1 = x
-    return tuple.0
-  }
-  expectEqual(1, derivative(at: 3.0, of: genericInitialNonactive))
-  */
-}
-
-// Tests TF-321.
-ForwardModeTests.test("TupleNonDifferentiableElements") {
-  // TF-964: Test tuple with non-tuple-typed adjoint value.
-  func tupleLet(_ x: Tracked<Float>) -> Tracked<Float> {
-    let tuple = (2 * x, 1)
-    return tuple.0
-  }
-  expectEqual((8, 2), valueWithDerivative(at: 4, of: tupleLet))
-
-  func tupleVar(_ x: Tracked<Float>) -> Tracked<Float> {
-    var tuple = (x, 1)
-    tuple.0 = x
-    tuple.1 = 1
-    return tuple.0
-  }
-  expectEqual((3, 1), valueWithDerivative(at: 3, of: tupleVar))
-
-  @differentiable(reverse)
-  func nested(_ x: Tracked<Float>) -> Tracked<Float> {
-    // Convoluted function computing `x * x`.
-    var tuple: (Int, (Int, Tracked<Float>), Tracked<Float>) = (1, (1, 0), 0)
-    tuple.0 = 1
-    tuple.1.0 = 1
-    tuple.1.1 = x
-    tuple.2 = x
-    return tuple.1.1 * tuple.2
-  }
-  // FIXME(SR-12911): Fix runtime segfault.
-  // expectEqual((16, 8), valueWithDerivative(at: 4, of: nested))
-
-  struct Wrapper<T> {
-    @differentiable(reverse where T : Differentiable)
-    func baz(_ x: T) -> T {
-      var tuple = (1, 1, x, 1)
-      tuple.0 = 1
-      tuple.2 = x
-      tuple.3 = 1
-      return tuple.2
-    }
-  }
-  func wrapper(_ x: Tracked<Float>) -> Tracked<Float> {
-    let w = Wrapper<Tracked<Float>>()
-    return w.baz(x)
-  }
-  expectEqual((3, 1), valueWithDerivative(at: 3, of: wrapper))
-}
-
-//===----------------------------------------------------------------------===//
-// Generics
-//===----------------------------------------------------------------------===//
-
-struct Tensor<Scalar : FloatingPoint & Differentiable>
-  : AdditiveArithmetic, Differentiable {
-  // NOTE: `value` must have type with known size (e.g. `Float`, not `Scalar`)
-  // until differentiation has indirect passing support.
-  var value: Float
-  init(_ value: Float) { self.value = value }
-}
-
-ForwardModeTests.test("GenericIdentity") {
-  func identity<T : Differentiable>(_ x: T) -> T {
-    return x
-  }
-  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
-    identity(x)
-  }
-  expectEqual(4, y)
-  expectEqual(1, differential(1))
-}
-
-ForwardModeTests.test("GenericTensorIdentity") {
-  func identity<T : FloatingPoint & Differentiable>(
-    _ x: Tensor<T>) -> Tensor<T> {
-    return x
-  }
-  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
-    identity(Tensor<Float>(x))
-  }
-  expectEqual(Tensor<Float>(4), y)
-  expectEqual(Tensor<Float>(1), differential(1))
-}
-
-ForwardModeTests.test("GenericTensorPlus") {
-  func plus<T : FloatingPoint & Differentiable>(_ x: Tensor<T>) -> Float {
-    return x.value + x.value
-  }
-  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
-    plus(Tensor<Float>(x))
-  }
-  expectEqual(8, y)
-  expectEqual(2, differential(1))
-}
-
-ForwardModeTests.test("GenericTensorBinaryInput") {
-  func binary<T : FloatingPoint & Differentiable>(
-    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
-    return x.value * y.value
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5) {
-    (x: Float, y: Float) in
-    binary(Tensor<Float>(x), Tensor<Float>(y))
-  }
-  expectEqual(20, y)
-  expectEqual(9, differential(1, 1))
-}
-
-ForwardModeTests.test("GenericTensorWithLets") {
-  func binary<T : FloatingPoint & Differentiable>(
-    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
-    let a = Tensor<T>(x.value)
-    let b = Tensor<T>(y.value)
-    return a.value * b.value
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5) {
-    (x: Float, y: Float) in
-    binary(Tensor<Float>(x), Tensor<Float>(y))
-  }
-  expectEqual(20, y)
-  expectEqual(9, differential(1, 1))
-}
-
-ForwardModeTests.test("GenericTensorWithVars") {
-  func binary<T : FloatingPoint & Differentiable>(
-    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
-    var a = Tensor<T>(x.value)
-    var b = Tensor<T>(y.value)
-    b = a
-    a = Tensor<T>(y.value)
-    return a.value * b.value
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5) {
-    (x: Float, y: Float) in
-    binary(Tensor<Float>(x), Tensor<Float>(y))
-  }
-  expectEqual(20, y)
-  expectEqual(9, differential(1, 1))
-}
-
-// Test case where associated derivative function's requirements are met.
-extension Tensor where Scalar : Numeric {
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
-  func mean() -> Tensor {
-    return self
-  }
-
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
-  func variance() -> Tensor {
-    return mean() // ok
-  }
-}
-_ = differential(at: Tensor<Float>(1), of: { $0.variance() })
-
-// Tests TF-508: differentiation requirements with dependent member types.
-protocol TF_508_Proto {
-  associatedtype Scalar
-}
-extension TF_508_Proto where Scalar : FloatingPoint {
-  @differentiable(
-    where Self : Differentiable, Scalar : Differentiable,
-          // Conformance requirement with dependent member type.
-          Self.TangentVector : TF_508_Proto
-  )
-  static func +(lhs: Self, rhs: Self) -> Self {
-    return lhs
-  }
-
-  @differentiable(
-    where Self : Differentiable, Scalar : Differentiable,
-          // Same-type requirement with dependent member type.
-          Self.TangentVector == Float
-  )
-  static func -(lhs: Self, rhs: Self) -> Self {
-    return lhs
-  }
-}
-extension TF_508_Proto where Self : Differentiable,
-                             Scalar : FloatingPoint & Differentiable,
-                             Self.TangentVector : TF_508_Proto {
-  @derivative(of: +)
-  static func jvpAdd(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (TangentVector, TangentVector) -> TangentVector) {
-    return (lhs, { (dlhs, drhs) in dlhs })
-  }
-}
-extension TF_508_Proto where Self : Differentiable,
-                             Scalar : FloatingPoint & Differentiable,
-                             Self.TangentVector == Float {
-  @derivative(of: -)
-  static func jvpSubtract(lhs: Self, rhs: Self)
-      -> (value: Self, differential: (TangentVector, TangentVector) -> TangentVector) {
-    return (lhs, { (dlhs, drhs) in dlhs })
-  }
-}
-
-struct TF_508_Struct<Scalar : AdditiveArithmetic>
-  : TF_508_Proto, AdditiveArithmetic {}
-extension TF_508_Struct : Differentiable where Scalar : Differentiable {
-  typealias TangentVector = TF_508_Struct
-}
-
-// func TF_508() {
-//   let x = TF_508_Struct<Float>()
-//   // Test conformance requirement with dependent member type.
-//   _ = differential(at: x, of: {
-//     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
-//     return x + x
-//   })
-//   // Test same-type requirement with dependent member type.
-//   _ = differential(at: x, of: {
-//     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
-//     return x - x
-//   })
-// }
-
-// TF-523
-struct TF_523_Struct : Differentiable & AdditiveArithmetic {
-  var a: Float = 1
-  typealias TangentVector = TF_523_Struct
-  typealias AllDifferentiableVariables = TF_523_Struct
-}
-
-@differentiable(reverse)
-func TF_523_f(_ x: TF_523_Struct) -> Float {
-  return x.a * 2
-}
-
-// TF-534: Thunk substitution map remapping.
-protocol TF_534_Layer : Differentiable {
-  associatedtype Input : Differentiable
-  associatedtype Output : Differentiable
-
-  @differentiable(reverse)
-  func callAsFunction(_ input: Input) -> Output
-}
-struct TF_534_Tensor<Scalar> : Differentiable {}
-
-func TF_534<Model: TF_534_Layer>(
-  _ model: inout Model, inputs: Model.Input
-) -> TF_534_Tensor<Float> where Model.Output == TF_534_Tensor<Float> {
-  return valueWithDifferential(at: model) { model -> Model.Output in
-    return model(inputs)
-  }.0
-}
-
-// TODO: uncomment once control flow is supported in forward mode.
-// TF-652: Test VJPEmitter substitution map generic signature.
-// The substitution map should have the VJP's generic signature, not the
-// original function's.
-// struct TF_652<Scalar> {}
-// extension TF_652 : Differentiable where Scalar : FloatingPoint {}
-
-// @differentiable(reverse, wrt: x where Scalar: FloatingPoint)
-// func test<Scalar: Numeric>(x: TF_652<Scalar>) -> TF_652<Scalar> {
-//   for _ in 0..<10 {
-//     let _ = x
-//   }
-//   return x
-// }
-
-//===----------------------------------------------------------------------===//
-// Tracked Generic.
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("GenericTrackedIdentity") {
-  func identity<T : Differentiable>(_ x: Tracked<T>) -> Tracked<T> {
-    return x
-  }
-  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
-    identity(Tracked(x))
-  }
-  expectEqual(4, y)
-  expectEqual(1, differential(1))
-}
-
-ForwardModeTests.test("GenericTrackedBinaryAdd") {
-  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
-    where T: Differentiable, T == T.TangentVector {
-    return x + y
-  }
-  let (y, differential) = valueWithDifferential(at: 4, 5) {
-    (x: Float, y: Float) in
-    add(Tracked(x), Tracked(y))
-  }
-  expectEqual(9, y)
-  expectEqual(2, differential(1, 1))
-}
-
-ForwardModeTests.test("GenericTrackedBinaryLets") {
-  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
-    where T: Differentiable & SignedNumeric,
-          T == T.TangentVector,
-          T == T.Magnitude {
-    let a = x * y // xy
-    let b = a + a // 2xy
-    return b + b // 4xy
-  }
-  // 4y + 4x
-  let (y, differential) = valueWithDifferential(at: 4, 5) { (x: Float, y: Float) in
-    add(Tracked(x), Tracked(y))
-  }
-  expectEqual(80, y)
-  expectEqual(36, differential(1, 1))
-}
-
-ForwardModeTests.test("GenericTrackedBinaryVars") {
-  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
-    where T: Differentiable & SignedNumeric,
-          T == T.TangentVector,
-          T == T.Magnitude {
-    var a = x * y // xy
-    a = a + a // 2xy
-    var b = x
-    b = a
-    return b + b // 4xy
-  }
-  // 4y + 4x
-  let (y, differential) = valueWithDifferential(at: 4, 5) { (x: Float, y: Float) in
-    add(Tracked(x), Tracked(y))
-  }
-  expectEqual(80, y)
-  expectEqual(36, differential(1, 1))
-}
-
-ForwardModeTests.testWithLeakChecking("TrackedDifferentiableFuncType") {
-  func valAndDeriv(
-    f: @escaping @differentiable(reverse) (Tracked<Float>) -> Tracked<Float>
-  ) -> (Tracked<Float>, Tracked<Float>) {
-    let (y, diff) = valueWithDifferential(at: 5, of: f)
-    return (y, diff(1))
-  }
-
-  func func1(_ x: Tracked<Float>) -> Tracked<Float> {
-    let a = x + x // 2x
-    let b = a + a // 4x
-    return b * b // 16x^2
-  }
-  let (val1, dv1) = valAndDeriv(f: func1)
-  expectEqual(400, val1)
-  expectEqual(160, dv1)
-}
-
-//===----------------------------------------------------------------------===//
-// Classes
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("Final") {
-  final class Final : Differentiable {
-    func method(_ x: Float) -> Float {
-      return x * x
-    }
-  }
-
-  for i in -5...5 {
-    expectEqual(
-      Float(i) * 2,
-      derivative(at: Float(i)) { x in Final().method(x) })
-  }
-}
-
-ForwardModeTests.test("Simple") {
-  class Super {
-    @differentiable(reverse, wrt: x)
-    func f(_ x: Float) -> Float {
-      return 2 * x
-    }
-    @derivative(of: f)
-    final func jvpf(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
-      return (f(x), { v in 2 * v })
-    }
-    @derivative(of: f)
-    final func vjpf(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-      return (f(x), { v in 2 * v })
-    }
-  }
-
-  class SubOverride : Super {
-    @differentiable(reverse, wrt: x)
-    override func f(_ x: Float) -> Float {
-      return 3 * x
-    }
-  }
-
-  class SubOverrideCustomDerivatives : Super {
-    @differentiable(reverse, wrt: x)
-    override func f(_ x: Float) -> Float {
-      return 3 * x
-    }
-    @derivative(of: f)
-    final func jvpf2(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
-      return (f(x), { v in 3 * v })
-    }
-    @derivative(of: f)
-    final func vjpf2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-      return (f(x), { v in 3 * v })
-    }
-  }
-
-  func classValueWithDerivative(_ c: Super) -> (Float, Float) {
-    return valueWithDerivative(at: 1) { c.f($0) }
-  }
-
-  expectEqual((2, 2), classValueWithDerivative(Super()))
-  expectEqual((3, 3), classValueWithDerivative(SubOverride()))
-  expectEqual((3, 3), classValueWithDerivative(SubOverrideCustomDerivatives()))
-}
-
-ForwardModeTests.test("SimpleWrtSelf") {
-  class Super : Differentiable {
-    var base: Float
-    // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
-    var _nontrivial: [Float] = []
-
-    // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
-    // @differentiable(reverse)
-    required init(base: Float) {
-      self.base = base
-    }
-
-    @differentiable(reverse, wrt: (self, x))
-    func f(_ x: Float) -> Float {
-      return base * x
-    }
-    @derivative(of: f)
-    final func jvpf(_ x: Float) -> (value: Float, differential: (TangentVector, Float) -> Float) {
-      return (f(x), { (dself, dx) in dself.base * dx })
-    }
-    @derivative(of: f)
-    final func vjpf(_ x: Float) -> (value: Float, pullback: (Float) -> (TangentVector, Float)) {
-      let base = self.base
-      return (f(x), { v in
-        (TangentVector(base: v * x, _nontrivial: []), base * v)
-      })
-    }
-  }
-
-  class SubOverride : Super {
-    @differentiable(reverse, wrt: (self, x))
-    override func f(_ x: Float) -> Float {
-      return 3 * x
-    }
-  }
-
-  class SubOverrideCustomDerivatives : Super {
-    @differentiable(reverse, wrt: (self, x))
-    @differentiable(reverse, wrt: x)
-    override func f(_ x: Float) -> Float {
-      return 3 * x
-    }
-    @derivative(of: f, wrt: x)
-    final func jvpf2(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
-      return (f(x), { v in 3 * v })
-    }
-    @derivative(of: f, wrt: x)
-    final func vjpf2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
-      return (f(x), { v in 3 * v })
-    }
-  }
-
-    // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
-  // let v = Super.TangentVector(base: 100, _nontrivial: [])
-  // expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
-  // expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))
-  // expectEqual(100, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
-
-  // `valueWithDerivative` is not used because the derivative requires `Super`
-  // to conform to `FloatingPoint`.
-  func classDifferential(
-    _ c: Super
-  ) -> (Float, (Super.TangentVector, Float) -> Float) {
-    return valueWithDifferential(at: c, 10) { (c: Super, x: Float) in c.f(x) }
-  }
-
-  let (y1, diff1) = classDifferential(Super(base: 5))
-  expectEqual(50, y1)
-  let c1 = Super.TangentVector(base: 1, _nontrivial: [])
-  expectEqual(1, diff1(c1, 1))
-  let (y2, diff2) = classDifferential(SubOverride(base: 5))
-  expectEqual(30, y2)
-  let c2 = SubOverride.TangentVector(base: 1, _nontrivial: [])
-  expectEqual(3, diff2(c2, 1))
-  let (y3, diff3) = classDifferential(SubOverrideCustomDerivatives(base: 5))
-  expectEqual(30, y3)
-  let c3 = SubOverrideCustomDerivatives.TangentVector(base: 1, _nontrivial: [])
-  expectEqual(3, diff3(c3, 1))
-}
-
-//===----------------------------------------------------------------------===//
-// Protocols
-//===----------------------------------------------------------------------===//
-
-protocol Prot : Differentiable {
-  @differentiable(reverse, wrt: x)
-  func foo(x: Float) -> Float
-}
-ForwardModeTests.test("Simple Protocol") {
-  struct Linear: Prot, AdditiveArithmetic {
-    typealias TangentVector = Linear
-
-    let m: Float
-    let b: Float
-
-    @differentiable(reverse, wrt: x)
-    func foo(x: Float) -> Float {
-      return m * x + b
-    }
-  }
-
-  func genericFoo<T: Prot>(_ t: T, _ x: Float) -> Float {
-    t.foo(x: x)
-  }
-  let inst = Linear(m: 5, b: -2)
-  let (y1, diff1) = valueWithDifferential(at: 5) { x in genericFoo(inst, x) }
-  expectEqual(23, y1)
-  expectEqual(5, diff1(1))
-}
-
-protocol DiffReq : Differentiable {
-  @differentiable(reverse, wrt: (self, x))
-  func f(_ x: Float) -> Float
-}
-
-extension DiffReq where TangentVector : AdditiveArithmetic {
-  @inline(never)  // Prevent specialization, to test all witness code.
-  func derivF(at x: Float) -> Float {
-    return (valueWithDifferential(at: x) { x in self.f(x) }).1(1)
-  }
-}
-
-struct Quadratic : DiffReq, AdditiveArithmetic {
-  typealias TangentVector = Quadratic
-
-  @differentiable(reverse)
-  let a: Float
-
-  @differentiable(reverse)
-  let b: Float
-
-  @differentiable(reverse)
-  let c: Float
-
-  init(_ a: Float, _ b: Float, _ c: Float) {
-    self.a = a
-    self.b = b
-    self.c = c
-  }
-
-  @differentiable(reverse, wrt: (self, x))
-  func f(_ x: Float) -> Float {
-    return a * x * x + b * x + c
-  }
-}
-
-ForwardModeTests.test("ProtocolFunc") {
-  expectEqual(12, Quadratic(11, 12, 13).derivF(at: 0))
-  expectEqual(2 * 11 + 12, Quadratic(11, 12, 13).derivF(at: 1))
-  expectEqual(2 * 11 * 2 + 12, Quadratic(11, 12, 13).derivF(at: 2))
-}
-
-// MARK: Constructor, accessor, and subscript requirements.
-
-protocol FunctionsOfX: Differentiable {
-  @differentiable(reverse)
-  init(x: Float)
-
-  @differentiable(reverse)
-  var x: Float { get }
-
-  @differentiable(reverse)
-  var y: Float { get }
-
-  @differentiable(reverse)
-  var z: Float { get }
-
-  @differentiable(reverse)
-  subscript() -> Float { get }
-}
-
-struct TestFunctionsOfX: FunctionsOfX {
-  @differentiable(reverse)
-  init(x: Float) {
-    self.x = x
-    self.y = x * x
-  }
-
-  /// x = x
-  var x: Float
-
-  /// y = x * x
-  var y: Float
-
-  /// z = x * x + x
-  var z: Float {
-    return y + x
-  }
-
-  @differentiable(reverse)
-  subscript() -> Float {
-    return z
-  }
-}
-
-@inline(never)  // Prevent specialization, to test all witness code.
-func derivatives<F: FunctionsOfX>(at x: Float, of: F.Type)
-  -> (Float, Float, Float, Float)
-{
-  let dxdx = derivative(at: x) { x in F(x: x).x }
-  let dydx = derivative(at: x) { x in F(x: x).y }
-  let dzdx = derivative(at: x) { x in F(x: x).z }
-  let dsubscriptdx = derivative(at: x) { x in F(x: x)[] }
-  return (dxdx, dydx, dzdx, dsubscriptdx)
-}
-
-ForwardModeTests.test("constructor, accessor, subscript") {
-  expectEqual(
-    (1.0, 4.0, 5.0, 5.0),
-    derivatives(at: 2.0, of: TestFunctionsOfX.self))
-}
-
-// MARK: - Test witness method SIL type computation.
-
-protocol P : Differentiable {
-  @differentiable(reverse, wrt: (x, y))
-  func foo(_ x: Float, _ y: Double) -> Float
-}
-struct S : P {
-  @differentiable(reverse, wrt: (x, y))
-  func foo(_ x: Float, _ y: Double) -> Float {
-    return x
-  }
-}
-
-// MARK: - Overridden protocol method adding differentiable attribute.
-
-public protocol Distribution {
-  associatedtype Value
-  func logProbability(of value: Value) -> Float
-}
-
-public protocol DifferentiableDistribution: Differentiable, Distribution {
-  @differentiable(reverse, wrt: self)
-  func logProbability(of value: Value) -> Float
-}
-
-struct Foo: DifferentiableDistribution {
-  @differentiable(reverse, wrt: self)
-  func logProbability(of value: Float) -> Float {
-    .zero
-  }
-}
-
-@differentiable(reverse)
-func blah<T: DifferentiableDistribution>(_ x: T) -> Float where T.Value: AdditiveArithmetic {
-  x.logProbability(of: .zero)
-}
-
-// Adding a more general `@differentiable` attribute.
-public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
-  where Value: Differentiable {
-  @differentiable(reverse, wrt: self)
-  @differentiable(reverse, wrt: (self, value))
-  func logProbability(of value: Value) -> Float
-}
-
-@differentiable(reverse)
-func blah2<T: DoubleDifferentiableDistribution>(_ x: T, _ value: T.Value) -> Float
-  where T.Value: AdditiveArithmetic {
-  x.logProbability(of: value)
-}
-
-protocol DifferentiableFoo {
-  associatedtype T: Differentiable
-  @differentiable(reverse, wrt: x)
-  func foo(_ x: T) -> Float
-}
-
-protocol MoreDifferentiableFoo: Differentiable, DifferentiableFoo {
-  @differentiable(reverse, wrt: (self, x))
-  func foo(_ x: T) -> Float
-}
-
-struct MoreDifferentiableFooStruct: MoreDifferentiableFoo {
-  @differentiable(reverse, wrt: (self, x))
-  func foo(_ x: Float) -> Float {
-    x
-  }
-}
-
-//===----------------------------------------------------------------------===//
-// Simple Math
-//===----------------------------------------------------------------------===//
-
-ForwardModeTests.test("Arithmetics") {
-  func foo1(x: Float, y: Float) -> Float {
-    return x * y
-  }
-  expectEqual(7, derivative(at: 3, 4, of: foo1))
-  func foo2(x: Float, y: Float) -> Float {
-    return -x * y
-  }
-  expectEqual(-7, derivative(at: 3, 4, of: foo2))
-  func foo3(x: Float, y: Float) -> Float {
-    return -x + y
-  }
-  expectEqual(0, derivative(at: 3, 4, of: foo3))
-}
-
-ForwardModeTests.test("Fanout") {
-  func foo1(x: Float) -> Float {
-     x - x
-  }
-  expectEqual(0, derivative(at: 100, of: foo1))
-  func foo2(x: Float) -> Float {
-     x + x
-  }
-  expectEqual(2, derivative(at: 100, of: foo2))
-  func foo3(x: Float, y: Float) -> Float {
-    x + x + x * y
-  }
-  expectEqual(7, derivative(at: 3, 2, of: foo3))
-}
-
-ForwardModeTests.test("FunctionCall") {
-  func foo(_ x: Float, _ y: Float) -> Float {
-    return 3 * x + { $0 * 3 }(3) * y
-  }
-  expectEqual(12, derivative(at: 3, 4, of: foo))
-  expectEqual(3, derivative(at: 3) { x in foo(x, 4) })
-}
-
-ForwardModeTests.test("ResultSelection") {
-  func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
-    return (x + 1, y + 2)
-  }
-  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).0 }))
-  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).1 }))
-
-  // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
-  /*
-  func tupleGeneric<T>(_ x: T, _ y: T) -> (T, T) {
-    return (x, y)
-  }
-  func tupleGenericFirst<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).0 }
-  func tupleGenericSecond<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).1 }
-  expectEqual(1, derivative(at: 3, 3, of: tupleGenericFirst))
-  expectEqual(1, derivative(at: 3, 3, of: tupleGenericSecond))
-  */
-}
-
-// TODO(TF-983): Support forward-mode differentiation of multiple results.
-/*
-ForwardModeTests.test("MultipleResults") {
-  // Test function returning a tuple of active results.
-  func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
-    return (x, y)
-  }
-  func multiply(_ x: Float, _ y: Float) -> Float {
-    let z = tuple(x, y)
-    // Note: both results (tuple elements) are active.
-    return z.0 * z.1
-  }
-  expectEqual((4, 3), gradient(at: 3, 4, of: multiply))
-  expectEqual((10, 5), gradient(at: 5, 10, of: multiply))
-
-  // Test function with multiple `inout` parameters.
-  func swap(_ x: inout Float, _ y: inout Float) {
-    let tmp = x; x = y; y = tmp
-  }
-  func multiply_swap(_ x: Float, _ y: Float) -> Float {
-    var tuple = (x, y)
-    swap(&tuple.0, &tuple.1)
-    return tuple.0 * tuple.1
-  }
-  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swap))
-  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swap))
-
-  // Test function with multiple `inout` parameters.
-  func swapGeneric<T>(_ x: inout T, _ y: inout T) {
-    let tmp = x; x = y; y = tmp
-  }
-  func multiply_swapGeneric(_ x: Float, _ y: Float) -> Float {
-    var tuple = (x, y)
-    swapGeneric(&tuple.0, &tuple.1)
-    return tuple.0 * tuple.1
-  }
-  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapGeneric))
-  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swapGeneric))
-
-  // Test function with multiple `inout` parameters and a formal result.
-  func swapAndReturnProduct(_ x: inout Float, _ y: inout Float) -> Float {
-    let tmp = x
-    x = y
-    y = tmp
-    return x * y
-  }
-  func multiply_swapAndReturnProduct(_ x: Float, _ y: Float) -> Float {
-    var x2 = x
-    var y2 = y
-    let result = swapAndReturnProduct(&x2, &y2)
-    return result
-  }
-  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
-  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
-}
-*/
-
-ForwardModeTests.test("CaptureLocal") {
-  let z: Float = 10
-  func foo(_ x: Float) -> Float {
-    return z * x
-  }
-  expectEqual(10, derivative(at: 0, of: foo))
-}
-
-var globalVar: Float = 10
-ForwardModeTests.test("CaptureGlobal") {
-  func foo(x: Float) -> Float {
-    globalVar += 20
-    return globalVar * x
-  }
-  expectEqual(30, derivative(at: 0, of: foo))
-}
-
-ForwardModeTests.test("Mutation") {
-  func fourthPower(x: Float) -> Float {
-    var a = x
-    a = a * x
-    a = a * x
-    return a * x
-  }
-  expectEqual(4 * 27, derivative(at: 3, of: fourthPower))
-}
-
-// Tests TF-21.
-ForwardModeTests.test("StructMemberwiseInitializer") {
-  struct Foo : AdditiveArithmetic, Differentiable {
-    var stored: Float
-    var computed: Float {
-      return stored * stored
-    }
-  }
-
-  let derivFoo = differential(at: Float(4), of: { input -> Foo in
-    let foo = Foo(stored: input)
-    let foo2 = foo + foo
-    return Foo(stored: foo2.stored)
-  })(1)
-  expectEqual(Foo.TangentVector(stored: 2), derivFoo)
-
-  let computed = derivative(at: Float(4)) { input -> Float in
-    let foo = Foo(stored: input)
-    return foo.computed
-  }
-  expectEqual(8, computed)
-
-  let derivProduct = derivative(at: Float(4)) { input -> Float in
-    let foo = Foo(stored: input)
-    return foo.computed * foo.stored
-  }
-  expectEqual(48, derivProduct)
-
-  struct Custom : AdditiveArithmetic, Differentiable {
-    var x: Float
-
-    // Custom initializer with `@differentiable`.
-    @differentiable(reverse)
-    init(x: Float) {
-      self.x = x
-    }
-  }
-
-  let derivCustom = differential(at: Float(4), of: { input -> Custom in
-    let foo = Custom(x: input)
-    return foo + foo
-  })(1)
-  expectEqual(Custom.TangentVector(x: 2), derivCustom)
-}
-
-// Tests TF-319: struct with non-differentiable constant stored property.
-ForwardModeTests.test("StructConstantStoredProperty") {
-  struct TF_319 : Differentiable {
-    var x: Float
-    @noDerivative let constant = Float(2)
-
-    @differentiable(reverse)
-    init(x: Float) {
-      self.x = x
-    }
-
-    @differentiable(reverse, wrt: (self, input))
-    func applied(to input: Float) -> Float {
-      return x * constant * input
-    }
-  }
-  func testStructInit(to input: Float) -> Float {
-    let model = TF_319(x: 10)
-    return model.applied(to: input)
-  }
-  expectEqual(6, derivative(at: 10, of: { TF_319(x: $0).applied(to: 3) }))
-  expectEqual(20, derivative(at: 3, of: testStructInit))
-}
-
-ForwardModeTests.test("StructMutation") {
-  struct Point : AdditiveArithmetic, Differentiable {
-    var x: Float
-    var y: Float
-    var z: Float
-  }
-
-  func double(_ input: Float) -> Point {
-    let point = Point(x: input, y: input, z: input)
-    return point + point
-  }
-  expectEqual(Point(x: 2, y: 2, z: 2), differential(at: 4, of: double)(1))
-
-  func fifthPower(_ input: Float) -> Float {
-    var point = Point(x: input, y: input, z: input)
-    point.x = point.x * input
-    point.y = point.x * input
-    return point.x * point.y
-  }
-  expectEqual(405, derivative(at: 3, of: fifthPower))
-
-  func mix(_ input: Float) -> Float {
-    var tuple = (point: Point(x: input, y: input, z: input), float: input)
-    tuple.point.x = tuple.point.x * tuple.float
-    tuple.point.y = tuple.point.x * input
-    return tuple.point.x * tuple.point.y
-  }
-  expectEqual(405, derivative(at: 3, of: mix))
-
-  // Test TF-282.
-  struct Add : Differentiable {
-    var bias: Float
-    func applied(to input: Float) -> Float {
-      var tmp = input
-      tmp = tmp + bias
-      return tmp
-    }
-  }
-  expectEqual(1, derivative(at: 1) { m in Add(bias: m).applied(to: 1) })
-}
-
-ForwardModeTests.test("StructGeneric") {
-  struct Generic<T : AdditiveArithmetic & Differentiable> : AdditiveArithmetic, Differentiable {
-    var x: T
-    var y: T
-    var z: T
-  }
-
-  let deriv = differential(at: Float(3), of: { input -> Generic<Float> in
-    var generic = Generic(x: input, y: input, z: input)
-    return generic
-  })(1)
-  expectEqual(Generic<Float>.TangentVector(x: 1, y: 1, z: 1), deriv)
-
-  func fifthPower(_ input: Float) -> Float {
-    var generic = Generic(x: input, y: input, z: input)
-    generic.x = generic.x * input
-    generic.y = generic.x * input
-    return generic.x * generic.y
-  }
-  expectEqual(405, derivative(at: 3, of: fifthPower))
-}
-
-ForwardModeTests.test("SubsetIndices") {
-  func deriv(_ lossFunction: @differentiable(reverse) (Float, Float) -> Float) -> Float {
-    return derivative(at: 1) { x in lossFunction(x * x, 10.0) }
-  }
-  expectEqual(2, deriv { x, y in x + y })
-
-  func derivWRTNonDiff(_ lossFunction: @differentiable(reverse) (Float, @noDerivative Int) -> Float) -> Float {
-    return derivative(at: 2) { x in lossFunction(x * x, 10) }
-  }
-  expectEqual(4, derivWRTNonDiff { x, y in x + Float(y) })
-}
-
-ForwardModeTests.test("ForceUnwrapping") {
-  func forceUnwrap<T: Differentiable & FloatingPoint>(_ t: T) -> Float where T == T.TangentVector {
-    derivative(at: t, Float(3)) { (x, y) in
-      (x as! Float) * y
-    }
-  }
-  expectEqual(5, forceUnwrap(Float(2)))
-}
-
-ForwardModeTests.test("NonVariedResult") {
-  @differentiable(reverse, wrt: x)
-  func nonWrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
-    y = x
-  }
-
-  @differentiable(reverse)
-  func wrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
-    y = x
-  }
-
-  @differentiable(reverse, wrt: x)
-  func nonWrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
-
-  @differentiable(reverse, wrt: x)
-  func wrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
-
-  @differentiable(reverse)
-  func variedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    nonWrtInoutParam(x, &result)
-    return result
-  }
-
-  @differentiable(reverse)
-  func variedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    wrtInoutParam(x, &result)
-    return result
-  }
-
-  @differentiable(reverse)
-  func nonVariedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    nonWrtInoutParamNonVaried(x, &result)
-    return result
-  }
-
-  @differentiable(reverse)
-  func nonVariedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
-    // expected-warning @+1 {{variable 'result' was never mutated}}
-    var result: Tracked<Float> = 0
-    return result
-  }
-
-  @differentiable(reverse)
-  func nonVariedResultTracked3(_ x: Tracked<Float>) -> Tracked<Float> {
-    return 0
-  }
-
-  @differentiable(reverse)
-  func nonVariedResultTracked4(_ x: Tracked<Float>) -> Tracked<Float> {
-    var result: Tracked<Float> = 0
-    wrtInoutParamNonVaried(x, &result)
-    return result
-  }
-}
-
-ForwardModeTests.test("ApplyNonActiveIndirectResult") {
-  func identity<T: Differentiable>(_ x: T) -> T { x }
-
-  @differentiable(reverse)
-  func applyNonactiveArgumentActiveIndirectResult(_ x: Tracked<Float>) -> Tracked<Float> {
-    var y = identity(0 as Tracked<Float>)
-    y = x
-    return y
-  }
-  expectEqual(1.0, derivative(at: 2, of: applyNonactiveArgumentActiveIndirectResult))
-}
-
-ForwardModeTests.test("SR-13530") {
-  // SR-13530: Test "leaked owned value" ownership verification failure related
-  // to differential generation for `copy_value` instruction.
-  @differentiable(reverse)
-  func SR_13530(_ x: NonresilientTracked<Float>) -> NonresilientTracked<Float> {
-    precondition(x >= 0)
-    return x
-  }
-  expectEqual(1, derivative(at: 2, of: SR_13530))
-}
-
-runAllTests()
+//var ForwardModeTests = TestSuite("ForwardModeDifferentiation")
+//
+////===----------------------------------------------------------------------===//
+//// Basic tests.
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("Identity") {
+//  func func_to_diff(x: Float) -> Float {
+//    return x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
+//  expectEqual(4, y)
+//  expectEqual(1, differential(1))
+//}
+//
+//ForwardModeTests.test("Unary") {
+//  func func_to_diff(x: Float) -> Float {
+//    return x * x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
+//  expectEqual(16, y)
+//  expectEqual(8, differential(1))
+//}
+//
+//ForwardModeTests.test("Binary") {
+//  func func_to_diff(x: Float, y: Float) -> Float {
+//    return x * y
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
+//  expectEqual(20, y)
+//  expectEqual(9, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("BinaryWithLets") {
+//  func func_to_diff(x: Float, y: Float) -> Float {
+//    let a = x + y
+//    let b = a
+//    return b * -y
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
+//  expectEqual(-45, y)
+//  expectEqual(-19, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("SubsetParametersDiff") {
+//  func func_to_diff1(x: Int, y: Float, z: Int) -> Float {
+//    return y
+//  }
+//  let (y1, differential1) = valueWithDifferential(at: 5) { y in
+//    func_to_diff1(x: 0, y: y, z: 0)
+//  }
+//  expectEqual(5, y1)
+//  expectEqual(1, differential1(1))
+//
+//  func func_to_diff2(x: Float, y: Int, z: Int) -> Float {
+//    return 2 * x
+//  }
+//  let (y2, differential2) = valueWithDifferential(at: 6) { x in
+//    func_to_diff2(x: x, y: 0, z: 0)
+//  }
+//  expectEqual(12, y2)
+//  expectEqual(2, differential2(1))
+//
+//  func func_to_diff3(x: Int, y: Int, z: Float) -> Float {
+//    return 3 * z
+//  }
+//  let (y3, differential3) = valueWithDifferential(at: 7) { z in
+//    func_to_diff3(x: 0, y: 0, z: z)
+//  }
+//  expectEqual(21, y3)
+//  expectEqual(3, differential3(1))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Functions with variables
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("UnaryWithVars") {
+//  func unary(x: Float) -> Float {
+//    var a = x
+//    a = x
+//    var b = a + 2
+//    b = b - 1
+//    let c: Float = 3
+//    var d = a + b + c - 1
+//    d = d + d
+//    return d
+//  }
+//
+//  let (y, differential) = valueWithDifferential(at: 4, of: unary)
+//  expectEqual(22, y)
+//  expectEqual(4, differential(1))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Functions with basic struct
+////===----------------------------------------------------------------------===//
+//
+//struct A: Differentiable & AdditiveArithmetic {
+//  var x: Float
+//}
+//
+//ForwardModeTests.test("StructInit") {
+//  func structInit(x: Float) -> A {
+//    return A(x: 2 * x)
+//  }
+//
+//  let (y, differential) = valueWithDifferential(at: 4, of: structInit)
+//  expectEqual(A(x: 8), y)
+//  expectEqual(A(x: 2), differential(1))
+//}
+//
+//ForwardModeTests.test("StructExtract") {
+//  func structExtract(x: A) -> Float {
+//    return 2 * x.x
+//  }
+//
+//  let (y, differential) = valueWithDifferential(
+//    at: A(x: 4),
+//    of: structExtract)
+//  expectEqual(8, y)
+//  expectEqual(2, differential(A(x: 1)))
+//}
+//
+//ForwardModeTests.test("LocalStructVariable") {
+//  func structExtract(x: A) -> A {
+//    let a = A(x: 2 * x.x) // 2x
+//    var b = A(x: a.x + 2) // 2x + 2
+//    b = A(x: b.x + a.x) // 2x + 2 + 2x = 4x + 2
+//    return b
+//  }
+//
+//  let (y, differential) = valueWithDifferential(
+//    at: A(x: 4),
+//    of: structExtract)
+//  expectEqual(A(x: 18), y)
+//  expectEqual(A(x: 4), differential(A(x: 1)))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Functions with methods
+////===----------------------------------------------------------------------===//
+//
+//extension A {
+//  func noParamMethodA() -> A {
+//    return A(x: 2 * x)
+//  }
+//
+//  func noParamMethodx() -> Float {
+//    return 2 * x
+//  }
+//
+//  static func *(lhs: A, rhs: A) -> A {
+//    return A(x: lhs.x * rhs.x)
+//  }
+//
+//  func complexBinaryMethod(u: A, v: Float) -> A {
+//    var b: A = u * A(x: 2)  // A(x: u * 2)
+//    b.x = b.x * v        // A(x: u * 2 * v)
+//    let c = b.x + 1      // u * 2 * v + 1
+//
+//    // A(x: u * 2 * v + 1 + u * 2 * v) = A(x: x * (4uv + 1))
+//    return A(x: x * (c + b.x))
+//  }
+//}
+//
+//ForwardModeTests.test("noParamMethodA") {
+//  let (y, differential) = valueWithDifferential(at: A(x: 4)) { x in
+//    x.noParamMethodA()
+//  }
+//  expectEqual(A(x: 8), y)
+//  expectEqual(A(x: 2), differential(A(x: 1)))
+//}
+//
+//ForwardModeTests.test("noParamMethodx") {
+//  let (y, differential) = valueWithDifferential(at: A(x: 4)) { x in
+//    x.noParamMethodx()
+//  }
+//  expectEqual(8, y)
+//  expectEqual(2, differential(A(x: 1)))
+//}
+//
+//ForwardModeTests.test("complexBinaryMethod") {
+//  let (y, differential) = valueWithDifferential(at: A(x: 4), A(x: 5), 3) {
+//    (x, y, z) in
+//    // derivative = A(x: 4uv + 4xv + 4ux + 1) = 4*5*3 + 4*4*3 + 4*5*4 + 1 = 189
+//    x.complexBinaryMethod(u: y, v: z)
+//  }
+//  expectEqual(A(x: 244), y)
+//  expectEqual(A(x: 189), differential(A(x: 1), A(x: 1), 1))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Tracked struct
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.testWithLeakChecking("TrackedIdentity") {
+//  func identity(x: Tracked<Float>) -> Tracked<Float> {
+//    return x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, of: identity)
+//  expectEqual(4, y)
+//  expectEqual(1, differential(1))
+//}
+//
+//ForwardModeTests.testWithLeakChecking("TrackedAddition") {
+//  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
+//    return x + y
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
+//  expectEqual(9, y)
+//  expectEqual(2, differential(1, 1))
+//}
+//
+//ForwardModeTests.testWithLeakChecking("TrackedDivision") {
+//  func divide(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
+//    return x / y
+//  }
+//  let (y, differential) = valueWithDifferential(at: 10, 5, of: divide)
+//  expectEqual(2, y)
+//  expectEqual(-0.2, differential(1, 1))
+//}
+//
+//ForwardModeTests.testWithLeakChecking("TrackedMultipleMultiplication") {
+//  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
+//    return x * y * x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
+//  expectEqual(80, y)
+//  // 2yx+xx
+//  expectEqual(56, differential(1, 1))
+//}
+//
+//ForwardModeTests.testWithLeakChecking("TrackedWithLets") {
+//  func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
+//    let a = x + y
+//    let b = a * a // (x+y)^2
+//    let c = b / x + y // (x+y)^2/x+y
+//    return c
+//  }
+//  // (3x^2+2xy-y^2)/x^2+1
+//  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
+//  expectEqual(25.25, y)
+//  expectEqual(4.9375, differential(1, 1))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Tuples
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("TupleLet") {
+//  do {
+//    func tupleLet(_ x: Float) -> Float {
+//      let tuple = (2 * x, x)
+//      return tuple.0
+//    }
+//    let (value, derivative) = valueWithDerivative(at: 4, of: tupleLet)
+//    expectEqual(8, value)
+//    expectEqual(2, derivative)
+//  }
+//}
+//
+//ForwardModeTests.test("TupleVar") {
+//  do {
+//    func tupleVar(_ x: Float) -> Float {
+//      var tuple = (2 * x, x)
+//      return tuple.0
+//    }
+//    let (value, derivative) = valueWithDerivative(at: 4, of: tupleVar)
+//    expectEqual(8, value)
+//    expectEqual(2, derivative)
+//  }
+//
+//  do {
+//    // TF-964: Test tuple with non-tuple-typed adjoint value.
+//    func TF_964(_ x: Float) -> Float {
+//      var tuple = (2 * x, 1)
+//      return tuple.0
+//    }
+//    let (value, derivative) = valueWithDerivative(at: 4, of: TF_964)
+//    expectEqual(8, value)
+//    expectEqual(2, derivative)
+//  }
+//}
+//
+//ForwardModeTests.test("TupleMutation") {
+//  func foo(_ x: Float) -> Float {
+//    var tuple = (x, x)
+//    tuple.0 = tuple.0 * x
+//    return x * tuple.0
+//  }
+//  expectEqual(27, derivative(at: 3, of: foo))
+//
+//  func fifthPower(_ x: Float) -> Float {
+//    var tuple = (x, x)
+//    tuple.0 = tuple.0 * x
+//    tuple.1 = tuple.0 * x
+//    return tuple.0 * tuple.1
+//  }
+//  expectEqual(405, derivative(at: 3, of: fifthPower))
+//
+//  func nested(_ x: Float) -> Float {
+//    var tuple = ((x, x), x)
+//    tuple.0.0 = tuple.0.0 * x
+//    tuple.0.1 = tuple.0.0 * x
+//    return tuple.0.0 * tuple.0.1
+//  }
+//  expectEqual(405, derivative(at: 3, of: nested))
+//
+//  func generic<T: Differentiable & AdditiveArithmetic>(_ x: T) -> T {
+//    var tuple = (x, x)
+//    return tuple.0
+//  }
+//  expectEqual(1, derivative(at: 3.0, of: generic))
+//
+//  // FIXME(TF-1033): Fix forward-mode ownership error for tuple with non-active
+//  // initial values.
+//  /*
+//  func genericInitialNonactive<T: Differentiable & AdditiveArithmetic>(
+//    _ x: T
+//  ) -> T {
+//    var tuple = (T.zero, T.zero)
+//    tuple.0 = x
+//    tuple.1 = x
+//    return tuple.0
+//  }
+//  expectEqual(1, derivative(at: 3.0, of: genericInitialNonactive))
+//  */
+//}
+//
+//// Tests TF-321.
+//ForwardModeTests.test("TupleNonDifferentiableElements") {
+//  // TF-964: Test tuple with non-tuple-typed adjoint value.
+//  func tupleLet(_ x: Tracked<Float>) -> Tracked<Float> {
+//    let tuple = (2 * x, 1)
+//    return tuple.0
+//  }
+//  expectEqual((8, 2), valueWithDerivative(at: 4, of: tupleLet))
+//
+//  func tupleVar(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var tuple = (x, 1)
+//    tuple.0 = x
+//    tuple.1 = 1
+//    return tuple.0
+//  }
+//  expectEqual((3, 1), valueWithDerivative(at: 3, of: tupleVar))
+//
+//  @differentiable(reverse)
+//  func nested(_ x: Tracked<Float>) -> Tracked<Float> {
+//    // Convoluted function computing `x * x`.
+//    var tuple: (Int, (Int, Tracked<Float>), Tracked<Float>) = (1, (1, 0), 0)
+//    tuple.0 = 1
+//    tuple.1.0 = 1
+//    tuple.1.1 = x
+//    tuple.2 = x
+//    return tuple.1.1 * tuple.2
+//  }
+//  // FIXME(SR-12911): Fix runtime segfault.
+//  // expectEqual((16, 8), valueWithDerivative(at: 4, of: nested))
+//
+//  struct Wrapper<T> {
+//    @differentiable(reverse where T : Differentiable)
+//    func baz(_ x: T) -> T {
+//      var tuple = (1, 1, x, 1)
+//      tuple.0 = 1
+//      tuple.2 = x
+//      tuple.3 = 1
+//      return tuple.2
+//    }
+//  }
+//  func wrapper(_ x: Tracked<Float>) -> Tracked<Float> {
+//    let w = Wrapper<Tracked<Float>>()
+//    return w.baz(x)
+//  }
+//  expectEqual((3, 1), valueWithDerivative(at: 3, of: wrapper))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Generics
+////===----------------------------------------------------------------------===//
+//
+//struct Tensor<Scalar : FloatingPoint & Differentiable>
+//  : AdditiveArithmetic, Differentiable {
+//  // NOTE: `value` must have type with known size (e.g. `Float`, not `Scalar`)
+//  // until differentiation has indirect passing support.
+//  var value: Float
+//  init(_ value: Float) { self.value = value }
+//}
+//
+//ForwardModeTests.test("GenericIdentity") {
+//  func identity<T : Differentiable>(_ x: T) -> T {
+//    return x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
+//    identity(x)
+//  }
+//  expectEqual(4, y)
+//  expectEqual(1, differential(1))
+//}
+//
+//ForwardModeTests.test("GenericTensorIdentity") {
+//  func identity<T : FloatingPoint & Differentiable>(
+//    _ x: Tensor<T>) -> Tensor<T> {
+//    return x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
+//    identity(Tensor<Float>(x))
+//  }
+//  expectEqual(Tensor<Float>(4), y)
+//  expectEqual(Tensor<Float>(1), differential(1))
+//}
+//
+//ForwardModeTests.test("GenericTensorPlus") {
+//  func plus<T : FloatingPoint & Differentiable>(_ x: Tensor<T>) -> Float {
+//    return x.value + x.value
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
+//    plus(Tensor<Float>(x))
+//  }
+//  expectEqual(8, y)
+//  expectEqual(2, differential(1))
+//}
+//
+//ForwardModeTests.test("GenericTensorBinaryInput") {
+//  func binary<T : FloatingPoint & Differentiable>(
+//    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
+//    return x.value * y.value
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5) {
+//    (x: Float, y: Float) in
+//    binary(Tensor<Float>(x), Tensor<Float>(y))
+//  }
+//  expectEqual(20, y)
+//  expectEqual(9, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("GenericTensorWithLets") {
+//  func binary<T : FloatingPoint & Differentiable>(
+//    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
+//    let a = Tensor<T>(x.value)
+//    let b = Tensor<T>(y.value)
+//    return a.value * b.value
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5) {
+//    (x: Float, y: Float) in
+//    binary(Tensor<Float>(x), Tensor<Float>(y))
+//  }
+//  expectEqual(20, y)
+//  expectEqual(9, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("GenericTensorWithVars") {
+//  func binary<T : FloatingPoint & Differentiable>(
+//    _ x: Tensor<T>, _ y: Tensor<T>) -> Float {
+//    var a = Tensor<T>(x.value)
+//    var b = Tensor<T>(y.value)
+//    b = a
+//    a = Tensor<T>(y.value)
+//    return a.value * b.value
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5) {
+//    (x: Float, y: Float) in
+//    binary(Tensor<Float>(x), Tensor<Float>(y))
+//  }
+//  expectEqual(20, y)
+//  expectEqual(9, differential(1, 1))
+//}
+//
+//// Test case where associated derivative function's requirements are met.
+//extension Tensor where Scalar : Numeric {
+//  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
+//  func mean() -> Tensor {
+//    return self
+//  }
+//
+//  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
+//  func variance() -> Tensor {
+//    return mean() // ok
+//  }
+//}
+//_ = differential(at: Tensor<Float>(1), of: { $0.variance() })
+//
+//// Tests TF-508: differentiation requirements with dependent member types.
+//protocol TF_508_Proto {
+//  associatedtype Scalar
+//}
+//extension TF_508_Proto where Scalar : FloatingPoint {
+//  @differentiable(
+//    where Self : Differentiable, Scalar : Differentiable,
+//          // Conformance requirement with dependent member type.
+//          Self.TangentVector : TF_508_Proto
+//  )
+//  static func +(lhs: Self, rhs: Self) -> Self {
+//    return lhs
+//  }
+//
+//  @differentiable(
+//    where Self : Differentiable, Scalar : Differentiable,
+//          // Same-type requirement with dependent member type.
+//          Self.TangentVector == Float
+//  )
+//  static func -(lhs: Self, rhs: Self) -> Self {
+//    return lhs
+//  }
+//}
+//extension TF_508_Proto where Self : Differentiable,
+//                             Scalar : FloatingPoint & Differentiable,
+//                             Self.TangentVector : TF_508_Proto {
+//  @derivative(of: +)
+//  static func jvpAdd(lhs: Self, rhs: Self)
+//      -> (value: Self, differential: (TangentVector, TangentVector) -> TangentVector) {
+//    return (lhs, { (dlhs, drhs) in dlhs })
+//  }
+//}
+//extension TF_508_Proto where Self : Differentiable,
+//                             Scalar : FloatingPoint & Differentiable,
+//                             Self.TangentVector == Float {
+//  @derivative(of: -)
+//  static func jvpSubtract(lhs: Self, rhs: Self)
+//      -> (value: Self, differential: (TangentVector, TangentVector) -> TangentVector) {
+//    return (lhs, { (dlhs, drhs) in dlhs })
+//  }
+//}
+//
+//struct TF_508_Struct<Scalar : AdditiveArithmetic>
+//  : TF_508_Proto, AdditiveArithmetic {}
+//extension TF_508_Struct : Differentiable where Scalar : Differentiable {
+//  typealias TangentVector = TF_508_Struct
+//}
+//
+//// func TF_508() {
+////   let x = TF_508_Struct<Float>()
+////   // Test conformance requirement with dependent member type.
+////   _ = differential(at: x, of: {
+////     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
+////     return x + x
+////   })
+////   // Test same-type requirement with dependent member type.
+////   _ = differential(at: x, of: {
+////     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
+////     return x - x
+////   })
+//// }
+//
+//// TF-523
+//struct TF_523_Struct : Differentiable & AdditiveArithmetic {
+//  var a: Float = 1
+//  typealias TangentVector = TF_523_Struct
+//  typealias AllDifferentiableVariables = TF_523_Struct
+//}
+//
+//@differentiable(reverse)
+//func TF_523_f(_ x: TF_523_Struct) -> Float {
+//  return x.a * 2
+//}
+//
+//// TF-534: Thunk substitution map remapping.
+//protocol TF_534_Layer : Differentiable {
+//  associatedtype Input : Differentiable
+//  associatedtype Output : Differentiable
+//
+//  @differentiable(reverse)
+//  func callAsFunction(_ input: Input) -> Output
+//}
+//struct TF_534_Tensor<Scalar> : Differentiable {}
+//
+//func TF_534<Model: TF_534_Layer>(
+//  _ model: inout Model, inputs: Model.Input
+//) -> TF_534_Tensor<Float> where Model.Output == TF_534_Tensor<Float> {
+//  return valueWithDifferential(at: model) { model -> Model.Output in
+//    return model(inputs)
+//  }.0
+//}
+//
+//// TODO: uncomment once control flow is supported in forward mode.
+//// TF-652: Test VJPEmitter substitution map generic signature.
+//// The substitution map should have the VJP's generic signature, not the
+//// original function's.
+//// struct TF_652<Scalar> {}
+//// extension TF_652 : Differentiable where Scalar : FloatingPoint {}
+//
+//// @differentiable(reverse, wrt: x where Scalar: FloatingPoint)
+//// func test<Scalar: Numeric>(x: TF_652<Scalar>) -> TF_652<Scalar> {
+////   for _ in 0..<10 {
+////     let _ = x
+////   }
+////   return x
+//// }
+//
+////===----------------------------------------------------------------------===//
+//// Tracked Generic.
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("GenericTrackedIdentity") {
+//  func identity<T : Differentiable>(_ x: Tracked<T>) -> Tracked<T> {
+//    return x
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4) { (x: Float) in
+//    identity(Tracked(x))
+//  }
+//  expectEqual(4, y)
+//  expectEqual(1, differential(1))
+//}
+//
+//ForwardModeTests.test("GenericTrackedBinaryAdd") {
+//  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
+//    where T: Differentiable, T == T.TangentVector {
+//    return x + y
+//  }
+//  let (y, differential) = valueWithDifferential(at: 4, 5) {
+//    (x: Float, y: Float) in
+//    add(Tracked(x), Tracked(y))
+//  }
+//  expectEqual(9, y)
+//  expectEqual(2, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("GenericTrackedBinaryLets") {
+//  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
+//    where T: Differentiable & SignedNumeric,
+//          T == T.TangentVector,
+//          T == T.Magnitude {
+//    let a = x * y // xy
+//    let b = a + a // 2xy
+//    return b + b // 4xy
+//  }
+//  // 4y + 4x
+//  let (y, differential) = valueWithDifferential(at: 4, 5) { (x: Float, y: Float) in
+//    add(Tracked(x), Tracked(y))
+//  }
+//  expectEqual(80, y)
+//  expectEqual(36, differential(1, 1))
+//}
+//
+//ForwardModeTests.test("GenericTrackedBinaryVars") {
+//  func add<T>(_ x: Tracked<T>, _ y: Tracked<T>) -> Tracked<T>
+//    where T: Differentiable & SignedNumeric,
+//          T == T.TangentVector,
+//          T == T.Magnitude {
+//    var a = x * y // xy
+//    a = a + a // 2xy
+//    var b = x
+//    b = a
+//    return b + b // 4xy
+//  }
+//  // 4y + 4x
+//  let (y, differential) = valueWithDifferential(at: 4, 5) { (x: Float, y: Float) in
+//    add(Tracked(x), Tracked(y))
+//  }
+//  expectEqual(80, y)
+//  expectEqual(36, differential(1, 1))
+//}
+//
+//ForwardModeTests.testWithLeakChecking("TrackedDifferentiableFuncType") {
+//  func valAndDeriv(
+//    f: @escaping @differentiable(reverse) (Tracked<Float>) -> Tracked<Float>
+//  ) -> (Tracked<Float>, Tracked<Float>) {
+//    let (y, diff) = valueWithDifferential(at: 5, of: f)
+//    return (y, diff(1))
+//  }
+//
+//  func func1(_ x: Tracked<Float>) -> Tracked<Float> {
+//    let a = x + x // 2x
+//    let b = a + a // 4x
+//    return b * b // 16x^2
+//  }
+//  let (val1, dv1) = valAndDeriv(f: func1)
+//  expectEqual(400, val1)
+//  expectEqual(160, dv1)
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Classes
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("Final") {
+//  final class Final : Differentiable {
+//    func method(_ x: Float) -> Float {
+//      return x * x
+//    }
+//  }
+//
+//  for i in -5...5 {
+//    expectEqual(
+//      Float(i) * 2,
+//      derivative(at: Float(i)) { x in Final().method(x) })
+//  }
+//}
+//
+//ForwardModeTests.test("Simple") {
+//  class Super {
+//    @differentiable(reverse, wrt: x)
+//    func f(_ x: Float) -> Float {
+//      return 2 * x
+//    }
+//    @derivative(of: f)
+//    final func jvpf(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+//      return (f(x), { v in 2 * v })
+//    }
+//    @derivative(of: f)
+//    final func vjpf(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+//      return (f(x), { v in 2 * v })
+//    }
+//  }
+//
+//  class SubOverride : Super {
+//    @differentiable(reverse, wrt: x)
+//    override func f(_ x: Float) -> Float {
+//      return 3 * x
+//    }
+//  }
+//
+//  class SubOverrideCustomDerivatives : Super {
+//    @differentiable(reverse, wrt: x)
+//    override func f(_ x: Float) -> Float {
+//      return 3 * x
+//    }
+//    @derivative(of: f)
+//    final func jvpf2(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+//      return (f(x), { v in 3 * v })
+//    }
+//    @derivative(of: f)
+//    final func vjpf2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+//      return (f(x), { v in 3 * v })
+//    }
+//  }
+//
+//  func classValueWithDerivative(_ c: Super) -> (Float, Float) {
+//    return valueWithDerivative(at: 1) { c.f($0) }
+//  }
+//
+//  expectEqual((2, 2), classValueWithDerivative(Super()))
+//  expectEqual((3, 3), classValueWithDerivative(SubOverride()))
+//  expectEqual((3, 3), classValueWithDerivative(SubOverrideCustomDerivatives()))
+//}
+//
+//ForwardModeTests.test("SimpleWrtSelf") {
+//  class Super : Differentiable {
+//    var base: Float
+//    // FIXME(TF-648): Dummy to make `Super.AllDifferentiableVariables` be nontrivial.
+//    var _nontrivial: [Float] = []
+//
+//    // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
+//    // @differentiable(reverse)
+//    required init(base: Float) {
+//      self.base = base
+//    }
+//
+//    @differentiable(reverse, wrt: (self, x))
+//    func f(_ x: Float) -> Float {
+//      return base * x
+//    }
+//    @derivative(of: f)
+//    final func jvpf(_ x: Float) -> (value: Float, differential: (TangentVector, Float) -> Float) {
+//      return (f(x), { (dself, dx) in dself.base * dx })
+//    }
+//    @derivative(of: f)
+//    final func vjpf(_ x: Float) -> (value: Float, pullback: (Float) -> (TangentVector, Float)) {
+//      let base = self.base
+//      return (f(x), { v in
+//        (TangentVector(base: v * x, _nontrivial: []), base * v)
+//      })
+//    }
+//  }
+//
+//  class SubOverride : Super {
+//    @differentiable(reverse, wrt: (self, x))
+//    override func f(_ x: Float) -> Float {
+//      return 3 * x
+//    }
+//  }
+//
+//  class SubOverrideCustomDerivatives : Super {
+//    @differentiable(reverse, wrt: (self, x))
+//    @differentiable(reverse, wrt: x)
+//    override func f(_ x: Float) -> Float {
+//      return 3 * x
+//    }
+//    @derivative(of: f, wrt: x)
+//    final func jvpf2(_ x: Float) -> (value: Float, differential: (Float) -> Float) {
+//      return (f(x), { v in 3 * v })
+//    }
+//    @derivative(of: f, wrt: x)
+//    final func vjpf2(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+//      return (f(x), { v in 3 * v })
+//    }
+//  }
+//
+//    // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
+//  // let v = Super.TangentVector(base: 100, _nontrivial: [])
+//  // expectEqual(100, pullback(at: 1337) { x in Super(base: x) }(v))
+//  // expectEqual(100, pullback(at: 1337) { x in SubOverride(base: x) }(v))
+//  // expectEqual(100, pullback(at: 1337) { x in SubOverrideCustomDerivatives(base: x) }(v))
+//
+//  // `valueWithDerivative` is not used because the derivative requires `Super`
+//  // to conform to `FloatingPoint`.
+//  func classDifferential(
+//    _ c: Super
+//  ) -> (Float, (Super.TangentVector, Float) -> Float) {
+//    return valueWithDifferential(at: c, 10) { (c: Super, x: Float) in c.f(x) }
+//  }
+//
+//  let (y1, diff1) = classDifferential(Super(base: 5))
+//  expectEqual(50, y1)
+//  let c1 = Super.TangentVector(base: 1, _nontrivial: [])
+//  expectEqual(1, diff1(c1, 1))
+//  let (y2, diff2) = classDifferential(SubOverride(base: 5))
+//  expectEqual(30, y2)
+//  let c2 = SubOverride.TangentVector(base: 1, _nontrivial: [])
+//  expectEqual(3, diff2(c2, 1))
+//  let (y3, diff3) = classDifferential(SubOverrideCustomDerivatives(base: 5))
+//  expectEqual(30, y3)
+//  let c3 = SubOverrideCustomDerivatives.TangentVector(base: 1, _nontrivial: [])
+//  expectEqual(3, diff3(c3, 1))
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Protocols
+////===----------------------------------------------------------------------===//
+//
+//protocol Prot : Differentiable {
+//  @differentiable(reverse, wrt: x)
+//  func foo(x: Float) -> Float
+//}
+//ForwardModeTests.test("Simple Protocol") {
+//  struct Linear: Prot, AdditiveArithmetic {
+//    typealias TangentVector = Linear
+//
+//    let m: Float
+//    let b: Float
+//
+//    @differentiable(reverse, wrt: x)
+//    func foo(x: Float) -> Float {
+//      return m * x + b
+//    }
+//  }
+//
+//  func genericFoo<T: Prot>(_ t: T, _ x: Float) -> Float {
+//    t.foo(x: x)
+//  }
+//  let inst = Linear(m: 5, b: -2)
+//  let (y1, diff1) = valueWithDifferential(at: 5) { x in genericFoo(inst, x) }
+//  expectEqual(23, y1)
+//  expectEqual(5, diff1(1))
+//}
+//
+//protocol DiffReq : Differentiable {
+//  @differentiable(reverse, wrt: (self, x))
+//  func f(_ x: Float) -> Float
+//}
+//
+//extension DiffReq where TangentVector : AdditiveArithmetic {
+//  @inline(never)  // Prevent specialization, to test all witness code.
+//  func derivF(at x: Float) -> Float {
+//    return (valueWithDifferential(at: x) { x in self.f(x) }).1(1)
+//  }
+//}
+//
+//struct Quadratic : DiffReq, AdditiveArithmetic {
+//  typealias TangentVector = Quadratic
+//
+//  @differentiable(reverse)
+//  let a: Float
+//
+//  @differentiable(reverse)
+//  let b: Float
+//
+//  @differentiable(reverse)
+//  let c: Float
+//
+//  init(_ a: Float, _ b: Float, _ c: Float) {
+//    self.a = a
+//    self.b = b
+//    self.c = c
+//  }
+//
+//  @differentiable(reverse, wrt: (self, x))
+//  func f(_ x: Float) -> Float {
+//    return a * x * x + b * x + c
+//  }
+//}
+//
+//ForwardModeTests.test("ProtocolFunc") {
+//  expectEqual(12, Quadratic(11, 12, 13).derivF(at: 0))
+//  expectEqual(2 * 11 + 12, Quadratic(11, 12, 13).derivF(at: 1))
+//  expectEqual(2 * 11 * 2 + 12, Quadratic(11, 12, 13).derivF(at: 2))
+//}
+//
+//// MARK: Constructor, accessor, and subscript requirements.
+//
+//protocol FunctionsOfX: Differentiable {
+//  @differentiable(reverse)
+//  init(x: Float)
+//
+//  @differentiable(reverse)
+//  var x: Float { get }
+//
+//  @differentiable(reverse)
+//  var y: Float { get }
+//
+//  @differentiable(reverse)
+//  var z: Float { get }
+//
+//  @differentiable(reverse)
+//  subscript() -> Float { get }
+//}
+//
+//struct TestFunctionsOfX: FunctionsOfX {
+//  @differentiable(reverse)
+//  init(x: Float) {
+//    self.x = x
+//    self.y = x * x
+//  }
+//
+//  /// x = x
+//  var x: Float
+//
+//  /// y = x * x
+//  var y: Float
+//
+//  /// z = x * x + x
+//  var z: Float {
+//    return y + x
+//  }
+//
+//  @differentiable(reverse)
+//  subscript() -> Float {
+//    return z
+//  }
+//}
+//
+//@inline(never)  // Prevent specialization, to test all witness code.
+//func derivatives<F: FunctionsOfX>(at x: Float, of: F.Type)
+//  -> (Float, Float, Float, Float)
+//{
+//  let dxdx = derivative(at: x) { x in F(x: x).x }
+//  let dydx = derivative(at: x) { x in F(x: x).y }
+//  let dzdx = derivative(at: x) { x in F(x: x).z }
+//  let dsubscriptdx = derivative(at: x) { x in F(x: x)[] }
+//  return (dxdx, dydx, dzdx, dsubscriptdx)
+//}
+//
+//ForwardModeTests.test("constructor, accessor, subscript") {
+//  expectEqual(
+//    (1.0, 4.0, 5.0, 5.0),
+//    derivatives(at: 2.0, of: TestFunctionsOfX.self))
+//}
+//
+//// MARK: - Test witness method SIL type computation.
+//
+//protocol P : Differentiable {
+//  @differentiable(reverse, wrt: (x, y))
+//  func foo(_ x: Float, _ y: Double) -> Float
+//}
+//struct S : P {
+//  @differentiable(reverse, wrt: (x, y))
+//  func foo(_ x: Float, _ y: Double) -> Float {
+//    return x
+//  }
+//}
+//
+//// MARK: - Overridden protocol method adding differentiable attribute.
+//
+//public protocol Distribution {
+//  associatedtype Value
+//  func logProbability(of value: Value) -> Float
+//}
+//
+//public protocol DifferentiableDistribution: Differentiable, Distribution {
+//  @differentiable(reverse, wrt: self)
+//  func logProbability(of value: Value) -> Float
+//}
+//
+//struct Foo: DifferentiableDistribution {
+//  @differentiable(reverse, wrt: self)
+//  func logProbability(of value: Float) -> Float {
+//    .zero
+//  }
+//}
+//
+//@differentiable(reverse)
+//func blah<T: DifferentiableDistribution>(_ x: T) -> Float where T.Value: AdditiveArithmetic {
+//  x.logProbability(of: .zero)
+//}
+//
+//// Adding a more general `@differentiable` attribute.
+//public protocol DoubleDifferentiableDistribution: DifferentiableDistribution
+//  where Value: Differentiable {
+//  @differentiable(reverse, wrt: self)
+//  @differentiable(reverse, wrt: (self, value))
+//  func logProbability(of value: Value) -> Float
+//}
+//
+//@differentiable(reverse)
+//func blah2<T: DoubleDifferentiableDistribution>(_ x: T, _ value: T.Value) -> Float
+//  where T.Value: AdditiveArithmetic {
+//  x.logProbability(of: value)
+//}
+//
+//protocol DifferentiableFoo {
+//  associatedtype T: Differentiable
+//  @differentiable(reverse, wrt: x)
+//  func foo(_ x: T) -> Float
+//}
+//
+//protocol MoreDifferentiableFoo: Differentiable, DifferentiableFoo {
+//  @differentiable(reverse, wrt: (self, x))
+//  func foo(_ x: T) -> Float
+//}
+//
+//struct MoreDifferentiableFooStruct: MoreDifferentiableFoo {
+//  @differentiable(reverse, wrt: (self, x))
+//  func foo(_ x: Float) -> Float {
+//    x
+//  }
+//}
+//
+////===----------------------------------------------------------------------===//
+//// Simple Math
+////===----------------------------------------------------------------------===//
+//
+//ForwardModeTests.test("Arithmetics") {
+//  func foo1(x: Float, y: Float) -> Float {
+//    return x * y
+//  }
+//  expectEqual(7, derivative(at: 3, 4, of: foo1))
+//  func foo2(x: Float, y: Float) -> Float {
+//    return -x * y
+//  }
+//  expectEqual(-7, derivative(at: 3, 4, of: foo2))
+//  func foo3(x: Float, y: Float) -> Float {
+//    return -x + y
+//  }
+//  expectEqual(0, derivative(at: 3, 4, of: foo3))
+//}
+//
+//ForwardModeTests.test("Fanout") {
+//  func foo1(x: Float) -> Float {
+//     x - x
+//  }
+//  expectEqual(0, derivative(at: 100, of: foo1))
+//  func foo2(x: Float) -> Float {
+//     x + x
+//  }
+//  expectEqual(2, derivative(at: 100, of: foo2))
+//  func foo3(x: Float, y: Float) -> Float {
+//    x + x + x * y
+//  }
+//  expectEqual(7, derivative(at: 3, 2, of: foo3))
+//}
+//
+//ForwardModeTests.test("FunctionCall") {
+//  func foo(_ x: Float, _ y: Float) -> Float {
+//    return 3 * x + { $0 * 3 }(3) * y
+//  }
+//  expectEqual(12, derivative(at: 3, 4, of: foo))
+//  expectEqual(3, derivative(at: 3) { x in foo(x, 4) })
+//}
+//
+//ForwardModeTests.test("ResultSelection") {
+//  func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
+//    return (x + 1, y + 2)
+//  }
+//  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).0 }))
+//  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).1 }))
+//
+//  // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
+//  /*
+//  func tupleGeneric<T>(_ x: T, _ y: T) -> (T, T) {
+//    return (x, y)
+//  }
+//  func tupleGenericFirst<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).0 }
+//  func tupleGenericSecond<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).1 }
+//  expectEqual(1, derivative(at: 3, 3, of: tupleGenericFirst))
+//  expectEqual(1, derivative(at: 3, 3, of: tupleGenericSecond))
+//  */
+//}
+//
+//// TODO(TF-983): Support forward-mode differentiation of multiple results.
+///*
+//ForwardModeTests.test("MultipleResults") {
+//  // Test function returning a tuple of active results.
+//  func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
+//    return (x, y)
+//  }
+//  func multiply(_ x: Float, _ y: Float) -> Float {
+//    let z = tuple(x, y)
+//    // Note: both results (tuple elements) are active.
+//    return z.0 * z.1
+//  }
+//  expectEqual((4, 3), gradient(at: 3, 4, of: multiply))
+//  expectEqual((10, 5), gradient(at: 5, 10, of: multiply))
+//
+//  // Test function with multiple `inout` parameters.
+//  func swap(_ x: inout Float, _ y: inout Float) {
+//    let tmp = x; x = y; y = tmp
+//  }
+//  func multiply_swap(_ x: Float, _ y: Float) -> Float {
+//    var tuple = (x, y)
+//    swap(&tuple.0, &tuple.1)
+//    return tuple.0 * tuple.1
+//  }
+//  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swap))
+//  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swap))
+//
+//  // Test function with multiple `inout` parameters.
+//  func swapGeneric<T>(_ x: inout T, _ y: inout T) {
+//    let tmp = x; x = y; y = tmp
+//  }
+//  func multiply_swapGeneric(_ x: Float, _ y: Float) -> Float {
+//    var tuple = (x, y)
+//    swapGeneric(&tuple.0, &tuple.1)
+//    return tuple.0 * tuple.1
+//  }
+//  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapGeneric))
+//  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swapGeneric))
+//
+//  // Test function with multiple `inout` parameters and a formal result.
+//  func swapAndReturnProduct(_ x: inout Float, _ y: inout Float) -> Float {
+//    let tmp = x
+//    x = y
+//    y = tmp
+//    return x * y
+//  }
+//  func multiply_swapAndReturnProduct(_ x: Float, _ y: Float) -> Float {
+//    var x2 = x
+//    var y2 = y
+//    let result = swapAndReturnProduct(&x2, &y2)
+//    return result
+//  }
+//  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
+//  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
+//}
+//*/
+//
+//ForwardModeTests.test("CaptureLocal") {
+//  let z: Float = 10
+//  func foo(_ x: Float) -> Float {
+//    return z * x
+//  }
+//  expectEqual(10, derivative(at: 0, of: foo))
+//}
+//
+//var globalVar: Float = 10
+//ForwardModeTests.test("CaptureGlobal") {
+//  func foo(x: Float) -> Float {
+//    globalVar += 20
+//    return globalVar * x
+//  }
+//  expectEqual(30, derivative(at: 0, of: foo))
+//}
+//
+//ForwardModeTests.test("Mutation") {
+//  func fourthPower(x: Float) -> Float {
+//    var a = x
+//    a = a * x
+//    a = a * x
+//    return a * x
+//  }
+//  expectEqual(4 * 27, derivative(at: 3, of: fourthPower))
+//}
+//
+//// Tests TF-21.
+//ForwardModeTests.test("StructMemberwiseInitializer") {
+//  struct Foo : AdditiveArithmetic, Differentiable {
+//    var stored: Float
+//    var computed: Float {
+//      return stored * stored
+//    }
+//  }
+//
+//  let derivFoo = differential(at: Float(4), of: { input -> Foo in
+//    let foo = Foo(stored: input)
+//    let foo2 = foo + foo
+//    return Foo(stored: foo2.stored)
+//  })(1)
+//  expectEqual(Foo.TangentVector(stored: 2), derivFoo)
+//
+//  let computed = derivative(at: Float(4)) { input -> Float in
+//    let foo = Foo(stored: input)
+//    return foo.computed
+//  }
+//  expectEqual(8, computed)
+//
+//  let derivProduct = derivative(at: Float(4)) { input -> Float in
+//    let foo = Foo(stored: input)
+//    return foo.computed * foo.stored
+//  }
+//  expectEqual(48, derivProduct)
+//
+//  struct Custom : AdditiveArithmetic, Differentiable {
+//    var x: Float
+//
+//    // Custom initializer with `@differentiable`.
+//    @differentiable(reverse)
+//    init(x: Float) {
+//      self.x = x
+//    }
+//  }
+//
+//  let derivCustom = differential(at: Float(4), of: { input -> Custom in
+//    let foo = Custom(x: input)
+//    return foo + foo
+//  })(1)
+//  expectEqual(Custom.TangentVector(x: 2), derivCustom)
+//}
+//
+//// Tests TF-319: struct with non-differentiable constant stored property.
+//ForwardModeTests.test("StructConstantStoredProperty") {
+//  struct TF_319 : Differentiable {
+//    var x: Float
+//    @noDerivative let constant = Float(2)
+//
+//    @differentiable(reverse)
+//    init(x: Float) {
+//      self.x = x
+//    }
+//
+//    @differentiable(reverse, wrt: (self, input))
+//    func applied(to input: Float) -> Float {
+//      return x * constant * input
+//    }
+//  }
+//  func testStructInit(to input: Float) -> Float {
+//    let model = TF_319(x: 10)
+//    return model.applied(to: input)
+//  }
+//  expectEqual(6, derivative(at: 10, of: { TF_319(x: $0).applied(to: 3) }))
+//  expectEqual(20, derivative(at: 3, of: testStructInit))
+//}
+//
+//ForwardModeTests.test("StructMutation") {
+//  struct Point : AdditiveArithmetic, Differentiable {
+//    var x: Float
+//    var y: Float
+//    var z: Float
+//  }
+//
+//  func double(_ input: Float) -> Point {
+//    let point = Point(x: input, y: input, z: input)
+//    return point + point
+//  }
+//  expectEqual(Point(x: 2, y: 2, z: 2), differential(at: 4, of: double)(1))
+//
+//  func fifthPower(_ input: Float) -> Float {
+//    var point = Point(x: input, y: input, z: input)
+//    point.x = point.x * input
+//    point.y = point.x * input
+//    return point.x * point.y
+//  }
+//  expectEqual(405, derivative(at: 3, of: fifthPower))
+//
+//  func mix(_ input: Float) -> Float {
+//    var tuple = (point: Point(x: input, y: input, z: input), float: input)
+//    tuple.point.x = tuple.point.x * tuple.float
+//    tuple.point.y = tuple.point.x * input
+//    return tuple.point.x * tuple.point.y
+//  }
+//  expectEqual(405, derivative(at: 3, of: mix))
+//
+//  // Test TF-282.
+//  struct Add : Differentiable {
+//    var bias: Float
+//    func applied(to input: Float) -> Float {
+//      var tmp = input
+//      tmp = tmp + bias
+//      return tmp
+//    }
+//  }
+//  expectEqual(1, derivative(at: 1) { m in Add(bias: m).applied(to: 1) })
+//}
+//
+//ForwardModeTests.test("StructGeneric") {
+//  struct Generic<T : AdditiveArithmetic & Differentiable> : AdditiveArithmetic, Differentiable {
+//    var x: T
+//    var y: T
+//    var z: T
+//  }
+//
+//  let deriv = differential(at: Float(3), of: { input -> Generic<Float> in
+//    var generic = Generic(x: input, y: input, z: input)
+//    return generic
+//  })(1)
+//  expectEqual(Generic<Float>.TangentVector(x: 1, y: 1, z: 1), deriv)
+//
+//  func fifthPower(_ input: Float) -> Float {
+//    var generic = Generic(x: input, y: input, z: input)
+//    generic.x = generic.x * input
+//    generic.y = generic.x * input
+//    return generic.x * generic.y
+//  }
+//  expectEqual(405, derivative(at: 3, of: fifthPower))
+//}
+//
+//ForwardModeTests.test("SubsetIndices") {
+//  func deriv(_ lossFunction: @differentiable(reverse) (Float, Float) -> Float) -> Float {
+//    return derivative(at: 1) { x in lossFunction(x * x, 10.0) }
+//  }
+//  expectEqual(2, deriv { x, y in x + y })
+//
+//  func derivWRTNonDiff(_ lossFunction: @differentiable(reverse) (Float, @noDerivative Int) -> Float) -> Float {
+//    return derivative(at: 2) { x in lossFunction(x * x, 10) }
+//  }
+//  expectEqual(4, derivWRTNonDiff { x, y in x + Float(y) })
+//}
+//
+//ForwardModeTests.test("ForceUnwrapping") {
+//  func forceUnwrap<T: Differentiable & FloatingPoint>(_ t: T) -> Float where T == T.TangentVector {
+//    derivative(at: t, Float(3)) { (x, y) in
+//      (x as! Float) * y
+//    }
+//  }
+//  expectEqual(5, forceUnwrap(Float(2)))
+//}
+//
+//ForwardModeTests.test("NonVariedResult") {
+//  @differentiable(reverse, wrt: x)
+//  func nonWrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
+//    y = x
+//  }
+//
+//  @differentiable(reverse)
+//  func wrtInoutParam<T: Differentiable>(_ x: T, _ y: inout T) {
+//    y = x
+//  }
+//
+//  @differentiable(reverse, wrt: x)
+//  func nonWrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
+//
+//  @differentiable(reverse, wrt: x)
+//  func wrtInoutParamNonVaried<T: Differentiable>(_ x: T, _ y: inout T) {}
+//
+//  @differentiable(reverse)
+//  func variedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var result: Tracked<Float> = 0
+//    nonWrtInoutParam(x, &result)
+//    return result
+//  }
+//
+//  @differentiable(reverse)
+//  func variedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var result: Tracked<Float> = 0
+//    wrtInoutParam(x, &result)
+//    return result
+//  }
+//
+//  @differentiable(reverse)
+//  func nonVariedResultTracked(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var result: Tracked<Float> = 0
+//    nonWrtInoutParamNonVaried(x, &result)
+//    return result
+//  }
+//
+//  @differentiable(reverse)
+//  func nonVariedResultTracked2(_ x: Tracked<Float>) -> Tracked<Float> {
+//    // expected-warning @+1 {{variable 'result' was never mutated}}
+//    var result: Tracked<Float> = 0
+//    return result
+//  }
+//
+//  @differentiable(reverse)
+//  func nonVariedResultTracked3(_ x: Tracked<Float>) -> Tracked<Float> {
+//    return 0
+//  }
+//
+//  @differentiable(reverse)
+//  func nonVariedResultTracked4(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var result: Tracked<Float> = 0
+//    wrtInoutParamNonVaried(x, &result)
+//    return result
+//  }
+//}
+//
+//ForwardModeTests.test("ApplyNonActiveIndirectResult") {
+//  func identity<T: Differentiable>(_ x: T) -> T { x }
+//
+//  @differentiable(reverse)
+//  func applyNonactiveArgumentActiveIndirectResult(_ x: Tracked<Float>) -> Tracked<Float> {
+//    var y = identity(0 as Tracked<Float>)
+//    y = x
+//    return y
+//  }
+//  expectEqual(1.0, derivative(at: 2, of: applyNonactiveArgumentActiveIndirectResult))
+//}
+//
+//ForwardModeTests.test("SR-13530") {
+//  // SR-13530: Test "leaked owned value" ownership verification failure related
+//  // to differential generation for `copy_value` instruction.
+//  @differentiable(reverse)
+//  func SR_13530(_ x: NonresilientTracked<Float>) -> NonresilientTracked<Float> {
+//    precondition(x >= 0)
+//    return x
+//  }
+//  expectEqual(1, derivative(at: 2, of: SR_13530))
+//}
+//
+//runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
JVP functions such as `valueWithDifferential` were removed from the Differentiable Programming Manifesto when making the [Swift evolution proposal](https://github.com/rxwei/swift-evolution/blob/autodiff/proposals/0000-differentiable-programming.md). @rxwei (sorry for mentioning you so many times in the past week) requested that JVP protocol witnesses be removed in two issues on JIRA: [SR-15578](https://bugs.swift.org/browse/SR-15578) and [SR-15581](https://bugs.swift.org/browse/SR-15581). I did not do that, but I did lay the groundwork for removal of forward-mode differentiation. I also removed manually synthesized derivatives for stdlib types (functions starting with `_jvp`).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This contributes to solving [SR-15577](https://bugs.swift.org/browse/SR-15577). It is inevitable that the public JVP functions will be removed to complete autodiff ABI stability. There are still more removals that must be done in C++ code in this repository, which I haven't gotten to yet. There is still a compiler option for enabling forward-mode differentiation (`-enable-experimental-forward-mode-differentiation`), which is why this PR is a WIP. Under my limited understanding, this PR will break that option. Could anyone show me how to disable it so I can complete this PR?

Attempting to remove the `_jvp` function for `SIMD(repeating:)` results in a compile-time error when building the standard library. I don't know how to work around it, so it is the only such function that remains. I expect that once autodiff is fully fixed up, it will be able to be removed too. It's not something you can access publicly, so it should be fine if it remains for now.

All tests pass under my changes, using macOS arm64 + Ninja. I did not test this on Swift for TensorFlow, because recent commits broke it beyond repair - the reason I'm fixing autodiff is to enable building S4TF again. Building S4TF provides a good litmus test of whether autodiff is truly stable, independently of the effort to resurrect it. I think it should be a validation test in the future. Reviewers, what are your thoughts on this?

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
