### PR TITLE
Add regression test for fixed crasher - rdar://46714549

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/rdar46714549.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar46714549.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+extension Array where Element == String {
+  typealias InternalTypeAlias = Int
+  func doSomething<R>(foo: (InternalTypeAlias) -> R) {}
+}


### PR DESCRIPTION
This was fixed all the way back in Swift 5.0.