### PR TITLE
MandatoryGenericSpecializer: fix two crashes

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2888,6 +2888,9 @@ bool swift::optimizeMemoryAccesses(SILFunction &fn) {
 }
 
 bool swift::eliminateDeadAllocations(SILFunction &fn) {
+  if (!fn.hasOwnership())
+    return false;
+
   bool changed = false;
   DeadEndBlocks deadEndBlocks(&fn);
 

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -253,6 +253,12 @@ optimizeInst(SILInstruction *inst, SILOptFunctionBuilder &funcBuilder,
     if (!callee || callee->isTransparent() == IsNotTransparent)
       return true;
 
+    if (callee->isExternalDeclaration())
+      getModule()->loadFunction(callee);
+
+    if (callee->isExternalDeclaration())
+      return true;
+
     // If the de-virtualized callee is a transparent function, inline it.
     SILInliner::inlineFullApply(newFAS, SILInliner::InlineKind::MandatoryInline,
                                 funcBuilder, deleter);

--- a/test/SILOptimizer/mandatory-specializer.sil
+++ b/test/SILOptimizer/mandatory-specializer.sil
@@ -1,0 +1,40 @@
+// RUN: %target-sil-opt -mandatory-generic-specializer %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// CHECK-LABEL: sil [no_allocation] @deserialize_and_inline_after_devirtualize
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function 'deserialize_and_inline_after_devirtualize'
+sil [no_allocation] @deserialize_and_inline_after_devirtualize : $@convention(thin) (@in Int) -> () {
+bb0(%0 : $*Int):
+  %1 = metatype $@thick Int.Type
+  %2 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %3 = apply %2<Int>(%0, %0, %1) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %4 = tuple()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil [no_allocation] @dont_do_dead_alloc_eimination_on_non_ossa
+// CHECK:         alloc_stack
+// CHECK-NOT:     load
+// CHECK:       } // end sil function 'dont_do_dead_alloc_eimination_on_non_ossa'
+sil [no_allocation] @dont_do_dead_alloc_eimination_on_non_ossa : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
+bb0(%0 : $Builtin.Int32):
+  %1 = alloc_stack $Builtin.Int32
+  store %0 to %1 : $*Builtin.Int32
+  %2 = load %1 : $*Builtin.Int32
+  dealloc_stack %1 : $*Builtin.Int32
+  return %2 : $Builtin.Int32
+}
+
+sil shared_external [transparent] [serialized] [thunk] [canonical] @$sSiSLsSL1loiySbx_xtFZTW : $@convention(witness_method: Comparable) (@in_guaranteed Int, @in_guaranteed Int, @thick Int.Type) -> Bool
+
+sil_witness_table public_external [serialized] Int: Comparable module Swift {
+  base_protocol Equatable: Int: Equatable module Swift
+  method #Comparable."<": <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : @$sSiSLsSL1loiySbx_xtFZTW
+}
+

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -588,6 +588,7 @@ int main(int argc, char **argv) {
   SILOpts.OptRecordFile = RemarksFilename;
   SILOpts.OptRecordPasses = RemarksPasses;
   SILOpts.checkSILModuleLeaks = true;
+  SILOpts.EnablePerformanceAnnotations = true;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {


### PR DESCRIPTION
* don't run dead alloc on non-ossa functions
* try to de-serialize transparent functions and don't inline if that doesn't succeed

rdar://87622503
