### PR TITLE
test: partially enable some C++ interop tests on Windows

### DIFF
--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,15 +1,13 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
-//
+
 // REQUIRES: executable_test
-//
-// We can't yet call member functions correctly on Windows (SR-13129).
-// XFAIL: OS=windows-msvc
 
 import MemberInline
 import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
+#if !os(Windows)    // SR-13129
 OperatorsTestSuite.test("LoadableIntWrapper.plus (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
@@ -18,6 +16,7 @@ OperatorsTestSuite.test("LoadableIntWrapper.plus (inline)") {
 
   expectEqual(19, result.value)
 }
+#endif
 
 OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
   var wrapper = LoadableIntWrapper(value: 42)
@@ -132,6 +131,7 @@ OperatorsTestSuite.test("DifferentTypesArrayByVal.subscript (inline)") {
   expectEqual(1.5.rounded(.up), resultDouble.rounded(.up))
 }
 
+#if !os(Windows)    // SR-13129
 OperatorsTestSuite.test("NonTrivialArrayByVal.subscript (inline)") {
   var arr = NonTrivialArrayByVal()
   let NonTrivialByVal = arr[0];
@@ -145,6 +145,7 @@ OperatorsTestSuite.test("NonTrivialArrayByVal.subscript (inline)") {
   expectEqual(5, NonTrivialByVal.e)
   expectEqual(6, NonTrivialByVal.f)
 }
+#endif
 
 OperatorsTestSuite.test("PtrByVal.subscript (inline)") {
   var arr = PtrByVal()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -3,17 +3,15 @@
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line
-//
+
 // REQUIRES: executable_test
-//
-// We can't yet call member functions correctly on Windows (SR-13129).
-// XFAIL: OS=windows-msvc
 
 import MemberOutOfLine
 import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
+#if !os(Windows)    // SR-13129
 OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
   let lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
@@ -22,6 +20,7 @@ OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
 
   expectEqual(65, result.value)
 }
+#endif
 
 OperatorsTestSuite.test("LoadableIntWrapper.call (out-of-line)") {
   let wrapper = LoadableIntWrapper(value: 42)


### PR DESCRIPTION
This enables the majority of the operator tests on Windows as these now
pass.  However, we cannot enable all of the tests, a few of them crash
due to invalid parameter ordering due to bugs in IRGen with C++ interop.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
