### PR TITLE
utils: adjust the LLVM build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1806,6 +1806,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
+                    -DLLVM_INCLUDE_BENCHMARKS:BOOL=FALSE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1806,8 +1806,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_SWIFT_BUILD:BOOL=NO
                     -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
-                    -DLLVM_INCLUDE_BENCHMARKS:BOOL=FALSE
-                    -DLIBCXX_INCLUDE_BENCHMARKS:BOOL=FALSE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"
@@ -1890,6 +1888,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 cmake_options=(
                     "${cmake_options[@]}"
                     "${llvm_cmake_options[@]}"
+                    -DLIBCXX_INCLUDE_BENCHMARKS:BOOL=FALSE
                 )
                 ;;
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1807,6 +1807,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_INCLUDE_BENCHMARKS:BOOL=FALSE
+                    -DLIBCXX_INCLUDE_BENCHMARKS:BOOL=FALSE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
                     -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"


### PR DESCRIPTION
This adjusts the build invocation for the LLVM portion on Unix
platforms.  With the imminent rebranch, the new LLVM will pull
in a new version of google-benchmark which requires C++20 support
in the C++ compiler which rules out some of the currently enabled
targets.  Disable the benchmarks which are not used currently any
way.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
