### PR TITLE
[Sema][SR-15273] Remove incorrect fix-it for access level in synthesized init witness conformance failure

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4348,9 +4348,9 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                        protoAccessScope.accessLevelForDiagnostics(),
                        proto->getName());
 
-        if (auto *decl = dyn_cast<AbstractFunctionDecl>(witness))
-          if (decl->isMemberwiseInitializer())
-            return;
+        auto *decl = dyn_cast<AbstractFunctionDecl>(witness);
+        if (decl && decl->isSynthesized())
+          return;
 
         diagnoseWitnessFixAccessLevel(diags, witness, requiredAccess,
                                       isSetter);

--- a/test/attr/accessibility_proto.swift
+++ b/test/attr/accessibility_proto.swift
@@ -104,3 +104,11 @@ public struct NonPublicMemberwiseInitStruct: PublicInitProto {
 // expected-error@-1 {{initializer 'init(value:)' must be declared public because it matches a requirement in public protocol 'PublicInitProto'}}
   public var value: Int
 }
+
+// SR-15273
+public protocol PublicEmptyInit {
+  init()
+}
+public struct Buggy: PublicEmptyInit { 
+  // expected-error@-1 {{initializer 'init()' must be declared public because it matches a requirement in public protocol 'PublicEmptyInit'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Skip access level check for synthesized `init` (memberwise or empty) in conformance checking as we can assume if this is the found witness it will be available for that type because compiler will synthesized them. 
I'm not entirely sure about this solution, maybe I'm missing some important aspect of why this shouldn't be allowed. 

**Some questions:**
I'm not sure this affects library evolution or ABI because for what I could see synthesized inits seems not to part of module interface. Example
```swift
// a.swift
public struct S {}
public struct A {
    public let i: Int
}
```
Module interface with `swiftc a.swift -enable-library-evolution -emit-module-interface` 

```
// swift-interface-format-version: 1.0
// swift-compiler-version: Apple Swift version 5.5.2 (swiftlang-1300.0.47.5 clang-1300.0.29.30)
// swift-module-flags: -target arm64-apple-macosx11.0 -enable-objc-interop -enable-library-evolution -module-name a
import Swift
import _Concurrency
public struct S {
}
public struct A {
  public let i: Swift.Int
}
```
* So my guess is the compiler will synthesized them when compiling module interface? 
* There are any explicit rational for the access checking to be enforced in synthesized init? Because it seems like they can be used as witness for internal conformances.
* There are any version of the compiler that will not synthesize memberwise init? 

I'm also thinking that maybe this is not correct because as mentioned the synthesized init is not part of the type public interface, so maybe assuming conformance outside the module will not be correct. But it just seems a little bit odd in this case the use having to be enforced to create and implement an explicit memberwise init just to make it public and satisfy conformance access so that is the main reason, but as I'm writing this it seems more like to be the correct approach. 

This PR is more a place to ask questions about this topic, but in more likely case this is not a viable solution we can go to the initial approach of just improving the diagnostics for this which will also solves the issue. Which may be just improving the wording and fix-it with a stub of the public init from protocol where the user will implement.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15273.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
