### PR TITLE
[cxx-interop] Fix crash when indexing with C++ interop enabled.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1019,7 +1019,9 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   // FIXME: This predicate matches the status quo, but there's no reason
   // indexing cannot run for actions that do not require stdlib e.g. to better
   // facilitate tests.
-  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(action)) {
+  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(action) &&
+      // TODO: indexing often crashes when interop is enabled (rdar://87719859).
+      !Invocation.getLangOptions().EnableCXXInterop) {
     emitIndexData(Instance);
   }
 

--- a/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
+++ b/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -c -index-system-modules -index-store-path %t -enable-cxx-interop
+//
+// REQUIRES: OS=macosx
+
+import Foundation
+
+func test(d: Date) {}


### PR DESCRIPTION
This is a stop-gap solution to prevent crashes.