### PR TITLE
[5.6][Sema][MiscDiag] Fix constantness diag to handle result builder patterns

### DIFF
--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -424,3 +424,32 @@ func testCallsWithinClosures(s: String, x: Int) {
     constantArgumentFunction("string with a single interpolation \(x)")
   }
 }
+
+@resultBuilder
+struct MyArrayBuilder {
+    typealias Component = [Int]
+    typealias Expression = Int
+    static func buildExpression(_ element: Expression) -> Component {
+        return [element]
+    }
+    static func buildBlock(_ components: Component...) -> Component {
+        return Array(components.joined())
+    }
+}
+
+struct MyArray {
+    public init(@MyArrayBuilder arr: () -> [Int]) {}
+}
+
+func testResultBuilder(x: Int, y: Int) -> MyArray {
+    let _: MyArray = MyArray {
+        constantArgumentFunctionReturningInt(x)
+          // expected-error@-1 {{argument must be an integer literal}}
+        constantArgumentFunctionReturningInt(y)
+          // expected-error@-1 {{argument must be an integer literal}}
+    }
+    let _: MyArray = MyArray {
+        constantArgumentFunctionReturningInt(x)
+          // expected-error@-1 {{argument must be an integer literal}}
+    }
+}


### PR DESCRIPTION
(This is a cherry-pick of PR #40579 to the release/5.6 branch.)

We currently have a problem with how constantness diagnostics
traverse the AST to look for function calls to diagnose. We
special case closure bodies and don't check them (unless they're
single expression closures) because closure bodies are type-
checked separately and will be covered later. This poses a problem
in certain AST structures, such as what we see with result builders,
because the call expressions are rooted in declarations, which aren't
checked in the closure body type-checking covered by MiscDiag.

This patch fixes the problem by manually checking all closure bodies
and stopping misc diagnostics from checking the bodies separately.

rdar://85737300
