### PR TITLE
SILOptimizer: disable a couple of tests for memory safety

### DIFF
--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
 
 // REQUIRES: optimized_stdlib
+// REQUIRES: rdar87618517
 
 import Swift
 

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
 
 // REQUIRES: optimized_stdlib
+// REQUIRES: rdar87618517
 
 import Swift
 


### PR DESCRIPTION
This disables two tests that have invalid memory usage issues.  Disable
the tests for the time being to allow the rebranch to continue.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
