### PR TITLE
[Clang importer] Don't emit diagnostics while pretty-printing.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -416,6 +416,9 @@ namespace {
     else
       nameStr = cast<clang::ObjCPropertyDecl>(decl)->getName().str();
     for (unsigned i = 1, n = overriddenNames.size(); i != n; ++i) {
+      if (ctx.Diags.isPrettyPrintingDecl())
+        continue;
+
       ctx.Diags.diagnose(SourceLoc(), diag::inconsistent_swift_name,
                          method == nullptr,
                          nameStr,


### PR DESCRIPTION
We missed a spot during name importing to check this flag.
Since we don't have a ClangImporter instance directly available,
just check the flag.

Fixes rdar://87718892.
