### PR TITLE
Enable lazy ClangImporter diagnostics by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -328,8 +328,8 @@ namespace swift {
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;
 
-    /// Enable experimental ClangImporter diagnostics.
-    bool EnableExperimentalClangImporterDiagnostics = false;
+    /// Disable experimental ClangImporter diagnostics.
+    bool DisableExperimentalClangImporterDiagnostics = false;
 
     /// Enable experimental eager Clang module diagnostics.
     bool EnableExperimentalEagerClangModuleDiagnostics = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -287,9 +287,9 @@ def enable_experimental_flow_sensitive_concurrent_captures :
   Flag<["-"], "enable-experimental-flow-sensitive-concurrent-captures">,
   HelpText<"Enable flow-sensitive concurrent captures">;
 
-def enable_experimental_clang_importer_diagnostics :
-  Flag<["-"], "enable-experimental-clang-importer-diagnostics">,
-  HelpText<"Enable experimental diagnostics when importing C, C++, and Objective-C libraries">;
+def disable_experimental_clang_importer_diagnostics :
+  Flag<["-"], "disable-experimental-clang-importer-diagnostics">,
+  HelpText<"Disable experimental diagnostics when importing C, C++, and Objective-C libraries">;
 
 def enable_experimental_eager_clang_module_diagnostics :
   Flag<["-"], "enable-experimental-eager-clang-module-diagnostics">,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2397,8 +2397,7 @@ void ClangImporter::Implementation::addImportDiagnostic(
     ImportDiagnosticTarget target, Diagnostic &&diag,
     const clang::SourceLocation &loc) {
   ImportDiagnostic importDiag = ImportDiagnostic(target, diag, loc);
-  if (!(SwiftContext.LangOpts.EnableExperimentalClangImporterDiagnostics ||
-        SwiftContext.LangOpts.EnableExperimentalEagerClangModuleDiagnostics) ||
+  if (SwiftContext.LangOpts.DisableExperimentalClangImporterDiagnostics ||
       CollectedDiagnostics.count(importDiag))
     return;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -470,10 +470,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalFlowSensitiveConcurrentCaptures |=
     Args.hasArg(OPT_enable_experimental_flow_sensitive_concurrent_captures);
 
-  Opts.EnableExperimentalClangImporterDiagnostics |=
-      Args.hasArg(OPT_enable_experimental_clang_importer_diagnostics);
+  Opts.DisableExperimentalClangImporterDiagnostics |=
+      Args.hasArg(OPT_disable_experimental_clang_importer_diagnostics);
 
   Opts.EnableExperimentalEagerClangModuleDiagnostics |=
+      !Args.hasArg(OPT_disable_experimental_clang_importer_diagnostics) &&
       Args.hasArg(OPT_enable_experimental_eager_clang_module_diagnostics);
 
   Opts.DisableImplicitConcurrencyModuleImport |=

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3627,7 +3627,7 @@ bool MissingMemberFailure::diagnoseAsError() {
         .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
     const auto &ctx = getSolution().getDC()->getASTContext();
-    if (ctx.LangOpts.EnableExperimentalClangImporterDiagnostics) {
+    if (!ctx.LangOpts.DisableExperimentalClangImporterDiagnostics) {
       ctx.getClangModuleLoader()->diagnoseMemberValue(getName().getFullName(),
                                                       baseType);
     }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -590,7 +590,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           .diagnose(Loc, diag::cannot_find_in_scope, Name,
                     Name.isOperator())
           .highlight(UDRE->getSourceRange());
-      if (Context.LangOpts.EnableExperimentalClangImporterDiagnostics) {
+      if (!Context.LangOpts.DisableExperimentalClangImporterDiagnostics) {
         Context.getClangModuleLoader()->diagnoseTopLevelValue(
             Name.getFullName());
       }

--- a/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
+++ b/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -enable-experimental-clang-importer-diagnostics -enable-objc-interop -import-objc-header %S/Inputs/experimental_clang_importer_diagnostics_bridging_header.h -typecheck %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -enable-objc-interop -import-objc-header %S/Inputs/experimental_clang_importer_diagnostics_bridging_header.h -typecheck %s 2>&1 | %FileCheck %s
 
 let s: PartialImport
 s.c = 5

--- a/test/ClangImporter/experimental_diagnostics_cfuncs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cfuncs.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 import cfuncs
 

--- a/test/ClangImporter/experimental_diagnostics_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_cmacros.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 import macros
 
@@ -12,7 +12,6 @@ _ = INVALID_INTEGER_LITERAL_2
 // CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}                                  ^
-
 
 _ = FUNC_LIKE_MACRO()
 // CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope

--- a/test/ClangImporter/experimental_diagnostics_cstructs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cstructs.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 import ctypes
 

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/experimental_diagnostics_lookup_accuracy.swift
+++ b/test/ClangImporter/experimental_diagnostics_lookup_accuracy.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace 
+// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace 
 
 // This test tests that requests for diagnosis, performed by name,
 // resolve to the correct Clang declarations, even when the same name is used

--- a/test/ClangImporter/experimental_diagnostics_no_noise.swift
+++ b/test/ClangImporter/experimental_diagnostics_no_noise.swift
@@ -1,0 +1,72 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+// REQUIRES: objc_interop
+
+// Referencing a single declaration should only surface diagnostics about that declaration, no more
+
+import IncompleteTypes
+import cfuncs
+import ctypes
+
+// CHECK-NOT: note
+// CHECK-NOT: warning
+// CHECK-NOT: error
+let bar = Bar()
+_ = bar.methodReturningForwardDeclaredInterface()
+// CHECK:      experimental_diagnostics_no_noise.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredInterface'
+// CHECK-NEXT: _ = bar.methodReturningForwardDeclaredInterface()
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: method 'methodReturningForwardDeclaredInterface' not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
+
+// CHECK-NOT: note
+// CHECK-NOT: warning
+// CHECK-NOT: error
+unsupported_parameter_type(1,2)
+// CHECK:      experimental_diagnostics_no_noise.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK-NEXT: unsupported_parameter_type(1,2)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'unsupported_parameter_type' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param2' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:{{[0-9]+}}: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+
+// CHECK-NOT: note
+// CHECK-NOT: warning
+// CHECK-NOT: error
+let s: PartialImport
+s.c = 5
+// CHECK:      experimental_diagnostics_no_noise.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: s.c = 5
+// CHECK-NEXT: ~ ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: field 'c' not imported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:{{[0-9]+}}: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.PartialImport:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
+// CHECK-NEXT:     public var a: Int32
+// CHECK-NEXT:                ^
+// CHECK-NEXT: ctypes.PartialImport:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
+// CHECK-NEXT:     public var b: Int32
+// CHECK-NEXT:                ^
+
+// CHECK-NOT: note
+// CHECK-NOT: warning
+// CHECK-NOT: error

--- a/test/ClangImporter/experimental_diagnostics_opt_out.swift
+++ b/test/ClangImporter/experimental_diagnostics_opt_out.swift
@@ -1,0 +1,36 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-experimental-clang-importer-diagnostics -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+
+// REQUIRES: objc_interop
+
+import cfuncs
+import ctypes
+import IncompleteTypes
+
+// CHECK-NOT: warning
+// CHECK-NOT: error
+// CHECK-NOT: note
+let bar = Bar()
+_ = bar.methodReturningForwardDeclaredInterface()
+// CHECK: experimental_diagnostics_opt_out.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredInterface'
+// CHECK-NOT: warning
+// CHECK-NOT: error
+// CHECK-NOT: note
+
+// CHECK-NOT: warning
+// CHECK-NOT: error
+let s: PartialImport
+s.c = 5
+// CHECK: experimental_diagnostics_opt_out.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'PartialImport' has no member 'c'
+// CHECK: ctypes.PartialImport:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'a'?
+// CHECK: ctypes.PartialImport:{{[0-9]+}}:{{[0-9]+}}: note: did you mean 'b'?
+// CHECK-NOT: warning
+// CHECK-NOT: error
+// CHECK-NOT: note
+
+// CHECK-NOT: warning
+// CHECK-NOT: error
+unsupported_parameter_type(1,2)
+// CHECK: experimental_diagnostics_opt_out.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK-NOT: warning
+// CHECK-NOT: error
+// CHECK-NOT: note

--- a/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace
 
 import macros
 


### PR DESCRIPTION
Replace the existing `-enable-experimental-clang-importer-diagnostics`
flag with an opt-out version entitled `-disable-experimentalc-clang-importer-diagnostics`.
Enable the beviour previously hidden behind the old flag by default.

Implements the changes described in [this forum post](https://forums.swift.org/t/pitch-lazy-clangimporter-diagnostics-enabled-by-default/54651).