### PR TITLE
[tests] Add availability around the String indic sequence tests

### DIFF
--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2289,49 +2289,51 @@ func expectBidirectionalCount(_ count: Int, _ string: String) {
     string.formIndex(before: &index)
   }
 
-  expectEqual(i, count)
+  expectEqual(count, i)
 }
 
-StringTests.test("GraphemeBreaking.Indic Sequences") {
-  let test1 = "\u{0915}\u{0924}" // 2
-  expectEqual(2, test1.count)
-  expectBidirectionalCount(2, test1)
+if #available(SwiftStdlib 5.6, *) {
+  StringTests.test("GraphemeBreaking.Indic Sequences") {
+    let test1 = "\u{0915}\u{0924}" // 2
+    expectEqual(2, test1.count)
+    expectBidirectionalCount(2, test1)
 
-  let test2 = "\u{0915}\u{094D}\u{0924}" // 1
-  expectEqual(1, test2.count)
-  expectBidirectionalCount(1, test2)
+    let test2 = "\u{0915}\u{094D}\u{0924}" // 1
+    expectEqual(1, test2.count)
+    expectBidirectionalCount(1, test2)
 
-  let test3 = "\u{0915}\u{094D}\u{094D}\u{0924}" // 1
-  expectEqual(1, test3.count)
-  expectBidirectionalCount(1, test3)
+    let test3 = "\u{0915}\u{094D}\u{094D}\u{0924}" // 1
+    expectEqual(1, test3.count)
+    expectBidirectionalCount(1, test3)
 
-  let test4 = "\u{0915}\u{094D}\u{200D}\u{0924}" // 1
-  expectEqual(1, test4.count)
-  expectBidirectionalCount(1, test4)
+    let test4 = "\u{0915}\u{094D}\u{200D}\u{0924}" // 1
+    expectEqual(1, test4.count)
+    expectBidirectionalCount(1, test4)
 
-  let test5 = "\u{0915}\u{093C}\u{200D}\u{094D}\u{0924}" // 1
-  expectEqual(1, test5.count)
-  expectBidirectionalCount(1, test5)
+    let test5 = "\u{0915}\u{093C}\u{200D}\u{094D}\u{0924}" // 1
+    expectEqual(1, test5.count)
+    expectBidirectionalCount(1, test5)
 
-  let test6 = "\u{0915}\u{093C}\u{094D}\u{200D}\u{0924}" // 1
-  expectEqual(1, test6.count)
-  expectBidirectionalCount(1, test6)
+    let test6 = "\u{0915}\u{093C}\u{094D}\u{200D}\u{0924}" // 1
+    expectEqual(1, test6.count)
+    expectBidirectionalCount(1, test6)
 
-  let test7 = "\u{0915}\u{094D}\u{0924}\u{094D}\u{092F}" // 1
-  expectEqual(1, test7.count)
-  expectBidirectionalCount(1, test7)
+    let test7 = "\u{0915}\u{094D}\u{0924}\u{094D}\u{092F}" // 1
+    expectEqual(1, test7.count)
+    expectBidirectionalCount(1, test7)
 
-  let test8 = "\u{0915}\u{094D}\u{0061}" // 2
-  expectEqual(2, test8.count)
-  expectBidirectionalCount(2, test8)
+    let test8 = "\u{0915}\u{094D}\u{0061}" // 2
+    expectEqual(2, test8.count)
+    expectBidirectionalCount(2, test8)
 
-  let test9 = "\u{0061}\u{094D}\u{0924}" // 2
-  expectEqual(2, test9.count)
-  expectBidirectionalCount(2, test9)
+    let test9 = "\u{0061}\u{094D}\u{0924}" // 2
+    expectEqual(2, test9.count)
+    expectBidirectionalCount(2, test9)
 
-  let test10 = "\u{003F}\u{094D}\u{0924}" // 2
-  expectEqual(2, test10.count)
-  expectBidirectionalCount(2, test10)
+    let test10 = "\u{003F}\u{094D}\u{0924}" // 2
+    expectEqual(2, test10.count)
+    expectBidirectionalCount(2, test10)
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
I forgot add availability for these tests causing them to fail on older OSes.

Fixes: rdar://87628594