### PR TITLE
[Reflection] Fix async task slab size calculation.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1372,8 +1372,8 @@ public:
     Chunk.Length = Slab->CurrentOffset;
     Chunk.Kind = AsyncTaskAllocationChunk::ChunkKind::Unknown;
 
-    // Total slab size is the slab's capacity plus the slab struct itself.
-    StoredPointer SlabSize = Slab->Capacity + sizeof(*Slab);
+    // Total slab size is the slab's capacity plus the header.
+    StoredPointer SlabSize = Slab->Capacity + HeaderSize;
 
     return {llvm::None, {Slab->Next, SlabSize, {Chunk}}};
   }


### PR DESCRIPTION
The calculation failed to account for padding after the slab struct itself. We already account for this padding in HeaderSize, so use that instead of the raw struct size.

rdar://87607280