### PR TITLE
[Concurrency] Adjust the task allocator slab size to 984 bytes.

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -284,8 +284,11 @@ public:
   }
 };
 
-/// The size of an allocator slab.
-static constexpr size_t SlabCapacity = 1000;
+/// The size of an allocator slab. We want the full allocation to fit into a
+/// 1024-byte malloc quantum. We subtract off the slab header size, plus a
+/// little extra to stay within our limits even when there's overhead from
+/// malloc stack logging.
+static constexpr size_t SlabCapacity = 1024 - StackAllocator<0, nullptr>::slabHeaderSize() - 8;
 extern Metadata TaskAllocatorSlabMetadata;
 
 using TaskAllocator = StackAllocator<SlabCapacity, &TaskAllocatorSlabMetadata>;

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -109,8 +109,8 @@ private:
     }
 
     /// The size of the slab header.
-    static size_t headerSize() {
-      return llvm::alignTo(sizeof(Slab), llvm::Align(alignment));
+    static constexpr size_t headerSize() {
+      return (sizeof(Slab) + alignment - 1) & ~(alignment - 1);
     }
 
     /// Return \p size with the added overhead of the slab header.
@@ -274,6 +274,10 @@ public:
       SWIFT_FATAL_ERROR(0, "not all allocations are deallocated");
     (void)freeAllSlabs(firstSlabIsPreallocated ? firstSlab->next : firstSlab);
     assert(getNumAllocatedSlabs() == 0);
+  }
+
+  static constexpr size_t slabHeaderSize() {
+    return Slab::headerSize();
   }
 
   /// Allocate a memory buffer of \p size.


### PR DESCRIPTION
A slab capacity of 1000 bytes was overflowing the 1024 byte malloc bucket when adding in the slab header. Adjust it down to 984 bytes.

rdar://87612288