### PR TITLE
Demangling: repair the build for the rebranch

### DIFF
--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -46,8 +46,8 @@ namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE
 
-LLVM_ATTRIBUTE_NORETURN void failAssert(const char *file, unsigned line,
-                                        NodePointer node, const char *expr);
+[[noreturn]] void failAssert(const char *file, unsigned line, NodePointer node,
+                             const char *expr);
 
 SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle


### PR DESCRIPTION
LLVM upstream removed `LLVM_NORETURN_ATTRIBUTE` as the minimum C++
standard has been C++11 for quite some time now.  Swift also has a
minimum of C++14.  Replace the use of the attribute with the moral
equivalent of `[[noreturn]]`.  The attribute was removed in
llvm/llvm-project commit 09529892b518c8df8c24395e68e0a7a5e8bda5fb.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
