### PR TITLE
Revert "Make Objective-C interoperability configurable in the runtime"

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -48,24 +48,6 @@
 #include "llvm/Support/Casting.h"
 
 namespace swift {
-
-template <typename Runtime> struct TargetGenericMetadataInstantiationCache;
-template <typename Runtime> struct TargetAnyClassMetadata;
-template <typename Runtime> struct TargetAnyClassMetadataObjCInterop;
-template <typename Runtime, typename TargetAnyClassMetadataVariant>
-struct TargetClassMetadata;
-template <typename Runtime> struct TargetStructMetadata;
-template <typename Runtime> struct TargetOpaqueMetadata;
-template <typename Runtime> struct TargetValueMetadata;
-template <typename Runtime> struct TargetForeignClassMetadata;
-template <typename Runtime> struct TargetContextDescriptor;
-template <typename Runtime> class TargetTypeContextDescriptor;
-template <typename Runtime> class TargetClassDescriptor;
-template <typename Runtime> class TargetValueTypeDescriptor;
-template <typename Runtime> class TargetEnumDescriptor;
-template <typename Runtime> class TargetStructDescriptor;
-template <typename Runtime> struct TargetGenericMetadataPattern;
-
 template <unsigned PointerSize>
 struct RuntimeTarget;
 
@@ -108,18 +90,6 @@ struct InProcess {
   using StoredSize = size_t;
   using StoredPointerDifference = ptrdiff_t;
 
-#ifdef SWIFT_OBJC_INTEROP
-  static constexpr bool ObjCInterop = true;
-  template <typename T>
-  using TargetAnyClassMetadata = TargetAnyClassMetadataObjCInterop<T>;
-#else
-  static constexpr bool ObjCInterop = false;
-  template <typename T>
-  using TargetAnyClassMetadata = TargetAnyClassMetadata<T>;
-#endif
-  template <typename T>
-  using TargetClassMetadata = TargetClassMetadata<T, TargetAnyClassMetadata<T>>;
-
   static_assert(sizeof(StoredSize) == sizeof(StoredPointerDifference),
                 "target uses differently-sized size_t and ptrdiff_t");
   
@@ -150,44 +120,14 @@ struct ExternalPointer {
   StoredPointer PointerValue;
 };
 
-template <typename Runtime> struct WithObjCInterop {
-  using StoredPointer = typename Runtime::StoredPointer;
-  using StoredSignedPointer = typename Runtime::StoredSignedPointer;
-  using StoredSize = typename Runtime::StoredSize;
-  using StoredPointerDifference = typename Runtime::StoredPointerDifference;
-  static constexpr size_t PointerSize = Runtime::PointerSize;
-  static constexpr bool ObjCInterop = true;
-  template <typename T>
-  using TargetAnyClassMetadata = TargetAnyClassMetadataObjCInterop<T>;
-};
-
-template <typename Runtime> struct NoObjCInterop {
-  using StoredPointer = typename Runtime::StoredPointer;
-  using StoredSignedPointer = typename Runtime::StoredSignedPointer;
-  using StoredSize = typename Runtime::StoredSize;
-  using StoredPointerDifference = typename Runtime::StoredPointerDifference;
-  static constexpr size_t PointerSize = Runtime::PointerSize;
-  static constexpr bool ObjCInterop = false;
-  template <typename T>
-  using TargetAnyClassMetadata = TargetAnyClassMetadata<T>;
-};
-
-/// An external process's runtime target, which may be a different architecture,
-/// and may or may not have Objective-C interoperability.
+/// An external process's runtime target, which may be a different architecture.
 template <typename Runtime>
 struct External {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;
   using StoredPointerDifference = typename Runtime::StoredPointerDifference;
-  template <typename T>
-  using TargetAnyClassMetadata =
-      typename Runtime::template TargetAnyClassMetadata<T>;
-  template <typename T>
-  using TargetClassMetadata = TargetClassMetadata<T, TargetAnyClassMetadata<T>>;
-
   static constexpr size_t PointerSize = Runtime::PointerSize;
-  static constexpr bool ObjCInterop = Runtime::ObjCInterop;
   const StoredPointer PointerValue;
   
   template <typename T>
@@ -538,6 +478,21 @@ namespace {
   };
 }
 
+template <typename Runtime> struct TargetGenericMetadataInstantiationCache;
+template <typename Runtime> struct TargetAnyClassMetadata;
+template <typename Runtime> struct TargetClassMetadata;
+template <typename Runtime> struct TargetStructMetadata;
+template <typename Runtime> struct TargetOpaqueMetadata;
+template <typename Runtime> struct TargetValueMetadata;
+template <typename Runtime> struct TargetForeignClassMetadata;
+template <typename Runtime> struct TargetContextDescriptor;
+template <typename Runtime> class TargetTypeContextDescriptor;
+template <typename Runtime> class TargetClassDescriptor;
+template <typename Runtime> class TargetValueTypeDescriptor;
+template <typename Runtime> class TargetEnumDescriptor;
+template <typename Runtime> class TargetStructDescriptor;
+template <typename Runtime> struct TargetGenericMetadataPattern;
+
 using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
 
 // FIXME: https://bugs.swift.org/browse/SR-1155
@@ -585,7 +540,7 @@ struct TargetMetadata {
 
 #if SWIFT_OBJC_INTEROP
 protected:
-  constexpr TargetMetadata(TargetAnyClassMetadataObjCInterop<Runtime> *isa)
+  constexpr TargetMetadata(TargetAnyClassMetadata<Runtime> *isa)
     : Kind(reinterpret_cast<StoredPointer>(isa)) {}
 #endif
 
@@ -729,23 +684,12 @@ public:
   getTypeContextDescriptor() const {
     switch (getKind()) {
     case MetadataKind::Class: {
-      if (Runtime::ObjCInterop) {
-        const auto cls = static_cast<const TargetClassMetadata<
-            Runtime, TargetAnyClassMetadataObjCInterop<Runtime>> *>(this);
-        if (!cls->isTypeMetadata())
-          return nullptr;
-        if (cls->isArtificialSubclass())
-          return nullptr;
-        return cls->getDescription();
-      } else {
-        const auto cls = static_cast<const TargetClassMetadata<
-            Runtime, TargetAnyClassMetadata<Runtime>> *>(this);
-        if (!cls->isTypeMetadata())
-          return nullptr;
-        if (cls->isArtificialSubclass())
-          return nullptr;
-        return cls->getDescription();
-      }
+      const auto cls = static_cast<const TargetClassMetadata<Runtime> *>(this);
+      if (!cls->isTypeMetadata())
+        return nullptr;
+      if (cls->isArtificialSubclass())
+        return nullptr;
+      return cls->getDescription();
     }
     case MetadataKind::Struct:
     case MetadataKind::Enum:
@@ -762,8 +706,7 @@ public:
 
   /// Get the class object for this type if it has one, or return null if the
   /// type is not a class (or not a class with a class object).
-  const typename Runtime::template TargetClassMetadata<Runtime> *
-  getClassObject() const;
+  const TargetClassMetadata<Runtime> *getClassObject() const;
 
   /// Retrieve the generic arguments of this type, if it has any.
   ConstTargetMetadataPointer<Runtime, swift::TargetMetadata> const *
@@ -797,9 +740,8 @@ public:
   typename std::enable_if<std::is_same<R, InProcess>::value, Class>::type
   getObjCClassObject() const {
     return reinterpret_cast<Class>(
-        const_cast<TargetClassMetadata<
-            InProcess, TargetAnyClassMetadataObjCInterop<InProcess>> *>(
-            getClassObject()));
+      const_cast<TargetClassMetadata<InProcess>*>(
+        getClassObject()));
   }
 #endif
 
@@ -835,9 +777,7 @@ template <typename Runtime>
 struct TargetHeapMetadataHeaderPrefix {
   /// Destroy the object, returning the allocated size of the object
   /// or 0 if the object shouldn't be deallocated.
-  TargetSignedPointer<Runtime, HeapObjectDestroyer *
-                                   __ptrauth_swift_heap_object_destructor>
-      destroy;
+  TargetSignedPointer<Runtime, HeapObjectDestroyer *__ptrauth_swift_heap_object_destructor> destroy;
 };
 using HeapMetadataHeaderPrefix =
   TargetHeapMetadataHeaderPrefix<InProcess>;
@@ -870,7 +810,7 @@ struct TargetHeapMetadata : TargetMetadata<Runtime> {
   constexpr TargetHeapMetadata(MetadataKind kind)
     : TargetMetadata<Runtime>(kind) {}
 #if SWIFT_OBJC_INTEROP
-  constexpr TargetHeapMetadata(TargetAnyClassMetadataObjCInterop<Runtime> *isa)
+  constexpr TargetHeapMetadata(TargetAnyClassMetadata<Runtime> *isa)
     : TargetMetadata<Runtime>(isa) {}
 #endif
 };
@@ -1009,8 +949,6 @@ struct TargetClassMetadataBounds : TargetMetadataBounds<Runtime> {
 
   using TargetMetadataBounds<Runtime>::NegativeSizeInWords;
   using TargetMetadataBounds<Runtime>::PositiveSizeInWords;
-  using TargetClassMetadata =
-      typename Runtime::template TargetClassMetadata<Runtime>;
 
   /// The offset from the address point of the metadata to the immediate
   /// members.
@@ -1023,13 +961,10 @@ struct TargetClassMetadataBounds : TargetMetadataBounds<Runtime> {
     : TargetMetadataBounds<Runtime>{negativeSizeInWords, positiveSizeInWords},
       ImmediateMembersOffset(immediateMembersOffset) {}
 
-  template <typename T>
-    using TargetClassMetadataT = typename Runtime::template TargetClassMetadata<T>;
-
   /// Return the basic bounds of all Swift class metadata.
   /// The immediate members offset will not be meaningful.
   static constexpr TargetClassMetadataBounds<Runtime> forSwiftRootClass() {
-    using Metadata = FullMetadata<TargetClassMetadataT<Runtime>>;
+    using Metadata = FullMetadata<TargetClassMetadata<Runtime>>;
     return forAddressPointAndSize(sizeof(typename Metadata::HeaderType),
                                   sizeof(Metadata));
   }
@@ -1072,67 +1007,39 @@ template <typename Runtime>
 struct TargetAnyClassMetadata : public TargetHeapMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSize = typename Runtime::StoredSize;
-  using TargetClassMetadata =
-      typename Runtime::template TargetClassMetadata<Runtime>;
 
-protected:
-  constexpr TargetAnyClassMetadata(
-      TargetAnyClassMetadataObjCInterop<Runtime> *isa,
-      TargetClassMetadata *superclass)
-      : TargetHeapMetadata<Runtime>(isa), Superclass(superclass) {}
+#if SWIFT_OBJC_INTEROP
+  constexpr TargetAnyClassMetadata(TargetAnyClassMetadata<Runtime> *isa,
+                                   TargetClassMetadata<Runtime> *superclass)
+    : TargetHeapMetadata<Runtime>(isa),
+      Superclass(superclass),
+      CacheData{nullptr, nullptr},
+      Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
+#endif
 
-public:
-  constexpr TargetAnyClassMetadata(TargetClassMetadata *superclass)
-      : TargetHeapMetadata<Runtime>(MetadataKind::Class),
-        Superclass(superclass) {}
+  constexpr TargetAnyClassMetadata(TargetClassMetadata<Runtime> *superclass)
+    : TargetHeapMetadata<Runtime>(MetadataKind::Class),
+      Superclass(superclass)
+#if SWIFT_OBJC_INTEROP
+      , CacheData{nullptr, nullptr},
+      Data(SWIFT_CLASS_IS_SWIFT_MASK)
+#endif
+      {}
+
+#if SWIFT_OBJC_INTEROP
+  // Allow setting the metadata kind to a class ISA on class metadata.
+  using TargetMetadata<Runtime>::getClassISA;
+  using TargetMetadata<Runtime>::setClassISA;
+#endif
 
   // Note that ObjC classes do not have a metadata header.
 
   /// The metadata for the superclass.  This is null for the root class.
-  TargetSignedPointer<Runtime, const TargetClassMetadata *
+  TargetSignedPointer<Runtime, const TargetClassMetadata<Runtime> *
                                    __ptrauth_swift_objc_superclass>
       Superclass;
 
-  /// Is this object a valid swift type metadata?  That is, can it be
-  /// safely downcast to ClassMetadata?
-  bool isTypeMetadata() const {
-    return true;
-  }
-  /// A different perspective on the same bit.
-  bool isPureObjC() const {
-    return !isTypeMetadata();
-  }
-};
-
 #if SWIFT_OBJC_INTEROP
-/// This is the class metadata object for all classes (Swift and ObjC) in a
-/// runtime that has Objective-C interoperability.
-template <typename Runtime>
-struct TargetAnyClassMetadataObjCInterop
-    : public TargetAnyClassMetadata<Runtime> {
-  using StoredPointer = typename Runtime::StoredPointer;
-  using StoredSize = typename Runtime::StoredSize;
-
-  using TargetClassMetadataObjCInterop =
-      TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
-
-  constexpr TargetAnyClassMetadataObjCInterop(
-      TargetAnyClassMetadataObjCInterop<Runtime> *isa,
-      TargetClassMetadataObjCInterop *superclass)
-      : TargetAnyClassMetadata<Runtime>(isa, superclass),
-        CacheData{nullptr, nullptr},
-        Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
-
-  constexpr TargetAnyClassMetadataObjCInterop(
-      TargetClassMetadataObjCInterop *superclass)
-      : TargetAnyClassMetadata<Runtime>(superclass), CacheData{nullptr,
-                                                               nullptr},
-        Data(SWIFT_CLASS_IS_SWIFT_MASK) {}
-
-  // Allow setting the metadata kind to a class ISA on class metadata.
-  using TargetMetadata<Runtime>::getClassISA;
-  using TargetMetadata<Runtime>::setClassISA;
-
   /// The cache data is used for certain dynamic lookups; it is owned
   /// by the runtime and generally needs to interoperate with
   /// Objective-C's use.
@@ -1145,29 +1052,26 @@ struct TargetAnyClassMetadataObjCInterop
   StoredSize Data;
   
   static constexpr StoredPointer offsetToData() {
-    return offsetof(TargetAnyClassMetadataObjCInterop, Data);
+    return offsetof(TargetAnyClassMetadata, Data);
   }
+#endif
 
   /// Is this object a valid swift type metadata?  That is, can it be
   /// safely downcast to ClassMetadata?
   bool isTypeMetadata() const {
+#if SWIFT_OBJC_INTEROP
     return (Data & SWIFT_CLASS_IS_SWIFT_MASK);
+#else
+    return true;
+#endif
   }
   /// A different perspective on the same bit
   bool isPureObjC() const {
     return !isTypeMetadata();
   }
 };
-
-using AnyClassMetadata =
-  TargetAnyClassMetadataObjCInterop<InProcess>;
-
-#else
-
 using AnyClassMetadata =
   TargetAnyClassMetadata<InProcess>;
-
-#endif
 
 using ClassIVarDestroyer =
   SWIFT_CC(swift) void(SWIFT_CONTEXT HeapObject *);
@@ -1178,28 +1082,23 @@ using ClassIVarDestroyer =
 ///
 /// Note that the layout of this type is compatible with the layout of
 /// an Objective-C class.
-///
-/// If the Runtime supports Objective-C interoperability, this class inherits
-/// from TargetAnyClassMetadataObjCInterop, otherwise it inherits from
-/// TargetAnyClassMetadata.
-template <typename Runtime, typename TargetAnyClassMetadataVariant>
-struct TargetClassMetadata : public TargetAnyClassMetadataVariant {
+template <typename Runtime>
+struct TargetClassMetadata : public TargetAnyClassMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSize = typename Runtime::StoredSize;
 
   TargetClassMetadata() = default;
-  constexpr TargetClassMetadata(const TargetAnyClassMetadataVariant &base,
-                                ClassFlags flags,
-                                ClassIVarDestroyer *ivarDestroyer,
-                                StoredPointer size, StoredPointer addressPoint,
-                                StoredPointer alignMask,
-                                StoredPointer classSize,
-                                StoredPointer classAddressPoint)
-      : TargetAnyClassMetadataVariant(base), Flags(flags),
-        InstanceAddressPoint(addressPoint), InstanceSize(size),
-        InstanceAlignMask(alignMask), Reserved(0), ClassSize(classSize),
-        ClassAddressPoint(classAddressPoint), Description(nullptr),
-        IVarDestroyer(ivarDestroyer) {}
+  constexpr TargetClassMetadata(const TargetAnyClassMetadata<Runtime> &base,
+             ClassFlags flags,
+             ClassIVarDestroyer *ivarDestroyer,
+             StoredPointer size, StoredPointer addressPoint,
+             StoredPointer alignMask,
+             StoredPointer classSize, StoredPointer classAddressPoint)
+    : TargetAnyClassMetadata<Runtime>(base),
+      Flags(flags), InstanceAddressPoint(addressPoint),
+      InstanceSize(size), InstanceAlignMask(alignMask),
+      Reserved(0), ClassSize(classSize), ClassAddressPoint(classAddressPoint),
+      Description(nullptr), IVarDestroyer(ivarDestroyer) {}
 
   // The remaining fields are valid only when isTypeMetadata().
   // The Objective-C runtime knows the offsets to some of these fields.
@@ -1251,7 +1150,7 @@ public:
   //   - class variables (if we choose to support these)
   //   - "tabulated" virtual methods
 
-  using TargetAnyClassMetadataVariant::isTypeMetadata;
+  using TargetAnyClassMetadata<Runtime>::isTypeMetadata;
 
   ConstTargetMetadataPointer<Runtime, TargetClassDescriptor>
   getDescription() const {
@@ -1451,18 +1350,7 @@ public:
     return metadata->getKind() == MetadataKind::Class;
   }
 };
-#if SWIFT_OBJC_INTEROP
-using ClassMetadata =
-    TargetClassMetadata<InProcess,
-                        TargetAnyClassMetadataObjCInterop<InProcess>>;
-#else
-using ClassMetadata =
-    TargetClassMetadata<InProcess, TargetAnyClassMetadata<InProcess>>;
-#endif
-
-template <typename Runtime>
-using TargetClassMetadataObjCInterOp =
-    TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
+using ClassMetadata = TargetClassMetadata<InProcess>;
 
 /// The structure of class metadata that's compatible with dispatch objects.
 /// This includes Swift heap metadata, followed by the vtable entries that
@@ -1510,7 +1398,7 @@ using HeapLocalVariableMetadata
 /// Swift-compiled.
 template <typename Runtime>
 struct TargetObjCClassWrapperMetadata : public TargetMetadata<Runtime> {
-  ConstTargetMetadataPointer<Runtime, TargetClassMetadataObjCInterOp> Class;
+  ConstTargetMetadataPointer<Runtime, TargetClassMetadata> Class;
 
   static bool classof(const TargetMetadata<Runtime> *metadata) {
     return metadata->getKind() == MetadataKind::ObjCClassWrapper;
@@ -2601,9 +2489,6 @@ public:
 /// A reference to a type.
 template <typename Runtime>
 struct TargetTypeReference {
-  template <typename T>
-  using TargetClassMetadata = typename T::template TargetClassMetadata<T>;
-
   union {
     /// A direct reference to a TypeContextDescriptor or ProtocolDescriptor.
     RelativeDirectPointer<TargetContextDescriptor<Runtime>>
@@ -2617,7 +2502,7 @@ struct TargetTypeReference {
     /// An indirect reference to an Objective-C class.
     RelativeDirectPointer<
         ConstTargetMetadataPointer<Runtime, TargetClassMetadata>>
-        IndirectObjCClass;
+      IndirectObjCClass;
 
     /// A direct reference to an Objective-C class name.
     RelativeDirectPointer<const char>
@@ -2644,11 +2529,11 @@ struct TargetTypeReference {
 #if SWIFT_OBJC_INTEROP
   /// If this type reference is one of the kinds that supports ObjC
   /// references,
-  const TargetClassMetadataObjCInterOp<Runtime> *
+  const TargetClassMetadata<Runtime> *
   getObjCClass(TypeReferenceKind kind) const;
 #endif
 
-  const TargetClassMetadataObjCInterOp<Runtime> * const *
+  const TargetClassMetadata<Runtime> * const *
   getIndirectObjCClass(TypeReferenceKind kind) const {
     assert(kind == TypeReferenceKind::IndirectObjCClass);
     return IndirectObjCClass.get();
@@ -2730,11 +2615,10 @@ public:
     return TypeRef.getDirectObjCClassName(getTypeKind());
   }
 
-  const TargetClassMetadataObjCInterOp<Runtime> *const *
-  getIndirectObjCClass() const {
+  const TargetClassMetadata<Runtime> * const *getIndirectObjCClass() const {
     return TypeRef.getIndirectObjCClass(getTypeKind());
   }
-
+  
   const TargetContextDescriptor<Runtime> *getTypeDescriptor() const {
     return TypeRef.getTypeDescriptor(getTypeKind());
   }

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -168,8 +168,6 @@ public:
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;
-  using TargetClassMetadata =
-      typename Runtime::template TargetClassMetadata<Runtime>;
 
 private:
   /// The maximum number of bytes to read when reading metadata. Anything larger
@@ -504,7 +502,7 @@ public:
     if (!meta || meta->getKind() != MetadataKind::Class)
       return StoredPointer();
 
-    auto classMeta = cast<TargetClassMetadata>(meta);
+    auto classMeta = cast<TargetClassMetadata<Runtime>>(meta);
     return stripSignedPointer(classMeta->Superclass);
   }
 
@@ -516,39 +514,39 @@ public:
     if (!meta || meta->getKind() != MetadataKind::Class)
       return None;
 
-    if (Runtime::ObjCInterop) {
-      // The following algorithm only works on the non-fragile Apple runtime.
+#if SWIFT_OBJC_INTEROP
+    // The following algorithm only works on the non-fragile Apple runtime.
 
-      // Grab the RO-data pointer.  This part is not ABI.
-      StoredPointer roDataPtr = readObjCRODataPtr(MetadataAddress);
-      if (!roDataPtr)
-        return None;
+    // Grab the RO-data pointer.  This part is not ABI.
+    StoredPointer roDataPtr = readObjCRODataPtr(MetadataAddress);
+    if (!roDataPtr)
+      return None;
 
-      // Get the address of the InstanceStart field.
-      auto address = roDataPtr + sizeof(uint32_t) * 1;
+    // Get the address of the InstanceStart field.
+    auto address = roDataPtr + sizeof(uint32_t) * 1;
 
-      unsigned start;
-      if (!Reader->readInteger(RemoteAddress(address), &start))
-        return None;
+    unsigned start;
+    if (!Reader->readInteger(RemoteAddress(address), &start))
+      return None;
 
-      return start;
-    } else {
-      // All swift class instances start with an isa pointer,
-      // followed by the retain counts (which are the size of a long long).
-      size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
-      size_t start = isaAndRetainCountSize;
+    return start;
+#else
+    // All swift class instances start with an isa pointer,
+    // followed by the retain counts (which are the size of a long long).
+    size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
+    size_t start = isaAndRetainCountSize;
 
-      auto classMeta = cast<TargetClassMetadata>(meta);
-      while (stripSignedPointer(classMeta->Superclass)) {
-        classMeta = cast<TargetClassMetadata>(
-            readMetadata(stripSignedPointer(classMeta->Superclass)));
+    auto classMeta = cast<TargetClassMetadata<Runtime>>(meta);
+    while (stripSignedPointer(classMeta->Superclass)) {
+      classMeta = cast<TargetClassMetadata<Runtime>>(
+          readMetadata(stripSignedPointer(classMeta->Superclass)));
 
-        // Subtract the size contribution of the isa and retain counts from
-        // the super class.
-        start += classMeta->InstanceSize - isaAndRetainCountSize;
-      }
-      return start;
+      // Subtract the size contribution of the isa and retain counts from 
+      // the super class.
+      start += classMeta->InstanceSize - isaAndRetainCountSize;
     }
+    return start;
+#endif
   }
 
   /// Given a pointer to the metadata, attempt to read the value
@@ -590,7 +588,7 @@ public:
     if (!Meta)
       return None;
 
-    if (auto ClassMeta = dyn_cast<TargetClassMetadata>(Meta)) {
+    if (auto ClassMeta = dyn_cast<TargetClassMetadata<Runtime>>(Meta)) {
       if (ClassMeta->isPureObjC()) {
         // If we can determine the Objective-C class name, this is probably an
         // error existential with NSError-compatible layout.
@@ -720,37 +718,37 @@ public:
       const TargetProtocolDescriptorRef<Runtime> &ProtocolAddress,
       Demangler &dem,
       Resolver resolver) {
-    if (Runtime::ObjCInterop) {
-      // Check whether we have an Objective-C protocol.
-      if (ProtocolAddress.isObjC()) {
-        auto Name = readObjCProtocolName(ProtocolAddress.getObjCProtocol());
-        StringRef NameStr(Name);
+#if SWIFT_OBJC_INTEROP
+    // Check whether we have an Objective-C protocol.
+    if (ProtocolAddress.isObjC()) {
+      auto Name = readObjCProtocolName(ProtocolAddress.getObjCProtocol());
+      StringRef NameStr(Name);
 
-        // If this is a Swift-defined protocol, demangle it.
-        if (NameStr.startswith("_TtP")) {
-          auto Demangled = dem.demangleSymbol(NameStr);
-          if (!Demangled)
+      // If this is a Swift-defined protocol, demangle it.
+      if (NameStr.startswith("_TtP")) {
+        auto Demangled = dem.demangleSymbol(NameStr);
+        if (!Demangled)
+          return resolver.failure();
+
+        // FIXME: This appears in _swift_buildDemanglingForMetadata().
+        while (Demangled->getKind() == Node::Kind::Global ||
+               Demangled->getKind() == Node::Kind::TypeMangling ||
+               Demangled->getKind() == Node::Kind::Type ||
+               Demangled->getKind() == Node::Kind::ProtocolList ||
+               Demangled->getKind() == Node::Kind::TypeList ||
+               Demangled->getKind() == Node::Kind::Type) {
+          if (Demangled->getNumChildren() != 1)
             return resolver.failure();
-
-          // FIXME: This appears in _swift_buildDemanglingForMetadata().
-          while (Demangled->getKind() == Node::Kind::Global ||
-                 Demangled->getKind() == Node::Kind::TypeMangling ||
-                 Demangled->getKind() == Node::Kind::Type ||
-                 Demangled->getKind() == Node::Kind::ProtocolList ||
-                 Demangled->getKind() == Node::Kind::TypeList ||
-                 Demangled->getKind() == Node::Kind::Type) {
-            if (Demangled->getNumChildren() != 1)
-              return resolver.failure();
-            Demangled = Demangled->getFirstChild();
-          }
-
-          return resolver.swiftProtocol(Demangled);
+          Demangled = Demangled->getFirstChild();
         }
 
-        // Otherwise, this is an imported protocol.
-        return resolver.objcProtocol(NameStr);
+        return resolver.swiftProtocol(Demangled);
       }
+
+      // Otherwise, this is an imported protocol.
+      return resolver.objcProtocol(NameStr);
     }
+#endif
 
     // Swift-native protocol.
     auto Demangled =
@@ -1421,7 +1419,7 @@ public:
           return readMetadataBoundsOfSuperclass(superclass);
         },
         [&](MetadataRef metadata) -> llvm::Optional<ClassMetadataBounds> {
-          auto cls = dyn_cast<TargetClassMetadata>(metadata);
+          auto cls = dyn_cast<TargetClassMetadata<Runtime>>(metadata);
           if (!cls)
             return None;
 
@@ -1661,10 +1659,6 @@ protected:
     return Reader->readString(RemoteAddress(namePtr), className);
   }
 
-  template <typename T>
-  using TargetClassMetadataT =
-      typename Runtime::template TargetClassMetadata<T>;
-
   MetadataRef readMetadata(StoredPointer address) {
     auto cached = MetadataCache.find(address);
     if (cached != MetadataCache.end())
@@ -1678,9 +1672,7 @@ protected:
 
     switch (getEnumeratedMetadataKind(KindValue)) {
       case MetadataKind::Class:
-
-        return _readMetadata<TargetClassMetadataT>(address);
-
+        return _readMetadata<TargetClassMetadata>(address);
       case MetadataKind::Enum:
         return _readMetadata<TargetEnumMetadata>(address);
       case MetadataKind::ErrorObject:
@@ -1787,7 +1779,7 @@ protected:
                                      bool skipArtificialSubclasses = false) {
     switch (metadata->getKind()) {
     case MetadataKind::Class: {
-      auto classMeta = cast<TargetClassMetadata>(metadata);
+      auto classMeta = cast<TargetClassMetadata<Runtime>>(metadata);
       while (true) {
         if (!classMeta->isTypeMetadata())
           return 0;
@@ -1809,7 +1801,7 @@ protected:
         if (!superMeta)
           return 0;
 
-        auto superclassMeta = dyn_cast<TargetClassMetadata>(superMeta);
+        auto superclassMeta = dyn_cast<TargetClassMetadata<Runtime>>(superMeta);
         if (!superclassMeta)
           return 0;
 
@@ -2700,7 +2692,7 @@ private:
 
   BuiltType readNominalTypeFromClassMetadata(MetadataRef origMetadata,
                                        bool skipArtificialSubclasses = false) {
-    auto classMeta = cast<TargetClassMetadata>(origMetadata);
+    auto classMeta = cast<TargetClassMetadata<Runtime>>(origMetadata);
     if (classMeta->isTypeMetadata())
       return readNominalTypeFromMetadata(origMetadata, skipArtificialSubclasses);
 
@@ -2723,10 +2715,6 @@ private:
     return BuiltObjCClass;
   }
 
-  using TargetClassMetadataObjCInterop =
-      swift::TargetClassMetadata<Runtime,
-                                 TargetAnyClassMetadataObjCInterop<Runtime>>;
-
   /// Given that the remote process is running the non-fragile Apple runtime,
   /// grab the ro-data from a class pointer.
   StoredPointer readObjCRODataPtr(StoredPointer classAddress) {
@@ -2735,10 +2723,9 @@ private:
 
 #if SWIFT_OBJC_INTEROP
     StoredPointer dataPtr;
-    if (!Reader->readInteger(
-            RemoteAddress(classAddress +
-                          TargetClassMetadataObjCInterop::offsetToData()),
-            &dataPtr))
+    if (!Reader->readInteger(RemoteAddress(classAddress +
+                               TargetClassMetadata<Runtime>::offsetToData()),
+                             &dataPtr))
       return StoredPointer();
 
     // Apply the data-pointer mask.

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -649,24 +649,13 @@ static RemoteASTContextImpl *createImpl(ASTContext &ctx,
                                       std::shared_ptr<MemoryReader> &&reader) {
   auto &target = ctx.LangOpts.Target;
   assert(target.isArch32Bit() || target.isArch64Bit());
-  bool objcInterop = ctx.LangOpts.EnableObjCInterop;
 
   if (target.isArch32Bit()) {
-    if (objcInterop) {
-      using Target = External<WithObjCInterop<RuntimeTarget<4>>>;
-      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
-    } else {
-      using Target = External<NoObjCInterop<RuntimeTarget<4>>>;
-      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
-    }
+    using Target = External<RuntimeTarget<4>>;
+    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
   } else {
-    if (objcInterop) {
-      using Target = External<WithObjCInterop<RuntimeTarget<8>>>;
-      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
-    } else {
-      using Target = External<NoObjCInterop<RuntimeTarget<8>>>;
-      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
-    }
+    using Target = External<RuntimeTarget<8>>;
+    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
   }
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -36,11 +36,7 @@ using namespace swift;
 using namespace swift::reflection;
 using namespace swift::remote;
 
-#if SWIFT_OBJC_INTEROP
-using Runtime = External<WithObjCInterop<RuntimeTarget<sizeof(uintptr_t)>>>;
-#else
-using Runtime = External<NoObjCInterOp<RuntimeTarget<sizeof(uintptr_t)>>>;
-#endif
+using Runtime = External<RuntimeTarget<sizeof(uintptr_t)>>;
 using NativeReflectionContext = swift::reflection::ReflectionContext<Runtime>;
 
 struct SwiftReflectionContext {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -487,9 +487,9 @@ public:
     return c;
 #endif
   }
-
-  template <>
-  inline const ClassMetadata *Metadata::getClassObject() const {
+  
+  template<> inline const ClassMetadata *
+  Metadata::getClassObject() const {
     switch (getKind()) {
     case MetadataKind::Class: {
       // Native Swift class metadata is also the class object.

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -611,25 +611,14 @@ static ReflectionContextHolder makeReflectionContextForObjectFiles(
   uint8_t pointerSize;
   Reader->queryDataLayout(DataLayoutQueryType::DLQ_GetPointerSize,
                           nullptr, &pointerSize);
+  
   switch (pointerSize) {
   case 4:
-    return makeReflectionContextForMetadataReader<
-    // FIXME: This could be configurable.
-#if SWIFT_OBJC_INTEROP
-        External<WithObjCInterop<RuntimeTarget<4>>>
-#else
-        External<NoObjCInterop<RuntimeTarget<4>>>
-#endif
-        >(std::move(Reader));
+    return makeReflectionContextForMetadataReader<External<RuntimeTarget<4>>>
+                                                            (std::move(Reader));
   case 8:
-    return makeReflectionContextForMetadataReader<
-    // FIXME: This could be configurable.
-#if SWIFT_OBJC_INTEROP
-        External<WithObjCInterop<RuntimeTarget<8>>>
-#else
-        External<NoObjCInterop<RuntimeTarget<8>>>
-#endif
-        >(std::move(Reader));
+    return makeReflectionContextForMetadataReader<External<RuntimeTarget<8>>>
+                                                            (std::move(Reader));
   default:
     fputs("unsupported word size in object file\n", stderr);
     abort();


### PR DESCRIPTION
Reverts apple/swift#40843