### PR TITLE
[interop] add an option to emit C++ header interface for a module

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -119,6 +119,8 @@ ERROR(error_mode_cannot_emit_reference_dependencies,none,
       "this mode does not support emitting reference dependency files", ())
 ERROR(error_mode_cannot_emit_header,none,
       "this mode does not support emitting Objective-C headers", ())
+ERROR(error_mode_cannot_emit_cxx_header,none,
+      "this mode does not support emitting C++ headers", ())
 ERROR(error_mode_cannot_emit_loaded_module_trace,none,
       "this mode does not support emitting the loaded module trace", ())
 ERROR(error_mode_cannot_emit_module,none,

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -31,6 +31,17 @@ struct SupplementaryOutputPaths {
   /// \sa swift::printAsObjC
   std::string ObjCHeaderOutputPath;
 
+  /// The path to which we should emit a C++ header for the module.
+  ///
+  /// Currently only makes sense when the compiler has whole module knowledge.
+  /// The modes for which it makes sense include both WMO and the "merge
+  /// modules" job that happens after the normal compilation jobs. That's where
+  /// the header is emitted in single-file mode, since it needs whole-module
+  /// information.
+  ///
+  /// \sa swift::printAsCxx
+  std::string CxxHeaderOutputPath;
+
   /// The path to which we should emit a serialized module.
   /// It is valid whenever there are any inputs.
   ///
@@ -160,7 +171,9 @@ struct SupplementaryOutputPaths {
   /// Apply a given function for each existing (non-empty string) supplementary output
   void forEachSetOutput(llvm::function_ref<void(const std::string&)> fn) const {
     if (!ObjCHeaderOutputPath.empty())
-      fn(ObjCHeaderOutputPath); 
+      fn(ObjCHeaderOutputPath);
+    if (!CxxHeaderOutputPath.empty())
+      fn(CxxHeaderOutputPath);
     if (!ModuleOutputPath.empty())
       fn(ModuleOutputPath); 
     if (!ModuleSourceInfoOutputPath.empty())
@@ -196,14 +209,16 @@ struct SupplementaryOutputPaths {
   }
 
   bool empty() const {
-    return ObjCHeaderOutputPath.empty() && ModuleOutputPath.empty() &&
-           ModuleDocOutputPath.empty() && DependenciesFilePath.empty() &&
+    return ObjCHeaderOutputPath.empty() && CxxHeaderOutputPath.empty() &&
+           ModuleOutputPath.empty() && ModuleDocOutputPath.empty() &&
+           DependenciesFilePath.empty() &&
            ReferenceDependenciesFilePath.empty() &&
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
            TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
-           ModuleSourceInfoOutputPath.empty() && ABIDescriptorOutputPath.empty() &&
-           ModuleSemanticInfoOutputPath.empty() &&
-           YAMLOptRecordPath.empty() && BitstreamOptRecordPath.empty();
+           ModuleSourceInfoOutputPath.empty() &&
+           ABIDescriptorOutputPath.empty() &&
+           ModuleSemanticInfoOutputPath.empty() && YAMLOptRecordPath.empty() &&
+           BitstreamOptRecordPath.empty();
   }
 };
 } // namespace swift

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -388,6 +388,7 @@ public:
   std::string getOutputFilenameForAtMostOnePrimary() const;
   std::string getMainInputFilenameForDebugInfoForAtMostOnePrimary() const;
   std::string getObjCHeaderOutputPathForAtMostOnePrimary() const;
+  std::string getCxxHeaderOutputPathForAtMostOnePrimary() const;
   std::string getModuleOutputPathForAtMostOnePrimary() const;
   std::string
   getReferenceDependenciesFilePathForPrimary(StringRef filename) const;

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -250,6 +250,7 @@ public:
   bool hasDependenciesPath() const;
   bool hasReferenceDependenciesPath() const;
   bool hasObjCHeaderOutputPath() const;
+  bool hasCxxHeaderOutputPath() const;
   bool hasLoadedModuleTracePath() const;
   bool hasModuleOutputPath() const;
   bool hasModuleDocOutputPath() const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -450,7 +450,7 @@ public:
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);
-  static bool canActionEmitObjCHeader(ActionType);
+  static bool canActionEmitClangHeader(ActionType);
   static bool canActionEmitLoadedModuleTrace(ActionType);
   static bool canActionEmitModule(ActionType);
   static bool canActionEmitModuleDoc(ActionType);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -532,6 +532,14 @@ def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
          SupplementaryOutput]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
+def emit_cxx_header : Flag<["-"], "emit-cxx-header">,
+  Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
+  HelpText<"Emit a C++ header file">;
+def emit_cxx_header_path : Separate<["-"], "emit-cxx-header-path">,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
+  MetaVarName<"<path>">, HelpText<"Emit a C++ header file to <path>">;
+
 def static : Flag<["-"], "static">,
   Flags<[FrontendOption, ModuleInterfaceOption, NoInteractiveOption]>,
   HelpText<"Make this module statically linkable and make the output of -emit-library a static library.">;

--- a/include/swift/PrintAsObjC/PrintAsObjC.h
+++ b/include/swift/PrintAsObjC/PrintAsObjC.h
@@ -26,6 +26,11 @@ namespace swift {
   ///
   /// Returns true on error.
   bool printAsObjC(raw_ostream &out, ModuleDecl *M, StringRef bridgingHeader);
+
+  /// Print the C++-compatible declarations in a module as a Clang header.
+  ///
+  /// Returns true on error.
+  bool printAsCXX(raw_ostream &os, ModuleDecl *M);
 }
 
 #endif

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -623,9 +623,14 @@ bool ArgsToFrontendOptionsConverter::checkUnusedSupplementaryOutputPaths()
                    diag::error_mode_cannot_emit_reference_dependencies);
     return true;
   }
-  if (!FrontendOptions::canActionEmitObjCHeader(Opts.RequestedAction) &&
+  if (!FrontendOptions::canActionEmitClangHeader(Opts.RequestedAction) &&
       Opts.InputsAndOutputs.hasObjCHeaderOutputPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_header);
+    return true;
+  }
+  if (!FrontendOptions::canActionEmitClangHeader(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasCxxHeaderOutputPath()) {
+    Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_cxx_header);
     return true;
   }
   if (!FrontendOptions::canActionEmitLoadedModuleTrace(Opts.RequestedAction) &&

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -310,6 +310,8 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
 
   auto objCHeaderOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_objc_header_path);
+  auto cxxHeaderOutput =
+      getSupplementaryFilenamesFromArguments(options::OPT_emit_cxx_header_path);
   auto moduleOutput =
       getSupplementaryFilenamesFromArguments(options::OPT_emit_module_path);
   auto moduleDocOutput =
@@ -339,8 +341,8 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_module_semantic_info_path);
   auto optRecordOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_save_optimization_record_path);
-  if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
-      !dependenciesFile || !referenceDependenciesFile ||
+  if (!objCHeaderOutput || !cxxHeaderOutput || !moduleOutput ||
+      !moduleDocOutput || !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput ||
       !moduleSourceInfoOutput || !moduleSummaryOutput || !abiDescriptorOutput ||
@@ -354,6 +356,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
   for (unsigned i = 0; i < N; ++i) {
     SupplementaryOutputPaths sop;
     sop.ObjCHeaderOutputPath = (*objCHeaderOutput)[i];
+    sop.CxxHeaderOutputPath = (*cxxHeaderOutput)[i];
     sop.ModuleOutputPath = (*moduleOutput)[i];
     sop.ModuleDocOutputPath = (*moduleDocOutput)[i];
     sop.DependenciesFilePath = (*dependenciesFile)[i];
@@ -439,6 +442,11 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       file_types::TY_ObjCHeader, "",
       defaultSupplementaryOutputPathExcludingExtension);
 
+  auto cxxHeaderOutputPath = determineSupplementaryOutputFilename(
+      OPT_emit_cxx_header, pathsFromArguments.CxxHeaderOutputPath,
+      file_types::TY_ObjCHeader, "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
   auto loadedModuleTracePath = determineSupplementaryOutputFilename(
       OPT_emit_loaded_module_trace, pathsFromArguments.LoadedModuleTracePath,
       file_types::TY_ModuleTrace, "",
@@ -493,6 +501,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
 
   SupplementaryOutputPaths sop;
   sop.ObjCHeaderOutputPath = objcHeaderOutputPath;
+  sop.CxxHeaderOutputPath = cxxHeaderOutputPath;
   sop.ModuleOutputPath = moduleOutputPath;
   sop.ModuleDocOutputPath = moduleDocOutputPath;
   sop.DependenciesFilePath = dependenciesFilePath;
@@ -578,6 +587,7 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
     return paths;
   const std::pair<file_types::ID, std::string &> typesAndStrings[] = {
       {file_types::TY_ObjCHeader, paths.ObjCHeaderOutputPath},
+      {file_types::TY_ObjCHeader, paths.CxxHeaderOutputPath},
       {file_types::TY_SwiftModuleFile, paths.ModuleOutputPath},
       {file_types::TY_SwiftModuleDocFile, paths.ModuleDocOutputPath},
       {file_types::TY_SwiftSourceInfoFile, paths.ModuleSourceInfoOutputPath},
@@ -606,17 +616,16 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
 Optional<std::vector<SupplementaryOutputPaths>>
 SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
   if (Arg *A = Args.getLastArg(
-        options::OPT_emit_objc_header_path,
-        options::OPT_emit_module_path,
-        options::OPT_emit_module_doc_path,
-        options::OPT_emit_dependencies_path,
-        options::OPT_emit_reference_dependencies_path,
-        options::OPT_serialize_diagnostics_path,
-        options::OPT_emit_loaded_module_trace_path,
-        options::OPT_emit_module_interface_path,
-        options::OPT_emit_private_module_interface_path,
-        options::OPT_emit_module_source_info_path,
-        options::OPT_emit_tbd_path)) {
+          options::OPT_emit_objc_header_path, options::OPT_emit_cxx_header_path,
+          options::OPT_emit_module_path, options::OPT_emit_module_doc_path,
+          options::OPT_emit_dependencies_path,
+          options::OPT_emit_reference_dependencies_path,
+          options::OPT_serialize_diagnostics_path,
+          options::OPT_emit_loaded_module_trace_path,
+          options::OPT_emit_module_interface_path,
+          options::OPT_emit_private_module_interface_path,
+          options::OPT_emit_module_source_info_path,
+          options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -96,6 +96,11 @@ CompilerInvocation::getObjCHeaderOutputPathForAtMostOnePrimary() const {
   return getPrimarySpecificPathsForAtMostOnePrimary()
       .SupplementaryOutputs.ObjCHeaderOutputPath;
 }
+std::string
+CompilerInvocation::getCxxHeaderOutputPathForAtMostOnePrimary() const {
+  return getPrimarySpecificPathsForAtMostOnePrimary()
+      .SupplementaryOutputs.CxxHeaderOutputPath;
+}
 std::string CompilerInvocation::getModuleOutputPathForAtMostOnePrimary() const {
   return getPrimarySpecificPathsForAtMostOnePrimary()
       .SupplementaryOutputs.ModuleOutputPath;

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -467,6 +467,12 @@ bool FrontendInputsAndOutputs::hasObjCHeaderOutputPath() const {
         return outs.ObjCHeaderOutputPath;
       });
 }
+bool FrontendInputsAndOutputs::hasCxxHeaderOutputPath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+        return outs.CxxHeaderOutputPath;
+      });
+}
 bool FrontendInputsAndOutputs::hasLoadedModuleTracePath() const {
   return hasSupplementaryOutputPath(
       [](const SupplementaryOutputPaths &outs) -> const std::string & {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -231,12 +231,11 @@ void FrontendOptions::forAllOutputPaths(
   }
   const SupplementaryOutputPaths &outs =
       input.getPrimarySpecificPaths().SupplementaryOutputs;
-  const std::string *outputs[] = {&outs.ModuleOutputPath,
-                                  &outs.ModuleDocOutputPath,
-                                  &outs.ModuleInterfaceOutputPath,
-                                  &outs.PrivateModuleInterfaceOutputPath,
-                                  &outs.ObjCHeaderOutputPath,
-                                  &outs.ModuleSourceInfoOutputPath};
+  const std::string *outputs[] = {
+      &outs.ModuleOutputPath,          &outs.ModuleDocOutputPath,
+      &outs.ModuleInterfaceOutputPath, &outs.PrivateModuleInterfaceOutputPath,
+      &outs.ObjCHeaderOutputPath,      &outs.CxxHeaderOutputPath,
+      &outs.ModuleSourceInfoOutputPath};
   for (const std::string *next : outputs) {
     if (!next->empty())
       fn(*next);
@@ -449,7 +448,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   llvm_unreachable("unhandled action");
 }
 
-bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
+bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::Parse:

--- a/test/Frontend/supplementary-output-support.swift
+++ b/test/Frontend/supplementary-output-support.swift
@@ -24,6 +24,13 @@
 // RUN: not %target-swift-frontend -resolve-imports -emit-objc-header %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_OBJC_HEADER %s
 // RESOLVE_IMPORTS_NO_OBJC_HEADER: error: this mode does not support emitting Objective-C headers{{$}}
 
+// RUN: not %target-swift-frontend -parse -emit-cxx-header %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_CXX_HEADER %s
+// PARSE_NO_CXX_HEADER: error: this mode does not support emitting C++ headers{{$}}
+// RUN: not %target-swift-frontend -dump-ast -emit-cxx-header %s 2>&1 | %FileCheck -check-prefix=DUMP_NO_CXX_HEADER %s
+// DUMP_NO_CXX_HEADER: error: this mode does not support emitting C++ headers{{$}}
+// RUN: not %target-swift-frontend -resolve-imports -emit-cxx-header %s 2>&1 | %FileCheck -check-prefix=RESOLVE_IMPORTS_NO_CXX_HEADER %s
+// RESOLVE_IMPORTS_NO_CXX_HEADER: error: this mode does not support emitting C++ headers{{$}}
+
 // RUN: not %target-swift-frontend -parse -emit-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=PARSE_NO_INTERFACE %s
 // PARSE_NO_INTERFACE: error: this mode does not support emitting module interface files{{$}}
 // RUN: not %target-swift-frontend -emit-silgen -emit-module-interface-path %t %s 2>&1 | %FileCheck -check-prefix=SILGEN_NO_INTERFACE %s

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-cxx-header-path %t/empty.h
+// RUN: %FileCheck %s < %t/empty.h
+
+// CHECK-NOT: @import Swift;
+
+// CHECK-LABEL: #ifndef EMPTY_SWIFT_H
+// CHECK-NEXT:  #define EMPTY_SWIFT_H
+
+// CHECK-LABEL: #if !defined(__has_include)
+// CHECK-NEXT: # define __has_include(x) 0
+// CHECK-NEXT: #endif
+
+// CHECK-LABEL: #if !defined(__has_attribute)
+// CHECK-NEXT: # define __has_attribute(x) 0
+// CHECK-NEXT: #endif
+
+// CHECK-LABEL: #if !defined(__has_feature)
+// CHECK-NEXT: # define __has_feature(x) 0
+// CHECK-NEXT: #endif
+
+// CHECK-LABEL: #if !defined(__has_warning)
+// CHECK-NEXT: # define __has_warning(x) 0
+// CHECK-NEXT: #endif
+
+// CHECK-LABEL: #include <Foundation/Foundation.h>
+// CHECK: #include <stdint.h>
+// CHECK: #include <stddef.h>
+// CHECK: #include <stdbool.h>
+
+// CHECK-LABEL: !defined(SWIFT_TYPEDEFS)
+// CHECK-NEXT:  # define SWIFT_TYPEDEFS 1
+// CHECK:       typedef float swift_float2  __attribute__((__ext_vector_type__(2)));
+// CHECK-NEXT:  typedef float swift_float3  __attribute__((__ext_vector_type__(3)));
+// CHECK-NEXT:  typedef float swift_float4  __attribute__((__ext_vector_type__(4)));
+// CHECK-NEXT:  typedef double swift_double2  __attribute__((__ext_vector_type__(2)));
+// CHECK-NEXT:  typedef double swift_double3  __attribute__((__ext_vector_type__(3)));
+// CHECK-NEXT:  typedef double swift_double4  __attribute__((__ext_vector_type__(4)));
+// CHECK-NEXT:  typedef int swift_int2  __attribute__((__ext_vector_type__(2)));
+// CHECK-NEXT:  typedef int swift_int3  __attribute__((__ext_vector_type__(3)));
+// CHECK-NEXT:  typedef int swift_int4  __attribute__((__ext_vector_type__(4)));
+// CHECK-NEXT:  typedef unsigned int swift_uint2  __attribute__((__ext_vector_type__(2)));
+// CHECK-NEXT:  typedef unsigned int swift_uint3  __attribute__((__ext_vector_type__(3)));
+// CHECK-NEXT:  typedef unsigned int swift_uint4  __attribute__((__ext_vector_type__(4)));
+
+// CHECK: # define SWIFT_METATYPE(X)
+// CHECK: # define SWIFT_CLASS
+// CHECK: # define SWIFT_CLASS_NAMED
+// CHECK: # define SWIFT_PROTOCOL
+// CHECK: # define SWIFT_PROTOCOL_NAMED
+// CHECK: # define SWIFT_EXTENSION(M)
+// CHECK: # define OBJC_DESIGNATED_INITIALIZER
+
+// CHECK-NOT: @


### PR DESCRIPTION
This is an initial patch to start adding support for emitting C++ header interfaces for a module. It adds two option flags - `-emit-cxx-header` and `-emit-cxx-header-path`, similar to what exists for Objective-C headers. The added flag calls into a new `printAsCxx` function, which doesn't print out the module contents yet, but will do so in the future. The `PrintAsObjC` library will be renamed to `PrintAsClang` in a follow-up PR.