### PR TITLE
[SIL] Added lexical flag to move_value.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5280,7 +5280,7 @@ move_value
 
 ::
 
-   sil-instruction ::= 'move_value' sil-operand
+   sil-instruction ::= 'move_value' '[lexical]'? sil-operand
 
    %1 = move_value %0 : $@_moveOnly A
 
@@ -5302,6 +5302,9 @@ associated with a let binding).
 NOTE: This instruction is used in an experimental feature called 'move only
 values'. A move_value instruction is an instruction that introduces (or injects)
 a type `T` into the move only value space.
+
+The ``lexical`` attribute specifies that the value corresponds to a local
+variable in the Swift source.
 
 release_value
 `````````````

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1263,12 +1263,13 @@ public:
                                                      operand, poisonRefs));
   }
 
-  MoveValueInst *createMoveValue(SILLocation loc, SILValue operand) {
+  MoveValueInst *createMoveValue(SILLocation loc, SILValue operand,
+                                 bool isLexical = false) {
     assert(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitMoveValueOperation");
-    return insert(new (getModule())
-                  MoveValueInst(getSILDebugLocation(loc), operand));
+    return insert(new (getModule()) MoveValueInst(getSILDebugLocation(loc),
+                                                  operand, isLexical));
   }
 
   MarkUnresolvedMoveAddrInst *createMarkUnresolvedMoveAddr(SILLocation loc,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1784,7 +1784,8 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitMoveValueInst(MoveValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   auto *MVI = getBuilder().createMoveValue(getOpLocation(Inst->getLoc()),
-                                           getOpValue(Inst->getOperand()));
+                                           getOpValue(Inst->getOperand()),
+                                           Inst->isLexical());
   MVI->setAllowsDiagnostics(Inst->getAllowDiagnostics());
   recordClonedInstruction(Inst, MVI);
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7457,13 +7457,17 @@ class MoveValueInst
   /// set to false, we shouldn't emit such a diagnostic. This is a short term
   /// addition until we get MoveOnly wrapper types into the SIL type system.
   bool allowDiagnostics = false;
+  bool lexical = false;
 
-  MoveValueInst(SILDebugLocation DebugLoc, SILValue operand)
-      : UnaryInstructionBase(DebugLoc, operand, operand->getType()) {}
+  MoveValueInst(SILDebugLocation DebugLoc, SILValue operand, bool isLexical)
+      : UnaryInstructionBase(DebugLoc, operand, operand->getType()),
+        lexical(isLexical) {}
 
 public:
   bool getAllowDiagnostics() const { return allowDiagnostics; }
   void setAllowsDiagnostics(bool newValue) { allowDiagnostics = newValue; }
+
+  bool isLexical() const { return lexical; };
 };
 
 /// Equivalent to a copy_addr to [init] except that it is used for diagnostics

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1896,6 +1896,8 @@ public:
   void visitMoveValueInst(MoveValueInst *I) {
     if (I->getAllowDiagnostics())
       *this << "[allows_diagnostics] ";
+    if (I->isLexical())
+      *this << "[lexical] ";
     *this << getIDAndType(I->getOperand());
   }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1984,10 +1984,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
   case SILInstructionKind::MoveValueInst: {
     auto Ty = MF->getType(TyID);
-    auto AllowsDiagnostics = bool(Attr);
+    bool AllowsDiagnostics = Attr & 0x1;
+    bool IsLexical = (Attr >> 1) & 0x1;
     auto *MVI = Builder.createMoveValue(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        IsLexical);
     MVI->setAllowsDiagnostics(AllowsDiagnostics);
     ResultInst = MVI;
     break;

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1463,7 +1463,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     } else if (auto *BBI = dyn_cast<BeginBorrowInst>(&SI)) {
       Attr = BBI->isLexical();
     } else if (auto *MVI = dyn_cast<MoveValueInst>(&SI)) {
-      Attr = MVI->getAllowDiagnostics();
+      Attr = unsigned(MVI->getAllowDiagnostics()) |
+             (unsigned(MVI->isLexical() << 1));
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -45,14 +45,22 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0(%0 :
-// CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
-// CHECK-NEXT: return
+// CHECK: bb0([[REGISTER_0:%[^,]+]] :
+// CHECK-NEXT: [[REGISTER_1:%[^,]+]] = move_value [[REGISTER_0]]
+// CHECK-NEXT: [[REGISTER_2:%[^,]+]] = move_value [allows_diagnostics] [[REGISTER_1]]
+// CHECK-NEXT: [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
+// CHECK-NEXT: [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
+// CHECK-NEXT: [[REGISTER_5:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_4]]
+// CHECK-NEXT: return [[REGISTER_5]]
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing'
 sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = move_value %0 : $Builtin.NativeObject
-  return %1 : $Builtin.NativeObject
+  %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
+  %3 = move_value [lexical] %2 : $Builtin.NativeObject
+  %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
+  %5 = move_value [lexical] [allows_diagnostics] %4 : $Builtin.NativeObject
+  return %5 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -69,16 +69,22 @@ bb0:
 }
 
 // CHECK-LABEL: sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0(%0 :
-// CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
-// CHECK-NEXT: %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
-// CHECK-NEXT: return
+// CHECK: bb0([[REGISTER_0:%[^,]+]] :
+// CHECK-NEXT: [[REGISTER_1:%[^,]+]] = move_value [[REGISTER_0]]
+// CHECK-NEXT: [[REGISTER_2:%[^,]+]] = move_value [allows_diagnostics] [[REGISTER_1]]
+// CHECK-NEXT: [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
+// CHECK-NEXT: [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
+// CHECK-NEXT: [[REGISTER_5:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_4]]
+// CHECK-NEXT: return [[REGISTER_5]]
 // CHECK-NEXT: } // end sil function 'test_movevalue_parsing'
 sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = move_value %0 : $Builtin.NativeObject
   %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
-  return %2 : $Builtin.NativeObject
+  %3 = move_value [lexical] %2 : $Builtin.NativeObject
+  %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
+  %5 = move_value [lexical] [allows_diagnostics] %4 : $Builtin.NativeObject
+  return %5 : $Builtin.NativeObject
 }
 
 // CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -70,3 +70,27 @@ sil [ossa] @caller_alloc_stack_lexical : $@convention(thin) () -> () {
   %res = apply %callee_alloc_stack() : $@convention(thin) () -> ()
   return %res : $()
 }
+
+sil [ossa] @callee_move_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+entry(%0 : @owned $Builtin.NativeObject):
+  %1 = move_value %0 : $Builtin.NativeObject
+  %2 = move_value [allows_diagnostics] %1 : $Builtin.NativeObject
+  %3 = move_value [lexical] %2 : $Builtin.NativeObject
+  %4 = move_value [allows_diagnostics] [lexical] %3 : $Builtin.NativeObject
+  return %4 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @caller_move_value {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REGISTER_0:%[^,]+]] :
+// CHECK:       [[REGISTER_1:%[^,]+]] = move_value [[REGISTER_0]]
+// CHECK:       [[REGISTER_2:%[^,]+]] = move_value [allows_diagnostics] [[REGISTER_1]]
+// CHECK:       [[REGISTER_3:%[^,]+]] = move_value [lexical] [[REGISTER_2]]
+// CHECK:       [[REGISTER_4:%[^,]+]] = move_value [allows_diagnostics] [lexical] [[REGISTER_3]]
+// CHECK:       return [[REGISTER_4]]
+// CHECK-LABEL: } // end sil function 'caller_move_value'
+sil [ossa] @caller_move_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+entry(%0 : @owned $Builtin.NativeObject):
+  %callee_move_value = function_ref @callee_move_value : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject
+  %res = apply %callee_move_value(%0) : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject
+  return %res : $Builtin.NativeObject
+}


### PR DESCRIPTION
The new flag will be used to track whether a move_value corresponds to a source-level lexical scope. Here, the flag is just added to the instruction and represented in textual and serialized SIL.
