### PR TITLE
Make Objective-C interoperability configurable in the runtime

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -168,6 +168,8 @@ public:
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;
+  using TargetClassMetadata =
+      typename Runtime::template TargetClassMetadata<Runtime>;
 
 private:
   /// The maximum number of bytes to read when reading metadata. Anything larger
@@ -502,7 +504,7 @@ public:
     if (!meta || meta->getKind() != MetadataKind::Class)
       return StoredPointer();
 
-    auto classMeta = cast<TargetClassMetadata<Runtime>>(meta);
+    auto classMeta = cast<TargetClassMetadata>(meta);
     return stripSignedPointer(classMeta->Superclass);
   }
 
@@ -514,39 +516,39 @@ public:
     if (!meta || meta->getKind() != MetadataKind::Class)
       return None;
 
-#if SWIFT_OBJC_INTEROP
-    // The following algorithm only works on the non-fragile Apple runtime.
+    if (Runtime::ObjCInterop) {
+      // The following algorithm only works on the non-fragile Apple runtime.
 
-    // Grab the RO-data pointer.  This part is not ABI.
-    StoredPointer roDataPtr = readObjCRODataPtr(MetadataAddress);
-    if (!roDataPtr)
-      return None;
+      // Grab the RO-data pointer.  This part is not ABI.
+      StoredPointer roDataPtr = readObjCRODataPtr(MetadataAddress);
+      if (!roDataPtr)
+        return None;
 
-    // Get the address of the InstanceStart field.
-    auto address = roDataPtr + sizeof(uint32_t) * 1;
+      // Get the address of the InstanceStart field.
+      auto address = roDataPtr + sizeof(uint32_t) * 1;
 
-    unsigned start;
-    if (!Reader->readInteger(RemoteAddress(address), &start))
-      return None;
+      unsigned start;
+      if (!Reader->readInteger(RemoteAddress(address), &start))
+        return None;
 
-    return start;
-#else
-    // All swift class instances start with an isa pointer,
-    // followed by the retain counts (which are the size of a long long).
-    size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
-    size_t start = isaAndRetainCountSize;
+      return start;
+    } else {
+      // All swift class instances start with an isa pointer,
+      // followed by the retain counts (which are the size of a long long).
+      size_t isaAndRetainCountSize = sizeof(StoredSize) + sizeof(long long);
+      size_t start = isaAndRetainCountSize;
 
-    auto classMeta = cast<TargetClassMetadata<Runtime>>(meta);
-    while (stripSignedPointer(classMeta->Superclass)) {
-      classMeta = cast<TargetClassMetadata<Runtime>>(
-          readMetadata(stripSignedPointer(classMeta->Superclass)));
+      auto classMeta = cast<TargetClassMetadata>(meta);
+      while (stripSignedPointer(classMeta->Superclass)) {
+        classMeta = cast<TargetClassMetadata>(
+            readMetadata(stripSignedPointer(classMeta->Superclass)));
 
-      // Subtract the size contribution of the isa and retain counts from 
-      // the super class.
-      start += classMeta->InstanceSize - isaAndRetainCountSize;
+        // Subtract the size contribution of the isa and retain counts from
+        // the super class.
+        start += classMeta->InstanceSize - isaAndRetainCountSize;
+      }
+      return start;
     }
-    return start;
-#endif
   }
 
   /// Given a pointer to the metadata, attempt to read the value
@@ -588,7 +590,7 @@ public:
     if (!Meta)
       return None;
 
-    if (auto ClassMeta = dyn_cast<TargetClassMetadata<Runtime>>(Meta)) {
+    if (auto ClassMeta = dyn_cast<TargetClassMetadata>(Meta)) {
       if (ClassMeta->isPureObjC()) {
         // If we can determine the Objective-C class name, this is probably an
         // error existential with NSError-compatible layout.
@@ -719,34 +721,36 @@ public:
       Demangler &dem,
       Resolver resolver) {
 #if SWIFT_OBJC_INTEROP
-    // Check whether we have an Objective-C protocol.
-    if (ProtocolAddress.isObjC()) {
-      auto Name = readObjCProtocolName(ProtocolAddress.getObjCProtocol());
-      StringRef NameStr(Name);
+    if (Runtime::ObjCInterop) {
+      // Check whether we have an Objective-C protocol.
+      if (ProtocolAddress.isObjC()) {
+        auto Name = readObjCProtocolName(ProtocolAddress.getObjCProtocol());
+        StringRef NameStr(Name);
 
-      // If this is a Swift-defined protocol, demangle it.
-      if (NameStr.startswith("_TtP")) {
-        auto Demangled = dem.demangleSymbol(NameStr);
-        if (!Demangled)
-          return resolver.failure();
-
-        // FIXME: This appears in _swift_buildDemanglingForMetadata().
-        while (Demangled->getKind() == Node::Kind::Global ||
-               Demangled->getKind() == Node::Kind::TypeMangling ||
-               Demangled->getKind() == Node::Kind::Type ||
-               Demangled->getKind() == Node::Kind::ProtocolList ||
-               Demangled->getKind() == Node::Kind::TypeList ||
-               Demangled->getKind() == Node::Kind::Type) {
-          if (Demangled->getNumChildren() != 1)
+        // If this is a Swift-defined protocol, demangle it.
+        if (NameStr.startswith("_TtP")) {
+          auto Demangled = dem.demangleSymbol(NameStr);
+          if (!Demangled)
             return resolver.failure();
-          Demangled = Demangled->getFirstChild();
+
+          // FIXME: This appears in _swift_buildDemanglingForMetadata().
+          while (Demangled->getKind() == Node::Kind::Global ||
+                 Demangled->getKind() == Node::Kind::TypeMangling ||
+                 Demangled->getKind() == Node::Kind::Type ||
+                 Demangled->getKind() == Node::Kind::ProtocolList ||
+                 Demangled->getKind() == Node::Kind::TypeList ||
+                 Demangled->getKind() == Node::Kind::Type) {
+            if (Demangled->getNumChildren() != 1)
+              return resolver.failure();
+            Demangled = Demangled->getFirstChild();
+          }
+
+          return resolver.swiftProtocol(Demangled);
         }
 
-        return resolver.swiftProtocol(Demangled);
+        // Otherwise, this is an imported protocol.
+        return resolver.objcProtocol(NameStr);
       }
-
-      // Otherwise, this is an imported protocol.
-      return resolver.objcProtocol(NameStr);
     }
 #endif
 
@@ -1419,7 +1423,7 @@ public:
           return readMetadataBoundsOfSuperclass(superclass);
         },
         [&](MetadataRef metadata) -> llvm::Optional<ClassMetadataBounds> {
-          auto cls = dyn_cast<TargetClassMetadata<Runtime>>(metadata);
+          auto cls = dyn_cast<TargetClassMetadata>(metadata);
           if (!cls)
             return None;
 
@@ -1659,6 +1663,10 @@ protected:
     return Reader->readString(RemoteAddress(namePtr), className);
   }
 
+  template <typename T>
+  using TargetClassMetadataT =
+      typename Runtime::template TargetClassMetadata<T>;
+
   MetadataRef readMetadata(StoredPointer address) {
     auto cached = MetadataCache.find(address);
     if (cached != MetadataCache.end())
@@ -1672,7 +1680,9 @@ protected:
 
     switch (getEnumeratedMetadataKind(KindValue)) {
       case MetadataKind::Class:
-        return _readMetadata<TargetClassMetadata>(address);
+
+        return _readMetadata<TargetClassMetadataT>(address);
+
       case MetadataKind::Enum:
         return _readMetadata<TargetEnumMetadata>(address);
       case MetadataKind::ErrorObject:
@@ -1779,7 +1789,7 @@ protected:
                                      bool skipArtificialSubclasses = false) {
     switch (metadata->getKind()) {
     case MetadataKind::Class: {
-      auto classMeta = cast<TargetClassMetadata<Runtime>>(metadata);
+      auto classMeta = cast<TargetClassMetadata>(metadata);
       while (true) {
         if (!classMeta->isTypeMetadata())
           return 0;
@@ -1801,7 +1811,7 @@ protected:
         if (!superMeta)
           return 0;
 
-        auto superclassMeta = dyn_cast<TargetClassMetadata<Runtime>>(superMeta);
+        auto superclassMeta = dyn_cast<TargetClassMetadata>(superMeta);
         if (!superclassMeta)
           return 0;
 
@@ -2692,7 +2702,7 @@ private:
 
   BuiltType readNominalTypeFromClassMetadata(MetadataRef origMetadata,
                                        bool skipArtificialSubclasses = false) {
-    auto classMeta = cast<TargetClassMetadata<Runtime>>(origMetadata);
+    auto classMeta = cast<TargetClassMetadata>(origMetadata);
     if (classMeta->isTypeMetadata())
       return readNominalTypeFromMetadata(origMetadata, skipArtificialSubclasses);
 
@@ -2715,6 +2725,10 @@ private:
     return BuiltObjCClass;
   }
 
+  using TargetClassMetadataObjCInterop =
+      swift::TargetClassMetadata<Runtime,
+                                 TargetAnyClassMetadataObjCInterop<Runtime>>;
+
   /// Given that the remote process is running the non-fragile Apple runtime,
   /// grab the ro-data from a class pointer.
   StoredPointer readObjCRODataPtr(StoredPointer classAddress) {
@@ -2723,9 +2737,10 @@ private:
 
 #if SWIFT_OBJC_INTEROP
     StoredPointer dataPtr;
-    if (!Reader->readInteger(RemoteAddress(classAddress +
-                               TargetClassMetadata<Runtime>::offsetToData()),
-                             &dataPtr))
+    if (!Reader->readInteger(
+            RemoteAddress(classAddress +
+                          TargetClassMetadataObjCInterop::offsetToData()),
+            &dataPtr))
       return StoredPointer();
 
     // Apply the data-pointer mask.

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -649,13 +649,24 @@ static RemoteASTContextImpl *createImpl(ASTContext &ctx,
                                       std::shared_ptr<MemoryReader> &&reader) {
   auto &target = ctx.LangOpts.Target;
   assert(target.isArch32Bit() || target.isArch64Bit());
+  bool objcInterop = ctx.LangOpts.EnableObjCInterop;
 
   if (target.isArch32Bit()) {
-    using Target = External<RuntimeTarget<4>>;
-    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    if (objcInterop) {
+      using Target = External<WithObjCInterop<RuntimeTarget<4>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    } else {
+      using Target = External<NoObjCInterop<RuntimeTarget<4>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    }
   } else {
-    using Target = External<RuntimeTarget<8>>;
-    return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    if (objcInterop) {
+      using Target = External<WithObjCInterop<RuntimeTarget<8>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    } else {
+      using Target = External<NoObjCInterop<RuntimeTarget<8>>>;
+      return new RemoteASTContextConcreteImpl<Target>(std::move(reader), ctx);
+    }
   }
 }
 

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -36,7 +36,11 @@ using namespace swift;
 using namespace swift::reflection;
 using namespace swift::remote;
 
-using Runtime = External<RuntimeTarget<sizeof(uintptr_t)>>;
+#if SWIFT_OBJC_INTEROP
+using Runtime = External<WithObjCInterop<RuntimeTarget<sizeof(uintptr_t)>>>;
+#else
+using Runtime = External<NoObjCInterop<RuntimeTarget<sizeof(uintptr_t)>>>;
+#endif
 using NativeReflectionContext = swift::reflection::ReflectionContext<Runtime>;
 
 struct SwiftReflectionContext {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -487,19 +487,21 @@ public:
     return c;
 #endif
   }
-  
-  template<> inline const ClassMetadata *
-  Metadata::getClassObject() const {
+
+  template <>
+  inline const ClassMetadata *Metadata::getClassObject() const {
     switch (getKind()) {
     case MetadataKind::Class: {
       // Native Swift class metadata is also the class object.
       return static_cast<const ClassMetadata *>(this);
     }
+#if SWIFT_OBJC_INTEROP
     case MetadataKind::ObjCClassWrapper: {
       // Objective-C class objects are referenced by their Swift metadata wrapper.
       auto wrapper = static_cast<const ObjCClassWrapperMetadata *>(this);
       return wrapper->Class;
     }
+#endif
     // Other kinds of types don't have class objects.
     default:
       return nullptr;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1111,6 +1111,7 @@ static bool isSubclass(const Metadata *subclass, const Metadata *superclass) {
     }
   }
   const ClassMetadata *swiftSubclass = cast<ClassMetadata>(subclass);
+#if SWIFT_OBJC_INTEROP
   if (auto *objcSuperclass = dyn_cast<ObjCClassWrapperMetadata>(superclass)) {
     // Walk up swiftSubclass's ancestors until we get to an ObjC class, then
     // kick over to swift_dynamicCastMetatype.
@@ -1123,6 +1124,7 @@ static bool isSubclass(const Metadata *subclass, const Metadata *superclass) {
         });
     return false;
   }
+#endif
   if (isa<ForeignClassMetadata>(superclass)) {
     // superclass is foreign, but subclass is not (if it were, the above
     // !isa<ClassMetadata> condition would have been entered).  Since it is not

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -611,14 +611,25 @@ static ReflectionContextHolder makeReflectionContextForObjectFiles(
   uint8_t pointerSize;
   Reader->queryDataLayout(DataLayoutQueryType::DLQ_GetPointerSize,
                           nullptr, &pointerSize);
-  
   switch (pointerSize) {
   case 4:
-    return makeReflectionContextForMetadataReader<External<RuntimeTarget<4>>>
-                                                            (std::move(Reader));
+    return makeReflectionContextForMetadataReader<
+    // FIXME: This could be configurable.
+#if SWIFT_OBJC_INTEROP
+        External<WithObjCInterop<RuntimeTarget<4>>>
+#else
+        External<NoObjCInterop<RuntimeTarget<4>>>
+#endif
+        >(std::move(Reader));
   case 8:
-    return makeReflectionContextForMetadataReader<External<RuntimeTarget<8>>>
-                                                            (std::move(Reader));
+    return makeReflectionContextForMetadataReader<
+    // FIXME: This could be configurable.
+#if SWIFT_OBJC_INTEROP
+        External<WithObjCInterop<RuntimeTarget<8>>>
+#else
+        External<NoObjCInterop<RuntimeTarget<8>>>
+#endif
+        >(std::move(Reader));
   default:
     fputs("unsupported word size in object file\n", stderr);
     abort();


### PR DESCRIPTION
In order to be able to debug, for example, a Linux process from a macOS host, we
need to be able to initialize a ReflectionContext without Objective-C
interoperability. This patch turns ObjCInterOp into another template trait, so
it's possible to instantiate a non-ObjC MetadataReader on a system built with
ObjC-interop (but not vice versa).

This patch changes the class hierarchy to

                          TargetMetadata<Runtime>
                                    |
                          TargetHeapMetadata<Runtime>
                                    |
                          TargetAnyClassMetadata<Runtime>
                                   /                \
                                  /               TargetAnyClassMetadataObjCInterop<Runtime>
                                 /                              \
TargetClassMetadata<Runtime, TargetAnyClassMetadata<Runtime>>    \
                                                                  \
                    TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>

TargetAnyClassMetadataObjCInterop inherits from TargetAnyClassMetadata because
most of the implementation is the same. This choice makes TargetClassMetadata a
bit tricky. In this patch I went with templating the parent class.

rdar://87179578

Relands https://github.com/apple/swift/pull/40843