### PR TITLE
[5.5] stdlib: change the console to UTF-8 on start

### DIFF
--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -31,6 +31,15 @@
 
 #include "../SwiftShims/LibcShims.h"
 
+#if defined(_WIN32)
+static void __attribute__((__constructor__))
+_swift_stdlib_configure_console_mode(void) {
+  static UINT uiPrevConsoleCP = GetConsoleOutputCP();
+  atexit([]() { SetConsoleOutputCP(uiPrevConsoleCP); });
+  SetConsoleOutputCP(CP_UTF8);
+}
+#endif
+
 SWIFT_RUNTIME_STDLIB_INTERNAL
 int _swift_stdlib_putchar_unlocked(int c) {
 #if defined(_WIN32)
@@ -42,9 +51,9 @@ int _swift_stdlib_putchar_unlocked(int c) {
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr,
-                                                  __swift_size_t size,
-                                                  __swift_size_t nitems) {
-    return fwrite(ptr, size, nitems, stdout);
+                                           __swift_size_t size,
+                                           __swift_size_t nitems) {
+  return fwrite(ptr, size, nitems, stdout);
 }
 
 SWIFT_RUNTIME_STDLIB_SPI

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -4,7 +4,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: linux
-// XFAIL: windows
 
 struct Boom: Error {}
 

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -8,7 +8,6 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // UNSUPPORTED: linux
-// XFAIL: windows
 
 @available(SwiftStdlib 5.5, *)
 func test_taskGroup_is_asyncSequence() async {

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -7,8 +7,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// XFAIL: OS=windows-msvc
-
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 


### PR DESCRIPTION
This adjusts the Windows console to switch the codepage to UTF-8.  This
is important as the default codepage (CP437) does not allow for UTF-8
output, but expects ASCII.  However, strings in Swift are assumed to be
UTF-8, which means that there is now a conversion mismatch.

Because the console mode persists beyond the duration of the application
as it is state local to the console and not the C runtime, we should
restore the state of the console before termination.  We do this by
registering a termination handler via `atexit`.  This means that an
abnormal termination (e.g. via `fatalError`) will irrevocably alter the
state of the console (interestingly enough, `chcp` will still report the
original console codepage even though the console will internally be set
to UTF-8).

Fixes: SR-13807
(cherry picked from commit 9847cab8d3e5b74101a54bd3871f5002ffaf688c)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
