### PR TITLE
[5.6] LoadableByAddress: Fix code that changes lowered return type of function.

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2362,7 +2362,7 @@ static bool rewriteFunctionReturn(StructLoweringState &pass) {
     }
 
     auto NewTy = SILFunctionType::get(
-        loweredTy->getSubstGenericSignature(),
+        loweredTy->getInvocationGenericSignature(),
         loweredTy->getExtInfo(),
         loweredTy->getCoroutineKind(),
         loweredTy->getCalleeConvention(),

--- a/test/IRGen/loadable_by_address_subst_function_type_return.swift
+++ b/test/IRGen/loadable_by_address_subst_function_type_return.swift
@@ -1,0 +1,18 @@
+// rdar://87792152
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
+
+public struct S1 {
+  var a: Int?
+  var b: Int?
+  var c: Int?
+}
+
+public struct S2 {
+  public func foo() {
+    _ = bar
+  }
+
+  func bar(_: S1) -> some Any {
+    return 0
+  }
+}


### PR DESCRIPTION
Explanation: Functions using opaque return types, with large value types as arguments or returns, could end up causing invalid SIL to be generated, leading to compiler crashes.

Scope: Bug fix

Issue: rdar://87792152

Risk: Low. One-line fix for a specific edge case that was mishandled.

Testing: Swift CI, project from original issue

Reviewed by: @slavapestov 