### PR TITLE
[Frontend] Add feature flag for the index unit path warning removal

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -14,6 +14,9 @@
     },
     {
       "name": "emit-abi-descriptor"
+    },
+    {
+      "name": "no-warn-superfluous-index-unit-path"
     }
   ]
 }


### PR DESCRIPTION
6e683ca823cc987544faa7a2696d3c5e70901432 removed the warning that was
being output when `-index-unit-output-path` was given without
`-index-store-path`. Add a feature flag to mark the compiler as having
removed this warning.

Resolves rdar://86833719.