### PR TITLE
test: disable Interop.Cxx.namespace.free-functions-irgen

### DIFF
--- a/test/Interop/Cxx/namespace/free-functions-irgen.swift
+++ b/test/Interop/Cxx/namespace/free-functions-irgen.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// REQUIRSE: SR15759
 
 import FreeFunctions
 


### PR DESCRIPTION
This test seems to be flakier on 5.5 than on main.  Disable the test on
the branch to get a more stable CI.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
