### PR TITLE
[Draft] Create new test for crash during error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Swift Programming Language
 
 
+
 | | **Architecture** | **main** | **Package** |
 |---|:---:|:---:|:---:|
 | **macOS**        | x86_64 |[![Build Status](https://ci.swift.org/job/oss-swift-incremental-RA-macos/lastCompletedBuild/badge/icon)](https://ci.swift.org/job/oss-swift-incremental-RA-macos)|[![Build Status](https://ci.swift.org/job/oss-swift-package-macos/lastCompletedBuild/badge/icon)](https://ci.swift.org/job/oss-swift-package-macos)|


### PR DESCRIPTION
I'm adding a space to the README because I don't know any other way to create an empty pull request. Please undo it once there are actual commits.

I encountered an "Abort trap: 6" when compiling the following code. In the error message, it showed a warning saying I should use `as?` or `as!`. Shouldn't that be a diagnostic warning, not a compiler crash?

```swift
import Foundation
import _Differentiation
import PythonKit

let constructor = PythonFunction { (params: Array) in
    let selfRef = params[0]
    let arg = params[1]
    selfRef.constructor_arg = arg
    return Python.None
}

let displayMethod = PythonFunction { (params: Array) in
    let arg = params[1]
    Python.print(arg)
    return Python.None
}

let Geeks = Python.type("Geeks", PythonObject(tupleOf: Python.object), [
    "__init__": constructor
] as [PythonObject: PythonObject])
```

PythonKit was updated today with support for lambdas, and I'm working on support for subclassing.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
