### PR TITLE
[RemoteMirror] Bump swift_reflection_libraryVersion to 3.

### DIFF
--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -47,6 +47,8 @@ extern unsigned long long swift_reflection_classIsSwiftMask;
 /// 2 - swift_reflection_iterateAsyncTaskAllocations has been replaced by
 ///     swift_reflection_asyncTaskSlabPointer and
 ///     swift_reflection_asyncTaskSlabAllocations.
+/// 3 - The async task slab size calculation is fixed to account for alignment,
+///     no longer short by 8 bytes.
 SWIFT_REMOTE_MIRROR_LINKAGE extern uint32_t swift_reflection_libraryVersion;
 
 /// Get the metadata version supported by the Remote Mirror library.

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -19,7 +19,7 @@ extern "C" {
 SWIFT_REMOTE_MIRROR_LINKAGE
 unsigned long long swift_reflection_classIsSwiftMask = 2;
 
-SWIFT_REMOTE_MIRROR_LINKAGE uint32_t swift_reflection_libraryVersion = 2;
+SWIFT_REMOTE_MIRROR_LINKAGE uint32_t swift_reflection_libraryVersion = 3;
 }
 
 #include "swift/Demangling/Demangler.h"


### PR DESCRIPTION
This indicates the presence of the fix for the async task slab size calculation in f3493bf1491c5a145b9945e048397fe76f50b8d4.

rdar://87607280