### PR TITLE
ModuleInterface: pass-down paths obfuscators to module interface building commands

### DIFF
--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -35,7 +35,7 @@ namespace swift {
 
 class PathRemapper {
   SmallVector<std::pair<std::string, std::string>, 2> PathMappings;
-
+  friend class PathObfuscator;
 public:
   /// Adds a mapping such that any paths starting with `FromPrefix` have that
   /// portion replaced with `ToPrefix`.
@@ -71,6 +71,11 @@ public:
   }
   std::string recover(StringRef Path) const {
     return recoverer.remapPath(Path);
+  }
+  void forEachPair(llvm::function_ref<void(StringRef, StringRef)> op) const {
+    for (auto pair: obfuscator.PathMappings) {
+      op(pair.first, pair.second);
+    }
   }
 };
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -174,6 +174,11 @@ public:
     SearchPathOpts.setImportSearchPaths(Paths);
   }
 
+  void setSerializedPathObfuscator(const PathObfuscator &obfuscator) {
+    FrontendOpts.serializedPathObfuscator = obfuscator;
+    SearchPathOpts.DeserializedPathRecoverer = obfuscator;
+  }
+
   ArrayRef<std::string> getImportSearchPaths() const {
     return SearchPathOpts.getImportSearchPaths();
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1341,6 +1341,15 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.getLangOptions().DisableAvailabilityChecking = true;
     GenericArgs.push_back("-disable-availability-checking");
   }
+
+  // Pass-down the obfuscators so we can get the serialized search paths properly.
+  genericSubInvocation.setSerializedPathObfuscator(
+    SearchPathOpts.DeserializedPathRecoverer);
+  SearchPathOpts.DeserializedPathRecoverer
+    .forEachPair([&](StringRef lhs, StringRef rhs) {
+      GenericArgs.push_back(ArgSaver.save(llvm::Twine("-serialized-path-obfuscate ")
+        + lhs + "=" + rhs).str());
+  });
 }
 
 bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(

--- a/test/ModuleInterface/obfuscator.swift
+++ b/test/ModuleInterface/obfuscator.swift
@@ -1,0 +1,33 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -module-name Foo -enable-library-evolution %s -DFoo -I %S/Inputs/imports-clang-modules/ -serialized-path-obfuscate %S=%S_obfuscated
+
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Bar.swiftinterface -module-name Bar -enable-library-evolution %s -DBar -I %t -serialized-path-obfuscate %S=%S_obfuscated
+
+// RUN: %target-swift-frontend -typecheck %s -I %t -serialized-path-obfuscate %S=%S_obfuscated -DFooBar
+
+#if Foo
+
+import A
+public func fooFunc() {}
+
+#endif
+
+#if Bar
+
+import Foo
+
+func barFunc() {
+	fooFunc()
+}
+
+#endif
+
+#if FooBar
+
+import Bar
+import A
+
+#endif


### PR DESCRIPTION
While implicitly building .swiftinterface, the interface may import other binary modules.
These binary modules may contain serialized search paths that have been obfuscated. To help
interface building commands recover these search paths, we need to pass down the obfuscators
to the module building commands.

rdar://87840268

