### PR TITLE
Make pseudocode look less like real code.

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -261,7 +261,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// The magnitude of a floating-point value `x` of type `F` can be calculated
   /// by using the following formula, where `**` is exponentiation:
   ///
-  ///     let magnitude = x.significand * F.radix ** x.exponent
+  ///     x.significand * (F.radix ** x.exponent)
   ///
   /// A conforming type may use any integer radix, but values other than 2 (for
   /// binary floating-point types) or 10 (for decimal floating-point types)


### PR DESCRIPTION
There isn't actually an `**` operator in Swift, so making the formula that
includes `**` for exponentiation look like Swift can lead to confusion.

Fixes <rdar://56184186>