### PR TITLE
[addr-move-function] Fix memory safety issue found by ASAN.

### DIFF
--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
 
 // REQUIRES: optimized_stdlib
-// REQUIRES: rdar87618517
-
-// rdar://87618517
-// UNSUPPORTED: asan
 
 import Swift
 

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -1,10 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil -o /dev/null
 
 // REQUIRES: optimized_stdlib
-// REQUIRES: rdar87618517
-
-// rdar://87618517
-// UNSUPPORTED: asan
 
 import Swift
 


### PR DESCRIPTION
The specific issue was I needed to add an '&' here:

```
-  for (auto closureUse : useState.closureUses) {
+  for (auto &closureUse : useState.closureUses) {
```

without this, we eventually grab a pointer into the temporary closureUse instead
of the reference to the actual value in the data structure which we are trying
to actually pass a pointer off to.

I also added some small improvements to the debug printing in the pass that I
think helps understand how the code works here.

rdar://87618517
