### PR TITLE
Rework the storage of generic parameter lists in generic contexts.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1061,7 +1061,21 @@ void *allocateMemoryForDecl(AllocatorTy &allocator, size_t baseSize,
 class alignas(8) _GenericContext {
 // Not really public. See GenericContext.
 public:
-  llvm::PointerIntPair<GenericParamList *, 1, bool> GenericParamsAndBit;
+  /// The state of the generic parameters.
+  enum class GenericParamsState: uint8_t {
+    /// The stored generic parameters represent parsed generic parameters,
+    /// written in the source.
+    Parsed = 0,
+    /// The stored generic parameters represent generic parameters that are
+    /// synthesized by the type checker but were not written in the source.
+    TypeChecked = 1,
+    /// The stored generic parameters represent both the parsed and
+    /// type-checked generic parameters.
+    ParsedAndTypeChecked = 2,
+  };
+
+  llvm::PointerIntPair<GenericParamList *, 2, GenericParamsState>
+      GenericParamsAndState;
 
   /// The trailing where clause.
   ///

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -985,7 +985,7 @@ GenericContext::GenericContext(DeclContextKind Kind, DeclContext *Parent,
     : _GenericContext(), DeclContext(Kind, Parent) {
   if (Params) {
     Params->setDeclContext(this);
-    GenericParamsAndBit.setPointerAndInt(Params, false);
+    GenericParamsAndState.setPointerAndInt(Params, GenericParamsState::Parsed);
   }
 }
 
@@ -1006,9 +1006,14 @@ GenericParamList *GenericContext::getGenericParams() const {
 }
 
 GenericParamList *GenericContext::getParsedGenericParams() const {
-  if (GenericParamsAndBit.getInt())
+  switch (GenericParamsAndState.getInt()) {
+  case GenericParamsState::Parsed:
+  case GenericParamsState::ParsedAndTypeChecked:
+    return GenericParamsAndState.getPointer();
+
+  case GenericParamsState::TypeChecked:
     return nullptr;
-  return GenericParamsAndBit.getPointer();
+  }
 }
 
 bool GenericContext::hasComputedGenericSignature() const {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2597,7 +2597,9 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
       outerParams->setDepth(depth--);
 
     return genericParams;
-  } else if (auto *proto = dyn_cast<ProtocolDecl>(value)) {
+  }
+
+  if (auto *proto = dyn_cast<ProtocolDecl>(value)) {
     // The generic parameter 'Self'.
     auto &ctx = value->getASTContext();
     auto selfId = ctx.Id_Self;
@@ -2615,7 +2617,8 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
                                            SourceLoc());
     return result;
   }
-  return nullptr;
+
+  return value->getParsedGenericParams();
 }
 
 NominalTypeDecl *


### PR DESCRIPTION
In generic contexts, rework the storage for generic parameter lists
to make it more explicit when we have parsed vs. synthesized vs.
parsed-and-type-checked generic parameter lists.
