### PR TITLE
AST: Handle concrete superclass conformance when forming forwarding substitutions

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3976,10 +3976,13 @@ operator()(CanType dependentType, Type conformingReplacementType,
           || conformingReplacementType->is<DependentMemberType>()
           || conformingReplacementType->is<TypeVariableType>())
          && "replacement requires looking up a concrete conformance");
-  // Lookup conformances for opened existential.
-  if (conformingReplacementType->isOpenedExistential()) {
-    return conformedProtocol->getModuleContext()->lookupConformance(
-        conformingReplacementType, conformedProtocol);
+  // A class-constrained archetype might conform to the protocol
+  // concretely.
+  if (auto *archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
+    if (auto superclassType = archetypeType->getSuperclass()) {
+      return conformedProtocol->getModuleContext()->lookupConformance(
+          archetypeType, conformedProtocol);
+    }
   }
   return ProtocolConformanceRef(conformedProtocol);
 }

--- a/test/SILGen/protocol_superclass_cycle.swift
+++ b/test/SILGen/protocol_superclass_cycle.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-silgen %s
+
+// When a protocol has a superclass requirement on 'Self' and the class
+// itself conforms concretely, the forwarding substitution map will have
+// a concrete conformance in it. Make sure this is handled correctly
+// without tripping the SIL verifier.
+
+class C: P {}
+
+protocol P: C {}
+
+func f<T : P>(_ t: T) {
+  // The weak reference causes us to form a SILBoxType, which is where
+  // the problematic conformance popped up.
+  _ = { [weak t] in _ = t }
+}


### PR DESCRIPTION
Consider this protocol and generic signature:

    class C {}
    protocol P : C {}

    <T where T : P>

Normally the forwarding substitution map for the generic environment
looks like this:

    - T := <<archetype for T>>
    _ T : P := <<abstract conformance to P>>

However, if the class itself conforms to P, ie

    class C : P {}

Then the conformance T : P must be the concrete conformance. Handle
this properly in MakeAbstractConformanceForGenericType.