### PR TITLE
Fix CI failure Constraints/result_builder_pairwise_build_block.swift

### DIFF
--- a/test/Constraints/result_builder_pairwise_build_block.swift
+++ b/test/Constraints/result_builder_pairwise_build_block.swift
@@ -137,7 +137,7 @@ let flatValues2 = Values(flat: {
   if false {
     "nah"
   }
-  if #available(SwiftStdlib 5.0, *) {
+  if #available(*) {
     5.0
   }
   #endif


### PR DESCRIPTION
This test is failing on earlier platforms. To fix this, we keep the `#available` but drop the platform specifier since this just testing `buildLimitedAvailability(_:)`.