### PR TITLE
Parse: Fix accidental parsing of ExistentialTypeRepr as OpaqueReturnTypeRepr and vice versa

### DIFF
--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -156,6 +156,17 @@ func anyAny() {
 
 protocol P1 {}
 protocol P2 {}
+do {
+  // Test that we don't accidentally misparse an 'any' type as a 'some' type
+  // and vice versa.
+  let _: P1 & any P2 // expected-error {{'any' should appear at the beginning of a composition}}
+  let _: any P1 & any P2 // expected-error {{'any' should appear at the beginning of a composition}}
+  let _: any P1 & some P2 // expected-error {{'some' should appear at the beginning of a composition}}
+  let _: some P1 & any P2
+  // expected-error@-1 {{'some' type can only be declared on a single property declaration}}
+  // expected-error@-2 {{'any' should appear at the beginning of a composition}}
+}
+
 struct ConcreteComposition: P1, P2 {}
 
 func testMetatypes() {


### PR DESCRIPTION
* We were setting `opaqueLoc` regardless of whether it was `any` or `some` that appeared after an ampersand, causing an `OpaqueReturnTypeRepr` to be constructed, e.g. `any P & any Q`. 
* We would always construct an `OpaqueReturnTypeRepr` when both `anyLoc` and `opaqueLoc` were valid, e.g. `any P & some Q`.
