### PR TITLE
Don't build Libcxx on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -819,7 +819,6 @@ swiftpm
 swift-driver
 xctest
 libicu
-libcxx
 swiftdocc
 
 build-ninja
@@ -832,7 +831,6 @@ install-swift-driver
 install-xctest
 install-libicu
 install-prefix=/usr
-install-libcxx
 install-sourcekit-lsp
 install-swiftdocc
 build-swift-static-stdlib
@@ -921,7 +919,6 @@ test-optimized
 lit-args=-v --time-tests
 
 build-ninja
-libcxx
 
 android
 android-ndk=%(ndk_path)s
@@ -941,7 +938,6 @@ host-test
 install-prefix=/usr
 install-llvm
 install-swift
-install-libcxx
 
 skip-test-linux
 skip-build-benchmarks
@@ -1100,7 +1096,6 @@ mixin-preset=
     mixin_linux_install_components_with_clang
 build-subdir=buildbot_incremental
 
-libcxx
 libicu
 llbuild
 swiftpm
@@ -1121,7 +1116,6 @@ install-swift-driver
 install-foundation
 install-libdispatch
 install-xctest
-install-libcxx
 
 [preset: buildbot_incremental_linux,long_test]
 mixin-preset=buildbot_incremental_linux
@@ -1669,6 +1663,7 @@ libdispatch
 libicu
 foundation
 xctest
+libcxx=false
 
 install-libicu
 install-foundation


### PR DESCRIPTION
Libcxx doesn't do anything on Linux, building it is a waste of time, and
it's failing to build in CI because it requires C++20, but the 16.04
builders only have Clang4, which doesn't support it. (e.g: https://ci.swift.org/job/swift-package-manager-Linux-smoke-test/4242/, https://ci.swift.org/job/swift-package-manager-Linux-smoke-test/4243/)