### PR TITLE
[Runtime] Fix a potential NULL pointer dereference.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -981,13 +981,15 @@ swift_conformsToProtocolMaybeInstantiateSuperclasses(
         foundWitness = witness;
         foundType = searchType;
       } else {
+        auto foundName = swift_getTypeName(foundType, true);
+        auto searchName = swift_getTypeName(searchType, true);
         swift::warning(RuntimeErrorFlagNone,
-                       "Warning: '%s' conforms to protocol '%s', but it also "
-                       "inherits conformance from '%s'.  Relying on a "
+                       "Warning: '%.*s' conforms to protocol '%s', but it also "
+                       "inherits conformance from '%.*s'.  Relying on a "
                        "particular conformance is undefined behaviour.\n",
-                       foundType->getDescription()->Name.get(),
+                       (int)foundName.length, foundName.data,
                        protocol->Name.get(),
-                       searchType->getDescription()->Name.get());
+                       (int)searchName.length, searchName.data);
       }
     }
   }

--- a/test/multifile/protocol-conformance-redundant.swift
+++ b/test/multifile/protocol-conformance-redundant.swift
@@ -8,7 +8,7 @@
 // REQUIRES: executable_test
 // XFAIL: windows
 
-// CHECK: Warning: 'Sub' conforms to protocol 'Hello', but it also inherits conformance from 'Super'.  Relying on a particular conformance is undefined behaviour.
+// CHECK: Warning: 'main.Sub' conforms to protocol 'Hello', but it also inherits conformance from 'Def.Super'.  Relying on a particular conformance is undefined behaviour.
 // CHECK: Hello
 
 import StdlibUnittest


### PR DESCRIPTION
If we find multiple conformances for the same protocol, we generate a warning.  This works fine for Swift types, but for Objective-C types it's possible that while generating the warning we might find that the type description is `NULL`.

Fix by using `swift_getTypeName()`.

rdar://86368350
