### PR TITLE
[Sema] Enable substituting the base of a dependent member type with an opened archetype.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3875,11 +3875,6 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
   if (auto *selfType = substBase->getAs<DynamicSelfType>())
     substBase = selfType->getSelfType();
 
-  // Error recovery path.
-  // FIXME: Generalized existentials will look here.
-  if (substBase->isOpenedExistential())
-    return failed();
-
   // If the parent is an archetype, extract the child archetype with the
   // given name.
   if (auto archetypeParent = substBase->getAs<ArchetypeType>()) {

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -20,3 +20,18 @@ struct Bar<T>: P {
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s25dependent_member_lowering3BarVyxGAA1PA2aEP1fyy1AQzFTW : $@convention(witness_method: P) <τ_0_0> (@in_guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, τ_0_0>, @in_guaranteed Bar<τ_0_0>) -> ()
   // CHECK:       bb0(%0 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, τ_0_0>, %1 : $*Bar<τ_0_0>):
 }
+
+protocol P0 {
+  associatedtype Foo
+  func foo() -> Foo
+}
+
+protocol P1: P0 where Foo == String {
+  func foo() -> String
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s25dependent_member_lowering26existentialDependentMemberySSAA2P1_pF : $@convention(thin) (@in_guaranteed P1) -> @owned String
+func existentialDependentMember(_ p1: P1) -> String {
+  // CHECK: $@convention(witness_method: P0) <τ_0_0 where τ_0_0 : P0> (@in_guaranteed τ_0_0) -> @out τ_0_0.Foo
+  return p1.foo()
+}


### PR DESCRIPTION
This is supported with the recent generalization of `OpenedArchetypeType` to behave similar to other archetype types.

Resolves: rdar://87776479 / [SR-15751](https://bugs.swift.org/browse/SR-15751)