### PR TITLE
[SourceKit] Ignore LLVM arguments in 'compile' request

### DIFF
--- a/lib/IDE/CompileInstance.cpp
+++ b/lib/IDE/CompileInstance.cpp
@@ -263,6 +263,11 @@ bool CompileInstance::setupCI(
     return false;
   }
 
+  // Since LLVM arguments are parsed into a global state, LLVM can't handle
+  // multiple argument sets in a process simultaneously. So let's ignore them.
+  // FIXME: Remove this if possible.
+  invocation.getFrontendOptions().LLVMArgs.clear();
+
   /// Declare the frontend to be used for multiple compilations.
   invocation.getFrontendOptions().ReuseFrontendForMutipleCompilations = true;
 

--- a/lib/IDE/CompileInstance.cpp
+++ b/lib/IDE/CompileInstance.cpp
@@ -294,7 +294,7 @@ void CompileInstance::performSema(
   if (CI && ArgsHash == CachedArgHash &&
       CachedReuseCount < Opts.MaxASTReuseCount) {
     CI->getASTContext().CancellationFlag = CancellationFlag;
-    if (performCachedSemaIfPossible(DiagC)) {
+    if (!performCachedSemaIfPossible(DiagC)) {
       // If we compileted cacehd Sema operation. We're done.
       ++CachedReuseCount;
       return;
@@ -311,6 +311,9 @@ void CompileInstance::performSema(
     CI.reset();
     return;
   }
+
+  CI->addDiagnosticConsumer(DiagC);
+  SWIFT_DEFER { CI->removeDiagnosticConsumer(DiagC); };
 
   // CI is potentially reusable.
   CachedArgHash = ArgsHash;

--- a/test/SourceKit/Compile/basic.swift
+++ b/test/SourceKit/Compile/basic.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar86809003
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/out)
 // RUN: split-file %s %t


### PR DESCRIPTION
LLVM arguments processing is a process wide global state. At this point, there's no way to localize it to a CompilerInstance. For now, ignore any LLVM arguments, so options from another compilation doesn't affect other compilations. 
rdar://86809003

along with a couple of bug fixes.