### PR TITLE
Allow global-actor isolation on top-level variables

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2815,7 +2815,8 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       if (!address) {
         address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
       } else {
-        assert(!ActorIso && "local var should not be actor isolated!");
+        assert((!ActorIso || Storage->isTopLevelGlobal()) &&
+               "local var should not be actor isolated!");
       }
       assert(address.isLValue() &&
              "physical lvalue decl ref must evaluate to an address");

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -271,7 +271,7 @@ GlobalActorAttributeRequest::evaluate(
   } else if (auto storage = dyn_cast<AbstractStorageDecl>(decl)) {
     // Subscripts and properties are fine...
     if (auto var = dyn_cast<VarDecl>(storage)) {
-      if (var->getDeclContext()->isLocalContext()) {
+      if (var->getDeclContext()->isLocalContext() && !var->isTopLevelGlobal()) {
         var->diagnose(diag::global_actor_on_local_variable, var->getName())
             .highlight(globalActorAttr->getRangeWithAt());
         return None;

--- a/test/SILGen/top_level_captures.swift
+++ b/test/SILGen/top_level_captures.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-async-top-level -emit-silgen %s | %FileCheck %s
 
 guard let x: Int = nil else { while true { } }
 

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefixes='CHECK,SYNC-CHECK'
+// RUN: %target-swift-emit-silgen -enable-experimental-async-top-level %s | %FileCheck %s --check-prefixes='CHECK,ASYNC-CHECK'
 
 enum MyError : Error {
   case A, B
@@ -17,7 +18,10 @@ throw MyError.A
 // CHECK: br bb2([[ERR2]] : $Error)
 
 // CHECK: bb1([[T0:%.*]] : $Int32):
-// CHECK: return [[T0]] : $Int32
+// SYNC-CHECK: return [[T0]] : $Int32
+// ASYNC-CHECK: [[EXITFUNC:%[0-9]+]] = function_ref @exit
+// ASYNC-CHECK: {{[0-9]+}} = apply [[EXITFUNC]]([[T0]])
+// ASYNC-CHECK: unreachable
 
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
 // CHECK: builtin "errorInMain"([[T0]] : $Error)

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
+
+// a
+// CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
+// b
+// CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1bSivp : $Int
+
+// CHECK-LABEL: sil hidden [ossa] @async_Main
+// CHECK: bb0:
+// CHECK-NEXT: alloc_global @$s24toplevel_globalactorvars1aSivp
+// CHECK-NEXT: [[AREF:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1aSivp : $*Int
+
+actor MyActorImpl {}
+
+@globalActor
+struct MyActor {
+    static let shared = MyActorImpl()
+}
+
+@MyActor
+var a = 10
+
+@MyActor
+func incrementA() {
+    a += 1
+}
+
+await print(a)
+
+// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+// CHECK: [[OLDACTOR:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+// CHECK: end_access [[AACCESS]]
+// CHECK: hop_to_executor [[OLDACTOR]]
+// CHECK: end_borrow [[ACTORREF]]
+
+await incrementA()
+
+// CHECK: [[INCREMENTA:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars10incrementAyyF
+// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+// CHECK: [[OLDACTOR:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+// CHECK: {{%[0-9]+}} = apply [[INCREMENTA]]()
+// CHECK: hop_to_executor [[OLDACTOR]]
+// CHECK: end_borrow [[ACTORREF]]
+
+await print(a)
+
+// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+// CHECK: [[OLDACTOR:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+// CHECK: end_access [[AACCESS]]
+// CHECK: hop_to_executor [[OLDACTOR]]
+// CHECK: end_borrow [[ACTORREF]]
+
+var b = 11
+
+// CHECK: alloc_global @$s24toplevel_globalactorvars1bSivp
+// CHECK: [[BGLOBAL_ADDR:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1bSivp
+// Int.init(_builtinIntegerLiteral:)
+// CHECK: [[INT_INIT_FUNC:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK: [[INITD_INT:%[0-9]+]] = apply [[INT_INIT_FUNC]]({{%[0-9]+}}, {{%[0-9]+}})
+// CHECK: store [[INITD_INT]] to [trivial] [[BGLOBAL_ADDR]]
+
+b += 1
+
+// CHECK-NOT: hop_to_executor
+// CHECK: [[BACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[BGLOBAL_ADDR]]
+// static Int.+= infix(_:_:)
+// CHECK: [[PE_INT_FUNC:%[0-9]+]] = function_ref @$sSi2peoiyySiz_SitFZ
+// CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[BACCESS]], {{%[0-9]+}}, {{%[0-9]+}})
+// CHECK: end_access [[BACCESS]]

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
 
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
@@ -10,8 +10,10 @@
 // CHECK-NEXT: alloc_global @$s24toplevel_globalactorvars1aSivp
 // CHECK-NEXT: [[AREF:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1aSivp : $*Int
 
+@available(SwiftStdlib 5.1, *)
 actor MyActorImpl {}
 
+@available(SwiftStdlib 5.1, *)
 @globalActor
 struct MyActor {
     static let shared = MyActorImpl()

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -74,3 +74,38 @@ b += 1
 // CHECK: [[PE_INT_FUNC:%[0-9]+]] = function_ref @$sSi2peoiyySiz_SitFZ
 // CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[BACCESS]], {{%[0-9]+}}, {{%[0-9]+}})
 // CHECK: end_access [[BACCESS]]
+
+
+// CHECK: bb1:
+if #available(SwiftStdlib 5.1, *) {
+    await print(a)
+
+    // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+    // CHECK: [[OLDACTOR:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+    // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+    // CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+    // CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+    // CHECK: end_access [[AACCESS]]
+    // CHECK: hop_to_executor [[OLDACTOR]]
+    // CHECK: end_borrow [[ACTORREF]]
+
+    await incrementA()
+
+    // CHECK: [[INCREMENTA:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars10incrementAyyF
+    // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+    // CHECK: [[OLDACTOR:%[0-9]+]] = builtin "getCurrentExecutor"() : $Optional<Builtin.Executor>
+    // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+    // CHECK: {{%[0-9]+}} = apply [[INCREMENTA]]()
+    // CHECK: hop_to_executor [[OLDACTOR]]
+    // CHECK: end_borrow [[ACTORREF]]
+
+
+    b += 1
+
+    // CHECK-NOT: hop_to_executor
+    // CHECK: [[BACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[BGLOBAL_ADDR]]
+    // static Int.+= infix(_:_:)
+    // CHECK: [[PE_INT_FUNC:%[0-9]+]] = function_ref @$sSi2peoiyySiz_SitFZ
+    // CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[BACCESS]], {{%[0-9]+}}, {{%[0-9]+}})
+    // CHECK: end_access [[BACCESS]]
+}


### PR DESCRIPTION
This PR fixes issues with global actor isolation on top-level global variables.

1) SILGen would crash on an assert if a variable in top-level code had actor isolation.
This is because SILGen was using the presence of an address to determine whether the variable was global or local.
Due to how the hybrid variables in top-level code are initialized, the address will already exist in the implicit main function, thus tripping on the assert if there is an associated actor isolation.

The fix is to check if the variable is a top-level global and not assert if it is and has global actor isolation.

2) When the use-site is wrapped in an `if` statement, the top-level code decl that is the decl-context for the top-level variable declaration is seen as a local context. This results in an error message saying that local variables can't have globals actor isolation.

The fix is to check if the variable is a top-level global and not emit an error message if it is.

The rest of this PR is adding testing for the various top-level code tests.