### PR TITLE
[5.6][Parser] Parse `(any P).self`

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1625,6 +1625,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));
     }
 
+    // 'any' followed by another identifier is an existential type.
+    if (Tok.isContextualKeyword("any") &&
+        peekToken().is(tok::identifier)) {
+      ParserResult<TypeRepr> ty = parseType();
+      auto *typeExpr = new (Context) TypeExpr(ty.get());
+      return makeParserResult(typeExpr);
+    }
+
     LLVM_FALLTHROUGH;
   case tok::kw_Self:     // Self
     return parseExprIdentifier();

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -202,3 +202,15 @@ func typealiasMemberReferences(metatype: Wrapper.Type) {
   let _: Wrapper.E.Protocol = metatype.E.self
   let _: (any Wrapper.E).Type = metatype.E.self
 }
+
+func testAnyTypeExpr() {
+  let _: (any P).Type = (any P).self
+
+  func test(_: (any P).Type) {}
+  test((any P).self)
+
+  // expected-error@+2 {{expected member name or constructor call after type name}}
+  // expected-note@+1 {{use '.self' to reference the type object}}
+  let invalid = any P
+  test(invalid)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/40949

A small bug in the parser preventing the new `any P` syntax from working in expression context. Parse `any P` as a type in expression context to support the `(any P).self` spelling for protocol metatypes.

Resolves: rdar://87908523