### PR TITLE
ABI: repair the build after #40927

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1108,7 +1108,7 @@ struct TargetAnyClassMetadataObjCInterop
   using StoredSize = typename Runtime::StoredSize;
 
   using TargetClassMetadataObjCInterop =
-      TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
+      swift::TargetClassMetadata<Runtime, TargetAnyClassMetadataObjCInterop<Runtime>>;
 
   constexpr TargetAnyClassMetadataObjCInterop(
       TargetAnyClassMetadataObjCInterop<Runtime> *isa,


### PR DESCRIPTION
This fixes the build on Windows by fixing the template code.  The
template type was not qualified and caused an ambiguity in the name
resolution with the local typename and the previously declared
namespaced name.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
