### PR TITLE
[IRGen] Pad generic environment descriptor before adding requirements

### DIFF
--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -118,7 +118,7 @@ public:
   }
 
   void addAlignmentPadding(Alignment align) {
-    auto misalignment = getNextOffsetFromGlobal() % IGM().getPointerAlignment();
+    auto misalignment = getNextOffsetFromGlobal() % align;
     if (misalignment != Size(0))
       add(llvm::ConstantAggregateZero::get(
             llvm::ArrayType::get(IGM().Int8Ty,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3732,6 +3732,11 @@ llvm::Constant *IRGenModule::getAddrOfGenericEnvironment(
                           .getIntValue());
         });
 
+        // Need to pad the structure after generic parameters
+        // up to four bytes because generic requirements that
+        // follow expect that alignment.
+        fields.addAlignmentPadding(Alignment(4));
+
         // Generic requirements
         irgen::addGenericRequirements(*this, fields, signature,
                                       signature.getRequirements());


### PR DESCRIPTION
Since `TargetGenericEnvironmentDescriptor` uses trailing objects to
store parameters, requirements and other information. IR Emission
should pad the structure to be 4 bytes aligned before adding generic
requirements, because that's the alignment expected by
`TargetGenericRequirementDescriptor`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
