### PR TITLE
Serialization: ignore XRefErrors in deserialization of members

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6308,6 +6308,34 @@ Decl *handleErrorAndSupplyMissingMember(ASTContext &context, Decl *container,
   return handleErrorAndSupplyMissingMiscMember(std::move(error));
 }
 
+static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
+    // Missing module errors are most likely caused by an
+    // implementation-only import hiding types and decls.
+    // rdar://problem/60291019
+    if (error.isA<XRefNonLoadedModuleError>()) {
+      consumeError(std::move(error));
+      return llvm::Error::success();
+    }
+
+    // Some of these errors may manifest as a TypeError with an
+    // XRefNonLoadedModuleError underneath. Catch those as well.
+    // rdar://66491720
+    if (error.isA<TypeError>()) {
+      auto errorInfo = takeErrorInfo(std::move(error));
+      auto *TE = static_cast<TypeError*>(errorInfo.get());
+
+      if (TE->underlyingReasonIsA<XRefNonLoadedModuleError>()) {
+        consumeError(std::move(errorInfo));
+        return llvm::Error::success();
+      }
+
+      return std::move(errorInfo);
+    }
+
+    return std::move(error);
+}
+
+
 void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   PrettyStackTraceDecl trace("loading members for", container);
   ++NumMemberListsLoaded;
@@ -6345,13 +6373,17 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
       assert(next.get() && "unchecked error deserializing next member");
       members.push_back(next.get());
     } else {
-      if (!getContext().LangOpts.EnableDeserializationRecovery)
-        fatal(next.takeError());
+      auto unconsumedError =
+          consumeErrorIfXRefNonLoadedModule(next.takeError());
+      if (unconsumedError) {
+        if (!getContext().LangOpts.EnableDeserializationRecovery)
+          fatal(std::move(unconsumedError));
 
-      Decl *suppliedMissingMember = handleErrorAndSupplyMissingMember(
-          getContext(), container, next.takeError());
-      if (suppliedMissingMember)
-        members.push_back(suppliedMissingMember);
+        Decl *suppliedMissingMember = handleErrorAndSupplyMissingMember(
+            getContext(), container, std::move(unconsumedError));
+        if (suppliedMissingMember)
+          members.push_back(suppliedMissingMember);
+      }
     }
   }
 
@@ -6371,33 +6403,6 @@ void ModuleFile::diagnoseMissingNamedMember(const IterableDeclContext *IDC,
   // TODO: Implement diagnostics for failed member lookups from module files.
   llvm_unreachable(
       "Missing member diangosis is not implemented for module files.");
-}
-
-static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
-    // Missing module errors are most likely caused by an
-    // implementation-only import hiding types and decls.
-    // rdar://problem/60291019
-    if (error.isA<XRefNonLoadedModuleError>()) {
-      consumeError(std::move(error));
-      return llvm::Error::success();
-    }
-
-    // Some of these errors may manifest as a TypeError with an
-    // XRefNonLoadedModuleError underneath. Catch those as well.
-    // rdar://66491720
-    if (error.isA<TypeError>()) {
-      auto errorInfo = takeErrorInfo(std::move(error));
-      auto *TE = static_cast<TypeError*>(errorInfo.get());
-
-      if (TE->underlyingReasonIsA<XRefNonLoadedModuleError>()) {
-        consumeError(std::move(errorInfo));
-        return llvm::Error::success();
-      }
-
-      return std::move(errorInfo);
-    }
-
-    return std::move(error);
 }
 
 void

--- a/test/Serialization/Inputs/CLibrary.h
+++ b/test/Serialization/Inputs/CLibrary.h
@@ -1,0 +1,7 @@
+
+#ifndef CLibrary_h
+#define CLibrary_h
+
+typedef struct __attribute__((__objc_bridge__(Object))) CObject *CObjectRef;
+
+#endif

--- a/test/Serialization/Inputs/module.modulemap
+++ b/test/Serialization/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+
+module CLibrary {
+  header "CLibrary.h"
+}

--- a/test/Serialization/implementation-only-open.swift
+++ b/test/Serialization/implementation-only-open.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/swift)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/swift/SwiftLibrary.swiftmodule %s -module-name SwiftLibrary -I%S/Inputs
+// RUN: %target-swift-frontend -verify -DCLIENT -c %s -module-name client -I%t/swift -o /dev/null
+
+#if CLIENT
+import SwiftLibrary
+
+public class MyObject: Object {
+}
+#else
+@_implementationOnly import CLibrary
+
+open class Object {
+  internal var storage: AnyObject
+  internal var raw: CObject { unsafeBitCast(storage, to: CObject.self) }
+
+  fileprivate init(object: CObject) {
+    self.storage = object
+  }
+}
+#endif


### PR DESCRIPTION
This applies similar handling to the member loading in the
deserialization of modules.  This allows the use of `open` classes with
members which are not exposed due to an `@_implementationOnly import`.

This partially resolves SR-15757!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
