### PR TITLE
RequirementMachine: Conditional requirement inference

### DIFF
--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -38,17 +38,21 @@ enum class DebugFlags : unsigned {
   /// Print debug output when concretizing nested types in the property map.
   ConcretizeNestedTypes = (1<<5),
 
+  /// Print debug output when inferring conditional requirements in the
+  /// property map.
+  ConditionalRequirements = (1<<6),
+
   /// Print debug output from the homotopy reduction algorithm.
-  HomotopyReduction = (1<<6),
+  HomotopyReduction = (1<<7),
 
   /// Print debug output from the minimal conformances algorithm.
-  MinimalConformances = (1<<7),
+  MinimalConformances = (1<<8),
 
   /// Print debug output from the protocol dependency graph.
-  ProtocolDependencies = (1<<8),
+  ProtocolDependencies = (1<<9),
 
   /// Print debug output from generic signature minimization.
-  Minimization = (1<<9),
+  Minimization = (1<<10),
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -386,9 +386,13 @@ findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn,
 
     const auto &otherRule = getRule(found->second);
 
-    // Prefer to delete "less canonical" rules.
-    if (rule.compare(otherRule, Context) > 0)
+    // If the new rule is conflicting, don't compare the rules at all
+    // and prefer to delete the new rule. Otherwise, prefer to delete
+    // the less canonical of the two rules.
+    if (rule.isConflicting() ||
+        rule.compare(otherRule, Context) > 0) {
       found = pair;
+    }
   }
 
   if (!found)

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -494,6 +494,51 @@ Type PropertyMap::getTypeFromSubstitutionSchema(
   });
 }
 
+/// This method takes a concrete type that was derived from a concrete type
+/// produced by RewriteContext::getSubstitutionSchemaFromType() either by
+/// extracting a structural sub-component or performing a (Swift AST)
+/// substitution using subst(). It returns a new concrete substitution schema
+/// and a new list of substitution terms.
+///
+/// For example, suppose we start with the concrete type
+///
+///   Dictionary<τ_0_0, Array<τ_0_1>> with substitutions {X.Y, Z}
+///
+/// We can extract out the structural sub-component Array<τ_0_1>. If we wish
+/// to build a new concrete substitution schema, we call this method with
+/// Array<τ_0_1> and the original substitutions {X.Y, Z}. This will produce
+/// the new schema Array<τ_0_0> with substitutions {Z}.
+///
+/// As another example, consider we start with the schema Bar<τ_0_0> with
+/// original substitutions {X.Y}, and perform a Swift AST subst() to get
+/// Foo<τ_0_0.A.B>. We can then call this method with Foo<τ_0_0.A.B> and
+/// the original substitutions {X.Y} to produce the new schema Foo<τ_0_0>
+/// with substitutions {X.Y.A.B}.
+CanType
+RewriteContext::remapConcreteSubstitutionSchema(
+    CanType concreteType,
+    ArrayRef<Term> substitutions,
+    SmallVectorImpl<Term> &result) {
+  assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+
+  if (!concreteType->hasTypeParameter())
+    return concreteType;
+
+  return CanType(concreteType.transformRec([&](Type t) -> Optional<Type> {
+    if (!t->isTypeParameter())
+      return None;
+
+    auto term = getRelativeTermForType(CanType(t), substitutions);
+
+    unsigned newIndex = result.size();
+    result.push_back(Term::get(term, *this));
+
+    return CanGenericTypeParamType::get(/*type sequence=*/ false,
+                                        /*depth=*/ 0, newIndex,
+                                        Context);
+  }));
+}
+
 /// Given a concrete type that may contain type parameters in structural positions,
 /// collect all the structural type parameter components, and replace them all with
 /// fresh generic parameters. The fresh generic parameters all have a depth of 0,

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -515,7 +515,7 @@ Type PropertyMap::getTypeFromSubstitutionSchema(
 /// the original substitutions {X.Y} to produce the new schema Foo<τ_0_0>
 /// with substitutions {X.Y.A.B}.
 CanType
-RewriteContext::remapConcreteSubstitutionSchema(
+RewriteContext::getRelativeSubstitutionSchemaFromType(
     CanType concreteType,
     ArrayRef<Term> substitutions,
     SmallVectorImpl<Term> &result) {

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -372,30 +372,21 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
   // Merging multiple superclass or concrete type rules can induce new rules
   // to unify concrete type constructor arguments.
   unsigned ruleCount = System.getRules().size();
-  SmallVector<InducedRule, 3> inducedRules;
 
   for (const auto &bucket : properties) {
     for (auto property : bucket) {
       addProperty(property.key, property.symbol,
-                  property.ruleID, inducedRules);
+                  property.ruleID);
     }
   }
 
   // Now, check for conflicts between superclass and concrete type rules.
-  checkConcreteTypeRequirements(inducedRules);
+  checkConcreteTypeRequirements();
 
   // Now, we merge concrete type rules with conformance rules, by adding
   // relations between associated type members of type parameters with
   // the concrete type witnesses in the concrete type's conformance.
-  concretizeNestedTypesFromConcreteParents(inducedRules);
-
-  // Some of the induced rules might be trivial; only count the induced rules
-  // where the left hand side is not already equivalent to the right hand side.
-  for (auto pair : inducedRules) {
-    // FIXME: Eventually, all induced rules will have a rewrite path.
-    (void) System.addRule(pair.LHS, pair.RHS,
-                          pair.Path.empty() ? nullptr : &pair.Path);
-  }
+  concretizeNestedTypesFromConcreteParents();
 
   unsigned addedNewRules = System.getRules().size() - ruleCount;
   for (unsigned i = ruleCount, e = System.getRules().size(); i < e; ++i) {

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -44,21 +44,6 @@ namespace rewriting {
 class MutableTerm;
 class Term;
 
-/// A new rule introduced during property map construction, as a result of
-/// unifying two property symbols that apply to the same common suffix term.
-struct InducedRule {
-  MutableTerm LHS;
-  MutableTerm RHS;
-  RewritePath Path;
-
-  InducedRule(MutableTerm LHS, MutableTerm RHS, RewritePath Path)
-    : LHS(LHS), RHS(RHS), Path(Path) {}
-
-  // FIXME: Eventually all induced rules will have a rewrite path.
-  InducedRule(MutableTerm LHS, MutableTerm RHS)
-    : LHS(LHS), RHS(RHS) {}
-};
-
 /// Stores a convenient representation of all "property-like" rewrite rules of
 /// the form T.[p] => T, where [p] is a property symbol, for some term 'T'.
 class PropertyBag {
@@ -258,14 +243,11 @@ private:
   bool checkRuleOnce(unsigned ruleID);
   bool checkRulePairOnce(unsigned firstRuleID, unsigned secondRuleID);
 
-  void addProperty(Term key, Symbol property, unsigned ruleID,
-                   SmallVectorImpl<InducedRule> &inducedRules);
+  void addProperty(Term key, Symbol property, unsigned ruleID);
 
-  void checkConcreteTypeRequirements(
-                   SmallVectorImpl<InducedRule> &inducedRules);
+  void checkConcreteTypeRequirements();
 
-  void concretizeNestedTypesFromConcreteParents(
-                   SmallVectorImpl<InducedRule> &inducedRules);
+  void concretizeNestedTypesFromConcreteParents();
 
   void concretizeNestedTypesFromConcreteParent(
                    Term key, RequirementKind requirementKind,
@@ -274,15 +256,13 @@ private:
                    ArrayRef<Term> substitutions,
                    ArrayRef<unsigned> conformsToRules,
                    ArrayRef<const ProtocolDecl *> conformsTo,
-                   llvm::TinyPtrVector<ProtocolConformance *> &conformances,
-                   SmallVectorImpl<InducedRule> &inducedRules);
+                   llvm::TinyPtrVector<ProtocolConformance *> &conformances);
 
   void concretizeTypeWitnessInConformance(
                    Term key, RequirementKind requirementKind,
                    Symbol concreteConformanceSymbol,
                    ProtocolConformance *concrete,
-                   AssociatedTypeDecl *assocType,
-                   SmallVectorImpl<InducedRule> &inducedRules) const;
+                   AssociatedTypeDecl *assocType) const;
 
   MutableTerm computeConstraintTermForTypeWitness(
       Term key, RequirementKind requirementKind,
@@ -295,8 +275,7 @@ private:
     unsigned concreteRuleID,
     unsigned conformanceRuleID,
     RequirementKind requirementKind,
-    Symbol concreteConformanceSymbol,
-    SmallVectorImpl<InducedRule> &inducedRules) const;
+    Symbol concreteConformanceSymbol) const;
 
   void verify() const;
 };

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -264,6 +264,10 @@ private:
                    ProtocolConformance *concrete,
                    AssociatedTypeDecl *assocType) const;
 
+  void inferConditionalRequirements(
+                   ProtocolConformance *concrete,
+                   ArrayRef<Term> substitutions) const;
+
   MutableTerm computeConstraintTermForTypeWitness(
       Term key, RequirementKind requirementKind,
       CanType concreteType, CanType typeWitness,

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -183,7 +183,7 @@ namespace {
                                                       lhsSubstitutions);
 
         SmallVector<Term, 3> result;
-        auto concreteType = ctx.remapConcreteSubstitutionSchema(
+        auto concreteType = ctx.getRelativeSubstitutionSchemaFromType(
             CanType(secondType), rhsSubstitutions, result);
 
         MutableTerm constraintTerm(subjectTerm);
@@ -204,7 +204,7 @@ namespace {
                                                       rhsSubstitutions);
 
         SmallVector<Term, 3> result;
-        auto concreteType = ctx.remapConcreteSubstitutionSchema(
+        auto concreteType = ctx.getRelativeSubstitutionSchemaFromType(
             CanType(firstType), lhsSubstitutions, result);
 
         MutableTerm constraintTerm(subjectTerm);
@@ -842,8 +842,8 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
   // Compute the concrete type symbol [concrete: C.X].
   SmallVector<Term, 3> result;
   auto typeWitnessSchema =
-      Context.remapConcreteSubstitutionSchema(typeWitness, substitutions,
-                                              result);
+      Context.getRelativeSubstitutionSchemaFromType(typeWitness, substitutions,
+                                                    result);
   auto typeWitnessSymbol =
       Symbol::forConcreteType(typeWitnessSchema, result, Context);
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -903,21 +903,6 @@ void RuleBuilder::addRequirement(const Requirement &req,
     // A superclass requirement T : C<X, Y> becomes a rewrite rule
     //
     //   T.[superclass: C<X, Y>] => T
-    //
-    // Together with a rewrite rule
-    //
-    //   [superclass: C<X, Y>].[layout: L] => [superclass: C<X, Y>]
-    //
-    // Where 'L' is either AnyObject or _NativeObject, depending on the
-    // ancestry of C.
-    //
-    // The second rule is marked permanent. Completion will derive a new
-    // rule as a consequence of these two rules:
-    //
-    //   T.[layout: L] => T
-    //
-    // The new rule will be marked redundant by homotopy reduction since
-    // it is a consequence of the other two rules.
     auto otherType = CanType(req.getSecondType());
 
     // Build the symbol [superclass: C<X, Y>].

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -65,7 +65,6 @@ getRuleForRequirement(const Requirement &req,
 /// appearing on the right hand side of conformance requirements.
 struct RuleBuilder {
   RewriteContext &Context;
-  bool Dump;
 
   /// The keys are the unique protocols we've added so far. The value indicates
   /// whether the protocol's SCC is an initial component for the rewrite system.
@@ -81,7 +80,9 @@ struct RuleBuilder {
   ///
   /// This is what breaks the cycle in requirement signature computation for a
   /// group of interdependent protocols.
-  llvm::DenseMap<const ProtocolDecl *, bool> ProtocolMap;
+  llvm::DenseMap<const ProtocolDecl *, bool> &ProtocolMap;
+
+  /// The keys of the above map in insertion order.
   std::vector<const ProtocolDecl *> Protocols;
 
   /// New rules to add which will be marked 'permanent'. These are rules for
@@ -95,7 +96,15 @@ struct RuleBuilder {
   /// eliminated by homotopy reduction.
   std::vector<std::pair<MutableTerm, MutableTerm>> RequirementRules;
 
-  RuleBuilder(RewriteContext &ctx, bool dump) : Context(ctx), Dump(dump) {}
+  /// Enables debugging output. Controlled by the -dump-requirement-machine
+  /// frontend flag.
+  bool Dump;
+
+  RuleBuilder(RewriteContext &ctx,
+              llvm::DenseMap<const ProtocolDecl *, bool> &protocolMap)
+      : Context(ctx), ProtocolMap(protocolMap),
+        Dump(ctx.getASTContext().LangOpts.DumpRequirementMachine) {}
+
   void addRequirements(ArrayRef<Requirement> requirements);
   void addRequirements(ArrayRef<StructuralRequirement> requirements);
   void addProtocols(ArrayRef<const ProtocolDecl *> proto);

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -55,6 +55,7 @@ void realizeInheritedRequirements(TypeDecl *decl, Type type,
 std::pair<MutableTerm, MutableTerm>
 getRuleForRequirement(const Requirement &req,
                       const ProtocolDecl *proto,
+                      Optional<ArrayRef<Term>> substitutions,
                       RewriteContext &ctx);
 
 /// A utility class for bulding rewrite rules from the top-level requirements

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -52,6 +52,11 @@ void realizeInheritedRequirements(TypeDecl *decl, Type type,
                                   ModuleDecl *moduleForInference,
                                   SmallVectorImpl<StructuralRequirement> &result);
 
+std::pair<MutableTerm, MutableTerm>
+getRuleForRequirement(const Requirement &req,
+                      const ProtocolDecl *proto,
+                      RewriteContext &ctx);
+
 /// A utility class for bulding rewrite rules from the top-level requirements
 /// of a generic signature.
 ///
@@ -88,10 +93,6 @@ struct RuleBuilder {
   /// New rules derived from requirements written by the user, which can be
   /// eliminated by homotopy reduction.
   std::vector<std::pair<MutableTerm, MutableTerm>> RequirementRules;
-
-  CanType getConcreteSubstitutionSchema(CanType concreteType,
-                                        const ProtocolDecl *proto,
-                                        SmallVectorImpl<Term> &result);
 
   RuleBuilder(RewriteContext &ctx, bool dump) : Context(ctx), Dump(dump) {}
   void addRequirements(ArrayRef<Requirement> requirements);

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -76,7 +76,7 @@ void RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RuleBuilder builder(Context, Dump);
+  RuleBuilder builder(Context, System.getProtocolMap());
   builder.addRequirements(sig.getRequirements());
 
   // Add the initial set of rewrite rules to the rewrite system.
@@ -115,7 +115,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
     llvm::dbgs() << " {\n";
   }
 
-  RuleBuilder builder(Context, Dump);
+  RuleBuilder builder(Context, System.getProtocolMap());
   builder.addProtocols(protos);
 
   // Add the initial set of rewrite rules to the rewrite system.
@@ -157,7 +157,7 @@ void RequirementMachine::initWithAbstractRequirements(
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RuleBuilder builder(Context, Dump);
+  RuleBuilder builder(Context, System.getProtocolMap());
   builder.addRequirements(requirements);
 
   // Add the initial set of rewrite rules to the rewrite system.
@@ -200,7 +200,7 @@ RequirementMachine::initWithWrittenRequirements(
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RuleBuilder builder(Context, Dump);
+  RuleBuilder builder(Context, System.getProtocolMap());
   builder.addRequirements(requirements);
 
   // Add the initial set of rewrite rules to the rewrite system.

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -33,6 +33,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("completion", DebugFlags::Completion)
       .Case("concrete-unification", DebugFlags::ConcreteUnification)
       .Case("concretize-nested-types", DebugFlags::ConcretizeNestedTypes)
+      .Case("conditional-requirements", DebugFlags::ConditionalRequirements)
       .Case("homotopy-reduction", DebugFlags::HomotopyReduction)
       .Case("minimal-conformances", DebugFlags::MinimalConformances)
       .Case("protocol-dependencies", DebugFlags::ProtocolDependencies)

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -170,6 +170,10 @@ public:
   MutableTerm getRelativeTermForType(CanType typeWitness,
                                      ArrayRef<Term> substitutions);
 
+  CanType getSubstitutionSchemaFromType(CanType concreteType,
+                                        const ProtocolDecl *proto,
+                                        SmallVectorImpl<Term> &result);
+
   AssociatedTypeDecl *getAssociatedTypeForSymbol(Symbol symbol);
 
   Symbol mergeAssociatedTypes(Symbol lhs, Symbol rhs);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -174,6 +174,10 @@ public:
                                         const ProtocolDecl *proto,
                                         SmallVectorImpl<Term> &result);
 
+  CanType remapConcreteSubstitutionSchema(CanType concreteType,
+                                          ArrayRef<Term> substitutions,
+                                          SmallVectorImpl<Term> &result);
+
   AssociatedTypeDecl *getAssociatedTypeForSymbol(Symbol symbol);
 
   Symbol mergeAssociatedTypes(Symbol lhs, Symbol rhs);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -174,9 +174,9 @@ public:
                                         const ProtocolDecl *proto,
                                         SmallVectorImpl<Term> &result);
 
-  CanType remapConcreteSubstitutionSchema(CanType concreteType,
-                                          ArrayRef<Term> substitutions,
-                                          SmallVectorImpl<Term> &result);
+  CanType getRelativeSubstitutionSchemaFromType(CanType concreteType,
+                                                ArrayRef<Term> substitutions,
+                                                SmallVectorImpl<Term> &result);
 
   AssociatedTypeDecl *getAssociatedTypeForSymbol(Symbol symbol);
 

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -607,6 +607,7 @@ void RewriteSystem::simplifyRightHandSidesAndSubstitutions() {
 bool RewriteSystem::isInMinimizationDomain(
     ArrayRef<const ProtocolDecl *> protos) const {
   assert(protos.size() <= 1);
+  assert(Protos.empty() || !protos.empty());
 
   if (protos.empty() && Protos.empty())
     return true;

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -152,7 +152,7 @@ void Rule::dump(llvm::raw_ostream &out) const {
   if (Redundant)
     out << " [redundant]";
   if (Conflicting)
-    out << "[conflicting]";
+    out << " [conflicting]";
 }
 
 RewriteSystem::RewriteSystem(RewriteContext &ctx)

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4683,6 +4683,8 @@ case TypeKind::Id:
       changed |= fieldTy != transformed;
       newFields.push_back(SILField(transformed, f.isMutable()));
     }
+    if (!changed)
+      return *this;
     boxTy = SILBoxType::get(Ptr->getASTContext(),
                             SILLayout::get(Ptr->getASTContext(),
                                            l->getGenericSignature(), newFields),

--- a/test/Generics/concrete_conflict_in_protocol.swift
+++ b/test/Generics/concrete_conflict_in_protocol.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures -requirement-machine-protocol-signatures=verify
+
+protocol P1 {
+  associatedtype T where T == Int
+}
+
+protocol P2 {
+  associatedtype T where T == String
+}
+
+protocol P3 {
+  associatedtype T where T == Float
+}
+
+// We end up with two redundant rules:
+//
+// [P4:T].[P1:T].[concrete: String]
+// [P4:T].[P1:T].[concrete: Float]
+//
+// These rules are unordered with respect to each other because concrete type
+// symbols are incomparable, but they conflict so we should not compare them;
+// just make sure we don't crash.
+
+// CHECK-LABEL: concrete_conflict_in_protocol.(file).P4@
+// CHECK-LABEL: Requirement signature: <Self where Self.[P4]T : P1, Self.[P4]T : P2, Self.[P4]T : P3>
+
+protocol P4 {
+  associatedtype T : P1 & P2 & P3
+  // expected-note@-1 2{{same-type constraint 'Self.T.T' == 'Int' implied here}}
+  // expected-error@-2 {{'Self.T.T' cannot be equal to both 'String' and 'Int'}}
+  // expected-error@-3 {{'Self.T.T' cannot be equal to both 'Float' and 'Int'}}
+}

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
 struct S {}
 class C {}
 

--- a/test/Generics/conditional_requirement_inference.swift
+++ b/test/Generics/conditional_requirement_inference.swift
@@ -1,58 +1,25 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
 
+protocol Equatable {}
 
-// Valid example
+struct Array<Element> {}
+
+extension Array : Equatable where Element : Equatable {}
+
 struct EquatableBox<T : Equatable> {
   // CHECK: Generic signature: <T, U where T == Array<U>, U : Equatable>
   func withArray<U>(_: U) where T == Array<U> {}
 }
 
-struct EquatableSequenceBox<T : Sequence> where T.Element : Equatable {
-  // CHECK: Generic signature: <T, U where T == Array<Array<U>>, U : Equatable>
-  func withArrayArray<U>(_: U) where T == Array<Array<U>> {}
-}
+// A conditional requirement with a protocol we haven't seen before.
+protocol First {}
 
+protocol Second {}
 
-// A very elaborate invalid example (see comment in mergeP1AndP2())
-struct G<T> {}
+extension Array : First where Element : Second {}
 
-protocol P {}
-extension G : P where T : P {}
-
-protocol P1 {
-  associatedtype T
-  associatedtype U where U == G<T>
-  associatedtype R : P1
-}
-
-protocol P2 {
-  associatedtype U : P
-  associatedtype R : P2
-}
-
-func takesP<T : P>(_: T.Type) {}
-// expected-note@-1 {{where 'T' = 'T.T'}}
-// expected-note@-2 {{where 'T' = 'T.R.T'}}
-// expected-note@-3 {{where 'T' = 'T.R.R.T'}}
-// expected-note@-4 {{where 'T' = 'T.R.R.R.T'}}
-
-// CHECK: Generic signature: <T where T : P1, T : P2>
-func mergeP1AndP2<T : P1 & P2>(_: T) {
-  // P1 implies that T.(R)*.U == G<T.(R)*.T>, and P2 implies that T.(R)*.U : P.
-  //
-  // These together would seem to imply that G<T.(R)*.T> : P, therefore
-  // the conditional conformance G : P should imply that T.(R)*.T : P.
-  //
-  // However, this would require us to infer an infinite number of
-  // conformance requirements in the signature of mergeP1AndP2() of the
-  // form T.(R)*.T : P.
-  //
-  // Since we're unable to represent that, make sure that a) we don't crash,
-  // b) we reject the conformance T.(R)*.T : P.
-
-  takesP(T.T.self) // expected-error {{global function 'takesP' requires that 'T.T' conform to 'P'}}
-  takesP(T.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.T' conform to 'P'}}
-  takesP(T.R.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.R.T' conform to 'P'}}
-  takesP(T.R.R.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.R.R.T' conform to 'P'}}
+struct SillyBox<T : First> {
+  // CHECK: Generic signature: <T, U where T == Array<U>, U : Second>
+  func withArray<U>(_: U) where T == Array<U> {}
 }

--- a/test/Generics/conditional_requirement_inference_2.swift
+++ b/test/Generics/conditional_requirement_inference_2.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+// A more complicated example.
+protocol Equatable {}
+
+struct Array<Element> {}
+
+extension Array : Equatable where Element : Equatable {}
+
+protocol Sequence {
+  associatedtype Element
+}
+
+extension Array : Sequence {}
+
+struct EquatableSequenceBox<T : Sequence> where T.Element : Equatable {
+  // CHECK: Generic signature: <T, U where T == Array<Array<U>>, U : Equatable>
+  func withArrayArray<U>(_: U) where T == Array<Array<U>> {}
+}

--- a/test/Generics/conditional_requirement_inference_unsupported.swift
+++ b/test/Generics/conditional_requirement_inference_unsupported.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+// A very elaborate invalid example (see comment in mergeP1AndP2())
+struct G<T> {}
+
+protocol P {}
+extension G : P where T : P {}
+
+protocol P1 {
+  associatedtype T
+  associatedtype U where U == G<T>
+  associatedtype R : P1
+}
+
+protocol P2 {
+  associatedtype U : P
+  associatedtype R : P2
+}
+
+func takesP<T : P>(_: T.Type) {}
+// expected-note@-1 {{where 'T' = 'T.R.T'}}
+// expected-note@-2 {{where 'T' = 'T.R.R.T'}}
+// expected-note@-3 {{where 'T' = 'T.R.R.R.T'}}
+
+// CHECK: Generic signature: <T where T : P1, T : P2>
+func mergeP1AndP2<T : P1 & P2>(_: T) {
+  // P1 implies that T.(R)*.U == G<T.(R)*.T>, and P2 implies that T.(R)*.U : P.
+  //
+  // These together would seem to imply that G<T.(R)*.T> : P, therefore
+  // the conditional conformance G : P should imply that T.(R)*.T : P.
+  //
+  // However, this would require us to infer an infinite number of
+  // conformance requirements in the signature of mergeP1AndP2() of the
+  // form T.(R)*.T : P.
+  //
+  // Since we're unable to represent that, make sure that a) we don't crash,
+  // b) we reject the conformance T.(R)*.T : P.
+
+  takesP(T.T.self)
+  takesP(T.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.T' conform to 'P'}}
+  takesP(T.R.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.R.T' conform to 'P'}}
+  takesP(T.R.R.R.T.self) // expected-error {{global function 'takesP' requires that 'T.R.R.R.T' conform to 'P'}}
+}

--- a/test/Generics/non_confluent.swift
+++ b/test/Generics/non_confluent.swift
@@ -34,3 +34,14 @@ func foo<T : P1 & P2>(_: T) {}
 
 extension P1 where Self : P2 {}
 // expected-error@-1 {{cannot build rewrite system for generic signature; depth limit exceeded}}
+
+struct S<U : P1> : P1 {
+  typealias T = S<S<U>>
+}
+
+protocol P3 {
+// expected-error@-1 {{cannot build rewrite system for protocol; depth limit exceeded}}
+  associatedtype T : P1 where T == S<U>
+// expected-error@-1 {{type 'Self.U' does not conform to protocol 'P1'}}
+  associatedtype U : P1
+}


### PR DESCRIPTION
If a type parameter is subject to both a conformance requirement
and a concrete type requirement, the concrete type might conform
conditionally.

In this case, introduce new requirements to satisfy the conditional
conformance.

Since this can add new hitherto-unseen protocols to the rewrite
system, restrict this feature to top-level generic signatures, and
not protocol requirement signatures. Allowing this to occur in
protocol requirement signatures would change the connectivity of
the protocol dependency graph (and hence the connected components)
during completion, which would be a major complication in the
design. The GSB already enforces this restriction.