### PR TITLE
mangling: take the constness of function parameters into mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -621,7 +621,7 @@ Types
   type-list ::= empty-list
 
                                                   // FIXME: Consider replacing 'h' with a two-char code
-  list-type ::= type identifier? 'Yk'? 'z'? 'h'? 'n'? 'Yi'? 'd'?  // type with optional label, '@noDerivative', inout convention, shared convention, owned convention, actor 'isolated', and variadic specifier
+  list-type ::= type identifier? 'Yk'? 'z'? 'h'? 'n'? 'Yi'? 'd'? 'Yt'?  // type with optional label, '@noDerivative', inout convention, shared convention, owned convention, actor 'isolated', variadic specifier, and compile-time constant
 
   METATYPE-REPR ::= 't'                      // Thin metatype representation
   METATYPE-REPR ::= 'T'                      // Thick metatype representation

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -328,6 +328,7 @@ NODE(AsyncSuspendResumePartialFunction)
 
 // Added in Swift 5.6
 NODE(AccessibleFunctionRecord)
+NODE(CompileTimeConst)
 
 // Added in Swift 5.7
 NODE(OpaqueReturnTypeIndexed)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2683,6 +2683,9 @@ void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
   if (flags.isIsolated())
     appendOperator("Yi");
 
+  if (flags.isCompileTimeConst())
+    appendOperator("Yt");
+
   if (!name.empty())
     appendIdentifier(name.str());
   if (flags.isVariadic())

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -777,6 +777,9 @@ NodePointer Demangler::demangleTypeAnnotation() {
   case 'k':
     return createType(
         createWithChild(Node::Kind::NoDerivative, popTypeAndGetChild()));
+  case 't':
+    return createType(
+        createWithChild(Node::Kind::CompileTimeConst, popTypeAndGetChild()));
   default:
     return nullptr;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -421,6 +421,7 @@ private:
     case Node::Kind::InfixOperator:
     case Node::Kind::Initializer:
     case Node::Kind::Isolated:
+    case Node::Kind::CompileTimeConst:
     case Node::Kind::PropertyWrapperBackingInitializer:
     case Node::Kind::PropertyWrapperInitFromProjectedValue:
     case Node::Kind::KeyPathGetterThunkHelper:
@@ -1461,6 +1462,10 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::Isolated:
     Printer << "isolated ";
+    print(Node->getChild(0), depth + 1);
+    return nullptr;
+  case Node::Kind::CompileTimeConst:
+    Printer << "_const ";
     print(Node->getChild(0), depth + 1);
     return nullptr;
   case Node::Kind::Shared:

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1823,6 +1823,11 @@ ManglingError Remangler::mangleIsolated(Node *node, unsigned depth) {
   return mangleSingleChildNode(node, depth + 1); // type
 }
 
+ManglingError Remangler::mangleCompileTimeConst(Node *node, unsigned depth) {
+  Buffer << "Yt";
+  return mangleSingleChildNode(node, depth + 1); // type
+}
+
 ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   Buffer << 'k';
   return mangleSingleChildNode(node, depth + 1); // type

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1969,6 +1969,12 @@ ManglingError Remangler::mangleIsolated(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleCompileTimeConst(Node *node, unsigned depth) {
+  RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1));
+  Buffer << "Yt";
+  return ManglingError::Success;
+}
+
 ManglingError Remangler::mangleShared(Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1));
   Buffer << 'h';

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -423,3 +423,4 @@ $s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aA
 $s17distributed_thunk2DAC1fyyFTE ---> distributed thunk for distributed_thunk.DA.f() -> ()
 $s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int
 $s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk for distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String
+$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()

--- a/test/SILGen/const_param.swift
+++ b/test/SILGen/const_param.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -parse-as-library %s -module-name A | %FileCheck %s
+
+func foo(_ a: _const Int) {}
+func bar(a: _const String) {}
+
+// CHECK: @$s1A3fooyySiYtF
+// CHECK: @$s1A3bar1aySSYt_tF
+
+// RUN: %swift-demangle s1A3fooyySiYtF | %FileCheck %s -check-prefix=CHECK-FOO
+
+// CHECK-FOO: A.foo(_const Swift.Int) -> ()
+
+// RUN: %swift-demangle s1A3bar1aySSYt_tF | %FileCheck %s -check-prefix=CHECK-BAR
+
+// CHECK-BAR: A.bar(a: _const Swift.String) -> ()


### PR DESCRIPTION
Taking the constness of parameters into mangling allows us to support overloads of
functions vary on the constness of specific parameters.

rdar://87954644