### PR TITLE
[test] Disable unsupported_opened_existential.swift

### DIFF
--- a/validation-test/compiler_crashers_2/unsupported_opened_existential.swift
+++ b/validation-test/compiler_crashers_2/unsupported_opened_existential.swift
@@ -1,5 +1,7 @@
 // RUN: not --crash %target-swift-frontend -emit-ir %s
 
+// REQUIRES: asserts
+
 func fetch() {
   sryMap { return "" }
   .napError{ $0.abc() }


### PR DESCRIPTION
This test is currently failing on some macOS bots (https://ci.swift.org/view/Dashboard/job/oss-swift_tools-R_stdlib-RD_test-simulator/6811/console). Disable it for now.

rdar://87869053