### PR TITLE
Gardening: fix comment typo in `build_swift/migration.py`

### DIFF
--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -8,7 +8,7 @@
 
 
 """
-Temporary module with functionaly used to migrate away from build-script-impl.
+Temporary module with functionality used to migrate away from build-script-impl.
 """
 
 


### PR DESCRIPTION
`with functionaly used to migrate` -> `with functionality used to migrate`