### PR TITLE
Sema: Back out https://github.com/apple/swift/pull/36752 entirely

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4157,35 +4157,6 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   }
 }
 
-static bool isSwiftRawRepresentableEnum(Type adoptee) {
-  auto *enumDecl = dyn_cast<EnumDecl>(adoptee->getAnyNominal());
-  return (enumDecl && enumDecl->hasRawType() && !enumDecl->isObjC());
-}
-
-// If the given witness matches a generic RawRepresentable function conforming
-// with a given protocol e.g. `func == <T : RawRepresentable>(lhs: T, rhs: T) ->
-// Bool where T.RawValue : Equatable`
-static bool isRawRepresentableGenericFunction(
-    ASTContext &ctx, const ValueDecl *witness,
-    const NormalProtocolConformance *conformance) {
-  auto *fnDecl = dyn_cast<AbstractFunctionDecl>(witness);
-  if (!fnDecl || !fnDecl->isStdlibDecl())
-    return false;
-
-  return fnDecl->isGeneric() && fnDecl->getGenericParams()->size() == 1 &&
-         fnDecl->getGenericRequirements().size() == 2 &&
-         llvm::all_of(
-             fnDecl->getGenericRequirements(), [&](Requirement genericReq) {
-               if (genericReq.getKind() != RequirementKind::Conformance)
-                 return false;
-               return genericReq.getProtocolDecl() ==
-                          ctx.getProtocol(
-                              KnownProtocolKind::RawRepresentable) ||
-                      genericReq.getProtocolDecl() ==
-                          conformance->getProtocol();
-             });
-}
-
 ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
@@ -4238,9 +4209,6 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
       !requirement->getAttrs().isUnavailable(getASTContext());
 
-  auto &ctx = getASTContext();
-  bool isEquatableConformance = (Conformance->getProtocol() ==
-                                 ctx.getProtocol(KnownProtocolKind::Equatable));
   if (findBestWitness(requirement,
                       considerRenames ? &ignoringNames : nullptr,
                       Conformance,
@@ -4248,28 +4216,6 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                       matches, numViable, bestIdx, doNotDiagnoseMatches)) {
     const auto &best = matches[bestIdx];
     auto witness = best.Witness;
-
-    if (canDerive &&
-        isEquatableConformance &&
-        isSwiftRawRepresentableEnum(Adoptee) &&
-        !Conformance->getDeclContext()->getParentModule()->isResilient()) {
-      // For swift enum types that can derive an Equatable conformance,
-      // if the best witness is the default implementation
-      //
-      //   func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool
-      //     where T.RawValue : Equatable
-      //
-      // let's return as missing and derive the conformance, since it will be
-      // more efficient than comparing rawValues.
-      //
-      // However, we only do this if the module is non-resilient. If it is
-      // resilient, this change can break ABI by publishing a synthesized ==
-      // declaration that may not exist in versions of the framework built
-      // with an older compiler.
-      if (isRawRepresentableGenericFunction(ctx, witness, Conformance)) {
-        return ResolveWitnessResult::Missing;
-      }
-    }
 
     // If the name didn't actually line up, complain.
     if (ignoringNames &&

--- a/test/DebugInfo/debug_scope_propagate.swift
+++ b/test/DebugInfo/debug_scope_propagate.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -g -O -emit-sil | %FileCheck %s
 
-public enum BenchmarkCategory : String {
+public enum BenchmarkCategory {
   case validation
   case api, Array, String, Dictionary, Codable, Set, Data, IndexPath, SIMD
 }

--- a/test/SILGen/enum_equatable_witness.swift
+++ b/test/SILGen/enum_equatable_witness.swift
@@ -9,7 +9,7 @@ public enum MyState : String {
 
 // CHECK-LABEL: sil [ossa] @$s4main11check_stateySiAA7MyStateOF : $@convention(thin) (MyState) -> Int {
 public func check_state(_ state : MyState) -> Int {
-  // FRAGILE: function_ref @$s4main7MyStateO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .opened ? 1 : 0
 }
@@ -22,7 +22,7 @@ public enum GenericMyState<T> : String {
 
 // CHECK-LABEL: sil [ossa] @$s4main19check_generic_stateySiAA14GenericMyStateOySiGF : $@convention(thin) (GenericMyState<Int>) -> Int {
 public func check_generic_state(_ state : GenericMyState<Int>) -> Int {
-  // FRAGILE: function_ref @$s4main14GenericMyStateO21__derived_enum_equalsySbACyxG_AEtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .opened ? 1 : 0
 }
@@ -35,7 +35,7 @@ public enum Regular {
 
 // CHECK-LABEL: sil [ossa] @$s4main13check_regularySiAA7RegularOF : $@convention(thin) (Regular) -> Int {
 public func check_regular(_ state : Regular) -> Int {
-  // FRAGILE: function_ref @$s4main7RegularO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .closed ? 1 : 0
 }
@@ -47,14 +47,14 @@ public enum Alphabet : String {
 
 // CHECK-LABEL: sil [ossa] @$s4main14check_alphabetySiAA8AlphabetOF : $@convention(thin) (Alphabet) -> Int {
 public func check_alphabet(_ state : Alphabet) -> Int {
-  // FRAGILE: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .E ? 1 : 0
 }
 
 // CHECK-LABEL: sil [ossa] @$s4main9compareItySbAA8AlphabetO_ADtF : $@convention(thin) (Alphabet, Alphabet) -> Bool {
 public func compareIt(_ state : Alphabet, _ rhs: Alphabet) -> Bool {
-  // FRAGILE: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == rhs
 }
@@ -66,14 +66,14 @@ public enum AlphabetInt : Int {
 
 // CHECK-LABEL: sil [ossa] @$s4main18check_alphabet_intySiAA11AlphabetIntOF : $@convention(thin) (AlphabetInt) -> Int {
 public func check_alphabet_int(_ state : AlphabetInt) -> Int {
-  // FRAGILE: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == .E ? 1 : 0
 }
 
 // CHECK-LABEL: sil [ossa] @$s4main9compareItySbAA11AlphabetIntO_ADtF : $@convention(thin) (AlphabetInt, AlphabetInt) -> Bool {
 public func compareIt(_ state : AlphabetInt, _ rhs: AlphabetInt) -> Bool {
-  // FRAGILE: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  // FRAGILE: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   // RESILIENT: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF
   return state == rhs
 }

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -178,7 +178,7 @@ public struct Int : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLit
 // CHECK:   %5 = apply %4(%0, %1, %3) : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool // user: %6
 // CHECK:   return %5 : $Bool
 // CHECK-LABEL: } // end sil function '$ss17FloatingPointSignOSQsSQ2eeoiySbx_xtFZTW'
-public enum FloatingPointSign: Int64 {
+public enum FloatingPointSign {
   /// The sign for a positive value.
   case plus
 

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -595,38 +595,6 @@
           "fixedbinaryorder": 0
         },
         {
-          "kind": "Function",
-          "name": "__derived_enum_equals",
-          "printedName": "__derived_enum_equals(_:_:)",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Bool",
-              "printedName": "Swift.Bool",
-              "usr": "s:Sb"
-            },
-            {
-              "kind": "TypeNominal",
-              "name": "Number",
-              "printedName": "cake.Number",
-              "usr": "s:4cake6NumberO"
-            },
-            {
-              "kind": "TypeNominal",
-              "name": "Number",
-              "printedName": "cake.Number",
-              "usr": "s:4cake6NumberO"
-            }
-          ],
-          "declKind": "Func",
-          "usr": "s:4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
-          "mangledName": "$s4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
-          "moduleName": "cake",
-          "static": true,
-          "implicit": true,
-          "funcSelfKind": "NonMutating"
-        },
-        {
           "kind": "Constructor",
           "name": "init",
           "printedName": "init(rawValue:)",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -597,38 +597,6 @@
           "moduleName": "cake"
         },
         {
-          "kind": "Function",
-          "name": "__derived_enum_equals",
-          "printedName": "__derived_enum_equals(_:_:)",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Bool",
-              "printedName": "Swift.Bool",
-              "usr": "s:Sb"
-            },
-            {
-              "kind": "TypeNominal",
-              "name": "Number",
-              "printedName": "cake.Number",
-              "usr": "s:4cake6NumberO"
-            },
-            {
-              "kind": "TypeNominal",
-              "name": "Number",
-              "printedName": "cake.Number",
-              "usr": "s:4cake6NumberO"
-            }
-          ],
-          "declKind": "Func",
-          "usr": "s:4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
-          "mangledName": "$s4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
-          "moduleName": "cake",
-          "static": true,
-          "implicit": true,
-          "funcSelfKind": "NonMutating"
-        },
-        {
           "kind": "Constructor",
           "name": "init",
           "printedName": "init(rawValue:)",


### PR DESCRIPTION
Unfortunately, we can't make this optimization work internally for now.
However, we can revisit it later. One strategy would be to emit the
witness as a private declaration, so that clients call it through the
witness table.

Fixes rdar://problem/86861522.