### PR TITLE
Utils: Update python linter to specify python3 installation of flake8

### DIFF
--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -45,8 +45,8 @@ but these were not found on your system.
 
 You can install these using:
 
-    python -m pip install flake8
-    python -m pip install flake8-import-order
+    python3 -m pip install flake8
+    python3 -m pip install flake8-import-order
 
 For more help, see http://flake8.pycqa.org.
 """


### PR DESCRIPTION
Update the `python_lint.py` installation suggestion for `flake8` to specify `python3` instead of `python`.