### PR TITLE
Add the `@exclusivity` attribute.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -705,6 +705,11 @@ DECL_ATTR(_unavailableFromAsync, UnavailableFromAsync,
   APIBreakingToAdd | APIStableToRemove,
   127)
 
+DECL_ATTR(exclusivity, Exclusivity,
+  OnVar |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  128)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1199,6 +1199,32 @@ public:
   }
 };
 
+/// Represents the exclusivity attribute.
+class ExclusivityAttr : public DeclAttribute {
+public:
+  enum Mode {
+    Checked,
+    Unchecked
+  };
+
+private:
+  Mode mode;
+
+public:
+  ExclusivityAttr(SourceLoc atLoc, SourceRange range, Mode mode)
+     : DeclAttribute(DAK_Exclusivity, atLoc, range, /*Implicit=*/false),
+       mode(mode) {}
+
+  ExclusivityAttr(Mode mode)
+    : ExclusivityAttr(SourceLoc(), SourceRange(), mode) {}
+
+  Mode getMode() const { return mode; }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Exclusivity;
+  }
+};
+
 /// Represents the side effects attribute.
 class EffectsAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5315,6 +5315,17 @@ ERROR(nonobjc_not_allowed,none,
 #undef OBJC_ATTR_SELECT
 
 //------------------------------------------------------------------------------
+// MARK: @exclusivity
+//------------------------------------------------------------------------------
+ERROR(exclusivity_on_wrong_decl,none,
+      "@exclusivity can only be used on class properties, static properties and global variables",
+      ())
+
+ERROR(exclusivity_on_computed_property,none,
+      "@exclusivity can only be used on stored properties",
+      ())
+
+//------------------------------------------------------------------------------
 // MARK: @_borrowed
 //------------------------------------------------------------------------------
 ERROR(borrowed_with_objc_dynamic,none,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -883,6 +883,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_ReferenceOwnership:
   case DAK_Effects:
   case DAK_Optimize:
+  case DAK_Exclusivity:
   case DAK_NonSendable:
     if (DeclAttribute::isDeclModifier(getKind())) {
       Printer.printKeyword(getAttrName(), Options);
@@ -1285,6 +1286,16 @@ StringRef DeclAttribute::getAttrName() const {
       return "_optimize(speed)";
     case OptimizationMode::ForSize:
       return "_optimize(size)";
+    default:
+      llvm_unreachable("Invalid optimization kind");
+    }
+  }
+  case DAK_Exclusivity: {
+    switch (cast<ExclusivityAttr>(this)->getMode()) {
+    case ExclusivityAttr::Checked:
+      return "exclusivity(checked)";
+    case ExclusivityAttr::Unchecked:
+      return "exclusivity(unchecked)";
     default:
       llvm_unreachable("Invalid optimization kind");
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1996,6 +1996,21 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
 
+  case DAK_Exclusivity: {
+    auto mode = parseSingleAttrOption<ExclusivityAttr::Mode>
+                            (*this, Loc, AttrRange, AttrName, DK)
+                       .when("checked", ExclusivityAttr::Mode::Checked)
+                       .when("unchecked", ExclusivityAttr::Mode::Unchecked)
+                       .diagnoseWhenOmitted();
+    if (!mode)
+      return false;
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) ExclusivityAttr(AtLoc, AttrRange, *mode));
+
+    break;
+  }
+
   case DAK_ReferenceOwnership: {
     // Handle weak/unowned/unowned(unsafe).
     auto Kind = AttrName == "weak" ? ReferenceOwnership::Weak

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -240,8 +240,14 @@ static bool shouldUseUnsafeEnforcement(VarDecl *var) {
   if (var->isDebuggerVar())
     return true;
 
-  // TODO: Check for the explicit "unsafe" attribute.
   return false;
+}
+
+static bool hasExclusivityAttr(VarDecl *var, ExclusivityAttr::Mode mode) {
+  if (!var)
+    return false;
+  auto *exclAttr = var->getAttrs().getAttribute<ExclusivityAttr>();
+  return exclAttr && exclAttr->getMode() == mode;
 }
 
 Optional<SILAccessEnforcement>
@@ -257,6 +263,10 @@ SILGenFunction::getDynamicEnforcement(VarDecl *var) {
   if (getOptions().EnforceExclusivityDynamic) {
     if (var && shouldUseUnsafeEnforcement(var))
       return SILAccessEnforcement::Unsafe;
+    if (hasExclusivityAttr(var, ExclusivityAttr::Unchecked))
+      return SILAccessEnforcement::Unsafe;
+    return SILAccessEnforcement::Dynamic;
+  } else if (hasExclusivityAttr(var, ExclusivityAttr::Checked)) {
     return SILAccessEnforcement::Dynamic;
   }
   return None;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1466,6 +1466,7 @@ namespace  {
     UNINTERESTING_ATTR(InheritsConvenienceInitializers)
     UNINTERESTING_ATTR(Inline)
     UNINTERESTING_ATTR(Optimize)
+    UNINTERESTING_ATTR(Exclusivity)
     UNINTERESTING_ATTR(NoLocks)
     UNINTERESTING_ATTR(NoAllocation)
     UNINTERESTING_ATTR(Inlinable)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4416,6 +4416,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::Exclusivity_DECL_ATTR: {
+        unsigned kind;
+        serialization::decls_block::ExclusivityDeclAttrLayout::readRecord(
+            scratch, kind);
+        Attr = new (ctx) ExclusivityAttr((ExclusivityAttr::Mode)kind);
+        break;
+      }
+
       case decls_block::Effects_DECL_ATTR: {
         unsigned kind;
         serialization::decls_block::EffectsDeclAttrLayout::readRecord(scratch,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 660; // remove nested archetypes
+const uint16_t SWIFTMODULE_VERSION_MINOR = 661; // @exclusivity attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1921,6 +1921,11 @@ namespace decls_block {
   using OptimizeDeclAttrLayout = BCRecordLayout<
     Optimize_DECL_ATTR,
     BCFixed<2>  // optimize value
+  >;
+
+  using ExclusivityDeclAttrLayout = BCRecordLayout<
+    Optimize_DECL_ATTR,
+    BCFixed<2>  // exclusivity mode
   >;
 
   using AvailableDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2520,6 +2520,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_Exclusivity: {
+      auto *theAttr = cast<ExclusivityAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[ExclusivityDeclAttrLayout::Code];
+      ExclusivityDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                            (unsigned)theAttr->getMode());
+      return;
+    }
+
     case DAK_Effects: {
       auto *theAttr = cast<EffectsAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[EffectsDeclAttrLayout::Code];

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -141,6 +141,7 @@ struct MyStruct {}
 // ON_GLOBALVAR-DAG: Keyword/None:                       GKInspectable[#Var Attribute#]; name=GKInspectable
 // ON_GLOBALVAR-DAG: Keyword/None:                       differentiable[#Var Attribute#]; name=differentiable
 // ON_GLOBALVAR-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
+// ON_GLOBALVAR-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_GLOBALVAR-NOT: Keyword
 // ON_GLOBALVAR: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_GLOBALVAR: End completions
@@ -172,6 +173,7 @@ struct _S {
 // ON_PROPERTY-DAG: Keyword/None:                       GKInspectable[#Var Attribute#]; name=GKInspectable
 // ON_PROPERTY-DAG: Keyword/None:                       differentiable[#Var Attribute#]; name=differentiable
 // ON_PROPERTY-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
+// ON_PROPERTY-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_PROPERTY-NOT: Keyword
 // ON_PROPERTY: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_PROPERTY-NOT: Decl[PrecedenceGroup]
@@ -257,6 +259,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // ON_MEMBER_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // ON_MEMBER_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
+// ON_MEMBER_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
@@ -307,6 +310,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       transpose[#Declaration Attribute#]; name=transpose
 // KEYWORD_LAST-DAG: Keyword/None:                       noDerivative[#Declaration Attribute#]; name=noDerivative
 // KEYWORD_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
+// KEYWORD_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST:                  End completions

--- a/test/SILGen/exclusivityattr.swift
+++ b/test/SILGen/exclusivityattr.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name=test %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ON
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name=test -enforce-exclusivity=none %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OFF
+
+@exclusivity(checked)
+var globalCheckedVar = 1
+
+@exclusivity(unchecked)
+var globalUncheckedVar = 1
+
+// CHECK-LABEL: sil [ossa] @$s4test13getCheckedVarSiyF
+// CHECK-ON:      begin_access [read] [dynamic]
+// CHECK-OFF:     begin_access [read] [dynamic]
+// CHECK:       } // end sil function '$s4test13getCheckedVarSiyF'
+public func getCheckedVar() -> Int {
+  return globalCheckedVar
+}
+
+// CHECK-LABEL: sil [ossa] @$s4test15getUncheckedVarSiyF
+// CHECK-ON:      begin_access [read] [unsafe]
+// CHECK-OFF-NOT: begin_access
+// CHECK:       } // end sil function '$s4test15getUncheckedVarSiyF'
+public func getUncheckedVar() -> Int {
+  return globalUncheckedVar
+}
+
+public class ExclusivityAttrStruct {
+
+// CHECK-LABEL: sil {{.*}}@$s4test21ExclusivityAttrStructC9staticVarSivsZ
+// CHECK-ON:      begin_access [modify] [unsafe]
+// CHECK:       } // end sil function '$s4test21ExclusivityAttrStructC9staticVarSivsZ'
+  @exclusivity(unchecked)
+  public static var staticVar: Int = 27
+}
+
+public class ExclusivityAttrClass {
+// CHECK-LABEL: sil {{.*}}@$s4test20ExclusivityAttrClassC11instanceVarSivs
+// CHECK-ON:      begin_access [modify] [unsafe]
+// CHECK:       } // end sil function '$s4test20ExclusivityAttrClassC11instanceVarSivs'
+  @exclusivity(unchecked)
+  public var instanceVar: Int = 27
+
+// CHECK-LABEL: sil {{.*}}@$s4test20ExclusivityAttrClassC18checkedInstanceVarSivs
+// CHECK-ON:      begin_access [modify] [dynamic]
+// CHECK-OFF:     begin_access [modify] [dynamic]
+// CHECK:       } // end sil function '$s4test20ExclusivityAttrClassC18checkedInstanceVarSivs'
+  @exclusivity(checked)
+  public var checkedInstanceVar: Int = 27
+
+// CHECK-LABEL: sil {{.*}}@$s4test20ExclusivityAttrClassC9staticVarSivsZ
+// CHECK-ON:      begin_access [modify] [unsafe]
+// CHECK:       } // end sil function '$s4test20ExclusivityAttrClassC9staticVarSivsZ'
+  @exclusivity(unchecked)
+  public static var staticVar: Int = 27
+}
+

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -263,6 +263,38 @@ class C {
   @_optimize(size) var c : Int // expected-error {{'@_optimize(size)' attribute cannot be applied to stored properties}}
 }
 
+
+@exclusivity(checked) // ok
+var globalCheckedVar = 1
+
+@exclusivity(unchecked) // ok
+var globalUncheckedVar = 1
+
+@exclusivity(abc) // // expected-error {{unknown option 'abc' for attribute 'exclusivity'}}
+var globalUnknownVar = 1
+
+struct ExclusivityAttrStruct {
+  @exclusivity(unchecked) // expected-error {{@exclusivity can only be used on class properties, static properties and global variables}}
+  var instanceVar: Int = 27
+
+  @exclusivity(unchecked) // ok
+  static var staticVar: Int = 27
+
+  @exclusivity(unchecked) // expected-error {{@exclusivity can only be used on stored properties}}
+  static var staticComputedVar: Int { return 1 }
+}
+
+class ExclusivityAttrClass {
+  @exclusivity(unchecked) // ok
+  var instanceVar: Int = 27
+
+  @exclusivity(unchecked) // ok
+  static var staticVar: Int = 27
+
+  @exclusivity(unchecked) // expected-error {{@exclusivity can only be used on stored properties}}
+  static var staticComputedVar: Int { return 1 }
+}
+
 class HasStorage {
   @_hasStorage var x : Int = 42  // ok, _hasStorage is allowed here
 }


### PR DESCRIPTION
The `@exclusivity(unchecked)` attribute can be used on variables to selectively disable exclusivity checking.
For completeness, also the `@exclusivity(checked)` variant is supported: it turns on exclusivity checking for specific variables if exclusivity enforcement is disabled by the command line option.

This new attribute is a missing implementation part of SE-0176 (https://github.com/apple/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md).

rdar://31121356
