### PR TITLE
Work around a possible platform/modules bug.

### DIFF
--- a/include/swift/SIL/BridgedSwiftObject.h
+++ b/include/swift/SIL/BridgedSwiftObject.h
@@ -18,7 +18,11 @@
 #ifndef SWIFT_SIL_BRIDGEDSWIFTOBJECT_H
 #define SWIFT_SIL_BRIDGEDSWIFTOBJECT_H
 
+#if defined(__OpenBSD__)
+#include <sys/stdint.h>
+#else
 #include <stdint.h>
+#endif
 
 #if !defined(__has_feature)
 #define __has_feature(feature) 0


### PR DESCRIPTION
On OpenBSD, `stdint.h` is a symlink to `sys/stdint.h`, and the platform
modulemap (basically identical to `libcxx/include/module.modulemap`) has
a defined submodule `std.depr.stdint_h`. When compiling happens with
`-fmodules`, which is what happens in bootstrap builds, this seems to
confuse clang royally and demands that `stdint.h` be included when it
already is.

I don't actually understand what the problem is here. The problem isn't
the symlink, but something... else. I think the problem is the fact that
`std.depr.stdint_h` exists which causes the problem somehow. Removing
the module fixes the problem, as does using a different include (like
`inttypes.h` which does not have a corresponding module) which includes
`stdint.h` transitively.

The other alternative is to counsel users trying to build for the
platform to disable libswift, which means that modules aren't used. This
would be OK, but given that eeckstein says that "*Currently* libswift
does not contain any "mandatory" code yet" (emphasis mine) suggests that
such counsel wouldn't be very durable.

Therefore, to make sure the build is unbroken, make this terrible little
hack for now.
