### PR TITLE
[5.6] mangling: take the constness of function parameters into mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -619,7 +619,7 @@ Types
   type-list ::= empty-list
 
                                                   // FIXME: Consider replacing 'h' with a two-char code
-  list-type ::= type identifier? 'Yk'? 'z'? 'h'? 'n'? 'Yi'? 'd'?  // type with optional label, '@noDerivative', inout convention, shared convention, owned convention, actor 'isolated', and variadic specifier
+  list-type ::= type identifier? 'Yk'? 'z'? 'h'? 'n'? 'Yi'? 'd'? 'Yt'?  // type with optional label, '@noDerivative', inout convention, shared convention, owned convention, actor 'isolated', variadic specifier, and compile-time constant
 
   METATYPE-REPR ::= 't'                      // Thin metatype representation
   METATYPE-REPR ::= 'T'                      // Thick metatype representation

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -325,5 +325,8 @@ NODE(IndexSubset)
 NODE(AsyncAwaitResumePartialFunction)
 NODE(AsyncSuspendResumePartialFunction)
 
+// Added in Swift 5.6
+NODE(CompileTimeConst)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2654,6 +2654,9 @@ void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
   if (flags.isIsolated())
     appendOperator("Yi");
 
+  if (flags.isCompileTimeConst())
+    appendOperator("Yt");
+
   if (!name.empty())
     appendIdentifier(name.str());
   if (flags.isVariadic())

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -763,6 +763,9 @@ NodePointer Demangler::demangleTypeAnnotation() {
   case 'k':
     return createType(
         createWithChild(Node::Kind::NoDerivative, popTypeAndGetChild()));
+  case 't':
+    return createType(
+        createWithChild(Node::Kind::CompileTimeConst, popTypeAndGetChild()));
   default:
     return nullptr;
   }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -419,6 +419,7 @@ private:
     case Node::Kind::InfixOperator:
     case Node::Kind::Initializer:
     case Node::Kind::Isolated:
+    case Node::Kind::CompileTimeConst:
     case Node::Kind::PropertyWrapperBackingInitializer:
     case Node::Kind::PropertyWrapperInitFromProjectedValue:
     case Node::Kind::KeyPathGetterThunkHelper:
@@ -1455,6 +1456,10 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::Isolated:
     Printer << "isolated ";
+    print(Node->getChild(0), depth + 1);
+    return nullptr;
+  case Node::Kind::CompileTimeConst:
+    Printer << "_const ";
     print(Node->getChild(0), depth + 1);
     return nullptr;
   case Node::Kind::Shared:

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1817,6 +1817,11 @@ ManglingError Remangler::mangleIsolated(Node *node, unsigned depth) {
   return mangleSingleChildNode(node, depth + 1); // type
 }
 
+ManglingError Remangler::mangleCompileTimeConst(Node *node, unsigned depth) {
+  Buffer << "Yt";
+  return mangleSingleChildNode(node, depth + 1); // type
+}
+
 ManglingError Remangler::mangleNoDerivative(Node *node, unsigned depth) {
   Buffer << 'k';
   return mangleSingleChildNode(node, depth + 1); // type

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1963,6 +1963,12 @@ ManglingError Remangler::mangleIsolated(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleCompileTimeConst(Node *node, unsigned depth) {
+  RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1));
+  Buffer << "Yt";
+  return ManglingError::Success;
+}
+
 ManglingError Remangler::mangleShared(Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1));
   Buffer << 'h';

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -421,3 +421,4 @@ $s13__lldb_expr_110$10016c2d8yXZ1B10$10016c2e0LLC ---> __lldb_expr_1.(unknown co
 $s__TJO ---> $s__TJO
 $s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3
 $s17distributed_thunk2DAC1fyyFTE ---> distributed thunk for distributed_thunk.DA.f() -> ()
+$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()

--- a/test/SILGen/const_param.swift
+++ b/test/SILGen/const_param.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen -parse-as-library %s -module-name A | %FileCheck %s
+
+func foo(_ a: _const Int) {}
+func bar(a: _const String) {}
+
+// CHECK: @$s1A3fooyySiYtF
+// CHECK: @$s1A3bar1aySSYt_tF
+
+// RUN: %swift-demangle s1A3fooyySiYtF | %FileCheck %s -check-prefix=CHECK-FOO
+
+// CHECK-FOO: A.foo(_const Swift.Int) -> ()
+
+// RUN: %swift-demangle s1A3bar1aySSYt_tF | %FileCheck %s -check-prefix=CHECK-BAR
+
+// CHECK-BAR: A.bar(a: _const Swift.String) -> ()


### PR DESCRIPTION
Explanation: Taking the constness of parameters into mangling allows us to support overloads of
functions that vary on the constness of specific parameters. We don't currently support such onverloads but this mangling enhancement can settle the ABI and allow such a feature in the future.

Reviewer: @artemcm and @eeckstein 

Risk: Very Low

Test: PR Testing

Original PR: https://github.com/apple/swift/pull/40974

rdar://87954644
