### PR TITLE
AST: Fix ValueDecl::isNativeMethodReplacement

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3064,7 +3064,7 @@ bool ValueDecl::isNativeMethodReplacement() const {
   if (isNativeDynamic())
     return true;
 
-  if (isObjCDynamicInGenericClass())
+  if (replacedDecl->isObjCDynamicInGenericClass())
     return replacedDecl->getModuleContext()->isImplicitDynamicEnabled();
 
   return false;

--- a/test/SILGen/Inputs/objc_dynamic_replacement_ext.swift
+++ b/test/SILGen/Inputs/objc_dynamic_replacement_ext.swift
@@ -14,3 +14,13 @@ public class Generic<ItemType>: NSObject {
 
   @objc public dynamic var y: Int = 0
 }
+
+@objc
+public protocol MyProto {
+  func doIt()
+}
+
+public final class MyGeneric<Item>: NSObject, MyProto {
+  public dynamic func doIt() {
+  }
+}

--- a/test/SILGen/objc_dynamic_replacement_ext.swift
+++ b/test/SILGen/objc_dynamic_replacement_ext.swift
@@ -79,3 +79,11 @@ extension Generic {
 // CHECK-NOT: sil {{.*}} @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivsTo : $@convention(objc_method) <ItemType> (Int, Generic<ItemType>) -> ()
 // CHECK-DAG: sil [dynamic_replacement_for "$s10SomeModule7GenericC1ySivs"] [ossa] @$s10SomeModule7GenericC28objc_dynamic_replacement_extE02__F2_ySivs : $@convention(method) <ItemType> (Int, @guaranteed Generic<ItemType>) -> ()
 }
+
+// IMPORT-DAG: sil [dynamically_replacable] [ossa] @$s10SomeModule9MyGenericC4doItyyF
+// IMPORT-DAG: sil [thunk] [ossa] @$s10SomeModule9MyGenericC4doItyyFTo
+// CHECK-NOT: s10SomeModule9MyGenericC28objc_dynamic_replacement_extE02__G6__doItyyFTo
+// CHECK-DAG: sil hidden [dynamic_replacement_for "$s10SomeModule9MyGenericC4doItyyF"] [ossa] @$s10SomeModule9MyGenericC28objc_dynamic_replacement_extE02__G6__doItyyF : $@convention(method) <Item>
+extension MyGeneric {
+    @_dynamicReplacement(for: doIt()) func __replacement__doIt() {}
+}


### PR DESCRIPTION
When we want to figure out whether a `@_dynamicReplacement(for:)` decl
should use native method replacement we need to check whether _the
replaced decl_ is objc dynamic in a generic class.

rdar://87428993