### PR TITLE
Fix section numberings in AndroidBuild.md

### DIFF
--- a/docs/AndroidBuild.md
+++ b/docs/AndroidBuild.md
@@ -7,7 +7,7 @@ Windows.
 - Install the latest version of [Visual Studio](https://www.visualstudio.com/downloads/)
 - Make sure to include the android NDK in your installation.
 
-## 1. Clone the repositories
+## 2. Clone the repositories
 1. Configure git to work with Unix file endings
 1. Clone `apple/swift-llvm` into a directory named `llvm`
 1. Clone `apple/swift-corelibs-libdispatch` into a directory named `swift-corelibs-libdispatch`
@@ -34,7 +34,7 @@ git clone https://github.com/apple/swift-corelibs-xctest swift-corelibs-xctest
 git clone https://github.com/compnerd/swift-build swift-build
 ```
 
-## 1. Acquire the lastest toolchain and dependencies
+## 3. Acquire the lastest toolchain and dependencies
 
 1. Download the toolchain, ICU, libxml2, and curl for android from
    [Azure](https://dev.azure.com/compnerd/swift-build) into `S:\b\a\Library`.
@@ -43,7 +43,7 @@ git clone https://github.com/compnerd/swift-build swift-build
   [compnerd/swift-build](https://www.github.com/compnerd/swift-build) under
   the utilities directory.
 
-## 1. Configure LLVM
+## 4. Configure LLVM
 
 ```cmd
 md S:\b\a\llvm
@@ -57,7 +57,7 @@ cmake -C S:\swift-build\cmake\caches\android-armv7.cmake                        
   S:/llvm
 ```
 
-## 1. Build and install the standard library
+## 5. Build and install the standard library
 
 - We must build and install the standard library to build the remainder of the
   SDK
@@ -79,7 +79,7 @@ ninja
 ninja install
 ```
 
-## 1. Build libdispatch
+## 6. Build libdispatch
 
 - We *cannot* install libdispatch until after all builds are complete as that
   will cause the Dispatch module to be imported twice and fail to build.
@@ -102,7 +102,7 @@ cmake -C S:\swift-build\cmake\caches\android-armv7.cmake                        
 ninja
 ```
 
-## 1. Build foundation
+## 7. Build foundation
 
 ```cmd
 md S:\b\a\foundation
@@ -131,7 +131,7 @@ cmake -C S:\swift-build\cmake\caches\android-armv7.cmake                        
 ninja
 ```
 
-## 1. Build XCTest
+## 8. Build XCTest
 
 ```cmd
 md S:\b\a\xctest
@@ -153,24 +153,23 @@ cmake -C S:\swift-build\cmake\caches\android-armv7.cmake                        
 ninja
 ```
 
-## 1. Install libdispatch
+## 9. Install libdispatch
 
 ```cmd
 cd S:\b\a\libdispatch
 ninja install
 ```
 
-## 1. Install Foundation
+## 10. Install Foundation
 
 ```cmd
 cd S:\b\a\foundation
 ninja install
 ```
 
-## 1. Install XCTest
+## 11. Install XCTest
 
 ```cmd
 cd S:\b\a\xctest
 ninja install
 ```
-


### PR DESCRIPTION
<!-- What's in this pull request? -->
Previously, each numbering was `1.`, when they should be monotonically increasing numbers.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
