### PR TITLE
Opaque parameters

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2789,7 +2789,8 @@ public:
   /// Get the ordinal of the anonymous opaque parameter of this decl with type
   /// repr `repr`, as introduce implicitly by an occurrence of "some" in return
   /// position e.g. `func f() -> some P`. Returns -1 if `repr` is not found.
-  unsigned getAnonymousOpaqueParamOrdinal(OpaqueReturnTypeRepr *repr) const;
+  Optional<unsigned> getAnonymousOpaqueParamOrdinal(
+      OpaqueReturnTypeRepr *repr) const;
 
   GenericSignature getOpaqueInterfaceGenericSignature() const {
     return OpaqueInterfaceGenericSignature;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -492,12 +492,15 @@ protected:
   SWIFT_INLINE_BITFIELD_EMPTY(TypeDecl, ValueDecl);
   SWIFT_INLINE_BITFIELD_EMPTY(AbstractTypeParamDecl, TypeDecl);
 
-  SWIFT_INLINE_BITFIELD_FULL(GenericTypeParamDecl, AbstractTypeParamDecl, 16+16+1,
+  SWIFT_INLINE_BITFIELD_FULL(GenericTypeParamDecl, AbstractTypeParamDecl, 16+16+1+1,
     : NumPadBits,
 
     Depth : 16,
     Index : 16,
-    TypeSequence : 1
+    TypeSequence : 1,
+
+    /// Whether this generic parameter represents an opaque type.
+    IsOpaqueType : 1
   );
 
   SWIFT_INLINE_BITFIELD_EMPTY(GenericTypeDecl, TypeDecl);
@@ -2993,9 +2996,14 @@ public:
 /// \code
 /// func min<T : Comparable>(x : T, y : T) -> T { ... }
 /// \endcode
-class GenericTypeParamDecl : public AbstractTypeParamDecl {
-public:
-  static const unsigned InvalidDepth = 0xFFFF;
+class GenericTypeParamDecl final :
+    public AbstractTypeParamDecl,
+    private llvm::TrailingObjects<GenericTypeParamDecl, OpaqueReturnTypeRepr *>{
+  friend TrailingObjects;
+
+  size_t numTrailingObjects(OverloadToken<OpaqueReturnTypeRepr *>) const {
+    return isOpaqueType() ? 1 : 0;
+  }
 
   /// Construct a new generic type parameter.
   ///
@@ -3006,7 +3014,29 @@ public:
   /// \param name The name of the generic parameter.
   /// \param nameLoc The location of the name.
   GenericTypeParamDecl(DeclContext *dc, Identifier name, SourceLoc nameLoc,
-                       bool isTypeSequence, unsigned depth, unsigned index);
+                       bool isTypeSequence, unsigned depth, unsigned index,
+                       bool isOpaqueType, OpaqueReturnTypeRepr *opaqueTypeRepr);
+
+public:
+  /// Construct a new generic type parameter.
+  ///
+  /// \param dc The DeclContext in which the generic type parameter's owner
+  /// occurs. This should later be overwritten with the actual declaration
+  /// context that owns the type parameter.
+  ///
+  /// \param name The name of the generic parameter.
+  /// \param nameLoc The location of the name.
+  GenericTypeParamDecl(DeclContext *dc, Identifier name, SourceLoc nameLoc,
+                       bool isTypeSequence, unsigned depth, unsigned index)
+      : GenericTypeParamDecl(dc, name, nameLoc, isTypeSequence, depth, index,
+                             false, nullptr) { }
+
+  static const unsigned InvalidDepth = 0xFFFF;
+
+  static GenericTypeParamDecl *
+  create(DeclContext *dc, Identifier name, SourceLoc nameLoc,
+         bool isTypeSequence, unsigned depth, unsigned index,
+         bool isOpaqueType, OpaqueReturnTypeRepr *opaqueTypeRepr);
 
   /// The depth of this generic type parameter, i.e., the number of outer
   /// levels of generic parameter lists that enclose this type parameter.
@@ -3034,8 +3064,32 @@ public:
   /// \code
   /// func foo<@_typeSequence T>(_ : T...) { }
   /// struct Foo<@_typeSequence T> { }
-  /// \encode
+  /// \endcode
   bool isTypeSequence() const { return Bits.GenericTypeParamDecl.TypeSequence; }
+
+  /// Determine whether this generic parameter represents an opaque type.
+  ///
+  /// \code
+  /// // "some P" is representated by a generic type parameter.
+  /// func f() -> [some P] { ... }
+  /// \endcode
+  bool isOpaqueType() const {
+    return Bits.GenericTypeParamDecl.IsOpaqueType;
+  }
+
+  /// Retrieve the opaque return type representation described by this
+  /// generic parameter, or NULL if any of the following are true:
+  ///   - the generic parameter does not describe an opaque type
+  ///   - the opaque type was introduced via the "named opaque parameters"
+  ///     extension, meaning that it was specified explicitly
+  ///   - the enclosing declaration was deserialized, in which case it lost
+  ///     the source location information and has no type representation.
+  OpaqueReturnTypeRepr *getOpaqueTypeRepr() const {
+    if (!isOpaqueType())
+      return nullptr;
+
+    return *getTrailingObjects<OpaqueReturnTypeRepr *>();
+  }
 
   /// The index of this generic type parameter within its generic parameter
   /// list.

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -47,6 +47,9 @@ enum class TypeReprKind : uint8_t {
 enum : unsigned { NumTypeReprKindBits =
   countBitsUsed(static_cast<unsigned>(TypeReprKind::Last_TypeRepr)) };
 
+class OpaqueReturnTypeRepr;
+using CollectedOpaqueReprs = SmallVector<OpaqueReturnTypeRepr *, 2>;
+
 /// Representation of a type as written in source.
 class alignas(1 << TypeReprAlignInBits) TypeRepr
     : public ASTAllocated<TypeRepr> {
@@ -164,6 +167,10 @@ public:
   /// Check recursively whether this type repr or any of its decendants are
   /// opaque return type reprs.
   bool hasOpaque();
+
+  /// Walk the type representation recursively, collecting any
+  /// `OpaqueReturnTypeRepr`s.
+  CollectedOpaqueReprs collectOpaqueReturnTypeReprs();
 
   //*** Allocation Routines ************************************************/
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -313,6 +313,10 @@ namespace swift {
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;
 
+    /// Enable experimental support for opaque parameter types, e.g.
+    /// `func f(collection: some Collection)`.
+    bool EnableExperimentalOpaqueParameters = false;
+
     /// Enable support for explicit existential types via the \c any
     /// keyword.
     bool EnableExplicitExistentialTypes = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -502,6 +502,10 @@ def enable_experimental_named_opaque_types :
   Flag<["-"], "enable-experimental-named-opaque-types">,
   HelpText<"Enable experimental support for named opaque result types">;
 
+def enable_experimental_opaque_parameters :
+  Flag<["-"], "enable-experimental-opaque-parameters">,
+  HelpText<"Enable experimental support for opaque parameters">;
+
 def enable_explicit_existential_types :
   Flag<["-"], "enable-explicit-existential-types">,
   HelpText<"Enable experimental support for explicit existential types">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -295,6 +295,10 @@ def enable_experimental_eager_clang_module_diagnostics :
   Flag<["-"], "enable-experimental-eager-clang-module-diagnostics">,
   HelpText<"Enable experimental eager diagnostics reporting on the importability of all referenced C, C++, and Objective-C libraries">;
 
+def enable_experimental_opaque_parameters :
+  Flag<["-"], "enable-experimental-opaque-parameters">,
+  HelpText<"Enable experimental support for opaque parameters">;
+
 def enable_experimental_pairwise_build_block :
   Flag<["-"], "enable-experimental-pairwise-build-block">,
   HelpText<"Enable experimental pairwise 'buildBlock' for result builders">;
@@ -501,10 +505,6 @@ def disable_subst_sil_function_types :
 def enable_experimental_named_opaque_types :
   Flag<["-"], "enable-experimental-named-opaque-types">,
   HelpText<"Enable experimental support for named opaque result types">;
-
-def enable_experimental_opaque_parameters :
-  Flag<["-"], "enable-experimental-opaque-parameters">,
-  HelpText<"Enable experimental support for opaque parameters">;
 
 def enable_explicit_existential_types :
   Flag<["-"], "enable-explicit-existential-types">,

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -234,9 +234,9 @@ static GenericTypeParamDecl*
 createGenericParam(ASTContext &ctx, const char *name, unsigned index) {
   ModuleDecl *M = ctx.TheBuiltinModule;
   Identifier ident = ctx.getIdentifier(name);
-  auto genericParam = new (ctx) GenericTypeParamDecl(
+  auto genericParam = GenericTypeParamDecl::create(
       &M->getMainFile(FileUnitKind::Builtin), ident, SourceLoc(),
-      /*type sequence*/ false, 0, index);
+      /*type sequence*/ false, 0, index, /*opaque type=*/false, nullptr);
   return genericParam;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4113,7 +4113,7 @@ GenericTypeParamDecl::GenericTypeParamDecl(
   assert(Bits.GenericTypeParamDecl.Index == index && "Truncation");
   Bits.GenericTypeParamDecl.TypeSequence = isTypeSequence;
   Bits.GenericTypeParamDecl.IsOpaqueType = isOpaqueType;
-  assert(!isOpaqueType || !opaqueTypeRepr);
+  assert(isOpaqueType || !opaqueTypeRepr);
   if (isOpaqueType)
     *getTrailingObjects<OpaqueReturnTypeRepr *>() = opaqueTypeRepr;
 
@@ -7877,7 +7877,7 @@ GenericTypeParamDecl *OpaqueTypeDecl::getExplicitGenericParam(
   return genericParamType->getDecl();
 }
 
-unsigned OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(
+Optional<unsigned> OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(
     OpaqueReturnTypeRepr *repr) const {
   assert(NamingDeclAndHasOpaqueReturnTypeRepr.getInt() &&
          "can't do opaque param lookup without underlying interface repr");
@@ -7885,7 +7885,7 @@ unsigned OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(
   auto found = std::find(opaqueReprs.begin(), opaqueReprs.end(), repr);
   if (found != opaqueReprs.end())
     return found - opaqueReprs.begin();
-  return -1;
+  return None;
 }
 
 Identifier OpaqueTypeDecl::getOpaqueReturnTypeIdentifier() const {

--- a/lib/AST/GenericParamList.cpp
+++ b/lib/AST/GenericParamList.cpp
@@ -73,9 +73,10 @@ GenericParamList::clone(DeclContext *dc) const {
   auto &ctx = dc->getASTContext();
   SmallVector<GenericTypeParamDecl *, 2> params;
   for (auto param : getParams()) {
-    auto *newParam = new (ctx) GenericTypeParamDecl(
+    auto *newParam = GenericTypeParamDecl::create(
         dc, param->getName(), SourceLoc(), param->isTypeSequence(),
-        GenericTypeParamDecl::InvalidDepth, param->getIndex());
+        GenericTypeParamDecl::InvalidDepth, param->getIndex(),
+        param->isOpaqueType(), param->getOpaqueTypeRepr());
     newParam->setImplicit(true);
     params.push_back(newParam);
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2603,9 +2603,10 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     // The generic parameter 'Self'.
     auto &ctx = value->getASTContext();
     auto selfId = ctx.Id_Self;
-    auto selfDecl = new (ctx)
-        GenericTypeParamDecl(proto, selfId, SourceLoc(),
-                             /*type sequence=*/false, /*depth=*/0, /*index=*/0);
+    auto selfDecl = GenericTypeParamDecl::create(
+        proto, selfId, SourceLoc(), /*type sequence=*/false,
+        /*depth=*/0, /*index=*/0, /*opaque type=*/false,
+        /*opaque type repr=*/nullptr);
     auto protoType = proto->getDeclaredInterfaceType();
     InheritedEntry selfInherited[1] = {
       InheritedEntry(TypeLoc::withoutLoc(protoType)) };

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -102,6 +102,25 @@ bool TypeRepr::hasOpaque() {
     findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
 }
 
+CollectedOpaqueReprs TypeRepr::collectOpaqueReturnTypeReprs() {
+  class Walker : public ASTWalker {
+    CollectedOpaqueReprs &Reprs;
+
+  public:
+    explicit Walker(CollectedOpaqueReprs &reprs) : Reprs(reprs) {}
+
+    bool walkToTypeReprPre(TypeRepr *repr) override {
+      if (auto opaqueRepr = dyn_cast<OpaqueReturnTypeRepr>(repr))
+        Reprs.push_back(opaqueRepr);
+      return true;
+    }
+  };
+
+  CollectedOpaqueReprs reprs;
+  walk(Walker(reprs));
+  return reprs;
+}
+
 SourceLoc TypeRepr::findUncheckedAttrLoc() const {
   auto typeRepr = this;
   while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -445,6 +445,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 
+  Opts.EnableExperimentalOpaqueParameters |=
+      Args.hasArg(OPT_enable_experimental_opaque_parameters);
+
   Opts.EnableExplicitExistentialTypes |=
       Args.hasArg(OPT_enable_explicit_existential_types);
 

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -105,9 +105,10 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
     // parameter list.
     const bool isTypeSequence =
         attributes.getAttribute<TypeSequenceAttr>() != nullptr;
-    auto Param = new (Context) GenericTypeParamDecl(
+    auto Param = GenericTypeParamDecl::create(
         CurDeclContext, Name, NameLoc, isTypeSequence,
-        GenericTypeParamDecl::InvalidDepth, GenericParams.size());
+        GenericTypeParamDecl::InvalidDepth, GenericParams.size(),
+        /*isOpaqueType=*/false, /*opaqueTypeRepr=*/nullptr);
     if (!Inherited.empty())
       Param->setInherited(Context.AllocateCopy(Inherited));
     GenericParams.push_back(Param);

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -38,9 +38,10 @@ static GenericParamList *cloneGenericParameters(ASTContext &ctx,
                                                 CanGenericSignature sig) {
   SmallVector<GenericTypeParamDecl *, 2> clonedParams;
   for (auto paramType : sig.getGenericParams()) {
-    auto clonedParam = new (ctx) GenericTypeParamDecl(
+    auto clonedParam = GenericTypeParamDecl::create(
         dc, paramType->getName(), SourceLoc(), paramType->isTypeSequence(),
-        paramType->getDepth(), paramType->getIndex());
+        paramType->getDepth(), paramType->getIndex(),
+        /*isOpaqueType=*/false, /*opaqueTypeRepr=*/nullptr);
     clonedParam->setDeclContext(dc);
     clonedParam->setImplicit(true);
     clonedParams.push_back(clonedParam);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -468,9 +468,10 @@ computeDesignatedInitOverrideSignature(ASTContext &ctx,
         depth = genericSig.getGenericParams().back()->getDepth() + 1;
 
       for (auto *param : genericParams->getParams()) {
-        auto *newParam = new (ctx) GenericTypeParamDecl(
+        auto *newParam = GenericTypeParamDecl::create(
             classDecl, param->getName(), SourceLoc(), param->isTypeSequence(),
-            depth, param->getIndex());
+            depth, param->getIndex(), param->isOpaqueType(),
+            /*opaqueTypeRepr=*/nullptr);
         newParams.push_back(newParam);
       }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -78,28 +78,6 @@ TypeChecker::gatherGenericParamBindingsText(
   return result.str().str();
 }
 
-// An alias to avoid repeating the `SmallVector`'s size parameter.
-using CollectedOpaqueReprs = SmallVector<OpaqueReturnTypeRepr *, 2>;
-
-/// Walk `repr` recursively, collecting any `OpaqueReturnTypeRepr`s.
-static CollectedOpaqueReprs collectOpaqueReturnTypeReprs(TypeRepr *repr) {
-  class Walker : public ASTWalker {
-    CollectedOpaqueReprs &Reprs;
-
-  public:
-    explicit Walker(CollectedOpaqueReprs &reprs) : Reprs(reprs) {}
-
-    bool walkToTypeReprPre(TypeRepr *repr) override {
-      if (auto opaqueRepr = dyn_cast<OpaqueReturnTypeRepr>(repr))
-        Reprs.push_back(opaqueRepr);
-      return true;
-    }
-  };
-
-  CollectedOpaqueReprs reprs;
-  repr->walk(Walker(reprs));
-  return reprs;
-}
 
 //
 // Generic functions
@@ -206,7 +184,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       return nullptr;
     }
   } else {
-    opaqueReprs = collectOpaqueReturnTypeReprs(repr);
+    opaqueReprs = repr->collectOpaqueReturnTypeReprs();
     SmallVector<GenericTypeParamType *, 2> genericParamTypes;
     SmallVector<Requirement, 2> requirements;
     for (unsigned i = 0; i < opaqueReprs.size(); ++i) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1047,9 +1047,9 @@ ModuleFile::getGenericSignatureChecked(serialization::GenericSignatureID ID) {
       auto paramTy = getType(rawParamIDs[i+1])->castTo<GenericTypeParamType>();
 
       if (!name.empty()) {
-        auto paramDecl = createDecl<GenericTypeParamDecl>(
+        auto paramDecl = GenericTypeParamDecl::create(
             getAssociatedModule(), name, SourceLoc(), paramTy->isTypeSequence(),
-            paramTy->getDepth(), paramTy->getIndex());
+            paramTy->getDepth(), paramTy->getIndex(), false, nullptr);
         paramTy = paramDecl->getDeclaredInterfaceType()
                    ->castTo<GenericTypeParamType>();
       }
@@ -2680,16 +2680,18 @@ public:
     bool isTypeSequence;
     unsigned depth;
     unsigned index;
+    bool isOpaqueType;
 
     decls_block::GenericTypeParamDeclLayout::readRecord(
-        scratch, nameID, isImplicit, isTypeSequence, depth, index);
+        scratch, nameID, isImplicit, isTypeSequence, depth, index,
+        isOpaqueType);
 
     // Always create GenericTypeParamDecls in the associated file; the real
     // context will reparent them.
     auto *DC = MF.getFile();
-    auto genericParam = MF.createDecl<GenericTypeParamDecl>(
+    auto genericParam = GenericTypeParamDecl::create(
         DC, MF.getIdentifier(nameID), SourceLoc(), isTypeSequence, depth,
-        index);
+        index, isOpaqueType, /*opaqueTypeRepr=*/nullptr);
     declOrOffset = genericParam;
 
     if (isImplicit)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 664; // parametrized protocols
+const uint16_t SWIFTMODULE_VERSION_MINOR = 665; // opaque type param bits
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1223,7 +1223,8 @@ namespace decls_block {
     BCFixed<1>,        // implicit flag
     BCFixed<1>,        // type sequence?
     BCVBR<4>,          // depth
-    BCVBR<4>           // index
+    BCVBR<4>,          // index
+    BCFixed<1>         // opaque type?
   >;
 
   using AssociatedTypeDeclLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3424,7 +3424,8 @@ public:
         S.Out, S.ScratchRecord, abbrCode,
         S.addDeclBaseNameRef(genericParam->getName()),
         genericParam->isImplicit(), genericParam->isTypeSequence(),
-        genericParam->getDepth(), genericParam->getIndex());
+        genericParam->getDepth(), genericParam->getIndex(),
+        genericParam->isOpaqueType());
   }
 
   void visitAssociatedTypeDecl(const AssociatedTypeDecl *assocType) {

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -1,0 +1,52 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-opaque-parameters -disable-availability-checking
+
+protocol P { }
+
+protocol Q {
+  associatedtype A: P & Equatable
+
+  func f() -> A
+}
+
+extension Int: P { }
+extension String: P { }
+
+// expected-note@+1{{requirement from conditional conformance of '[Double]' to 'Q'}}
+extension Array: Q where Element: P, Element: Equatable {
+  func f() -> Element {
+    return first!
+  }
+}
+
+extension Set: Q where Element: P, Element: Equatable {
+  func f() -> Element {
+    return first!
+  }
+}
+
+// expected-note@+2{{where 'some Q' = 'Int'}}
+// expected-note@+1{{in call to function 'takesQ'}}
+func takesQ(_ q: some Q) -> Bool {
+  return q.f() == q.f()
+}
+
+func testTakesQ(arrayOfInts: [Int], setOfStrings: Set<String>, i: Int) {
+  _ = takesQ(arrayOfInts)
+  _ = takesQ(setOfStrings)
+  _ = takesQ(i) // expected-error{{global function 'takesQ' requires that 'Int' conform to 'Q'}}
+
+  let f = takesQ // expected-error{{generic parameter 'some Q' could not be inferred}}
+  let _: ([String]) -> Bool = takesQ
+  let _: ([Double]) -> Bool = takesQ // expected-error{{global function 'takesQ' requires that 'Double' conform to 'P'}}
+  _ = f
+}
+
+// expected-note@+1{{where 'some P' = '[Int]'}}
+func takeMultiple<T>(_: T, _: some Q, _: some P) { }
+
+func testTakeMultiple(
+  arrayOfInts: [Int], setOfStrings: Set<String>, i: Int, d: Double
+) {
+  takeMultiple(d, arrayOfInts, i)
+  takeMultiple(d, arrayOfInts, arrayOfInts) // expected-error{{global function 'takeMultiple' requires that '[Int]' conform to 'P'}}
+}

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -51,6 +51,22 @@ func testTakeMultiple(
   takeMultiple(d, arrayOfInts, arrayOfInts) // expected-error{{global function 'takeMultiple' requires that '[Int]' conform to 'P'}}
 }
 
+// inout
+
+func anyInOut(_: inout some P) { }
+
+func testAnyInOut() {
+  var i = 17
+  anyInOut(&i)
+}
+
+// In structural positions.
+func anyDictionary(_ dict: [some Hashable: some Any]) { }
+
+func testAnyDictionary(numberNames: [Int: String]) {
+  anyDictionary(numberNames)
+}
+
 // Combine with parameterized protocol types
 protocol PrimaryCollection: Collection {
   @_primaryAssociatedType associatedtype Element

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -22,11 +22,12 @@ using namespace swift::unittest;
 
 static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
                                 Identifier name) {
-  auto wrapped = new (ctx) GenericTypeParamDecl(fileForLookups,
-                                                ctx.getIdentifier("Wrapped"),
-                                                SourceLoc(),
-                                                /*type sequence*/ false,
-                                                /*depth*/0, /*index*/0);
+  auto wrapped = GenericTypeParamDecl::create(fileForLookups,
+                                              ctx.getIdentifier("Wrapped"),
+                                              SourceLoc(),
+                                              /*type sequence*/ false,
+                                              /*depth*/0, /*index*/0,
+                                              /*opaque type*/false, nullptr);
   auto params = GenericParamList::create(ctx, SourceLoc(), wrapped,
                                          SourceLoc());
   auto decl = new (ctx) EnumDecl(SourceLoc(), name, SourceLoc(),


### PR DESCRIPTION
Implement function parameters of the form `some P` be synthesizing an
implicit generic parameter whose requirements come from the opaque
type. We then map the opaque type back to the generic parameter, and
print as the opaque type. This allows us to write functions with
implicit generic parameters:

```swift
func f(_: some Collection) { }
```

which is equivalent to:

```swift
func f<T: Collection>(_: T) { }
```

where `T` is an otherwise-unused generic parameter name.

All of this is behind the experimental frontend flag
`-enable-experimental-opaque-parameters`.

Tracked via rdar://86032821