### PR TITLE
AST,Sema: track and emit un-deserialized members

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2781,6 +2781,8 @@ ERROR(inheritance_from_class_with_missing_vtable_entries,none,
       "cannot inherit from class %0 because it has overridable members that "
       "could not be loaded",
       (Identifier))
+NOTE(inheritance_from_class_with_missing_vtable_entry, none,
+     "could not deserialize %0", (DeclName))
 ERROR(inheritance_from_class_with_missing_vtable_entries_versioned,none,
       "cannot inherit from class %0 (compiled with Swift %1) because it has "
       "overridable members that could not be loaded in Swift %2",

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2553,6 +2553,10 @@ public:
         if (!isInvalidSuperclass) {
           CD->diagnose(diag::inheritance_from_class_with_missing_vtable_entries,
                        Super->getName());
+          for (const auto &member : Super->getMembers())
+            if (const auto *MMD = dyn_cast<MissingMemberDecl>(member))
+              CD->diagnose(diag::inheritance_from_class_with_missing_vtable_entry,
+                           MMD->getName());
           isInvalidSuperclass = true;
         }
       }

--- a/test/Serialization/Inputs/CLibrary.h
+++ b/test/Serialization/Inputs/CLibrary.h
@@ -1,0 +1,7 @@
+
+#ifndef CLibrary_h
+#define CLibrary_h
+
+typedef struct __attribute__((__objc_bridge__(Object))) CObject *CObjectRef;
+
+#endif

--- a/test/Serialization/Inputs/module.modulemap
+++ b/test/Serialization/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+
+module CLibrary {
+  header "CLibrary.h"
+}

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -87,7 +87,19 @@ public class UserDynamicConvenienceSub: UserDynamicConvenience {
 }
 _ = UserDynamicConvenienceSub(conveniently: 0)
 
-public class UserSub : User {} // expected-error {{cannot inherit from class 'User' because it has overridable members that could not be loaded}}
+public class UserSub : User {}
+// expected-error@-1 {{cannot inherit from class 'User' because it has overridable members that could not be loaded}}
+// expected-note@-2 {{could not deserialize 'wrappedProp'}}
+// expected-note@-3 {{could not deserialize 'returnsWrappedMethod()'}}
+// expected-note@-4 {{could not deserialize 'constrainedWrapped'}}
+// expected-note@-5 {{could not deserialize 'subscript(_:)'}}
+// expected-note@-6 {{could not deserialize 'subscript(_:)'}}
+// expected-note@-7 {{could not deserialize 'init(wrapped:)'}}
+// expected-note@-8 {{could not deserialize 'init(generic:)'}}
+// expected-note@-9 {{could not deserialize 'init(wrappedRequired:)'}}
+// expected-note@-10 {{could not deserialize 'init(wrappedRequiredInSub:)'}}
+// expected-note@-11 {{could not deserialize 'init(wrappedDynamic:)'}}
+// expected-note@-12 {{could not deserialize 'init(wrappedRequiredDynamic:)'}}
 
 #endif // VERIFY
 

--- a/test/Serialization/implementation-only-open.swift
+++ b/test/Serialization/implementation-only-open.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/swift)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/swift/SwiftLibrary.swiftmodule %s -module-name SwiftLibrary -I%S/Inputs
+// RUN: %target-typecheck-verify-swift -DCLIENT -c %s -module-name client -I%t/swift
+
+#if CLIENT
+import SwiftLibrary
+
+public class MyObject: Object {
+// expected-error@-1 {{cannot inherit from class 'Object' because it has overridable members that could not be loaded}}
+// expected-note@-2 {{could not deserialize 'raw'}}
+// expected-note@-3 {{could not deserialize 'init(object:)'}}
+}
+#else
+@_implementationOnly import CLibrary
+
+open class Object {
+  internal var storage: AnyObject
+  internal var raw: CObject { unsafeBitCast(storage, to: CObject.self) }
+
+  fileprivate init(object: CObject) {
+    self.storage = object
+  }
+}
+#endif


### PR DESCRIPTION
This adds tracking of the vtable holes due to a failure to deserialize
vtable entries.  This allows for the user to be able to identify what
member failed to be deserialied and can aid in understanding why an
`open` class may not be subclassed.

Future improvements here would allow tracing the XRefPath which failed
to be deserialied.  However, this still provides an improvement over the
existing experience where there is no available information on why the
class cannot be inherited from.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
