### PR TITLE
[interop][SwiftToC++] print C++ interface for top-level Swift functions

### DIFF
--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -54,6 +54,16 @@ namespace objc_translation {
                        bool checkParent = true);
 
 } // end namespace objc_translation
+
+namespace cxx_translation {
+
+/// Returns true if the given value decl D is visible to C++ of its
+/// own accord (i.e. without considering its context)
+bool isVisibleToCxx(const ValueDecl *VD, AccessLevel minRequiredAccess,
+                    bool checkParent = true);
+
+} // end namespace cxx_translation
+
 } // end namespace swift
 
 #endif

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -150,3 +150,20 @@ isVisibleToObjC(const ValueDecl *VD, AccessLevel minRequiredAccess,
   }
   return false;
 }
+
+bool swift::cxx_translation::isVisibleToCxx(const ValueDecl *VD,
+                                            AccessLevel minRequiredAccess,
+                                            bool checkParent) {
+  if (VD->isObjC())
+    return false;
+  if (VD->getFormalAccess() >= minRequiredAccess) {
+    return true;
+  } else if (checkParent) {
+    if (auto ctor = dyn_cast<ConstructorDecl>(VD)) {
+      // Check if we're overriding an initializer that is visible to obj-c
+      if (auto parent = ctor->getOverriddenDecl())
+        return isVisibleToCxx(parent, minRequiredAccess, false);
+    }
+  }
+  return false;
+}

--- a/lib/PrintAsClang/CMakeLists.txt
+++ b/lib/PrintAsClang/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_swift_host_library(swiftPrintAsClang STATIC
+  CxxSynthesis.cpp
   DeclAndTypePrinter.cpp
   ModuleContentsWriter.cpp
   PrintAsClang.cpp)

--- a/lib/PrintAsClang/CxxSynthesis.cpp
+++ b/lib/PrintAsClang/CxxSynthesis.cpp
@@ -1,0 +1,37 @@
+//===--- CxxSynthesis.cpp - Rules for synthesizing C++ code -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "CxxSynthesis.h"
+
+using namespace swift;
+using namespace cxx_synthesis;
+
+StringRef cxx_synthesis::getCxxImplNamespaceName() { return "_impl"; }
+
+/// Print a C++ namespace declaration with the give name and body.
+void CxxPrinter::printNamespace(
+    llvm::function_ref<void(raw_ostream &OS)> namePrinter,
+    llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const {
+  os << "namespace ";
+  namePrinter(os);
+  os << " {\n\n";
+  bodyPrinter(os);
+  os << "\n} // namespace ";
+  namePrinter(os);
+  os << "\n\n";
+}
+
+void CxxPrinter::printNamespace(
+    StringRef name,
+    llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const {
+  printNamespace([&](raw_ostream &os) { os << name; }, bodyPrinter);
+}

--- a/lib/PrintAsClang/CxxSynthesis.h
+++ b/lib/PrintAsClang/CxxSynthesis.h
@@ -1,0 +1,49 @@
+//===--- CxxSynthesis.h - Rules for synthesizing C++ code -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PRINTASCLANG_CXXSYNTHESIS_H
+#define SWIFT_PRINTASCLANG_CXXSYNTHESIS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace swift {
+
+namespace cxx_synthesis {
+
+/// Return the name of the implementation namespace that is used to hide
+/// declarations from the namespace that corresponds to the imported Swift
+/// module in C++.
+StringRef getCxxImplNamespaceName();
+
+class CxxPrinter {
+public:
+  CxxPrinter(raw_ostream &os) : os(os) {}
+
+  /// Print a C++ namespace declaration with the give name and body.
+  void
+  printNamespace(llvm::function_ref<void(raw_ostream &OS)> namePrinter,
+                 llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const;
+
+  void
+  printNamespace(StringRef name,
+                 llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const;
+
+private:
+  raw_ostream &os;
+};
+
+} // end namespace cxx_synthesis
+} // end namespace swift
+
+#endif

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "DeclAndTypePrinter.h"
+#include "CxxSynthesis.h"
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ClangSwiftTypeCorrespondence.h"
 #include "swift/AST/Comment.h"
@@ -54,7 +56,7 @@ static bool isAnyObjectOrAny(Type type) {
 }
 
 /// Returns true if \p name matches a keyword in any Clang language mode.
-static bool isClangKeyword(Identifier name) {
+static bool isClangKeyword(StringRef name) {
   static const llvm::DenseSet<StringRef> keywords = []{
     llvm::DenseSet<StringRef> set;
     // FIXME: clang::IdentifierInfo /nearly/ has the API we need to do this
@@ -67,11 +69,14 @@ static bool isClangKeyword(Identifier name) {
     return set;
   }();
 
-  if (name.empty())
-    return false;
-  return keywords.contains(name.str());
+  return keywords.contains(name);
 }
 
+static bool isClangKeyword(Identifier name) {
+  if (name.empty())
+    return false;
+  return isClangKeyword(name.str());
+}
 
 namespace {
   /// Whether the type being printed is in function param position.
@@ -104,6 +109,7 @@ class DeclAndTypePrinter::Implementation
   // but it makes the code simpler to have it here too.
   raw_ostream &os;
   DeclAndTypePrinter &owningPrinter;
+  OutputLanguageMode outputLang;
 
   SmallVector<const FunctionType *, 4> openFunctionTypes;
 
@@ -111,9 +117,15 @@ class DeclAndTypePrinter::Implementation
     return owningPrinter.M.getASTContext();
   }
 
+  // Returns an implementation that prints to the module's prologue.
+  Implementation getModuleProloguePrinter() {
+    return Implementation(owningPrinter.prologueOS, owningPrinter, outputLang);
+  }
+
 public:
-  explicit Implementation(raw_ostream &out, DeclAndTypePrinter &owner)
-    : os(out), owningPrinter(owner) {}
+  explicit Implementation(raw_ostream &out, DeclAndTypePrinter &owner,
+                          OutputLanguageMode outputLang)
+      : os(out), owningPrinter(owner), outputLang(outputLang) {}
 
   void print(const Decl *D) {
     PrettyStackTraceDecl trace("printing", D);
@@ -422,7 +434,7 @@ private:
       Type objTy;
       std::tie(objTy, kind) =
           getObjectTypeAndOptionality(param, param->getInterfaceType());
-      print(objTy, kind, Identifier(), IsFunctionParam);
+      print(objTy, kind, "", IsFunctionParam);
     }
     os << ")";
 
@@ -716,7 +728,61 @@ private:
     }
   }
 
-  void printAbstractFunctionAsFunction(FuncDecl *FD) {
+  /// Print the core function declaration for a given function with the given
+  /// name.
+  void printFunctionDeclAsCFunctionDecl(FuncDecl *FD, StringRef name,
+                                        Type resultTy,
+                                        bool printEmptyParamNames = false) {
+    // The result type may be a partial function type we need to close
+    // up later.
+    PrintMultiPartType multiPart(*this);
+
+    OptionalTypeKind kind;
+    Type objTy;
+    std::tie(objTy, kind) = getObjectTypeAndOptionality(FD, resultTy);
+    visitPart(objTy, kind);
+
+    os << ' ' << name << '(';
+
+    auto params = FD->getParameters();
+    if (params->size()) {
+      size_t index = 1;
+      interleaveComma(*params, os, [&](const ParamDecl *param) {
+        OptionalTypeKind kind;
+        Type objTy;
+        std::tie(objTy, kind) =
+            getObjectTypeAndOptionality(param, param->getInterfaceType());
+        std::string paramName =
+            param->getName().empty() ? "" : param->getName().str().str();
+        if (printEmptyParamNames && paramName.empty()) {
+          llvm::raw_string_ostream os(paramName);
+          os << "_" << index;
+        }
+        print(objTy, kind, paramName, IsFunctionParam);
+        ++index;
+      });
+    } else {
+      os << "void";
+    }
+
+    os << ')';
+
+    // Finish the result type.
+    multiPart.finish();
+  }
+
+  /// Print C or C++ trailing attributes for a function declaration.
+  void printFunctionClangAttributes(FuncDecl *FD, FunctionType *funcTy) {
+    if (funcTy->getResult()->isUninhabited()) {
+      os << " SWIFT_NORETURN";
+    } else if (!funcTy->getResult()->isVoid() &&
+               !FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+      os << " SWIFT_WARN_UNUSED_RESULT";
+    }
+  }
+
+  // Print out the function signature for a @_cdecl function.
+  void printAbstractFunctionAsCFunction(FuncDecl *FD) {
     printDocumentationComment(FD);
     Optional<ForeignAsyncConvention> asyncConvention
       = FD->getForeignAsyncConvention();
@@ -728,52 +794,118 @@ private:
     auto resultTy = getForeignResultType(
         FD, funcTy, asyncConvention, errorConvention);
 
+    assert(FD->getAttrs().hasAttribute<CDeclAttr>() && "not a cdecl function");
     os << "SWIFT_EXTERN ";
+    printFunctionDeclAsCFunctionDecl(
+        FD, FD->getAttrs().getAttribute<CDeclAttr>()->Name, resultTy);
+    printFunctionClangAttributes(FD, funcTy);
+    printAvailability(FD);
+    os << ";\n";
+  }
 
-    // The result type may be a partial function type we need to close
-    // up later.
-    PrintMultiPartType multiPart(*this);
+  struct FuncionSwiftABIInformation {
+    FuncionSwiftABIInformation(FuncDecl *FD, Mangle::ASTMangler &mangler) {
+      isCDecl = FD->getAttrs().hasAttribute<CDeclAttr>();
+      if (!isCDecl) {
+        auto mangledName = mangler.mangleAnyDecl(FD, /*prefix=*/true);
+        symbolName = FD->getASTContext().AllocateCopy(mangledName);
+      } else {
+        symbolName = FD->getAttrs().getAttribute<CDeclAttr>()->Name;
+      }
+    }
 
-    OptionalTypeKind kind;
-    Type objTy;
-    std::tie(objTy, kind) = getObjectTypeAndOptionality(FD, resultTy);
-    visitPart(objTy, kind);
+    StringRef getSymbolName() const { return symbolName; }
 
-    assert(FD->getAttrs().hasAttribute<CDeclAttr>()
-           && "not a cdecl function");
+    bool useCCallingConvention() const { return isCDecl; }
 
-    os << ' ' << FD->getAttrs().getAttribute<CDeclAttr>()->Name << '(';
+    bool useMangledSymbolName() const { return !isCDecl; }
+
+  private:
+    bool isCDecl;
+    StringRef symbolName;
+  };
+
+  // Print out the extern C Swift ABI function signature.
+  FuncionSwiftABIInformation
+  printSwiftABIFunctionSignatureAsCxxFunction(FuncDecl *FD) {
+    assert(outputLang == OutputLanguageMode::Cxx);
+    Optional<ForeignAsyncConvention> asyncConvention =
+        FD->getForeignAsyncConvention();
+    Optional<ForeignErrorConvention> errorConvention =
+        FD->getForeignErrorConvention();
+    assert(!FD->getGenericSignature() &&
+           "top-level generic functions not supported here");
+    // FIXME (Alex): Make type adjustments for C++.
+    auto funcTy = FD->getInterfaceType()->castTo<FunctionType>();
+    auto resultTy =
+        getForeignResultType(FD, funcTy, asyncConvention, errorConvention);
+
+    Mangle::ASTMangler mangler;
+    FuncionSwiftABIInformation funcABI(FD, mangler);
+
+    os << "extern \"C\" ";
+    printFunctionDeclAsCFunctionDecl(FD, funcABI.getSymbolName(), resultTy);
+    // Swift functions can't throw exceptions, we can only
+    // throw them from C++ when emitting C++ inline thunks for the Swift
+    // functions.
+    os << " noexcept";
+    if (!funcABI.useCCallingConvention())
+      os << " SWIFT_CALL";
+    printAvailability(FD);
+    os << ';';
+    if (funcABI.useMangledSymbolName()) {
+      // add a comment with a demangled function name.
+      os << " // ";
+      FD->getName().print(os);
+    }
+    os << "\n";
+    return funcABI;
+  }
+
+  // Print out the C++ inline function thunk that
+  // represents the Swift function in C++.
+  void printAbstractFunctionAsCxxFunctionThunk(
+      FuncDecl *FD, const FuncionSwiftABIInformation &funcABI) {
+    assert(outputLang == OutputLanguageMode::Cxx);
+    printDocumentationComment(FD);
+
+    Optional<ForeignAsyncConvention> asyncConvention =
+        FD->getForeignAsyncConvention();
+    Optional<ForeignErrorConvention> errorConvention =
+        FD->getForeignErrorConvention();
+    assert(!FD->getGenericSignature() &&
+           "top-level generic functions not supported here");
+    auto funcTy = FD->getInterfaceType()->castTo<FunctionType>();
+    auto resultTy =
+        getForeignResultType(FD, funcTy, asyncConvention, errorConvention);
+
+    os << "inline ";
+    printFunctionDeclAsCFunctionDecl(FD,
+                                     FD->getName().getBaseIdentifier().get(),
+                                     resultTy, /*printEmptyParamNames=*/true);
+    // FIXME: Support throwing exceptions for Swift errors.
+    os << " noexcept";
+    printFunctionClangAttributes(FD, funcTy);
+    printAvailability(FD);
+    os << " {\n";
+    os << "  return " << cxx_synthesis::getCxxImplNamespaceName()
+       << "::" << funcABI.getSymbolName() << '(';
 
     auto params = FD->getParameters();
     if (params->size()) {
-      interleave(*params,
-                 [&](const ParamDecl *param) {
-                   OptionalTypeKind kind;
-                   Type objTy;
-                   std::tie(objTy, kind) = getObjectTypeAndOptionality(
-                       param, param->getInterfaceType());
-                   print(objTy, kind, param->getName(), IsFunctionParam);
-                 },
-                 [&] { os << ", "; });
-    } else {
-      os << "void";
+      size_t index = 1;
+      interleaveComma(*params, os, [&](const ParamDecl *param) {
+        if (param->hasName()) {
+          os << param->getName();
+        } else {
+          os << "_" << index;
+        }
+        ++index;
+      });
     }
 
-    os << ')';
-
-    // Finish the result type.
-    multiPart.finish();
-
-    if (funcTy->getResult()->isUninhabited()) {
-      os << " SWIFT_NORETURN";
-    } else if (!funcTy->getResult()->isVoid() &&
-               !FD->getAttrs().hasAttribute<DiscardableResultAttr>()) {
-      os << " SWIFT_WARN_UNUSED_RESULT";
-    }
-
-    printAvailability(FD);
-
-    os << ";\n";
+    os << ");\n";
+    os << "}\n";
   }
 
   enum class PrintLeadingSpace : bool {
@@ -979,10 +1111,18 @@ private:
   }
 
   void visitFuncDecl(FuncDecl *FD) {
+    if (outputLang == OutputLanguageMode::Cxx) {
+      // Emit the underlying C signature that matches the Swift ABI
+      // in the generated C++ implementation prologue for the module.
+      auto funcABI = getModuleProloguePrinter()
+                         .printSwiftABIFunctionSignatureAsCxxFunction(FD);
+      printAbstractFunctionAsCxxFunctionThunk(FD, funcABI);
+      return;
+    }
     if (FD->getDeclContext()->isTypeContext())
       printAbstractFunctionAsMethod(FD, FD->isStatic());
     else
-      printAbstractFunctionAsFunction(FD);
+      printAbstractFunctionAsCFunction(FD);
   }
 
   void visitConstructorDecl(ConstructorDecl *CD) {
@@ -1177,7 +1317,7 @@ private:
       OptionalTypeKind kind;
       Type objTy;
       std::tie(objTy, kind) = getObjectTypeAndOptionality(VD, ty);
-      print(objTy, kind, objCName);
+      print(objTy, kind, objCName.str().str());
     }
 
     printSwift3ObjCDeprecatedInference(VD);
@@ -1922,23 +2062,24 @@ private:
   void finishFunctionType(const FunctionType *FT) {
     os << ")(";
     if (!FT->getParams().empty()) {
-      interleave(FT->getParams(),
-                 [this](const AnyFunctionType::Param &param) {
-                   switch (param.getValueOwnership()) {
-                   case ValueOwnership::Default:
-                   case ValueOwnership::Shared:
-                     break;
-                   case ValueOwnership::Owned:
-                     os << "SWIFT_RELEASES_ARGUMENT ";
-                     break;
-                   case ValueOwnership::InOut:
-                     llvm_unreachable("bad specifier");
-                   }
+      interleave(
+          FT->getParams(),
+          [this](const AnyFunctionType::Param &param) {
+            switch (param.getValueOwnership()) {
+            case ValueOwnership::Default:
+            case ValueOwnership::Shared:
+              break;
+            case ValueOwnership::Owned:
+              os << "SWIFT_RELEASES_ARGUMENT ";
+              break;
+            case ValueOwnership::InOut:
+              llvm_unreachable("bad specifier");
+            }
 
-                   print(param.getParameterType(), OTK_None, param.getLabel(),
-                         IsFunctionParam);
-                 },
-                 [this] { os << ", "; });
+            print(param.getParameterType(), OTK_None,
+                  param.getLabel().str().str(), IsFunctionParam);
+          },
+          [this] { os << ", "; });
     } else {
       os << "void";
     }
@@ -2013,7 +2154,7 @@ private:
   /// visitPart().
 public:
   void print(Type ty, Optional<OptionalTypeKind> optionalKind,
-             Identifier name = Identifier(),
+             std::string name = "",
              IsFunctionParam_t isFuncParam = IsNotFunctionParam) {
     PrettyStackTraceType trace(getASTContext(), "printing", ty);
 
@@ -2027,19 +2168,21 @@ public:
     visitPart(ty, optionalKind);
     if (!name.empty()) {
       os << ' ' << name;
-      if (isClangKeyword(name)) {
+      if (isClangKeyword(name))
         os << '_';
-      }
     }
   }
 };
 
 auto DeclAndTypePrinter::getImpl() -> Implementation {
-  return Implementation(os, *this);
+  return Implementation(os, *this, outputLang);
 }
 
 bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
-  return !VD->isInvalid() && isVisibleToObjC(VD, minRequiredAccess) &&
+  return !VD->isInvalid() &&
+         (outputLang == OutputLanguageMode::Cxx
+              ? cxx_translation::isVisibleToCxx(VD, minRequiredAccess)
+              : isVisibleToObjC(VD, minRequiredAccess)) &&
          !VD->getAttrs().hasAttribute<ImplementationOnlyAttr>();
 }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_PRINTASCLANG_DECLANDTYPEPRINTER_H
 #define SWIFT_PRINTASCLANG_DECLANDTYPEPRINTER_H
 
+#include "OutputLanguageMode.h"
+
 #include "swift/AST/Type.h"
 // for OptionalTypeKind
 #include "swift/ClangImporter/ClangImporter.h"
@@ -35,8 +37,10 @@ private:
 
   ModuleDecl &M;
   raw_ostream &os;
+  raw_ostream &prologueOS;
   const DelayedMemberSet &delayedMembers;
   AccessLevel minRequiredAccess;
+  OutputLanguageMode outputLang;
 
   struct CTypeInfo {
     StringRef name;
@@ -59,9 +63,11 @@ private:
   Implementation getImpl();
 
 public:
-  DeclAndTypePrinter(ModuleDecl &mod, raw_ostream &out,
-                     DelayedMemberSet &delayed, AccessLevel access)
-    : M(mod), os(out), delayedMembers(delayed), minRequiredAccess(access) {}
+  DeclAndTypePrinter(ModuleDecl &mod, raw_ostream &out, raw_ostream &prologueOS,
+                     DelayedMemberSet &delayed, AccessLevel access,
+                     OutputLanguageMode outputLang)
+      : M(mod), os(out), prologueOS(prologueOS), delayedMembers(delayed),
+        minRequiredAccess(access), outputLang(outputLang) {}
 
   /// Returns true if \p VD should be included in a compatibility header for
   /// the options the printer was constructed with.

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -266,6 +266,12 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
          "#  define SWIFT_EXTERN extern\n"
          "# endif\n"
          "#endif\n";
+  auto emitMacro = [&](StringRef name, StringRef value) {
+    out << "#if !defined(" << name << ")\n";
+    out << "# define " << name << " " << value << "\n";
+    out << "#endif\n";
+  };
+  emitMacro("SWIFT_CALL", "__attribute__((swiftcall))");
   static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,
               "need to add SIMD typedefs here if max elements is increased");
 }
@@ -373,25 +379,28 @@ static void writeImports(raw_ostream &out,
 }
 
 static void writePostImportPrologue(raw_ostream &os, ModuleDecl &M) {
-  os <<
-      "#pragma clang diagnostic ignored \"-Wproperty-attribute-mismatch\"\n"
-      "#pragma clang diagnostic ignored \"-Wduplicate-method-arg\"\n"
-      "#if __has_warning(\"-Wpragma-clang-attribute\")\n"
-      "# pragma clang diagnostic ignored \"-Wpragma-clang-attribute\"\n"
-      "#endif\n"
-      "#pragma clang diagnostic ignored \"-Wunknown-pragmas\"\n"
-      "#pragma clang diagnostic ignored \"-Wnullability\"\n"
-      "\n"
-      "#if __has_attribute(external_source_symbol)\n"
-      "# pragma push_macro(\"any\")\n"
-      "# undef any\n"
-      "# pragma clang attribute push("
+  os << "#pragma clang diagnostic ignored \"-Wproperty-attribute-mismatch\"\n"
+        "#pragma clang diagnostic ignored \"-Wduplicate-method-arg\"\n"
+        "#if __has_warning(\"-Wpragma-clang-attribute\")\n"
+        "# pragma clang diagnostic ignored \"-Wpragma-clang-attribute\"\n"
+        "#endif\n"
+        "#pragma clang diagnostic ignored \"-Wunknown-pragmas\"\n"
+        "#pragma clang diagnostic ignored \"-Wnullability\"\n"
+        "#pragma clang diagnostic ignored "
+        "\"-Wdollar-in-identifier-extension\"\n"
+        "\n"
+        "#if __has_attribute(external_source_symbol)\n"
+        "# pragma push_macro(\"any\")\n"
+        "# undef any\n"
+        "# pragma clang attribute push("
         "__attribute__((external_source_symbol(language=\"Swift\", "
-          "defined_in=\"" << M.getNameStr() << "\",generated_declaration))), "
+        "defined_in=\""
+     << M.getNameStr()
+     << "\",generated_declaration))), "
         "apply_to=any(function,enum,objc_interface,objc_category,"
-           "objc_protocol))\n"
-      "# pragma pop_macro(\"any\")\n"
-      "#endif\n\n";
+        "objc_protocol))\n"
+        "# pragma pop_macro(\"any\")\n"
+        "#endif\n\n";
 }
 
 static void writeEpilogue(raw_ostream &os) {

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/functions.h
 
 // RUN: %target-clangxx -c %s -I %t -o %t/cdecl-execution.o
-// RUN: %target-build-swift %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift-link-cxx %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/cdecl-execution
 // RUN: %target-run %t/cdecl-execution

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/functions.h
 
-// RUN: %target-interop-clangxx -c %s -I %t -o %t/cdecl-execution.o
-// RUN: %target-build-swift-link-cxx %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/cdecl-execution.o
+// RUN: %target-interop-build-swift %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/cdecl-execution
 // RUN: %target-run %t/cdecl-execution

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/functions.h
+
+// RUN: %target-clangxx -c %s -I %t -o %t/cdecl-execution.o
+// RUN: %target-build-swift %S/cdecl.swift -o %t/cdecl-execution %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+
+// RUN: %target-codesign %t/cdecl-execution
+// RUN: %target-run %t/cdecl-execution
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "functions.h"
+
+int main() {
+  assert(CdeclFunctions::differentCDeclName(1, 1) == 2);
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/functions.h
 
 // RUN: %target-clangxx -c %s -I %t -o %t/cdecl-execution.o
-// RUN: %target-build-swift %S/cdecl.swift -o %t/cdecl-execution %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
 
 // RUN: %target-codesign %t/cdecl-execution
 // RUN: %target-run %t/cdecl-execution

--- a/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/cdecl-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/cdecl.swift -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/functions.h
 
-// RUN: %target-clangxx -c %s -I %t -o %t/cdecl-execution.o
+// RUN: %target-interop-clangxx -c %s -I %t -o %t/cdecl-execution.o
 // RUN: %target-build-swift-link-cxx %S/cdecl.swift -o %t/cdecl-execution -Xlinker %t/cdecl-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/cdecl-execution

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/empty.h
+// RUN: %FileCheck %s < %t/empty.h
+
+// RUN: %check-cxx-header-in-clang -std=c++14 %t/empty.h
+// RUN: %check-cxx-header-in-clang -std=c++17 %t/empty.h
+
+// CHECK-LABEL: namespace CdeclFunctions {
+
+// CHECK: namespace _impl {
+// CHECK: extern "C" int cfuncPassTwo(int x, int y) noexcept;
+// CHECK: }
+
+@_cdecl("cfuncPassTwo")
+public func differentCDeclName(x: CInt, y: CInt) -> CInt { return x + y }
+
+// CHECK: inline int differentCDeclName(int x, int y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: return _impl::cfuncPassTwo(x, y);
+// CHECK: }

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-cxx-header-in-clang -std=c++14 %t/functions.h
+// RUN: %check-cxx-header-in-clang -std=c++17 %t/functions.h
+
+// CHECK-LABEL: namespace Functions {
+
+// CHECK-LABEL: namespace _impl {
+
+// CHECK: extern "C" void $s9Functions16alwaysDeprecatedyyF(void) noexcept SWIFT_CALL SWIFT_DEPRECATED; // alwaysDeprecated()
+// CHECK: extern "C" void $s9Functions19alwaysDeprecatedTwoyyF(void) noexcept SWIFT_CALL SWIFT_DEPRECATED_MSG("it should not be used"); // alwaysDeprecatedTwo()
+// CHECK: extern "C" void $s9Functions17alwaysUnavailableyyF(void) noexcept SWIFT_CALL SWIFT_UNAVAILABLE; // alwaysUnavailable()
+// CHECK: extern "C" void $s9Functions24alwaysUnavailableMessageyyF(void) noexcept SWIFT_CALL SWIFT_UNAVAILABLE_MSG("stuff happened"); // alwaysUnavailableMessage()
+// CHECK: extern "C" void $s9Functions22singlePlatAvailabilityyyF(void) noexcept SWIFT_CALL SWIFT_AVAILABILITY(macos,introduced=11); // singlePlatAvailability()
+
+// CHECK: }
+
+// CHECK: inline void alwaysDeprecated(void) noexcept SWIFT_DEPRECATED {
+@available(*, deprecated)
+public func alwaysDeprecated() {}
+
+// CHECK: inline void alwaysDeprecatedTwo(void) noexcept SWIFT_DEPRECATED_MSG("it should not be used")
+@available(*, deprecated, message: "it should not be used")
+public func alwaysDeprecatedTwo() {}
+
+// CHECK: inline void alwaysUnavailable(void) noexcept SWIFT_UNAVAILABLE
+@available(*, unavailable)
+public func alwaysUnavailable() {}
+
+// CHECK: inline void alwaysUnavailableMessage(void) noexcept SWIFT_UNAVAILABLE_MSG("stuff happened")
+@available(*, unavailable, message: "stuff happened")
+public func alwaysUnavailableMessage() {}
+
+// CHECK: inline void singlePlatAvailability(void) noexcept SWIFT_AVAILABILITY(macos,introduced=11)
+@available(macOS 11, *)
+public func singlePlatAvailability() {}

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
+
+// RUN: %target-clangxx -c %s -I %t -o %t/swift-functions-execution.o
+// RUN: %target-build-swift %S/swift-functions.swift -o %t/swift-functions-execution %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+
+// RUN: %target-codesign %t/swift-functions-execution
+// RUN: %target-run %t/swift-functions-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "functions.h"
+
+int main() {
+  Functions::passVoidReturnVoid();
+  Functions::passIntReturnVoid(-1);
+  assert(Functions::passTwoIntReturnIntNoArgLabel(1, 2) == 42);
+  assert(Functions::passTwoIntReturnInt(1, 2) == 3);
+  assert(Functions::passTwoIntReturnIntNoArgLabelParamName(1, 4) == 5);
+  return 0;
+}
+
+// CHECK: passVoidReturnVoid
+// CHECK-NEXT: passIntReturnVoid -1
+// CHECK-NEXT: passTwoIntReturnIntNoArgLabel

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 
 // RUN: %target-clangxx -c %s -I %t -o %t/swift-functions-execution.o
-// RUN: %target-build-swift %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift-link-cxx %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/swift-functions-execution
 // RUN: %target-run %t/swift-functions-execution | %FileCheck %s

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 
 // RUN: %target-clangxx -c %s -I %t -o %t/swift-functions-execution.o
-// RUN: %target-build-swift %S/swift-functions.swift -o %t/swift-functions-execution %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -Xfrontend -enable-cxx-interop
 
 // RUN: %target-codesign %t/swift-functions-execution
 // RUN: %target-run %t/swift-functions-execution | %FileCheck %s

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 
-// RUN: %target-interop-clangxx -c %s -I %t -o %t/swift-functions-execution.o
-// RUN: %target-build-swift-link-cxx %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o
+// RUN: %target-interop-build-swift %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/swift-functions-execution
 // RUN: %target-run %t/swift-functions-execution | %FileCheck %s

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/swift-functions.swift -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 
-// RUN: %target-clangxx -c %s -I %t -o %t/swift-functions-execution.o
+// RUN: %target-interop-clangxx -c %s -I %t -o %t/swift-functions-execution.o
 // RUN: %target-build-swift-link-cxx %S/swift-functions.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/swift-functions-execution

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-cxx-header-in-clang -std=c++14 %t/functions.h
+// RUN: %check-cxx-header-in-clang -std=c++17 %t/functions.h
+
+// CHECK-LABEL: namespace Functions {
+
+// CHECK-LABEL: namespace _impl {
+
+// CHECK: extern "C" void $s9Functions17passIntReturnVoid1xys5Int32V_tF(int x) noexcept SWIFT_CALL; // passIntReturnVoid(x:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(int x, int y) noexcept SWIFT_CALL; // passTwoIntReturnInt(x:y:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(int, int) noexcept SWIFT_CALL; // passTwoIntReturnIntNoArgLabel(_:_:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(int x2, int y2) noexcept SWIFT_CALL; // passTwoIntReturnIntNoArgLabelParamName(_:_:)
+// CHECK: extern "C" void $s9Functions014passVoidReturnC0yyF(void) noexcept SWIFT_CALL; // passVoidReturnVoid()
+
+// CHECK: }
+
+public func passIntReturnVoid(x: CInt) { print("passIntReturnVoid \(x)") }
+
+// CHECK: inline void passIntReturnVoid(int x) noexcept {
+// CHECK: return _impl::$s9Functions17passIntReturnVoid1xys5Int32V_tF(x);
+// CHECK: }
+
+public func passTwoIntReturnInt(x: CInt, y: CInt) -> CInt { return x + y }
+
+// CHECK: inline int passTwoIntReturnInt(int x, int y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: return _impl::$s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(x, y);
+// CHECK: }
+
+public func passTwoIntReturnIntNoArgLabel(_: CInt, _: CInt) -> CInt {
+  print("passTwoIntReturnIntNoArgLabel")
+  return 42
+}
+
+// CHECK: inline int passTwoIntReturnIntNoArgLabel(int _1, int _2) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: return _impl::$s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(_1, _2);
+// CHECK: }
+
+public func passTwoIntReturnIntNoArgLabelParamName(_ x2: CInt, _ y2: CInt) -> CInt { return x2 + y2 }
+
+// CHECK: inline int passTwoIntReturnIntNoArgLabelParamName(int x2, int y2) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:   return _impl::$s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(x2, y2);
+// CHECK: }
+
+public func passVoidReturnVoid() { print("passVoidReturnVoid") }
+
+// CHECK: inline void passVoidReturnVoid(void) noexcept {
+// CHECK: return _impl::$s9Functions014passVoidReturnC0yyF();
+// CHECK: }

--- a/test/Interop/SwiftToCxx/lit.local.cfg
+++ b/test/Interop/SwiftToCxx/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.swift', '.cpp']

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -17,6 +17,5 @@ else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
 
-config.substitutions.insert(0, ('%target-build-swift-link-cxx', '%target-build-swift -Xfrontend -enable-cxx-interop ' + libc_opt))
-
-config.substitutions.insert(0, ('%target-interop-clangxx', '%target-clangxx ' + clang_opt))
+config.substitutions.insert(0, ('%target-interop-build-swift', '%target-build-swift -Xfrontend -enable-cxx-interop ' + libc_opt))
+config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx ' + clang_opt))

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -6,9 +6,12 @@ def get_target_os():
     (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
     return run_os
 
+libc_opt = ''
 if get_target_os() in ['windows-msvc']:
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
+    libc_opt = '-libc MT '
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
 
+config.substitutions.insert(0, ('%target-build-swift-link-cxx', '%target-build-swift -Xfrontend -enable-cxx-interop ' + libc_opt))

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -7,11 +7,16 @@ def get_target_os():
     return run_os
 
 libc_opt = ''
+clang_opt = ''
+
 if get_target_os() in ['windows-msvc']:
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
-    libc_opt = '-libc MT '
+    #libc_opt = '-libc MT '
+    clang_opt = '-D_MT -D_DLL -Xclang --dependent-lib=msvcrt -Xclang --dependent-lib=oldnames '
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
 
 config.substitutions.insert(0, ('%target-build-swift-link-cxx', '%target-build-swift -Xfrontend -enable-cxx-interop ' + libc_opt))
+
+config.substitutions.insert(0, ('%target-interop-clangxx', '%target-clangxx ' + clang_opt))


### PR DESCRIPTION
Emit C++ function thunks that correspond to Swift top-level functions, alongside their `extern "C"` function signatures, which are places in the `_impl` namespace in the module's namespace.