### PR TITLE
Make top-level code variables `@MainActor @preconcurrency`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4771,7 +4771,9 @@ ERROR(global_actor_non_unsafe_init,none,
       "global actor attribute %0 argument can only be '(unsafe)'", (Type))
 ERROR(global_actor_non_final_class,none,
       "non-final class %0 cannot be a global actor", (DeclName))
-      
+ERROR(global_actor_top_level_var,none,
+      "top-level code variables cannot have a global actor", ())
+
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",
       (DescriptiveDeclKind, DeclName, StringRef, StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8949,6 +8949,14 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
     }
   }
 
+  if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
+    ASTContext &ctx = dc->getASTContext();
+    if (ctx.LangOpts.EnableExperimentalAsyncTopLevel) {
+      if (Type mainActor = ctx.getMainActorType())
+        return ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/false);
+    }
+  }
+
   return ActorIsolation::forUnspecified();
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -733,9 +733,15 @@ bool Decl::preconcurrency() const {
   if (isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext()))
     return true;
 
+  // Variables declared in top-level code are @_predatesConcurrency
+  if (const VarDecl *var = dyn_cast<VarDecl>(this)) {
+    const LangOptions &langOpts = getASTContext().LangOpts;
+    return !langOpts.isSwiftVersionAtLeast(6) &&
+           langOpts.EnableExperimentalAsyncTopLevel && var->isTopLevelGlobal();
+  }
+
   return false;
 }
-
 
 Expr *AbstractFunctionDecl::getSingleExpressionBody() const {
   assert(hasSingleExpressionBody() && "Not a single-expression body");

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -271,7 +271,12 @@ GlobalActorAttributeRequest::evaluate(
   } else if (auto storage = dyn_cast<AbstractStorageDecl>(decl)) {
     // Subscripts and properties are fine...
     if (auto var = dyn_cast<VarDecl>(storage)) {
-      if (var->getDeclContext()->isLocalContext() && !var->isTopLevelGlobal()) {
+      if (var->isTopLevelGlobal() &&
+          var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel) {
+        var->diagnose(diag::global_actor_top_level_var)
+            .highlight(globalActorAttr->getRangeWithAt());
+        return None;
+      } else if (var->getDeclContext()->isLocalContext()) {
         var->diagnose(diag::global_actor_on_local_variable, var->getName())
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
@@ -3505,6 +3510,14 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
+    ASTContext &ctx = var->getASTContext();
+    if (var->isTopLevelGlobal() &&
+        ctx.LangOpts.EnableExperimentalAsyncTopLevel) {
+      if (Type mainActor = ctx.getMainActorType())
+        return inferredIsolation(
+            ActorIsolation::forGlobalActor(mainActor,
+                                           /*unsafe=*/false));
+    }
     if (auto isolation = getActorIsolationFromWrappedProperty(var))
       return inferredIsolation(isolation);
   }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3516,7 +3516,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
       if (Type mainActor = ctx.getMainActorType())
         return inferredIsolation(
             ActorIsolation::forGlobalActor(mainActor,
-                                           /*unsafe=*/false));
+                                           /*unsafe=*/var->preconcurrency()));
     }
     if (auto isolation = getActorIsolationFromWrappedProperty(var))
       return inferredIsolation(isolation);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -199,6 +199,8 @@ public:
   }
 
   /// Determine the isolation rules for a given declaration.
+  /// The isolation restriction represents the isolation requirement of the
+  /// using context.
   ///
   /// \param fromExpression Indicates that the reference is coming from an
   /// expression.

--- a/test/Concurrency/toplevel/Inputs/foo.swift
+++ b/test/Concurrency/toplevel/Inputs/foo.swift
@@ -1,0 +1,3 @@
+func foo() -> Int {
+    a + 10
+}

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -3,6 +3,10 @@
 
 var a = 10
 
+@MainActor
+var b = 14
+// CHECK: top-level code variables cannot have a global actor
+
 func nonIsolatedSynchronous() {
     print(a)
 // Swift6-CHECK: var 'a' isolated to global actor 'MainActor'

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -1,0 +1,40 @@
+// RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 6 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift6-CHECK,CHECK'
+// RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 5 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift5-CHECK,CHECK'
+
+var a = 10
+
+func nonIsolatedSynchronous() {
+    print(a)
+// Swift6-CHECK: var 'a' isolated to global actor 'MainActor'
+// Swift6-CHECK: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
+
+// Swift5-CHECK-NOT: var 'a' isolated to global actor 'MainActor'
+// Swift5-CHECK-NOT: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
+}
+
+func nonIsolatedAsync() async {
+    print(a)
+// CHECK: expression is 'async' but is not marked with 'await'
+// CHECK: property access is 'async'
+}
+
+await nonIsolatedAsync()
+
+// Swift6-CHECK: foo.swift{{.*}}var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context
+// Swift6-CHECK: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
+// Swift6-CHECK: var declared here
+
+// Swift5-CHECK-NOT: foo.swift{{.*}}var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context
+// Swift5-CHECK-NOT: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
+// Swift5-CHECK-NOT: var declared here
+
+@MainActor
+func isolated() {
+    print(a)
+}
+
+func asyncFun() async {
+    await print(a)
+}
+
+await asyncFun()

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -1,111 +1,126 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -disable-availability-checking -enable-experimental-async-top-level %s | %FileCheck %s
 
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
-// b
-// CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1bSivp : $Int
 
 // CHECK-LABEL: sil hidden [ossa] @async_Main
 // CHECK: bb0:
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor
 // CHECK-NEXT: [[MAIN:%.*]] = apply [[GET_MAIN]]()
-// CHECK-NEXT: alloc_global @$s24toplevel_globalactorvars1aSivp
-// CHECK-NEXT: [[AREF:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1aSivp : $*Int
 
-@available(SwiftStdlib 5.1, *)
 actor MyActorImpl {}
 
-@available(SwiftStdlib 5.1, *)
 @globalActor
 struct MyActor {
     static let shared = MyActorImpl()
 }
 
-@MyActor
 var a = 10
 
+// a initialization
+// CHECK: alloc_global @$s24toplevel_globalactorvars1aSivp
+// CHECK: [[AREF:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1aSivp
+// CHECK: [[TEN_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 10
+// CHECK: [[INT_TYPE:%[0-9]+]] = metatype $@thin Int.Type
+// CHECK: [[INT_INIT:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK: [[TEN:%[0-9]+]] = apply [[INT_INIT]]([[TEN_LIT]], [[INT_TYPE]])
+// CHECK: store [[TEN]] to [trivial] [[AREF]]
+
 @MyActor
-func incrementA() {
-    a += 1
+func printFromMyActor(value : Int) {
+    print(value)
 }
 
-await print(a)
+print(a)
 
-// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
-// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
-// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
-// CHECK: end_access [[AACCESS]]
-// CHECK: hop_to_executor [[MAIN]]
-// CHECK: end_borrow [[ACTORREF]]
-
-await incrementA()
-
-// CHECK: [[INCREMENTA:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars10incrementAyyF
-// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
-// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-// CHECK: {{%[0-9]+}} = apply [[INCREMENTA]]()
-// CHECK: hop_to_executor [[MAIN]]
-// CHECK: end_borrow [[ACTORREF]]
-
-await print(a)
-
-// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
-// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
-// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
-// CHECK: end_access [[AACCESS]]
-// CHECK: hop_to_executor [[MAIN]]
-// CHECK: end_borrow [[ACTORREF]]
-
-var b = 11
-
-// CHECK: alloc_global @$s24toplevel_globalactorvars1bSivp
-// CHECK: [[BGLOBAL_ADDR:%[0-9]+]] = global_addr @$s24toplevel_globalactorvars1bSivp
-// Int.init(_builtinIntegerLiteral:)
-// CHECK: [[INT_INIT_FUNC:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
-// CHECK: [[INITD_INT:%[0-9]+]] = apply [[INT_INIT_FUNC]]({{%[0-9]+}}, {{%[0-9]+}})
-// CHECK: store [[INITD_INT]] to [trivial] [[BGLOBAL_ADDR]]
-
-b += 1
-
+// print
 // CHECK-NOT: hop_to_executor
-// CHECK: [[BACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[BGLOBAL_ADDR]]
+
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+// CHECK: end_access [[AACCESS]]
+// CHECK-NOT: hop_to_executor
+
+a += 1
+
+// CHECK: [[ONE_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [[INT_TYPE:%[0-9]+]] = metatype $@thin Int.Type
+// CHECK: [[INT_INIT:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK: [[ONE:%[0-9]+]] = apply [[INT_INIT]]([[ONE_LIT]], [[INT_TYPE]])
+// CHECK-NOT: hop_to_executor
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[AREF]] : $*Int
 // static Int.+= infix(_:_:)
 // CHECK: [[PE_INT_FUNC:%[0-9]+]] = function_ref @$sSi2peoiyySiz_SitFZ
-// CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[BACCESS]], {{%[0-9]+}}, {{%[0-9]+}})
-// CHECK: end_access [[BACCESS]]
+// CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[AACCESS]], [[ONE]], {{%[0-9]+}})
+// CHECK: end_access [[AACCESS]]
+// CHECK-NOT: hop_to_executor
 
 
+await printFromMyActor(value: a)
+
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+// CHECK: end_access [[AACCESS]]
+
+// CHECK: [[PRINTFROMMYACTOR_FUNC:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars16printFromMyActor5valueySi_tF
+// CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+// CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+// CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
+// CHECK: hop_to_executor [[MAIN]]
+// CHECK: end_borrow [[ACTORREF]]
+
+if a < 10 {
+// CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+// CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+// CHECK: end_access [[AACCESS]]
+
+// CHECK: [[TEN_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 10
+// CHECK: [[INT_TYPE:%[0-9]+]] = metatype $@thin Int.Type
+// CHECK: [[INT_INIT:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK: [[TEN:%[0-9]+]] = apply [[INT_INIT]]([[TEN_LIT]], [[INT_TYPE]])
+// function_ref static Swift.Int.< infix(Swift.Int, Swift.Int) -> Swift.Bool
+// CHECK: [[LESS_FUNC:%[0-9]+]] = function_ref @$sSi1loiySbSi_SitFZ
+// CHECK: [[WRAPPED_COND:%[0-9]+]] = apply [[LESS_FUNC]]([[AGLOBAL]], [[TEN]], {{%[0-9]+}})
+// CHECK: [[COND:%[0-9]+]] = struct_extract [[WRAPPED_COND]]
+// CHECK: cond_br [[COND]], bb1, bb2
 // CHECK: bb1:
-if #available(SwiftStdlib 5.1, *) {
-    await print(a)
 
-    // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
-    // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+    print(a)
+
+    // print
+    // CHECK-NOT: hop_to_executor
+
     // CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
     // CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
     // CHECK: end_access [[AACCESS]]
-    // CHECK: hop_to_executor [[MAIN]]
-    // CHECK: end_borrow [[ACTORREF]]
-
-    await incrementA()
-
-    // CHECK: [[INCREMENTA:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars10incrementAyyF
-    // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
-    // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-    // CHECK: {{%[0-9]+}} = apply [[INCREMENTA]]()
-    // CHECK: hop_to_executor [[MAIN]]
-    // CHECK: end_borrow [[ACTORREF]]
-
-
-    b += 1
-
     // CHECK-NOT: hop_to_executor
-    // CHECK: [[BACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[BGLOBAL_ADDR]]
+
+    a += 1
+
+    // CHECK: [[ONE_LIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
+    // CHECK: [[INT_TYPE:%[0-9]+]] = metatype $@thin Int.Type
+    // CHECK: [[INT_INIT:%[0-9]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+    // CHECK: [[ONE:%[0-9]+]] = apply [[INT_INIT]]([[ONE_LIT]], [[INT_TYPE]])
+    // CHECK-NOT: hop_to_executor
+    // CHECK: [[AACCESS:%[0-9]+]] = begin_access [modify] [dynamic] [[AREF]] : $*Int
     // static Int.+= infix(_:_:)
     // CHECK: [[PE_INT_FUNC:%[0-9]+]] = function_ref @$sSi2peoiyySiz_SitFZ
-    // CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[BACCESS]], {{%[0-9]+}}, {{%[0-9]+}})
-    // CHECK: end_access [[BACCESS]]
+    // CHECK: [[INCREMENTED:%[0-9]+]] = apply [[PE_INT_FUNC]]([[AACCESS]], [[ONE]], {{%[0-9]+}})
+    // CHECK: end_access [[AACCESS]]
+    // CHECK-NOT: hop_to_executor
+
+
+    await printFromMyActor(value: a)
+
+    // CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
+    // CHECK: [[AGLOBAL:%[0-9]+]] = load [trivial] [[AACCESS]] : $*Int
+    // CHECK: end_access [[AACCESS]]
+
+    // CHECK: [[PRINTFROMMYACTOR_FUNC:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars16printFromMyActor5valueySi_tF
+    // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
+    // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
+    // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
+    // CHECK: hop_to_executor [[MAIN]]
+    // CHECK: end_borrow [[ACTORREF]]
 }


### PR DESCRIPTION
This patch gets the semantics roughly where we want them. The top-level code context is set to run on the main actor and the top-level variables are `@MainActor @preconcurrency`. This pairing reduces the number of hops between actors for top-level code, provides some level of safety, and keeps the code breakage fairly minimal.

The next PR contains `await` detection to turn the top-level code into an async context once the first use of `await` is used in the top-level. If no `await`s are used, the top-level should behave _exactly_ the same as it does today to keep current scripts working.