### PR TITLE
[SourceKit] Compute code completion type relation when wrapping a ContextFreeCodeCompletionResult in a CodeCompletionResult

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_IDE_CODECOMPLETION_H
 #define SWIFT_IDE_CODECOMPLETION_H
 
+#include "CodeCompletionResultType.h"
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
@@ -701,31 +702,6 @@ enum class CodeCompletionResultKind : uint8_t {
   MAX_VALUE = BuiltinOperator
 };
 
-/// Describes the relationship between the type of the completion results and
-/// the expected type at the code completion position.
-enum class CodeCompletionResultTypeRelation : uint8_t {
-  /// The result does not have a type (e.g. keyword).
-  NotApplicable,
-
-  /// The type relation have not been calculated.
-  Unknown,
-
-  /// The relationship of the result's type to the expected type is not
-  /// invalid, not convertible, and not identical.
-  Unrelated,
-
-  /// The result's type is invalid at the expected position.
-  Invalid,
-
-  /// The result's type is convertible to the type of the expected.
-  Convertible,
-
-  /// The result's type is identical to the type of the expected.
-  Identical,
-
-  MAX_VALUE = Identical
-};
-
 /// The parts of a \c CodeCompletionResult that are not dependent on the context
 /// it appears in and can thus be cached.
 class ContextFreeCodeCompletionResult {
@@ -749,6 +725,7 @@ class ContextFreeCodeCompletionResult {
   StringRef ModuleName;
   StringRef BriefDocComment;
   ArrayRef<StringRef> AssociatedUSRs;
+  CodeCompletionResultType ResultType;
 
   ContextFreeNotRecommendedReason NotRecommended : 3;
   static_assert(int(ContextFreeNotRecommendedReason::MAX_VALUE) < 1 << 3, "");
@@ -772,13 +749,15 @@ public:
       CodeCompletionOperatorKind KnownOperatorKind, bool IsSystem,
       CodeCompletionString *CompletionString, StringRef ModuleName,
       StringRef BriefDocComment, ArrayRef<StringRef> AssociatedUSRs,
+      CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
       StringRef DiagnosticMessage)
       : Kind(Kind), KnownOperatorKind(KnownOperatorKind), IsSystem(IsSystem),
         CompletionString(CompletionString), ModuleName(ModuleName),
         BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
-        NotRecommended(NotRecommended), DiagnosticSeverity(DiagnosticSeverity),
+        ResultType(ResultType), NotRecommended(NotRecommended),
+        DiagnosticSeverity(DiagnosticSeverity),
         DiagnosticMessage(DiagnosticMessage) {
     this->AssociatedKind.Opaque = AssociatedKind;
     assert((NotRecommended == ContextFreeNotRecommendedReason::None) ==
@@ -805,13 +784,14 @@ public:
   ContextFreeCodeCompletionResult(
       CodeCompletionResultKind Kind, CodeCompletionString *CompletionString,
       CodeCompletionOperatorKind KnownOperatorKind, StringRef BriefDocComment,
+      CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
       StringRef DiagnosticMessage)
       : ContextFreeCodeCompletionResult(
             Kind, /*AssociatedKind=*/0, KnownOperatorKind,
             /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
-            BriefDocComment, /*AssociatedUSRs=*/{}, NotRecommended,
+            BriefDocComment, /*AssociatedUSRs=*/{}, ResultType, NotRecommended,
             DiagnosticSeverity, DiagnosticMessage) {}
 
   /// Constructs a \c Keyword result.
@@ -821,12 +801,14 @@ public:
   /// same \c CodeCompletionResultSink as the result itself.
   ContextFreeCodeCompletionResult(CodeCompletionKeywordKind Kind,
                                   CodeCompletionString *CompletionString,
-                                  StringRef BriefDocComment)
+                                  StringRef BriefDocComment,
+                                  CodeCompletionResultType ResultType)
       : ContextFreeCodeCompletionResult(
             CodeCompletionResultKind::Keyword, static_cast<uint8_t>(Kind),
             CodeCompletionOperatorKind::None, /*IsSystem=*/false,
             CompletionString, /*ModuleName=*/"", BriefDocComment,
-            /*AssociatedUSRs=*/{}, ContextFreeNotRecommendedReason::None,
+            /*AssociatedUSRs=*/{}, ResultType,
+            ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
 
   /// Constructs a \c Literal result.
@@ -835,13 +817,15 @@ public:
   /// result, typically by storing them in the same \c CodeCompletionResultSink
   /// as the result itself.
   ContextFreeCodeCompletionResult(CodeCompletionLiteralKind LiteralKind,
-                                  CodeCompletionString *CompletionString)
+                                  CodeCompletionString *CompletionString,
+                                  CodeCompletionResultType ResultType)
       : ContextFreeCodeCompletionResult(
             CodeCompletionResultKind::Literal,
             static_cast<uint8_t>(LiteralKind), CodeCompletionOperatorKind::None,
             /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
             /*BriefDocComment=*/"",
-            /*AssociatedUSRs=*/{}, ContextFreeNotRecommendedReason::None,
+            /*AssociatedUSRs=*/{}, ResultType,
+            ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
 
   /// Constructs a \c Declaration result.
@@ -852,7 +836,7 @@ public:
   ContextFreeCodeCompletionResult(
       CodeCompletionString *CompletionString, const Decl *AssociatedDecl,
       StringRef ModuleName, StringRef BriefDocComment,
-      ArrayRef<StringRef> AssociatedUSRs,
+      ArrayRef<StringRef> AssociatedUSRs, CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
       StringRef DiagnosticMessage)
@@ -861,7 +845,7 @@ public:
             static_cast<uint8_t>(getCodeCompletionDeclKind(AssociatedDecl)),
             CodeCompletionOperatorKind::None, getDeclIsSystem(AssociatedDecl),
             CompletionString, ModuleName, BriefDocComment, AssociatedUSRs,
-            NotRecommended, DiagnosticSeverity, DiagnosticMessage) {
+            ResultType, NotRecommended, DiagnosticSeverity, DiagnosticMessage) {
     assert(AssociatedDecl && "should have a decl");
   }
 
@@ -898,6 +882,8 @@ public:
   StringRef getBriefDocComment() const { return BriefDocComment; }
 
   ArrayRef<StringRef> getAssociatedUSRs() const { return AssociatedUSRs; }
+
+  const CodeCompletionResultType &getResultType() const { return ResultType; }
 
   ContextFreeNotRecommendedReason getNotRecommendedReason() const {
     return NotRecommended;
@@ -962,9 +948,7 @@ private:
   CodeCompletionResultTypeRelation TypeDistance : 3;
   static_assert(int(CodeCompletionResultTypeRelation::MAX_VALUE) < 1 << 3, "");
 
-public:
-  /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
-  /// information.
+  /// Memberwise initializer
   /// The \c ContextFree result must outlive this result. Typically, this is
   /// done by allocating the two in the same sink or adopting the context free
   /// sink in the sink that allocates this result.
@@ -980,6 +964,23 @@ public:
         DiagnosticSeverity(DiagnosticSeverity),
         DiagnosticMessage(DiagnosticMessage), NumBytesToErase(NumBytesToErase),
         TypeDistance(TypeDistance) {}
+
+public:
+  /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
+  /// information.
+  /// This computes the type relation between the completion item and its
+  /// expected type context.
+  /// The \c ContextFree result must outlive this result. Typically, this is
+  /// done by allocating the two in the same sink or adopting the context free
+  /// sink in the sink that allocates this result.
+  CodeCompletionResult(const ContextFreeCodeCompletionResult &ContextFree,
+                       SemanticContextKind SemanticContext,
+                       CodeCompletionFlair Flair, uint8_t NumBytesToErase,
+                       const ExpectedTypeContext *TypeContext,
+                       const DeclContext *DC,
+                       ContextualNotRecommendedReason NotRecommended,
+                       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
+                       StringRef DiagnosticMessage);
 
   const ContextFreeCodeCompletionResult &getContextFreeResult() const {
     return ContextFree;
@@ -997,7 +998,16 @@ public:
   /// context free result outlives the result the result returned by this
   /// method.
   CodeCompletionResult *withFlair(CodeCompletionFlair newFlair,
-                                  CodeCompletionResultSink &Sink);
+                                  CodeCompletionResultSink &Sink) const;
+
+  /// Copy this result to \p Sink with \p newFlair . Note that this does NOT
+  /// copy the context free result. Thus the caller needs to ensure that the
+  /// context free result outlives the result the result returned by this
+  /// method.
+  CodeCompletionResult *withContextFreeResultSemanticContextAndFlair(
+      const ContextFreeCodeCompletionResult &NewContextFree,
+      SemanticContextKind NewSemanticContext, CodeCompletionFlair NewFlair,
+      CodeCompletionResultSink &Sink) const;
 
   CodeCompletionResultKind getKind() const {
     return getContextFreeResult().getKind();

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -701,6 +701,31 @@ enum class CodeCompletionResultKind : uint8_t {
   MAX_VALUE = BuiltinOperator
 };
 
+/// Describes the relationship between the type of the completion results and
+/// the expected type at the code completion position.
+enum class CodeCompletionResultTypeRelation : uint8_t {
+  /// The result does not have a type (e.g. keyword).
+  NotApplicable,
+
+  /// The type relation have not been calculated.
+  Unknown,
+
+  /// The relationship of the result's type to the expected type is not
+  /// invalid, not convertible, and not identical.
+  Unrelated,
+
+  /// The result's type is invalid at the expected position.
+  Invalid,
+
+  /// The result's type is convertible to the type of the expected.
+  Convertible,
+
+  /// The result's type is identical to the type of the expected.
+  Identical,
+
+  MAX_VALUE = Identical
+};
+
 /// The parts of a \c CodeCompletionResult that are not dependent on the context
 /// it appears in and can thus be cached.
 class ContextFreeCodeCompletionResult {
@@ -909,34 +934,6 @@ public:
 /// A single code completion result enriched with information that depend on
 /// the completion's usage context.
 class CodeCompletionResult {
-public:
-  /// Describes the relationship between the type of the completion results and
-  /// the expected type at the code completion position.
-  enum class ExpectedTypeRelation : uint8_t {
-    /// The result does not have a type (e.g. keyword).
-    NotApplicable,
-
-    /// The type relation have not been calculated.
-    Unknown,
-
-    /// The relationship of the result's type to the expected type is not
-    /// invalid, not convertible, and not identical.
-    Unrelated,
-
-    /// The result's type is invalid at the expected position.
-    Invalid,
-
-    /// The result's type is convertible to the type of the expected.
-    Convertible,
-
-    /// The result's type is identical to the type of the expected.
-    Identical,
-
-    MAX_VALUE = Identical
-  };
-
-
-private:
   const ContextFreeCodeCompletionResult &ContextFree;
   SemanticContextKind SemanticContext : 3;
   static_assert(int(SemanticContextKind::MAX_VALUE) < 1 << 3, "");
@@ -962,7 +959,9 @@ public:
   static const unsigned MaxNumBytesToErase = 127;
 
 private:
-  ExpectedTypeRelation TypeDistance : 3;
+  CodeCompletionResultTypeRelation TypeDistance : 3;
+  static_assert(int(CodeCompletionResultTypeRelation::MAX_VALUE) < 1 << 3, "");
+
 public:
   /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
   /// information.
@@ -972,7 +971,7 @@ public:
   CodeCompletionResult(const ContextFreeCodeCompletionResult &ContextFree,
                        SemanticContextKind SemanticContext,
                        CodeCompletionFlair Flair, uint8_t NumBytesToErase,
-                       ExpectedTypeRelation TypeDistance,
+                       CodeCompletionResultTypeRelation TypeDistance,
                        ContextualNotRecommendedReason NotRecommended,
                        CodeCompletionDiagnosticSeverity DiagnosticSeverity,
                        StringRef DiagnosticMessage)
@@ -1024,7 +1023,9 @@ public:
 
   bool isSystem() const { return getContextFreeResult().isSystem(); }
 
-  ExpectedTypeRelation getExpectedTypeRelation() const { return TypeDistance; }
+  CodeCompletionResultTypeRelation getExpectedTypeRelation() const {
+    return TypeDistance;
+  }
 
   /// Get the contextual not-recommended reason. This disregards context-free
   /// not recommended reasons.

--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -1,0 +1,162 @@
+//===--- CodeCompletionResultType.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_CODECOMPLETIONRESULTTYPE_H
+#define SWIFT_IDE_CODECOMPLETIONRESULTTYPE_H
+
+#include "swift/AST/Types.h"
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+namespace ide {
+
+/// The expected contextual type(s) for code-completion.
+class ExpectedTypeContext {
+  /// Possible types of the code completion expression.
+  llvm::SmallVector<Type, 4> PossibleTypes;
+
+  /// Pre typechecked type of the expression at the completion position.
+  Type IdealType;
+
+  /// Whether the `ExpectedTypes` comes from a single-expression body, e.g.
+  /// `foo({ here })`.
+  ///
+  /// Since the input may be incomplete, we take into account that the types are
+  /// only a hint.
+  bool IsImplicitSingleExpressionReturn = false;
+  bool PreferNonVoid = false;
+
+public:
+  ExpectedTypeContext() = default;
+
+  bool empty() const { return PossibleTypes.empty(); }
+
+  ArrayRef<Type> getPossibleTypes() const { return PossibleTypes; }
+
+  void setPossibleTypes(ArrayRef<Type> Types) {
+    PossibleTypes.clear();
+    PossibleTypes.reserve(Types.size());
+    for (auto T : Types) {
+      if (T) {
+        PossibleTypes.push_back(T);
+      }
+    }
+  }
+
+  Type getIdealType() const { return IdealType; }
+
+  void setIdealType(Type IdealType) { this->IdealType = IdealType; }
+
+  bool requiresNonVoid() const {
+    if (IsImplicitSingleExpressionReturn)
+      return false;
+    if (PreferNonVoid)
+      return true;
+    if (PossibleTypes.empty())
+      return false;
+    return llvm::all_of(PossibleTypes, [](Type Ty) { return !Ty->isVoid(); });
+  }
+
+  bool isImplicitSingleExpressionReturn() const {
+    return IsImplicitSingleExpressionReturn;
+  }
+
+  void
+  setIsImplicitSingleExpressionReturn(bool IsImplicitSingleExpressionReturn) {
+    this->IsImplicitSingleExpressionReturn = IsImplicitSingleExpressionReturn;
+  }
+
+  bool getPreferNonVoid() const { return PreferNonVoid; }
+
+  void setPreferNonVoid(bool PreferNonVoid) {
+    this->PreferNonVoid = PreferNonVoid;
+  }
+};
+
+/// Describes the relationship between the type of the completion results and
+/// the expected type at the code completion position.
+enum class CodeCompletionResultTypeRelation : uint8_t {
+  /// The result does not have a type (e.g. keyword).
+  NotApplicable,
+
+  /// The type relation have not been calculated.
+  Unknown,
+
+  /// The relationship of the result's type to the expected type is not
+  /// invalid, not convertible, and not identical.
+  Unrelated,
+
+  /// The result's type is invalid at the expected position.
+  Invalid,
+
+  /// The result's type is convertible to the type of the expected.
+  Convertible,
+
+  /// The result's type is identical to the type of the expected.
+  Identical,
+
+  MAX_VALUE = Identical
+};
+
+/// The type returned by a \c ContextFreeCodeCompletionResult. Can be either of
+/// the following:
+///  - Have the NotApplicable flag set: The completion result doesn't produce
+///    something that's valid inside an expression like a keyword
+///  - An null type if the completion result produces something that's
+///    valid inside an expression but the result type isn't known
+///  - A proper type if the type produced by this completion result is known
+class CodeCompletionResultType {
+public:
+  enum class Flags : unsigned {
+    IsNotApplicable = 1 << 0,
+    /// If \p AlsoConsiderMetatype is set the code completion item will be
+    /// considered as producing the declared interface type (which is passed as
+    /// \p ResultTypes ) as well as the corresponding metatype.
+    /// This allows us to suggest 'Int' as 'Identical' for both of the following
+    /// functions
+    ///
+    ///   func receiveInstance(_: Int) {}
+    ///   func receiveMetatype(_: Int.Type) {}
+    AlsoConsiderMetatype = 1 << 1
+  };
+
+private:
+  llvm::PointerIntPair<Type, 2, OptionSet<Flags>> TypeAndFlags;
+
+  CodeCompletionResultType(Type Ty, OptionSet<Flags> Flag)
+      : TypeAndFlags(Ty, Flag) {}
+
+public:
+  static CodeCompletionResultType notApplicable() {
+    return CodeCompletionResultType(Type(), Flags::IsNotApplicable);
+  }
+  static CodeCompletionResultType unknown() {
+    return CodeCompletionResultType(Type(), /*Flags=*/0);
+  }
+  CodeCompletionResultType(Type Ty, bool AlsoConsiderMetatype = false)
+      : CodeCompletionResultType(Ty, AlsoConsiderMetatype
+                                         ? Flags::AlsoConsiderMetatype
+                                         : OptionSet<Flags>()) {}
+
+  bool isNotApplicable() const {
+    return TypeAndFlags.getInt().contains(Flags::IsNotApplicable);
+  }
+
+  /// Calculates the type realtion of this type to the given
+  CodeCompletionResultTypeRelation
+  calculateTypeRelation(const ExpectedTypeContext *TypeContext,
+                        const DeclContext *DC) const;
+};
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_CODECOMPLETIONRESULTTYPE_H

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_library(swiftIDE STATIC
   CodeCompletionCache.cpp
   CodeCompletionDiagnostics.cpp
   CodeCompletionResultPrinter.cpp
+  CodeCompletionResultType.cpp
   CommentConversion.cpp
   CompileInstance.cpp
   CompletionInstance.cpp

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -226,7 +226,8 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
             kind, associatedKind, opKind, isSystem, string, moduleName,
             briefDocComment,
             copyArray(*V.Allocator, ArrayRef<StringRef>(assocUSRs)),
-            notRecommended, diagSeverity, diagMessage);
+            CodeCompletionResultType::unknown(), notRecommended, diagSeverity,
+            diagMessage);
 
     V.Results.push_back(result);
   }

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -86,8 +86,8 @@ class CodeCompletionResultBuilder {
   llvm::PointerUnion<const ModuleDecl *, const clang::Module *>
       CurrentModule;
   ExpectedTypeContext declTypeContext;
-  CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
-      CodeCompletionResult::ExpectedTypeRelation::Unknown;
+  CodeCompletionResultTypeRelation ExpectedTypeRelation =
+      CodeCompletionResultTypeRelation::Unknown;
   bool Cancelled = false;
   ContextFreeNotRecommendedReason ContextFreeNotRecReason =
       ContextFreeNotRecommendedReason::None;
@@ -159,8 +159,7 @@ public:
     Flair |= Options;
   }
 
-  void
-  setExpectedTypeRelation(CodeCompletionResult::ExpectedTypeRelation relation) {
+  void setExpectedTypeRelation(CodeCompletionResultTypeRelation relation) {
     ExpectedTypeRelation = relation;
   }
 

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -35,41 +35,6 @@ class ModuleDecl;
 
 namespace ide {
 
-/// The expected contextual type(s) for code-completion.
-struct ExpectedTypeContext {
-  /// Possible types of the code completion expression.
-  llvm::SmallVector<Type, 4> possibleTypes;
-
-  /// Pre typechecked type of the expression at the completion position.
-  Type idealType;
-
-  /// Whether the `ExpectedTypes` comes from a single-expression body, e.g.
-  /// `foo({ here })`.
-  ///
-  /// Since the input may be incomplete, we take into account that the types are
-  /// only a hint.
-  bool isImplicitSingleExpressionReturn = false;
-  bool preferNonVoid = false;
-
-  bool empty() const { return possibleTypes.empty(); }
-  bool requiresNonVoid() const {
-    if (isImplicitSingleExpressionReturn)
-      return false;
-    if (preferNonVoid)
-      return true;
-    if (possibleTypes.empty())
-      return false;
-    return std::all_of(possibleTypes.begin(), possibleTypes.end(), [](Type Ty) {
-      return !Ty->isVoid();
-    });
-  }
-
-  ExpectedTypeContext() = default;
-  ExpectedTypeContext(ArrayRef<Type> types, bool isImplicitSingleExprReturn)
-      : possibleTypes(types.begin(), types.end()),
-        isImplicitSingleExpressionReturn(isImplicitSingleExprReturn) {}
-};
-
 class CodeCompletionResultBuilder {
   friend CodeCompletionStringPrinter;
   
@@ -86,14 +51,20 @@ class CodeCompletionResultBuilder {
   llvm::PointerUnion<const ModuleDecl *, const clang::Module *>
       CurrentModule;
   ExpectedTypeContext declTypeContext;
-  CodeCompletionResultTypeRelation ExpectedTypeRelation =
-      CodeCompletionResultTypeRelation::Unknown;
   bool Cancelled = false;
   ContextFreeNotRecommendedReason ContextFreeNotRecReason =
       ContextFreeNotRecommendedReason::None;
   ContextualNotRecommendedReason ContextualNotRecReason =
       ContextualNotRecommendedReason::None;
   StringRef BriefDocComment;
+
+  /// The result type that this completion item produces.
+  CodeCompletionResultType ResultType = CodeCompletionResultType::unknown();
+
+  /// The context in which this completion item is used. Used to compute the
+  /// type relation to \c ResultType.
+  const ExpectedTypeContext *TypeContext;
+  const DeclContext *DC = nullptr;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
                         StringRef Text);
@@ -159,8 +130,33 @@ public:
     Flair |= Options;
   }
 
-  void setExpectedTypeRelation(CodeCompletionResultTypeRelation relation) {
-    ExpectedTypeRelation = relation;
+  /// Indicate that the code completion item does not produce something with a
+  /// sensible result type, like a keyword or a method override suggestion.
+  void setResultTypeNotApplicable() {
+    ResultType = CodeCompletionResultType::notApplicable();
+  }
+
+  /// Set the result type of this code completion item and the context that the
+  /// item may be used in.
+  /// If \p AlsoConsiderMetatype is \c true the code completion item will be
+  /// considered as producing the declared interface type (which is passed as
+  /// \p ResultTypes ) as well as the corresponding metatype.
+  /// This allows us to suggest 'Int' as 'Identical' for both of the following
+  /// functions
+  ///
+  ///   func receiveInstance(_: Int) {}
+  ///   func receiveMetatype(_: Int.Type) {}
+  void setResultType(Type ResultType, bool AlsoConsiderMetatype = false) {
+    this->ResultType =
+        CodeCompletionResultType(ResultType, AlsoConsiderMetatype);
+  }
+
+  /// Set context in which this code completion item occurs. Used to compute the
+  /// item's type relation.
+  void setTypeContext(const ExpectedTypeContext &TypeContext,
+                      const DeclContext *DC) {
+    this->TypeContext = &TypeContext;
+    this->DC = DC;
   }
 
   void withNestedGroup(CodeCompletionString::Chunk::ChunkKind Kind,

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -1,0 +1,104 @@
+//===--- CodeCompletionResultType.cpp -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDE/CodeCompletionResultType.h"
+#include "swift/Sema/IDETypeChecking.h"
+
+using namespace swift;
+using namespace ide;
+
+static CodeCompletionResultTypeRelation
+calculateTypeRelation(Type Ty, Type ExpectedTy, const DeclContext &DC) {
+  if (Ty.isNull() || ExpectedTy.isNull() || Ty->is<ErrorType>() ||
+      ExpectedTy->is<ErrorType>())
+    return CodeCompletionResultTypeRelation::Unrelated;
+
+  // Equality/Conversion of GenericTypeParameterType won't account for
+  // requirements – ignore them
+  if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
+    if (Ty->isEqual(ExpectedTy))
+      return CodeCompletionResultTypeRelation::Identical;
+    bool isAny = false;
+    isAny |= ExpectedTy->isAny();
+    isAny |= ExpectedTy->is<ArchetypeType>() &&
+             !ExpectedTy->castTo<ArchetypeType>()->hasRequirements();
+
+    if (!isAny && isConvertibleTo(Ty, ExpectedTy, /*openArchetypes=*/true,
+                                  const_cast<DeclContext &>(DC)))
+      return CodeCompletionResultTypeRelation::Convertible;
+  }
+  if (auto FT = Ty->getAs<AnyFunctionType>()) {
+    if (FT->getResult()->isVoid())
+      return CodeCompletionResultTypeRelation::Invalid;
+  }
+  return CodeCompletionResultTypeRelation::Unrelated;
+}
+
+static CodeCompletionResultTypeRelation
+calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
+                         const DeclContext &DC) {
+  if (Ty->isVoid() && typeContext.requiresNonVoid())
+    return CodeCompletionResultTypeRelation::Invalid;
+  if (typeContext.empty())
+    return CodeCompletionResultTypeRelation::Unknown;
+
+  if (auto funcTy = Ty->getAs<AnyFunctionType>())
+    Ty = funcTy->removeArgumentLabels(1);
+
+  auto Result = CodeCompletionResultTypeRelation::Unrelated;
+  for (auto expectedTy : typeContext.getPossibleTypes()) {
+    // Do not use Void type context for a single-expression body, since the
+    // implicit return does not constrain the expression.
+    //
+    //     { ... -> ()  in x } // x can be anything
+    //
+    // This behaves differently from explicit return, and from non-Void:
+    //
+    //     { ... -> Int in x }        // x must be Int
+    //     { ... -> ()  in return x } // x must be Void
+    if (typeContext.isImplicitSingleExpressionReturn() && expectedTy->isVoid())
+      continue;
+
+    Result = std::max(Result, calculateTypeRelation(Ty, expectedTy, DC));
+  }
+
+  // Map invalid -> unrelated when in a single-expression body, since the
+  // input may be incomplete.
+  if (typeContext.isImplicitSingleExpressionReturn() &&
+      Result == CodeCompletionResultTypeRelation::Invalid)
+    Result = CodeCompletionResultTypeRelation::Unrelated;
+  
+  return Result;
+}
+
+CodeCompletionResultTypeRelation
+CodeCompletionResultType::calculateTypeRelation(
+    const ExpectedTypeContext *TypeContext, const DeclContext *DC) const {
+  if (isNotApplicable()) {
+    return CodeCompletionResultTypeRelation::NotApplicable;
+  }
+
+  Type ResultTy = TypeAndFlags.getPointer();
+  if (!TypeContext || !DC || !ResultTy) {
+    return CodeCompletionResultTypeRelation::Unknown;
+  }
+  
+  CodeCompletionResultTypeRelation Result =
+      calculateMaxTypeRelation(ResultTy, *TypeContext, *DC);
+  if (TypeAndFlags.getInt().contains(Flags::AlsoConsiderMetatype)) {
+    Result =
+        std::max(Result, calculateMaxTypeRelation(
+                             MetatypeType::get(ResultTy, DC->getASTContext()),
+                             *TypeContext, *DC));
+  }
+  return Result;
+}

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -94,7 +94,7 @@
 // CHECK-FOUNDATION: var uppercased: String
 
 // Note: ok to map base name down to a keyword.
-// CHECK-FOUNDATION: func `do`(_: Selector!)
+// CHECK-FOUNDATION: func `do`(_: Selector)
 
 // Note: Strip names preceded by a gerund.
 // CHECK-FOUNDATION: func startSquashing(_: Bee)

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -947,7 +947,7 @@ __attribute__((availability(macosx, introduced = 10.52)))
 @end
 
 @interface NSObject (Silly)
--(void)doSelector:(SEL)selector;
+- (void)doSelector:(nonnull SEL)selector;
 @end
 
 @interface Bee (Gerunds)
@@ -1071,7 +1071,7 @@ extern NSString *NSHTTPRequestKey;
 @end
 
 @interface NSObject (Selectors)
--(void)messageSomeObject:(nonnull id)object selector:(SEL)selector;
+- (void)messageSomeObject:(nonnull id)object selector:(nonnull SEL)selector;
 @end
 
 @interface NSOperation : NSObject

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -28,6 +28,7 @@ using swift::ide::CodeCompletionKeywordKind;
 using swift::ide::CodeCompletionLiteralKind;
 using swift::ide::CodeCompletionOperatorKind;
 using swift::ide::CodeCompletionResultKind;
+using swift::ide::CodeCompletionResultTypeRelation;
 using swift::ide::CodeCompletionString;
 using swift::ide::SemanticContextKind;
 using SwiftResult = swift::ide::CodeCompletionResult;
@@ -135,7 +136,7 @@ public:
 
   bool isSystem() const { return getSwiftResult().isSystem(); }
 
-  SwiftResult::ExpectedTypeRelation getExpectedTypeRelation() const {
+  CodeCompletionResultTypeRelation getExpectedTypeRelation() const {
     return getSwiftResult().getExpectedTypeRelation();
   }
 
@@ -190,7 +191,7 @@ class CompletionBuilder {
   CompletionSink &sink;
   const SwiftResult &base;
   bool modified = false;
-  SwiftResult::ExpectedTypeRelation typeRelation;
+  CodeCompletionResultTypeRelation typeRelation;
   SemanticContextKind semanticContext;
   CodeCompletionFlair flair;
   CodeCompletionString *completionString;
@@ -209,7 +210,7 @@ public:
     moduleImportDepth = value;
   }
 
-  void setExpectedTypeRelation(SwiftResult::ExpectedTypeRelation Relation) {
+  void setExpectedTypeRelation(CodeCompletionResultTypeRelation Relation) {
     modified = true;
     typeRelation = Relation;
   }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -191,7 +191,6 @@ class CompletionBuilder {
   CompletionSink &sink;
   const SwiftResult &base;
   bool modified = false;
-  CodeCompletionResultTypeRelation typeRelation;
   SemanticContextKind semanticContext;
   CodeCompletionFlair flair;
   CodeCompletionString *completionString;
@@ -208,11 +207,6 @@ public:
   void setModuleImportDepth(Optional<uint8_t> value) {
     assert(!value || *value <= Completion::maxModuleImportDepth);
     moduleImportDepth = value;
-  }
-
-  void setExpectedTypeRelation(CodeCompletionResultTypeRelation Relation) {
-    modified = true;
-    typeRelation = Relation;
   }
 
   void setSemanticContext(SemanticContextKind kind) {

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -116,7 +116,7 @@ std::vector<Completion *> SourceKit::CodeCompletion::extendCompletions(
         }
         if (isVoid)
           builder.setExpectedTypeRelation(
-              SwiftResult::ExpectedTypeRelation::Invalid);
+              CodeCompletionResultTypeRelation::Invalid);
       }
     }
 
@@ -163,8 +163,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     auto *swiftResult = new (sink.allocator) CodeCompletion::SwiftResult(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
-        /*NumBytesToErase=*/0,
-        CodeCompletionResult::ExpectedTypeRelation::Unknown,
+        /*NumBytesToErase=*/0, CodeCompletionResultTypeRelation::Unknown,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 
@@ -482,7 +481,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
       if (options.hideLowPriority &&
           (completion->isNotRecommended() ||
            completion->getExpectedTypeRelation() ==
-               SwiftResult::ExpectedTypeRelation::Invalid))
+               CodeCompletionResultTypeRelation::Invalid))
         continue;
 
       NameStyle style(completion->getName());
@@ -510,7 +509,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
             break;
         }
         if (completion->getExpectedTypeRelation() >=
-                SwiftResult::ExpectedTypeRelation::Convertible ||
+                CodeCompletionResultTypeRelation::Convertible ||
             (completion->getKind() == CodeCompletionResultKind::Literal &&
              completionKind != CompletionKind::StmtOrExpr &&
              typeContextKind < TypeContextKind::Required))
@@ -545,7 +544,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
     if (completion->getKind() == CodeCompletionResultKind::Literal &&
         typeContextKind == TypeContextKind::Required &&
         completion->getExpectedTypeRelation() <
-            SwiftResult::ExpectedTypeRelation::Convertible &&
+            CodeCompletionResultTypeRelation::Convertible &&
         completion->getLiteralKind() !=
             CodeCompletionLiteralKind::BooleanLiteral &&
         completion->getLiteralKind() != CodeCompletionLiteralKind::NilLiteral)
@@ -687,7 +686,7 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
   switch (completion->getKind()) {
   case CodeCompletionResultKind::Literal:
     if (completion->getExpectedTypeRelation() >=
-        SwiftResult::ExpectedTypeRelation::Convertible) {
+        CodeCompletionResultTypeRelation::Convertible) {
       return ResultBucket::LiteralTypeMatch;
     } else if (!hasRequiredTypes) {
       return ResultBucket::Literal;
@@ -703,14 +702,14 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
   case CodeCompletionResultKind::Pattern:
   case CodeCompletionResultKind::Declaration:
     switch (completion->getExpectedTypeRelation()) {
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::Convertible:
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::Identical:
+    case swift::ide::CodeCompletionResultTypeRelation::Convertible:
+    case swift::ide::CodeCompletionResultTypeRelation::Identical:
       return ResultBucket::NormalTypeMatch;
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::NotApplicable:
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::Unknown:
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::Unrelated:
+    case swift::ide::CodeCompletionResultTypeRelation::NotApplicable:
+    case swift::ide::CodeCompletionResultTypeRelation::Unknown:
+    case swift::ide::CodeCompletionResultTypeRelation::Unrelated:
       return ResultBucket::Normal;
-    case swift::ide::CodeCompletionResult::ExpectedTypeRelation::Invalid:
+    case swift::ide::CodeCompletionResultTypeRelation::Invalid:
       if (!skipMetaGroups)
         return ResultBucket::NotRecommended;
       return ResultBucket::Normal;
@@ -860,7 +859,7 @@ static bool isTopNonLiteralResult(Item &item, ResultBucket literalBucket) {
            SemanticContextKind::CurrentNominal;
   case ResultBucket::LiteralTypeMatch:
     return completion->getExpectedTypeRelation() >=
-           SwiftResult::ExpectedTypeRelation::Convertible;
+           CodeCompletionResultTypeRelation::Convertible;
   default:
     llvm_unreachable("invalid literal bucket");
   }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -93,30 +93,6 @@ std::vector<Completion *> SourceKit::CodeCompletion::extendCompletions(
       if (info.completionContext->typeContextKind ==
               TypeContextKind::Required &&
           result->getKind() == CodeCompletionResultKind::Declaration) {
-        // FIXME: because other-module results are cached, they will not be
-        // given a type-relation of invalid.  As a hack, we look at the text of
-        // the result type and look for 'Void'.
-        bool isVoid = false;
-        auto chunks = result->getCompletionString()->getChunks();
-        for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i) {
-          using ChunkKind = ide::CodeCompletionString::Chunk::ChunkKind;
-          bool isVoid = false;
-          if (i->is(ChunkKind::TypeAnnotation)) {
-            isVoid = i->getText() == "Void";
-            break;
-          } else if (i->is(ChunkKind::TypeAnnotationBegin)) {
-            auto n = i + 1, t = i + 2;
-            isVoid =
-                // i+1 has text 'Void'.
-                n != e && n->hasText() && n->getText() == "Void" &&
-                // i+2 terminates the group.
-                (t == e || t->endsPreviousNestedGroup(i->getNestingLevel()));
-            break;
-          }
-        }
-        if (isVoid)
-          builder.setExpectedTypeRelation(
-              CodeCompletionResultTypeRelation::Invalid);
       }
     }
 
@@ -158,12 +134,13 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         new (sink.allocator) ContextFreeCodeCompletionResult(
             CodeCompletionResultKind::Pattern, completionString,
             CodeCompletionOperatorKind::None, /*BriefDocComment=*/"",
+            CodeCompletionResultType::unknown(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
     auto *swiftResult = new (sink.allocator) CodeCompletion::SwiftResult(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
-        /*NumBytesToErase=*/0, CodeCompletionResultTypeRelation::Unknown,
+        /*NumBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 
@@ -1138,7 +1115,6 @@ bool LimitedResultView::walk(CodeCompletionView::Walker &walker) const {
 CompletionBuilder::CompletionBuilder(CompletionSink &sink,
                                      const SwiftResult &base)
     : sink(sink), base(base) {
-  typeRelation = base.getExpectedTypeRelation();
   semanticContext = base.getSemanticContext();
   flair = base.getFlair();
   completionString =
@@ -1194,15 +1170,12 @@ Completion *CompletionBuilder::finish() {
             contextFreeBase.getModuleName(),
             contextFreeBase.getBriefDocComment(),
             contextFreeBase.getAssociatedUSRs(),
+            contextFreeBase.getResultType(),
             contextFreeBase.getNotRecommendedReason(),
             contextFreeBase.getDiagnosticSeverity(),
             contextFreeBase.getDiagnosticMessage());
-
-    newBase = new (sink.allocator) SwiftResult(
-        *contextFreeResult, semanticContext, flair, base.getNumBytesToErase(),
-        typeRelation, base.getContextualNotRecommendedReason(),
-        base.getContextualDiagnosticSeverity(),
-        base.getContextualDiagnosticMessage());
+    newBase = base.withContextFreeResultSemanticContextAndFlair(
+        *contextFreeResult, semanticContext, flair, sink.swiftSink);
 
     llvm::raw_svector_ostream OSS(nameStorage);
     ide::printCodeCompletionResultFilterName(*newBase, OSS);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -923,14 +923,15 @@ static void transformAndForwardResults(
         new (innerSink.allocator) ContextFreeCodeCompletionResult(
             CodeCompletionResultKind::BuiltinOperator, completionString,
             CodeCompletionOperatorKind::None,
-            /*BriefDocComment=*/"", ContextFreeNotRecommendedReason::None,
+            /*BriefDocComment=*/"", CodeCompletionResultType::notApplicable(),
+            ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None,
             /*DiagnosticMessage=*/"");
     auto *paren = new (innerSink.allocator) CodeCompletion::SwiftResult(
         *contextFreeResult, SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
-        CodeCompletionResultTypeRelation::NotApplicable,
+        /*TypeContext=*/nullptr, /*DC=*/nullptr,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -165,7 +165,7 @@ deliverCodeCompleteResults(SourceKit::CodeCompletionConsumer &SKConsumer,
         case CodeCompletionLiteralKind::ColorLiteral:
           if (hasRequiredType &&
               Result->getExpectedTypeRelation() <
-                  CodeCompletionResult::ExpectedTypeRelation::Convertible)
+                  CodeCompletionResultTypeRelation::Convertible)
             continue;
           break;
         default:
@@ -526,17 +526,17 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   static UIdent CCTypeRelIdentical("source.codecompletion.typerelation.identical");
 
   switch (Result->getExpectedTypeRelation()) {
-  case CodeCompletionResult::ExpectedTypeRelation::NotApplicable:
+  case CodeCompletionResultTypeRelation::NotApplicable:
     Info.TypeRelation = CCTypeRelNotApplicable; break;
-  case CodeCompletionResult::ExpectedTypeRelation::Unknown:
+  case CodeCompletionResultTypeRelation::Unknown:
     Info.TypeRelation = CCTypeRelUnknown; break;
-  case CodeCompletionResult::ExpectedTypeRelation::Unrelated:
+  case CodeCompletionResultTypeRelation::Unrelated:
     Info.TypeRelation = CCTypeRelUnrelated; break;
-  case CodeCompletionResult::ExpectedTypeRelation::Invalid:
+  case CodeCompletionResultTypeRelation::Invalid:
     Info.TypeRelation = CCTypeRelInvalid; break;
-  case CodeCompletionResult::ExpectedTypeRelation::Convertible:
+  case CodeCompletionResultTypeRelation::Convertible:
     Info.TypeRelation = CCTypeRelConvertible; break;
-  case CodeCompletionResult::ExpectedTypeRelation::Identical:
+  case CodeCompletionResultTypeRelation::Identical:
     Info.TypeRelation = CCTypeRelIdentical; break;
   }
 
@@ -930,7 +930,7 @@ static void transformAndForwardResults(
         *contextFreeResult, SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
-        CodeCompletionResult::ExpectedTypeRelation::NotApplicable,
+        CodeCompletionResultTypeRelation::NotApplicable,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4189,7 +4189,7 @@ int main(int argc, char *argv[]) {
         auto contextualResult = new CodeCompletionResult(
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
-            /*numBytesToErase=*/0, CodeCompletionResultTypeRelation::Unknown,
+            /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
             ContextualNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
         contextualResults.push_back(contextualResult);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4189,8 +4189,7 @@ int main(int argc, char *argv[]) {
         auto contextualResult = new CodeCompletionResult(
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
-            /*numBytesToErase=*/0,
-            CodeCompletionResult::ExpectedTypeRelation::Unknown,
+            /*numBytesToErase=*/0, CodeCompletionResultTypeRelation::Unknown,
             ContextualNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
         contextualResults.push_back(contextualResult);


### PR DESCRIPTION
This is the last refactoring before we can start computing type relations for global results from the code completion cache.