### PR TITLE
[CodeComplete] Compute type relations for global cached results

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -63,7 +63,7 @@ bool isDynamicLookup(Type T);
 
 void postProcessCompletionResults(
     MutableArrayRef<CodeCompletionResult *> results, CompletionKind Kind,
-    DeclContext *DC, CodeCompletionResultSink *Sink);
+    const DeclContext *DC, CodeCompletionResultSink *Sink);
 
 void deliverCompletionResults(CodeCompletionContext &CompletionContext,
                               CompletionLookup &Lookup, DeclContext *DC,

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -70,6 +70,10 @@ public:
 
     std::vector<const ContextFreeCodeCompletionResult *> Results;
 
+    /// The arena that contains the \c USRBasedTypes of the
+    /// \c ContextFreeCodeCompletionResult in this cache value.
+    USRBasedTypeArena USRTypeArena;
+
     Value() : Allocator(std::make_shared<llvm::BumpPtrAllocator>()) {}
   };
   using ValueRefCntPtr = llvm::IntrusiveRefCntPtr<Value>;

--- a/include/swift/IDE/CodeCompletionConsumer.h
+++ b/include/swift/IDE/CodeCompletionConsumer.h
@@ -29,7 +29,8 @@ public:
   virtual void
   handleResultsAndModules(CodeCompletionContext &context,
                           ArrayRef<RequestedCachedModule> requestedModules,
-                          DeclContext *DC) = 0;
+                          const ExpectedTypeContext *TypeContext,
+                          const DeclContext *DC) = 0;
 };
 
 /// A simplified code completion consumer interface that clients can use to get
@@ -40,7 +41,8 @@ struct SimpleCachingCodeCompletionConsumer : public CodeCompletionConsumer {
   // Implement the CodeCompletionConsumer interface.
   void handleResultsAndModules(CodeCompletionContext &context,
                                ArrayRef<RequestedCachedModule> requestedModules,
-                               DeclContext *DCForModules) override;
+                               const ExpectedTypeContext *TypeContext,
+                               const DeclContext *DCForModules) override;
 
   /// Clients should override this method to receive \p Results.
   virtual void handleResults(CodeCompletionContext &context) = 0;

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -390,7 +390,7 @@ public:
   /// StringRefs outlive this result, typically by storing them in the same
   /// \c CodeCompletionResultSink as the result itself.
   static ContextFreeCodeCompletionResult *createPatternOrBuiltInOperatorResult(
-      llvm::BumpPtrAllocator &Allocator, CodeCompletionResultKind Kind,
+      CodeCompletionResultSink &Sink, CodeCompletionResultKind Kind,
       CodeCompletionString *CompletionString,
       CodeCompletionOperatorKind KnownOperatorKind,
       NullTerminatedStringRef BriefDocComment,
@@ -405,7 +405,7 @@ public:
   /// \p BriefDocComment outlive this result, typically by storing them in
   /// the same \c CodeCompletionResultSink as the result itself.
   static ContextFreeCodeCompletionResult *
-  createKeywordResult(llvm::BumpPtrAllocator &Allocator,
+  createKeywordResult(CodeCompletionResultSink &Sink,
                       CodeCompletionKeywordKind Kind,
                       CodeCompletionString *CompletionString,
                       NullTerminatedStringRef BriefDocComment,
@@ -417,7 +417,7 @@ public:
   /// result, typically by storing them in the same \c CodeCompletionResultSink
   /// as the result itself.
   static ContextFreeCodeCompletionResult *
-  createLiteralResult(llvm::BumpPtrAllocator &Allocator,
+  createLiteralResult(CodeCompletionResultSink &Sink,
                       CodeCompletionLiteralKind LiteralKind,
                       CodeCompletionString *CompletionString,
                       CodeCompletionResultType ResultType);
@@ -428,7 +428,7 @@ public:
   /// \c StringRefs outlive this result, typically by storing them in the same
   /// \c CodeCompletionResultSink as the result itself.
   static ContextFreeCodeCompletionResult *createDeclResult(
-      llvm::BumpPtrAllocator &Allocator, CodeCompletionString *CompletionString,
+      CodeCompletionResultSink &Sink, CodeCompletionString *CompletionString,
       const Decl *AssociatedDecl, NullTerminatedStringRef ModuleName,
       NullTerminatedStringRef BriefDocComment,
       ArrayRef<NullTerminatedStringRef> AssociatedUSRs,
@@ -566,6 +566,8 @@ public:
   /// information.
   /// This computes the type relation between the completion item and its
   /// expected type context.
+  /// See \c CodeCompletionResultType::calculateTypeRelation for documentation
+  /// on \p USRTypeContext.
   /// The \c ContextFree result must outlive this result. Typically, this is
   /// done by allocating the two in the same sink or adopting the context free
   /// sink in the sink that allocates this result.
@@ -574,6 +576,7 @@ public:
                        CodeCompletionFlair Flair, uint8_t NumBytesToErase,
                        const ExpectedTypeContext *TypeContext,
                        const DeclContext *DC,
+                       const USRBasedTypeContext *USRTypeContext,
                        ContextualNotRecommendedReason NotRecommended,
                        CodeCompletionDiagnosticSeverity DiagnosticSeverity,
                        NullTerminatedStringRef DiagnosticMessage);

--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -15,6 +15,8 @@
 
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/StringMap.h"
 
 namespace swift {
 namespace ide {
@@ -107,54 +109,254 @@ enum class CodeCompletionResultTypeRelation : uint8_t {
   MAX_VALUE = Identical
 };
 
-/// The type returned by a \c ContextFreeCodeCompletionResult. Can be either of
-/// the following:
-///  - Have the NotApplicable flag set: The completion result doesn't produce
-///    something that's valid inside an expression like a keyword
-///  - An null type if the completion result produces something that's
-///    valid inside an expression but the result type isn't known
-///  - A proper type if the type produced by this completion result is known
-class CodeCompletionResultType {
+class USRBasedType;
+
+/// Holds \c USRBasedTypes. Two \c USRBasedTypes with the same USR are
+/// represented by the same object if they live in the same arena.
+class USRBasedTypeArena {
+  friend class USRBasedType;
+
+  /// The allocator allocating the \c USRBasedTypes
+  llvm::BumpPtrAllocator Allocator;
+
+  /// Maps USRs to their \c USRBasedType instances.
+  llvm::StringMap<const USRBasedType *> CanonicalTypes;
+
+  /// Cache of the \c Void type because its frequently needed to compute type
+  /// relations.
+  const USRBasedType *VoidType;
+
 public:
-  enum class Flags : unsigned {
-    IsNotApplicable = 1 << 0,
-    /// If \p AlsoConsiderMetatype is set the code completion item will be
-    /// considered as producing the declared interface type (which is passed as
-    /// \p ResultTypes ) as well as the corresponding metatype.
-    /// This allows us to suggest 'Int' as 'Identical' for both of the following
-    /// functions
-    ///
-    ///   func receiveInstance(_: Int) {}
-    ///   func receiveMetatype(_: Int.Type) {}
-    AlsoConsiderMetatype = 1 << 1
+  /// Return the USR-based \c Void type.
+  const USRBasedType *getVoidType() const;
+
+  USRBasedTypeArena();
+};
+
+/// The equivalent of a \c ExpectedTypeContext to compute the type relation of
+/// \c USRBasedTypes.
+class USRBasedTypeContext {
+public:
+  class ContextualType {
+    /// The types that the result type must be identical/convertible to to
+    /// compute the type relation. Needs to be a vector because for the
+    /// conextual type `some MyProto & MyOtherProto`, the return type must be
+    /// convertible to both \c MyProto and \c MyOtherProto to be considered
+    /// convertible.
+    llvm::SmallVector<const USRBasedType *, 1> Types;
+
+    /// Whether a match against this type should be considered convertible
+    /// instead of identical. This is used to model optional conversions.
+    /// If we have
+    ///   let x: Int? = #^COMPLETE^#
+    /// we add both 'Int?' and 'Int' as contextual types to the
+    /// USRBasedTypeContext, but an identical match against 'Int' should only
+    /// be considered convertible.
+    bool IsConvertible;
+
+  public:
+    /// Compute the type relation of \p ResultType to this conextual type.
+    CodeCompletionResultTypeRelation
+    typeRelation(const USRBasedType *ResultType,
+                 const USRBasedType *VoidType) const;
+
+    ContextualType(ArrayRef<const USRBasedType *> Types, bool IsConvertible)
+        : Types(Types.begin(), Types.end()), IsConvertible(IsConvertible) {
+      assert(!Types.empty() && "USRBasedTypeContext::ContextualType should "
+                               "contain at least one type");
+    }
   };
 
 private:
-  llvm::PointerIntPair<Type, 2, OptionSet<Flags>> TypeAndFlags;
+  /// The arena in which the contextual types of this type context are
+  /// allocated.
+  const USRBasedTypeArena &Arena;
 
-  CodeCompletionResultType(Type Ty, OptionSet<Flags> Flag)
-      : TypeAndFlags(Ty, Flag) {}
+  SmallVector<ContextualType, 4> ContextualTypes;
+
+public:
+  /// Create a USR-based equivalent of the \p TypeContext.
+  USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
+                      USRBasedTypeArena &Arena);
+
+  /// Type relation of \p ResultType to this context.
+  CodeCompletionResultTypeRelation
+  typeRelation(const USRBasedType *ResultType) const;
+};
+
+/// A type that is purely USR-based and thus independent of an \c ASTContext.
+/// Its identity is defined by its USR. The object also stores the USRs of all
+/// its known supertypes (its superclasses and protocol conformances declared
+/// within the same module) so it is able to determine whether one type is
+/// convertible to another.
+/// Because the type is purely based on USRs, it can be serialized into the code
+/// completion cache and read from it later.
+/// \c USRBasedTypes are always allocated within a \c USRBasedTypeArena. Types
+/// in the same arena that have the same USR are represented by the same object.
+/// \c USRBasedTypes always represent canonical types so that equivalent types
+/// are represented by the same USR.
+/// A type with an empty USR represents the null type.
+class USRBasedType {
+  StringRef USR;
+
+  /// The superclasses of the type and all protocol conformances that are
+  /// declared in the same module that the type was defined.
+  ArrayRef<const USRBasedType *> Supertypes;
+
+  /// Memberwise initializer. \p USR and \p Supertypes need to be allocated in
+  /// the same arena as this \c USRBasedType.
+  USRBasedType(StringRef USR, ArrayRef<const USRBasedType *> Supertypes)
+      : USR(USR), Supertypes(Supertypes) {}
+
+  /// Implementation of \c typeRelation. \p VisistedTypes keeps track which
+  /// types have already been visited.
+  CodeCompletionResultTypeRelation
+  typeRelationImpl(const USRBasedType *ResultType, const USRBasedType *VoidType,
+                   SmallPtrSetImpl<const USRBasedType *> &VisitedTypes) const;
+
+public:
+  /// A null \c USRBasedType that's represented by an empty USR and has no
+  /// supertypes.
+  static const USRBasedType *null(USRBasedTypeArena &Arena);
+
+  /// Construct a \c USRBasedType from an AST-bound type. Computes the type's
+  /// supertypes.
+  static const USRBasedType *fromType(Type Ty, USRBasedTypeArena &Arena);
+
+  /// Construct as \c USRBasedType from a USR and its supertypes. This method
+  /// takes care of copying \p USR and \p Supertypes to \p Arena.
+  static const USRBasedType *fromUSR(StringRef USR,
+                                     ArrayRef<const USRBasedType *> Supertypes,
+                                     USRBasedTypeArena &Arena);
+
+  StringRef getUSR() const { return USR; }
+  ArrayRef<const USRBasedType *> getSupertypes() const { return Supertypes; }
+
+  /// Compute the relation of \c ResultType when to this contextual type.
+  CodeCompletionResultTypeRelation
+  typeRelation(const USRBasedType *ResultType,
+               const USRBasedType *VoidType) const;
+};
+
+/// The type returned by a \c ContextFreeCodeCompletionResult. Can be either of
+/// the following:
+///  - NotApplicable: The completion result doesn't produce something that's
+///    valid inside an expression like a keyword
+///  - An empty list of types if the completion result produces something that's
+///    valid inside an expression but the result type isn't known
+///  - A list of proper type if the type produced by this completion result is
+///    known
+/// A \c CodeCompletionResultType does not have a single unique type because for
+/// code completion we consider e.g. the expression \c Int as producing both an
+/// \c Int metatype and an \c Int instance type. Thus we consider both the
+/// instance and the metatype as result types of the expression \c Int.
+class CodeCompletionResultType {
+  /// \c ResultType1AndIsApplicable and \c ResultType2 store the following
+  /// information:
+  ///  - Whether the type is not applicable (see above). In this case
+  ///    \c ResultType1 and \c ResultType2 should be \c nullptr.
+  ///  - \c ResultType1 and \c ResultType2 form a collection of at most two
+  ///    result types. A \c CodeCompletionResultType cannot have a single unique
+  ///    type because for code completion we consider e.g. \c Int as producing
+  ///    both an \c Int metatype and an \c Int instance.
+  ///    It would be nice if we could use a SmallVector to store those types
+  ///    instead but \c CodeCompletionResultType is allocated in a bump
+  ///    allocator and freeing the bump allocator does not call the
+  ///    SmallVecotor's destructor, leaking potential heap memory. Since we only
+  ///    need two result types at the moment, I decided to implement it in a
+  ///    hacky way with two pointers.
+  /// The \c getResultTypes and \c isApplicable methods mask away this
+  /// implementation detail.
+  llvm::PointerIntPair<PointerUnion<Type, const USRBasedType *>, 1, bool>
+      ResultType1AndIsApplicable;
+  PointerUnion<Type, const USRBasedType *> ResultType2;
+
+  llvm::SmallVector<PointerUnion<Type, const USRBasedType *>, 1>
+  getResultTypes() const {
+    if (ResultType1AndIsApplicable.getPointer() && ResultType2) {
+      return {ResultType1AndIsApplicable.getPointer(), ResultType2};
+    } else if (ResultType1AndIsApplicable.getPointer()) {
+      return {ResultType1AndIsApplicable.getPointer()};
+    } else {
+      assert(
+          !ResultType2 &&
+          "We shouldn't have a second result type if there was no first one");
+      return {};
+    }
+  }
+
+  /// Memberwise initializer
+  CodeCompletionResultType(bool IsApplicable,
+                           PointerUnion<Type, const USRBasedType *> ResultType1,
+                           PointerUnion<Type, const USRBasedType *> ResultType2)
+      : ResultType1AndIsApplicable(ResultType1, IsApplicable),
+        ResultType2(ResultType2) {}
 
 public:
   static CodeCompletionResultType notApplicable() {
-    return CodeCompletionResultType(Type(), Flags::IsNotApplicable);
+    return CodeCompletionResultType(/*IsApplicable=*/true,
+                                    /*ResultType1=*/nullptr,
+                                    /*ResultType2=*/nullptr);
   }
+
   static CodeCompletionResultType unknown() {
-    return CodeCompletionResultType(Type(), /*Flags=*/0);
-  }
-  CodeCompletionResultType(Type Ty, bool AlsoConsiderMetatype = false)
-      : CodeCompletionResultType(Ty, AlsoConsiderMetatype
-                                         ? Flags::AlsoConsiderMetatype
-                                         : OptionSet<Flags>()) {}
-
-  bool isNotApplicable() const {
-    return TypeAndFlags.getInt().contains(Flags::IsNotApplicable);
+    return CodeCompletionResultType(ArrayRef<Type>());
   }
 
-  /// Calculates the type realtion of this type to the given
+  explicit CodeCompletionResultType(ArrayRef<Type> Types)
+      : CodeCompletionResultType(
+            /*IsApplicable=*/false,
+            /*ResultType1=*/Types.size() > 0 ? Types[0] : nullptr,
+            /*ResultType2=*/Types.size() > 1 ? Types[1] : nullptr) {
+    assert(Types.size() <= 2 && "Can only store two different result types in "
+                                "CodeCompletionResultType");
+  }
+
+  explicit CodeCompletionResultType(Type Ty)
+      : CodeCompletionResultType(ArrayRef<Type>(Ty)) {}
+
+  explicit CodeCompletionResultType(ArrayRef<const USRBasedType *> Types)
+      : CodeCompletionResultType(
+            /*IsApplicable=*/false,
+            /*ResultType1=*/Types.size() > 0 ? Types[0] : nullptr,
+            /*ResultType2=*/Types.size() > 1 ? Types[1] : nullptr) {
+    assert(Types.size() <= 2 && "Can only store two different result types in "
+                                "CodeCompletionResultType");
+  }
+
+  /// Returns whether the \c CodeCompletionResult type is backed by USRs and
+  /// thus not associated with any AST.
+  /// Intended to be used in assertions.
+  bool isBackedByUSRs() const;
+
+  /// Returns whether the \c CodeCompletionREsultType is considered not
+  /// applicable (see comment on \c CodeCompletionResultType).
+  bool isNotApplicable() const { return ResultType1AndIsApplicable.getInt(); }
+
+  /// Return the result types as a \c USRBasedTypes, converting an AST-bound
+  /// type to a \c USRBasedTypes if necessary.
+  llvm::SmallVector<const USRBasedType *, 1>
+  getUSRBasedResultTypes(USRBasedTypeArena &Arena) const;
+
+  /// Return the same \c CodeCompletionResultType with the guarantee that it is
+  /// backed by USRs instead of AST-bound types
+  CodeCompletionResultType usrBasedType(USRBasedTypeArena &Arena) const;
+
+  /// Calculates the type relation of this type to the given type context. The
+  /// caller is responsible for creating a \p USRTypeContext that matches the
+  /// \p TypeContext and \p DC, because it might be able to pre-compute it for
+  /// result types of multiple code completion items.
+  ///
+  /// \p USRTypeContext may be \c nullptr in one of the following situations:
+  ///  - If \p TypeContext or \p DC are \c nullptr
+  ///  - If the caller can guarantee that this \c CodeCompletionResultType is
+  ///    AST-based
+  /// In all other cases the \p USRTypeContext must contain types allocated in
+  /// the same arena as the \c USRBasedType of this \c CodeCompletionResultType.
   CodeCompletionResultTypeRelation
   calculateTypeRelation(const ExpectedTypeContext *TypeContext,
-                        const DeclContext *DC) const;
+                        const DeclContext *DC,
+                        const USRBasedTypeContext *USRTypeContext) const;
 };
 } // namespace ide
 } // namespace swift

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -226,6 +226,10 @@ public:
 
   void setIdealExpectedType(Type Ty) { expectedTypeContext.setIdealType(Ty); }
 
+  const ExpectedTypeContext *getExpectedTypeContext() const {
+    return &expectedTypeContext;
+  }
+
   CodeCompletionContext::TypeContextKind typeContextKind() const {
     if (expectedTypeContext.empty() &&
         !expectedTypeContext.getPreferNonVoid()) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1162,7 +1162,7 @@ static void addConditionalCompilationFlags(ASTContext &Ctx,
 /// If \p Sink is nullptr, the pointee of each result may be modified in place.
 void swift::ide::postProcessCompletionResults(
     MutableArrayRef<CodeCompletionResult *> results, CompletionKind Kind,
-    DeclContext *DC, CodeCompletionResultSink *Sink) {
+    const DeclContext *DC, CodeCompletionResultSink *Sink) {
   for (CodeCompletionResult *&result : results) {
     bool modified = false;
     auto flair = result->getFlair();
@@ -1318,7 +1318,8 @@ void swift::ide::deliverCompletionResults(
                                CompletionContext.CodeCompletionKind, DC,
                                /*Sink=*/nullptr);
 
-  Consumer.handleResultsAndModules(CompletionContext, RequestedModules, DC);
+  Consumer.handleResultsAndModules(CompletionContext, RequestedModules,
+                                   Lookup.getExpectedTypeContext(), DC);
 }
 
 bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {

--- a/lib/IDE/CodeCompletionConsumer.cpp
+++ b/lib/IDE/CodeCompletionConsumer.cpp
@@ -16,10 +16,10 @@
 using namespace swift;
 using namespace swift::ide;
 
-static MutableArrayRef<CodeCompletionResult *>
-copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
-                          CodeCompletionCache::Value &source, bool onlyTypes,
-                          bool onlyPrecedenceGroups) {
+static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
+    CodeCompletionResultSink &targetSink, CodeCompletionCache::Value &source,
+    bool onlyTypes, bool onlyPrecedenceGroups,
+    const ExpectedTypeContext *TypeContext, const DeclContext *DC) {
 
   // We will be adding foreign results (from another sink) into TargetSink.
   // TargetSink should have an owning pointer to the allocator that keeps the
@@ -74,6 +74,9 @@ copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
       return true;
     };
   }
+
+  USRBasedTypeContext USRTypeContext(TypeContext, source.USRTypeArena);
+
   for (auto contextFreeResult : source.Results) {
     if (!shouldIncludeResult(contextFreeResult)) {
       continue;
@@ -81,7 +84,7 @@ copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
     auto contextualResult = new (*targetSink.Allocator) CodeCompletionResult(
         *contextFreeResult, SemanticContextKind::OtherModule,
         CodeCompletionFlair(),
-        /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
+        /*numBytesToErase=*/0, TypeContext, DC, &USRTypeContext,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
     targetSink.Results.push_back(contextualResult);
@@ -93,7 +96,8 @@ copyCodeCompletionResults(CodeCompletionResultSink &targetSink,
 
 void SimpleCachingCodeCompletionConsumer::handleResultsAndModules(
     CodeCompletionContext &context,
-    ArrayRef<RequestedCachedModule> requestedModules, DeclContext *DC) {
+    ArrayRef<RequestedCachedModule> requestedModules,
+    const ExpectedTypeContext *TypeContext, const DeclContext *DC) {
 
   // Use the current SourceFile as the DeclContext so that we can use it to
   // perform qualified lookup, and to get the correct visibility for
@@ -117,6 +121,7 @@ void SimpleCachingCodeCompletionConsumer::handleResultsAndModules(
       Sink.enableCallPatternHeuristics = context.getCallPatternHeuristics();
       Sink.includeObjectLiterals = context.includeObjectLiterals();
       Sink.addCallWithNoDefaultArgs = context.addCallWithNoDefaultArgs();
+      Sink.setProduceContextFreeResults((*V)->USRTypeArena);
       lookupCodeCompletionResultsFromModule(Sink, R.TheModule, R.Key.AccessPath,
                                             R.Key.ResultsHaveLeadingDot, SF);
       (*V)->Allocator = Sink.Allocator;
@@ -127,13 +132,19 @@ void SimpleCachingCodeCompletionConsumer::handleResultsAndModules(
       // properities) and simply store pointers to the context free results that
       // back the contextual results.
       for (auto Result : Sink.Results) {
-        CachedResults.push_back(Result->getContextFreeResultPtr());
+        assert(
+            Result->getContextFreeResult().getResultType().isBackedByUSRs() &&
+            "Results stored in the cache should have their result types backed "
+            "by a USR because the cache might outlive the ASTContext the "
+            "results were created from.");
+        CachedResults.push_back(&Result->getContextFreeResult());
       }
       context.Cache.set(R.Key, *V);
     }
     assert(V.hasValue());
-    auto newItems = copyCodeCompletionResults(
-        context.getResultSink(), **V, R.OnlyTypes, R.OnlyPrecedenceGroups);
+    auto newItems =
+        copyCodeCompletionResults(context.getResultSink(), **V, R.OnlyTypes,
+                                  R.OnlyPrecedenceGroups, TypeContext, DC);
     postProcessCompletionResults(newItems, context.CodeCompletionKind, DC,
                                  &context.getResultSink());
   }

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -125,7 +125,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     ContextFreeResult = ContextFreeCodeCompletionResult::createDeclResult(
-        Allocator, CCS, AssociatedDecl, ModuleName,
+        Sink, CCS, AssociatedDecl, ModuleName,
         NullTerminatedStringRef(BriefDocComment, Allocator),
         copyAssociatedUSRs(Allocator, AssociatedDecl), ResultType,
         ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
@@ -135,14 +135,14 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
 
   case CodeCompletionResultKind::Keyword:
     ContextFreeResult = ContextFreeCodeCompletionResult::createKeywordResult(
-        Allocator, KeywordKind, CCS,
+        Sink, KeywordKind, CCS,
         NullTerminatedStringRef(BriefDocComment, Allocator), ResultType);
     break;
   case CodeCompletionResultKind::BuiltinOperator:
   case CodeCompletionResultKind::Pattern:
     ContextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
-            Allocator, Kind, CCS, CodeCompletionOperatorKind::None,
+            Sink, Kind, CCS, CodeCompletionOperatorKind::None,
             NullTerminatedStringRef(BriefDocComment, Allocator), ResultType,
             ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
             ContextFreeDiagnosticMessage);
@@ -150,35 +150,49 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
   case CodeCompletionResultKind::Literal:
     assert(LiteralKind.hasValue());
     ContextFreeResult = ContextFreeCodeCompletionResult::createLiteralResult(
-        Allocator, *LiteralKind, CCS, ResultType);
+        Sink, *LiteralKind, CCS, ResultType);
     break;
   }
 
-  CodeCompletionDiagnosticSeverity ContextualDiagnosticSeverity =
-      CodeCompletionDiagnosticSeverity::None;
-  NullTerminatedStringRef ContextualDiagnosticMessage;
-  if (ContextualNotRecReason != ContextualNotRecommendedReason::None) {
-    // FIXME: We should generate the message lazily.
-    if (const auto *VD = dyn_cast<ValueDecl>(AssociatedDecl)) {
-      CodeCompletionDiagnosticSeverity severity;
-      SmallString<256> message;
-      llvm::raw_svector_ostream messageOS(message);
-      if (!getContextualCompletionDiagnostics(ContextualNotRecReason, VD,
-                                              severity, messageOS)) {
-        ContextualDiagnosticSeverity = severity;
-        ContextualDiagnosticMessage =
-            NullTerminatedStringRef(message, Allocator);
+  if (Sink.shouldProduceContextFreeResults()) {
+    // If the sink only intends to store the context free results in the cache,
+    // we don't need to compute any contextual properties.
+    return new (Allocator) CodeCompletionResult(
+        *ContextFreeResult, SemanticContextKind::None, CodeCompletionFlair(),
+        /*NumBytesToErase=*/0, /*TypeContext=*/nullptr,
+        /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
+        ContextualNotRecommendedReason::None,
+        CodeCompletionDiagnosticSeverity::None, "");
+  } else {
+    CodeCompletionDiagnosticSeverity ContextualDiagnosticSeverity =
+        CodeCompletionDiagnosticSeverity::None;
+    NullTerminatedStringRef ContextualDiagnosticMessage;
+    if (ContextualNotRecReason != ContextualNotRecommendedReason::None) {
+      // FIXME: We should generate the message lazily.
+      if (const auto *VD = dyn_cast<ValueDecl>(AssociatedDecl)) {
+        CodeCompletionDiagnosticSeverity severity;
+        SmallString<256> message;
+        llvm::raw_svector_ostream messageOS(message);
+        if (!getContextualCompletionDiagnostics(ContextualNotRecReason, VD,
+                                                severity, messageOS)) {
+          ContextualDiagnosticSeverity = severity;
+          ContextualDiagnosticMessage =
+              NullTerminatedStringRef(message, Allocator);
+        }
       }
     }
+    assert(
+        ContextFreeResult != nullptr &&
+        "ContextFreeResult should have been constructed by the switch above");
+    // We know that the ContextFreeResult has an AST-based type because it was
+    // just computed and not read from the cache and
+    // Sink.shouldProduceContextFreeResults() is false. So we can pass nullptr
+    // for USRTypeContext.
+    return new (Allocator) CodeCompletionResult(
+        *ContextFreeResult, SemanticContext, Flair, NumBytesToErase,
+        TypeContext, DC, /*USRTypeContext=*/nullptr, ContextualNotRecReason,
+        ContextualDiagnosticSeverity, ContextualDiagnosticMessage);
   }
-
-  assert(ContextFreeResult != nullptr &&
-         "ContextFreeResult should have been constructed by the switch above");
-  CodeCompletionResult *result = new (Allocator) CodeCompletionResult(
-      *ContextFreeResult, SemanticContext, Flair, NumBytesToErase, TypeContext,
-      DC, ContextualNotRecReason, ContextualDiagnosticSeverity,
-      ContextualDiagnosticMessage);
-  return result;
 }
 
 void CodeCompletionResultBuilder::finishResult() {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -62,7 +62,7 @@ class CodeCompletionResultBuilder {
 
   /// The context in which this completion item is used. Used to compute the
   /// type relation to \c ResultType.
-  const ExpectedTypeContext *TypeContext;
+  const ExpectedTypeContext *TypeContext = nullptr;
   const DeclContext *DC = nullptr;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
@@ -137,17 +137,11 @@ public:
 
   /// Set the result type of this code completion item and the context that the
   /// item may be used in.
-  /// If \p AlsoConsiderMetatype is \c true the code completion item will be
-  /// considered as producing the declared interface type (which is passed as
-  /// \p ResultTypes ) as well as the corresponding metatype.
-  /// This allows us to suggest 'Int' as 'Identical' for both of the following
-  /// functions
-  ///
-  ///   func receiveInstance(_: Int) {}
-  ///   func receiveMetatype(_: Int.Type) {}
-  void setResultType(Type ResultType, bool AlsoConsiderMetatype = false) {
-    this->ResultType =
-        CodeCompletionResultType(ResultType, AlsoConsiderMetatype);
+  /// This is not a single unique type because for code completion we consider
+  /// e.g. \c Int as producing both an \c Int metatype and an \c Int instance
+  /// type.
+  void setResultTypes(ArrayRef<Type> ResultTypes) {
+    this->ResultType = CodeCompletionResultType(ResultTypes);
   }
 
   /// Set context in which this code completion item occurs. Used to compute the

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -11,22 +11,247 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/IDE/CodeCompletionResultType.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/USRGeneration.h"
 #include "swift/Sema/IDETypeChecking.h"
 
 using namespace swift;
 using namespace ide;
+using TypeRelation = CodeCompletionResultTypeRelation;
 
-static CodeCompletionResultTypeRelation
-calculateTypeRelation(Type Ty, Type ExpectedTy, const DeclContext &DC) {
+// MARK: - USRBasedTypeContext
+
+USRBasedTypeContext::USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
+                                         USRBasedTypeArena &Arena)
+    : Arena(Arena) {
+
+  for (auto possibleTy : TypeContext->getPossibleTypes()) {
+    ContextualTypes.emplace_back(USRBasedType::fromType(possibleTy, Arena),
+                                 /*IsConvertible=*/false);
+
+    // Add the unwrapped optional types as 'convertible' contextual types.
+    auto UnwrappedOptionalType = possibleTy->getOptionalObjectType();
+    while (UnwrappedOptionalType) {
+      ContextualTypes.emplace_back(
+          USRBasedType::fromType(UnwrappedOptionalType, Arena),
+          /*IsConvertible=*/true);
+      UnwrappedOptionalType = UnwrappedOptionalType->getOptionalObjectType();
+    }
+
+    // If the contextual type is an opaque return type, make the protocol a
+    // contextual type. E.g. if we have
+    //   func foo() -> some View { #^COMPLETE^# }
+    // we should show items conforming to `View` as convertible.
+    if (auto OpaqueType = possibleTy->getAs<OpaqueTypeArchetypeType>()) {
+      llvm::SmallVector<const USRBasedType *, 1> USRTypes;
+      if (auto Superclass = OpaqueType->getSuperclass()) {
+        USRTypes.push_back(USRBasedType::fromType(Superclass, Arena));
+      }
+      for (auto Proto : OpaqueType->getConformsTo()) {
+        USRTypes.push_back(
+            USRBasedType::fromType(Proto->getDeclaredInterfaceType(), Arena));
+      }
+      // Archetypes are also be used to model generic return types, in which
+      // case they don't have any conformsTo entries. We simply ignore those.
+      if (!USRTypes.empty()) {
+        ContextualTypes.emplace_back(USRTypes, /*IsConvertible=*/false);
+      }
+    }
+  }
+}
+
+TypeRelation
+USRBasedTypeContext::typeRelation(const USRBasedType *ResultType) const {
+  const USRBasedType *VoidType = Arena.getVoidType();
+  if (ResultType == VoidType) {
+    // Void is not convertible to anything and we don't report Void <-> Void
+    // identical matches (see USRBasedType::typeRelation). So we don't have to
+    // check anything if the result returns Void.
+    return TypeRelation::Unknown;
+  }
+
+  TypeRelation Res = TypeRelation::Unknown;
+  for (auto &ContextualType : ContextualTypes) {
+    Res = std::max(Res, ContextualType.typeRelation(ResultType, VoidType));
+  }
+  return Res;
+}
+
+// MARK: - USRBasedTypeArena
+
+USRBasedTypeArena::USRBasedTypeArena() {
+  // '$sytD' is the USR of the Void type.
+  VoidType = USRBasedType::fromUSR("$sytD", {}, *this);
+}
+
+const USRBasedType *USRBasedTypeArena::getVoidType() const { return VoidType; }
+
+// MARK: - USRBasedType
+
+TypeRelation USRBasedType::typeRelationImpl(
+    const USRBasedType *ResultType, const USRBasedType *VoidType,
+    SmallPtrSetImpl<const USRBasedType *> &VisitedTypes) const {
+
+  // `this` is the contextual type.
+  if (this == VoidType) {
+    // We don't report Void <-> Void matches because that would boost
+    // methods returning Void in e.g.
+    // func foo() { #^COMPLETE^# }
+    // because #^COMPLETE^# is implicitly returned. But that's not very
+    // helpful.
+    return TypeRelation::Unknown;
+  }
+  if (ResultType == this) {
+    return TypeRelation::Identical;
+  }
+  for (const USRBasedType *Supertype : ResultType->getSupertypes()) {
+    if (!VisitedTypes.insert(Supertype).second) {
+      // Already visited this type.
+      continue;
+    }
+    if (this->typeRelation(Supertype, VoidType) >= TypeRelation::Convertible) {
+      return TypeRelation::Convertible;
+    }
+  }
+  // TypeRelation computation based on USRs is an under-approximation because we
+  // don't take into account generic conversions or retroactive conformance of
+  // library types. Hence, we can't know for sure that ResultType is not
+  // convertible to `this` type and thus can't return Unrelated or Invalid here.
+  return TypeRelation::Unknown;
+}
+
+const USRBasedType *USRBasedType::null(USRBasedTypeArena &Arena) {
+  return USRBasedType::fromUSR(/*USR=*/"", /*Supertypes=*/{}, Arena);
+}
+
+const USRBasedType *
+USRBasedType::fromUSR(StringRef USR, ArrayRef<const USRBasedType *> Supertypes,
+                      USRBasedTypeArena &Arena) {
+  auto ExistingTypeIt = Arena.CanonicalTypes.find(USR);
+  if (ExistingTypeIt != Arena.CanonicalTypes.end()) {
+    assert(ArrayRef<const USRBasedType *>(ExistingTypeIt->second->Supertypes) ==
+               Supertypes &&
+           "Same USR but different supertypes?");
+    return ExistingTypeIt->second;
+  }
+  // USR and Supertypes need to be allocated in the arena to be passed into the
+  // USRBasedType constructor. The elements of Supertypes are already allocated
+  // in the arena.
+  USR = USR.copy(Arena.Allocator);
+  Supertypes = Supertypes.copy(Arena.Allocator);
+
+  const USRBasedType *Result =
+      new (Arena.Allocator) USRBasedType(USR, Supertypes);
+  Arena.CanonicalTypes[USR] = Result;
+  return Result;
+}
+
+const USRBasedType *USRBasedType::fromType(Type Ty, USRBasedTypeArena &Arena) {
+  if (!Ty) {
+    return USRBasedType::null(Arena);
+  }
+
+  // USRBasedTypes are backed by canonical types so that equivalent types have
+  // the same USR.
+  Ty = Ty->getCanonicalType();
+
+  // For opaque types like 'some View', consider them equivalent to 'View'.
+  if (auto OpaqueType = Ty->getAs<OpaqueTypeArchetypeType>()) {
+    if (auto Existential = OpaqueType->getExistentialType()) {
+      Ty = Existential;
+    }
+  }
+  // We can't represent more complicated archetypes like 'some View & MyProto'
+  // in USRBasedType yet. Simply map them to null types for now.
+  if (Ty->hasArchetype()) {
+    return USRBasedType::null(Arena);
+  }
+
+  SmallVector<const USRBasedType *, 2> Supertypes;
+  if (auto Nominal = Ty->getAnyNominal()) {
+    // Sorted conformances so we get a deterministic supertype order and can
+    // assert that USRBasedTypes with the same USR have the same supertypes.
+    auto Conformances = Nominal->getAllConformances(/*sorted=*/true);
+    Supertypes.reserve(Conformances.size());
+    for (auto Conformance : Conformances) {
+      if (Conformance->getDeclContext()->getParentModule() !=
+          Nominal->getModuleContext()) {
+        // Only include conformances that are declared within the module of the
+        // type to avoid caching retroactive conformances which might not
+        // exist when using the code completion cache from a different module.
+        continue;
+      }
+      Supertypes.push_back(USRBasedType::fromType(
+          Conformance->getProtocol()->getDeclaredInterfaceType(), Arena));
+    }
+  }
+  Type Superclass = Ty->getSuperclass();
+  while (Superclass) {
+    Supertypes.push_back(USRBasedType::fromType(Superclass, Arena));
+    Superclass = Superclass->getSuperclass();
+  }
+
+  SmallString<32> USR;
+  llvm::raw_svector_ostream OS(USR);
+  printTypeUSR(Ty, OS);
+
+  assert(llvm::all_of(Supertypes, [&USR](const USRBasedType *Ty) {
+    return Ty->getUSR() != USR;
+  }) && "Circular supertypes?");
+
+  llvm::SmallPtrSet<const USRBasedType *, 2> ImpliedSupertypes;
+  for (auto Supertype : Supertypes) {
+    ImpliedSupertypes.insert(Supertype->getSupertypes().begin(),
+                             Supertype->getSupertypes().end());
+  }
+  llvm::erase_if(Supertypes, [&ImpliedSupertypes](const USRBasedType *Ty) {
+    return ImpliedSupertypes.contains(Ty);
+  });
+
+  return USRBasedType::fromUSR(USR, Supertypes, Arena);
+}
+
+TypeRelation USRBasedType::typeRelation(const USRBasedType *ResultType,
+                                        const USRBasedType *VoidType) const {
+  SmallPtrSet<const USRBasedType *, 4> VisitedTypes;
+  return this->typeRelationImpl(ResultType, VoidType, VisitedTypes);
+}
+
+// MARK: - USRBasedTypeContext
+
+TypeRelation USRBasedTypeContext::ContextualType::typeRelation(
+    const USRBasedType *ResultType, const USRBasedType *VoidType) const {
+  assert(!Types.empty() && "A contextual type should have at least one type");
+
+  /// Types is a conjunction, not a disjunction (see documentation on Types),
+  /// so we need to compute the minimum type relation here.
+  TypeRelation Result = TypeRelation::Identical;
+  for (auto ContextType : Types) {
+    Result = std::min(Result, ContextType->typeRelation(ResultType, VoidType));
+  }
+
+  if (IsConvertible && Result == TypeRelation::Identical) {
+    Result = TypeRelation::Convertible;
+  }
+  return Result;
+}
+
+// MARK: - CodeCompletionResultType
+
+static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
+                                          const DeclContext &DC) {
   if (Ty.isNull() || ExpectedTy.isNull() || Ty->is<ErrorType>() ||
       ExpectedTy->is<ErrorType>())
-    return CodeCompletionResultTypeRelation::Unrelated;
+    return TypeRelation::Unrelated;
 
   // Equality/Conversion of GenericTypeParameterType won't account for
   // requirements – ignore them
   if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
     if (Ty->isEqual(ExpectedTy))
-      return CodeCompletionResultTypeRelation::Identical;
+      return TypeRelation::Identical;
     bool isAny = false;
     isAny |= ExpectedTy->isAny();
     isAny |= ExpectedTy->is<ArchetypeType>() &&
@@ -34,27 +259,27 @@ calculateTypeRelation(Type Ty, Type ExpectedTy, const DeclContext &DC) {
 
     if (!isAny && isConvertibleTo(Ty, ExpectedTy, /*openArchetypes=*/true,
                                   const_cast<DeclContext &>(DC)))
-      return CodeCompletionResultTypeRelation::Convertible;
+      return TypeRelation::Convertible;
   }
   if (auto FT = Ty->getAs<AnyFunctionType>()) {
     if (FT->getResult()->isVoid())
-      return CodeCompletionResultTypeRelation::Invalid;
+      return TypeRelation::Invalid;
   }
-  return CodeCompletionResultTypeRelation::Unrelated;
+  return TypeRelation::Unrelated;
 }
 
-static CodeCompletionResultTypeRelation
+static TypeRelation
 calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
                          const DeclContext &DC) {
   if (Ty->isVoid() && typeContext.requiresNonVoid())
-    return CodeCompletionResultTypeRelation::Invalid;
+    return TypeRelation::Invalid;
   if (typeContext.empty())
-    return CodeCompletionResultTypeRelation::Unknown;
+    return TypeRelation::Unknown;
 
   if (auto funcTy = Ty->getAs<AnyFunctionType>())
     Ty = funcTy->removeArgumentLabels(1);
 
-  auto Result = CodeCompletionResultTypeRelation::Unrelated;
+  auto Result = TypeRelation::Unrelated;
   for (auto expectedTy : typeContext.getPossibleTypes()) {
     // Do not use Void type context for a single-expression body, since the
     // implicit return does not constrain the expression.
@@ -74,31 +299,66 @@ calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
   // Map invalid -> unrelated when in a single-expression body, since the
   // input may be incomplete.
   if (typeContext.isImplicitSingleExpressionReturn() &&
-      Result == CodeCompletionResultTypeRelation::Invalid)
-    Result = CodeCompletionResultTypeRelation::Unrelated;
-  
+      Result == TypeRelation::Invalid)
+    Result = TypeRelation::Unrelated;
+
   return Result;
 }
 
-CodeCompletionResultTypeRelation
-CodeCompletionResultType::calculateTypeRelation(
-    const ExpectedTypeContext *TypeContext, const DeclContext *DC) const {
+bool CodeCompletionResultType::isBackedByUSRs() const {
+  return llvm::all_of(
+      getResultTypes(),
+      [](const PointerUnion<Type, const USRBasedType *> &ResultType) {
+        return ResultType.is<const USRBasedType *>();
+      });
+}
+
+llvm::SmallVector<const USRBasedType *, 1>
+CodeCompletionResultType::getUSRBasedResultTypes(
+    USRBasedTypeArena &Arena) const {
+  llvm::SmallVector<const USRBasedType *, 1> USRBasedTypes;
+  auto ResultTypes = getResultTypes();
+  USRBasedTypes.reserve(ResultTypes.size());
+  for (auto ResultType : ResultTypes) {
+    if (auto USRType = ResultType.dyn_cast<const USRBasedType *>()) {
+      USRBasedTypes.push_back(USRType);
+    } else {
+      USRBasedTypes.push_back(
+          USRBasedType::fromType(ResultType.get<Type>(), Arena));
+    }
+  }
+  return USRBasedTypes;
+}
+
+CodeCompletionResultType
+CodeCompletionResultType::usrBasedType(USRBasedTypeArena &Arena) const {
+  return CodeCompletionResultType(this->getUSRBasedResultTypes(Arena));
+}
+
+TypeRelation CodeCompletionResultType::calculateTypeRelation(
+    const ExpectedTypeContext *TypeContext, const DeclContext *DC,
+    const USRBasedTypeContext *USRTypeContext) const {
   if (isNotApplicable()) {
-    return CodeCompletionResultTypeRelation::NotApplicable;
+    return TypeRelation::NotApplicable;
   }
 
-  Type ResultTy = TypeAndFlags.getPointer();
-  if (!TypeContext || !DC || !ResultTy) {
-    return CodeCompletionResultTypeRelation::Unknown;
+  if (!TypeContext || !DC) {
+    return TypeRelation::Unknown;
   }
-  
-  CodeCompletionResultTypeRelation Result =
-      calculateMaxTypeRelation(ResultTy, *TypeContext, *DC);
-  if (TypeAndFlags.getInt().contains(Flags::AlsoConsiderMetatype)) {
-    Result =
-        std::max(Result, calculateMaxTypeRelation(
-                             MetatypeType::get(ResultTy, DC->getASTContext()),
-                             *TypeContext, *DC));
+
+  TypeRelation Res = TypeRelation::Unknown;
+  for (auto Ty : getResultTypes()) {
+    if (auto USRType = Ty.dyn_cast<const USRBasedType *>()) {
+      if (!USRTypeContext) {
+        assert(false && "calculateTypeRelation must have a USRBasedTypeContext "
+                        "passed if it contains a USR-based result type");
+        continue;
+      }
+      Res = std::max(Res, USRTypeContext->typeRelation(USRType));
+    } else {
+      Res = std::max(
+          Res, calculateMaxTypeRelation(Ty.get<Type>(), *TypeContext, *DC));
+    }
   }
-  return Result;
+  return Res;
 }

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -184,6 +184,14 @@ const USRBasedType *USRBasedType::fromType(Type Ty, USRBasedTypeArena &Arena) {
         // exist when using the code completion cache from a different module.
         continue;
       }
+      if (Conformance->getProtocol()->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+        // FIXME: Sendable conformances are lazily synthesized as they are
+        // needed by the compiler. Depending on whether we checked whether a
+        // type conforms to Sendable before constructing the USRBasedType, we
+        // get different results for its conformance. For now, always drop the
+        // Sendable conformance.
+        continue;
+      }
       Supertypes.push_back(USRBasedType::fromType(
           Conformance->getProtocol()->getDeclaredInterfaceType(), Arena));
     }

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -25,7 +25,7 @@ func testSync() -> Int{
 // 'async'-ness in the cache. (rdar://78317170)
 
 // GLOBAL_IN_SYNC: Begin completions
-// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_SYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_SYNC: End completions
@@ -33,7 +33,7 @@ func testSync() -> Int{
 func testAsync() async -> Int {
     #^GLOBAL_IN_ASYNC^#
 // GLOBAL_IN_ASYNC: Begin completions
-// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_ASYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_ASYNC: End completions

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -1,0 +1,218 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ImportPath)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
+
+// BEGIN Lib.swift
+
+public protocol MyBaseProto {}
+
+public protocol MyProto: MyBaseProto {}
+
+public protocol MyOtherProto {}
+
+public struct Foo: MyProto {
+	public init() {}
+}
+public struct Bar: MyOtherProto {
+	public init() {}
+}
+public struct FooBar: MyProto, MyOtherProto {
+	public init() {}
+}
+
+public func makeFoo() -> Foo {
+	return Foo()
+}
+
+public let GLOBAL_FOO = Foo()
+
+public class MyClass {}
+public class MySubclass: MyClass {}
+public class MySubclassConformingToMyProto: MyClass, MyProto {}
+
+public func makeMyClass() -> MyClass { return MyClass() }
+public func makeMySubclass() -> MySubclass { return MySubclass() }
+
+public func returnSomeMyProto() -> some MyProto { return Foo() }
+
+public protocol ProtoWithAssocType {
+  associatedtype MyAssoc
+}
+
+public struct StructWithAssocType: ProtoWithAssocType {
+  public typealias MyAssoc = Int
+}
+
+public func makeProtoWithAssocType() -> some ProtoWithAssocType { return StructWithAssocType() }
+
+// BEGIN test.swift
+
+import Lib
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s
+// Perform the same completion again, this time using the code completion cache that implicitly gets added to swift-ide-test
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s
+
+func test() -> MyProto {
+	return #^COMPLETE^#
+}
+
+// CHECK: Begin completions
+// CHECK-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// CHECK-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// CHECK-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Identical]: returnSomeMyProto()[#MyProto#];
+// CHECK: End completions
+
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE_OPAQUE_COMPOSITION -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_OPAQUE_COMPOSITION
+// Perform the same completion again, this time using the code completion cache that implicitly gets added to swift-ide-test
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE_OPAQUE_COMPOSITION -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=COMPLETE_OPAQUE_COMPOSITION
+
+func testOpaqueComposition() -> some MyProto & MyOtherProto {
+	return #^COMPLETE_OPAQUE_COMPOSITION^#
+}
+
+// COMPLETE_OPAQUE_COMPOSITION: Begin completions
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[GlobalVar]/OtherModule[Lib]: GLOBAL_FOO[#Foo#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeFoo()[#Foo#];
+// COMPLETE_OPAQUE_COMPOSITION-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
+// COMPLETE_OPAQUE_COMPOSITION: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token ALSO_CONSIDER_METATYPE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=ALSO_CONSIDER_METATYPE
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token ALSO_CONSIDER_METATYPE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=ALSO_CONSIDER_METATYPE
+
+func testAlsoConsiderMetatype() -> MyClass.Type {
+  return #^ALSO_CONSIDER_METATYPE^#
+}
+// ALSO_CONSIDER_METATYPE: Begin completions
+// ALSO_CONSIDER_METATYPE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Identical]: MyClass[#MyClass#];
+// FIXME: MySubclass should be 'Convertible' but we don't currently store metatype supertypes in USRBasedType.
+// ALSO_CONSIDER_METATYPE-DAG: Decl[Class]/OtherModule[Lib]: MySubclass[#MySubclass#];
+// ALSO_CONSIDER_METATYPE: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token OPAQUE_WITH_CLASS -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=OPAQUE_WITH_CLASS
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token OPAQUE_WITH_CLASS -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=OPAQUE_WITH_CLASS
+func testOpaqueWithClass<T: MyClass & MyProto>() -> T {
+  return #^OPAQUE_WITH_CLASS^#
+}
+
+// FIXME: We don't support USR-based type comparison in generic contexts. MySubclassConformingToMyProto should be 'Convertible'
+// OPAQUE_WITH_CLASS: Begin completions
+// OPAQUE_WITH_CLASS-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMySubclass()[#MySubclass#];
+// OPAQUE_WITH_CLASS-DAG: Decl[Class]/OtherModule[Lib]:       MySubclass[#MySubclass#];
+// OPAQUE_WITH_CLASS-DAG: Decl[Class]/OtherModule[Lib]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
+// OPAQUE_WITH_CLASS-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMyClass()[#MyClass#];
+// OPAQUE_WITH_CLASS-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// OPAQUE_WITH_CLASS-DAG: Decl[FreeFunction]/OtherModule[Lib]: returnSomeMyProto()[#MyProto#];
+// OPAQUE_WITH_CLASS: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token GENERIC_RETURN -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=GENERIC_RETURN
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token GENERIC_RETURN -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=GENERIC_RETURN
+func testGenericReturn<T: MyProto>() -> T {
+  return #^GENERIC_RETURN^#
+}
+
+// FIXME: We don't support USR-based type comparison in generic contexts. MyProto and returnMyProto should be 'Identical'. makeFoo and FooBar should be 'Convertible'
+// GENERIC_RETURN: Begin completions
+// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
+// GENERIC_RETURN-DAG: Decl[GlobalVar]/OtherModule[Lib]: GLOBAL_FOO[#Foo#];
+// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// GENERIC_RETURN-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// GENERIC_RETURN-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeFoo()[#Foo#];
+// GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]: FooBar[#FooBar#];
+// GENERIC_RETURN-DAG: Decl[FreeFunction]/OtherModule[Lib]: returnSomeMyProto()[#MyProto#];
+// GENERIC_RETURN: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token OPAQUE_CLASS_AND_PROTOCOL -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=OPAQUE_CLASS_AND_PROTOCOL
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token OPAQUE_CLASS_AND_PROTOCOL -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=OPAQUE_CLASS_AND_PROTOCOL
+func testGenericReturn() -> some MyClass & MyProto {
+  return #^OPAQUE_CLASS_AND_PROTOCOL^#
+}
+
+// OPAQUE_CLASS_AND_PROTOCOL: Begin completions
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMySubclass()[#MySubclass#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Class]/OtherModule[Lib]:       MySubclass[#MySubclass#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMyClass()[#MyClass#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyProto[#MyProto#];
+// OPAQUE_CLASS_AND_PROTOCOL-DAG: Decl[FreeFunction]/OtherModule[Lib]: returnSomeMyProto()[#MyProto#];
+// OPAQUE_CLASS_AND_PROTOCOL: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token TRANSITIVE_CONFORMANCE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=TRANSITIVE_CONFORMANCE
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token TRANSITIVE_CONFORMANCE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=TRANSITIVE_CONFORMANCE
+func testGenericReturn() -> MyBaseProto {
+  return #^TRANSITIVE_CONFORMANCE^#
+}
+
+// TRANSITIVE_CONFORMANCE: Begin completions
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: MyOtherProto[#MyOtherProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]:       MyClass[#MyClass#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyBaseProto[#MyBaseProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeMyClass()[#MyClass#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
+// TRANSITIVE_CONFORMANCE: End completions
+
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE
+func protoWithAssocType() -> ProtoWithAssocType {
+  return #^PROTO_WITH_ASSOC_TYPE^#
+}
+
+// PROTO_WITH_ASSOC_TYPE: Begin completions
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: StructWithAssocType[#StructWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Identical]: makeProtoWithAssocType()[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: ProtoWithAssocType[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE: End completions
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_OPAQUE_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_OPAQUE_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE
+func protoWithAssocTypeInOpaqueContext() -> some ProtoWithAssocType {
+  return #^PROTO_WITH_ASSOC_TYPE_OPAQUE_CONTEXT^#
+}
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath
+// Perform the same completion again, this time using the code completion cache
+// RUN: %swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT
+func protoWithAssocTypeInGenericContext<T: ProtoWithAssocType>() -> T {
+  return #^PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT^#
+}
+
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT: Begin completions
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Struct]/OtherModule[Lib]: StructWithAssocType[#StructWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[FreeFunction]/OtherModule[Lib]: makeProtoWithAssocType()[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: ProtoWithAssocType[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT: End completions
+

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -68,7 +68,7 @@ func testUnknown() {
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "Int",
 // OPTIONALCONTEXT:       key.typename: "Int",
-// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "nil",
 // OPTIONALCONTEXT:       key.typename: "Int?",

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -133,7 +133,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         CodeCompletionString::create(sink.allocator, chunk);
     auto *contextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
-            sink.allocator, CodeCompletionResultKind::Pattern, completionString,
+            sink.swiftSink, CodeCompletionResultKind::Pattern, completionString,
             CodeCompletionOperatorKind::None, /*BriefDocComment=*/"",
             CodeCompletionResultType::unknown(),
             ContextFreeNotRecommendedReason::None,
@@ -142,7 +142,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
         /*NumBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-        ContextualNotRecommendedReason::None,
+        /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 
     CompletionBuilder builder(sink, *swiftResult);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -911,7 +911,7 @@ static void transformAndForwardResults(
         CodeCompletionString::create(innerSink.allocator, chunks);
     ContextFreeCodeCompletionResult *contextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
-            innerSink.allocator, CodeCompletionResultKind::BuiltinOperator,
+            innerSink.swiftSink, CodeCompletionResultKind::BuiltinOperator,
             completionString, CodeCompletionOperatorKind::None,
             /*BriefDocComment=*/"", CodeCompletionResultType::notApplicable(),
             ContextFreeNotRecommendedReason::None,
@@ -921,7 +921,7 @@ static void transformAndForwardResults(
         *contextFreeResult, SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
-        /*TypeContext=*/nullptr, /*DC=*/nullptr,
+        /*TypeContext=*/nullptr, /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
         ContextualNotRecommendedReason::None,
         CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4188,7 +4188,7 @@ int main(int argc, char *argv[]) {
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
             /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-            ContextualNotRecommendedReason::None,
+            /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
         contextualResults.push_back(contextualResult);
       }


### PR DESCRIPTION
Computing the type relation for every item in the code completion cache is way to expensive (~4x slowdown for global completion that imports `SwiftUI`). Instead, compute a type’s supertypes (protocol conformances and superclasses) once and write their USRs to the cache. To compute a type relation we can then check if the contextual type is in the completion item’s supertypes.

This reduces the overhead of computing the type relations (again global completion that imports `SwiftUI`) to ~6% – measured by instructions executed.

Technically, we might miss some conversions like
- retroactive conformances inside another module (because we can’t cache them if that other module isn’t imported)
- complex generic conversions (just too complicated to model using USRs)

Because of this, we never report an `unrelated` type relation for global items but always default to `unknown`.

But I believe this change covers the most common cases and is a good tradeoff between accuracy and performance.

rdar://83846531

---

@rintaro I needed to undo the change you suggested in https://github.com/apple/swift/pull/40999#discussion_r806541085:

When we were only storing AST-based types, we could have a boolean flag to also consider metatypes. This trick is harder to pull off with USR-based types, because we can’t just invoke the MetatypeType constructor with the instance type.

We could hack together a USR-based instance type to Metatype transformation by appending an "m" to the instance type’s USR but I decided to store the metatype as another possible result type of `CodeCompletionResultType` because:
1. Performing USR manipulations when computing type relations seems pretty fragile to me
2. We don’t have an option to store a metatype’s supertypes if we just append an "m" to the USR and thus can’t determine "Convertible" type relations for metatypes (to be fair we can’t do this today either but it should be possible by computing the metatype supertypes in `USRBasedType::fromType`
3. I think we can afford to save another word by making `CodeCompletionResultType` contain `SmallVector<Type, 1>` instead of `Type`.