### PR TITLE
Skip SwiftDocC tests in buildbot_osx_package

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1340,6 +1340,8 @@ mixin-preset=
 
 # SKIP LLDB TESTS (67923799)
 skip-test-lldb
+# SKIP SWIFT-DOCC TESTS (87784021)
+skip-test-swiftdocc
 
 [preset: buildbot_osx_package,use_os_runtime]
 mixin-preset=


### PR DESCRIPTION
<!-- What's in this pull request? -->
This skips the Swift-DocC tests in the buildbot_osx_package preset while we investigate a recent set of occasional test failures. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
