### PR TITLE
Gardening: add syntax highlighting to `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
   within a result type, including having multiple opaque types in the same
   result. For example:
 
-  ```
+  ```swift
   func getSomeDictionary() -> [some Hashable: some Codable] {
     return [ 1: "One", 2: "Two" ]
   }


### PR DESCRIPTION
SE-0328 item didn't have syntax highlighting enabled.