### PR TITLE
[SILOptimizer] Let visitTransitiveEndBorrows take SILValues.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1203,7 +1203,7 @@ void findTransitiveReborrowBaseValuePairs(
 /// Given a begin of a borrow scope, visit all end_borrow users of the borrow or
 /// its reborrows.
 void visitTransitiveEndBorrows(
-    BorrowedValue beginBorrow,
+    SILValue value,
     function_ref<void(EndBorrowInst *)> visitEndBorrow);
 
 /// Whether the specified lexical begin_borrow instruction is nested.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1504,10 +1504,10 @@ void swift::findTransitiveReborrowBaseValuePairs(
 }
 
 void swift::visitTransitiveEndBorrows(
-    BorrowedValue beginBorrow,
+    SILValue value,
     function_ref<void(EndBorrowInst *)> visitEndBorrow) {
   GraphNodeWorklist<SILValue, 4> worklist;
-  worklist.insert(beginBorrow.value);
+  worklist.insert(value);
 
   while (!worklist.empty()) {
     auto val = worklist.pop();

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -623,7 +623,7 @@ void AliasAnalysis::computeImmutableScope(SingleValueInstruction *beginScopeInst
       addEndScopeInst(endAccess);
     }
   } else {
-    visitTransitiveEndBorrows(BorrowedValue(beginScopeInst), addEndScopeInst);
+    visitTransitiveEndBorrows(beginScopeInst, addEndScopeInst);
   }
 
   // Second step: walk up the control flow until the beginScopeInst and add

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -292,7 +292,7 @@ void DCE::markLive() {
           SmallVector<SILValue, 4> roots;
           findGuaranteedReferenceRoots(borrowInst->getOperand(), roots);
           for (auto root : roots) {
-            visitTransitiveEndBorrows(BorrowedValue(root),
+            visitTransitiveEndBorrows(root,
                                       [&](EndBorrowInst *endBorrow) {
                                         markInstructionLive(endBorrow);
                                       });

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -938,3 +938,37 @@ exit(%lifetime_2 : @guaranteed $Klass, %struct_lifetime_2 : @guaranteed $NonTriv
   %retval = tuple ()
   return %retval : $()
 }
+
+sil [ossa] @testBorrowedSwitch : $@convention(thin) (Optional<@sil_unmanaged AnyObject>) -> () {
+bb0(%0 : $Optional<@sil_unmanaged AnyObject>):
+  switch_enum %0 : $Optional<@sil_unmanaged AnyObject>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%2 : $@sil_unmanaged AnyObject):
+  %3 = unmanaged_to_ref %2 : $@sil_unmanaged AnyObject to $AnyObject
+  %4 = unchecked_ownership_conversion %3 : $AnyObject, @unowned to @guaranteed
+  %5 = begin_borrow [lexical] %4 : $AnyObject
+  end_borrow %5 : $AnyObject
+  end_borrow %4 : $AnyObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %242 = tuple ()
+  return %242 : $()
+}
+
+// rdar://87985420 - crash in nullptr returned by findGuaranteedReferenceRoots
+// Test that a boorrow scope introduced by unchecked_ownership_conversion is not
+// deleted by DCE.
+sil [ossa] @testUncheckedConvertToGuaranteed : $@convention(thin) (@sil_unmanaged AnyObject) -> () {
+bb0(%0 : $@sil_unmanaged AnyObject):
+  %3 = unmanaged_to_ref %0 : $@sil_unmanaged AnyObject to $AnyObject
+  %4 = unchecked_ownership_conversion %3 : $AnyObject, @unowned to @guaranteed
+  %5 = begin_borrow [lexical] %4 : $AnyObject
+  end_borrow %5 : $AnyObject
+  end_borrow %4 : $AnyObject
+  %242 = tuple ()
+  return %242 : $()
+}


### PR DESCRIPTION
Previously, visitTransitiveEndBorrows took BorrowedValues.  However,
there is at least one kind of borrow--namely,
unchecked_ownership_conversion insts--that is not currently permitted by
the BorrowedValue API.  The long term fix is to make BorrowedValue
handle such instructions.  For now, change visitTransitiveEndBorrows to
take SILValues so that unchecked_ownership_conversion can be passed to
the API.

rdar://87985420