### PR TITLE
[Sema] Avoid computing raw values for enum cases in swiftinterface files

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1094,6 +1094,14 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
   if (!rawTy) {
     return std::make_tuple<>();
   }
+  
+  // Avoid computing raw values for enum cases in swiftinterface files since raw
+  // values are intentionally omitted from them (unless the enum is @objc).
+  // Without bailing here, incorrect raw values can be automatically generated
+  // and incorrect diagnostics may be omitted for some decls.
+  SourceFile *Parent = ED->getDeclContext()->getParentSourceFile();
+  if (Parent && Parent->Kind == SourceFileKind::Interface && !ED->isObjC())
+    return std::make_tuple<>();
 
   if (!computeAutomaticEnumValueKind(ED)) {
     return std::make_tuple<>();

--- a/test/ModuleInterface/Inputs/enums-layout-helper.swift
+++ b/test/ModuleInterface/Inputs/enums-layout-helper.swift
@@ -46,6 +46,12 @@ public enum FutureproofEnum: Int {
   case d
 }
 
+// CHECK-LABEL: public enum FutureproofUnicodeScalarEnum : Swift.Unicode.Scalar
+public enum FutureproofUnicodeScalarEnum: Unicode.Scalar {
+  // CHECK-NEXT: case a{{$}}
+  case a = "A"
+}
+
 // CHECK-LABEL: indirect public enum FutureproofIndirectEnum
 public indirect enum FutureproofIndirectEnum {
   // CHECK-NEXT: case a{{$}}

--- a/test/ModuleInterface/enums-layout.swift
+++ b/test/ModuleInterface/enums-layout.swift
@@ -1,12 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
+// RUN: %target-swift-frontend -enable-objc-interop -compile-module-from-interface %t/Lib.swiftinterface -o  %t/compiled-from-interface.swiftmodule -module-name Lib
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
 
 // Try again using a single-frontend build.
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -whole-module-optimization -emit-module-interface-path %t/Lib.swiftinterface -emit-module -o %t/unused.swiftmodule -enable-library-evolution -Xfrontend -enable-objc-interop -Xfrontend -disable-objc-attr-requires-foundation-module -swift-version 5 %S/Inputs/enums-layout-helper.swift -module-name Lib
 // RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-SINGLE-FRONTEND %S/Inputs/enums-layout-helper.swift < %t/Lib.swiftinterface
+// RUN: %target-swift-frontend -enable-objc-interop -compile-module-from-interface %t/Lib.swiftinterface -o  %t/compiled-from-interface.swiftmodule -module-name Lib
 // RUN: %target-swift-frontend -enable-objc-interop -O -emit-ir -primary-file %s -I %t -Xllvm -swiftmergefunc-threshold=0 | %FileCheck %s
 
 

--- a/test/ModuleInterface/enums-layout.swift
+++ b/test/ModuleInterface/enums-layout.swift
@@ -42,6 +42,16 @@ func testFrozenObjCEnum() -> FrozenObjCEnum {
   return .b
 } // CHECK-NEXT: {{^}$}}
 
+// CHECK-LABEL: define{{.+}}testFutureproofUnicodeScalarEnum
+func testFutureproofUnicodeScalarEnum() -> FutureproofUnicodeScalarEnum {
+  // CHECK: [[CASE:%.+]] = load i32, i32* @"$s3Lib28FutureproofUnicodeScalarEnumO1ayA2CmFWC"
+  // CHECK: [[METADATA_RESPONSE:%.+]] = tail call swiftcc %swift.metadata_response @"$s3Lib28FutureproofUnicodeScalarEnumOMa"
+  // CHECK: [[METADATA:%.+]] = extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0
+  // CHECK: call void {{%.+}}(%swift.opaque* noalias %0, i32 [[CASE]], %swift.type* [[METADATA]])
+  // CHECK-NEXT: ret void
+  return .a
+}
+
 // CHECK-LABEL: define{{.+}}testFutureproofIndirectEnum
 func testFutureproofIndirectEnum() -> FutureproofIndirectEnum {
   // CHECK: [[CASE:%.+]] = load i32, i32* @"$s3Lib23FutureproofIndirectEnumO1cyA2CmFWC"


### PR DESCRIPTION
Raw values of enum cases are not emitted when printing their declarations in a swiftinterface file unless the enum is `@objc`. `EnumRawValuesRequest` always expects to be able to compute a raw value for an enum case and therefore emits an error diagnostic about missing explicit raw values on enum cases in a swiftinterface when the the raw value cannot be derived implicitly (e.g. for `Int` or `String` enums). The fix short-circuits raw value determination when the enum decl is in a swiftinterface file and is not `@objc`.

Resolves SR-14355 and rdar://75451691