### PR TITLE
Minor latent bug fix in findGuaranteedReferenceRoots.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -854,8 +854,10 @@ void swift::findGuaranteedReferenceRoots(SILValue value,
   while (auto value = worklist.pop()) {
     if (auto *arg = dyn_cast<SILPhiArgument>(value)) {
       if (auto *terminator = arg->getSingleTerminator()) {
-        worklist.insert(terminator->getOperand(arg->getIndex()));
-        continue;
+        if (terminator->isTransformationTerminator()) {
+          worklist.insert(terminator->getOperand(0));
+          continue;
+        }
       }
     } else if (auto *inst = value->getDefiningInstruction()) {
       if (auto *result =


### PR DESCRIPTION
Fix an obvious mistake that happens to not break anything in practice.

Note that the argument index of a terminator result is not the same as
an operand index for the terminator instruction.
