### PR TITLE
[5.6] SIL optimizer: temporarily disable immortal arc elimination

### DIFF
--- a/libswift/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassUtils.swift
@@ -23,7 +23,10 @@ struct PassContext {
   fileprivate let passContext: BridgedPassContext
   
   var isSwift51RuntimeAvailable: Bool {
-    PassContext_isSwift51RuntimeAvailable(passContext) != 0
+    // Temporarily disable optimizations based on deployment target.
+    // rdar://87898692
+    return false
+    // PassContext_isSwift51RuntimeAvailable(passContext) != 0
   }
   
   var aliasAnalysis: AliasAnalysis {

--- a/test/SILOptimizer/immortal-arc-elimination.sil
+++ b/test/SILOptimizer/immortal-arc-elimination.sil
@@ -12,10 +12,12 @@ import SwiftShims
 
 sil_global public_external @_swiftEmptyArrayStorage : $_SwiftEmptyArrayStorage
 
+// Check if the optimization is disbled.
+// rdar://87898692
 
 // CHECK-LABEL: sil @testEmptyArraySingleton
 // CHECK:       global_addr
-// CHECK-NOT:   retain
+// CHECK:       retain
 // CHECK: } // end sil function 'testEmptyArraySingleton'
 sil @testEmptyArraySingleton : $@convention(thin) () -> @owned Builtin.BridgeObject {
 bb0:
@@ -39,7 +41,7 @@ sil_global private @staticArray : $_ContiguousArrayStorage<Int> = {
 
 // CHECK-LABEL: sil @testGlobalValue
 // CHECK:       global_value
-// CHECK-NOT:   retain
+// CHECK:       retain
 // CHECK: } // end sil function 'testGlobalValue'
 sil @testGlobalValue : $@convention(thin) () -> @owned Builtin.BridgeObject {
 bb0:

--- a/test/SILOptimizer/immortal-arc-elimination.swift
+++ b/test/SILOptimizer/immortal-arc-elimination.swift
@@ -11,9 +11,12 @@
 // Check that the optimizer can remove "unbalanced" retains for immortal objects.
 // But only with a Swift 5.1 runtime (which supports immortal objects).
 
+// Check if the optimization is disbled.
+// rdar://87898692
+
 // CHECK-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
 // CHECK:       global_addr
-// CHECK-NOT:   retain
+// CHECK:       retain
 // CHECK: } // end sil function '$s4test10emptyArraySaySiGyF'
 @inline(never)
 func emptyArray() -> [Int] {
@@ -23,7 +26,7 @@ func emptyArray() -> [Int] {
 
 // CHECK-LABEL: sil hidden [noinline] @$s4test13constantArraySaySiGyF
 // CHECK:       global_value
-// CHECK-NOT:   retain
+// CHECK:       retain
 // CHECK: } // end sil function '$s4test13constantArraySaySiGyF'
 @inline(never)
 func constantArray() -> [Int] {


### PR DESCRIPTION
Optimizations based on deployment targets do not interfere well with inlinable functions

rdar://87898692
