### PR TITLE
[Parser] Don't parse 'any identifier' as a type when the identifier is on the next line.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1627,7 +1627,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
 
     // 'any' followed by another identifier is an existential type.
     if (Tok.isContextualKeyword("any") &&
-        peekToken().is(tok::identifier)) {
+        peekToken().is(tok::identifier) &&
+        !peekToken().isAtStartOfLine()) {
       ParserResult<TypeRepr> ty = parseType();
       auto *typeExpr = new (Context) TypeExpr(ty.get());
       return makeParserResult(typeExpr);

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -213,4 +213,12 @@ func testAnyTypeExpr() {
   // expected-note@+1 {{use '.self' to reference the type object}}
   let invalid = any P
   test(invalid)
+
+  // Make sure 'any' followed by an identifier
+  // on the next line isn't parsed as a type.
+  func doSomething() {}
+
+  let any = 10
+  let _ = any
+  doSomething()
 }


### PR DESCRIPTION
Otherwise, we'll break code that uses `any` as the name of a variable, e.g.

```swift
func doSomething() {}

let any = 10
let _ = any
doSomething()
```

Resolves: rdar://88083607