### PR TITLE
[5.6][Parser] Don't parse 'any identifier' as a type when the identifier is on the next line.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1627,7 +1627,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
 
     // 'any' followed by another identifier is an existential type.
     if (Tok.isContextualKeyword("any") &&
-        peekToken().is(tok::identifier)) {
+        peekToken().is(tok::identifier) &&
+        !peekToken().isAtStartOfLine()) {
       ParserResult<TypeRepr> ty = parseType();
       auto *typeExpr = new (Context) TypeExpr(ty.get());
       return makeParserResult(typeExpr);

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -213,4 +213,12 @@ func testAnyTypeExpr() {
   // expected-note@+1 {{use '.self' to reference the type object}}
   let invalid = any P
   test(invalid)
+
+  // Make sure 'any' followed by an identifier
+  // on the next line isn't parsed as a type.
+  func doSomething() {}
+
+  let any = 10
+  let _ = any
+  doSomething()
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/41023

* **Explanation**: This fixes a source break caused by https://github.com/apple/swift/pull/40968 that prevents code using `any` as a local variable name from compiling when followed on the next line by another identifier, e.g. a function call. The fix is to not parse `any identifier` as a type if the identifier is on the next line.
* **Scope**: The bug affects code that uses the name `any` as an identifier.
* **Risk**: Low.
* **Testing**: Added a unit test for the code pattern that broke.

Resolves: rdar://88083607
