### PR TITLE
Disable deployment target specific optimizations for inlinable functions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyStrongRetainRelease.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyStrongRetainRelease.swift
@@ -76,18 +76,18 @@ private func isNotReferenceCounted(value: Value, context: PassContext) -> Bool {
       return isNotReferenceCounted(value: uci.operand, context: context)
     case let urc as UncheckedRefCastInst:
       return isNotReferenceCounted(value: urc.operand, context: context)
-    case is GlobalValueInst:
+    case let gvi as GlobalValueInst:
       // Since Swift 5.1, statically allocated objects have "immortal" reference
       // counts. Therefore we can safely eliminate unbalaced retains and
       // releases, because they are no-ops on immortal objects.
       // Note that the `simplifyGlobalValuePass` pass is deleting balanced
       // retains/releases, which doesn't require a Swift 5.1 minimum deployment
       // targert.
-      return context.isSwift51RuntimeAvailable
+      return gvi.function.isSwift51RuntimeAvailable
     case let rptr as RawPointerToRefInst:
       // Like `global_value` but for the empty collection singletons from the
       // stdlib, e.g. the empty Array singleton.
-      if context.isSwift51RuntimeAvailable {
+      if rptr.function.isSwift51RuntimeAvailable {
         // The pattern generated for empty collection singletons is:
         //     %0 = global_addr @_swiftEmptyArrayStorage
         //     %1 = address_to_pointer %0

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
@@ -22,10 +22,6 @@ struct PassContext {
 
   let _bridged: BridgedPassContext
 
-  var isSwift51RuntimeAvailable: Bool {
-    PassContext_isSwift51RuntimeAvailable(_bridged) != 0
-  }
-
   var aliasAnalysis: AliasAnalysis {
     let bridgedAA = PassContext_getAliasAnalysis(_bridged)
     return AliasAnalysis(bridged: bridgedAA)

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -52,6 +52,13 @@ final public class Function : CustomStringConvertible, HasName {
   public var argumentTypes: ArgumentTypeArray { ArgumentTypeArray(function: self) }
   public var resultType: Type { SILFunction_getSILResultType(bridged).type }
 
+  /// True, if the function runs with a swift 5.1 runtime.
+  /// Note that this is function specific, because inlinable functions are de-serialized
+  /// in a client module, which might be compiled with a different deployment target.
+  public var isSwift51RuntimeAvailable: Bool {
+    SILFunction_isSwift51RuntimeAvailable(bridged) != 0
+  }
+
   // Only to be called by PassContext
   public func _modifyEffects(_ body: (inout FunctionEffects) -> ()) {
     body(&effects)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -205,6 +205,7 @@ SwiftInt SILFunction_getSelfArgumentIndex(BridgedFunction function);
 SwiftInt SILFunction_getNumSILArguments(BridgedFunction function);
 BridgedType SILFunction_getSILArgumentType(BridgedFunction function, SwiftInt idx);
 BridgedType SILFunction_getSILResultType(BridgedFunction function);
+SwiftInt SILFunction_isSwift51RuntimeAvailable(BridgedFunction function);
 
 BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global);
 BridgedStringRef SILGlobalVariable_debugDescription(BridgedGlobalVar global);

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -86,8 +86,6 @@ void SILPassManager_registerFunctionPass(BridgedStringRef name,
 void SILCombine_registerInstructionPass(BridgedStringRef name,
                                         BridgedInstructionPassRunFn runFn);
 
-SwiftInt PassContext_isSwift51RuntimeAvailable(BridgedPassContext context);
-
 BridgedAliasAnalysis PassContext_getAliasAnalysis(BridgedPassContext context);
 
 BridgedMemoryBehavior AliasAnalysis_getMemBehavior(BridgedAliasAnalysis aa,

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -213,6 +213,16 @@ BridgedType SILFunction_getSILResultType(BridgedFunction function) {
   return {resTy.getOpaqueValue()};
 }
 
+SwiftInt SILFunction_isSwift51RuntimeAvailable(BridgedFunction function) {
+  SILFunction *f = castToFunction(function);
+  if (f->getResilienceExpansion() != ResilienceExpansion::Maximal)
+    return 0;
+
+  ASTContext &ctxt = f->getModule().getASTContext();
+  return AvailabilityContext::forDeploymentTarget(ctxt).isContainedIn(
+    ctxt.getSwift51Availability());
+}
+
 //===----------------------------------------------------------------------===//
 //                               SILBasicBlock
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1240,13 +1240,6 @@ void PassContext_fixStackNesting(BridgedPassContext passContext,
   }
 }
 
-SwiftInt PassContext_isSwift51RuntimeAvailable(BridgedPassContext context) {
-  SILPassManager *pm = castToPassInvocation(context)->getPassManager();
-  ASTContext &ctxt = pm->getModule()->getASTContext();
-  return AvailabilityContext::forDeploymentTarget(ctxt).isContainedIn(
-    ctxt.getSwift51Availability());
-}
-
 BridgedAliasAnalysis PassContext_getAliasAnalysis(BridgedPassContext context) {
   SwiftPassInvocation *invocation = castToPassInvocation(context);
   SILPassManager *pm = invocation->getPassManager();

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1408,6 +1408,11 @@ static bool isApplyOfBuiltin(SILInstruction &I, BuiltinValueKind kind) {
 }
 
 static bool isApplyOfKnownAvailability(SILInstruction &I) {
+  // Inlinable functions can be deserialized in other modules which can be
+  // compiled with a different deployment target.
+  if (I.getFunction()->getResilienceExpansion() != ResilienceExpansion::Maximal)
+    return false;
+
   auto apply = FullApplySite::isa(&I);
   if (!apply)
     return false;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2512,7 +2512,20 @@ usePrespecialized(SILOptFunctionBuilder &funcBuilder, ApplySite apply,
     auto specializationAvail = SA->getAvailability();
     auto &ctxt = funcBuilder.getModule().getSwiftModule()->getASTContext();
     auto deploymentAvail = AvailabilityContext::forDeploymentTarget(ctxt);
-    auto currentFnAvailability = apply.getFunction()->getAvailabilityForLinkage();
+    auto currentFn = apply.getFunction();
+    auto isInlinableCtxt = (currentFn->getResilienceExpansion()
+                             == ResilienceExpansion::Minimal);
+    auto currentFnAvailability = currentFn->getAvailabilityForLinkage();
+
+    // If we are in an inlineable function we can't use the specialization except
+    // the inlinable function itself has availability we can use.
+    if (currentFnAvailability.isAlwaysAvailable() && isInlinableCtxt) {
+      continue;
+    }
+    else if (isInlinableCtxt) {
+      deploymentAvail = currentFnAvailability;
+    }
+
     if (!currentFnAvailability.isAlwaysAvailable() &&
         !deploymentAvail.isContainedIn(currentFnAvailability))
       deploymentAvail = currentFnAvailability;

--- a/test/SILOptimizer/constant_propagation_availability.swift
+++ b/test/SILOptimizer/constant_propagation_availability.swift
@@ -1,7 +1,11 @@
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos10.15 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_15 %s
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos10.14 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_14 %s
-// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.15 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_15 %s
+// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.15 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_15 --check-prefix=CHECK-macosx10_15_opt %s
 // RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.14 -emit-sil %s | %FileCheck --check-prefix=CHECK-macosx10_14 %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-swift-frontend -O -target %target-cpu-apple-macos10.15 -module-name=Test -emit-module -emit-module-path %t/Test.swiftmodule %s
+// RUN: %sil-opt -target %target-cpu-apple-macos10.15 %t/Test.swiftmodule | %FileCheck --check-prefix=CHECK-inlinable %s
 
 // REQUIRES: OS=macosx
 
@@ -24,12 +28,30 @@ public func testAvailabilityPropagation() -> Int {
   }
 }
 
+@inlinable
+public func testInlinable() -> Int {
+  if #available(macOS 10.15, *) {
+    return newFunction()
+  } else {
+    return 0
+  }
+}
+
 // CHECK-macosx10_15-LABEL: sil @$s33constant_propagation_availability27testAvailabilityPropagationSiyF : $@convention(thin) () -> Int {
 // CHECK-macosx10_15-NOT: apply
 // CHECK-macosx10_15:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11newFunctionSiyF
 // CHECK-macosx10_15:  apply [[F]]() : $@convention(thin) () -> Int
 // CHECK-macosx10_15-NOT: apply
 // CHECK-macosx10_15: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
+
+// After serialization, availability checks can be constant folded.
+
+// CHECK-macosx10_15_opt-LABEL: sil @$s33constant_propagation_availability13testInlinableSiyF : $@convention(thin) () -> Int {
+// CHECK-macosx10_15_opt-NOT: apply
+// CHECK-macosx10_15_opt:  [[F:%.*]] = function_ref @$s33constant_propagation_availability11newFunctionSiyF
+// CHECK-macosx10_15_opt:  apply [[F]]() : $@convention(thin) () -> Int
+// CHECK-macosx10_15_opt-NOT: apply
+// CHECK-macosx10_15_opt: } // end sil function '$s33constant_propagation_availability13testInlinableSiyF'
 
 // CHECK-macosx10_14-LABEL: sil @$s33constant_propagation_availability27testAvailabilityPropagationSiyF : $@convention(thin) () -> Int {
 // CHECK-macosx10_14:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
@@ -41,3 +63,10 @@ public func testAvailabilityPropagation() -> Int {
 // CHECK-macosx10_14: } // end sil function '$s33constant_propagation_availability27testAvailabilityPropagationSiyF'
 
 // CHECK-macosx10_14: sil [readnone] [_semantics "availability.osversion"] @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+
+// CHECK-inlinable-LABEL: sil {{.*}} @$s4Test13testInlinableSiyF  : $@convention(thin) () -> Int {
+// CHECK-inlinable:  [[F:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF
+// CHECK-inlinable:  apply [[F]]
+// CHECK-inlinable:  [[F:%.*]] = function_ref @$s4Test11newFunctionSiyF
+// CHECK-inlinable:  apply [[F]]() : $@convention(thin) () -> Int
+// CHECK-inlinable: } // end sil function '$s4Test13testInlinableSiyF'

--- a/test/SILOptimizer/immortal-arc-elimination.sil
+++ b/test/SILOptimizer/immortal-arc-elimination.sil
@@ -28,7 +28,7 @@ bb0:
 }
 
 
-sil_global private @staticArray : $_ContiguousArrayStorage<Int> = {
+sil_global @staticArray : $_ContiguousArrayStorage<Int> = {
   %0 = integer_literal $Builtin.Int64, 0
   %1 = struct $UInt (%0 : $Builtin.Int64)
   %2 = struct $Int (%0 : $Builtin.Int64)
@@ -49,4 +49,15 @@ bb0:
   return %1 : $Builtin.BridgeObject
 }
 
+// CHECK-LABEL: sil [serialized] @testGlobalValueSerialized
+// CHECK:       global_value
+// CHECK:       retain
+// CHECK: } // end sil function 'testGlobalValueSerialized'
+sil [serialized] @testGlobalValueSerialized : $@convention(thin) () -> @owned Builtin.BridgeObject {
+bb0:
+  %0 = global_value @staticArray : $_ContiguousArrayStorage<Int>
+  %1 = unchecked_ref_cast %0 : $_ContiguousArrayStorage<Int> to $Builtin.BridgeObject
+  strong_retain %1 : $Builtin.BridgeObject
+  return %1 : $Builtin.BridgeObject
+}
 


### PR DESCRIPTION
The specified deployment target only applies to the currently compiled module, but not to any client modules, which use inlinable functions from the current module.
Therefore, optimizations which depend on the deployment target must not optimize inlinable functions, except they run after the module has been serialized.

* constant folding of availability checks
* simplification of ARC operations on immortal objects (which depends on the 5.1 runtime)

rdar://88117184

The same thing needs to be done in Sema. There is already a PR for this: https://github.com/apple/swift/pull/33855, but unfortunately currently reverted.