### PR TITLE
[cast-optimizer] Fix incorrect handling of returned pointers.

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1547,7 +1547,7 @@ static bool optimizeStaticallyKnownProtocolConformance(
     auto &Ctx = Mod.getASTContext();
     auto *SM = Mod.getSwiftModule();
 
-    auto Proto = dyn_cast<ProtocolDecl>(TargetType->getAnyNominal());
+    auto *Proto = dyn_cast_or_null<ProtocolDecl>(TargetType->getAnyNominal());
     if (!Proto)
       return false;
 

--- a/test/SILOptimizer/sil_combine_casts.sil
+++ b/test/SILOptimizer/sil_combine_casts.sil
@@ -332,3 +332,25 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
   %15 = tuple ()
   return %15 : $()
 }
+
+public protocol AnyAction {
+}
+
+public struct MyAction : AnyAction {
+}
+
+// Make sure that we do not crash on this test case!
+//
+// TODO: Maybe we could handle this?
+sil shared @cast_optimizer_metatype_crasher : $@convention(thin) (@thick MyAction.Type) -> @thick AnyAction.Type {
+bb0(%0 : $@thick MyAction.Type):
+  %1 = alloc_stack $@thick AnyAction.Type
+  %2 = alloc_stack $@thick MyAction.Type
+  store %0 to %2 : $*@thick MyAction.Type
+  unconditional_checked_cast_addr MyAction.Type in %2 : $*@thick MyAction.Type to AnyAction.Type in %1 : $*@thick AnyAction.Type
+  dealloc_stack %2 : $*@thick MyAction.Type
+  %6 = tuple ()
+  %7 = load %1 : $*@thick AnyAction.Type
+  dealloc_stack %1 : $*@thick AnyAction.Type
+  return %7 : $@thick AnyAction.Type
+}


### PR DESCRIPTION
Put simply, the method Type::getAnyNominal() returns either a nominal type or a
nullptr. We are then casting it using dyn_cast to a ProtocolDecl. dyn_cast is
not allowed to handle nullptrs... hence the crash. The fix is to use the API
dyn_cast_or_null, the specific cast meant for this case!

In terms of how this effects the flow of the code in such a case, we will just
bail early if we have a non-nominal type today (which to me means at least
metatypes, which is this case).

I included a test case that we crash on without my change today and just do not
optimize.

rdar://87989767
