### PR TITLE
[AutoDiff] Add missing constraint to Array.DifferentiableView declaration

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -17,7 +17,7 @@ import Swift
 //===----------------------------------------------------------------------===//
 
 // TODO(TF-938): Add `Element: Differentiable` requirement.
-extension Array {
+extension Array where Element: Differentiable {
   /// The view of an array as the differentiable product manifold of `Element`
   /// multiplied with itself `count` times.
   @frozen

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -16,7 +16,6 @@ import Swift
 // Protocol conformances
 //===----------------------------------------------------------------------===//
 
-// TODO(TF-938): Add `Element: Differentiable` requirement.
 extension Array where Element: Differentiable {
   /// The view of an array as the differentiable product manifold of `Element`
   /// multiplied with itself `count` times.


### PR DESCRIPTION
<!-- What's in this pull request? -->
It builds just fine when the `where Element: Differentiable` constraint is added.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves TF-938.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
