### PR TITLE
Don't import string macros with invalid UTF-8

### DIFF
--- a/include/swift/Basic/Unicode.h
+++ b/include/swift/Basic/Unicode.h
@@ -68,6 +68,12 @@ bool isSingleUnicodeScalar(StringRef S);
 
 unsigned extractFirstUnicodeScalar(StringRef S);
 
+/// Returns true if \p S does not contain any ill-formed subsequences. This does
+/// not check whether all of the characters in it are actually allocated or
+/// used correctly; it just checks that every byte can be grouped into a code
+/// unit (Unicode scalar).
+bool isWellFormedUTF8(StringRef S);
+
 } // end namespace unicode
 } // end namespace swift
 

--- a/lib/Basic/Unicode.cpp
+++ b/lib/Basic/Unicode.cpp
@@ -123,3 +123,8 @@ unsigned swift::unicode::extractFirstUnicodeScalar(StringRef S) {
   (void)Result;
   return Scalar;
 }
+
+bool swift::unicode::isWellFormedUTF8(StringRef S) {
+  const llvm::UTF8 *begin = S.bytes_begin();
+  return llvm::isLegalUTF8String(&begin, S.bytes_end());
+}

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/PrettyStackTrace.h"
+#include "swift/Basic/Unicode.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
@@ -194,7 +195,11 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
   if (!importTy)
     return nullptr;
 
-  return Impl.createConstant(name, DC, importTy, parsed->getString(),
+  StringRef text = parsed->getString();
+  if (!unicode::isWellFormedUTF8(text))
+    return nullptr;
+
+  return Impl.createConstant(name, DC, importTy, text,
                              ConstantConvertKind::None, /*static*/ false,
                              ClangN);
 }

--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -74,6 +74,12 @@ func testCFString() -> String {
   return str
 }
 
+func testInvalidStringLiterals() {
+  // <rdar://67840900> - assertion/crash from importing a macro with a string
+  // literal containing invalid UTF-8 characters
+  _ = INVALID_UTF8_STRING // expected-error {{cannot find 'INVALID_UTF8_STRING' in scope}}
+}
+
 func testInvalidIntegerLiterals() {
   var l1 = INVALID_INTEGER_LITERAL_1 // expected-error {{cannot find 'INVALID_INTEGER_LITERAL_1' in scope}}
   // FIXME: <rdar://problem/16445608> Swift should set up a DiagnosticConsumer for Clang

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -35,6 +35,7 @@
 #define UTF8_STRING u8"Swift 🏃"
 #define OBJC_STRING @"Unicode! ✨"
 #define CF_STRING CFSTR("Swift")
+#define INVALID_UTF8_STRING "\xFF\xFF\xFF\xFF\xFF\xFF"
 
 #define INVALID_INTEGER_LITERAL_1 10_9
 #define INVALID_INTEGER_LITERAL_2 10abc


### PR DESCRIPTION
Swift string literals are only permitted to contain well-formed UTF-8, but C does not share this restriction, and ClangImporter wasn't checking for that before it created `StringLiteralExpr`s for imported macros; this could cause crashes when importing a header. This commit makes us drop these macros instead.

Although invalid UTF-8 always *did* cause a segfault in my testing, I'm not convinced that there isn't a way to cause a miscompile with a bug like this. If we somehow did generate code that fed ill-formed UTF-8 to the builtin literal init for Swift.String, the resulting string could cause undefined behavior at runtime. So I have additionally added a defensive assertion to StringLiteralInst that any UTF-8 string represented in SIL is well-formed. Hopefully that will catch any non-crashing compiler bugs like this one.

Fixes rdar://67840900.
