### PR TITLE
[CodeCompletion] Let FindLocalVal walk into ExprPattern

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2778,40 +2778,7 @@ swift::getDirectlyInheritedNominalTypeDecls(
 }
 
 void FindLocalVal::checkPattern(const Pattern *Pat, DeclVisibilityKind Reason) {
-  switch (Pat->getKind()) {
-  case PatternKind::Tuple:
-    for (auto &field : cast<TuplePattern>(Pat)->getElements())
-      checkPattern(field.getPattern(), Reason);
-    return;
-  case PatternKind::Paren:
-  case PatternKind::Typed:
-  case PatternKind::Binding:
-    return checkPattern(Pat->getSemanticsProvidingPattern(), Reason);
-  case PatternKind::Named:
-    return checkValueDecl(cast<NamedPattern>(Pat)->getDecl(), Reason);
-  case PatternKind::EnumElement: {
-    auto *OP = cast<EnumElementPattern>(Pat);
-    if (OP->hasSubPattern())
-      checkPattern(OP->getSubPattern(), Reason);
-    return;
-  }
-  case PatternKind::OptionalSome:
-    checkPattern(cast<OptionalSomePattern>(Pat)->getSubPattern(), Reason);
-    return;
-
-  case PatternKind::Is: {
-    auto *isPat = cast<IsPattern>(Pat);
-    if (isPat->hasSubPattern())
-      checkPattern(isPat->getSubPattern(), Reason);
-    return;
-  }
-
-  // Handle non-vars.
-  case PatternKind::Bool:
-  case PatternKind::Expr:
-  case PatternKind::Any:
-    return;
-  }
+  Pat->forEachVariable([&](VarDecl *VD) { checkValueDecl(VD, Reason); });
 }
 void FindLocalVal::checkValueDecl(ValueDecl *D, DeclVisibilityKind Reason) {
   if (!D)

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -547,3 +547,23 @@ func testGuardCase(x:FooStruct?) {
 // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<FooStruct>#]; name=none
 // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#FooStruct#})[#Optional<FooStruct>#]; name=some()
 // OPTIONAL_FOOSTRUCT: End completions
+
+func returnOpt() -> String? { nil }
+func returnOptTuple() -> (String, String)? { nil}
+func test_rdar86050684() {
+  guard let local1 = returnOpt() else { return }
+  guard let (local2, _) =  returnOptTuple() else { return }
+  if let (local3, _) = returnOptTuple() {
+    if case (let local4, _)? = returnOptTuple() {
+      let (local5, _) = returnOptTuple() ?? ("", "")
+      _ = #^RDAR86050684^#
+// RDAR86050684: Begin completions
+// RDAR86050684-DAG: Decl[LocalVar]/Local:               local1[#String#];
+// RDAR86050684-DAG: Decl[LocalVar]/Local:               local2[#String#];
+// RDAR86050684-DAG: Decl[LocalVar]/Local:               local3[#String#];
+// RDAR86050684-DAG: Decl[LocalVar]/Local:               local4[#String#];
+// RDAR86050684-DAG: Decl[LocalVar]/Local:               local5[#String#];
+// RDAR86050684: End completions
+    }
+  }
+}


### PR DESCRIPTION
Some conditions in control flow statements are parsed as expression patterns, then resolved to "pattern"s later in Sema. In code completion, they might not be type checked at all. Previously, when collecting visible declarations for completion candidates, it didn't walk into `ExprPattern`, and thus it didn't find the variables inside. Use standard `Pattern::forEachVariable()` that looks into `ExprPattern` instead of using its custom recursive logic.

rdar://86050684

