### PR TITLE
[Serialization] Restrict loading all swiftmodules by compiler tag

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -308,8 +308,8 @@ static ValidationInfo validateControlBlock(
       break;
     }
     case control_block::REVISION: {
-      // Tagged compilers should load only resilient modules if they were
-      // produced by the exact same version.
+      // Tagged compilers should only load modules if they were
+      // produced by the exact same compiler tag.
 
       // Disable this restriction for compiler testing by setting this
       // env var to any value.
@@ -328,7 +328,7 @@ static ValidationInfo validateControlBlock(
         !version::Version::getCurrentCompilerVersion().empty();
 
       StringRef moduleRevision = blobData;
-      if (isCompilerTagged && !moduleRevision.empty()) {
+      if (isCompilerTagged) {
         StringRef compilerRevision = forcedDebugRevision ?
           forcedDebugRevision : version::getSwiftRevision();
         if (moduleRevision != compilerRevision)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1006,17 +1006,12 @@ void Serializer::writeHeader(const SerializationOptions &options) {
 
     Target.emit(ScratchRecord, M->getASTContext().LangOpts.Target.str());
 
-    // Write the producer's Swift revision only for resilient modules.
-    if (M->getResilienceStrategy() != ResilienceStrategy::Default) {
-      auto revision = version::getSwiftRevision();
-
-      static const char* forcedDebugRevision =
-        ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
-      if (forcedDebugRevision)
-        revision = forcedDebugRevision;
-
-      Revision.emit(ScratchRecord, revision);
-    }
+    // Write the producer's Swift revision.
+    static const char* forcedDebugRevision =
+      ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
+    auto revision = forcedDebugRevision ?
+      forcedDebugRevision : version::getSwiftRevision();
+    Revision.emit(ScratchRecord, revision);
 
     IsOSSA.emit(ScratchRecord, options.IsOSSA);
 

--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -8,20 +8,20 @@ public func foo() {}
 
 /// Build Lib as a resilient and non-resilient swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name ResilientLib -enable-library-evolution
-// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name NonresilientLib
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name NonResilientLib
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
 // RUN:   %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name TaggedLib -enable-library-evolution
 
 
 /// 2. Test importing the non-resilient untagged library
-// BEGIN NonresilientClient.swift
-import NonresilientLib
+// BEGIN NonResilientClient.swift
+import NonResilientLib
 foo()
 
-/// Building a NonresilientLib client should always succeed
-// RUN: %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+/// Building a NonResilientLib client should reject the import for a tagged compiler
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
-// RUN:   %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+// RUN:   not %target-swift-frontend -typecheck %t/NonResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck -check-prefix=CHECK-NON-RESILIENT %s
+// CHECK-NON-RESILIENT: compiled module was created by a different version of the compiler; rebuild 'NonResilientLib' and try again: {{.*}}NonResilientLib.swiftmodule
 
 
 /// 3. Test importing the resilient untagged library
@@ -47,7 +47,7 @@ foo()
 import TaggedLib
 foo()
 
-/// Importing TaggedLib should success with the same tag or a dev compiler
+/// Importing TaggedLib should succeed with the same tag or a dev compiler
 // RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
 // RUN:   %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 // RUN: %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache


### PR DESCRIPTION
Swiftmodule loading was previously restricted by compiler tag only for resilient modules. This left room for resilient modules with a corrupted control block to pass as non-resilient/untagged modules.

Apply the same check for non-resilient modules (so all modules) when read from a tagged compiler. This should patch the hole that let the compiler read from incompatible swiftmodules recently.

rdar://88081456