### PR TITLE
RequirementMachine: Fix some bugs with concrete conformance minimization

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -509,7 +509,7 @@ namespace swift {
 
     /// Maximum term length for requirement machine Knuth-Bendix completion
     /// algorithm.
-    unsigned RequirementMachineDepthLimit = 10;
+    unsigned RequirementMachineDepthLimit = 12;
 
     /// Enable the new experimental protocol requirement signature minimization
     /// algorithm.

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -486,7 +486,9 @@ void RewriteSystem::minimizeRewriteSystem() {
   performHomotopyReduction([&](unsigned ruleID) -> bool {
     const auto &rule = getRule(ruleID);
 
-    if (rule.isSimplified() &&
+    if ((rule.isLHSSimplified() ||
+         rule.isRHSSimplified() ||
+         rule.isSubstitutionSimplified()) &&
         !rule.isAnyConformanceRule())
       return true;
 
@@ -696,7 +698,9 @@ void RewriteSystem::verifyMinimizedRules(
     // rules, which unfortunately might no be redundant, because we try to keep
     // them in the original protocol definition for compatibility with the
     // GenericSignatureBuilder's minimization algorithm.
-    if (rule.isSimplified() &&
+    if ((rule.isLHSSimplified() ||
+         rule.isRHSSimplified() ||
+         rule.isSubstitutionSimplified()) &&
         !rule.isRedundant() &&
         !rule.isProtocolConformanceRule()) {
       llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -481,20 +481,20 @@ void RewriteSystem::minimizeRewriteSystem() {
   propagateExplicitBits();
 
   // First pass:
-  // - Eliminate all simplified non-conformance rules.
+  // - Eliminate all LHS-simplified non-conformance rules.
+  // - Eliminate all RHS-simplified and substitution-simplified rules.
   // - Eliminate all rules with unresolved symbols.
   performHomotopyReduction([&](unsigned ruleID) -> bool {
     const auto &rule = getRule(ruleID);
 
-    if ((rule.isLHSSimplified() ||
-         rule.isRHSSimplified() ||
-         rule.isSubstitutionSimplified()) &&
+    if (rule.isLHSSimplified() &&
         !rule.isAnyConformanceRule())
       return true;
 
-    // Other rules involving unresolved name symbols are derived from an
-    // associated type introduction rule together with a conformance rule.
-    // They are eliminated in the first pass.
+    if (rule.isRHSSimplified() ||
+        rule.isSubstitutionSimplified())
+      return true;
+
     if (rule.getLHS().containsUnresolvedSymbols())
       return true;
 
@@ -694,13 +694,11 @@ void RewriteSystem::verifyMinimizedRules(
       continue;
     }
 
-    // Simplified rules should be redundant, unless they're protocol conformance
-    // rules, which unfortunately might no be redundant, because we try to keep
-    // them in the original protocol definition for compatibility with the
-    // GenericSignatureBuilder's minimization algorithm.
-    if ((rule.isLHSSimplified() ||
-         rule.isRHSSimplified() ||
-         rule.isSubstitutionSimplified()) &&
+    // LHS-simplified rules should be redundant, unless they're protocol
+    // conformance rules, which unfortunately might no be redundant, because
+    // we try to keep them in the original protocol definition for
+    // compatibility with the GenericSignatureBuilder's minimization algorithm.
+    if (rule.isLHSSimplified() &&
         !rule.isRedundant() &&
         !rule.isProtocolConformanceRule()) {
       llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
@@ -708,8 +706,19 @@ void RewriteSystem::verifyMinimizedRules(
       abort();
     }
 
+    // RHS-simplified and substitution-simplified rules should be redundant.
+    if ((rule.isRHSSimplified() ||
+         rule.isSubstitutionSimplified()) &&
+        !rule.isRedundant()) {
+      llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
+      dump(llvm::errs());
+      abort();
+    }
+
     if (rule.isRedundant() &&
         rule.isAnyConformanceRule() &&
+        !rule.isRHSSimplified() &&
+        !rule.isSubstitutionSimplified() &&
         !rule.containsUnresolvedSymbols() &&
         !redundantConformances.count(ruleID)) {
       llvm::errs() << "Minimal conformance is redundant: " << rule << "\n\n";

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -514,7 +514,9 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
     // For every rule, looking for other rules that overlap with this rule.
     for (unsigned i = 0, e = Rules.size(); i < e; ++i) {
       const auto &lhs = getRule(i);
-      if (lhs.isSimplified())
+      if (lhs.isLHSSimplified() ||
+          lhs.isRHSSimplified() ||
+          lhs.isSubstitutionSimplified())
         continue;
 
       // Look up every suffix of this rule in the trie using findAll(). This
@@ -527,7 +529,9 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
       while (from < to) {
         Trie.findAll(from, to, [&](unsigned j) {
           const auto &rhs = getRule(j);
-          if (rhs.isSimplified())
+          if (rhs.isLHSSimplified() ||
+              rhs.isRHSSimplified() ||
+              rhs.isSubstitutionSimplified())
             return;
 
           if (from == lhs.getLHS().begin()) {
@@ -619,7 +623,8 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
     resolvedCriticalPairs.clear();
     resolvedLoops.clear();
 
-    simplifyRightHandSidesAndSubstitutions();
+    simplifyRightHandSides();
+    simplifyLeftHandSideSubstitutions();
 
     // If the added rules merged any associated types, process the merges now
     // before we continue with the completion procedure. This is important

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -375,6 +375,10 @@ void MinimalConformances::collectConformanceRules() {
     if (rule.isRedundant())
       continue;
 
+    if (rule.isRHSSimplified() ||
+        rule.isSubstitutionSimplified())
+      continue;
+
     if (rule.containsUnresolvedSymbols())
       continue;
 

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -400,9 +400,13 @@ void MinimalConformances::collectConformanceRules() {
       MutableTerm mutTerm(lhs.begin(), lhs.end() - 2);
       assert(!mutTerm.empty());
 
+#ifndef NDEBUG
       bool simplified = System.simplify(mutTerm);
-      assert(!simplified || rule.isSimplified());
+      // FIXME: Perhaps even if the rule is LHS-simplified, it's parent should be
+      // canonical?
+      assert(!simplified || rule.isRHSSimplified());
       (void) simplified;
+#endif
 
       mutTerm.add(Symbol::forProtocol(parentProto, Context));
 

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -381,6 +381,9 @@ void MinimalConformances::collectConformanceRules() {
     if (!rule.isAnyConformanceRule())
       continue;
 
+    if (!System.isInMinimizationDomain(rule.getLHS().getRootProtocols()))
+      continue;
+
     ConformanceRules.push_back(ruleID);
 
     // Initially, every non-redundant conformance rule can be expressed
@@ -810,7 +813,10 @@ void MinimalConformances::verifyMinimalConformanceEquations() const {
 /// made redundant by concrete conformances.
 void MinimalConformances::computeMinimalConformances(bool firstPass) {
   for (unsigned ruleID : ConformanceRules) {
-    const auto &paths = ConformancePaths[ruleID];
+    auto found = ConformancePaths.find(ruleID);
+    assert(found != ConformancePaths.end());
+
+    const auto &paths = found->second;
 
     if (firstPass) {
       bool derivedViaConcrete = false;

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -345,7 +345,9 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
   SmallVector<std::vector<Property>, 4> properties;
 
   for (const auto &rule : System.getRules()) {
-    if (rule.isSimplified())
+    if (rule.isLHSSimplified() ||
+        rule.isRHSSimplified() ||
+        rule.isSubstitutionSimplified())
       continue;
 
     // Identity conformances ([P].[P] => [P]) are permanent rules, but we

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -288,9 +288,10 @@ void RequirementMachine::dump(llvm::raw_ostream &out) const {
   if (Sig)
     out << Sig;
   else if (!Params.empty()) {
-    out << "fresh signature ";
+    out << "fresh signature <";
     for (auto paramTy : Params)
       out << " " << Type(paramTy);
+    out << " >";
   } else {
     auto protos = System.getProtocols();
     assert(!protos.empty());

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -554,6 +554,7 @@ void RewriteSystem::simplifyRightHandSidesAndSubstitutions() {
       llvm::dbgs() << "$ Right hand side simplification recorded a loop at ";
       llvm::dbgs() << lhs << ": ";
       loop.dump(llvm::dbgs(), MutableTerm(lhs), *this);
+      llvm::dbgs() << "\n";
     }
 
     recordRewriteLoop(MutableTerm(lhs), loop);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -476,9 +476,7 @@ void RewriteSystem::simplifyLeftHandSides() {
 
   for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
-    if (rule.isLHSSimplified() ||
-        rule.isRHSSimplified() ||
-        rule.isSubstitutionSimplified())
+    if (rule.isLHSSimplified())
       continue;
 
     // First, see if the left hand side of this rule can be reduced using
@@ -494,9 +492,7 @@ void RewriteSystem::simplifyLeftHandSides() {
 
         // Ignore other deleted rules.
         const auto &otherRule = getRule(*otherRuleID);
-        if (otherRule.isLHSSimplified() ||
-            otherRule.isRHSSimplified() ||
-            otherRule.isSubstitutionSimplified())
+        if (otherRule.isLHSSimplified())
           continue;
 
         if (Debug.contains(DebugFlags::Completion)) {
@@ -523,9 +519,7 @@ void RewriteSystem::simplifyRightHandSides() {
 
   for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
-    if (rule.isLHSSimplified() ||
-        rule.isRHSSimplified() ||
-        rule.isSubstitutionSimplified())
+    if (rule.isRHSSimplified())
       continue;
 
     // Now, try to reduce the right hand side.
@@ -577,9 +571,7 @@ void RewriteSystem::simplifyRightHandSides() {
 void RewriteSystem::simplifyLeftHandSideSubstitutions() {
   for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
-    if (rule.isLHSSimplified() ||
-        rule.isRHSSimplified() ||
-        rule.isSubstitutionSimplified())
+    if (rule.isSubstitutionSimplified())
       continue;
 
     auto lhs = rule.getLHS();

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -410,8 +410,6 @@ private:
   /// algorithms.
   std::vector<RewriteLoop> Loops;
 
-  bool isInMinimizationDomain(ArrayRef<const ProtocolDecl *> protos) const;
-
   void recordRewriteLoop(MutableTerm basepoint,
                          RewritePath path);
 
@@ -430,6 +428,8 @@ private:
       llvm::DenseSet<unsigned> &redundantConformances);
 
 public:
+  bool isInMinimizationDomain(ArrayRef<const ProtocolDecl *> protos) const;
+
   ArrayRef<RewriteLoop> getLoops() const {
     return Loops;
   }

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -315,12 +315,20 @@ public:
   void verifyRewriteRules(ValidityPolicy policy) const;
 
 private:
+  struct CriticalPair {
+    MutableTerm LHS;
+    MutableTerm RHS;
+    RewritePath Path;
+
+    CriticalPair(MutableTerm lhs, MutableTerm rhs, RewritePath path)
+      : LHS(lhs), RHS(rhs), Path(path) {}
+  };
+
   bool
   computeCriticalPair(
       ArrayRef<Symbol>::const_iterator from,
       const Rule &lhs, const Rule &rhs,
-      std::vector<std::pair<MutableTerm, MutableTerm>> &pairs,
-      std::vector<RewritePath> &paths,
+      std::vector<CriticalPair> &pairs,
       std::vector<RewriteLoop> &loops) const;
 
   /// Constructed from a rule of the form X.[P2:T] => X.[P1:T] by

--- a/test/Generics/concrete_conformance_minimization.swift
+++ b/test/Generics/concrete_conformance_minimization.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+struct MyOptionSet : OptionSet {
+  let rawValue: UInt
+}
+
+struct G1<T : OptionSet> where T.RawValue: FixedWidthInteger & UnsignedInteger {}
+
+// CHECK-LABEL: ExtensionDecl line={{[0-9]+}} base=G1
+// CHECK-NEXT: Generic signature: <T where T == MyOptionSet>
+extension G1 where T == MyOptionSet {}
+
+struct G2<T : SIMD> {}
+
+// CHECK-LABEL: ExtensionDecl line={{[0-9]+}} base=G2
+// CHECK-NEXT: Generic signature: <T where T == SIMD2<Double>>
+extension G2 where T == SIMD2<Double> {}

--- a/test/Generics/conditional_requirement_inference_2.swift
+++ b/test/Generics/conditional_requirement_inference_2.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
 
 // A more complicated example.
 protocol Equatable {}


### PR DESCRIPTION
A common minimization problem is to turn a signature of the form:

    <T where T : P, T == SomeConcreteP>

into

    <T where T == SomeConcreteP>

Since the property map concretizes nested types of T to the type witnesses of the (SomeConcreteP : P) conformance, this produces a large number of rewrite rules and homotopy generators, so the minimization is a good stress-test for various internal assertions in the Requirement Machine.

This comes up surprisingly often in real code, for example

    struct Holder<T : OptionSet> where T : FixedWidthInteger & UnsignedInteger {}

    extension Holder where T == MyOptionSet { ... }