### PR TITLE
[test] Reenable the stdlib ABI checker in PR tests

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-array-cow-checks.test
+++ b/test/api-digester/stability-stdlib-abi-with-array-cow-checks.test
@@ -3,6 +3,7 @@
 // RUN: %api-digester -diagnose-sdk -module Swift -o %t.tmp/changes.txt -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi -avoid-location
 // RUN: %clang -E -P -x c %S/stability-stdlib-abi-without-asserts.test -o - > %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %S/stability-stdlib-abi-with-asserts.test -o - >> %t.tmp/stability-stdlib-abi.swift.expected
+// RUN: %clang -E -P -x c %S/stability-stdlib-abi-with-array-cow-checks.test -o - >> %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/stability-stdlib-abi.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-abi.swift.expected.sorted
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed -E -e '/^\s*$/d' -e 's/ in _[0-9A-F]{32}/ in #UNSTABLE ID#/g' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected.sorted %t.tmp/changes.txt.tmp
@@ -11,10 +12,11 @@
 
 // Welcome, Build Wrangler!
 //
-// This file lists APIs that are unique to stdlib builds with assertions.
-// (It is combined with the stability-stdlib-abi-without-asserts.test file
-// to generate a full list of potentially breaking API changes. In most cases
-// you'll want to edit that file instead of this one.)
+// This file lists APIs that are unique to stdlib builds with array_cow_checks.
+// (It is combined with the stability-stdlib-abi-without-asserts.test and
+// stability-stdlib-abi-with-asserts.test files to generate a full list of
+// potentially breaking API changes. In most cases you'll want to edit that file
+// instead of this one.)
 //
 // A failure in this test indicates that there is a potential breaking change in
 // the Standard Library. If you observe a failure outside of a PR test, please
@@ -39,7 +41,7 @@
 //                                            -- Your friendly stdlib engineers
 
 // REQUIRES: swift_stdlib_asserts
-// UNSUPPORTED: array_cow_checks
+// REQUIRES: array_cow_checks
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
@@ -56,12 +58,8 @@
 
 // Note: normally you'll need to add new entries to
 // `stability-stdlib-abi-without-asserts.test`, not this file.
-Func _collectReferencesInsideObject(_:) is a new API without @available attribute
-Func _loadDestroyTLSCounter() is a new API without @available attribute
-Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
-Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
-Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
-Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
-Struct _RuntimeFunctionCounters is a new API without @available attribute
+Func _COWChecksEnabled() is a new API without @available attribute
+Func _swift_isImmutableCOWBuffer(_:) is a new API without @available attribute
+Func _swift_setImmutableCOWBuffer(_:_:) is a new API without @available attribute
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
The asserts test currently requires `array_cow_checks`, but that feature isn't enabled by default during PR tests.

rdar://88153292
