### PR TITLE
[stdlib] Update platform versions for SwiftStdlib 5.6; define placeholders for SwiftStdlib 5.7

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -301,7 +301,7 @@ extension Task where Success == Never, Failure == Never {
   /// The current task's base priority.
   ///
   /// If you access this property outside of any task, this returns nil
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.7, *)
   public static var basePriority: TaskPriority? {
     withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.

--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -90,7 +90,7 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 
   // Finally, take a slow path through the standard library to see if the
   // current environment can accept a larger stack allocation.
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) //SwiftStdlib 5.6
+  guard #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) //SwiftStdlib 5.6
   else {
     return false
   }

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1846,8 +1846,7 @@
           "name": "CodingKeyRepresentable",
           "printedName": "CodingKeyRepresentable",
           "usr": "s:s22CodingKeyRepresentableP",
-          "mangledName": "$ss22CodingKeyRepresentableP",
-          "isABIPlaceholder": true
+          "mangledName": "$ss22CodingKeyRepresentableP"
         },
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1713,8 +1713,7 @@
           "name": "CodingKeyRepresentable",
           "printedName": "CodingKeyRepresentable",
           "usr": "s:s22CodingKeyRepresentableP",
-          "mangledName": "$ss22CodingKeyRepresentableP",
-          "isABIPlaceholder": true
+          "mangledName": "$ss22CodingKeyRepresentableP"
         },
         {
           "kind": "Conformance",

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -30,7 +30,7 @@ SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4
 SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
 SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
 SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
-SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 
 # Local Variables:
 # mode: conf-unix

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -31,6 +31,7 @@ SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
 SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
 SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
 SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
+SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
Set platform version numbers for `SwiftStdlib 5.6` to match the SDK releases that shipped with Xcode 13.3 beta 1.

Define the `SwiftStdlib 5.7` macro with placeholder version numbers, and update APIs that are currently scheduled to ship from the main branch to use this instead of the generic `SwiftStdlib 9999`.

rdar://88154764