### PR TITLE
[5.6][stdlib] Define platform version numbers for SwiftStdlib 5.6

### DIFF
--- a/stdlib/public/core/TemporaryAllocation.swift
+++ b/stdlib/public/core/TemporaryAllocation.swift
@@ -90,7 +90,7 @@ internal func _isStackAllocationSafe(byteCount: Int, alignment: Int) -> Bool {
 
   // Finally, take a slow path through the standard library to see if the
   // current environment can accept a larger stack allocation.
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) //SwiftStdlib 5.6
+  guard #available(macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4, *) //SwiftStdlib 5.6
   else {
     return false
   }

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1846,8 +1846,7 @@
           "name": "CodingKeyRepresentable",
           "printedName": "CodingKeyRepresentable",
           "usr": "s:s22CodingKeyRepresentableP",
-          "mangledName": "$ss22CodingKeyRepresentableP",
-          "isABIPlaceholder": true
+          "mangledName": "$ss22CodingKeyRepresentableP"
         },
         {
           "kind": "Conformance",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1713,8 +1713,7 @@
           "name": "CodingKeyRepresentable",
           "printedName": "CodingKeyRepresentable",
           "usr": "s:s22CodingKeyRepresentableP",
-          "mangledName": "$ss22CodingKeyRepresentableP",
-          "isABIPlaceholder": true
+          "mangledName": "$ss22CodingKeyRepresentableP"
         },
         {
           "kind": "Conformance",

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -30,7 +30,7 @@ SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4
 SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0
 SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
 SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
-SwiftStdlib 5.6:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
(Cherry picked from aa3b48f4322a09c5a99408474cfaf4a6dab5f34a in https://github.com/apple/swift/pull/41046)

Set platform version numbers for `SwiftStdlib 5.6` to match the SDK releases that shipped with Xcode 13.3 beta 1.

(Note: the stdlib module in Xcode 13.3 beta 1 already includes this change.)

rdar://88154764
