### PR TITLE
[Sema] Check protocol conformance availability for member reference and type erasing expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 ## Swift 5.7
 
+* The compiler now correctly emits warnings for more kinds of expressions where a protocol conformance is used and may be unavailable at runtime. Previously, member reference expressions and type erasing expressions that used potentially unavailable conformances were not diagnosed, leading to potential crashes at runtime.
+
+  ```swift
+  struct Pancake {}
+  protocol Food {}
+
+  extension Food {
+    var isGlutenFree: Bool { false }
+  }
+
+  @available(macOS 12.0, *)
+  extension Pancake: Food {}
+
+  @available(macOS 11.0, *)
+  func eatPancake(_ pancake: Pancake) {
+    if (pancake.isGlutenFree) { // warning: conformance of 'Pancake' to 'Food' is only available in macOS 12.0 or newer
+      eatFood(pancake) // warning: conformance of 'Pancake' to 'Food' is only available in macOS 12.0 or newer
+    }
+  }
+
+  func eatFood(_ food: Food) {}
+  ```
+
 * [SE-0328][]:
 
   Opaque types (expressed with 'some') can now be used in structural positions

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2950,15 +2950,15 @@ private:
     // writeback. The AST should have this information.
     walkInContext(E, E->getBase(), MemberAccessContext::Getter);
 
-    ValueDecl *D = E->getMember().getDecl();
+    ConcreteDeclRef DR = E->getMember();
     // Diagnose for the member declaration itself.
-    if (diagnoseDeclAvailability(D, E->getNameLoc().getSourceRange(),
-                                 nullptr, Where))
+    if (diagnoseDeclRefAvailability(DR, E->getNameLoc().getSourceRange(),
+                                    getEnclosingApplyExpr(), None))
       return;
 
     // Diagnose for appropriate accessors, given the access context.
     auto *DC = Where.getDeclContext();
-    maybeDiagStorageAccess(D, E->getSourceRange(), DC);
+    maybeDiagStorageAccess(DR.getDecl(), E->getSourceRange(), DC);
   }
 
   /// Walk a keypath expression, checking all of its components for

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2863,6 +2863,12 @@ public:
         return skipChildren();
       }
     }
+    
+    if (auto EE = dyn_cast<ErasureExpr>(E)) {
+      for (ProtocolConformanceRef C : EE->getConformances()) {
+        diagnoseConformanceAvailability(E->getLoc(), C, Where);
+      }
+    }
 
     return visitChildren();
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3099,7 +3099,8 @@ bool ExprAvailabilityWalker::diagnoseDeclRefAvailability(
       return true;
   }
 
-  diagnoseDeclAvailability(D, R, call, Where, Flags);
+  if (diagnoseDeclAvailability(D, R, call, Where, Flags))
+      return true;
 
   if (R.isValid()) {
     if (diagnoseSubstitutionMapAvailability(R.Start, declRef.getSubstitutions(),

--- a/test/Sema/conformance_availability.swift
+++ b/test/Sema/conformance_availability.swift
@@ -7,6 +7,7 @@ func takesHorse<T : Horse>(_: T) {}
 
 extension Horse {
   func giddyUp() {}
+  var isGalloping: Bool { true }
 }
 
 struct UsesHorse<T : Horse> {}
@@ -16,11 +17,13 @@ public struct HasUnavailableConformance1 {}
 
 @available(*, unavailable)
 extension HasUnavailableConformance1 : Horse {}
-// expected-note@-1 4{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 6{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance1(x: HasUnavailableConformance1) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance1>.self // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
 }
 
@@ -28,6 +31,8 @@ func passUnavailableConformance1(x: HasUnavailableConformance1) {
 func passUnavailableConformance1a(x: HasUnavailableConformance1) {
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
+  _ = x[keyPath: \.isGalloping]
   _ = UsesHorse<HasUnavailableConformance1>.self
 }
 
@@ -36,11 +41,13 @@ public struct HasUnavailableConformance2 {}
 
 @available(macOS, unavailable)
 extension HasUnavailableConformance2 : Horse {}
-// expected-note@-1 3{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 5{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance2(x: HasUnavailableConformance2) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
   _ = UsesHorse<HasUnavailableConformance2>.self // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
 }
 
@@ -49,6 +56,8 @@ func passUnavailableConformance2a(x: HasUnavailableConformance2) {
   // This is allowed
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
+  _ = x[keyPath: \.isGalloping]
 }
 
 // Swift version unavailability
@@ -56,11 +65,13 @@ public struct HasUnavailableConformance3 {}
 
 @available(swift 12)
 extension HasUnavailableConformance3 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
+// expected-note@-1 10{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
 
 func passUnavailableConformance3(x: HasUnavailableConformance3) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance3>.self // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
 }
 
@@ -68,6 +79,8 @@ func passUnavailableConformance3(x: HasUnavailableConformance3) {
 func passUnavailableConformance3a(x: HasUnavailableConformance3) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance3>.self // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
 }
 
@@ -76,11 +89,13 @@ public struct HasUnavailableConformance4 {}
 
 @available(macOS, obsoleted: 10.1)
 extension HasUnavailableConformance4 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
+// expected-note@-1 10{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
 
 func passUnavailableConformance4(x: HasUnavailableConformance4) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance4>.self // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
 }
 
@@ -88,6 +103,8 @@ func passUnavailableConformance4(x: HasUnavailableConformance4) {
 func passUnavailableConformance4a(x: HasUnavailableConformance4) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance4>.self // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
 }
 
@@ -96,11 +113,13 @@ public struct HasUnavailableConformance5 {}
 
 @available(swift, obsoleted: 4)
 extension HasUnavailableConformance5 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
+// expected-note@-1 10{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
 
 func passUnavailableConformance5(x: HasUnavailableConformance5) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance5>.self // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
 }
 
@@ -108,6 +127,8 @@ func passUnavailableConformance5(x: HasUnavailableConformance5) {
 func passUnavailableConformance5a(x: HasUnavailableConformance5) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = UsesHorse<HasUnavailableConformance5>.self // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
 }
 
@@ -116,11 +137,13 @@ public struct HasUnavailableConformance6 {}
 
 @available(*, unavailable, message: "This conformance is bad")
 extension HasUnavailableConformance6 : Horse {}
-// expected-note@-1 3{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 5{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance6(x: HasUnavailableConformance6) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
   _ = UsesHorse<HasUnavailableConformance6>.self // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
 }
 
@@ -133,6 +156,8 @@ extension HasDeprecatedConformance1 : Horse {}
 func passDeprecatedConformance1(x: HasDeprecatedConformance1) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
+  _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
   _ = UsesHorse<HasDeprecatedConformance1>.self // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
 }
 
@@ -140,6 +165,8 @@ func passDeprecatedConformance1(x: HasDeprecatedConformance1) {
 func passDeprecatedConformance1a(x: HasDeprecatedConformance1) {
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
+  _ = x[keyPath: \.isGalloping]
   _ = UsesHorse<HasDeprecatedConformance1>.self
 }
 
@@ -152,6 +179,8 @@ extension HasDeprecatedConformance2 : Horse {}
 func passDeprecatedConformance2(x: HasDeprecatedConformance2) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
+  _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
   _ = UsesHorse<HasDeprecatedConformance2>.self // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
 }
 
@@ -159,6 +188,8 @@ func passDeprecatedConformance2(x: HasDeprecatedConformance2) {
 func passDeprecatedConformance2a(x: HasDeprecatedConformance2) {
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
+  _ = x[keyPath: \.isGalloping]
   _ = UsesHorse<HasDeprecatedConformance2>.self
 }
 
@@ -171,6 +202,8 @@ extension HasDeprecatedConformance3 : Horse {}
 func passDeprecatedConformance3(x: HasDeprecatedConformance3) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
+  _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
   _ = UsesHorse<HasDeprecatedConformance3>.self // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
 }
 
@@ -181,6 +214,8 @@ func passDeprecatedConformance3a(x: HasDeprecatedConformance3) {
     // deprecation diagnostics in it.
     takesHorse(x)
     x.giddyUp()
+    _ = x.isGalloping
+    _ = x[keyPath: \.isGalloping]
     _ = UsesHorse<HasDeprecatedConformance3>.self
   }
 }
@@ -196,11 +231,17 @@ extension HasAvailableConformance1 : Horse {}
 // in test/Sema/conformance_availability_warn.swift for the same example
 // but without this flag.
 
-func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 3{{add @available attribute to enclosing global function}}
+func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
   x.giddyUp() // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+
+  _ = x.isGalloping // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
   _ = UsesHorse<HasAvailableConformance1>.self // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
@@ -211,6 +252,8 @@ func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 3
 func passAvailableConformance1a(x: HasAvailableConformance1) {
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
+  _ = x[keyPath: \.isGalloping]
   _ = UsesHorse<HasAvailableConformance1>.self
 }
 

--- a/test/Sema/conformance_availability.swift
+++ b/test/Sema/conformance_availability.swift
@@ -4,6 +4,7 @@
 
 public protocol Horse {}
 func takesHorse<T : Horse>(_: T) {}
+func takesHorseExistential(_: Horse) {}
 
 extension Horse {
   func giddyUp() {}
@@ -17,10 +18,11 @@ public struct HasUnavailableConformance1 {}
 
 @available(*, unavailable)
 extension HasUnavailableConformance1 : Horse {}
-// expected-note@-1 6{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 7{{conformance of 'HasUnavailableConformance1' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance1(x: HasUnavailableConformance1) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance1' to 'Horse' is unavailable}}
@@ -30,6 +32,7 @@ func passUnavailableConformance1(x: HasUnavailableConformance1) {
 @available(*, unavailable)
 func passUnavailableConformance1a(x: HasUnavailableConformance1) {
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = x[keyPath: \.isGalloping]
@@ -41,10 +44,11 @@ public struct HasUnavailableConformance2 {}
 
 @available(macOS, unavailable)
 extension HasUnavailableConformance2 : Horse {}
-// expected-note@-1 5{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 6{{conformance of 'HasUnavailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance2(x: HasUnavailableConformance2) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance2' to 'Horse' is unavailable in macOS}}
@@ -55,6 +59,7 @@ func passUnavailableConformance2(x: HasUnavailableConformance2) {
 func passUnavailableConformance2a(x: HasUnavailableConformance2) {
   // This is allowed
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = x[keyPath: \.isGalloping]
@@ -65,10 +70,11 @@ public struct HasUnavailableConformance3 {}
 
 @available(swift 12)
 extension HasUnavailableConformance3 : Horse {}
-// expected-note@-1 10{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
+// expected-note@-1 12{{conformance of 'HasUnavailableConformance3' to 'Horse' was introduced in Swift 12}}
 
 func passUnavailableConformance3(x: HasUnavailableConformance3) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
@@ -78,6 +84,7 @@ func passUnavailableConformance3(x: HasUnavailableConformance3) {
 @available(swift 12)
 func passUnavailableConformance3a(x: HasUnavailableConformance3) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance3' to 'Horse' is unavailable}}
@@ -89,10 +96,11 @@ public struct HasUnavailableConformance4 {}
 
 @available(macOS, obsoleted: 10.1)
 extension HasUnavailableConformance4 : Horse {}
-// expected-note@-1 10{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
+// expected-note@-1 12{{conformance of 'HasUnavailableConformance4' to 'Horse' was obsoleted in macOS 10.1}}
 
 func passUnavailableConformance4(x: HasUnavailableConformance4) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
@@ -102,6 +110,7 @@ func passUnavailableConformance4(x: HasUnavailableConformance4) {
 @available(macOS, obsoleted: 10.1)
 func passUnavailableConformance4a(x: HasUnavailableConformance4) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable in macOS}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance4' to 'Horse' is unavailable}}
@@ -113,10 +122,11 @@ public struct HasUnavailableConformance5 {}
 
 @available(swift, obsoleted: 4)
 extension HasUnavailableConformance5 : Horse {}
-// expected-note@-1 10{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
+// expected-note@-1 12{{conformance of 'HasUnavailableConformance5' to 'Horse' was obsoleted in Swift 4}}
 
 func passUnavailableConformance5(x: HasUnavailableConformance5) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
@@ -126,6 +136,7 @@ func passUnavailableConformance5(x: HasUnavailableConformance5) {
 @available(swift, obsoleted: 4)
 func passUnavailableConformance5a(x: HasUnavailableConformance5) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance5' to 'Horse' is unavailable}}
@@ -137,10 +148,11 @@ public struct HasUnavailableConformance6 {}
 
 @available(*, unavailable, message: "This conformance is bad")
 extension HasUnavailableConformance6 : Horse {}
-// expected-note@-1 5{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
+// expected-note@-1 6{{conformance of 'HasUnavailableConformance6' to 'Horse' has been explicitly marked unavailable here}}
 
 func passUnavailableConformance6(x: HasUnavailableConformance6) {
   takesHorse(x) // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
+  takesHorseExistential(x) // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
   x.giddyUp() // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
   _ = x.isGalloping // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasUnavailableConformance6' to 'Horse' is unavailable: This conformance is bad}}
@@ -155,6 +167,7 @@ extension HasDeprecatedConformance1 : Horse {}
 
 func passDeprecatedConformance1(x: HasDeprecatedConformance1) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
   _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
   _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance1' to 'Horse' is deprecated}}
@@ -164,6 +177,7 @@ func passDeprecatedConformance1(x: HasDeprecatedConformance1) {
 @available(*, deprecated)
 func passDeprecatedConformance1a(x: HasDeprecatedConformance1) {
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = x[keyPath: \.isGalloping]
@@ -178,6 +192,7 @@ extension HasDeprecatedConformance2 : Horse {}
 
 func passDeprecatedConformance2(x: HasDeprecatedConformance2) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
   _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
   _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance2' to 'Horse' is deprecated: This conformance is deprecated}}
@@ -187,6 +202,7 @@ func passDeprecatedConformance2(x: HasDeprecatedConformance2) {
 @available(*, deprecated)
 func passDeprecatedConformance2a(x: HasDeprecatedConformance2) {
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = x[keyPath: \.isGalloping]
@@ -201,6 +217,7 @@ extension HasDeprecatedConformance3 : Horse {}
 
 func passDeprecatedConformance3(x: HasDeprecatedConformance3) {
   takesHorse(x) // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
   x.giddyUp() // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
   _ = x.isGalloping // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
   _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasDeprecatedConformance3' to 'Horse' was deprecated in macOS 10.8}}
@@ -213,6 +230,7 @@ func passDeprecatedConformance3a(x: HasDeprecatedConformance3) {
     // This branch is dead with our minimum deployment target, so don't emit
     // deprecation diagnostics in it.
     takesHorse(x)
+    takesHorseExistential(x)
     x.giddyUp()
     _ = x.isGalloping
     _ = x[keyPath: \.isGalloping]
@@ -231,8 +249,11 @@ extension HasAvailableConformance1 : Horse {}
 // in test/Sema/conformance_availability_warn.swift for the same example
 // but without this flag.
 
-func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5{{add @available attribute to enclosing global function}}
+func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+
+  takesHorseExistential(x) // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
   x.giddyUp() // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
@@ -251,6 +272,7 @@ func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5
 @available(macOS 100, *)
 func passAvailableConformance1a(x: HasAvailableConformance1) {
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = x[keyPath: \.isGalloping]

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -4,6 +4,7 @@
 
 public protocol Horse {}
 func takesHorse<T : Horse>(_: T) {}
+func takesHorseExistential(_: Horse) {}
 
 extension Horse {
   func giddyUp() {}
@@ -23,10 +24,13 @@ extension HasAvailableConformance1 : Horse {}
 // test case in test/Sema/conformance_availability.swift for the same
 // example but with this flag.
 
-func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5{{add @available attribute to enclosing global function}}
+func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  
   x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
   
@@ -43,6 +47,7 @@ func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5
 @available(macOS 100, *)
 func passAvailableConformance1a(x: HasAvailableConformance1) {
   takesHorse(x)
+  takesHorseExistential(x)
   x.giddyUp()
   _ = x.isGalloping
   _ = UsesHorse<HasAvailableConformance1>.self

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -7,6 +7,7 @@ func takesHorse<T : Horse>(_: T) {}
 
 extension Horse {
   func giddyUp() {}
+  var isGalloping: Bool { true }
 }
 
 struct UsesHorse<T : Horse> {}
@@ -22,11 +23,17 @@ extension HasAvailableConformance1 : Horse {}
 // test case in test/Sema/conformance_availability.swift for the same
 // example but with this flag.
 
-func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 3{{add @available attribute to enclosing global function}}
+func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 5{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
   x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  
+  _ = x.isGalloping // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+  
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
   // expected-note@-1 {{add 'if #available' version check}}
 
   _ = UsesHorse<HasAvailableConformance1>.self // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
@@ -37,5 +44,6 @@ func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 3
 func passAvailableConformance1a(x: HasAvailableConformance1) {
   takesHorse(x)
   x.giddyUp()
+  _ = x.isGalloping
   _ = UsesHorse<HasAvailableConformance1>.self
 }


### PR DESCRIPTION
Diagnose uses of potentially unavailable protocol conformances in member reference expressions (`x.foo` where `foo` is a property of `x`) and type erasure expressions (`let p: P = S` where `S` conforms to `P`) since unguarded uses of these conformances can cause crashes at runtime.

Expands conformance availability tests to include test cases covering member references, key paths, and invocation of functions taking existentials.

Resolves rdar://87795154 and rdar://83731428.
