### PR TITLE
Make remote-run use tar to transfer files.

### DIFF
--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -5,22 +5,15 @@ CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
 CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
 
-CHECK-NEXT: /usr/bin/ssh -n
+CHECK: /usr/bin/ssh
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
+CHECK-SAME: some_user@some_host -- '/usr/bin/tar' '-x' '-j' '-P' '-C' '/' '-f' '-'
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' {{.*}} 'cp'
 
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 

--- a/test/remote-run/dry-run-remote.test-sh
+++ b/test/remote-run/dry-run-remote.test-sh
@@ -1,23 +1,16 @@
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --input-prefix %S/Inputs/ some_user@some_host ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
 
-CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/input/upload'
-CHECK-INPUT-NEXT: /usr/bin/sftp
-CHECK-INPUT-SAME: some_user@some_host
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/1.txt' '/xyz-REMOTE/input/upload/1.txt'
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/2.txt' '/xyz-REMOTE/input/upload/2.txt'
-CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' 'ls'
+CHECK-INPUT: /usr/bin/ssh some_user@some_host -- '/usr/bin/tar' '-x' '-j' '-P' '-C' '/' '-f' '-'
+
+CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}} 'ls'
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/nested)
 RUN: touch %t/nested/input %t/nested/BAD
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 
-CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
-CHECK-OUTPUT-SAME: some_user@some_host
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
-CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-OUTPUT: /usr/bin/ssh some_user@some_host -- '/usr/bin/tar' '-x' '-j' '-P' '-C' '/' '-f' '-'
+CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}} 'cp'
 CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 CHECK-OUTPUT-NEXT: /usr/bin/sftp
 CHECK-OUTPUT-SAME: some_user@some_host

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -5,11 +5,8 @@ RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S
 RUN: test -z "`ls %t`"
 RUN: test ! -e %t-REMOTE
 
-CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input/upload
-CHECK-INPUT-NEXT: /usr/bin/sftp
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/1.txt' '{{.+}}-REMOTE/input/upload/1.txt'
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/2.txt' '{{.+}}-REMOTE/input/upload/2.txt'
-CHECK-INPUT: /usr/bin/env ls
+CHECK-INPUT: /usr/bin/tar
+CHECK-INPUT: /usr/bin/env {{.*}} ls
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/nested)
@@ -17,11 +14,8 @@ RUN: touch %t/nested/input %t/nested/BAD
 RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 RUN: test ! -e %t-REMOTE
 
-CHECK-OUTPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/output' '{{.+}}-REMOTE/output/nested/output'
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/input' '{{.+}}-REMOTE/output/nested/input'
-CHECK-OUTPUT: /usr/bin/env cp
+CHECK-OUTPUT: /usr/bin/tar
+CHECK-OUTPUT: /usr/bin/env {{.*}} cp
 CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 CHECK-OUTPUT-NEXT: /usr/bin/sftp
 CHECK-OUTPUT-DAG: -get '{{.+}}-REMOTE/output/nested/output' '{{.+}}/nested/output'

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -5,4 +5,4 @@ RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v 
 
 CHECK: {{^:foo: :bar:$}}
 
-VERBOSE: /usr/bin/env BAR=bar FOO=foo sh -c echo ":${FOO}:" ":${BAR}:"
+VERBOSE: /usr/bin/env BAR=bar FOO=foo {{.*}} sh -c echo ":${FOO}:" ":${BAR}:"

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -5,22 +5,15 @@ CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
 CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
 
-CHECK-NEXT: /usr/bin/ssh -n
+CHECK: /usr/bin/ssh
 CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
+CHECK-SAME: some_user@some_host -- '/usr/bin/tar' '-x' '-j' '-P' '-C' '/' '-f' '-'
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' {{.*}} 'cp'
 
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 
@@ -34,10 +27,8 @@ CHECK-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'
 # Make sure things work without a port.
 RUN: %remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-PORTLESS %s
 
-CHECK-PORTLESS: /usr/bin/sftp
-CHECK-PORTLESS-SAME: -i spiderman
-CHECK-PORTLESS-SAME: some_user@some_host
+CHECK-PORTLESS: /usr/bin/tar
 
 CHECK-PORTLESS: /usr/bin/ssh -n
 CHECK-PORTLESS-SAME: -i spiderman
-CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' {{.*}} 'cp'

--- a/test/remote-run/port.test-sh
+++ b/test/remote-run/port.test-sh
@@ -1,12 +1,7 @@
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
-CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-CHECK-NEXT: /usr/bin/sftp
-CHECK-SAME: -P 12345
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
-CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK: /usr/bin/ssh -p 12345 some_user@some_host -- '/usr/bin/tar' '-x' '-j' '-P' '-C' '/' '-f' '-'
+CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' {{.*}} 'cp'
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 CHECK-NEXT: /usr/bin/sftp
 CHECK-SAME: -P 12345

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -5,4 +5,4 @@ RUN: %debug-remote-run -v echo hello 2>&1 >/dev/null | %FileCheck -check-prefix 
 
 CHECK: {{^hello$}}
 
-VERBOSE: /usr/bin/env echo hello
+VERBOSE: /usr/bin/env {{.*}} echo hello

--- a/test/remote-run/upload-and-download.test-sh
+++ b/test/remote-run/upload-and-download.test-sh
@@ -26,11 +26,8 @@ RUN: ls %t-REMOTE/output/nested/ | %FileCheck -check-prefix CHECK-REMOTE %s
 
 RUN: %debug-remote-run -v --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s
 
-VERBOSE: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-VERBOSE-NEXT: /usr/bin/sftp
-VERBOSE-DAG: -put '{{.+}}/nested/output' '{{.+}}-REMOTE/output/nested/output'
-VERBOSE-DAG: -put '{{.+}}/nested/input' '{{.+}}-REMOTE/output/nested/input'
-VERBOSE: /usr/bin/env cp
+VERBOSE: /usr/bin/tar
+VERBOSE: /usr/bin/env {{.*}} cp
 VERBOSE-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
 VERBOSE-NEXT: /usr/bin/sftp
 VERBOSE-DAG: -get '{{.+}}-REMOTE/output/nested/output' '{{.+}}/nested/output'

--- a/test/remote-run/upload-stderr.test-sh
+++ b/test/remote-run/upload-stderr.test-sh
@@ -3,6 +3,6 @@ REQUIRES: sftp_server
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/REMOTE/input)
 RUN: chmod a-w %t/REMOTE/input
-RUN: %debug-remote-run --remote-dir %t/REMOTE --input-prefix %S/Inputs/upload/ true -- %S/Inputs/upload/1.txt 2>&1 | %FileCheck %s
+RUN: %debug-remote-run --ignore-tar-failure --remote-dir %t/REMOTE --input-prefix %S/Inputs/upload/ true -- %S/Inputs/upload/1.txt 2>&1 | %FileCheck %s
 
-CHECK: Permission denied
+CHECK: Can't create '{{.+}}/REMOTE/input/1.txt'

--- a/test/remote-run/upload.test-sh
+++ b/test/remote-run/upload.test-sh
@@ -32,8 +32,5 @@ CHECK: {{^1.txt$}}
 CHECK-NEXT: {{^2.txt$}}
 CHECK-NOT: BAD
 
-VERBOSE-NESTED: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input/upload
-VERBOSE-NESTED-NEXT: /usr/bin/sftp
-VERBOSE-NESTED-DAG: -put '{{.+}}/Inputs/upload/1.txt' '{{.+}}-REMOTE/input/upload/1.txt'
-VERBOSE-NESTED-DAG: -put '{{.+}}/Inputs/upload/2.txt' '{{.+}}-REMOTE/input/upload/2.txt'
-VERBOSE-NESTED: /usr/bin/env ls
+VERBOSE-NESTED: /usr/bin/tar
+VERBOSE-NESTED: /usr/bin/env {{.*}} ls

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -18,6 +18,10 @@ import os
 import posixpath
 import subprocess
 import sys
+import tarfile
+import tempfile
+import shutil
+import errno
 
 def quote(arg):
     return repr(arg)
@@ -26,6 +30,7 @@ class CommandRunner(object):
     def __init__(self):
         self.verbose = False
         self.dry_run = False
+        self.ignore_tar_failure = False
 
     @staticmethod
     def _dirnames(files):
@@ -39,17 +44,48 @@ class CommandRunner(object):
         return subprocess.Popen(command, **kwargs)
 
     def send(self, local_to_remote_files):
-        # Prepare the remote directory structure.
-        # FIXME: This could be folded into the sftp connection below.
-        dirs_to_make = self._dirnames(local_to_remote_files.values())
-        self.run_remote(['/bin/mkdir', '-p'] + dirs_to_make)
+        # Use tar to transfer the files we want
+        tmpdirname = tempfile.mkdtemp()
+        try:
+            archivename = os.path.join(tmpdirname, 'sent.tar.bz2')
+            with tarfile.open(name=archivename, mode='w:bz2') as archive:
+                for local_file, remote_file in local_to_remote_files.items():
+                    try:
+                        archive.add(local_file, arcname=remote_file)
+                    except OSError as e:
+                        if e.errno == errno.ENOENT:
+                            print("warning: {} not found".format(local_file),
+                                  file=sys.stderr)
 
-        # Send the local files.
-        sftp_commands = ("-put {0} {1}".format(quote(local_file), 
-                                               quote(remote_file))
-                         for local_file, remote_file
-                         in local_to_remote_files.items())
-        self.run_sftp(sftp_commands)
+                            # In this case, we need to add the containing
+                            # directory to the tar file if we haven't already
+                            dirname = posixpath.dirname(remote_file)
+                            try:
+                                dirinfo = archive.getmember(dirname)
+                            except KeyError:
+                                dirinfo = tarfile.TarInfo(posixpath.dirname(remote_file))
+                                dirinfo.type = tarfile.DIRTYPE
+                                dirinfo.mode = 0o755
+                                archive.addfile(dirinfo)
+                        else:
+                            raise
+
+            invocation = self.remote_invocation(['/usr/bin/tar', '-x', '-j', '-P',
+                                                 '-C', '/', '-f', '-'],
+                                                block_stdin=False)
+            with open(archivename, 'rb') as archive:
+                untar = self.popen(invocation, stdin=archive)
+                if self.dry_run:
+                    return
+                _, _ = untar.communicate()
+                if untar.returncode:
+                    if self.ignore_tar_failure:
+                        print("warning: /usr/bin/tar failed with code {}"\
+                              .format(untar.returncode))
+                    else:
+                        sys.exit(untar.returncode)
+        finally:
+            shutil.rmtree(tmpdirname)
 
     def fetch(self, local_to_remote_files):
         # Prepare the local directory structure.
@@ -95,6 +131,7 @@ class CommandRunner(object):
 
 class RemoteCommandRunner(CommandRunner):
     def __init__(self, host, identity_path, ssh_options, config_file):
+        super(RemoteCommandRunner, self).__init__()
         if ':' in host:
             (self.remote_host, self.port) = host.rsplit(':', 1)
         else:
@@ -104,8 +141,9 @@ class RemoteCommandRunner(CommandRunner):
         self.ssh_options = ssh_options
         self.config_file = config_file
 
-    def common_options(self, port_flag):
+    def common_options(self, port_flag, block_stdin=False):
         port_option = [port_flag, self.port] if self.port else []
+        stdin_option = ['-n'] if block_stdin else []
         config_option = ['-F', self.config_file] if self.config_file else []
         identity_option = (
             ['-i', self.identity_path] if self.identity_path else [])
@@ -115,11 +153,12 @@ class RemoteCommandRunner(CommandRunner):
         # https://spapas.github.io/2016/04/27/python-nested-list-comprehensions/
         extra_options = [arg for option in self.ssh_options
                              for arg in ["-o", option]]
-        return port_option + identity_option + config_option + extra_options
+        return (stdin_option + port_option + identity_option +
+                config_option + extra_options)
 
-    def remote_invocation(self, command):
-        return (['/usr/bin/ssh', '-n'] +
-                self.common_options(port_flag='-p') +
+    def remote_invocation(self, command, block_stdin=True):
+        return (['/usr/bin/ssh'] +
+                self.common_options(port_flag='-p', block_stdin=block_stdin) +
                 [self.remote_host, '--'] +
                 [quote(arg) for arg in command])
 
@@ -130,9 +169,10 @@ class RemoteCommandRunner(CommandRunner):
 
 class LocalCommandRunner(CommandRunner):
     def __init__(self, sftp_server_path):
+        super(LocalCommandRunner, self).__init__()
         self.sftp_server_path = sftp_server_path
 
-    def remote_invocation(self, command):
+    def remote_invocation(self, command, block_stdin=True):
         return command
 
     def sftp_invocation(self):
@@ -183,6 +223,9 @@ def main():
                         help='run commands locally instead of over SSH, for '
                              'debugging purposes. The "host" argument is '
                              'omitted.')
+    parser.add_argument('--ignore-tar-failure', action='store_true',
+                        dest='ignore_tar_failure',
+                        help='ignore error returns from tar (for debugging).')
 
     parser.add_argument('host',
                         help='the host to connect to, in the form '
@@ -202,6 +245,7 @@ def main():
                                      args.config_file)
     runner.dry_run = args.dry_run
     runner.verbose = args.verbose or args.dry_run
+    runner.ignore_tar_failure = args.ignore_tar_failure
 
     assert not args.remote_dir == '/'
 


### PR DESCRIPTION
Rather than using `sftp`, which seems to sometimes fail to transfer file mtimes properly on some of our test platforms, use `tar` to transfer files to the test system.

rdar://88179140
