### PR TITLE
Add option to reduce build times when using ThinLTO and ld64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,13 @@ set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     option only affects the tools that run on the host (the compiler), and has
     no effect on the target libraries (the standard library and the runtime).")
 
+option(SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS
+    "When building ThinLTO using ld64 on Darwin, controls whether to opt out of
+    LLVM IR optimizations when linking targets that will get
+    little benefit from it (e.g. tools for bootstrapping or
+    debugging Swift)"
+    FALSE)
+
 option(BOOTSTRAPPING_MODE [=[
 How to build the swift compiler modules. Possible values are
     OFF:           build without swift modules

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -902,3 +902,17 @@ function(set_swift_llvm_is_available name)
   target_compile_definitions(${name} PRIVATE
     $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:SWIFT_LLVM_SUPPORT_IS_AVAILABLE>)
 endfunction()
+
+# Given the conditions to check to apply the linker flags
+# are not trivial and can be easily forgotten,
+# we preferred to provide a function to configure the targets
+# that on Darwin can skip the IR optimizations when
+# linking with ThinLTO
+function(target_thinlto_ld64_add_flto_codegen_only target)
+  if (SWIFT_TOOLS_ENABLE_LTO STREQUAL "thin" AND
+      LLVM_LINKER_IS_LD64 AND
+      SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS
+      )
+    target_link_options(${target} PRIVATE "LINKER:-flto-codegen-only")
+  endif()
+endfunction()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -915,17 +915,3 @@ function(set_swift_llvm_is_available name)
   target_compile_definitions(${name} PRIVATE
     $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:SWIFT_LLVM_SUPPORT_IS_AVAILABLE>)
 endfunction()
-
-# Given the conditions to check to apply the linker flags
-# are not trivial and can be easily forgotten,
-# we preferred to provide a function to configure the targets
-# that on Darwin can skip the IR optimizations when
-# linking with ThinLTO
-function(target_thinlto_ld64_add_flto_codegen_only target)
-  if (SWIFT_TOOLS_ENABLE_LTO STREQUAL "thin" AND
-      LLVM_LINKER_IS_LD64 AND
-      SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS
-      )
-    target_link_options(${target} PRIVATE "LINKER:-flto-codegen-only")
-  endif()
-endfunction()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -636,7 +636,7 @@ macro(add_swift_lib_subdirectory name)
 endmacro()
 
 function(add_swift_host_tool executable)
-  set(options HAS_SWIFT_MODULES)
+  set(options HAS_SWIFT_MODULES THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY)
   set(single_parameter_options SWIFT_COMPONENT BOOTSTRAPPING)
   set(multiple_parameter_options LLVM_LINK_COMPONENTS)
 
@@ -857,6 +857,19 @@ function(add_swift_host_tool executable)
         $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:"SHELL:-Xclang --dependent-lib=msvcrt$<$<CONFIG:Debug>:d>">
         )
     endif()
+  endif()
+
+  if(ASHT_THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY)
+    string(CONCAT lto_codegen_only_link_options
+      "$<"
+        "$<AND:"
+          "$<BOOL:${LLVM_LINKER_IS_LD64}>,"
+          "$<BOOL:${SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS}>,"
+          "$<STREQUAL:${SWIFT_TOOLS_ENABLE_LTO},thin>"
+        ">:"
+        "LINKER:-flto-codegen-only"
+      ">")
+    target_link_options(${executable} PRIVATE "${lto_codegen_only_link_options}")
   endif()
 
   if(NOT ${ASHT_SWIFT_COMPONENT} STREQUAL "no_component")

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -10,6 +10,7 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     SWIFT_COMPONENT no_component
     HAS_SWIFT_MODULES
     BOOTSTRAPPING 0
+    THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
   )
   target_link_libraries(swift-frontend-bootstrapping0
                         PRIVATE
@@ -21,8 +22,6 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/${CMAKE_CFG_INTDIR}/bin")
 
-  target_thinlto_ld64_add_flto_codegen_only(swift-frontend-bootstrapping0)
-
   # Bootstrapping - level 1
 
   add_swift_host_tool(swift-frontend-bootstrapping1
@@ -30,6 +29,7 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     SWIFT_COMPONENT no_component
     HAS_SWIFT_MODULES
     BOOTSTRAPPING 1
+    THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
   )
   target_link_libraries(swift-frontend-bootstrapping1
                         PRIVATE
@@ -40,8 +40,6 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/${CMAKE_CFG_INTDIR}/bin")
-
-  target_thinlto_ld64_add_flto_codegen_only(swift-frontend-bootstrapping1)
 endif()
 
 add_swift_host_tool(swift-frontend

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -21,6 +21,8 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/${CMAKE_CFG_INTDIR}/bin")
 
+  target_thinlto_ld64_add_flto_codegen_only(swift-frontend-bootstrapping0)
+
   # Bootstrapping - level 1
 
   add_swift_host_tool(swift-frontend-bootstrapping1
@@ -38,6 +40,8 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/${CMAKE_CFG_INTDIR}/bin")
+
+  target_thinlto_ld64_add_flto_codegen_only(swift-frontend-bootstrapping1)
 endif()
 
 add_swift_host_tool(swift-frontend

--- a/tools/swift-ast-script/CMakeLists.txt
+++ b/tools/swift-ast-script/CMakeLists.txt
@@ -9,3 +9,5 @@ target_link_libraries(swift-ast-script
                       PRIVATE
                         swiftAST
                         swiftFrontendTool)
+
+target_thinlto_ld64_add_flto_codegen_only(swift-ast-script)

--- a/tools/swift-ast-script/CMakeLists.txt
+++ b/tools/swift-ast-script/CMakeLists.txt
@@ -4,10 +4,9 @@ add_swift_host_tool(swift-ast-script
   ASTScriptEvaluator.cpp
   swift-ast-script.cpp
   SWIFT_COMPONENT tools
+  THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
 )
 target_link_libraries(swift-ast-script
                       PRIVATE
                         swiftAST
                         swiftFrontendTool)
-
-target_thinlto_ld64_add_flto_codegen_only(swift-ast-script)

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -8,3 +8,4 @@ target_link_libraries(swift-dependency-tool
                         swiftAST
                         swiftParse
                         swiftClangImporter)
+

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -1,11 +1,10 @@
 add_swift_host_tool(swift-dependency-tool
   swift-dependency-tool.cpp
   SWIFT_COMPONENT tools
+  THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
 )
 target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
                         swiftClangImporter)
-
-target_thinlto_ld64_add_flto_codegen_only(swift-dependency-tool)

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -8,3 +8,4 @@ target_link_libraries(swift-dependency-tool
                         swiftParse
                         swiftClangImporter)
 
+target_thinlto_ld64_add_flto_codegen_only(swift-dependency-tool)

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -21,6 +21,8 @@ if(LLVM_ENABLE_LIBXML2)
   endif()
 endif()
 
+target_thinlto_ld64_add_flto_codegen_only(swift-ide-test)
+
 # Create a symlink for swift-api-dump.py in the bin directory
 swift_create_post_build_symlink(swift-ide-test
   SOURCE "${SWIFT_SOURCE_DIR}/utils/swift-api-dump.py"

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_swift_host_tool(swift-ide-test
   ModuleAPIDiff.cpp
   XMLValidator.cpp
   SWIFT_COMPONENT tools
+  THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
 )
 target_link_libraries(swift-ide-test
                       PRIVATE
@@ -20,8 +21,6 @@ if(LLVM_ENABLE_LIBXML2)
     include_directories(SYSTEM "/usr/local/include")
   endif()
 endif()
-
-target_thinlto_ld64_add_flto_codegen_only(swift-ide-test)
 
 # Create a symlink for swift-api-dump.py in the bin directory
 swift_create_post_build_symlink(swift-ide-test

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -13,3 +13,4 @@ if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swift-frontend clang-resource-headers)
 endif()
 
+target_thinlto_ld64_add_flto_codegen_only(swift-remoteast-test)

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_host_tool(swift-remoteast-test
   swift-remoteast-test.cpp
   SWIFT_COMPONENT testsuite-tools
+  THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
 )
 target_link_libraries(swift-remoteast-test
                       PRIVATE
@@ -12,5 +13,3 @@ set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
 if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swift-frontend clang-resource-headers)
 endif()
-
-target_thinlto_ld64_add_flto_codegen_only(swift-remoteast-test)

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -13,3 +13,4 @@ set_target_properties(swift-remoteast-test PROPERTIES ENABLE_EXPORTS 1)
 if(NOT SWIFT_BUILT_STANDALONE)
   add_dependencies(swift-frontend clang-resource-headers)
 endif()
+

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -515,6 +515,14 @@ def create_argument_parser():
            help='the maximum number of parallel link jobs to use when '
                 'compiling swift tools.')
 
+    option('--swift-tools-ld64-lto-codegen-only-for-supporting-targets',
+           toggle_true,
+           default=False,
+           help='When building ThinLTO using ld64 on Darwin, controls whether '
+                'to opt out of LLVM IR optimizations when linking targets that '
+                'will get little benefit from it (e.g. tools for '
+                'bootstrapping or debugging Swift)')
+
     option('--dsymutil-jobs', store_int,
            default=defaults.DSYMUTIL_JOBS,
            metavar='COUNT',

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -220,6 +220,7 @@ EXPECTED_DEFAULTS = {
     'swift_freestanding_is_darwin': False,
     'swift_stdlib_assertions': True,
     'swift_stdlib_build_variant': 'Debug',
+    'swift_tools_ld64_lto_codegen_only_for_supporting_targets': False,
     'swift_tools_max_parallel_lto_link_jobs':
         defaults.SWIFT_MAX_PARALLEL_LTO_LINK_JOBS,
     'swift_user_visible_version': defaults.SWIFT_USER_VISIBLE_VERSION,
@@ -714,6 +715,7 @@ EXPECTED_OPTIONS = [
     IntOption('--jobs', dest='build_jobs'),
     IntOption('--llvm-max-parallel-lto-link-jobs'),
     IntOption('--swift-tools-max-parallel-lto-link-jobs'),
+    EnableOption('--swift-tools-ld64-lto-codegen-only-for-supporting-targets'),
     IntOption('-j', dest='build_jobs'),
     IntOption('--dsymutil-jobs', dest='dsymutil_jobs'),
 

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -65,6 +65,9 @@ class Swift(product.Product):
 
         self.cmake_options.extend(self._enable_stdlib_unicode_data)
 
+        self.cmake_options.extend(
+            self._swift_tools_ld64_lto_codegen_only_for_supporting_targets)
+
     @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool
@@ -183,6 +186,11 @@ updated without updating swift.py?")
     def _build_swift_private_stdlib(self):
         return [('SWIFT_STDLIB_BUILD_PRIVATE:BOOL',
                  self.args.build_swift_private_stdlib)]
+
+    @property
+    def _swift_tools_ld64_lto_codegen_only_for_supporting_targets(self):
+        return [('SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL',
+                 self.args.swift_tools_ld64_lto_codegen_only_for_supporting_targets)]
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -64,7 +64,8 @@ class SwiftTestCase(unittest.TestCase):
             build_swift_stdlib_static_print=False,
             build_swift_stdlib_unicode_data=True,
             swift_freestanding_is_darwin=False,
-            build_swift_private_stdlib=True)
+            build_swift_private_stdlib=True,
+            swift_tools_ld64_lto_codegen_only_for_supporting_targets=False)
 
         # Setup shell
         shell.dry_run = True
@@ -102,6 +103,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_FREESTANDING_IS_DARWIN:BOOL=FALSE',
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
+            '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -124,6 +126,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_FREESTANDING_IS_DARWIN:BOOL=FALSE',
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
+            '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 
@@ -388,3 +391,16 @@ class SwiftTestCase(unittest.TestCase):
              'FALSE'],
             [x for x in swift.cmake_options
                 if 'SWIFT_STDLIB_BUILD_PRIVATE' in x])
+
+    def test_swift_tools_ld64_lto_codegen_only_for_supporting_targets(self):
+        self.args.swift_tools_ld64_lto_codegen_only_for_supporting_targets = True
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertEqual(
+            ['-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL='
+             'TRUE'],
+            [x for x in swift.cmake_options
+                if 'SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS' in x])


### PR DESCRIPTION
Internal configurations targeting Darwin employ ThinLTO to
improve compiler performance, however using it on all executable
causes build time to increase with no matching benefit.

To reduce build times in such configurations, we allow some
ancillary targets to opt out of LLVM IR optimizations when linking
ThinLTO with ld64 (e.g. tools used for bootstrapping or debugging the
Swift compiler) -- this behaviour is opt in through a new flag
`--swift-tools-ld64-lto-codegen-only-for-supporting-targets`.

Addresses rdar://76702687