### PR TITLE
[CMake] set target architecture for Darwin idiomatically

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -162,9 +162,9 @@ function(_add_host_variant_c_compile_link_flags name)
     # side effects are introduced should a new search path be added.
     target_compile_options(${name} PRIVATE
       $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:
-      -arch ${SWIFT_HOST_VARIANT_ARCH}
       "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks"
     >)
+    set_property(TARGET ${name} PROPERTY OSX_ARCHITECTURES "${SWIFT_HOST_VARIANT_ARCH}")
   endif()
 
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)


### PR DESCRIPTION
Previously we were setting `-arch` explicitly and unsetting
`CMAKE_OSX_ARCHITECTURES`; however this approach does not work when
building on Apple Silicon, since in there CMake 3.19+ enforces a default
value
(https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5291/diffs),
and this would result in the inability to compile code for x86_64.

This is a similar approach used for stdlib targets in #38415

Addresses rdar://88100025