### PR TITLE
Concurrent top-level detection

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -582,6 +582,9 @@ public:
 
   ArrayRef<OpaqueTypeDecl *> getOpaqueReturnTypeDecls();
 
+  /// Returns true if the source file contains concurrency in the top-level
+  bool isAsyncTopLevelSourceFile() const;
+
 private:
 
   /// If not \c None, the underlying vector contains the parsed tokens of this

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -161,7 +161,7 @@ public:
 
   SourceLoc getLBraceLoc() const { return LBLoc; }
   SourceLoc getRBraceLoc() const { return RBLoc; }
-  
+
   SourceRange getSourceRange() const { return SourceRange(LBLoc, RBLoc); }
 
   bool empty() const { return getNumElements() == 0; }
@@ -182,7 +182,9 @@ public:
   ArrayRef<ASTNode> getElements() const {
     return {getTrailingObjects<ASTNode>(), Bits.BraceStmt.NumElements};
   }
-  
+
+  ASTNode findAsyncNode();
+
   static bool classof(const Stmt *S) { return S->getKind() == StmtKind::Brace; }
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3246,6 +3246,21 @@ public:
   bool isCached() const { return true; }
 };
 
+class GetSourceFileAsyncNode
+    : public SimpleRequest<GetSourceFileAsyncNode, ASTNode(const SourceFile *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ASTNode evaluate(Evaluator &evaluator, const SourceFile *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -372,3 +372,6 @@ SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetSourceFileAsyncNode,
+              AwaitExpr *(const SourceFile *),
+              Cached, NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -736,8 +736,8 @@ bool Decl::preconcurrency() const {
   // Variables declared in top-level code are @_predatesConcurrency
   if (const VarDecl *var = dyn_cast<VarDecl>(this)) {
     const LangOptions &langOpts = getASTContext().LangOpts;
-    return !langOpts.isSwiftVersionAtLeast(6) &&
-           langOpts.EnableExperimentalAsyncTopLevel && var->isTopLevelGlobal();
+    return !langOpts.isSwiftVersionAtLeast(6) && var->isTopLevelGlobal() &&
+           var->getDeclContext()->isAsyncContext();
   }
 
   return false;
@@ -8946,9 +8946,8 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
-    ASTContext &ctx = dc->getASTContext();
-    if (ctx.LangOpts.EnableExperimentalAsyncTopLevel) {
-      if (Type mainActor = ctx.getMainActorType())
+    if (dc->isAsyncContext()) {
+      if (Type mainActor = dc->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/false);
     }
   }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1228,8 +1228,13 @@ bool DeclContext::isAsyncContext() const {
   case DeclContextKind::GenericTypeDecl:
     return false;
   case DeclContextKind::FileUnit:
+    if (const SourceFile *sf = dyn_cast<SourceFile>(this))
+      return getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
+             sf->isAsyncTopLevelSourceFile();
+    return false;
   case DeclContextKind::TopLevelCodeDecl:
-    return getASTContext().LangOpts.EnableExperimentalAsyncTopLevel;
+    return getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
+           getParent()->isAsyncContext();
   case DeclContextKind::AbstractClosureExpr:
     return cast<AbstractClosureExpr>(this)->isBodyAsync();
   case DeclContextKind::AbstractFunctionDecl: {

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/Stmt.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Pattern.h"
@@ -153,6 +154,65 @@ BraceStmt *BraceStmt::create(ASTContext &ctx, SourceLoc lbloc,
   void *Buffer = ctx.Allocate(totalSizeToAlloc<ASTNode>(elts.size()),
                               alignof(BraceStmt));
   return ::new(Buffer) BraceStmt(lbloc, elts, rbloc, implicit);
+}
+
+ASTNode BraceStmt::findAsyncNode() {
+  // TODO: Statements don't track their ASTContext/evaluator, so I am not making
+  // this a request. It probably should be a request at some point.
+  //
+  // While we're at it, it would be very nice if this could be a const
+  // operation, but the AST-walking is not a const operation.
+
+  // A walker that looks for 'async' and 'await' expressions
+  // that aren't nested within closures or nested declarations.
+  class FindInnerAsync : public ASTWalker {
+    ASTNode AsyncNode;
+
+    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+      // If we've found an 'await', record it and terminate the traversal.
+      if (isa<AwaitExpr>(expr)) {
+        AsyncNode = expr;
+        return {false, nullptr};
+      }
+
+      // Do not recurse into other closures.
+      if (isa<ClosureExpr>(expr))
+        return {false, expr};
+
+      return {true, expr};
+    }
+
+    bool walkToDeclPre(Decl *decl) override {
+      // Do not walk into function or type declarations.
+      if (auto *patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+        if (patternBinding->isAsyncLet())
+          AsyncNode = patternBinding;
+
+        return true;
+      }
+
+      return false;
+    }
+
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
+      if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {
+        if (forEach->getAwaitLoc().isValid()) {
+          AsyncNode = forEach;
+          return {false, nullptr};
+        }
+      }
+
+      return {true, stmt};
+    }
+
+  public:
+    ASTNode getAsyncNode() { return AsyncNode; }
+  };
+
+  FindInnerAsync asyncFinder;
+  walk(asyncFinder);
+
+  return asyncFinder.getAsyncNode();
 }
 
 SourceLoc ReturnStmt::getStartLoc() const {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -271,8 +271,7 @@ GlobalActorAttributeRequest::evaluate(
   } else if (auto storage = dyn_cast<AbstractStorageDecl>(decl)) {
     // Subscripts and properties are fine...
     if (auto var = dyn_cast<VarDecl>(storage)) {
-      if (var->isTopLevelGlobal() &&
-          var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel) {
+      if (var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext()) {
         var->diagnose(diag::global_actor_top_level_var)
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
@@ -3510,10 +3509,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
-    ASTContext &ctx = var->getASTContext();
-    if (var->isTopLevelGlobal() &&
-        ctx.LangOpts.EnableExperimentalAsyncTopLevel) {
-      if (Type mainActor = ctx.getMainActorType())
+    if (var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext()) {
+      if (Type mainActor = var->getASTContext().getMainActorType())
         return inferredIsolation(
             ActorIsolation::forGlobalActor(mainActor,
                                            /*unsafe=*/var->preconcurrency()));

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1492,9 +1492,7 @@ public:
   static Context forTopLevelCode(TopLevelCodeDecl *D) {
     // Top-level code implicitly handles errors.
     return Context(/*handlesErrors=*/true,
-                   /*handlesAsync=*/
-                   D->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel,
-                   None);
+                   /*handlesAsync=*/D->isAsyncContext(), None);
   }
 
   static Context forFunction(AbstractFunctionDecl *D) {

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 5 %s -verify
+
+// enable-experimental-async-top-level is passed and an await is used in the
+// top-level, so the top-level code is a concurrent context. Variables are
+// declared with `@_predatesConcurrency @MainActor`, and the top-level is run on
+// the main actor.
+
+var a = 10 // expected-note {{mutation of this var is only permitted within the actor}}
+
+func nonIsolatedSync() {
+    // Okay because `a` is '@_predatesConcurrency'
+    print(a)
+    a = a + 10
+}
+
+@MainActor
+func isolatedSync() {
+    print(a)
+    a = a + 10
+}
+
+func nonIsolatedAsync() async {
+    await print(a)
+    a = a + 10
+    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
+    // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
+    // expected-note@-3:9 {{property access is 'async'}}
+}
+
+@MainActor
+func isolatedAsync() async {
+    print(a)
+    a = a + 10
+}
+
+nonIsolatedSync()
+isolatedSync()
+await nonIsolatedAsync()
+await isolatedAsync()
+
+print(a)
+
+if a > 10 {
+    nonIsolatedSync()
+    isolatedSync()
+    await nonIsolatedAsync()
+    await isolatedAsync()
+
+    print(a)
+}

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 6 %s -verify
+
+var a = 10
+// expected-note@-1 2 {{var declared here}}
+// expected-note@-2 2 {{mutation of this var is only permitted within the actor}}
+
+func nonIsolatedSync() { //expected-note 3 {{add '@MainActor' to make global function 'nonIsolatedSync()' part of global actor 'MainActor'}}
+    print(a)    // expected-error {{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    a = a + 10
+    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
+    // expected-error@-2:9 {{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+
+}
+
+@MainActor
+func isolatedSync() {
+    print(a)
+    a = a + 10
+}
+
+func nonIsolatedAsync() async {
+    await print(a)
+    a = a + 10
+    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
+    // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
+    // expected-note@-3:9 {{property access is 'async'}}
+}
+
+@MainActor
+func isolatedAsync() async {
+    print(a)
+    a = a + 10
+}
+
+nonIsolatedSync()
+isolatedSync()
+await nonIsolatedAsync()
+await isolatedAsync()
+
+print(a)
+
+if a > 10 {
+    nonIsolatedSync()
+    isolatedSync()
+    await nonIsolatedAsync()
+    await isolatedAsync()
+
+    print(a)
+}

--- a/test/Concurrency/toplevel/no-async-5-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-5-top-level.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 5 %s -verify
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -swift-version 5 %s -verify
+
+// Even though enable-experimental-async-top-level is enabled, there are no
+// `await`s made from the top-level, so it is not an async context. `a` is just
+// a normal top-level global variable with no actor isolation.
+
+var a = 10
+
+func nonIsolatedSync() {
+    print(a)
+    a = a + 10
+}
+
+@MainActor
+func isolatedSync() { // expected-note 2 {{calls to global function 'isolatedSync()' from outside of its actor context are implicitly asynchronous}}
+    print(a)
+    a = a + 10
+}
+
+func nonIsolatedAsync() async {
+    await print(a) // expected-warning {{no 'async' operations occur within 'await' expression}}
+    a = a + 10
+}
+
+@MainActor
+func isolatedAsync() async { // expected-note 2 {{calls to global function 'isolatedAsync()' from outside of its actor context are implicitly asynchronous}}
+    print(a)
+    a = a + 10
+}
+
+nonIsolatedSync()
+isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
+nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
+isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
+// expected-error@-1 {{'async' call in a function that does not support concurrency}}
+
+print(a)
+
+if a > 10 {
+    nonIsolatedSync()
+    isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
+    nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
+    isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
+    // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+
+    print(a)
+}

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 6 %s -verify
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -swift-version 6 %s -verify
+
+// Even though enable-experimental-async-top-level is enabled, there are no
+// 'await's made from the top-level, thus the top-level is not an asynchronous
+// context. `a` is just a normal top-level global variable with no actor
+// isolation.
+
+var a = 10 // expected-note 15 {{var declared here}}
+
+func nonIsolatedSync() {
+    print(a) // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+    a = a + 10 // expected-warning 2 {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+}
+
+@MainActor
+func isolatedSync() { // expected-note 2 {{calls to global function 'isolatedSync()' from outside of its actor context are implicitly asynchronous}}
+    print(a) // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+    a = a + 10 // expected-warning 2 {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+}
+
+func nonIsolatedAsync() async {
+    await print(a) // expected-warning {{no 'async' operations occur within 'await' expression}}
+    // expected-warning@-1 {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+    a = a + 10 // expected-warning 2 {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+}
+
+@MainActor
+func isolatedAsync() async { // expected-note 2 {{calls to global function 'isolatedAsync()' from outside of its actor context are implicitly asynchronous}}
+    print(a) // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+    a = a + 10 // expected-warning 2 {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+}
+
+nonIsolatedSync()
+isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
+nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
+isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
+// expected-error@-1 {{'async' call in a function that does not support concurrency}}
+
+print(a) // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+
+if a > 10 { // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+    nonIsolatedSync()
+    isolatedSync() // expected-error {{call to main actor-isolated global function 'isolatedSync()' in a synchronous nonisolated context}}
+    nonIsolatedAsync() // expected-error {{'async' call in a function that does not support concurrency}}
+    isolatedAsync() // expected-error {{call to main actor-isolated global function 'isolatedAsync()' in a synchronous nonisolated context}}
+    // expected-error@-1 {{'async' call in a function that does not support concurrency}}
+
+    print(a) // expected-warning {{reference to var 'a' is not concurrency-safe because it involves shared mutable state}}
+}

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefixes='CHECK,SYNC-CHECK'
-// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s --check-prefixes='CHECK,ASYNC-CHECK'
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle -enable-experimental-async-top-level %s | %FileCheck %s
 
 func markUsed<T>(_ t: T) {}
 
@@ -11,13 +11,7 @@ func trap() -> Never {
 // CHECK-LABEL: sil [ossa] @main
 // CHECK: bb0({{%.*}} : $Int32, {{%.*}} : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
 
-// async setup call to @async_Main (this is in @main)
-// ASYNC-CHECK: [[ASYNC_MAIN:%[0-9]+]] = function_ref @async_Main : $@convention(thin) @async () -> ()
-// ASYNC-CHECK: [[THUNK:%[0-9]+]] = function_ref @$sIetH_yts5Error_pIegHrzo_TR
-
-// Actual body of async top-level
-// ASYNC-CHECK-LABEL: sil hidden [ossa] @async_Main
-// ASYNC-CHECK: bb0:
+// CHECK-NOT: @async_Main
 
 
 // -- initialize x
@@ -127,11 +121,7 @@ defer {
 
 
 // CHECK: [[RET:%[0-9]+]] = struct $Int32
-// SYNC-CHECK: return [[RET]]
-
-// ASYNC-CHECK: [[EXITFUNC:%[0-9]+]] = function_ref @exit
-// ASYNC-CHECK: apply [[EXITFUNC]]([[RET]]) : $@convention(c) (Int32) -> Never
-// ASYNC-CHECK: unreachable
+// CHECK: return [[RET]]
 
 // CHECK-LABEL: sil hidden [ossa] @$s8toplevel7print_xyyF
 

--- a/test/SILGen/toplevel_errors.swift
+++ b/test/SILGen/toplevel_errors.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefixes='CHECK,SYNC-CHECK'
-// RUN: %target-swift-emit-silgen -enable-experimental-async-top-level %s | %FileCheck %s --check-prefixes='CHECK,ASYNC-CHECK'
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-async-top-level %s | %FileCheck %s
 
 enum MyError : Error {
   case A, B
@@ -18,10 +18,7 @@ throw MyError.A
 // CHECK: br bb2([[ERR2]] : $Error)
 
 // CHECK: bb1([[T0:%.*]] : $Int32):
-// SYNC-CHECK: return [[T0]] : $Int32
-// ASYNC-CHECK: [[EXITFUNC:%[0-9]+]] = function_ref @exit
-// ASYNC-CHECK: {{[0-9]+}} = apply [[EXITFUNC]]([[T0]])
-// ASYNC-CHECK: unreachable
+// CHECK: return [[T0]] : $Int32
 
 // CHECK: bb2([[T0:%.*]] : @owned $Error):
 // CHECK: builtin "errorInMain"([[T0]] : $Error)


### PR DESCRIPTION
This PR gets the semantics for detecting when to make top-level code a concurrent context. For compatibility reasons, we want scripts written in top-level code without concurrency today in Swift 5 to work exactly the same way when the async top-level lands. To ensure this, the top-level needs to detect when concurrency features are being used before behaving as an async context. The implementation of this is to detect when an `await` keyword has been used before switching the top-level code context to an asynchronous context. If there are no suspension points directly in the top-level, the context is not asynchronous.

The implications of making the top-level code an asynchronous context include overload resolution behavior and semantics around spinning up a runloop in the implicit `async_Main` function. These two changes to behavior could cause unintended script breakage. Thus, if there are no `await` calls made, the top-level will behave exactly as it did before.