### PR TITLE
Support file compilation dir

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -840,6 +840,10 @@ def coverage_prefix_map : Separate<["-"], "coverage-prefix-map">,
   Flags<[FrontendOption]>,
   HelpText<"Remap source paths in coverage info">, MetaVarName<"<prefix=replacement>">;
 
+def file_compilation_dir : Separate<["-"], "file-compilation-dir">,
+  Flags<[FrontendOption]>, MetaVarName<"<path>">,
+  HelpText<"The compilation directory to embed in the debug info. Coverage mapping is not supported yet.">;
+
 def debug_info_format : Joined<["-"], "debug-info-format=">,
   Flags<[FrontendOption]>,
   HelpText<"Specify the debug info format type to either 'dwarf' or 'codeview'">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -334,6 +334,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     auto OptArg = inputArgs.getLastArgNoClaim(options::OPT_O_Group);
     if (!OptArg || OptArg->getOption().matches(options::OPT_Onone))
       arguments.push_back("-enable-anonymous-context-mangled-names");
+
+    // TODO: Should we support -fcoverage-compilation-dir?
+    inputArgs.AddAllArgs(arguments, options::OPT_file_compilation_dir);
   }
 
   // Pass through any subsystem flags.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1797,10 +1797,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                                           RenderedArgs, SDKPath,
                                           ResourceDir);
     }
-    // TODO: Should we support -fdebug-compilation-dir?
-    llvm::SmallString<256> cwd;
-    llvm::sys::fs::current_path(cwd);
-    Opts.DebugCompilationDir = std::string(cwd.str());
+
+    if (const Arg *A = Args.getLastArg(OPT_file_compilation_dir))
+      Opts.DebugCompilationDir = A->getValue();
+    else {
+      llvm::SmallString<256> cwd;
+      llvm::sys::fs::current_path(cwd);
+      Opts.DebugCompilationDir = std::string(cwd.str());
+    }
   }
 
   if (const Arg *A = Args.getLastArg(options::OPT_debug_info_format)) {

--- a/test/DebugInfo/file_compilation_dir.swift
+++ b/test/DebugInfo/file_compilation_dir.swift
@@ -1,0 +1,20 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir /path/to \
+// RUN:   %s -o - -emit-ir | %FileCheck --check-prefix=CHECK-ABS %s
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
+// RUN: cd %t
+// RUN: cp %s .
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir /path/to \
+// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL %s
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir . \
+// RUN:   file_compilation_dir.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL-CWD %s
+
+func foo() {}
+
+// CHECK-ABS: !DIFile(filename: "{{.*}}/file_compilation_dir.swift", directory: "/path/to")
+// CHECK-REL: !DIFile(filename: "file_compilation_dir.swift", directory: "/path/to")
+// CHECK-REL-CWD: !DIFile(filename: "file_compilation_dir.swift", directory: ".")

--- a/test/DebugInfo/file_compilation_dir_windows.swift
+++ b/test/DebugInfo/file_compilation_dir_windows.swift
@@ -1,0 +1,20 @@
+// REQUIRES: OS=windows-msvc
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir Z:\path\to \
+// RUN:   %s -o - -emit-ir | %FileCheck --check-prefix=CHECK-ABS %s
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
+// RUN: cd %t
+// RUN: xcopy %s .
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir Z:\path\to \
+// RUN:   file_compilation_dir_windows.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL %s
+// RUN: %target-swiftc_driver -g \
+// RUN:   -c -file-compilation-dir . \
+// RUN:   file_compilation_dir_windows.swift -o - -emit-ir | %FileCheck --check-prefix=CHECK-REL-CWD %s
+
+func foo() {}
+
+// CHECK-ABS: !DIFile(filename: "{{[a-zA-Z]:\\\\.*\\\\}}file_compilation_dir_windows.swift", directory: "Z:\\path\\to")
+// CHECK-REL: !DIFile(filename: "file_compilation_dir_windows.swift", directory: "Z:\\path\\to")
+// CHECK-REL-CWD: !DIFile(filename: "file_compilation_dir_windows.swift", directory: ".")


### PR DESCRIPTION
The original [PR](https://github.com/apple/swift/pull/40735) is merged to main.
In short, this flag gives us identical debug info paths regardless of what location we compiled the file from.
It's a small but useful feature, and hope it can happen on Swift 5.6.

Resolves [SR-5694](https://bugs.swift.org/browse/SR-5694).

