### PR TITLE
[Test] Reenable test/Runtime/linux-fatal-backtrace.swift.

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
-// REQUIRES: rdar87867848
 // XFAIL: CPU=s390x
 
 // NOTE: not.py is used above instead of "not --crash" because %target-run


### PR DESCRIPTION
Just running this through PR testing to see how it fails. I'll add a proper fix here before trying to merge anything.