### PR TITLE
[ABI] Add predicate to identify sections containing reflection data

### DIFF
--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -68,7 +68,8 @@ public:
 
   bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
     return sectionName.startswith("__swift5_") ||
-           sectionName == "__DATA_CONST,__const";
+           sectionName == "__DATA_CONST,__const" ||
+           sectionName == "__DATA,__const";
   }
 };
 

--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -33,12 +33,12 @@ public:
   }
   /// Predicate to identify if the named section can contain reflection data.
   virtual bool sectionContainsReflectionData(llvm::StringRef sectionName) {
-    return getSectionName(fieldmd) == sectionName ||
-           getSectionName(assocty) == sectionName ||
-           getSectionName(builtin) == sectionName ||
-           getSectionName(capture) == sectionName ||
-           getSectionName(typeref) == sectionName ||
-           getSectionName(reflstr) == sectionName;
+    return sectionName == getSectionName(fieldmd) ||
+           sectionName == getSectionName(assocty) ||
+           sectionName == getSectionName(builtin) ||
+           sectionName == getSectionName(capture) ||
+           sectionName == getSectionName(typeref) ||
+           sectionName == getSectionName(reflstr);
   }
 };
 
@@ -67,6 +67,9 @@ public:
   }
 
   bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
+    // For Mach-O, the caller must call this function twice, once with just the
+    // section name (ex `__swift5_fieldmd`), and again with the segment
+    // qualified section name (ex `__DATA,__const`).
     return sectionName.startswith("__swift5_") ||
            sectionName == "__DATA_CONST,__const" ||
            sectionName == "__DATA,__const";

--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -31,10 +31,20 @@ public:
   virtual llvm::Optional<llvm::StringRef> getSegmentName() {
     return {};
   }
+  virtual bool sectionContainsReflectionData(llvm::StringRef sectionName) {
+    return getSectionName(fieldmd) == sectionName ||
+           getSectionName(assocty) == sectionName ||
+           getSectionName(builtin) == sectionName ||
+           getSectionName(capture) == sectionName ||
+           getSectionName(typeref) == sectionName ||
+           getSectionName(reflstr) == sectionName;
+  }
 };
 
 /// Responsible for providing the Mach-O reflection section identifiers.
 class SwiftObjectFileFormatMachO : public SwiftObjectFileFormat {
+  using super = SwiftObjectFileFormat;
+
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
@@ -55,6 +65,11 @@ public:
   }
   llvm::Optional<llvm::StringRef> getSegmentName() override {
     return {"__TEXT"};
+  }
+
+  bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
+    return super::sectionContainsReflectionData(sectionName) ||
+           sectionName == "__DATA_CONST,__const";
   }
 };
 

--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -32,14 +32,7 @@ public:
     return {};
   }
   /// Predicate to identify if the named section can contain reflection data.
-  virtual bool sectionContainsReflectionData(llvm::StringRef sectionName) {
-    return sectionName == getSectionName(fieldmd) ||
-           sectionName == getSectionName(assocty) ||
-           sectionName == getSectionName(builtin) ||
-           sectionName == getSectionName(capture) ||
-           sectionName == getSectionName(typeref) ||
-           sectionName == getSectionName(reflstr);
-  }
+  virtual bool sectionContainsReflectionData(llvm::StringRef sectionName) = 0;
 };
 
 /// Responsible for providing the Mach-O reflection section identifiers.
@@ -96,6 +89,10 @@ public:
     }
     llvm_unreachable("Section type not found.");
   }
+
+  bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
+    return sectionName.startswith("swift5_");
+  }
 };
 
 /// Responsible for providing the COFF reflection section identifiers
@@ -117,6 +114,10 @@ public:
       return ".sw5rfst";
     }
     llvm_unreachable("Section  not found.");
+  }
+
+  bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
+    return sectionName.startswith(".sw5");
   }
 };
 } // namespace swift

--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -31,6 +31,7 @@ public:
   virtual llvm::Optional<llvm::StringRef> getSegmentName() {
     return {};
   }
+  /// Predicate to identify if the named section can contain reflection data.
   virtual bool sectionContainsReflectionData(llvm::StringRef sectionName) {
     return getSectionName(fieldmd) == sectionName ||
            getSectionName(assocty) == sectionName ||
@@ -43,8 +44,6 @@ public:
 
 /// Responsible for providing the Mach-O reflection section identifiers.
 class SwiftObjectFileFormatMachO : public SwiftObjectFileFormat {
-  using super = SwiftObjectFileFormat;
-
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
@@ -68,7 +67,7 @@ public:
   }
 
   bool sectionContainsReflectionData(llvm::StringRef sectionName) override {
-    return super::sectionContainsReflectionData(sectionName) ||
+    return sectionName.startswith("__swift5_") ||
            sectionName == "__DATA_CONST,__const";
   }
 };


### PR DESCRIPTION
`ABI/ObjectFile.h` abstracts reflection section names across platforms (binary file formats). However, some non-root reflection data is stored in general purpose sections, for example on Darwin type metadata can be placed in `__DATA_CONST,__const`, such as data that has loader fixups (bindings or relocations).

This change introduces a new predicate function to check if a section name could contain reflection data. These are the swift specific reflections sections, as well as general purpose sections that vary by platform. This initial change adds `__DATA_CONST,__const` for Mach-O files.

This will be used by overrides of `MemoryReader::resolvePointer`, to know whether an address is from a reflection section or not. If the section doesn't contain reflection data, then `resolvePointer` should not return a symbol.