### PR TITLE
Fix incorrect scopes of variables declared in guard let statements (again)

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1386,8 +1386,13 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
 
     switch (elt.getKind()) {
     case StmtConditionElement::CK_PatternBinding: {
-      InitializationPtr initialization =
-        emitPatternBindingInitialization(elt.getPattern(), FalseDest);
+          // Begin a new binding scope, which is popped when the next innermost debug
+          // scope ends. The cleanup location loc isn't the perfect source location
+          // but it's close enough.
+          B.getSILGenFunction().enterDebugScope(loc,
+                                                      /*isBindingScope=*/true);
+        InitializationPtr initialization =
+          emitPatternBindingInitialization(elt.getPattern(), FalseDest);
 
       // Emit the initial value into the initialization.
       FullExpr Scope(Cleanups, CleanupLocation(elt.getInitializer()));

--- a/test/DebugInfo/guard-let-scope.swift
+++ b/test/DebugInfo/guard-let-scope.swift
@@ -4,9 +4,10 @@ func f(c: AnyObject?) {
   let x = c
   // CHECK: sil_scope [[S1:[0-9]+]] { {{.*}} parent @{{.*}}1f
   // CHECK: sil_scope [[S2:[0-9]+]] { {{.*}} parent [[S1]] }
-  // CHECK: sil_scope [[S3:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:17 parent [[S2]] }
+  // CHECK: sil_scope [[S3:[0-9]+]] { {{.*}} parent [[S2]] }
+  // CHECK: sil_scope [[S4:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:17 parent [[S3]] }
   // CHECK: debug_value %{{.*}} : $Optional<AnyObject>, let, name "x"{{.*}} scope [[S2]]
-  // CHECK: debug_value %{{.*}} : $AnyObject, let, name "x", {{.*}} scope [[S3]]
+  // CHECK: debug_value %{{.*}} : $AnyObject, let, name "x", {{.*}} scope [[S4]]
   guard let x = x else {
     fatalError(".")
   }

--- a/test/DebugInfo/guard-let-scope2.swift
+++ b/test/DebugInfo/guard-let-scope2.swift
@@ -1,0 +1,27 @@
+// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-debuginfo %s \
+// RUN:  | %FileCheck %s
+import Foundation
+
+func takeClosure2 (_ closure: @escaping () -> Bool) {  assert(closure()) }
+
+struct SomeObject {
+  var s = ""
+  var today = Date()
+}
+
+public func f(x: String?) throws {
+  var s : SomeObject? =  nil
+  takeClosure2 {
+    s = SomeObject()
+    return s != nil
+  }
+  // CHECK: sil_scope [[S1:[0-9]+]] { {{.*}} parent @{{.*}}1f
+  // CHECK: sil_scope [[S2:[0-9]+]] { {{.*}} parent [[S1]] }
+  // CHECK: sil_scope [[S3:[0-9]+]] { {{.*}} parent [[S2]] }
+  // CHECK: alloc_stack {{.*}} $SomeObject, let, name "s", {{.*}} scope [[S3]]
+  guard let s = s else {
+    assert(false)
+    return
+  }
+}

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -30,18 +30,18 @@ public class M {
 
 // CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 5
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 5
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 5
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 6
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 6
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 6
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 6
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 6
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 5
-// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 6
+// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 6
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 5
-// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 5
-// CHECK-NEXT:   throw %{{.*}} : $Error, loc {{.*}}:26:5, scope 5
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 6
+// CHECK-NEXT:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 6
+// CHECK-NEXT:   throw %{{.*}} : $Error, loc {{.*}}:26:5, scope 6
 // CHECK: end sil function '$s3del1MC4fromAcA12WithDelegate_p_tKcfc'


### PR DESCRIPTION
This leads to an assertion failure in IRGen. A `guard let foo = foo` statement
needs to introduce a new lexical scope so the newely introduced binding can be
distinguished from the one it shadows.

rdar://86579287
