### PR TITLE
Correctly detect the ability to use the Swift Concurrency runtime on Darwin platforms

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2011,9 +2011,7 @@ if os.path.exists(static_libswiftCore_path):
 
 # Determine whether the concurrency runtime is available.
 if 'concurrency' in config.available_features:
-    if 'use_os_stdlib' not in lit_config.params:
-        config.available_features.add('concurrency_runtime')
-    elif run_vendor == 'apple':
+    if run_vendor == 'apple':
         # OS version in which concurrency was introduced
         CONCURRENCY_OS_VERSION = {
             'macosx': '12',
@@ -2034,9 +2032,9 @@ if 'concurrency' in config.available_features:
 	}
         concurrency_back_deploy_version = CONCURRENCY_BACK_DEPLOY_VERSION.get(run_os, '')
 
-        if run_vers >= concurrency_os_version:
+        if sw_vers_vers >= concurrency_os_version:
             config.available_features.add('concurrency_runtime')
-        elif 'back_deploy_concurrency' in config.available_features and run_vers >= concurrency_back_deploy_version:
+        elif 'back_deploy_concurrency' in config.available_features and sw_vers_vers >= concurrency_back_deploy_version:
             config.available_features.add('concurrency_runtime')
     else:
         config.available_features.add('concurrency_runtime')


### PR DESCRIPTION
... we shouldn't run any of these runtime tests on platforms older than
macOS 10.15 / iOS 13. Fixes rdar://87742748.
