### PR TITLE
Add a new virtual function to MemoryReader: resolvePointerAsSymbol

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -134,10 +134,21 @@ public:
     // Default implementation returns the read value as is.
     return RemoteAbsolutePointer("", readValue);
   }
-  
+
+  /// Atempt to resolve the pointer to a symbol for the given remote address.
+  virtual llvm::Optional<RemoteAbsolutePointer>
+  resolvePointerAsSymbol(RemoteAddress address) {
+    return llvm::None;
+  }
+
   /// Attempt to read and resolve a pointer value at the given remote address.
   llvm::Optional<RemoteAbsolutePointer> readPointer(RemoteAddress address,
                                                     unsigned pointerSize) {
+    // Try to resolve the pointer as a symbol first, as reading memory
+    // may potentially be expensive.
+    if (auto symbolPointer = resolvePointerAsSymbol(address))
+      return symbolPointer;
+
     auto result = readBytes(address, pointerSize);
     if (!result)
       return llvm::None;


### PR DESCRIPTION
This new function allows subclasses to attempt to resolve a pointer to
a symbol before any memory is read, which can be potentially expensive
(for example, in LLDB).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
