### PR TITLE
Determine concurrency diagnostic behavior based on conformance context.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2905,7 +2905,7 @@ bool ConformanceChecker::checkActorIsolation(
   bool isCrossActor = false;
   bool witnessIsUnsafe = false;
   DiagnosticBehavior behavior = SendableCheckContext(
-      witness->getInnermostDeclContext()).defaultDiagnosticBehavior();
+      Conformance->getDeclContext()).defaultDiagnosticBehavior();
   Type witnessGlobalActor;
   switch (auto witnessRestriction =
               ActorIsolationRestriction::forDeclaration(

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -29,9 +29,15 @@ struct S3_P1: P1 {
   nonisolated func onMainActor() { }
 }
 
+struct S4_P1_quitely: P1 {
+  @SomeGlobalActor func onMainActor() { }
+}
+
+@SomeGlobalActor
 struct S4_P1: P1 {
   @SomeGlobalActor func onMainActor() { } // expected-warning{{instance method 'onMainActor()' isolated to global actor 'SomeGlobalActor' can not satisfy corresponding requirement from protocol 'P1' isolated to global actor 'MainActor'}}
 }
+
 
 @MainActor(unsafe)
 protocol P2 {

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -29,7 +29,7 @@ struct S3_P1: P1 {
   nonisolated func onMainActor() { }
 }
 
-struct S4_P1_quitely: P1 {
+struct S4_P1_quietly: P1 {
   @SomeGlobalActor func onMainActor() { }
 }
 

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
 actor SomeActor { }


### PR DESCRIPTION
**Explanation**: When determining whether to warn, error, or be silent about concurrency-related issues detected between a protocol requirement and its witness, decide based on the context of the conformance rather than based on the context of the witness.
**Scope**: Manifests as extraneous warnings in SwiftUI apps that introduce conformances to `UIViewRepresentable`.
**Radar/SR Issue**: rdar://88205585
**Risk**: Low.
**Testing**: PR testing and CI .
**Reviewed By**: John McCall
**Original PR**: https://github.com/apple/swift/pull/41076
