### PR TITLE
Attach Lazy ClangImporter Diagnostics as Notes to Sema Diagnostics

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1217,9 +1217,6 @@ public:
   InheritedProtocolConformance *
   getInheritedConformance(Type type, ProtocolConformance *inherited);
 
-  /// Check if \p decl is included in LazyContexts.
-  bool isLazyContext(const DeclContext *decl);
-
   /// Get the lazy data for the given declaration.
   ///
   /// \param lazyLoader If non-null, the lazy loader to use when creating the

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -182,8 +182,14 @@ public:
   /// Imports a clang decl directly, rather than looking up its name.
   virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
 
-  /// Emits any import diagnostics associated with the provided decl.
-  virtual void diagnoseDeclDirectly(const clang::NamedDecl *decl) = 0;
+  /// Emits diagnostics for any declarations named name
+  /// whose direct declaration context is a TU.
+  virtual void diagnoseTopLevelValue(const DeclName &name) = 0;
+
+  /// Emit diagnostics for declarations named name that are members
+  /// of the provided baseType.
+  virtual void diagnoseMemberValue(const DeclName &name,
+                                   const Type &baseType) = 0;
 
   /// Instantiate and import class template using given arguments.
   ///

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -107,9 +107,9 @@ NOTE(macro_not_imported_invalid_numeric_literal, none, "invalid numeric literal"
 NOTE(macro_not_imported_unsupported_literal, none, "only numeric and string macro literals supported", ())
 NOTE(macro_not_imported_nested_cast, none, "non-null nested casts not supported", ())
 
-ERROR(macro_not_imported_function_like, none, "macro '%0' not imported: function like macros not supported", (StringRef))
-ERROR(macro_not_imported_unsupported_structure, none, "macro '%0' not imported: structure not supported", (StringRef))
-ERROR(macro_not_imported, none, "macro '%0' not imported", (StringRef))
+NOTE(macro_not_imported_function_like, none, "macro '%0' not imported: function like macros not supported", (StringRef))
+NOTE(macro_not_imported_unsupported_structure, none, "macro '%0' not imported: structure not supported", (StringRef))
+NOTE(macro_not_imported, none, "macro '%0' not imported", (StringRef))
 
 NOTE(return_type_not_imported, none, "return type not imported", ())
 NOTE(parameter_type_not_imported, none, "parameter %0 not imported", (const clang::NamedDecl*))
@@ -117,10 +117,10 @@ NOTE(incomplete_interface, none, "interface %0 is incomplete", (const clang::Nam
 NOTE(incomplete_protocol, none, "protocol %0 is incomplete", (const clang::NamedDecl*))
 NOTE(unsupported_builtin_type, none, "built-in type '%0' not supported", (StringRef))
 
-WARNING(record_field_not_imported, none, "field %0 not imported", (const clang::NamedDecl*))
-WARNING(invoked_func_not_imported, none, "function %0 not imported", (const clang::NamedDecl*))
-WARNING(record_method_not_imported, none, "method %0 not imported", (const clang::NamedDecl*))
-WARNING(objc_property_not_imported, none, "property %0 not imported", (const clang::NamedDecl*))
+NOTE(record_field_not_imported, none, "field %0 not imported", (const clang::NamedDecl*))
+NOTE(invoked_func_not_imported, none, "function %0 not imported", (const clang::NamedDecl*))
+NOTE(record_method_not_imported, none, "method %0 not imported", (const clang::NamedDecl*))
+NOTE(objc_property_not_imported, none, "property %0 not imported", (const clang::NamedDecl*))
 
 NOTE(forward_declared_interface_label, none, "interface %0 forward declared here", (const clang::NamedDecl*))
 NOTE(forward_declared_protocol_label, none, "protocol %0 forward declared here", (const clang::NamedDecl*))

--- a/include/swift/AST/LazyResolver.h
+++ b/include/swift/AST/LazyResolver.h
@@ -85,9 +85,6 @@ public:
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) = 0;
 
-  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
-                                          DeclName name) = 0;
-
   /// Populates the given vector with all conformances for \p D.
   ///
   /// The implementation should \em not call setConformances on \p D.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -491,6 +491,9 @@ void lookupVisibleMemberDecls(VisibleDeclConsumer &Consumer,
 
 namespace namelookup {
 
+void extractDirectlyReferencedNominalTypes(
+    Type type, SmallVectorImpl<NominalTypeDecl *> &decls);
+
 /// Once name lookup has gathered a set of results, perform any necessary
 /// steps to prune the result set before returning it to the caller.
 void pruneLookupResultSet(const DeclContext *dc, NLOptions options,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -517,8 +517,13 @@ public:
   /// Imports a clang decl directly, rather than looking up it's name.
   Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
 
-  /// Emits any pending diagnostics associated with the provided decl.
-  void diagnoseDeclDirectly(const clang::NamedDecl *decl) override;
+  /// Emits diagnostics for any declarations named name
+  /// whose direct declaration context is a TU.
+  void diagnoseTopLevelValue(const DeclName &name) override;
+
+  /// Emit diagnostics for declarations named name that are members
+  /// of the provided baseType.
+  void diagnoseMemberValue(const DeclName &name, const Type &baseType) override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2503,10 +2503,6 @@ ASTContext::getInheritedConformance(Type type, ProtocolConformance *inherited) {
   return result;
 }
 
-bool ASTContext::isLazyContext(const DeclContext *dc) {
-  return getImpl().LazyContexts.count(dc) != 0;
-}
-
 LazyContextData *ASTContext::getOrCreateLazyContextData(
                                                 const DeclContext *dc,
                                                 LazyMemberLoader *lazyLoader) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -404,11 +404,6 @@ public:
   std::unordered_set<ImportDiagnostic, ImportDiagnosticHasher>
       CollectedDiagnostics;
 
-  // ClangNodes for which all import diagnostics have been both collected and
-  // emitted.
-  std::unordered_set<ImportDiagnosticTarget, ImportDiagnosticTargetHasher>
-      DiagnosedValues;
-
   const bool ImportForwardDeclarations;
   const bool DisableSwiftBridgeAttr;
   const bool BridgingHeaderExplicitlyRequested;
@@ -1455,9 +1450,6 @@ public:
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;
 
-  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
-                                          DeclName name) override;
-
 private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
@@ -1600,8 +1592,14 @@ public:
   void lookupAllObjCMembers(SwiftLookupTable &table,
                             VisibleDeclConsumer &consumer);
 
-  /// Emit any import diagnostics associated with the given name.
-  void diagnoseValue(SwiftLookupTable &table, DeclName name);
+  /// Emits diagnostics for any declarations named name
+  /// whose direct declaration context is a TU.
+  void diagnoseTopLevelValue(const DeclName &name);
+
+  /// Emit diagnostics for declarations named name that are members
+  /// of the provided container.
+  void diagnoseMemberValue(const DeclName &name,
+                           const clang::DeclContext *container);
 
   /// Emit any import diagnostics associated with the given Clang node.
   void diagnoseTargetDirectly(ImportDiagnosticTarget target);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3626,6 +3626,11 @@ bool MissingMemberFailure::diagnoseAsError() {
     emitDiagnostic(diagnostic, baseType, getName())
         .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
+    const auto &ctx = getSolution().getDC()->getASTContext();
+    if (ctx.LangOpts.EnableExperimentalClangImporterDiagnostics) {
+      ctx.getClangModuleLoader()->diagnoseMemberValue(getName().getFullName(),
+                                                      baseType);
+    }
   };
 
   TypoCorrectionResults corrections(getName(), nameLoc);

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -590,6 +590,10 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
           .diagnose(Loc, diag::cannot_find_in_scope, Name,
                     Name.isOperator())
           .highlight(UDRE->getSourceRange());
+      if (Context.LangOpts.EnableExperimentalClangImporterDiagnostics) {
+        Context.getClangModuleLoader()->diagnoseTopLevelValue(
+            Name.getFullName());
+      }
     };
 
     if (!isConfused) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6402,13 +6402,6 @@ void ModuleFile::loadAllMembers(Decl *container, uint64_t contextData) {
   }
 }
 
-void ModuleFile::diagnoseMissingNamedMember(const IterableDeclContext *IDC,
-                                            DeclName name) {
-  // TODO: Implement diagnostics for failed member lookups from module files.
-  llvm_unreachable(
-      "Missing member diangosis is not implemented for module files.");
-}
-
 static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
     // Missing module errors are most likely caused by an
     // implementation-only import hiding types and decls.

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -699,9 +699,6 @@ public:
   virtual void loadAllMembers(Decl *D,
                               uint64_t contextData) override;
 
-  virtual void diagnoseMissingNamedMember(const IterableDeclContext *IDC,
-                                          DeclName name) override;
-
   virtual TinyPtrVector<ValueDecl *>
   loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
                    uint64_t contextData) override;

--- a/test/ClangImporter/Inputs/custom-modules/CommonName.h
+++ b/test/ClangImporter/Inputs/custom-modules/CommonName.h
@@ -1,0 +1,5 @@
+struct MyStruct {
+  int _Complex commonName;
+};
+
+_Complex int commonName();

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -266,3 +266,8 @@ module LocalVsFileScope {
   header "LocalVsFileScope.h"
   export *
 }
+
+module CommonName {
+  header "CommonName.h"
+  export *
+}

--- a/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
+++ b/test/ClangImporter/experimental_clang_importer_diagnostics_bridging_header.swift
@@ -2,18 +2,21 @@
 
 let s: PartialImport
 s.c = 5
-// CHECK:      experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: s.c = 5
+// CHECK-NEXT: ~ ^
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:3: note: field 'c' not imported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
 // CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
-// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
-// CHECK-NEXT: s.c = 5
-// CHECK-NEXT: ~ ^
 
 _ = CFunctionReturningAForwardDeclaredInterface()
-// CHECK: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: function 'CFunctionReturningAForwardDeclaredInterface' not imported
 // CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
 // CHECK-NEXT: ^
 // CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: return type not imported
@@ -25,20 +28,20 @@ _ = CFunctionReturningAForwardDeclaredInterface()
 // CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
-// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 _ = FUNC_LIKE_MACRO()
-// CHECK:      experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
-// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
 // CHECK-NEXT: _ = FUNC_LIKE_MACRO()
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:9: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
+// CHECK-NEXT: {{^}}        ^
 
 unsupported_return_type()
-// CHECK: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK:      experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'unsupported_return_type' in scope
+// CHECK-NEXT: unsupported_return_type()
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: function 'unsupported_return_type' not imported
 // CHECK-NEXT:      _Complex int unsupported_return_type();
 // CHECK-NEXT: {{^}}^
 // CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: return type not imported
@@ -47,6 +50,3 @@ unsupported_return_type()
 // CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
 // CHECK-NEXT:      _Complex int unsupported_return_type();
 // CHECK-NEXT: {{^}}^
-// CHECK-NEXT: experimental_clang_importer_diagnostics_bridging_header.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'unsupported_return_type' in scope
-// CHECK-NEXT: unsupported_return_type()
-// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_cfuncs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cfuncs.swift
@@ -3,7 +3,10 @@
 import cfuncs
 
 unsupported_parameter_type(1,2)
-// CHECK:      cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_parameter_type' not imported
+// CHECK:      experimental_diagnostics_cfuncs.swift:5:1: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK-NEXT: unsupported_parameter_type(1,2)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_parameter_type' not imported
 // CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
 // CHECK-NEXT: {{^}}^
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: parameter 'param2' not imported
@@ -12,12 +15,12 @@ unsupported_parameter_type(1,2)
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: built-in type 'Complex' not supported
 // CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
 // CHECK-NEXT: {{^}}                                           ^
-// CHECK-NEXT: experimental_diagnostics_cfuncs.swift:5:1: error: cannot find 'unsupported_parameter_type' in scope
-// CHECK-NEXT: unsupported_parameter_type(1,2)
-// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
 
 unsupported_return_type()
-// CHECK: cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK:      experimental_diagnostics_cfuncs.swift:19:1: error: cannot find 'unsupported_return_type' in scope
+// CHECK-NEXT: unsupported_return_type()
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_return_type' not imported
 // CHECK-NEXT:      _Complex int unsupported_return_type();
 // CHECK-NEXT: {{^}}^
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: return type not imported
@@ -26,15 +29,31 @@ unsupported_return_type()
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
 // CHECK-NEXT:      _Complex int unsupported_return_type();
 // CHECK-NEXT: {{^}}^
-// CHECK-NEXT: experimental_diagnostics_cfuncs.swift:19:1: error: cannot find 'unsupported_return_type' in scope
-// CHECK-NEXT: unsupported_return_type()
-// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~
 
 unsupported_parameter_type(1,2)
-// CHECK: experimental_diagnostics_cfuncs.swift:33:1: error: cannot find 'unsupported_parameter_type' in scope
+// CHECK:      experimental_diagnostics_cfuncs.swift:33:1: error: cannot find 'unsupported_parameter_type' in scope
 // CHECK-NEXT: unsupported_parameter_type(1,2)
 // CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_parameter_type' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: parameter 'param2' not imported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
+// CHECK-NEXT: {{^}}                                           ^
+
 unsupported_return_type()
-// CHECK: experimental_diagnostics_cfuncs.swift:37:1: error: cannot find 'unsupported_return_type' in scope
+// CHECK:      experimental_diagnostics_cfuncs.swift:47:1: error: cannot find 'unsupported_return_type' in scope
 // CHECK-NEXT: unsupported_return_type()
 // CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_return_type' not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      _Complex int unsupported_return_type();
+// CHECK-NEXT: {{^}}^

--- a/test/ClangImporter/experimental_diagnostics_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_cmacros.swift
@@ -3,146 +3,141 @@
 import macros
 
 _ = INVALID_INTEGER_LITERAL_2
-// CHECK:      macros.h:{{[0-9]+}}:{{[0-9]+}}: error: invalid digit 'a' in decimal constant
-// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
-// CHECK-NEXT: {{^}}                                    ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_INTEGER_LITERAL_2' in scope
+// CHECK-NEXT: _ = INVALID_INTEGER_LITERAL_2
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_INTEGER_LITERAL_2' not imported
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}                                  ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_INTEGER_LITERAL_2' in scope
-// CHECK-NEXT: _ = INVALID_INTEGER_LITERAL_2
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~
-
 
 
 _ = FUNC_LIKE_MACRO()
-_ = FUNC_LIKE_MACRO()
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+// CHECK-NEXT: _ = FUNC_LIKE_MACRO()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
 // CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
 // CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
+_ = FUNC_LIKE_MACRO()
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
 // CHECK-NEXT: _ = FUNC_LIKE_MACRO()
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'FUNC_LIKE_MACRO' in scope
-// CHECK-NEXT: _ = FUNC_LIKE_MACRO()
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
-
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
+// CHECK-NEXT: {{^}}        ^
 
 
 _ = INVALID_ARITHMETIC_1
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_1' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_1' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_1
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_2
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_2' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_2' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_2
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_3
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_3' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_3' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_3
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_4
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_4' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_4' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_4
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_5
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_5' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_5' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_5
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_6
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_6' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_6' in scope
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_6
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
+// CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_7
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_7' in scope
+// CHECK-NEXT: _ = INVALID_ARITHMETIC_7
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_7' not imported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
 // CHECK-NEXT: {{^}}                               ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'INVALID_ARITHMETIC_7' in scope
-// CHECK-NEXT: _ = INVALID_ARITHMETIC_7
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
-
 
 
 _ = CHAR_LITERAL
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'CHAR_LITERAL' not imported
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CHAR_LITERAL' in scope
+// CHECK-NEXT: _ = CHAR_LITERAL
+// CHECK-NEXT:     ^~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'CHAR_LITERAL' not imported
 // CHECK-NEXT:      #define CHAR_LITERAL 'a'
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
 // CHECK-NEXT:      #define CHAR_LITERAL 'a'
 // CHECK-NEXT: {{^}}                     ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CHAR_LITERAL' in scope
-// CHECK-NEXT: _ = CHAR_LITERAL
-// CHECK-NEXT:     ^~~~~~~~~~~~
-
 
 
 UNSUPPORTED_1
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_1' not imported: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_1' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_1' in scope
 // CHECK-NEXT: UNSUPPORTED_1
 // CHECK-NEXT: ^~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
+// CHECK-NEXT: {{^}}        ^
 
 UNSUPPORTED_2
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_2' not imported: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_2' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_2' in scope
 // CHECK-NEXT: UNSUPPORTED_2
 // CHECK-NEXT: ^~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
 
 UNSUPPORTED_3
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_3' not imported: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_3' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_3' in scope
 // CHECK-NEXT: UNSUPPORTED_3
 // CHECK-NEXT: ^~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
+// CHECK-NEXT: {{^}}        ^
 
 UNSUPPORTED_4
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_4' not imported: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_4' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_4' in scope
 // CHECK-NEXT: UNSUPPORTED_4
 // CHECK-NEXT: ^~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
+// CHECK-NEXT: {{^}}        ^
 
 UNSUPPORTED_5
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_5' not imported: structure not supported
-// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
-// CHECK-NEXT: {{^}}        ^
-// CHECK-NEXT: experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_5' in scope
+// CHECK:      experimental_diagnostics_cmacros.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'UNSUPPORTED_5' in scope
 // CHECK-NEXT: UNSUPPORTED_5
 // CHECK-NEXT: ^~~~~~~~~~~~~
+// CHECK-NEXT: macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_5' not imported: structure not supported
+// CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
+// CHECK-NEXT: {{^}}        ^

--- a/test/ClangImporter/experimental_diagnostics_cstructs.swift
+++ b/test/ClangImporter/experimental_diagnostics_cstructs.swift
@@ -4,31 +4,37 @@ import ctypes
 
 let s: PartialImport
 s.c = 5
-// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK:      experimental_diagnostics_cstructs.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
+// CHECK-NEXT: s.c = 5
+// CHECK-NEXT: ~ ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: field 'c' not imported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
 // CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
-// CHECK-NEXT: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:3: error: value of type 'PartialImport' has no member 'c'
-// CHECK-NEXT: s.c = 5
-// CHECK-NEXT: ~ ^
 
 partialImport.c = 5
-// CHECK: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:15: error: value of type 'PartialImport' has no member 'c'
+// CHECK:      experimental_diagnostics_cstructs.swift:{{[0-9]+}}:15: error: value of type 'PartialImport' has no member 'c'
 // CHECK-NEXT: partialImport.c = 5
 // CHECK-NEXT: ~~~~~~~~~~~~~ ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: field 'c' not imported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex c;
+// CHECK-NEXT:   ^
 
 var newPartialImport = PartialImport()
 newPartialImport.a = 5
 newPartialImport.b = 5
 newPartialImport.d = 5
-// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'd' not imported
+// CHECK:      experimental_diagnostics_cstructs.swift:{{[0-9]+}}:18: error: value of type 'PartialImport' has no member 'd'
+// CHECK-NEXT: newPartialImport.d = 5
+// CHECK-NEXT: ~~~~~~~~~~~~~~~~ ^
+// CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: field 'd' not imported
 // CHECK-NEXT:   int _Complex d;
 // CHECK-NEXT:   ^
 // CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
 // CHECK-NEXT:   int _Complex d;
 // CHECK-NEXT:   ^
-// CHECK: experimental_diagnostics_cstructs.swift:{{[0-9]+}}:18: error: value of type 'PartialImport' has no member 'd'
-// CHECK-NEXT: newPartialImport.d = 5
-// CHECK-NEXT: ~~~~~~~~~~~~~~~~ ^

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types.swift
@@ -6,41 +6,44 @@ import IncompleteTypes
 
 let bar = Bar()
 _ = bar.methodReturningForwardDeclaredInterface()
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredInterface' not imported
-// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
-// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
-// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
-// CHECK-NEXT: @class ForwardDeclaredInterface;
-// CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredInterface'
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredInterface'
 // CHECK-NEXT: _ = bar.methodReturningForwardDeclaredInterface()
 // CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodReturningForwardDeclaredInterface' not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
 
 _ = bar.methodTakingAForwardDeclaredInterfaceAsAParameter(nil, andAnother: nil)
-// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
-// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
-// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
-// CHECK-NEXT:                                                           ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
-// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
-// CHECK-NEXT:                                                           ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
-// CHECK-NEXT: @class ForwardDeclaredInterface;
-// CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredInterfaceAsAParameter'
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredInterfaceAsAParameter'
 // CHECK-NEXT: _ = bar.methodTakingAForwardDeclaredInterfaceAsAParameter(nil, andAnother: nil)
 // CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: interface 'ForwardDeclaredInterface' is incomplete
+// CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
+// CHECK-NEXT:                                                           ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
+// CHECK-NEXT: @class ForwardDeclaredInterface;
+// CHECK-NEXT: ^
 
 bar.propertyUsingAForwardDeclaredInterface = nil
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredInterface' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredInterface'
+// CHECK-NEXT: bar.propertyUsingAForwardDeclaredInterface = nil
+// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: property 'propertyUsingAForwardDeclaredInterface' not imported
 // CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
@@ -49,12 +52,12 @@ bar.propertyUsingAForwardDeclaredInterface = nil
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredInterface'
-// CHECK-NEXT: bar.propertyUsingAForwardDeclaredInterface = nil
-// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 _ = CFunctionReturningAForwardDeclaredInterface()
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionReturningAForwardDeclaredInterface' not imported
 // CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -66,12 +69,12 @@ _ = CFunctionReturningAForwardDeclaredInterface()
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredInterface' in scope
-// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredInterface()
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' in scope
+// CHECK-NEXT: CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
 // CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
@@ -83,29 +86,29 @@ CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' forward declared here
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' in scope
-// CHECK-NEXT: CFunctionTakingAForwardDeclaredInterfaceAsAParameter(nil)
-// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 _ = bar.methodReturningForwardDeclaredProtocol()
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredProtocol' not imported
-// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
-// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
-// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
-// CHECK-NEXT: ^
-// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
-// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
-// CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredProtocol'
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodReturningForwardDeclaredProtocol'
 // CHECK-NEXT: _ = bar.methodReturningForwardDeclaredProtocol()
 // CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodReturningForwardDeclaredProtocol' not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
+// CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
+// CHECK-NEXT: ^
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
+// CHECK-NEXT: @protocol ForwardDeclaredProtocol;
+// CHECK-NEXT: ^
 
 _ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
-// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredProtocolAsAParameter'
+// CHECK-NEXT: _ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
 // CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
@@ -117,12 +120,12 @@ _ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:9: error: value of type 'Bar' has no member 'methodTakingAForwardDeclaredProtocolAsAParameter'
-// CHECK-NEXT: _ = bar.methodTakingAForwardDeclaredProtocolAsAParameter(nil)
-// CHECK-NEXT:     ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 bar.propertyUsingAForwardDeclaredProtocol = nil
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredProtocol' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredProtocol'
+// CHECK-NEXT: bar.propertyUsingAForwardDeclaredProtocol = nil
+// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: property 'propertyUsingAForwardDeclaredProtocol' not imported
 // CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
@@ -131,12 +134,12 @@ bar.propertyUsingAForwardDeclaredProtocol = nil
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: value of type 'Bar' has no member 'propertyUsingAForwardDeclaredProtocol'
-// CHECK-NEXT: bar.propertyUsingAForwardDeclaredProtocol = nil
-// CHECK-NEXT: ~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 _ = CFunctionReturningAForwardDeclaredProtocol()
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
+// CHECK:      experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredProtocol' in scope
+// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredProtocol()
+// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
 // CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -148,12 +151,12 @@ _ = CFunctionReturningAForwardDeclaredProtocol()
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:5: error: cannot find 'CFunctionReturningAForwardDeclaredProtocol' in scope
-// CHECK-NEXT: _ = CFunctionReturningAForwardDeclaredProtocol()
-// CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
+// CHECK: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' in scope
+// CHECK-NEXT: CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
+// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
 // CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
@@ -165,6 +168,3 @@ CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' forward declared here
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
-// CHECK-NEXT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:1: error: cannot find 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' in scope
-// CHECK-NEXT: CFunctionTakingAForwardDeclaredProtocolAsAParameter(nil)
-// CHECK-NEXT: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
+++ b/test/ClangImporter/experimental_diagnostics_incomplete_types_negative.swift
@@ -6,69 +6,69 @@ import IncompleteTypes
 
 let foo = Foo()
 _ = foo.methodReturningCompleteInterface()
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodReturningCompleteInterface' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteInterface'
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: method 'methodReturningCompleteInterface' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteInterface'
 
 _ = foo.methodTakingACompleteInterfaceAsAParameter(nil, andAnother: nil)
-// CHECK-NOT:     IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodTakingACompleteInterfaceAsAParameter:andAnother:' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteInterfaceAsAParameter'
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: method 'methodTakingACompleteInterfaceAsAParameter:andAnother:' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteInterfaceAsAParameter'
 
 foo.propertyUsingACompleteInterface = nil
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: note: value of type 'Foo' has no member 'propertyUsingACompleteInterface'
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: property 'propertyUsingACompleteInterface' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'propertyUsingACompleteInterface'
 
 _ = CFunctionReturningACompleteInterface()
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionReturningACompleteInterface' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteInterface' in scope
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'CFunctionReturningACompleteInterface' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteInterface' in scope
 
 CFunctionTakingACompleteInterfaceAsAParameter(nil)
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionTakingACompleteInterfaceAsAParameter' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteInterfaceAsAParameter' in scope
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'CFunctionTakingACompleteInterfaceAsAParameter' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: interface 'CompleteInterface' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteInterfaceAsAParameter' in scope
 
 _ = foo.methodReturningCompleteProtocol()
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodReturningCompleteProtocol' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteProtocol'
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: method 'methodReturningCompleteProtocol' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodReturningCompleteProtocol'
 
 _ = foo.methodTakingACompleteProtocolAsAParameter(nil)
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: method 'methodTakingACompleteProtocolAsAParameter:' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteProtocolAsAParameter'
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: method 'methodTakingACompleteProtocolAsAParameter:' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'methodTakingACompleteProtocolAsAParameter'
 
 foo.propertyUsingACompleteProtocol = nil
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: note: value of type 'Foo' has no member 'propertyUsingACompleteProtocol'
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: property 'propertyUsingACompleteProtocol' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: value of type 'Foo' has no member 'propertyUsingACompleteProtocol'
 
 _ = CFunctionReturningACompleteProtocol()
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionReturningACompleteProtocol' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteProtocol' in scope
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'CFunctionReturningACompleteProtocol' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: return type not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionReturningACompleteProtocol' in scope
 
 CFunctionTakingACompleteProtocolAsAParameter(nil)
-// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: warning: function 'CFunctionTakingACompleteProtocolAsAParameter' not imported
+// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteProtocolAsAParameter' in scope
+// CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: function 'CFunctionTakingACompleteProtocolAsAParameter' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: parameter 'param1' not imported
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' is incomplete
 // CHECK-NOT: IncompleteTypes.h:{{[0-9]+}}:{{[0-9]+}}: note: protocol 'CompleteProtocol' forward declared here
-// CHECK-NOT: experimental_diagnostics_incomplete_types.swift:{{[0-9]+}}:{{[0-9]+}}: error: cannot find 'CFunctionTakingACompleteProtocolAsAParameter' in scope

--- a/test/ClangImporter/experimental_diagnostics_lookup_accuracy.swift
+++ b/test/ClangImporter/experimental_diagnostics_lookup_accuracy.swift
@@ -1,0 +1,35 @@
+// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -enable-experimental-clang-importer-diagnostics -typecheck %s 2>&1 | %FileCheck %s --strict-whitespace 
+
+// This test tests that requests for diagnosis, performed by name,
+// resolve to the correct Clang declarations, even when the same name is used
+// in multiple contexts.
+
+import CommonName
+
+// Free C function
+commonName()
+// CHECK:      experimental_diagnostics_lookup_accuracy.swift:10:1: error: cannot find 'commonName' in scope
+// CHECK-NEXT: commonName()
+// CHECK-NEXT: ^~~~~~~~~~
+// CHECK-NEXT: CommonName.h:5:1: note: function 'commonName' not imported
+// CHECK-NEXT:      _Complex int commonName();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: CommonName.h:5:1: note: return type not imported
+// CHECK-NEXT:      _Complex int commonName();
+// CHECK-NEXT: {{^}}^
+// CHECK-NEXT: CommonName.h:5:1: note: built-in type 'Complex' not supported
+// CHECK-NEXT:      _Complex int commonName();
+// CHECK-NEXT: {{^}}^
+
+// C struct field
+let s: MyStruct
+s.commonName = 5
+// CHECK:      experimental_diagnostics_lookup_accuracy.swift:26:3: error: value of type 'MyStruct' has no member 'commonName'
+// CHECK-NEXT: s.commonName = 5
+// CHECK-NEXT: ~ ^
+// CHECK-NEXT: CommonName.h:2:3: note: field 'commonName' not imported
+// CHECK-NEXT:   int _Complex commonName;
+// CHECK-NEXT:   ^
+// CHECK-NEXT: CommonName.h:2:3: note: built-in type 'Complex' not supported
+// CHECK-NEXT:   int _Complex commonName;
+// CHECK-NEXT:   ^

--- a/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_unreferenced_cmacros.swift
@@ -5,28 +5,28 @@ import macros
 _ = INVALID_INTEGER_LITERAL_2
 
 // Test that experimental diagnostics for the function like macro in the same header is suppressed.
-// CHECK: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
 // CHECK-NOT: #define FUNC_LIKE_MACRO() 0
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_1' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_1' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_2' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_2' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_3' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_3' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_4' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_4' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_5' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_5' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_6' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_6' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: invalid arithmetic operand; only valid integers supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'INVALID_ARITHMETIC_7' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: operator '%' not supported in macro arithmetic
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'CHAR_LITERAL' not imported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'CHAR_LITERAL' not imported
 // CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: only numeric and string macro literals supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_1' not imported: structure not supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_2' not imported: structure not supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_3' not imported: structure not supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_4' not imported: structure not supported
-// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: error: macro 'UNSUPPORTED_5' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK-NOT: macros.h:{{[0-9]+}}:{{[0-9]+}}: note: macro 'UNSUPPORTED_5' not imported: structure not supported

--- a/test/ClangImporter/experimental_eager_diagnostics.swift
+++ b/test/ClangImporter/experimental_eager_diagnostics.swift
@@ -9,7 +9,7 @@ import macros
 
 // C Functions
 
-// CHECK:      cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_parameter_type' not imported
+// CHECK:      cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_parameter_type' not imported
 // CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
 // CHECK-NEXT: {{^}}^
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:44: note: parameter 'param2' not imported
@@ -19,7 +19,7 @@ import macros
 // CHECK-NEXT:      int unsupported_parameter_type(int param1, _Complex int param2);
 // CHECK-NEXT: {{^}}                                           ^
 
-// CHECK: cfuncs.h:{{[0-9]+}}:1: warning: function 'unsupported_return_type' not imported
+// CHECK: cfuncs.h:{{[0-9]+}}:1: note: function 'unsupported_return_type' not imported
 // CHECK-NEXT:      _Complex int unsupported_return_type();
 // CHECK-NEXT: {{^}}^
 // CHECK-NEXT: cfuncs.h:{{[0-9]+}}:1: note: return type not imported
@@ -31,14 +31,14 @@ import macros
 
 // C structs
 
-// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'c' not imported
+// CHECK:      ctypes.h:{{[0-9]+}}:3: note: field 'c' not imported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
 // CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
 // CHECK-NEXT:   int _Complex c;
 // CHECK-NEXT:   ^
 
-// CHECK:      ctypes.h:{{[0-9]+}}:3: warning: field 'd' not imported
+// CHECK:      ctypes.h:{{[0-9]+}}:3: note: field 'd' not imported
 // CHECK-NEXT:   int _Complex d;
 // CHECK-NEXT:   ^
 // CHECK-NEXT: ctypes.h:{{[0-9]+}}:3: note: built-in type 'Complex' not supported
@@ -47,7 +47,7 @@ import macros
 
 // Incomplete types
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredProtocol' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: property 'propertyUsingAForwardDeclaredProtocol' not imported
 // CHECK-NEXT: @property id<ForwardDeclaredProtocol> propertyUsingAForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: protocol 'ForwardDeclaredProtocol' is incomplete
@@ -57,7 +57,7 @@ import macros
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: property 'propertyUsingAForwardDeclaredInterface' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: property 'propertyUsingAForwardDeclaredInterface' not imported
 // CHECK-NEXT: @property ForwardDeclaredInterface* propertyUsingAForwardDeclaredInterface;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: interface 'ForwardDeclaredInterface' is incomplete
@@ -67,7 +67,7 @@ import macros
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredProtocol' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodReturningForwardDeclaredProtocol' not imported
 // CHECK-NEXT: - (NSObject<ForwardDeclaredProtocol> *) methodReturningForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -80,7 +80,7 @@ import macros
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodReturningForwardDeclaredInterface' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodReturningForwardDeclaredInterface' not imported
 // CHECK-NEXT: - (ForwardDeclaredInterface *) methodReturningForwardDeclaredInterface;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -93,7 +93,7 @@ import macros
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
 
-// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodTakingAForwardDeclaredProtocolAsAParameter:' not imported
 // CHECK-NEXT: - (int)methodTakingAForwardDeclaredProtocolAsAParameter:(id<ForwardDeclaredProtocol>)param1;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
@@ -106,7 +106,7 @@ import macros
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 
-// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: warning: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
+// CHECK:     IncompleteTypes.h:{{[0-9]+}}:1: note: method 'methodTakingAForwardDeclaredInterfaceAsAParameter:andAnother:' not imported
 // CHECK-NEXT: - (int)methodTakingAForwardDeclaredInterfaceAsAParameter:(ForwardDeclaredInterface *)param1 andAnother:(ForwardDeclaredInterface *)param2;
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
@@ -119,7 +119,7 @@ import macros
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredInterface' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionReturningAForwardDeclaredInterface' not imported
 // CHECK-NEXT: ForwardDeclaredInterface* CFunctionReturningAForwardDeclaredInterface();
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -132,7 +132,7 @@ import macros
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionReturningAForwardDeclaredProtocol' not imported
 // CHECK-NEXT: NSObject<ForwardDeclaredProtocol> *CFunctionReturningAForwardDeclaredProtocol();
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:1: note: return type not imported
@@ -145,7 +145,7 @@ import macros
 // CHECK-NEXT: @protocol ForwardDeclaredProtocol;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionTakingAForwardDeclaredInterfaceAsAParameter' not imported
 // CHECK-NEXT: void CFunctionTakingAForwardDeclaredInterfaceAsAParameter(ForwardDeclaredInterface* param1);
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:59: note: parameter 'param1' not imported
@@ -158,7 +158,7 @@ import macros
 // CHECK-NEXT: @class ForwardDeclaredInterface;
 // CHECK-NEXT: ^
 
-// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: warning: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
+// CHECK: IncompleteTypes.h:{{[0-9]+}}:1: note: function 'CFunctionTakingAForwardDeclaredProtocolAsAParameter' not imported
 // CHECK-NEXT: void CFunctionTakingAForwardDeclaredProtocolAsAParameter(id<ForwardDeclaredProtocol> param1);
 // CHECK-NEXT: ^
 // CHECK-NEXT: IncompleteTypes.h:{{[0-9]+}}:58: note: parameter 'param1' not imported
@@ -173,52 +173,49 @@ import macros
 
 // Macros
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'CHAR_LITERAL' not imported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'CHAR_LITERAL' not imported
 // CHECK-NEXT:      #define CHAR_LITERAL 'a'
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:22: note: only numeric and string macro literals supported
 // CHECK-NEXT:      #define CHAR_LITERAL 'a'
 // CHECK-NEXT: {{^}}                     ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'FUNC_LIKE_MACRO' not imported: function like macros not supported
 // CHECK-NEXT:      #define FUNC_LIKE_MACRO() 0
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_3' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_4' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_4                                                   \
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_5' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_5 1 + VERSION_STRING
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_6' not imported: structure not supported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_6 1 + 'c'
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'INVALID_ARITHMETIC_7' not imported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_7' not imported
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:32: note: operator '%' not supported in macro arithmetic
 // CHECK-NEXT:      #define INVALID_ARITHMETIC_7 3 % 2
 // CHECK-NEXT: {{^}}                               ^
 
-// CHECK:      macros.h:{{[0-9]+}}:{{[0-9]+}}: error: invalid digit 'a' in decimal constant
-// CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
-// CHECK-NEXT: {{^}}                                    ^
-// CHECK-NEXT: macros.h:{{[0-9]+}}:9: error: macro 'INVALID_INTEGER_LITERAL_2' not imported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_INTEGER_LITERAL_2' not imported
 // CHECK-NEXT:      #define INVALID_INTEGER_LITERAL_2 10abc
 // CHECK-NEXT: {{^}}        ^
 // CHECK-NEXT: macros.h:{{[0-9]+}}:35: note: invalid numeric literal
@@ -226,22 +223,22 @@ import macros
 // CHECK-NEXT: {{^}}                                  ^
 
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_1' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_1' not imported: structure not supported
 // CHECK-NEXT:      #define UNSUPPORTED_1 FUNC_LIKE_MACRO()
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_2' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_2' not imported: structure not supported
 // CHECK-NEXT:      #define UNSUPPORTED_2 FUNC_LIKE_MACRO_2(1)
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_3' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_3' not imported: structure not supported
 // CHECK-NEXT:      #define UNSUPPORTED_3 1 + FUNC_LIKE_MACRO_2(1)
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_4' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_4' not imported: structure not supported
 // CHECK-NEXT:      #define UNSUPPORTED_4                                                          \
 // CHECK-NEXT: {{^}}        ^
 
-// CHECK:      macros.h:{{[0-9]+}}:9: error: macro 'UNSUPPORTED_5' not imported: structure not supported
+// CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'UNSUPPORTED_5' not imported: structure not supported
 // CHECK-NEXT:      #define UNSUPPORTED_5 1 + 1 + 1
 // CHECK-NEXT: {{^}}        ^


### PR DESCRIPTION
### Behaviour Change

Clang importer diagnostics that are produced as a result of a reference in Swift code are attached as notes to the Sema produced diagnostic that indicates the declaration is unavailable.

This has the added benefit that ClangDiagnostics are produced as many times as referenced from Swift, whereas previosly it was just the first time. 

**Old Behaviour**
```swift
badCFunc()
// CHECK: warning: 'badCFunc' could not be imported
// ...
// CHECK: error: cannot find 'badCFunc' in scope
badCFunc()
// CHECK: error: cannot find 'badCFunc' in scope
```
**New Behaviour**
```swift
badCFunc()
// CHECK: error: cannot find 'badCFunc' in scope
// CHECK: enote: 'badCFunc' could not be imported
// ...
badCFunc()
// CHECK: error: cannot find 'badCFunc' in scope
// CHECK: enote: 'badCFunc' could not be imported
// ...
```

As a result of this change, the eager diagnostic mode only produces notes. This is somewhat unorthodox, notes are typically attached to some other error or warning. This can be addressed if it is a concern.

### Implementation Change

Previously, diagnostics were produced via calls to one of `diagnoseValue`, `diagnoseMissingMember` or `diagnoseDeclDirectly` from outside the ClangImporter. As I mention, these calls were made outside the ClangImporter, but still relatively close. This had the above "only report diagnostics for the first usage" effect. The aforementioned methods have been consolidated into `diagnoseTopLevelValue` and `diagnoseMemberValue`. These calls are made in Sema, directly after the diagnostic reporting the declaration could not be found is produced.

#### diagnoseTopLevelValue

This method is to be used to look up top level declarations whose containing context
is not known (ex: A C function, a macro etc).

```cpp
/// Emits diagnostics for any declarations named name
/// whose direct declaration context is a TU.
virtual void diagnoseTopLevelValue(const DeclName &name) = 0;
```

#### diagnoseMemberValue

This method is to be used to look up declarations where the context
is required to disambiguate between declarations. Typically, this means
members (the context being the containing decl). You could use this
to diagnose a top level declaration from a specific translation unit, 
but there no point in doing so.

```cpp
/// Emit diagnostics for declarations named name that are members
/// of the provided baseType.
virtual void diagnoseMemberValue(const DeclName &name,
                                 const Type &baseType) = 0;
```