### PR TITLE
[Distributed] Issues on 32bit, disable for now

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_generic.swift
@@ -15,6 +15,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 // XFAIL: *
 // FIXME(distributed): generics will come very shortly
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
@@ -17,6 +17,9 @@
 // FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
 // UNSUPPORTED: linux
 
+// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import _Distributed
 import FakeDistributedActorSystems
 


### PR DESCRIPTION
These tests have issues on 32 bit, we'll get to it.

rdar://87568630 - segmentation fault on 32-bit WatchOS simulator