### PR TITLE
[SE-327] Remove need for `convenience` for delegating initializers of an actor.

### DIFF
--- a/docs/SILInitializerConventions.md
+++ b/docs/SILInitializerConventions.md
@@ -1,0 +1,184 @@
+# SIL Initializer Conventions
+
+A nominal type can define a number of initializers, some of which may
+delegate initialization to another initializer. There are specific calling
+conventions for these initializers within SIL that make up a part of the ABI
+for a type. This document aims to summarize the key calling conventions for
+these initializers.
+
+
+# Structs and Enums
+
+The delegation status for the initializer of a struct or enum is not encoded
+in the definitions of these initializers. Thus, all of these initializers
+have an implicit `metatype` argument for the instance to be passed in as the
+last argument to the initializer. Using `<...>` as a stand-in for other
+arguments that are part of the usual function calling convention, consider this
+example:
+
+```swift
+// the non-delegating init MyStruct.init(final:)
+sil hidden [ossa] @$s4test8MyStructV5finalACSi_tcfC : $@convention(method) (<...>, @thin MyStruct.Type) -> MyStruct {
+bb0(<...>, %meta : $@thin MyStruct.Type):
+  %a = alloc_box ${ var MyStruct }, var, name "self"
+  %b = mark_uninitialized [rootself] %a : ${ var MyStruct }
+  %c = begin_borrow [lexical] %b : ${ var MyStruct }
+  %d = project_box %c : ${ var MyStruct }, 0
+  
+  // ... initialize properties, etc ...
+  
+  %end = load [trivial] %d : $*MyStruct
+  end_borrow %c : ${ var MyStruct }
+  destroy_value %b : ${ var MyStruct }
+  return %end : $MyStruct
+}
+
+
+// the delegating init MyStruct.init(delegates:)
+sil hidden [ossa] @$s4test8MyStructV9delegatesACyt_tcfC : $@convention(method) (<...>, @thin MyStruct.Type) -> MyStruct {
+bb0(<...>, %meta : $@thin MyStruct.Type):
+  // Same allocation as the non-delegating:
+  %a = alloc_box ${ var MyStruct }, var, name "self"
+  %b = mark_uninitialized [rootself] %a : ${ var MyStruct }
+  %c = begin_borrow [lexical] %b : ${ var MyStruct }
+  %d = project_box %c : ${ var MyStruct }, 0
+  
+  // ... delegate to MyStruct.init(final:) ...
+  
+  %ctor = function_ref @$s4test8MyStructV5finalACSi_tcfC : $@convention(method) (Int, @thin MyStruct.Type) -> MyStruct
+  %ret = apply %ctor(<...>, %meta) : $@convention(method) (Int, @thin MyStruct.Type) -> MyStruct
+  
+  assign %ret to %d : $*MyStruct
+  %end = load [trivial] %d : $*MyStruct
+  end_borrow %c : ${ var MyStruct }
+  destroy_value %b : ${ var MyStruct }
+  return %end : $MyStruct
+}
+```
+
+It's important to note that all initializers take a metadata argument, 
+regardless of whether it is a delegating initializer. There is also no
+separation between allocating and non-allocating initializer entrypoints.
+All initializers may perform allocation.
+
+# Classes
+
+Every designated initializer has two entry-points. One performs allocation 
+(i.e., the "allocating" entry) before continuing at the second entrypoint 
+which does the initialization (i.e., the "initializing" entrypoint). 
+Here's an example of `MyClass.init(final:)`, which is a designated initializer,
+with its two entry-points:
+
+```swift
+// MyClass.__allocating_init(final:)
+sil hidden [exact_self_class] [ossa] @$s4test7MyClassC5finalACSi_tcfC : $@convention(method) (<...>, @thick MyClass.Type) -> @owned MyClass {
+bb0(%0 : $Int, %1 : $@thick MyClass.Type):
+  %2 = alloc_ref $MyClass
+  // function_ref MyClass.init(final:)
+  %3 = function_ref @$s4test7MyClassC5finalACSi_tcfc : $@convention(method) (Int, @owned MyClass) -> @owned MyClass
+  %4 = apply %3(%0, %2) : $@convention(method) (Int, @owned MyClass) -> @owned MyClass // user: %5
+  return %4 : $MyClass
+}
+
+// MyClass.init(final:)
+sil hidden [ossa] @$s4test7MyClassC5finalACSi_tcfc : $@convention(method) (Int, @owned MyClass) -> @owned MyClass {
+bb0(<...>, %1 : @owned $MyClass):
+  %4 = mark_uninitialized [rootself] %1 : $MyClass
+  
+  // ... initialize MyClass ...
+  
+  %11 = copy_value %4 : $MyClass
+  destroy_value %4 : $MyClass
+  return %11 : $MyClass
+}
+```
+
+In the mangling of these entrypoint labels, the uppercase `C` suffix indicates
+that it's the allocating entrypoint, whereas the lowercase `c` is the 
+initializing entrypoint. Only the allocating entrypoint is published in the
+type's vtable:
+
+```swift
+sil_vtable MyClass {
+  // ...
+  #MyClass.init!allocator: (MyClass.Type) -> (<...>) -> MyClass : @$s4test7MyClassC5finalACSi_tcfC	// MyClass.__allocating_init(final:)
+}
+```
+
+The initializing entrypoint is only referenced by either it's corresponding
+allocating entrypoint, or by a sub-class that is delegating up in a `super.init`
+call. For example, if we had:
+
+```swift
+class MyClass {
+  var x: Int
+  init(final x: Int) {
+    self.x = x
+  }
+}
+
+class MyDerivedClass: MyClass {
+  var y: Int
+  init(subFinal y: Int) {
+    self.y = y
+    super.init(final: y)
+  }
+}
+```
+
+Then the `super.init(final: y)` call directly invokes `MyClass.init(final:)`'s
+initializing entrypoint, bypassing its allocating init. Here's what that looks
+like in SIL:
+
+```
+// MyDerivedClass.__allocating_init(final:)
+sil hidden [exact_self_class] [ossa] @$s4test14MyDerivedClassC5finalACSi_tcfC : $@convention(method) (Int, @thick MyDerivedClass.Type) -> @owned MyDerivedClass {
+  // ... calls $s4test14MyDerivedClassC5finalACSi_tcfc in the usual way ...
+}
+
+// MyDerivedClass.init(final:)
+sil hidden [ossa] @$s4test14MyDerivedClassC5finalACSi_tcfc : $@convention(method) (Int, @owned MyDerivedClass) -> @owned MyDerivedClass {
+bb0(%0 : $Int, %1 : @owned $MyDerivedClass):
+  %2 = alloc_box ${ var MyDerivedClass }, let, name "self"
+  %3 = mark_uninitialized [derivedself] %2 : ${ var MyDerivedClass }
+  %4 = begin_borrow [lexical] %3 : ${ var MyDerivedClass }
+  %5 = project_box %4 : ${ var MyDerivedClass }, 0
+  debug_value %0 : $Int, let, name "y", argno 1
+  store %1 to [init] %5 : $*MyDerivedClass
+  
+  // ... initialize self.y ...
+  
+  // perform the super call. notice the ownership transfer to the super.init.
+  %14 = load [take] %5 : $*MyDerivedClass
+  %15 = upcast %14 : $MyDerivedClass to $MyClass
+  // function_ref MyClass.init(final:)
+  %16 = function_ref @$s4test7MyClassC5finalACSi_tcfc : $@convention(method) (Int, @owned MyClass) -> @owned MyClass // user: %17
+  %17 = apply %16(%0, %15) : $@convention(method) (Int, @owned MyClass) -> @owned MyClass // user: %18
+  %18 = unchecked_ref_cast %17 : $MyClass to $MyDerivedClass
+  store %18 to [init] %5 : $*MyDerivedClass       // id: %19
+  
+  // return as usual
+  %20 = load [copy] %5 : $*MyDerivedClass
+  end_borrow %4 : ${ var MyDerivedClass }
+  destroy_value %3 : ${ var MyDerivedClass }
+  return %20 : $MyDerivedClass
+}
+```
+
+# Actors
+
+There does not exist a sub-actor that inherits from some other actor in the type
+system. As a result, the `convenience` keyword is not required for actor 
+initializers in the source code. Without inheritance, only the allocating
+entry-points can ever be used by an actor. 
+
+Nevertheless, internally the compiler will still differentiate between 
+convenience and designated initializers. So everything discussed
+earlier for classes also apply to actors. The body of the initializer determines
+whether the compiler internally treats it as `convenience` or not. For example,
+an internally designated initializer for an actor still emits two entry-points,
+but the initializing entrypoint is exclusively used by its corresponding
+allocating entrypoint.
+
+
+ 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3572,7 +3572,7 @@ ERROR(designated_init_in_extension,none,
 ERROR(cfclass_designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0",
       (DeclName))
-ERROR(enumstruct_convenience_init,none,
+ERROR(no_convenience_keyword_init,none,
       "initializers in %0 are not marked with 'convenience'",
       (StringRef))
 ERROR(nonclass_convenience_init,none,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3066,10 +3066,14 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
     }
 
     // Convenience initializers have a dynamic 'self' in '-swift-version 5'.
+    //
+    // NOTE: it's important that we check if it's a convenience init only after
+    // confirming it's not semantically final, or else there can be a request
+    // evaluator cycle to determine the init kind for actors, which are final.
     if (Ctx.isSwiftVersionAtLeast(5)) {
-      if (wantDynamicSelf && CD->isConvenienceInit())
+      if (wantDynamicSelf)
         if (auto *classDecl = selfTy->getClassOrBoundGenericClass())
-          if (!classDecl->isSemanticallyFinal())
+          if (!classDecl->isSemanticallyFinal() && CD->isConvenienceInit())
             isDynamicSelf = true;
     }
   } else if (isa<DestructorDecl>(AFD)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3075,13 +3075,13 @@ void ValueDecl::setIsObjC(bool value) {
 bool ValueDecl::isSemanticallyFinal() const {
   // Actor types are semantically final.
   if (auto classDecl = dyn_cast<ClassDecl>(this)) {
-    if (classDecl->isActor())
+    if (classDecl->isAnyActor())
       return true;
   }
 
   // As are members of actor types.
   if (auto classDecl = getDeclContext()->getSelfClassDecl()) {
-    if (classDecl->isActor())
+    if (classDecl->isAnyActor())
       return true;
   }
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -669,13 +669,14 @@ IsSerialized_t SILDeclRef::isSerialized() const {
     return IsSerialized;
 
   // The allocating entry point for designated initializers are serialized
-  // if the class is @usableFromInline or public.
+  // if the class is @usableFromInline or public. Actors are excluded because
+  // whether the init is designated is not clearly reflected in the source code.
   if (kind == SILDeclRef::Kind::Allocator) {
     auto *ctor = cast<ConstructorDecl>(d);
-    if (ctor->isDesignatedInit() &&
-        ctor->getDeclContext()->getSelfClassDecl()) {
-      if (!ctor->hasClangNode())
-        return IsSerialized;
+    if (auto classDecl = ctor->getDeclContext()->getSelfClassDecl()) {
+      if (!classDecl->isAnyActor() && ctor->isDesignatedInit())
+        if (!ctor->hasClangNode())
+          return IsSerialized;
     }
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -379,40 +379,64 @@ CtorInitializerKind
 InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
   auto &diags = decl->getASTContext().Diags;
 
-  // Convenience inits are only allowed on classes and in extensions thereof.
-  if (decl->getAttrs().hasAttribute<ConvenienceAttr>()) {
-    if (auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl()) {
-      auto classDecl = dyn_cast<ClassDecl>(nominal);
+  if (auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl()) {
 
-      // Forbid convenience inits on Foreign CF types, as Swift does not yet
-      // support user-defined factory inits.
-      if (classDecl &&
-          classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType) {
-        diags.diagnose(decl->getLoc(), diag::cfclass_convenience_init);
-      }
+    // Convenience inits are only allowed on classes and in extensions thereof.
+    if (auto convenAttr = decl->getAttrs().getAttribute<ConvenienceAttr>()) {
+      if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
+        if (classDecl->isAnyActor()) {
+          // For an actor "convenience" is not required, but we'll honor it.
+          diags.diagnose(decl->getLoc(),
+                diag::no_convenience_keyword_init, "actors")
+            .fixItRemove(convenAttr->getLocation())
+            .warnUntilSwiftVersion(6);
 
-      if (!classDecl) {
-        auto ConvenienceLoc =
-          decl->getAttrs().getAttribute<ConvenienceAttr>()->getLocation();
+        } else { // not an actor
+          // Forbid convenience inits on Foreign CF types, as Swift does not yet
+          // support user-defined factory inits.
+          if (classDecl->getForeignClassKind() == ClassDecl::ForeignKind::CFType)
+            diags.diagnose(decl->getLoc(), diag::cfclass_convenience_init);
+        }
 
-        // Produce a tailored diagnostic for structs and enums.
+      } else { // not a ClassDecl
+        auto ConvenienceLoc = convenAttr->getLocation();
+
+        // Produce a tailored diagnostic for structs and enums. They should
+        // not have `convenience`.
         bool isStruct = dyn_cast<StructDecl>(nominal) != nullptr;
         if (isStruct || dyn_cast<EnumDecl>(nominal)) {
-          diags.diagnose(decl->getLoc(), diag::enumstruct_convenience_init,
+          diags.diagnose(decl->getLoc(), diag::no_convenience_keyword_init,
                          isStruct ? "structs" : "enums")
             .fixItRemove(ConvenienceLoc);
         } else {
-          diags.diagnose(decl->getLoc(), diag::nonclass_convenience_init,
-                         nominal->getName())
+          diags.diagnose(decl->getLoc(), diag::no_convenience_keyword_init,
+                         nominal->getName().str())
             .fixItRemove(ConvenienceLoc);
         }
         return CtorInitializerKind::Designated;
       }
+
+      return CtorInitializerKind::Convenience;
     }
 
-    return CtorInitializerKind::Convenience;
+    // if there is no `convenience` keyword...
 
-  } else if (auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl()) {
+    // actors infer whether they are `convenience` from their body kind.
+    if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
+      if (classDecl->isAnyActor()) {
+        auto kind = decl->getDelegatingOrChainedInitKind();
+        switch (kind.initKind) {
+          case BodyInitKind::ImplicitChained:
+          case BodyInitKind::Chained:
+          case BodyInitKind::None:
+            return CtorInitializerKind::Designated;
+
+          case BodyInitKind::Delegating:
+            return CtorInitializerKind::Convenience;
+        }
+      }
+    }
+
     // A designated init for a class must be written within the class itself.
     //
     // This is because designated initializers of classes get a vtable entry,
@@ -437,10 +461,11 @@ InitKindRequest::evaluate(Evaluator &evaluator, ConstructorDecl *decl) const {
         return CtorInitializerKind::Convenience;
       }
     }
+  } // end of Nominal context
 
-    if (decl->getDeclContext()->getExtendedProtocolDecl()) {
-      return CtorInitializerKind::Convenience;
-    }
+  // initializers in protocol extensions must be convenience inits
+  if (decl->getDeclContext()->getExtendedProtocolDecl()) {
+    return CtorInitializerKind::Convenience;
   }
 
   return CtorInitializerKind::Designated;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2832,6 +2832,13 @@ public:
         return false;
     }
 
+    // do not skip the body of an actor initializer.
+    // they are checked to determine delegation status
+    if (auto *ctor = dyn_cast<ConstructorDecl>(AFD))
+      if (auto *nom = ctor->getParent()->getSelfNominalTypeDecl())
+        if (nom->isAnyActor())
+          return false;
+
     // Skipping all bodies won't serialize anything, so can skip regardless
     if (getASTContext().TypeCheckerOpts.SkipFunctionBodies ==
         FunctionBodySkipping::All)

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1702,6 +1702,7 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
   ASTContext &ctx = classDecl->getASTContext();
   bool wantSuperInitCall = false;
   bool isDelegating = false;
+
   auto initKindAndExpr = ctor->getDelegatingOrChainedInitKind();
   switch (initKindAndExpr.initKind) {
   case BodyInitKind::Delegating:

--- a/test/Concurrency/Runtime/Inputs/MysteryInit.swift
+++ b/test/Concurrency/Runtime/Inputs/MysteryInit.swift
@@ -1,0 +1,19 @@
+
+// This input is useful to ensure the delegation status of
+// an actor's initializer does not affect ABI stability
+public actor BigFoot {
+
+  public let name: String
+
+  private init(withName name: String) {
+    self.name = name
+  }
+
+  public init?() {
+  #if DELEGATES
+    self.init(withName: "Sasquatch")
+  #else
+    return nil
+  #endif
+  }
+}

--- a/test/Concurrency/Runtime/actor_init_abi.swift
+++ b/test/Concurrency/Runtime/actor_init_abi.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+
+// NOTE: the two tests below look like a lot of copy-pasting, but the only thing that's varying between
+// the two checks is whether "-D DELEGATES" is passed when compiling MysteryInit and whether the check-prefix when running the executable matches that or not.
+
+/// -----------------------------------------------------------------------
+/// Check if the actor init in the library can change from delegating to non-delegating
+/// -----------------------------------------------------------------------
+
+// ------> first library DOES delegate
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MysteryInit)) -D DELEGATES -Xfrontend -disable-availability-checking -enable-library-evolution %S/Inputs/MysteryInit.swift -emit-module -emit-module-path %t/MysteryInit.swiftmodule -module-name MysteryInit
+// RUN: %target-codesign %t/%target-library-name(MysteryInit)
+
+
+// ------> make sure that works
+// RUN: %target-build-swift -parse-as-library  -Xfrontend -disable-availability-checking %s -lMysteryInit -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(MysteryInit) | %FileCheck --check-prefix=CHECK-DELEGATES %s
+
+// ------> do a little internal sanity check on this test itself
+// RUN: %target-run %t/main %t/%target-library-name(MysteryInit) | not %FileCheck --check-prefix=CHECK-NO-DELEGATES %s
+
+// ------> now recompile that library's init so it DOES NOT delegate, without recompiling executable
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MysteryInit)) -Xfrontend -disable-availability-checking -enable-library-evolution %S/Inputs/MysteryInit.swift -emit-module -emit-module-path %t/MysteryInit.swiftmodule -module-name MysteryInit
+// RUN: %target-codesign %t/%target-library-name(MysteryInit)
+
+// ------> re-run executable
+// RUN: %target-run %t/main %t/%target-library-name(MysteryInit) | %FileCheck --check-prefix=CHECK-NO-DELEGATES %s
+
+
+/// -----------------------------------------------------------------------
+/// now, other direction: Check if the actor init can change from non-delegating to delegating
+/// -----------------------------------------------------------------------
+
+// ------> library currently DOES NOT delegate. recompile executable to match.
+// RUN: %target-build-swift -parse-as-library  -Xfrontend -disable-availability-checking %s -lMysteryInit -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(MysteryInit) | %FileCheck --check-prefix=CHECK-NO-DELEGATES %s
+
+// ------> now recompile that library's init so it DOES delegate, without recompiling executable
+// RUN: %target-build-swift-dylib(%t/%target-library-name(MysteryInit)) -D DELEGATES -Xfrontend -disable-availability-checking -enable-library-evolution %S/Inputs/MysteryInit.swift -emit-module -emit-module-path %t/MysteryInit.swiftmodule -module-name MysteryInit
+// RUN: %target-codesign %t/%target-library-name(MysteryInit)
+
+// ------> re-run executable
+// RUN: %target-run %t/main %t/%target-library-name(MysteryInit) | %FileCheck --check-prefix=CHECK-DELEGATES %s
+
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import MysteryInit
+
+@main
+struct Main {
+  static func main() {
+    switch BigFoot() {
+    case .none:
+      print("bigfoot is myth")
+      // CHECK-NO-DELEGATES: bigfoot is myth
+    default:
+      print("bigfoot is real")
+      // CHECK-DELEGATES: bigfoot is real
+    }
+  }
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -861,14 +861,14 @@ actor SomeActorWithInits {
     self.nonisolated()
   }
 
-  convenience init(i3: Bool) {
+  convenience init(i3: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
     self.init(i1: i3)
     _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from a non-isolated context}}
     self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context}}
     self.nonisolated()
   }
 
-  convenience init(i4: Bool) async {
+  convenience init(i4: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
     self.init(i1: i4)
     _ = mutableState
     self.isolated()
@@ -894,14 +894,14 @@ actor SomeActorWithInits {
     _ = mutableState // will be caught by flow-isolation
   }
 
-  @MainActor convenience init(i7: Bool) {
+  @MainActor convenience init(i7: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{14-26=}}
     self.init(i1: i7)
     _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from the main actor}}
     self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from the main actor}}
     self.nonisolated()
   }
 
-  @MainActor convenience init(i8: Bool) async {
+  @MainActor convenience init(i8: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{14-26=}}
     self.init(i1: i8)
     _ = await mutableState
     await self.isolated()
@@ -1244,9 +1244,9 @@ actor Counter {
 
   }
 
-  convenience init(material: Int) async {
+  init(material: Int) async {
     self.init()
-    self.counter = 10 // FIXME: this should work, and also needs to work in definite initialization by injecting hops
+    self.counter = 10
   }
 }
 
@@ -1273,17 +1273,17 @@ actor Butterfly {
 
   nonisolated init(async: Void) async {}
 
-  nonisolated convenience init(icecream: Void) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init(icecream: Void) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
     self.init()
     self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
   }
 
-  nonisolated convenience init(cookies: Void) async {
+  nonisolated init(cookies: Void) async {
     self.init()
     self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
   }
 
-  convenience init(brownies: Void) {
+  init(brownies: Void) {
     self.init()
     self.flapsPerSec = 0 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
   }

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -55,3 +55,7 @@ actor Dril: NSObject {
     return true
   }
 }
+
+
+// makes sure the synthesized init's delegation kind is determined correctly.
+actor Pumpkin: NSObject {}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -21,11 +21,11 @@ actor A2 {
     self.localVar = value
   }
 
-  convenience init(forwardSync value: NotConcurrent) {
+  init(forwardSync value: NotConcurrent) {
     self.init(value: value)
   }
 
-  convenience init(delegatingSync value: NotConcurrent) {
+  init(delegatingSync value: NotConcurrent) {
     self.init(forwardSync: value)
   }
 
@@ -33,11 +33,11 @@ actor A2 {
     self.localVar = value
   }
 
-  convenience init(forwardAsync value: NotConcurrent) async {
+  init(forwardAsync value: NotConcurrent) async {
     await self.init(valueAsync: value)
   }
 
-  nonisolated convenience init(nonisoAsync value: NotConcurrent, _ c: Int) async {
+  nonisolated init(nonisoAsync value: NotConcurrent, _ c: Int) async {
     if c == 0 {
       await self.init(valueAsync: value)
     } else {
@@ -45,7 +45,7 @@ actor A2 {
     }
   }
 
-  convenience init(delegatingAsync value: NotConcurrent, _ c: Int) async {
+  init(delegatingAsync value: NotConcurrent, _ c: Int) async {
     if c == 0 {
       await self.init(valueAsync: value)
     } else if c == 1 {

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -305,7 +305,7 @@ actor Convenient {
         self.x = val
     }
 
-    convenience init(bigVal: Int) {
+    init(bigVal: Int) {
         if bigVal < 0 {
             self.init(val: 0)
             say(msg: "hello from actor!")
@@ -316,21 +316,21 @@ actor Convenient {
         Task { await self.mutateIsolatedState() }
     }
 
-    convenience init!(biggerVal1 biggerVal: Int) {
+    init!(biggerVal1 biggerVal: Int) {
         guard biggerVal < 1234567 else { return nil }
         self.init(bigVal: biggerVal)
         say(msg: "hello?")
     }
 
     @MainActor
-    convenience init?(biggerVal2 biggerVal: Int) async {
+    init?(biggerVal2 biggerVal: Int) async {
         guard biggerVal < 1234567 else { return nil }
         self.init(bigVal: biggerVal)
         say(msg: "hello?")
         await mutateIsolatedState()
     }
 
-    convenience init() async {
+    init() async {
         self.init(val: 10)
         self.x += 1
         mutateIsolatedState()
@@ -351,7 +351,7 @@ actor Convenient {
         Task { self }
     }
 
-    convenience init(throwyConvenient val: Int) throws {
+    init(throwyConvenient val: Int) throws {
         try self.init(throwyDesignated: val)
         say(msg: "hello?")
         Task { self }
@@ -387,13 +387,13 @@ actor MyActor {
 
     func helloWorld() {}
 
-    convenience init(ci1 c: Bool) {
+    init(ci1 c: Bool) {
         self.init(i1: c)
         Task { self }
         callMethod(self)
     }
 
-    convenience init(ci2 c: Bool) async {
+    init(ci2 c: Bool) async {
       self.init(i1: c)
       self.x = 1
       callMethod(self)

--- a/test/Distributed/distributed_actor_initialization.swift
+++ b/test/Distributed/distributed_actor_initialization.swift
@@ -55,7 +55,7 @@ distributed actor OK6 {
 
 distributed actor OKMulti {
 
-  convenience init(y: Int, system: FakeActorSystem) { // ok
+  convenience init(y: Int, system: FakeActorSystem) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
     self.init(actorSystem: system)
   }
 
@@ -63,7 +63,7 @@ distributed actor OKMulti {
 
 distributed actor OKMultiDefaultValues {
 
-  convenience init(y: Int, system: FakeActorSystem, x: Int = 1234) { // ok
+  init(y: Int, system: FakeActorSystem, x: Int = 1234) { // ok
     self.init(actorSystem: system)
   }
 

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -204,14 +204,14 @@ func test_params(
 distributed actor DijonMustard {
   nonisolated init(system: FakeActorSystem) {} // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
 
-  convenience init(conv: FakeActorSystem) {
+  convenience init(conv: FakeActorSystem) { // expected-warning {{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
     self.init(system: conv)
     self.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from a non-isolated context}}
   }
 
   func f() {} // expected-note {{distributed actor-isolated instance method 'f()' declared here}}
 
-  nonisolated convenience init(conv2: FakeActorSystem) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init(conv2: FakeActorSystem) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
     self.init(system: conv2)
   }
 }

--- a/test/SILGen/inlinable_attribute.swift
+++ b/test/SILGen/inlinable_attribute.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name inlinable_attribute -emit-verbose-sil -warnings-as-errors -disable-availability-checking %s | %FileCheck %s
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute15fragileFunctionyyF : $@convention(thin) () -> ()
 @inlinable public func fragileFunction() {
@@ -33,6 +33,32 @@ public class MyCls {
 
   // CHECK-LABEL: sil [ossa] @$s19inlinable_attribute5MyClsC15convenienceInitACyt_tcfC : $@convention(method) (@thick MyCls.Type) -> @owned MyCls
   public convenience init(convenienceInit: ()) {
+    self.init(designatedInit: ())
+  }
+}
+
+public actor MyAct {
+  // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute5MyActCfD : $@convention(method) (@owned MyAct) -> ()
+  @inlinable deinit {}
+
+  /// whether delegating or not, the initializers for an actor are not serialized unless marked inlinable.
+
+  // CHECK-LABEL: sil [exact_self_class] [ossa] @$s19inlinable_attribute5MyActC14designatedInitACyt_tcfC : $@convention(method) (@thick MyAct.Type) -> @owned MyAct
+  // CHECK-LABEL: sil [ossa] @$s19inlinable_attribute5MyActC14designatedInitACyt_tcfc : $@convention(method) (@owned MyAct) -> @owned MyAct
+  public init(designatedInit: ()) {}
+
+  // CHECK-LABEL: sil [ossa] @$s19inlinable_attribute5MyActC15convenienceInitACyt_tcfC : $@convention(method) (@thick MyAct.Type) -> @owned MyAct
+  public init(convenienceInit: ()) {
+    self.init(designatedInit: ())
+  }
+
+
+  // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s19inlinable_attribute5MyActC0A14DesignatedInitACyt_tcfC : $@convention(method) (@thick MyAct.Type) -> @owned MyAct
+  // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute5MyActC0A14DesignatedInitACyt_tcfc : $@convention(method) (@owned MyAct) -> @owned MyAct
+  @inlinable public init(inlinableDesignatedInit: ()) {}
+
+  // CHECK-LABEL: sil [serialized] [ossa] @$s19inlinable_attribute5MyActC0A15ConvenienceInitACyt_tcfC : $@convention(method) (@thick MyAct.Type) -> @owned MyAct
+  @inlinable public init(inlinableConvenienceInit: ()) {
     self.init(designatedInit: ())
   }
 }


### PR DESCRIPTION
For more details: https://github.com/apple/swift-evolution/blob/main/proposals/0327-actor-initializers.md#syntactic-form

Resolves rdar://87568153

TODOs:

- [x] complete implementation
- [x] update tests
- [x] finish editing `SILInitializerConventions.rst`
- [x] Make sure the delegation status of an actor's init doesn't introduce an ABI break.