### PR TITLE
Remove unnecessary comment

### DIFF
--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -179,8 +179,6 @@ extension _UnsafeBitset: Sequence {
   }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
 extension _UnsafeBitset {
   @frozen
   @usableFromInline


### PR DESCRIPTION
<!-- What's in this pull request? -->
What purpose does this serve? Shouldn't there be a different separator (e.g. the one shown below) that is descriptive? This is a leftover from a commit 3 years ago, where another separator with the same style was merged. That separator was overwritten, but this one remains.

```swift
//===--------------------===//
// Description
//===--------------------===//
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
