### PR TITLE
[Reflection] Resolve direct symbolic reference pointers

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -420,7 +420,8 @@ public:
           return nullptr;
         }
       } else {
-        resolved = RemoteAbsolutePointer("", remoteAddress);
+        resolved =
+            Reader->resolvePointer(RemoteAddress(remoteAddress), remoteAddress);
       }
 
       switch (kind) {

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -420,8 +420,9 @@ public:
           return nullptr;
         }
       } else {
-        resolved =
-            Reader->resolvePointer(RemoteAddress(remoteAddress), remoteAddress);
+        resolved = Reader->resolvePointer(RemoteAddress(remoteAddress), 0);
+        if (!resolved)
+          resolved = RemoteAbsolutePointer("", remoteAddress);
       }
 
       switch (kind) {


### PR DESCRIPTION
When resolving symbolic references in mangled names, indirect and direct references are handled slightly differently. Indirect references call `readPointer` which in turn calls `resolvePointer`, which is desired. Direct references, however, aren't being passed to `resolvePointer`, which means the benefits of doing so are missed for direct references.

This change calls `resolvePointer` on direct symbolic references.

When exercised from lldb, this patch saves thousands of memory reads[1].

1. These memory reads are done in the name of loading context descriptors. That loading work isn't needed when a symbol is available instead.