### PR TITLE
Task Priority Escalation

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -297,7 +297,6 @@ public:
   /// Generally this should be done immediately after updating
   /// ActiveTask.
   void flagAsRunning();
-  void flagAsRunning_slow();
 
   /// Flag that this task is now suspended.  This can update the
   /// priority stored in the job flags if the priority hsa been
@@ -306,7 +305,6 @@ public:
   /// somewhere.  TODO: record where the task is enqueued if
   /// possible.
   void flagAsSuspended();
-  void flagAsSuspended_slow();
 
   /// Flag that this task is now completed. This normally does not do anything
   /// but can be used to locally insert logging.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -290,6 +290,22 @@ public:
     return ResumeTask(ResumeContext); // 'return' forces tail call
   }
 
+  /// A task can have the following states:
+  ///   * suspended: In this state, a task is considered not runnable
+  ///   * enqueued: In this state, a task is considered runnable
+  ///   * running on a thread
+  ///   * completed
+  ///
+  /// The following state transitions are possible:
+  ///       suspended -> enqueued
+  ///       suspended -> running
+  ///       enqueued -> running
+  ///       running -> suspended
+  ///       running -> completed
+  ///       running -> enqueued
+  ///
+  /// The 4 methods below are how a task switches from one state to another.
+
   /// Flag that this task is now running.  This can update
   /// the priority stored in the job flags if the priority has been
   /// escalated.
@@ -298,13 +314,11 @@ public:
   /// ActiveTask.
   void flagAsRunning();
 
-  /// Flag that this task is now suspended.  This can update the
-  /// priority stored in the job flags if the priority hsa been
-  /// escalated.  Generally this should be done immediately after
-  /// clearing ActiveTask and immediately before enqueuing the task
-  /// somewhere.  TODO: record where the task is enqueued if
-  /// possible.
+  /// Flag that this task is now suspended.
   void flagAsSuspended();
+
+  /// Flag that the task is to be enqueued on the provided executor
+  void flagAsEnqueuedOnExecutor(ExecutorRef newExecutor);
 
   /// Flag that this task is now completed. This normally does not do anything
   /// but can be used to locally insert logging.

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -106,6 +106,7 @@ class ReflectionContext
   typename super::StoredPointer target_future_adapter = 0;
   typename super::StoredPointer target_task_wait_throwing_resume_adapter = 0;
   typename super::StoredPointer target_task_future_wait_resume_adapter = 0;
+  bool supportsPriorityEscalation = false;
 
 public:
   using super::getBuilder;
@@ -164,7 +165,7 @@ public:
 
   ReflectionContext(const ReflectionContext &other) = delete;
   ReflectionContext &operator=(const ReflectionContext &other) = delete;
-  
+
   MemoryReader &getReader() {
     return *this->Reader;
   }
@@ -367,7 +368,7 @@ public:
 
         auto Begin = RemoteRef<void>(Addr, BufStart);
         auto Size = COFFSec->VirtualSize;
-        
+
         // FIXME: This code needs to be cleaned up and updated
         // to make it work for 32 bit platforms.
         Begin = Begin.atByteOffset(8);
@@ -605,7 +606,7 @@ public:
   }
 
   /// Parses metadata information from an ELF image. Because the Section
-  /// Header Table maybe be missing (for example, when reading from a 
+  /// Header Table maybe be missing (for example, when reading from a
   /// process) this method optionally receives a buffer with the contents
   /// of the image's file, from where it will the necessary information.
   ///
@@ -652,19 +653,19 @@ public:
     auto Magic = this->getReader().readBytes(ImageStart, sizeof(uint32_t));
     if (!Magic)
       return false;
-    
+
     uint32_t MagicWord;
     memcpy(&MagicWord, Magic.get(), sizeof(MagicWord));
-    
+
     // 32- and 64-bit Mach-O.
     if (MagicWord == llvm::MachO::MH_MAGIC) {
       return readMachOSections<MachOTraits<4>>(ImageStart);
     }
-    
+
     if (MagicWord == llvm::MachO::MH_MAGIC_64) {
       return readMachOSections<MachOTraits<8>>(ImageStart);
     }
-    
+
     // PE. (This just checks for the DOS header; `readPECOFF` will further
     // validate the existence of the PE header.)
     auto MagicBytes = (const char*)Magic.get();
@@ -739,7 +740,7 @@ public:
       return true;
     return ownsAddress(RemoteAddress(*MetadataAddress));
   }
-  
+
   /// Returns true if the address falls within a registered image.
   bool ownsAddressRaw(RemoteAddress Address) {
     for (auto Range : imageRanges) {
@@ -1214,7 +1215,7 @@ public:
     }
     return llvm::None;
   }
-  
+
   /// Fetch the metadata pointer from a metadata allocation, or 0 if this
   /// allocation's tag is not handled or an error occurred.
   StoredPointer allocationMetadataPointer(
@@ -1312,7 +1313,7 @@ public:
       getReader().readPointer(AllocationPoolAddrAddr, sizeof(StoredPointer));
     if (!AllocationPoolAddr)
       return "failed to read value of " + AllocationPoolPointerName;
-    
+
     struct PoolRange {
       StoredPointer Begin;
       StoredSize Remaining;
@@ -1358,10 +1359,10 @@ public:
         Allocation.Ptr = RemoteAddr;
         Allocation.Size = Header->Size;
         Call(Allocation);
-        
+
         Offset += sizeof(AllocationHeader) + Header->Size;
       }
-      
+
       TrailerPtr = Trailer->PrevTrailer;
     }
     return llvm::None;
@@ -1442,13 +1443,20 @@ public:
 
   std::pair<llvm::Optional<std::string>, AsyncTaskInfo>
   asyncTaskInfo(StoredPointer AsyncTaskPtr) {
-    auto AsyncTaskObj = readObj<AsyncTask<Runtime>>(AsyncTaskPtr);
+    loadTargetPointers();
+
+    if (supportsPriorityEscalation) {
+      return {std::string("Failure reading async task with escalation support"), {}};
+    }
+
+    using AsyncTask = AsyncTask<Runtime, ActiveTaskStatusWithoutEscalation<Runtime>>;
+    auto AsyncTaskObj = readObj<AsyncTask>(AsyncTaskPtr);
     if (!AsyncTaskObj)
       return {std::string("failure reading async task"), {}};
 
     AsyncTaskInfo Info{};
     Info.JobFlags = AsyncTaskObj->Flags;
-    Info.TaskStatusFlags = AsyncTaskObj->PrivateStorage.Status.Flags;
+    Info.TaskStatusFlags = AsyncTaskObj->PrivateStorage.Status.Flags[0];
     Info.Id =
         AsyncTaskObj->Id | ((uint64_t)AsyncTaskObj->PrivateStorage.Id << 32);
     Info.AllocatorSlabPtr = AsyncTaskObj->PrivateStorage.Allocator.FirstSlab;
@@ -1482,7 +1490,7 @@ public:
         Info.ChildTasks.push_back(ChildTask);
 
         StoredPointer ChildFragmentAddr =
-            ChildTask + sizeof(AsyncTask<Runtime>);
+            ChildTask + sizeof(AsyncTask);
         auto ChildFragmentObj =
             readObj<ChildFragment<Runtime>>(ChildFragmentAddr);
         if (ChildFragmentObj)
@@ -1499,8 +1507,8 @@ public:
     // that's available.
     int IsCancelledFlag = 0x100;
     int IsRunningFlag = 0x800;
-    if (!(AsyncTaskObj->PrivateStorage.Status.Flags & IsCancelledFlag) &&
-        !(AsyncTaskObj->PrivateStorage.Status.Flags & IsRunningFlag)) {
+    if (!(AsyncTaskObj->PrivateStorage.Status.Flags[0] & IsCancelledFlag) &&
+        !(AsyncTaskObj->PrivateStorage.Status.Flags[0] & IsRunningFlag)) {
       auto ResumeContext = AsyncTaskObj->ResumeContextAndReserved[0];
       while (ResumeContext) {
         auto ResumeContextObj = readObj<AsyncContext<Runtime>>(ResumeContext);
@@ -1551,7 +1559,7 @@ public:
 private:
   // Get the most human meaningful "run job" function pointer from the task,
   // like AsyncTask::getResumeFunctionForLogging does.
-  StoredPointer getRunJob(const AsyncTask<Runtime> *AsyncTaskObj) {
+  StoredPointer getRunJob(const AsyncTask<Runtime, ActiveTaskStatusWithoutEscalation<Runtime>> *AsyncTaskObj) {
     auto Fptr = stripSignedPointer(AsyncTaskObj->RunJob);
 
     loadTargetPointers();
@@ -1610,6 +1618,11 @@ private:
         getFunc("_swift_concurrency_debug_task_wait_throwing_resume_adapter");
     target_task_future_wait_resume_adapter =
         getFunc("_swift_concurrency_debug_task_future_wait_resume_adapter");
+    auto supportsPriorityEscalationAddr = getReader().getSymbolAddress("_swift_concurrency_debug_supportsPriorityEscalation");
+    if (supportsPriorityEscalationAddr) {
+      getReader().readInteger(supportsPriorityEscalationAddr, &supportsPriorityEscalation);
+    }
+
     setupTargetPointers = true;
   }
 

--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -94,28 +94,34 @@ struct StackAllocator {
 };
 
 template <typename Runtime>
-struct ActiveTaskStatus {
+struct ActiveTaskStatusWithEscalation {
+  uint32_t Flags;
+  uint32_t DrainLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
   typename Runtime::StoredPointer Record;
-  typename Runtime::StoredSize Flags;
 };
 
 template <typename Runtime>
+struct ActiveTaskStatusWithoutEscalation {
+  uint32_t Flags[sizeof(typename Runtime::StoredPointer) == 8 ? 2 : 1];
+  typename Runtime::StoredPointer Record;
+};
+
+template <typename Runtime, typename ActiveTaskStatus>
 struct AsyncTaskPrivateStorage {
-  ActiveTaskStatus<Runtime> Status;
+  ActiveTaskStatus Status;
   StackAllocator<Runtime> Allocator;
   typename Runtime::StoredPointer Local;
   typename Runtime::StoredPointer ExclusivityAccessSet[2];
   uint32_t Id;
 };
 
-template <typename Runtime>
+template <typename Runtime, typename ActiveTaskStatus>
 struct AsyncTask: Job<Runtime> {
-  // On 64-bit, there's a Reserved64 after ResumeContext.  
+  // On 64-bit, there's a Reserved64 after ResumeContext.
   typename Runtime::StoredPointer ResumeContextAndReserved[
     sizeof(typename Runtime::StoredPointer) == 8 ? 2 : 1];
-
   union {
-    AsyncTaskPrivateStorage<Runtime> PrivateStorage;
+    AsyncTaskPrivateStorage<Runtime, ActiveTaskStatus> PrivateStorage;
     typename Runtime::StoredPointer PrivateStorageRaw[14];
   };
 };

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -627,6 +627,17 @@ void swift_task_switch(SWIFT_ASYNC_CONTEXT AsyncContext *resumeToContext,
                        TaskContinuationFunction *resumeFunction,
                        ExecutorRef newExecutor);
 
+/// Mark a task for enqueue on a new executor and then enqueue it.
+///
+/// The resumption function pointer and continuation should be set
+/// appropriately in the task.
+///
+/// Generally you should call swift_task_switch to switch execution
+/// synchronously when possible.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void
+swift_task_enqueueTaskOnExecutor(AsyncTask *task, ExecutorRef executor);
+
 /// Enqueue the given job to run asynchronously on the given executor.
 ///
 /// The resumption function pointer and continuation should be set

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -41,6 +41,17 @@
 #endif
 #endif
 
+// Does the runtime provide priority escalation support?
+#ifndef SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+#if SWIFT_CONCURRENCY_ENABLE_DISPATCH && \
+    __has_include(<dispatch/swift_concurrency_private.h>) && __APPLE__ && \
+    SWIFT_POINTER_IS_8_BYTES
+#define SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION 1
+#else
+#define SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION 0
+#endif
+#endif /* SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION */
+
 namespace swift {
 class DefaultActor;
 class TaskOptionRecord;

--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -1,0 +1,64 @@
+//===--- DispatchShims.h - Shims for dispatch vended APIs --------------------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_DISPATCHSHIMS_H
+#define SWIFT_CONCURRENCY_DISPATCHSHIMS_H
+
+#include "Concurrency.h"
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+#include <dispatch/swift_concurrency_private.h>
+
+// Provide wrappers with runtime checks to make sure that the dispatch functions
+// are only called on OS-es where they are supported
+dispatch_thread_override_info_s
+swift_dispatch_thread_get_current_override_qos_floor()
+{
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+    return dispatch_thread_get_current_override_qos_floor();
+  }
+
+  return (dispatch_thread_override_info_s) {0};
+}
+
+int
+swift_dispatch_thread_override_self(qos_class_t override_qos) {
+
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+    return dispatch_thread_override_self(override_qos);
+  }
+
+  return 0;
+}
+
+int
+swift_dispatch_lock_override_start_with_debounce(dispatch_lock_t *lock_addr,
+   dispatch_tid_t expected_thread, qos_class_t override_to_apply) {
+
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+    return dispatch_lock_override_start_with_debounce(lock_addr, expected_thread, override_to_apply);
+  }
+
+  return 0;
+}
+
+int
+swift_dispatch_lock_override_end(qos_class_t override_to_end) {
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+    return dispatch_lock_override_end(override_to_end);
+  }
+
+  return 0;
+}
+#endif
+
+#endif /* SWIFT_CONCURRENCY_DISPATCHSHIMS_H */

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -159,6 +159,10 @@ OVERRIDE_TASK(task_suspend, AsyncTask *,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
               swift::, ,)
 
+OVERRIDE_TASK(task_enqueueTaskOnExecutor, void,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
+              (AsyncTask *task, ExecutorRef newExecutor), (task, newExecutor))
+
 OVERRIDE_TASK(continuation_init, AsyncTask *,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
               swift::, (ContinuationAsyncContext *context,

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1617,9 +1617,9 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   // executor.
   SWIFT_TASK_DEBUG_LOG("switch failed, task %p enqueued on executor %p", task,
                        newExecutor.getIdentity());
-  task->flagAsSuspended();
+
+  task->flagAsEnqueuedOnExecutor(newExecutor);
   _swift_task_clearCurrent();
-  swift_task_enqueue(task, newExecutor);
 }
 
 /*****************************************************************************/

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -45,6 +45,10 @@ const void *const _swift_concurrency_debug_task_wait_throwing_resume_adapter;
 SWIFT_EXPORT_FROM(swift_Concurrency)
 const void *const _swift_concurrency_debug_task_future_wait_resume_adapter;
 
+/// Whether the runtime we are inspecting supports priority escalation
+SWIFT_EXPORT_FROM(swift_Concurrency)
+bool _swift_concurrency_debug_supportsPriorityEscalation;
+
 } // namespace swift
 
 #endif

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -27,6 +27,7 @@
 #include "Tracing.h"
 #include "Debug.h"
 #include "Error.h"
+#include <atomic>
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
@@ -72,6 +73,9 @@ using TaskGroup = swift::TaskGroup;
 Metadata swift::TaskAllocatorSlabMetadata;
 const void *const swift::_swift_concurrency_debug_asyncTaskSlabMetadata =
     &TaskAllocatorSlabMetadata;
+
+bool swift::_swift_concurrency_debug_supportsPriorityEscalation =
+    SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION;
 
 void FutureFragment::destroy() {
   auto queueHead = waitQueue.load(std::memory_order_acquire);

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -622,7 +622,7 @@ void TaskGroupImpl::offer(AsyncTask *completedTask, AsyncContext *context) {
         _swift_tsan_acquire(static_cast<Job *>(waitingTask));
 
         // TODO: allow the caller to suggest an executor
-        swift_task_enqueueGlobal(waitingTask);
+        waitingTask->flagAsEnqueuedOnExecutor(ExecutorRef::generic());
         return;
       } // else, try again
     }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -26,6 +26,7 @@
 #include "swift/Runtime/Error.h"
 #include "swift/Runtime/Exclusivity.h"
 #include "swift/Runtime/HeapObject.h"
+#include <atomic>
 
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
@@ -38,6 +39,10 @@
 #define VC_EXTRA_LEAN
 #define NOMINMAX
 #include <Windows.h>
+#endif
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+#include <dispatch/swift_concurrency_private.h>
 #endif
 
 namespace swift {
@@ -167,8 +172,69 @@ public:
 } // end anonymous namespace
 
 /// The current state of a task's status records.
+///
+///
+/// The runtime needs to track the following state about the task in within the
+/// same atomic:
+///
+/// * The current status of the task (whether it is running, waiting in a queue,
+/// waiting on another task to finish, etc.)
+/// * The cancellation state
+/// * The locked state of the status record
+/// * The current maximum priority of the task
+/// * The identity of the thread executing the task
+/// * Pointer to head of TaskStatusRecords
+///
+/// It is important for all of this information to be in the same atomic so that
+/// when the task's state changes, the information is visible to all threads that
+/// may be modifying the task, allowing the algorithm to eventually converge.
+///
+/// Some changes to task state, like cancellation are local to the concurrency
+/// runtime library but others like priority escalation require deeper integration
+/// with the OS in order to have the intended side effects. On Darwin, Swift
+/// Concurrency Tasks runs on dispatch's queues. As such, we need to use an
+/// encoding of thread identity vended by libdispatch called dispatch_lock_t,
+/// and a futex-style dispatch API in order to escalate the priority of a thread.
+/// When the thread gives up running a task, the priority escalation that may
+/// have been applied on the thread, is removed. Henceforth, the dispatch_lock_t
+/// tracked in the ActiveTaskStatus will be called the ExecutionLock.
+///
+/// In order to keep the entire ActiveTaskStatus size to 2 words, the thread
+/// identity is only tracked on platforms which can support 128 bit atomic
+/// operations. The ActiveTaskStatus's layout has thus been changed to have the
+/// following layout depending on the system configuration supported:
+///
+/// 32 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=1
+///
+///          Flags               Exeuction Lock           Unused           TaskStatusRecord *
+/// |----------------------|----------------------|----------------------|-------------------|
+///          32 bits                32 bits                32 bits              32 bits
+///
+/// 64 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=1
+///
+///         Flags              Execution Lock      TaskStatusRecord *
+/// |----------------------|-------------------|----------------------|
+///          32 bits                32 bits              64 bits
+///
+/// 32 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=0
+///
+///          Flags             TaskStatusRecord *
+/// |----------------------|----------------------|
+///          32 bits                32 bits
+//
+/// 64 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=0
+///
+///         Flags                  Unused            TaskStatusRecord *
+/// |----------------------|----------------------|---------------------|
+///         32 bits                 32 bits                64 bits
+///
+/// Note: This layout is intentional so that we can then do 64 bit atomics on
+/// just the top 64 bits of atomic state, including escalation of a thread. We
+/// only need to do double wide atomics if we need to reach for the
+/// StatusRecord pointers and therefore have to update the flags at the same
+/// time.
 class alignas(sizeof(void*) * 2) ActiveTaskStatus {
-  enum : uintptr_t {
+  enum : uint32_t {
     /// The max priority of the task. This is always >= basePriority in the task
     PriorityMask = 0xFF,
 
@@ -184,20 +250,42 @@ class alignas(sizeof(void*) * 2) ActiveTaskStatus {
     /// priority recorded in the Job header.
     IsEscalated = 0x400,
 
-    /// Whether the task is actively running.
-    /// We don't really need to be tracking this in the runtime right
-    /// now, but we will need to eventually track enough information to
-    /// escalate the thread that's running a task, so doing the stores
-    /// necessary to maintain this gives us a more realistic baseline
-    /// for performance.
+#if !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    /// Whether the task is actively running. On systems which cannot track the
+    /// identity of the drainer (see above), we use one bit in the flags to track
+    /// whether or not task is running. Otherwise, the drain lock tells us
+    /// whether or not it is running.
     IsRunning = 0x800,
+#endif
+
   };
 
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
+  uint32_t Flags;
+  dispatch_lock_t ExecutionLock;
+  uint32_t Unused;
+#elif SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_8_BYTES
+  uint32_t Flags;
+  dispatch_lock_t ExecutionLock;
+#elif !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
+  uint32_t Flags;
+#else /* !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_8_BYTES */
+  uint32_t Flags;
+  uint32_t Unused;
+#endif
   TaskStatusRecord *Record;
-  uintptr_t Flags;
 
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
   ActiveTaskStatus(TaskStatusRecord *record, uintptr_t flags)
-    : Record(record), Flags(flags) {}
+    : Flags(flags), ExecutionLock(DLOCK_OWNER_NULL), Record(record) {}
+
+  ActiveTaskStatus(TaskStatusRecord *record, uintptr_t flags, dispatch_lock_t executionLockValue)
+    : Flags(flags), ExecutionLock(executionLockValue), Record(record) {}
+
+#else
+  ActiveTaskStatus(TaskStatusRecord *record, uintptr_t flags)
+    : Flags(flags), Record(record) {}
+#endif
 
 public:
 #ifdef __GLIBCXX__
@@ -207,23 +295,62 @@ public:
   ActiveTaskStatus() = default;
 #endif
 
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
   constexpr ActiveTaskStatus(JobPriority priority)
-      : Record(nullptr), Flags(uintptr_t(priority)) {}
+      : Flags(uintptr_t(priority)), ExecutionLock(DLOCK_OWNER_NULL), Record(nullptr) {}
+#else
+  constexpr ActiveTaskStatus(JobPriority priority)
+      : Flags(uintptr_t(priority)), Record(nullptr) {}
+#endif
 
   /// Is the task currently cancelled?
   bool isCancelled() const { return Flags & IsCancelled; }
   ActiveTaskStatus withCancelled() const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return ActiveTaskStatus(Record, Flags | IsCancelled, ExecutionLock);
+#else
     return ActiveTaskStatus(Record, Flags | IsCancelled);
+#endif
   }
 
   /// Is the task currently running?
   /// Eventually we'll track this with more specificity, like whether
   /// it's running on a specific thread, enqueued on a specific actor,
   /// etc.
-  bool isRunning() const { return Flags & IsRunning; }
+  bool isRunning() const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  return dispatch_lock_is_locked(ExecutionLock);
+#else
+    return Flags & IsRunning;
+#endif
+  }
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  static size_t executionLockOffset() {
+    return offsetof(ActiveTaskStatus, ExecutionLock);
+  }
+#endif
+
+  uint32_t currentExecutionLockOwner() const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  return dispatch_lock_owner(ExecutionLock);
+#else
+  return 0;
+#endif
+  }
+
   ActiveTaskStatus withRunning(bool isRunning) const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+  if (isRunning) {
+    assert(!dispatch_lock_is_locked(ExecutionLock));
+    return ActiveTaskStatus(Record, Flags, dispatch_lock_value_for_self());
+  } else {
+    return ActiveTaskStatus(Record, Flags, ExecutionLock & ~DLOCK_OWNER_MASK);
+  }
+#else
     return ActiveTaskStatus(Record, isRunning ? (Flags | IsRunning)
                                               : (Flags & ~IsRunning));
+#endif
   }
 
   /// Is there an active lock on the cancellation information?
@@ -231,7 +358,11 @@ public:
   ActiveTaskStatus withLockingRecord(TaskStatusRecord *lockRecord) const {
     assert(!isStatusRecordLocked());
     assert(lockRecord->Parent == Record);
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return ActiveTaskStatus(lockRecord, Flags | IsStatusRecordLocked, ExecutionLock);
+#else
     return ActiveTaskStatus(lockRecord, Flags | IsStatusRecordLocked);
+#endif
   }
 
   JobPriority getStoredPriority() const {
@@ -243,23 +374,33 @@ public:
 
   /// Creates a new active task status for a task with the specified priority
   /// and masks away any existing priority related flags on the task status. All
-  /// other flags about the task are unmodified. This is only safe to use to
-  /// generate an initial task status for a new task that is not yet running.
+  /// other flags about the task are unmodified. This is only safe to use when
+  /// we know that the task we're modifying is not running.
   ActiveTaskStatus withNewPriority(JobPriority priority) const {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    assert(ExecutionLock == DLOCK_OWNER_NULL);
+#endif
     return ActiveTaskStatus(Record,
                             (Flags & ~PriorityMask) | uintptr_t(priority));
   }
 
   ActiveTaskStatus withEscalatedPriority(JobPriority priority) const {
     assert(priority > getStoredPriority());
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
     return ActiveTaskStatus(Record,
                             (Flags & ~PriorityMask)
-                               | IsEscalated | uintptr_t(priority));
+                               | IsEscalated | uintptr_t(priority), ExecutionLock);
+#else
+    return ActiveTaskStatus(Record, (Flags & ~PriorityMask) | IsEscalated | uintptr_t(priority));
+#endif
   }
 
   ActiveTaskStatus withoutStoredPriorityEscalation() const {
-    assert(isStoredPriorityEscalated());
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return ActiveTaskStatus(Record, Flags & ~IsEscalated, ExecutionLock);
+#else
     return ActiveTaskStatus(Record, Flags & ~IsEscalated);
+#endif
   }
 
   /// Return the innermost cancellation record.  Code running
@@ -269,7 +410,11 @@ public:
     return Record;
   }
   ActiveTaskStatus withInnermostRecord(TaskStatusRecord *newRecord) {
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
+    return ActiveTaskStatus(newRecord, Flags, ExecutionLock);
+#else
     return ActiveTaskStatus(newRecord, Flags);
+#endif
   }
 
   static TaskStatusRecord *getStatusRecordParent(TaskStatusRecord *ptr);
@@ -284,6 +429,14 @@ public:
     concurrency::trace::task_status_changed(task, Flags);
   }
 };
+
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
+static_assert(sizeof(ActiveTaskStatus) == 4 * sizeof(uintptr_t),
+  "ActiveTaskStatus is 4 words large");
+#else
+static_assert(sizeof(ActiveTaskStatus) == 2 * sizeof(uintptr_t),
+  "ActiveTaskStatus is 2 words large");
+#endif
 
 /// The size of an allocator slab. We want the full allocation to fit into a
 /// 1024-byte malloc quantum. We subtract off the slab header size, plus a

--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -9,6 +9,8 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+//
+// UNSUPPORTED: OS=macosx,ios,watchos,tvos
 
 import Swift
 import _Concurrency

--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -1,0 +1,203 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Xfrontend -disable-availability-checking -parse-as-library -o %t/async_task_priority
+// RUN: %target-codesign %t/async_task_priority
+// RUN: %target-run %t/async_task_priority
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import Darwin
+@_predatesConcurrency import Dispatch
+import StdlibUnittest
+
+func loopUntil(priority: TaskPriority) async {
+  while (Task.currentPriority != priority) {
+    await Task.sleep(1_000_000_000)
+  }
+}
+
+func print(_ s: String = "") {
+  fputs("\(s)\n", stderr)
+}
+
+func expectedBasePri(priority: TaskPriority) -> TaskPriority {
+  let basePri = Task.basePriority!
+  print("Testing basePri matching expected pri - \(basePri) == \(priority)")
+  expectEqual(basePri, priority)
+
+  return basePri
+}
+
+func expectedEscalatedPri(priority: TaskPriority) -> TaskPriority {
+  let curPri = Task.currentPriority
+  print("Testing escalated matching expected pri - \(curPri) == \(priority)")
+  expectEqual(curPri, priority)
+
+  return curPri
+}
+
+func testNestedTaskPriority(basePri: TaskPriority, curPri: TaskPriority) async {
+    let _ = expectedBasePri(priority: basePri)
+    let _ = expectedEscalatedPri(priority: curPri)
+}
+
+func childTaskWaitingForEscalation(sem: DispatchSemaphore, basePri: TaskPriority, curPri : TaskPriority) async {
+    sem.wait() /* Wait to be escalated */
+    let _ = await testNestedTaskPriority(basePri: basePri, curPri: curPri)
+}
+
+
+@main struct Main {
+  static func main() async {
+
+    let top_level = detach { /* To detach from main actor when running work */
+
+      let tests = TestSuite("Task Priority manipulations")
+      if #available(SwiftStdlib 5.1, *) {
+
+        tests.test("Basic escalation test when task is running") {
+            let parentPri = Task.currentPriority
+
+            let sem = DispatchSemaphore(value: 0)
+            let task = Task(priority: .background) {
+                let _ = expectedBasePri(priority: .background)
+
+                // Wait until task is running before asking to be escalated
+                sem.signal()
+                sleep(1)
+
+                let _ = expectedEscalatedPri(priority: parentPri)
+            }
+
+            // Wait till child runs and asks to be escalated
+            sem.wait()
+            await task.value
+        }
+
+        tests.test("Basic escalation when task is suspended") {
+            let parentPri = Task.currentPriority
+
+            let task = Task(priority: .background) {
+                await loopUntil(priority: parentPri) /* Suspend task until it is escalated */
+
+                let _ = expectedEscalatedPri(priority: parentPri)
+            }
+            await task.value // Escalate task BG -> DEF
+        }
+
+        tests.test("Structured concurrency priority propagation") {
+          let task = Task(priority: .background) {
+            await loopUntil(priority: .default)
+
+            let basePri = expectedBasePri(priority: .background)
+            let curPri = expectedEscalatedPri(priority: .default)
+
+            // Structured concurrency via async let, escalated priority of
+            // parent should propagate
+            print("Testing propagation for async let structured concurrency child")
+            async let child = testNestedTaskPriority(basePri: basePri, curPri: curPri)
+            await child
+
+            let dispatchGroup = DispatchGroup()
+            // Structured concurrency via task groups, escalated priority should
+            // propagate
+            await withTaskGroup(of: Void.self, returning: Void.self) { group in
+              dispatchGroup.enter()
+              group.addTask {
+                print("Testing propagation for task group regular child")
+                let _ = await testNestedTaskPriority(basePri: basePri, curPri: curPri)
+                dispatchGroup.leave()
+                return
+              }
+
+              dispatchGroup.enter()
+              group.addTask(priority: .utility) {
+                print("Testing propagation for task group child with specified priority")
+                let _ = await testNestedTaskPriority(basePri: .utility, curPri: curPri)
+                dispatchGroup.leave()
+                return
+              }
+
+              // Wait for child tasks to finish running, don't await since that
+              // will escalate them
+              dispatchGroup.wait()
+            }
+          }
+
+          await task.value // Escalate task BG->DEF
+        }
+
+        tests.test("Unstructured tasks priority propagation") {
+          let task = Task(priority : .background) {
+            await loopUntil(priority: .default)
+
+            let basePri = expectedBasePri(priority: .background)
+            let _ = expectedEscalatedPri(priority: .default)
+
+            let group = DispatchGroup()
+
+            // Create an unstructured task
+            group.enter()
+            let _ = Task {
+              let _ = await testNestedTaskPriority(basePri: basePri, curPri: basePri)
+              group.leave()
+              return
+            }
+
+            // Wait for unstructured task to finish running, don't await it
+            // since that will escalate
+            group.wait()
+          }
+
+          await task.value // Escalate task BG->DEF
+        }
+
+        tests.test("Task escalation propagation to SC children") {
+            // Create a task tree and then escalate the parent
+            let parentPri = Task.currentPriority
+            let basePri : TaskPriority = .background
+
+            let sem = DispatchSemaphore(value: 0)
+            let sem2 = DispatchSemaphore(value : 0)
+
+            let task = Task(priority: basePri) {
+
+                async let child = childTaskWaitingForEscalation(sem: sem2, basePri: basePri, curPri: parentPri)
+
+                await withTaskGroup(of: Void.self, returning: Void.self) { group in
+                    group.addTask {
+                        let _ = await childTaskWaitingForEscalation(sem: sem2, basePri: basePri, curPri: parentPri)
+                    }
+                    group.addTask(priority: .utility) {
+                        let _ = await childTaskWaitingForEscalation(sem: sem2, basePri: .utility, curPri: parentPri)
+                    }
+
+                    sem.signal() // Ask for escalation after creating full task tree
+                    sleep(1)
+
+                    let _ = expectedBasePri(priority: basePri)
+                    let _ = expectedEscalatedPri(priority: parentPri)
+
+                    sem2.signal() // Ask async let child to evaluate
+                    sem2.signal() // Ask task group child 1 to evaluate
+                    sem2.signal() // Ask task group child 2 to evaluate
+                }
+            }
+
+            // Wait until children are created and then ask for escalation of
+            // top level
+            sem.wait()
+            await task.value
+        }
+      }
+      await runAllTestsAsync()
+    }
+
+    await top_level.value
+  }
+}


### PR DESCRIPTION
This change has 3 major parts to it: 

1.  Change ActiveTaskStatus layout in order to be able to track the identity
    of the thread that is executing the task as part of the ActiveTaskStatus

2.  Allow concurrent modifications to the ActiveTaskStatus while another
    thread has the task status record lock.
    
    Today, if a thread is holding the StatusRecordLock, then no other
    modification of the task status is possible - including a thread
    starting to execute the task or stopping execution of the task.
    However, the TaskStatusRecordLock is really about protecting the linked
    list that is maintained in the ActiveTaskStatus. As such, other
    operations which don't need to look at that linked list of us records
    really shouldn't have to block on the StatusRecordLock.
    
    This change allows for concurrent modification of the ActiveTaskStatus while
    the TaskStatusRecordLock is held. In particular, a task can cancelled,
    escalated, start and stop running, all while another thread is holding onto
    the task's StatusRecordLock. In the event of cancellation and
    escalation, the task's StatusRecordLock must be acquired in order to propagate
    cancellation and escalation to its child tasks but it is not needed to cancel
    or escalate the task itself.

3.  Implement task priority escalation on Apple platforms
    
    A task can be in one of 4 states over its lifetime:
    
        (a) suspended
        (b) enqueued
        (c) running
        (d) completed
    
    This change provides priority inversion avoidance support if a task gets
    escalated when it is in state (a), (c), (d).

Rdar: rdar://76127624