### PR TITLE
[AutoDiff] Use consistent VJP-JVP order in stdlib

### DIFF
--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -31,6 +31,16 @@ import Swift
 %  constraint = 'where T == T.TangentVector' if T == 'T' else ''
 @inlinable
 @derivative(of: fma)
+func _vjpFma${generic_signature} (
+  _ x: ${T},
+  _ y: ${T},
+  _ z: ${T}
+) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T}, ${T})) ${constraint} {
+  return (fma(x, y, z), { v in (v * y, v * x, v) })
+}
+
+@inlinable
+@derivative(of: fma)
 func _jvpFma${generic_signature} (
   _ x: ${T},
   _ y: ${T},
@@ -40,13 +50,12 @@ func _jvpFma${generic_signature} (
 }
 
 @inlinable
-@derivative(of: fma)
-func _vjpFma${generic_signature} (
+@derivative(of: remainder)
+func _vjpRemainder${generic_signature} (
   _ x: ${T},
-  _ y: ${T},
-  _ z: ${T}
-) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T}, ${T})) ${constraint} {
-  return (fma(x, y, z), { v in (v * y, v * x, v) })
+  _ y: ${T}
+) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T})) ${constraint} {
+  return (remainder(x, y), { v in (v, -v * ((x / y).rounded(.toNearestOrEven))) })
 }
 
 @inlinable
@@ -62,12 +71,12 @@ func _jvpRemainder${generic_signature} (
 }
 
 @inlinable
-@derivative(of: remainder)
-func _vjpRemainder${generic_signature} (
+@derivative(of: fmod)
+func _vjpFmod${generic_signature} (
   _ x: ${T},
   _ y: ${T}
 ) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T})) ${constraint} {
-  return (remainder(x, y), { v in (v, -v * ((x / y).rounded(.toNearestOrEven))) })
+  return (fmod(x, y), { v in (v, -v * ((x / y).rounded(.towardZero))) })
 }
 
 @inlinable
@@ -80,15 +89,6 @@ func _jvpFmod${generic_signature} (
     Unimplemented JVP for 'fmod(_:)'. \
     https://bugs.swift.org/browse/TF-1108 tracks this issue
     """)
-}
-
-@inlinable
-@derivative(of: fmod)
-func _vjpFmod${generic_signature} (
-  _ x: ${T},
-  _ y: ${T}
-) -> (value: ${T}, pullback: (${T}) -> (${T}, ${T})) ${constraint} {
-  return (fmod(x, y), { v in (v, -v * ((x / y).rounded(.towardZero))) })
 }
 
 %  for derivative_kind in ['vjp', 'jvp']:

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -91,7 +91,7 @@ func _vjpFmod${generic_signature} (
   return (fmod(x, y), { v in (v, -v * ((x / y).rounded(.towardZero))) })
 }
 
-%  for derivative_kind in ['jvp', 'vjp']:
+%  for derivative_kind in ['vjp', 'jvp']:
 %    linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 @inlinable
 @derivative(of: sqrt)
@@ -133,11 +133,11 @@ func _${derivative_kind}Trunc${generic_signature} (
 ) -> (value: ${T}, ${linear_map_kind}: (${T}) -> ${T}) ${constraint} {
   return (trunc(x), { v in 0 })
 }
-%  end # for derivative_kind in ['jvp', 'vjp']:
+%  end # for derivative_kind in ['vjp', 'jvp']:
 %end # for T in ['T', 'Double']:
 
 // Unary functions
-%for derivative_kind in ['jvp', 'vjp']:
+%for derivative_kind in ['vjp', 'jvp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
@@ -277,7 +277,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 #endif
 %    end # if T == 'Float80':
 %  end # for T in ['Float', 'Double', 'Float80']:
-%end # for derivative_kind in ['jvp', 'vjp']:
+%end # for derivative_kind in ['vjp', 'jvp']:
 
 // Binary functions
 %for T in ['Float', 'Double', 'Float80']:


### PR DESCRIPTION
<!-- What's in this pull request? -->
In all other files within the `_Differentiation` module, VJP goes before JVP. Yet, in `TgmathDerivatives.swift.gyb`, it is the opposite order right now. This can be seen in the [Differentiation](https://github.com/philipturner/differentiation), which takes the output of running files through gyb.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
