### PR TITLE
[AutoDiff] Add missing derivatives to FloatingPointDifferentiation.swift.gyb

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -38,7 +38,6 @@ def Availability(bits):
 
 ${Availability(bits)}
 extension ${Self}: Differentiable {
-  ${Availability(bits)}
   public typealias TangentVector = ${Self}
 }
 
@@ -48,7 +47,7 @@ extension ${Self}: Differentiable {
 
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
-extension ${Self} {
+extension ${Self} { // TODO: extract these to a ['vjp', 'jvp'] gyb loop
   @inlinable
   @derivative(of: -)
   static func _vjpNegate(
@@ -66,24 +65,43 @@ extension ${Self} {
   }
 
   @inlinable
-  @derivative(of: negate)
+  @derivative(of: negate) // TODO: add test for this
   mutating func _vjpNegateAssign() -> (value: Void, pullback: (inout Self) -> Void) {
     negate()
     return ((), { v in v.negate() })
   }
 
   @inlinable
-  @derivative(of: negate)
+  @derivative(of: negate) // TODO: add test for this
   mutating func _jvpNegateAssign() -> (value: Void, differential: (inout Self) -> Void) {
     negate()
     return ((), { dx in dx.negate() })
+  }
+
+  @inlinable
+  @derivative(of: formSquareRoot) // TODO: add test for this
+  mutating func _vjpFormSquareRoot() -> (
+    value: Void, pullback: (inout Self) -> Void
+  ) {
+    formSquareRoot()
+    let value = self
+    return ((), { v in v /= 2 * value })
+  }
+
+  @inlinable
+  @derivative(of: formSquareRoot) // TODO: add test for this
+  mutating func _jvpFormSquareRoot() -> (
+    value: Void, differential: (inout Self) -> Void
+  ) {
+    formSquareRoot()
+    let value = self
+    return ((), { dx in dx /= 2 * value })
   }
 }
 
 /// Derivatives of standard binary operators.
 ${Availability(bits)}
 extension ${Self} {
-  ${Availability(bits)}
   @inlinable
   @derivative(of: +)
   static func _vjpAdd(
@@ -93,7 +111,6 @@ extension ${Self} {
     return (lhs + rhs, { v in (v, v) })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: +)
   static func _jvpAdd(
@@ -103,7 +120,6 @@ extension ${Self} {
     return (lhs + rhs, { (dlhs, drhs) in dlhs + drhs })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: +=)
   static func _vjpAddAssign(
@@ -114,7 +130,6 @@ extension ${Self} {
     return ((), { v in v })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: +=)
   static func _jvpAddAssign(
@@ -125,7 +140,6 @@ extension ${Self} {
     return ((), { $0 += $1 })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: -)
   static func _vjpSubtract(
@@ -135,7 +149,6 @@ extension ${Self} {
     return (lhs - rhs, { v in (v, -v) })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: -)
   static func _jvpSubtract(
@@ -145,7 +158,6 @@ extension ${Self} {
     return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: -=)
   static func _vjpSubtractAssign(
@@ -156,7 +168,6 @@ extension ${Self} {
     return ((), { v in -v })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: -=)
   static func _jvpSubtractAssign(
@@ -167,7 +178,6 @@ extension ${Self} {
     return ((), { $0 -= $1 })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: *)
   static func _vjpMultiply(
@@ -177,7 +187,6 @@ extension ${Self} {
     return (lhs * rhs, { v in (rhs * v, lhs * v) })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: *)
   static func _jvpMultiply(
@@ -187,7 +196,6 @@ extension ${Self} {
     return (lhs * rhs, { (dlhs, drhs) in lhs * drhs + rhs * dlhs })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: *=)
   static func _vjpMultiplyAssign(
@@ -203,7 +211,6 @@ extension ${Self} {
     })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: *=)
   static func _jvpMultiplyAssign(
@@ -215,7 +222,6 @@ extension ${Self} {
     return ((), { $0 = $0 * rhs + oldLhs * $1 })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: /)
   static func _vjpDivide(
@@ -225,7 +231,6 @@ extension ${Self} {
     return (lhs / rhs, { v in (v / rhs, -lhs / (rhs * rhs) * v) })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: /)
   static func _jvpDivide(
@@ -235,7 +240,6 @@ extension ${Self} {
     return (lhs / rhs, { (dlhs, drhs) in dlhs / rhs - lhs / (rhs * rhs) * drhs })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: /=)
   static func _vjpDivideAssign(
@@ -251,7 +255,6 @@ extension ${Self} {
     })
   }
 
-  ${Availability(bits)}
   @inlinable
   @derivative(of: /=)
   static func _jvpDivideAssign(
@@ -261,6 +264,32 @@ extension ${Self} {
     let oldLhs = lhs
     lhs /= rhs
     return ((), { $0 = ($0 * rhs - oldLhs * $1) / (rhs * rhs)  })
+  }
+}
+
+/// Derivatives of tertiary operators
+${Availability(bits)}
+extension ${Self} {
+  @inlinable
+  @derivative(of: addProduct) // TODO: add test for this
+  mutating func _vjpAddProduct(
+    _ lhs: Self, 
+    _ rhs: Self
+  ) -> (value: Void, pullback: (inout Self) -> (Self, Self)) {
+    addProduct(lhs, rhs)
+    return ((), { v in (v * rhs, v * lhs) })
+  }
+
+  @inlinable
+  @derivative(of: addProduct) // TODO: add test for this
+  mutating func _jvpAddProduct(
+    _ lhs: Self, 
+    _ rhs: Self
+  ) -> (value: Void, differential: (inout Self, Self, Self) -> Void) {
+    addProduct(lhs, rhs)
+    return ((), { (dSelf, dlhs, drhs) in 
+      dSelf = dlhs * rhs + drhs * lhs + dSelf 
+    })
   }
 }
 
@@ -275,7 +304,7 @@ where
   Self == Self.TangentVector
 {
   @inlinable
-  @derivative(of: addingProduct)
+  @derivative(of: addingProduct) // TODO: change test for this (it passed with incorrect pullback)
   func _vjpAddingProduct(
     _ lhs: Self, 
     _ rhs: Self
@@ -284,7 +313,7 @@ where
   }
 
   @inlinable
-  @derivative(of: addingProduct)
+  @derivative(of: addingProduct) // TODO: add test for this
   func _jvpAddingProduct(
     _ lhs: Self, 
     _ rhs: Self
@@ -293,31 +322,7 @@ where
       dlhs * rhs + drhs * lhs + dSelf 
     })
   }
-/*
-  @usableFromInline
-  @derivative(of: negate)
-  mutating func _vjpAddProduct(
-    _ lhs: Self, 
-    _ rhs: Self
-  ) -> (value: Void, pullback: (inout Self) -> (Void, Self, Self)) {
-fatalError()
-  //  addProduct(lhs, rhs)
-  //  return ((), { v in (v * rhs, v * lhs) })
-  }
 
-  @inlinable
-  @derivative(of: Self.addProduct) // try static?
-  func _jvpAddProduct(
-    _ lhs: Self, 
-    _ rhs: Self
-  ) -> (value: Void, differential: (Self, Self, Self) -> Self) {
-  fatalError()
-  //  addProduct(lhs, rhs)
-  //  return ((), { (dSelf, dlhs, drhs) in 
-  //    dSelf = dlhs * rhs + drhs * lhs + dSelf 
-  //  })
-  }
-*/
   @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
@@ -326,20 +331,16 @@ fatalError()
   }
 
   @inlinable
-  @derivative(of: squareRoot)
+  @derivative(of: squareRoot) // TODO: add test for this
   func _jvpSquareRoot() -> (value: Self, differential: (Self) -> Self) {
     let value = squareRoot()
     return (value, { dx in dx / (2 * value) })
   }
-/*
-  @inlinable
-  @derivative(of: formSquareRoot)
-  mutating func 
-*/
+
   @inlinable
   @derivative(of: minimum)
-  static func _vjpMinimum(
-    _ x: Self, 
+  static func _vjpMinimum( // TODO: differentiate minimumMagnitude using gyb loop
+    _ x: Self,
     _ y: Self
   ) -> ( // TODO: try using `Self` instead of `TangentVector` here
     value: Self, pullback: (Self) -> (Self, Self)
@@ -349,8 +350,8 @@ fatalError()
   }
 
   @inlinable
-  @derivative(of: minimum)
-  static func _jvpMinimum(
+  @derivative(of: minimum) // TODO: add test for this
+  static func _jvpMinimum( // TODO: differentiate minimumMagnitude using gyb loop
     _ x: Self, 
     _ y: Self
   ) -> (
@@ -362,7 +363,7 @@ fatalError()
 
   @inlinable
   @derivative(of: maximum)
-  static func _vjpMaximum(
+  static func _vjpMaximum( // TODO: differentiate maximumMagnitude using gyb loop
     _ x: Self, 
     _ y: Self
   ) -> (
@@ -373,8 +374,8 @@ fatalError()
   }
 
   @inlinable
-  @derivative(of: maximum)
-  static func _jvpMaximum(
+  @derivative(of: maximum) // TODO: add test for this
+  static func _jvpMaximum( // TODO: differentiate maximumMagnitude using gyb loop
     _ x: Self, 
     _ y: Self
   ) -> (

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -47,56 +47,36 @@ extension ${Self}: Differentiable {
 
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
-extension ${Self} { // TODO: extract these to a ['vjp', 'jvp'] gyb loop
+extension ${Self} {
+%for derivative_kind in ['vjp', 'jvp']:
+%  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
   @inlinable
   @derivative(of: -)
-  static func _vjpNegate(
+  static func _${derivative_kind}Negate(
     _ x: ${Self}
-  ) -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
+  ) -> (value: ${Self}, ${linear_map_kind}: (${Self}) -> ${Self}) {
     return (-x, { v in -v })
   }
 
   @inlinable
-  @derivative(of: -)
-  static func _jvpNegate(
-    _ x: ${Self}
-  ) -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
-    return (-x, { dx in -dx })
-  }
-
-  @inlinable
   @derivative(of: negate) // TODO: add test for this
-  mutating func _vjpNegateAssign() -> (value: Void, pullback: (inout Self) -> Void) {
-    negate()
-    return ((), { v in v.negate() })
-  }
-
-  @inlinable
-  @derivative(of: negate) // TODO: add test for this
-  mutating func _jvpNegateAssign() -> (value: Void, differential: (inout Self) -> Void) {
+  mutating func _${derivative_kind}NegateAssign() -> (
+    value: Void, ${linear_map_kind}: (inout Self) -> Void
+  ) {
     negate()
     return ((), { dx in dx.negate() })
   }
 
   @inlinable
   @derivative(of: formSquareRoot) // TODO: add test for this
-  mutating func _vjpFormSquareRoot() -> (
-    value: Void, pullback: (inout Self) -> Void
+  mutating func _${derivative_kind}FormSquareRoot() -> (
+    value: Void, ${linear_map_kind}: (inout Self) -> Void
   ) {
     formSquareRoot()
     let value = self
     return ((), { v in v /= 2 * value })
   }
-
-  @inlinable
-  @derivative(of: formSquareRoot) // TODO: add test for this
-  mutating func _jvpFormSquareRoot() -> (
-    value: Void, differential: (inout Self) -> Void
-  ) {
-    formSquareRoot()
-    let value = self
-    return ((), { dx in dx /= 2 * value })
-  }
+%end # for derivative_kind in ['jvp', 'vjp']:
 }
 
 /// Derivatives of standard binary operators.
@@ -337,51 +317,54 @@ where
     return (value, { dx in dx / (2 * value) })
   }
 
+%for suffix in ['', 'Magnitude']:
+%  op = 'abs' if suffix == 'Magnitude' else ''
   @inlinable
-  @derivative(of: minimum)
-  static func _vjpMinimum( // TODO: differentiate minimumMagnitude using gyb loop
+  @derivative(of: minimum${suffix})
+  static func _vjpMinimum${suffix}(
     _ x: Self,
     _ y: Self
   ) -> ( // TODO: try using `Self` instead of `TangentVector` here
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
-    if x <= y || y.isNaN { return (x, { v in (v, .zero) }) }
-    return (y, { v in (.zero, v) })
+    if ${op}(x) <= ${op}(y) || y.isNaN { return (${op}(x), { v in (v, .zero) }) }
+    return (${op}(y), { v in (.zero, v) })
   }
 
   @inlinable
-  @derivative(of: minimum) // TODO: add test for this
-  static func _jvpMinimum( // TODO: differentiate minimumMagnitude using gyb loop
+  @derivative(of: minimum${suffix}) // TODO: add test for this
+  static func _jvpMinimum${suffix}(
     _ x: Self, 
     _ y: Self
   ) -> (
     value: Self, differential: (Self, Self) -> (Self)
   ) {
-    if x <= y || y.isNaN { return (x, { (dx, _) in dx }) }
-    return (y, { (_, dy) in dy })
+    if ${op}(x) <= ${op}(y) || y.isNaN { return (${op}(x), { (dx, _) in dx }) }
+    return (${op}(y), { (_, dy) in dy })
   }
 
   @inlinable
-  @derivative(of: maximum)
-  static func _vjpMaximum( // TODO: differentiate maximumMagnitude using gyb loop
+  @derivative(of: maximum${suffix})
+  static func _vjpMaximum${suffix}(
     _ x: Self, 
     _ y: Self
   ) -> (
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
-    if x > y || y.isNaN { return (x, { v in (v, .zero) }) }
-    return (y, { v in (.zero, v) })
+    if ${op}(x) > ${op}(y) || y.isNaN { return (${op}(x), { v in (v, .zero) }) }
+    return (${op}(y), { v in (.zero, v) })
   }
 
   @inlinable
-  @derivative(of: maximum) // TODO: add test for this
-  static func _jvpMaximum( // TODO: differentiate maximumMagnitude using gyb loop
+  @derivative(of: maximum${suffix}) // TODO: add test for this
+  static func _jvpMaximum${suffix}(
     _ x: Self, 
     _ y: Self
   ) -> (
     value: Self, differential: (Self, Self) -> (Self)
   ) {
-    if x > y || y.isNaN { return (x, { (dx, _) in dx }) }
-    return (y, { (_, dy) in dy })
+    if ${op}(x) > ${op}(y) || y.isNaN { return (${op}(x), { (dx, _) in dx }) }
+    return (${op}(y), { (_, dy) in dy })
   }
+%end # for suffix in ['', 'Magnitude']:
 }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -250,8 +250,10 @@ extension ${Self} {
 /// Derivatives of tertiary operators
 ${Availability(bits)}
 extension ${Self} {
+  // TODO(SR-15793) enable derivative of `addProduct` once bug is fixed
+  /*
   @inlinable
-  @derivative(of: addProduct) // TODO: add test for this
+  @derivative(of: addProduct)
   mutating func _vjpAddProduct(
     _ lhs: Self, 
     _ rhs: Self
@@ -261,16 +263,17 @@ extension ${Self} {
   }
 
   @inlinable
-  @derivative(of: addProduct) // TODO: add test for this
+  @derivative(of: addProduct) 
   mutating func _jvpAddProduct(
     _ lhs: Self, 
     _ rhs: Self
   ) -> (value: Void, differential: (inout Self, Self, Self) -> Void) {
     addProduct(lhs, rhs)
     return ((), { (dSelf, dlhs, drhs) in 
-      dSelf = dlhs * rhs + drhs * lhs + dSelf 
+      dSelf = dSelf + dlhs * rhs + drhs * lhs
     })
   }
+  */
 }
 
 % if bits == 80 or bits == 16:
@@ -284,7 +287,7 @@ where
   Self == Self.TangentVector
 {
   @inlinable
-  @derivative(of: addingProduct) // TODO: change test for this (it passed with incorrect pullback)
+  @derivative(of: addingProduct)
   func _vjpAddingProduct(
     _ lhs: Self, 
     _ rhs: Self
@@ -293,13 +296,13 @@ where
   }
 
   @inlinable
-  @derivative(of: addingProduct) // TODO: add test for this
+  @derivative(of: addingProduct)
   func _jvpAddingProduct(
     _ lhs: Self, 
     _ rhs: Self
   ) -> (value: Self, differential: (Self, Self, Self) -> Self) {
     return (addingProduct(lhs, rhs), { (dSelf, dlhs, drhs) in 
-      dlhs * rhs + drhs * lhs + dSelf 
+      dSelf + dlhs * rhs + drhs * lhs
     })
   }
 

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -68,7 +68,7 @@ extension ${Self} {
   }
 
   @inlinable
-  @derivative(of: formSquareRoot) // TODO: add test for this
+  @derivative(of: formSquareRoot)
   mutating func _${derivative_kind}FormSquareRoot() -> (
     value: Void, ${linear_map_kind}: (inout Self) -> Void
   ) {
@@ -303,19 +303,15 @@ where
     })
   }
 
+%for derivative_kind in ['vjp', 'jvp']:
+%  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
   @inlinable
   @derivative(of: squareRoot)
-  func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
+  func _${derivative_kind}SquareRoot() -> (value: Self, ${linear_map_kind}: (Self) -> Self) {
     let value = squareRoot()
     return (value, { v in v / (2 * value) })
   }
-
-  @inlinable
-  @derivative(of: squareRoot) // TODO: add test for this
-  func _jvpSquareRoot() -> (value: Self, differential: (Self) -> Self) {
-    let value = squareRoot()
-    return (value, { dx in dx / (2 * value) })
-  }
+%end # for derivative_kind in ['jvp', 'vjp']:
 
 %for suffix in ['', 'Magnitude']:
 %  op = 'abs' if suffix == 'Magnitude' else ''

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -327,8 +327,8 @@ where
   ) -> ( // TODO: try using `Self` instead of `TangentVector` here
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
-    if ${op}(x) <= ${op}(y) || y.isNaN { return (${op}(x), { v in (v, .zero) }) }
-    return (${op}(y), { v in (.zero, v) })
+    if ${op}(x) <= ${op}(y) || y.isNaN { return (x, { v in (v, .zero) }) }
+    return (y, { v in (.zero, v) })
   }
 
   @inlinable
@@ -339,8 +339,8 @@ where
   ) -> (
     value: Self, differential: (Self, Self) -> (Self)
   ) {
-    if ${op}(x) <= ${op}(y) || y.isNaN { return (${op}(x), { (dx, _) in dx }) }
-    return (${op}(y), { (_, dy) in dy })
+    if ${op}(x) <= ${op}(y) || y.isNaN { return (x, { (dx, _) in dx }) }
+    return (y, { (_, dy) in dy })
   }
 
   @inlinable
@@ -351,8 +351,8 @@ where
   ) -> (
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
-    if ${op}(x) > ${op}(y) || y.isNaN { return (${op}(x), { v in (v, .zero) }) }
-    return (${op}(y), { v in (.zero, v) })
+    if ${op}(x) > ${op}(y) || y.isNaN { return (x, { v in (v, .zero) }) }
+    return (y, { v in (.zero, v) })
   }
 
   @inlinable
@@ -363,8 +363,8 @@ where
   ) -> (
     value: Self, differential: (Self, Self) -> (Self)
   ) {
-    if ${op}(x) > ${op}(y) || y.isNaN { return (${op}(x), { (dx, _) in dx }) }
-    return (${op}(y), { (_, dy) in dy })
+    if ${op}(x) > ${op}(y) || y.isNaN { return (x, { (dx, _) in dx }) }
+    return (y, { (_, dy) in dy })
   }
 %end # for suffix in ['', 'Magnitude']:
 }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -274,7 +274,7 @@ where
   func _jvpAddingProduct(
     _ lhs: Self, 
     _ rhs: Self
-  ) -> (value: Self, differential: (Self, Self, Self) -> (Self)) {
+  ) -> (value: Self, differential: (Self, Self, Self) -> Self) {
     return (addingProduct(lhs, rhs), { (dSelf, dlhs, drhs) in 
       dlhs * rhs + drhs * lhs + dSelf 
     })
@@ -283,15 +283,15 @@ where
   @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
-    let y = squareRoot()
-    return (y, { v in v / (2 * y) })
+    let value = squareRoot()
+    return (value, { v in v / (2 * value) })
   }
 
   @inlinable
   @derivative(of: squareRoot)
   func _jvpSquareRoot() -> (value: Self, differential: (Self) -> Self) {
-    let y = squareRoot()
-    return (y, { v in v / (2 * y) })
+    let value = squareRoot()
+    return (value, { dx in dx / (2 * value) })
   }
 
   @inlinable
@@ -299,7 +299,7 @@ where
   static func _vjpMinimum(
     _ x: Self, 
     _ y: Self
-  ) -> (
+  ) -> ( // TODO: try using `Self` instead of `TangentVector` here
     value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
   ) {
     if x <= y || y.isNaN { return (x, { v in (v, .zero) }) }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -21,7 +21,7 @@ bits = self_type.bits
 
 def Availability(bits):
     if bits == 16:
-        return '@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)'
+        return '@available(SwiftStdlib 5.3, *)'
     return ''
 }%
 
@@ -29,7 +29,7 @@ def Availability(bits):
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 % end
 % if bits == 16:
-#if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
 
 //===----------------------------------------------------------------------===//
@@ -40,11 +40,6 @@ ${Availability(bits)}
 extension ${Self}: Differentiable {
   ${Availability(bits)}
   public typealias TangentVector = ${Self}
-
-  ${Availability(bits)}
-  public mutating func move(by offset: TangentVector) {
-    self += offset
-  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -54,19 +49,19 @@ extension ${Self}: Differentiable {
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
 extension ${Self} {
-  @usableFromInline
-  @_transparent
+  @inlinable
   @derivative(of: -)
-  static func _vjpNegate(x: ${Self})
-    -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
+  static func _vjpNegate(
+    _ x: ${Self}
+  ) -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
     return (-x, { v in -v })
   }
 
-  @usableFromInline
-  @_transparent
+  @inlinable
   @derivative(of: -)
-  static func _jvpNegate(x: ${Self})
-  -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
+  static func _jvpNegate(
+    _ x: ${Self}
+  ) -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
     return (-x, { dx in -dx })
   }
 }
@@ -75,116 +70,116 @@ extension ${Self} {
 ${Availability(bits)}
 extension ${Self} {
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +)
   static func _vjpAdd(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, pullback: (${Self}) -> (${Self}, ${Self})) {
     return (lhs + rhs, { v in (v, v) })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +)
   static func _jvpAdd(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs + rhs, { (dlhs, drhs) in dlhs + drhs })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +=)
-  static func _vjpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, pullback: (inout ${Self}) -> ${Self}
-  ) {
+  static func _vjpAddAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
     lhs += rhs
     return ((), { v in v })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +=)
-  static func _jvpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, differential: (inout ${Self}, ${Self}) -> Void
-  ) {
+  static func _jvpAddAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, differential: (inout ${Self}, ${Self}) -> Void) {
     lhs += rhs
     return ((), { $0 += $1 })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _vjpSubtract(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, pullback: (${Self}) -> (${Self}, ${Self})) {
     return (lhs - rhs, { v in (v, -v) })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _jvpSubtract(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs - rhs, { (dlhs, drhs) in dlhs - drhs })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -=)
-  static func _vjpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, pullback: (inout ${Self}) -> ${Self}
-  ) {
+  static func _vjpSubtractAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
     lhs -= rhs
     return ((), { v in -v })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -=)
-  static func _jvpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, differential: (inout ${Self}, ${Self}) -> Void
-  ) {
+  static func _jvpSubtractAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, differential: (inout ${Self}, ${Self}) -> Void) {
     lhs -= rhs
     return ((), { $0 -= $1 })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *)
   static func _vjpMultiply(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, pullback: (${Self}) -> (${Self}, ${Self})) {
     return (lhs * rhs, { v in (rhs * v, lhs * v) })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *)
   static func _jvpMultiply(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs * rhs, { (dlhs, drhs) in lhs * drhs + rhs * dlhs })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *=)
-  static func _vjpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, pullback: (inout ${Self}) -> ${Self}
-  ) {
+  static func _vjpMultiplyAssign(
+    _ lhs: inout ${Self},
+    _ rhs: ${Self}
+  ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
     defer { lhs *= rhs }
     return ((), { [lhs = lhs] v in
       let drhs = lhs * v
@@ -194,44 +189,44 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *=)
-  static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, differential: (inout ${Self}, ${Self}) -> Void
-  ) {
+  static func _jvpMultiplyAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, differential: (inout ${Self}, ${Self}) -> Void) {
     let oldLhs = lhs
     lhs *= rhs
     return ((), { $0 = $0 * rhs + oldLhs * $1 })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /)
   static func _vjpDivide(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, pullback: (${Self}) -> (${Self}, ${Self})) {
     return (lhs / rhs, { v in (v / rhs, -lhs / (rhs * rhs) * v) })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /)
   static func _jvpDivide(
-    lhs: ${Self}, rhs: ${Self}
+    _ lhs: ${Self}, 
+    _ rhs: ${Self}
   ) -> (value: ${Self}, differential: (${Self}, ${Self}) -> ${Self}) {
     return (lhs / rhs, { (dlhs, drhs) in dlhs / rhs - lhs / (rhs * rhs) * drhs })
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /=)
-  static func _vjpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, pullback: (inout ${Self}) -> ${Self}
-  ) {
+  static func _vjpDivideAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
     defer { lhs /= rhs }
     return ((), { [lhs = lhs] v in
       let drhs = -lhs / (rhs * rhs) * v
@@ -241,12 +236,12 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /=)
-  static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
-    value: Void, differential: (inout ${Self}, ${Self}) -> Void
-  ) {
+  static func _jvpDivideAssign(
+    _ lhs: inout ${Self}, 
+    _ rhs: ${Self}
+  ) -> (value: Void, differential: (inout ${Self}, ${Self}) -> Void) {
     let oldLhs = lhs
     lhs /= rhs
     return ((), { $0 = ($0 * rhs - oldLhs * $1) / (rhs * rhs)  })
@@ -263,15 +258,16 @@ where
   Self: Differentiable,
   Self == Self.TangentVector
 {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @derivative(of: addingProduct)
   func _vjpAddingProduct(
-    _ lhs: Self, _ rhs: Self
+    _ lhs: Self, 
+    _ rhs: Self
   ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
-    return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
+    return (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
     let y = squareRoot()
@@ -280,7 +276,10 @@ where
 
   @inlinable
   @derivative(of: minimum)
-  static func _vjpMinimum(_ x: Self, _ y: Self) -> (
+  static func _vjpMinimum(
+    _ x: Self, 
+    _ y: Self
+  ) -> (
     value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
   ) {
     if x <= y || y.isNaN { return (x, { v in (v, .zero) }) }
@@ -289,7 +288,10 @@ where
 
   @inlinable
   @derivative(of: maximum)
-  static func _vjpMaximum(_ x: Self, _ y: Self) -> (
+  static func _vjpMaximum(
+    _ x: Self, 
+    _ y: Self
+  ) -> (
     value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
   ) {
     if x > y || y.isNaN { return (x, { v in (v, .zero) }) }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -50,8 +50,15 @@ ${Availability(bits)}
 extension ${Self} {
 %for derivative_kind in ['vjp', 'jvp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
+  // TODO: Add derivative of `init<Source>()` where Source: FloatingPoint
+  // TODO: Add derivative of `init(signOf:magnitudeOf:)`
+  // TODO: Add derivative of `sign`
+  // TODO: Add derivative of `magnitude`
+  // TODO: Add derivative of `round()`
+  // TODO: Add derivative of `rounded()`
+
   @inlinable
-  @derivative(of: -) // TODO: add test for JVP for of this
+  @derivative(of: -)
   static func _${derivative_kind}Negate(
     _ x: ${Self}
   ) -> (value: ${Self}, ${linear_map_kind}: (${Self}) -> ${Self}) {
@@ -59,7 +66,7 @@ extension ${Self} {
   }
 
   @inlinable
-  @derivative(of: negate) // TODO: add test for this
+  @derivative(of: negate)
   mutating func _${derivative_kind}NegateAssign() -> (
     value: Void, ${linear_map_kind}: (inout Self) -> Void
   ) {
@@ -82,6 +89,11 @@ extension ${Self} {
 /// Derivatives of standard binary operators.
 ${Availability(bits)}
 extension ${Self} {
+  // TODO: Add derivative of `formRemainder(dividingBy:)`
+  // TODO: Add derivative of `formTruncatingRemainder(dividingBy:)`
+  // TODO: Add derivative of `remainder(dividingBy:)`
+  // TODO: Add derivative of `truncatingRemainder(dividingBy:)`
+
   @inlinable
   @derivative(of: +)
   static func _vjpAdd(

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -180,9 +180,10 @@ extension ${Self} {
     _ lhs: inout ${Self},
     _ rhs: ${Self}
   ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
-    defer { lhs *= rhs }
-    return ((), { [lhs = lhs] v in
-      let drhs = lhs * v
+    let oldLhs = lhs
+    lhs *= rhs
+    return ((), { v in
+      let drhs = oldLhs * v
       v *= rhs
       return drhs
     })
@@ -227,9 +228,10 @@ extension ${Self} {
     _ lhs: inout ${Self}, 
     _ rhs: ${Self}
   ) -> (value: Void, pullback: (inout ${Self}) -> ${Self}) {
-    defer { lhs /= rhs }
-    return ((), { [lhs = lhs] v in
-      let drhs = -lhs / (rhs * rhs) * v
+    let oldLhs = lhs
+    lhs /= rhs
+    return ((), { v in
+      let drhs = -oldLhs / (rhs * rhs) * v
       v /= rhs
       return drhs
     })
@@ -268,8 +270,26 @@ where
   }
 
   @inlinable
+  @derivative(of: addingProduct)
+  func _jvpAddingProduct(
+    _ lhs: Self, 
+    _ rhs: Self
+  ) -> (value: Self, differential: (Self, Self, Self) -> (Self)) {
+    return (addingProduct(lhs, rhs), { (dSelf, dlhs, drhs) in 
+      dlhs * rhs + drhs * lhs + dSelf 
+    })
+  }
+
+  @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
+    let y = squareRoot()
+    return (y, { v in v / (2 * y) })
+  }
+
+  @inlinable
+  @derivative(of: squareRoot)
+  func _jvpSquareRoot() -> (value: Self, differential: (Self) -> Self) {
     let y = squareRoot()
     return (y, { v in v / (2 * y) })
   }
@@ -287,6 +307,18 @@ where
   }
 
   @inlinable
+  @derivative(of: minimum)
+  static func _jvpMinimum(
+    _ x: Self, 
+    _ y: Self
+  ) -> (
+    value: Self, differential: (TangentVector, TangentVector) -> (TangentVector)
+  ) {
+    if x <= y || y.isNaN { return (x, { (dx, _) in dx }) }
+    return (y, { (_, dy) in dy })
+  }
+
+  @inlinable
   @derivative(of: maximum)
   static func _vjpMaximum(
     _ x: Self, 
@@ -296,5 +328,17 @@ where
   ) {
     if x > y || y.isNaN { return (x, { v in (v, .zero) }) }
     return (y, { v in (.zero, v) })
+  }
+
+  @inlinable
+  @derivative(of: maximum)
+  static func _jvpMaximum(
+    _ x: Self, 
+    _ y: Self
+  ) -> (
+    value: Self, differential: (TangentVector, TangentVector) -> (TangentVector)
+  ) {
+    if x > y || y.isNaN { return (x, { (dx, _) in dx }) }
+    return (y, { (_, dy) in dy })
   }
 }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -64,6 +64,20 @@ extension ${Self} {
   ) -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
     return (-x, { dx in -dx })
   }
+
+  @inlinable
+  @derivative(of: negate)
+  mutating func _vjpNegateAssign() -> (value: Void, pullback: (inout Self) -> Void) {
+    negate()
+    return ((), { v in v.negate() })
+  }
+
+  @inlinable
+  @derivative(of: negate)
+  mutating func _jvpNegateAssign() -> (value: Void, differential: (inout Self) -> Void) {
+    negate()
+    return ((), { dx in dx.negate() })
+  }
 }
 
 /// Derivatives of standard binary operators.
@@ -279,7 +293,31 @@ where
       dlhs * rhs + drhs * lhs + dSelf 
     })
   }
+/*
+  @usableFromInline
+  @derivative(of: negate)
+  mutating func _vjpAddProduct(
+    _ lhs: Self, 
+    _ rhs: Self
+  ) -> (value: Void, pullback: (inout Self) -> (Void, Self, Self)) {
+fatalError()
+  //  addProduct(lhs, rhs)
+  //  return ((), { v in (v * rhs, v * lhs) })
+  }
 
+  @inlinable
+  @derivative(of: Self.addProduct) // try static?
+  func _jvpAddProduct(
+    _ lhs: Self, 
+    _ rhs: Self
+  ) -> (value: Void, differential: (Self, Self, Self) -> Self) {
+  fatalError()
+  //  addProduct(lhs, rhs)
+  //  return ((), { (dSelf, dlhs, drhs) in 
+  //    dSelf = dlhs * rhs + drhs * lhs + dSelf 
+  //  })
+  }
+*/
   @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
@@ -293,14 +331,18 @@ where
     let value = squareRoot()
     return (value, { dx in dx / (2 * value) })
   }
-
+/*
+  @inlinable
+  @derivative(of: formSquareRoot)
+  mutating func 
+*/
   @inlinable
   @derivative(of: minimum)
   static func _vjpMinimum(
     _ x: Self, 
     _ y: Self
   ) -> ( // TODO: try using `Self` instead of `TangentVector` here
-    value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
+    value: Self, pullback: (Self) -> (Self, Self)
   ) {
     if x <= y || y.isNaN { return (x, { v in (v, .zero) }) }
     return (y, { v in (.zero, v) })
@@ -312,7 +354,7 @@ where
     _ x: Self, 
     _ y: Self
   ) -> (
-    value: Self, differential: (TangentVector, TangentVector) -> (TangentVector)
+    value: Self, differential: (Self, Self) -> (Self)
   ) {
     if x <= y || y.isNaN { return (x, { (dx, _) in dx }) }
     return (y, { (_, dy) in dy })
@@ -324,7 +366,7 @@ where
     _ x: Self, 
     _ y: Self
   ) -> (
-    value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
+    value: Self, pullback: (Self) -> (Self, Self)
   ) {
     if x > y || y.isNaN { return (x, { v in (v, .zero) }) }
     return (y, { v in (.zero, v) })
@@ -336,7 +378,7 @@ where
     _ x: Self, 
     _ y: Self
   ) -> (
-    value: Self, differential: (TangentVector, TangentVector) -> (TangentVector)
+    value: Self, differential: (Self, Self) -> (Self)
   ) {
     if x > y || y.isNaN { return (x, { (dx, _) in dx }) }
     return (y, { (_, dy) in dy })

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -51,7 +51,7 @@ extension ${Self} {
 %for derivative_kind in ['vjp', 'jvp']:
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
   @inlinable
-  @derivative(of: -)
+  @derivative(of: -) // TODO: add test for JVP for of this
   static func _${derivative_kind}Negate(
     _ x: ${Self}
   ) -> (value: ${Self}, ${linear_map_kind}: (${Self}) -> ${Self}) {
@@ -313,54 +313,40 @@ where
   }
 %end # for derivative_kind in ['jvp', 'vjp']:
 
-%for suffix in ['', 'Magnitude']:
-%  op = 'abs' if suffix == 'Magnitude' else ''
+%for compare_op in ['minimum', 'maximum']:
+%  compare_symbol = '<=' if compare_op == 'minimum' else '>'
+%  compare_camel = 'Minimum' if compare_op == 'minimum' else 'Maximum' # to ensure camel case
+%  for suffix in ['', 'Magnitude']:
+%    magnitude_op = 'abs' if suffix == 'Magnitude' else ''
   @inlinable
-  @derivative(of: minimum${suffix})
-  static func _vjpMinimum${suffix}(
+  @derivative(of: ${compare_op}${suffix})
+  static func _vjp${compare_camel}${suffix}(
     _ x: Self,
     _ y: Self
   ) -> ( // TODO: try using `Self` instead of `TangentVector` here
     value: Self, pullback: (Self) -> (Self, Self)
   ) {
-    if ${op}(x) <= ${op}(y) || y.isNaN { return (x, { v in (v, .zero) }) }
-    return (y, { v in (.zero, v) })
+    if ${magnitude_op}(x) ${compare_symbol} ${magnitude_op}(y) || y.isNaN { 
+      return (x, { v in (v, .zero) }) 
+    } else {
+      return (y, { v in (.zero, v) })
+    }
   }
 
   @inlinable
-  @derivative(of: minimum${suffix}) // TODO: add test for this
-  static func _jvpMinimum${suffix}(
+  @derivative(of: ${compare_op}${suffix})
+  static func _jvp${compare_camel}${suffix}(
     _ x: Self, 
     _ y: Self
   ) -> (
     value: Self, differential: (Self, Self) -> (Self)
   ) {
-    if ${op}(x) <= ${op}(y) || y.isNaN { return (x, { (dx, _) in dx }) }
-    return (y, { (_, dy) in dy })
+    if ${magnitude_op}(x) ${compare_symbol} ${magnitude_op}(y) || y.isNaN { 
+      return (x, { (dx, _) in dx }) 
+    } else {
+      return (y, { (_, dy) in dy })
+    }
   }
-
-  @inlinable
-  @derivative(of: maximum${suffix})
-  static func _vjpMaximum${suffix}(
-    _ x: Self, 
-    _ y: Self
-  ) -> (
-    value: Self, pullback: (Self) -> (Self, Self)
-  ) {
-    if ${op}(x) > ${op}(y) || y.isNaN { return (x, { v in (v, .zero) }) }
-    return (y, { v in (.zero, v) })
-  }
-
-  @inlinable
-  @derivative(of: maximum${suffix}) // TODO: add test for this
-  static func _jvpMaximum${suffix}(
-    _ x: Self, 
-    _ y: Self
-  ) -> (
-    value: Self, differential: (Self, Self) -> (Self)
-  ) {
-    if ${op}(x) > ${op}(y) || y.isNaN { return (x, { (dx, _) in dx }) }
-    return (y, { (_, dy) in dy })
-  }
-%end # for suffix in ['', 'Magnitude']:
+%  end # for suffix in ['', 'Magnitude']:
+%end # for compare_op in ['minimum', 'maximum']:
 }

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -44,7 +44,7 @@ where
 {
   // NOTE(TF-1094): serialized `@derivative` for `.swiftinterface` compilation.
   @inlinable
-  @derivative(of: subscript(_:).get)
+  @derivative(of: subscript(_:))
   internal func _vjpSubscript(_ index: Int)
     -> (value: Scalar, pullback: (Scalar.TangentVector) -> TangentVector)
   {
@@ -56,7 +56,7 @@ where
   }
 
   @inlinable
-  @derivative(of: subscript(_:).get)
+  @derivative(of: subscript(_:))
   internal func _jvpSubscript(index: Int)
     -> (value: Scalar, differential: (TangentVector) -> Scalar.TangentVector)
   {

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -44,7 +44,7 @@ where
 {
   // NOTE(TF-1094): serialized `@derivative` for `.swiftinterface` compilation.
   @inlinable
-  @derivative(of: subscript(_:))
+  @derivative(of: subscript(_:).get)
   internal func _vjpSubscript(_ index: Int)
     -> (value: Scalar, pullback: (Scalar.TangentVector) -> TangentVector)
   {
@@ -56,7 +56,7 @@ where
   }
 
   @inlinable
-  @derivative(of: subscript(_:))
+  @derivative(of: subscript(_:).get)
   internal func _jvpSubscript(index: Int)
     -> (value: Scalar, differential: (TangentVector) -> Scalar.TangentVector)
   {

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -75,8 +75,22 @@ FloatingPointDerivativeTests.test("${Self}./") {
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {
-  expectEqual(0.5, gradient(at: 1, of: { $0.squareRoot() }))
-  expectEqual(0.25, gradient(at: 4, of: { $0.squareRoot() }))
+%  for differential_op in ['gradient', 'derivative']:
+  do { // prevent `altSquareRoot` from being declared twice in same scope
+    expectEqual(0.5, ${differential_op}(at: 1, of: { $0.squareRoot() }))
+    expectEqual(0.25, ${differential_op}(at: 4, of: { $0.squareRoot() }))
+
+    @differentiable(reverse)
+    func altSquareRoot(_ x: ${Self}) -> ${Self} {
+      var output = x
+      output.formSquareRoot()
+      return output
+    }
+
+    expectEqual(0.5, ${differential_op}(at: 1, of: { altSquareRoot($0) }))
+    expectEqual(0.25, ${differential_op}(at: 4, of: { altSquareRoot($0) }))
+  }
+%  end # for derivative_op in ['gradient', 'derivative']:
 }
 
 FloatingPointDerivativeTests.test("${Self}.addingProduct") {

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -99,6 +99,30 @@ FloatingPointDerivativeTests.test("${Self}.maximum") {
   expectEqual((0.0, 1.0), gradient(at: .nan, ${Self}(1), of: { ${Self}.maximum($0, $1) }))
 }
 
+FloatingPointDerivativeTests.test("${Self}.minimumMagnitude") {
+%  for s1 in ['+', '-']:
+%    for s2 in ['+', '-']:
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(${s1}1), ${Self}(${s2}2), of: { ${Self}.minimumMagnitude($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(${s1}1), ${Self}(${s2}1), of: { ${Self}.minimumMagnitude($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(${s1}2), ${Self}(${s2}1), of: { ${Self}.minimumMagnitude($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(${s1}1), ${s2}.nan, of: { ${Self}.minimumMagnitude($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${s1}.nan, ${Self}(${s2}1), of: { ${Self}.minimumMagnitude($0, $1) }))
+%    end # for s2 in ['+', '-']:
+%  end # for s1 in ['+', '-']:
+}
+
+FloatingPointDerivativeTests.test("${Self}.maximumMagnitude") {
+%  for s1 in ['+', '-']:
+%    for s2 in ['+', '-']:
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(${s1}1), ${Self}(${s2}2), of: { ${Self}.maximumMagnitude($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(${s1}1), ${Self}(${s2}1), of: { ${Self}.maximumMagnitude($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(${s1}2), ${Self}(${s2}1), of: { ${Self}.maximumMagnitude($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(${s1}1), ${s2}.nan, of: { ${Self}.maximumMagnitude($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${s1}.nan, ${Self}(${s2}1), of: { ${Self}.maximumMagnitude($0, $1) }))
+%    end # for s2 in ['+', '-']:
+%  end # for s1 in ['+', '-']:
+}
+
 %if Self == 'Float80':
 #endif
 %end

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -42,12 +42,35 @@ FloatingPointDerivativeTests.test("${Self}.+") {
   expectEqual(20, differential(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10), ${Self}(10)))
 }
 
-FloatingPointDerivativeTests.test("${Self}.-") {
+FloatingPointDerivativeTests.test("${Self}.-(_:_:)") {
   expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), of: -))
   expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), of: -)(${Self}(10)))
 
   expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), of: -))
   expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), of: -)(${Self}(5), ${Self}(10)))
+}
+
+FloatingPointDerivativeTests.test("${Self}.-(_:)") {
+  expectEqual(-1, gradient(at: ${Self}(5), of: { -$0 }))
+  expectEqual(-1, derivative(at: ${Self}(5), of: { -$0 }))
+
+  expectEqual(-1, gradient(at: ${Self}(-5), of: { -$0 }))
+  expectEqual(-1, derivative(at: ${Self}(-5), of: { -$0 }))
+}
+
+FloatingPointDerivativeTests.test("${Self}.negate") {
+  @differentiable(reverse)
+  func negate(_ x: ${Self}) -> ${Self} {
+    var output = x
+    output.negate()
+    return output
+  }
+
+  expectEqual(-1, gradient(at: ${Self}(5), of: { negate($0) }))
+  expectEqual(-1, derivative(at: ${Self}(5), of: { negate($0) }))
+
+  expectEqual(-1, gradient(at: ${Self}(-5), of: { negate($0) }))
+  expectEqual(-1, derivative(at: ${Self}(-5), of: { negate($0) }))
 }
 
 FloatingPointDerivativeTests.test("${Self}.*") {
@@ -75,19 +98,23 @@ FloatingPointDerivativeTests.test("${Self}./") {
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {
+%  for differential_op in ['gradient', 'derivative']:
+  expectEqual(0.5, ${differential_op}(at: 1, of: { $0.squareRoot() }))
+  expectEqual(0.25, ${differential_op}(at: 4, of: { $0.squareRoot() }))
+%  end # for derivative_op in ['gradient', 'derivative']:
+}
+
+FloatingPointDerivativeTests.test("${Self}.formSquareRoot") {
   @differentiable(reverse)
-  func altSquareRoot(_ x: ${Self}) -> ${Self} {
+  func formSquareRoot(_ x: ${Self}) -> ${Self} {
     var output = x
     output.formSquareRoot()
     return output
   }
 
 %  for differential_op in ['gradient', 'derivative']:
-  expectEqual(0.5, ${differential_op}(at: 1, of: { $0.squareRoot() }))
-  expectEqual(0.5, ${differential_op}(at: 1, of: { altSquareRoot($0) }))
-
-  expectEqual(0.25, ${differential_op}(at: 4, of: { $0.squareRoot() }))  
-  expectEqual(0.25, ${differential_op}(at: 4, of: { altSquareRoot($0) }))
+  expectEqual(0.5, ${differential_op}(at: 1, of: { formSquareRoot($0) }))
+  expectEqual(0.25, ${differential_op}(at: 4, of: { formSquareRoot($0) }))
 %  end # for derivative_op in ['gradient', 'derivative']:
 }
 

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -75,27 +75,41 @@ FloatingPointDerivativeTests.test("${Self}./") {
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {
-%  for differential_op in ['gradient', 'derivative']:
-  do { // prevent `altSquareRoot` from being declared twice in same scope
-    expectEqual(0.5, ${differential_op}(at: 1, of: { $0.squareRoot() }))
-    expectEqual(0.25, ${differential_op}(at: 4, of: { $0.squareRoot() }))
-
-    @differentiable(reverse)
-    func altSquareRoot(_ x: ${Self}) -> ${Self} {
-      var output = x
-      output.formSquareRoot()
-      return output
-    }
-
-    expectEqual(0.5, ${differential_op}(at: 1, of: { altSquareRoot($0) }))
-    expectEqual(0.25, ${differential_op}(at: 4, of: { altSquareRoot($0) }))
+  @differentiable(reverse)
+  func altSquareRoot(_ x: ${Self}) -> ${Self} {
+    var output = x
+    output.formSquareRoot()
+    return output
   }
+
+%  for differential_op in ['gradient', 'derivative']:
+  expectEqual(0.5, ${differential_op}(at: 1, of: { $0.squareRoot() }))
+  expectEqual(0.5, ${differential_op}(at: 1, of: { altSquareRoot($0) }))
+
+  expectEqual(0.25, ${differential_op}(at: 4, of: { $0.squareRoot() }))  
+  expectEqual(0.25, ${differential_op}(at: 4, of: { altSquareRoot($0) }))
 %  end # for derivative_op in ['gradient', 'derivative']:
 }
 
 FloatingPointDerivativeTests.test("${Self}.addingProduct") {
   expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, of: { $0.addingProduct($1, $2) }))
+  expectEqual(6, derivative(at: ${Self}(10), 3, 2, of: { $0.addingProduct($1, $2) }))
 }
+
+// TODO(SR-15793) enable tests of `addProduct` once bug is fixed
+/*
+FloatingPointDerivativeTests.test("${Self}.addProduct") {
+  @differentiable(reverse)
+  func addProduct(_ x: ${Self}, _ y: ${Self}, _ z: ${Self}) -> ${Self} {
+    var output = x
+    output.addProduct(y, z)
+    return output
+  }
+
+  expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, of: { addProduct($0, $1, $2) }))
+  expectEqual(6, derivative(at: ${Self}(10), 3, 2, of: { addProduct($0, $1, $2) }))
+}
+*/
 
 FloatingPointDerivativeTests.test("${Self}.minimum") {
   expectEqual((1.0, 0.0), gradient(at: ${Self}(1), ${Self}(2), of: { ${Self}.minimum($0, $1) }))


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add missing derivatives of protocol methods and enforce consistent code style. 

Partially resolves SR-15796.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
`FloatingPoint.addProduct` is disabled because of SR-15793. Also, some functions will not be implemented until https://github.com/apple/swift/pull/40986 is resolved.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
