### PR TITLE
[Distributed] Augment distributed accessor to lookup witness tables for decode call

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -292,6 +292,7 @@ IDENTIFIER(using)
 IDENTIFIER(InvocationDecoder)
 IDENTIFIER(whenLocal)
 IDENTIFIER(decodeNextArgument)
+IDENTIFIER(SerializationRequirement)
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -69,32 +69,44 @@ llvm::Value *irgen::emitDistributedActorInitializeRemote(
 namespace {
 
 struct ArgumentDecoderInfo {
+  /// The instance of the decoder this information belongs to.
   llvm::Value *Decoder;
 
+  /// The type of `decodeNextArgument` method.
   CanSILFunctionType MethodType;
+
+  /// The pointer to `decodeNextArgument` method which
+  /// could be used to form a call to it.
   FunctionPointer MethodPtr;
+
+  /// Protocol requirements associated with the generic
+  /// parameter `Argument` of this decode method.
+  GenericSignature::RequiredProtocols ProtocolRequirements;
 
   ArgumentDecoderInfo(llvm::Value *decoder, CanSILFunctionType decodeMethodTy,
                       FunctionPointer decodePtr)
-      : Decoder(decoder), MethodType(decodeMethodTy), MethodPtr(decodePtr) {}
+      : Decoder(decoder), MethodType(decodeMethodTy), MethodPtr(decodePtr),
+        ProtocolRequirements(findProtocolRequirements(decodeMethodTy)) {}
 
   CanSILFunctionType getMethodType() const { return MethodType; }
 
-  CanGenericSignature getGenericSignature() const {
-    return MethodType->getInvocationGenericSignature();
-  }
-
-  GenericSignature::RequiredProtocols getProtocolRequirements() const {
-    auto signature = getGenericSignature();
-    auto genericParams = signature.getGenericParams();
-
-    // func decodeNextArgument<Arg : <SerializationRequirement>() throws -> Arg
-    assert(genericParams.size() == 1);
-    return signature->getRequiredProtocols(genericParams.front());
+  ArrayRef<ProtocolDecl *> getProtocolRequirements() const {
+    return ProtocolRequirements;
   }
 
   /// Form a callee to a decode method - `decodeNextArgument`.
   Callee getCallee() const;
+
+private:
+  static GenericSignature::RequiredProtocols
+  findProtocolRequirements(CanSILFunctionType decodeMethodTy) {
+    auto signature = decodeMethodTy->getInvocationGenericSignature();
+    auto genericParams = signature.getGenericParams();
+
+    // func decodeNextArgument<Arg : #SerializationRequirement#>() throws -> Arg
+    assert(genericParams.size() == 1);
+    return signature->getRequiredProtocols(genericParams.front());
+  }
 };
 
 class DistributedAccessor {
@@ -130,7 +142,7 @@ private:
                       Explosion &arguments);
 
   void lookupWitnessTables(llvm::Value *value,
-                           GenericSignature::RequiredProtocols protocols,
+                           ArrayRef<ProtocolDecl *> protocols,
                            Explosion &witnessTables);
 
   /// Load witness table addresses (if any) from the given buffer
@@ -449,7 +461,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
 }
 
 void DistributedAccessor::lookupWitnessTables(
-    llvm::Value *value, GenericSignature::RequiredProtocols protocols,
+    llvm::Value *value, ArrayRef<ProtocolDecl *> protocols,
     Explosion &witnessTables) {
   auto conformsToProtocol = IGM.getConformsToProtocolFn();
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -472,26 +472,66 @@ GetDistributedActorArgumentDecodingMethodRequest::evaluate(Evaluator &evaluator,
   auto members = TypeChecker::lookupMember(actor->getDeclContext(), decoderTy,
                                            DeclNameRef(ctx.Id_decodeNextArgument));
 
+  // typealias SerializationRequirement = any ...
+  auto serializerType = getAssociatedTypeOfDistributedSystem(
+                            actor, ctx.Id_SerializationRequirement)
+                            ->castTo<ExistentialType>()
+                            ->getConstraintType()
+                            ->getDesugaredType();
+
+  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
+  if (auto composition = serializerType->getAs<ProtocolCompositionType>()) {
+    for (auto member : composition->getMembers()) {
+      if (auto *protocol = member->getAs<ProtocolType>())
+        serializationReqs.insert(protocol->getDecl());
+    }
+  } else {
+    auto protocol = serializerType->castTo<ProtocolType>()->getDecl();
+    serializationReqs.insert(protocol);
+  }
+
   SmallVector<FuncDecl *, 2> candidates;
-  // Looking for `decodeNextArgument<Arg>() throws -> Arg`
+  // Looking for `decodeNextArgument<Arg: <SerializationReq>>() throws -> Arg`
   for (auto &member : members) {
     auto *FD = dyn_cast<FuncDecl>(member.getValueDecl());
     if (!FD || FD->hasAsync() || !FD->hasThrows())
       continue;
 
     auto *params = FD->getParameters();
+    // No arguemnts.
     if (params->size() != 0)
       continue;
 
     auto genericParamList = FD->getGenericParams();
-    if (genericParamList->size() == 1) {
-      auto paramTy = genericParamList->getParams()[0]
-                         ->getInterfaceType()
-                         ->getMetatypeInstanceType();
+    // A single generic parameter.
+    if (genericParamList->size() != 1)
+      continue;
 
-      if (FD->getResultInterfaceType()->isEqual(paramTy))
-        candidates.push_back(FD);
-    }
+    auto paramTy = genericParamList->getParams()[0]
+                       ->getInterfaceType()
+                       ->getMetatypeInstanceType();
+
+    // `decodeNextArgument` should return its generic parameter value
+    if (!FD->getResultInterfaceType()->isEqual(paramTy))
+      continue;
+
+    // Let's find out how many serialization requirements does this method cover
+    // e.g. `Codable` is two requirements - `Encodable` and `Decodable`.
+    unsigned numSerializationReqsCovered = llvm::count_if(
+        FD->getGenericRequirements(), [&](const Requirement &requirement) {
+          if (!(requirement.getFirstType()->isEqual(paramTy) &&
+                requirement.getKind() == RequirementKind::Conformance))
+            return 0;
+
+          return serializationReqs.count(requirement.getProtocolDecl()) ? 1 : 0;
+        });
+
+    // If the current method covers all of the serialization requirements,
+    // it's a match. Note that it might also have other requirements, but
+    // we let that go as long as there are no two candidates that differ
+    // only in generic requirements.
+    if (numSerializationReqsCovered == serializationReqs.size())
+      candidates.push_back(FD);
   }
 
   // Type-checker should reject any definition of invocation decoder

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -285,7 +285,6 @@ extension DistributedActorSystem {
       let returnType = try invocationDecoder.decodeReturnType() ?? returnTypeFromTypeInfo
       // let errorType = try invocation.decodeErrorType() // TODO: decide how to use?
 
-      var decoderAny = invocationDecoder as Any
       // Execute the target!
       try await _executeDistributedTarget(
         on: actor,
@@ -419,12 +418,7 @@ public protocol DistributedTargetInvocationDecoder : AnyObject {
 //  /// buffer for all the arguments and their expected types. The 'pointer' passed here is a pointer
 //  /// to a "slot" in that pre-allocated buffer. That buffer will then be passed to a thunk that
 //  /// performs the actual distributed (local) instance method invocation.
-//  mutating func decodeNextArgument<Argument: SerializationRequirement>(
-//      into pointer: UnsafeMutablePointer<Argument> // pointer to our hbuffer
-//  ) throws
-
-  // FIXME(distributed): remove this since it must have the ': SerializationRequirement'
-  func decodeNextArgument<Argument>() throws -> Argument
+//  mutating func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument
 
   func decodeErrorType() throws -> Any.Type?
 

--- a/test/Distributed/Inputs/FakeDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/FakeDistributedActorSystems.swift
@@ -311,7 +311,7 @@ public class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
     return genericSubs
   }
 
-  public func decodeNextArgument<Argument>() throws -> Argument {
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
     guard argumentIndex < arguments.count else {
       fatalError("Attempted to decode more arguments than stored! Index: \(argumentIndex), args: \(arguments)")
     }

--- a/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
+++ b/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
@@ -36,8 +36,8 @@ struct ActorAddress: Hashable, Sendable, Codable {
 
 final class FakeActorSystem: DistributedActorSystem {
   typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocation
-  typealias InvocationEncoder = FakeInvocation
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
   typealias SerializationRequirement = Codable
 
   func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act?
@@ -82,19 +82,23 @@ struct FakeDistributedSystemError: DistributedActorSystemError {
   let message: String
 }
 
-class FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvocationDecoder {
+// === Sending / encoding -------------------------------------------------
+struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
   typealias SerializationRequirement = Codable
 
-  func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws {}
-  func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
 
-  // === Receiving / decoding -------------------------------------------------
+// === Receiving / decoding -------------------------------------------------
+class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_decode.swift
+++ b/test/Distributed/Runtime/distributed_actor_decode.swift
@@ -113,7 +113,7 @@ class FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvoc
   // === Receiving / decoding -------------------------------------------------
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -133,7 +133,7 @@ class FakeDistributedInvocation: DistributedTargetInvocationEncoder, Distributed
   func decodeGenericSubstitutions() throws -> [Any.Type] {
     []
   }
-  func decodeNextArgument<Argument>() throws -> Argument {
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
     fatalError()
   }
   func decodeReturnType() throws -> Any.Type? {

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -70,8 +70,8 @@ var nextID: Int = 1
 
 struct FakeActorSystem: DistributedActorSystem {
   public typealias ActorID = ActorAddress
-  public typealias InvocationDecoder = FakeInvocation
-  public typealias InvocationEncoder = FakeInvocation
+  public typealias InvocationDecoder = FakeInvocationDecoder
+  public typealias InvocationEncoder = FakeInvocationEncoder
   public typealias SerializationRequirement = Codable
 
   init() {
@@ -121,24 +121,25 @@ struct FakeActorSystem: DistributedActorSystem {
 
 }
 
-public struct FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvocationDecoder {
-  public typealias SerializationRequirement = Codable
+// === Sending / encoding -------------------------------------------------
+struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
+  typealias SerializationRequirement = Codable
 
-  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  public mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws {}
-  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  public mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
+}
 
-  // === Receiving / decoding -------------------------------------------------
+// === Receiving / decoding -------------------------------------------------
+class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
+  typealias SerializationRequirement = Codable
 
-  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public mutating func decodeNextArgument<Argument>(
-    _ argumentType: Argument.Type,
-    into pointer: UnsafeMutablePointer<Argument> // pointer to our hbuffer
-  ) throws { /* ... */ }
-  public func decodeReturnType() throws -> Any.Type? { nil }
-  public func decodeErrorType() throws -> Any.Type? { nil }
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 typealias DefaultDistributedActorSystem = FakeActorSystem

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -109,7 +109,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -113,7 +113,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -227,7 +227,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   }
 
   var argumentIndex: Int = 0
-  func decodeNextArgument<Argument>() throws -> Argument {
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
     guard argumentIndex < arguments.count else {
       fatalError("Attempted to decode more arguments than stored! Index: \(argumentIndex), args: \(arguments)")
     }

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -126,7 +126,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -217,7 +217,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
@@ -110,7 +110,7 @@ class FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvoc
   // === Receiving / decoding -------------------------------------------------
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument{ fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument{ fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_self_calls.swift
+++ b/test/Distributed/Runtime/distributed_actor_self_calls.swift
@@ -111,7 +111,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -98,7 +98,7 @@ class FakeInvocation: DistributedTargetInvocationEncoder, DistributedTargetInvoc
   // === Receiving / decoding -------------------------------------------------
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/Runtime/distributed_func_metadata.swift
+++ b/test/Distributed/Runtime/distributed_func_metadata.swift
@@ -115,7 +115,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
@@ -108,7 +108,19 @@ public distributed actor MyOtherActor {
 // CHECK-NEXT: [[ARG_0_SIZE:%.*]] = and i32 [[ARG_0_SIZE_ADJ]], -16
 // CHECK-NEXT: [[ARG_0_VALUE_BUF:%.*]] = call swiftcc i8* @swift_task_alloc(i32 [[ARG_0_SIZE]])
 // CHECK-NEXT: [[ARG_0_RES_SLOT:%.*]] = bitcast i8* [[ARG_0_VALUE_BUF]] to %swift.opaque*
-// CHECK-NEXT: call swiftcc void {{.*}}(%swift.opaque* noalias nocapture sret(%swift.opaque) [[ARG_0_RES_SLOT]], %swift.type* %arg_type, %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself %1, %swift.error** noalias nocapture dereferenceable(4) %swifterror)
+// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %arg_type, %swift.protocol* @"$sSeMp")
+// CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq i8** [[ENCODABLE_WITNESS]], null
+// CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness, label [[CONT:%.*]]
+// CHECK: missing-witness:
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK: [[DECODABLE_WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %arg_type, %swift.protocol* @"$sSEMp")
+// CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq i8** [[DECODABLE_WITNESS]], null
+// CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness1, label [[CONT:%.*]]
+// CHECK: missing-witness1:
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK: call swiftcc void {{.*}}(%swift.opaque* noalias nocapture sret(%swift.opaque) [[ARG_0_RES_SLOT]], %swift.type* %arg_type, i8** [[ENCODABLE_WITNESS]], i8** [[DECODABLE_WITNESS]], %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself %1, %swift.error** noalias nocapture dereferenceable(4) %swifterror)
 
 // CHECK: store %swift.error* null, %swift.error** %swifterror
 // CHECK-NEXT: [[ARG_0_VAL_ADDR:%.*]] = bitcast i8* [[ARG_0_VALUE_BUF]] to %TSi*
@@ -163,10 +175,10 @@ public distributed actor MyOtherActor {
 
 /// Initialize the result buffer with values produced by the thunk
 
-// CHECK: %._guts1 = getelementptr inbounds %TSS, %TSS* [[COERCED_RESULT_SLOT]], i32 0, i32 0
-// CHECK: store i32 {{.*}}, i32* %._guts1._object._count._value
-// CHECK: store i8 {{.*}}, i8* %._guts1._object._discriminator._value
-// CHECK: store i16 {{.*}}, i16* %._guts1._object._flags._value, align 2
+// CHECK: %._guts2 = getelementptr inbounds %TSS, %TSS* [[COERCED_RESULT_SLOT]], i32 0, i32 0
+// CHECK: store i32 {{.*}}, i32* %._guts2._object._count._value
+// CHECK: store i8 {{.*}}, i8* %._guts2._object._discriminator._value
+// CHECK: store i16 {{.*}}, i16* %._guts2._object._flags._value, align 2
 
 // CHECK: {{.*}} = call i1 (i8*, i1, ...) @llvm.coro.end.async({{.*}}, %swift.context* {{.*}}, %swift.error* {{.*}})
 
@@ -195,10 +207,10 @@ public distributed actor MyOtherActor {
 // CHECK-NEXT: [[THUNK_ASYNC_CONTEXT:%.*]] = call swiftcc i8* @swift_task_alloc(i32 [[CONTEXT_SIZE]])
 
 // CHECK: [[TMP_STR_ARG:%.*]] = bitcast { i32, i32, i32 }* %temp-coercion.coerced to %TSS*
-// CHECK-NEXT: %._guts1 = getelementptr inbounds %TSS, %TSS* [[TMP_STR_ARG]], i32 0, i32 0
+// CHECK-NEXT: %._guts2 = getelementptr inbounds %TSS, %TSS* [[TMP_STR_ARG]], i32 0, i32 0
 
-// CHECK: store i32 {{.*}}, i32* %._guts1._object._count._value
-// CHECK: [[VARIANT:%.*]] = bitcast %Ts13_StringObjectV7VariantO* %._guts1._object._variant to i32*
+// CHECK: store i32 {{.*}}, i32* %._guts2._object._count._value
+// CHECK: [[VARIANT:%.*]] = bitcast %Ts13_StringObjectV7VariantO* %._guts2._object._variant to i32*
 // CHECK-NEXT: store i32 {{.*}}, i32* [[VARIANT]]
 
 // CHECK: [[STR_ARG_SIZE_PTR:%.*]] = getelementptr inbounds { i32, i32, i32 }, { i32, i32, i32 }* %temp-coercion.coerced, i32 0, i32 0

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -108,7 +108,19 @@ public distributed actor MyOtherActor {
 // CHECK-NEXT: [[ARG_0_SIZE:%.*]] = and i64 [[ARG_0_SIZE_ADJ]], -16
 // CHECK-NEXT: [[ARG_0_VALUE_BUF:%.*]] = call swiftcc i8* @swift_task_alloc(i64 [[ARG_0_SIZE]])
 // CHECK-NEXT: [[ARG_0_RES_SLOT:%.*]] = bitcast i8* [[ARG_0_VALUE_BUF]] to %swift.opaque*
-// CHECK-NEXT: call swiftcc void {{.*}}(%swift.opaque* noalias nocapture sret(%swift.opaque) [[ARG_0_RES_SLOT]], %swift.type* %arg_type, %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself %1, %swift.error** noalias nocapture swifterror dereferenceable(8) %swifterror)
+// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %arg_type, %swift.protocol* @"$sSeMp")
+// CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq i8** [[ENCODABLE_WITNESS]], null
+// CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness, label [[CONT:%.*]]
+// CHECK: missing-witness:
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK: [[DECODABLE_WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %arg_type, %swift.protocol* @"$sSEMp")
+// CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq i8** [[DECODABLE_WITNESS]], null
+// CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness1, label [[CONT:%.*]]
+// CHECK: missing-witness1:
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK: call swiftcc void {{.*}}(%swift.opaque* noalias nocapture sret(%swift.opaque) [[ARG_0_RES_SLOT]], %swift.type* %arg_type, i8** [[ENCODABLE_WITNESS]], i8** [[DECODABLE_WITNESS]], %T27FakeDistributedActorSystems0A17InvocationDecoderC* swiftself %1, %swift.error** noalias nocapture swifterror dereferenceable(8) %swifterror)
 
 // CHECK: store %swift.error* null, %swift.error** %swifterror
 // CHECK-NEXT: [[ARG_0_VAL_ADDR:%.*]] = bitcast i8* [[ARG_0_VALUE_BUF]] to %TSi*

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -66,7 +66,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -113,7 +113,7 @@ public class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Codable
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   public func decodeReturnType() throws -> Any.Type? { nil }
   public func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/SILGen/distributed_thunk.swift
+++ b/test/SILGen/distributed_thunk.swift
@@ -118,7 +118,7 @@ public class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Codable
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   public func decodeReturnType() throws -> Any.Type? { nil }
   public func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/Serialization/Inputs/def_distributed.swift
+++ b/test/Serialization/Inputs/def_distributed.swift
@@ -111,7 +111,7 @@ public class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Codable
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   public func decodeReturnType() throws -> Any.Type? { nil }
   public func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/TBD/distributed.swift
+++ b/test/TBD/distributed.swift
@@ -126,7 +126,7 @@ public class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Codable
 
   public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   public func decodeReturnType() throws -> Any.Type? { nil }
   public func decodeErrorType() throws -> Any.Type? { nil }
 }

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -171,7 +171,7 @@ class FakeInvocationDecoder : DistributedTargetInvocationDecoder {
   typealias SerializationRequirement = Codable
 
   func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument>() throws -> Argument { fatalError() }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
   func decodeReturnType() throws -> Any.Type? { nil }
   func decodeErrorType() throws -> Any.Type? { nil }
 }


### PR DESCRIPTION
`decodeNextArgument` requires (at least) that argument type conform
 to a serialization requirement, witness table(s) for all protocol
requirements have to be lookup up by accessor to form correct
`decodeNextArgument` invocation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
