### PR TITLE
Ensure that we warn about non-local non-@unchecked Sendable conformance

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3979,10 +3979,9 @@ bool swift::checkSendableConformance(
 
   // Sendable can only be used in the same source file.
   auto conformanceDecl = conformanceDC->getAsDecl();
-  auto behavior = SendableCheckContext(conformanceDC)
+  auto behavior = SendableCheckContext(conformanceDC, check)
       .defaultDiagnosticBehavior();
   if (conformanceDC->getParentSourceFile() &&
-      nominal->getParentSourceFile() &&
       conformanceDC->getParentSourceFile() != nominal->getParentSourceFile()) {
     conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,
                               nominal->getDescriptiveKind(),

--- a/test/Concurrency/Inputs/NonStrictModule.swift
+++ b/test/Concurrency/Inputs/NonStrictModule.swift
@@ -1,1 +1,3 @@
 public class NonStrictClass { }
+
+public struct NonStrictStruct { }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -147,6 +147,7 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
 }
 
 // rdar://86653457 - Crash due to missing Sendable conformances.
+// expected-warning@+1{{non-final class 'Klass' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 class Klass<Output: Sendable>: Sendable {}
 final class SubKlass: Klass<[S]> {}
 public struct S {}

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -17,3 +17,5 @@ func testA(a: A) async {
   // CHECK: note: struct 'StrictStruct' does not conform to the 'Sendable' protocol
   // CHECK: note: class 'NonStrictClass' does not conform to the 'Sendable' protocol
 }
+
+extension NonStrictStruct: @unchecked Sendable { }

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -44,6 +44,7 @@ actor A7 {
 @available(SwiftStdlib 5.1, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
+  // expected-warning@-2{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
@@ -52,6 +53,7 @@ class C1: Actor {
 @available(SwiftStdlib 5.1, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
+  // expected-warning@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -62,6 +64,7 @@ class C2: Actor {
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
+  // expected-warning@-3{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 


### PR DESCRIPTION
**Explanation**: Ensure that we diagnose explicit conformances to `Sendable` for non-final classes and when making another module's type to conform to `Sendable` without the required `@unchecked`. This was an error in Swift 5.5, and needs to at least warn in Swift 5.6 so we don't accept unsafe code.
**Scope**: Swift 5.6 accidentally allows some `Sendable` conformances that were prohibited by Swift 5.5. Only code written for the Swift 5.6 beta will be affected.
**Radar/SR Issue**: rdar://88273082
**Risk**: Low.
**Testing**: PR testing and CI .
**Original PR**: https://github.com/apple/swift/pull/41103
