### PR TITLE
Fix crash on systems with pointer authentication.

### DIFF
--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -442,6 +442,10 @@ static void hashStringForType(IRGenModule &IGM, CanType Ty, raw_ostream &Out,
       hashStringForType(IGM, UnwrappedTy->getCanonicalType(), Out, genericEnv);
       Out << ">";
     }
+  } else if (auto ETy = dyn_cast<ExistentialType>(Ty)) {
+    // Look through existential types
+    hashStringForType(IGM, ETy->getConstraintType()->getCanonicalType(),
+                      Out, genericEnv);
   } else if (auto GTy = dyn_cast<AnyGenericType>(Ty)) {
     // For generic and non-generic value types, use the mangled declaration
     // name, and ignore all generic arguments.


### PR DESCRIPTION
`hashStringForType()` needed updating to deal with `ExistentialType`.

rdar://87717024
