### PR TITLE
Make sure to transfer mod-times when using sftp.

### DIFF
--- a/utils/remote-run
+++ b/utils/remote-run
@@ -124,7 +124,7 @@ class RemoteCommandRunner(CommandRunner):
                 [quote(arg) for arg in command])
 
     def sftp_invocation(self):
-        return (['/usr/bin/sftp', '-b', '-', '-q', '-r'] +
+        return (['/usr/bin/sftp', '-b', '-', '-q', '-r', '-p'] +
                 self.common_options(port_flag='-P') +
                 [self.remote_host])
 


### PR DESCRIPTION
We should be using the '-p' switch for this, otherwise sometimes things fail because of code signature mismatches.

rdar://88179140
