### PR TITLE
🍒 [5.6] Remove Task.CancellationError in doc comments

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -100,7 +100,7 @@ extension Task {
   /// depending on the executor's scheduling details.
   ///
   /// If the task throws an error, this property propagates that error.
-  /// Tasks that respond to cancellation by throwing `Task.CancellationError`
+  /// Tasks that respond to cancellation by throwing `CancellationError`
   /// have that error propagated here upon cancellation.
   ///
   /// - Returns: The task's result.

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -72,7 +72,7 @@ extension Task where Success == Never, Failure == Never {
 extension Task where Success == Never, Failure == Never {
   /// Throws an error if the task was canceled.
   ///
-  /// The error is always an instance of `Task.CancellationError`.
+  /// The error is always an instance of `CancellationError`.
   ///
   /// - SeeAlso: `isCancelled()`
   public static func checkCancellation() throws {


### PR DESCRIPTION
**Description:** Task.CancellationError has been renamed to CancellationError. Fix two doc comments that still used the old name.
**Risk:** Low
**Review by:** @amartini51 @kavon  
**Testing:** CI validation
**Original PR:** https://github.com/apple/swift/pull/41097
**Radar:** rdar://88292687