### PR TITLE
[CSApply] Result coercion check should always use resolved type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8802,7 +8802,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
       return convertType &&
           !convertType->hasPlaceholder() &&
           !target.isOptionalSomePatternInit() &&
-          !(solution.getType(resultExpr)->isUninhabited() &&
+          !(solution.getResolvedType(resultExpr)->isUninhabited() &&
             cs.getContextualTypePurpose(target.getAsExpr())
               == CTP_ReturnSingleExpr);
     };

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar88285682.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar88285682.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+struct S {
+  func crash() -> Never {
+    fatalError("")
+  }
+}
+
+class A {
+  func value() -> Int { 42 }
+}
+
+class B : A {
+  let value: S = S()
+
+  func test() throws -> B {
+    value.crash() // Ok
+  }
+}


### PR DESCRIPTION
`shouldCoerceToContextualType` used `solution.getType(ASTNode)`
which returns a type that has type variables in it. To properly
check whether result type needs a coercion it has to be resolved
first which is done via `solution.getResultType(ASTNode)`.

Resolves: rdar://88285682

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
