### PR TITLE
[5.6][CSApply] Result coercion check should always use resolved type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8695,7 +8695,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
       return convertType &&
           !convertType->hasPlaceholder() &&
           !target.isOptionalSomePatternInit() &&
-          !(solution.getType(resultExpr)->isUninhabited() &&
+          !(solution.getResolvedType(resultExpr)->isUninhabited() &&
             cs.getContextualTypePurpose(target.getAsExpr())
               == CTP_ReturnSingleExpr);
     };

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar88285682.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar88285682.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+struct S {
+  func crash() -> Never {
+    fatalError("")
+  }
+}
+
+class A {
+  func value() -> Int { 42 }
+}
+
+class B : A {
+  let value: S = S()
+
+  func test() throws -> B {
+    value.crash() // Ok
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/41108

---

- Explanation:

Fix a crash when function body consists of a single expression that returns `Never`
from a method call on overloaded base.

`shouldCoerceToContextualType` used `solution.getType(ASTNode)`
which returns a type that has type variables in it. To properly
check whether result type needs a coercion it has to be resolved
first which is done via `solution.getResultType(ASTNode)`.

- Scope: Single-expression function bodies where method call returns `Never` on overloaded base type.

- Main Branch PR: https://github.com/apple/swift/pull/41108

- Resolves: rdar://88285682

- Risk: Very low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://88285682
(cherry picked from commit 48ffeddbc74682abc1bda0d02de8daf78987d9d7)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
