### PR TITLE
SIL: Detect and bail out on infinite aggregates.

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1290,7 +1290,13 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
   // All resilient structs have the same opaque lowering, since they are
   // indistinguishable as values --- except that we have to track
   // ABI-accessibility.
-  if (IGM.isResilient(D, ResilienceExpansion::Maximal)) {
+  //
+  // Treat infinitely-sized types as resilient as well, since they can never
+  // be concretized.
+  if (IGM.isResilient(D, ResilienceExpansion::Maximal)
+      || IGM.getSILTypes().getTypeLowering(SILType::getPrimitiveAddressType(type),
+                                            TypeExpansionContext::minimal())
+            .getRecursiveProperties().isInfinite()) {
     auto structAccessible =
       IsABIAccessible_t(IGM.getSILModule().isTypeMetadataAccessible(type));
     return &getResilientStructTypeInfo(structAccessible);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -109,6 +109,11 @@ bool SILType::isTrivial(const SILFunction &F) const {
 }
 
 bool SILType::isEmpty(const SILFunction &F) const {
+  // Infinite types are never empty.
+  if (F.getTypeLowering(*this).getRecursiveProperties().isInfinite()) {
+    return false;
+  }
+  
   if (auto tupleTy = getAs<TupleType>()) {
     // A tuple is empty if it either has no elements or if all elements are
     // empty.

--- a/test/SILGen/infinite_type_from_generic_substitution.swift
+++ b/test/SILGen/infinite_type_from_generic_substitution.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-emit-sil -verify %s
+
+protocol P {
+    associatedtype A
+}
+
+struct S<T: P> {
+    var s: T.A
+}
+
+struct SR: P {
+    typealias A = S<SR>
+}
+
+struct SU<T: P> {
+    var x: S<T>
+}
+
+func foo(x: SU<SR>) -> SU<SR> { return x }
+func bar(x: S<SR>) -> S<SR> { return x }
+func bas(x: S<SR>) -> S<SR> { return x.s }
+
+enum E<T: P> {
+    case recursive(T.A)
+    case blah
+}
+
+struct ER: P {
+    typealias A = E<ER>
+}
+
+enum EU<T: P> {
+    case x(E<T>)
+}
+
+func zim(x: EU<ER>) -> EU<ER> { return x }
+func zang(x: E<ER>) -> E<ER> { return x }


### PR DESCRIPTION
Sema diagnoses obvious cases of value types defined in terms of themselves,
but it can't catch cases that arise as a result of generic substitution,
such as if a generic struct has a field of associated type that becomes the
same as the struct type itself. SIL may end up handling these types, even
though they can't be instantiated (the runtime will complain and crash if
the metadata is requested), either during SILGen because they were written
in source code, or as a result of generic specialization during optimization.
SIL thus can't rely on diagnostics preventing such types from appearing, so
it needs to be able to continue gracefully when they show up. Add checks
in type lowering for when a struct or enum lowering ends up depending on
itself, and generate an infinite type lowering that's opaque and address-only.

Fixes rdar://80310017