### PR TITLE
[CopyPropagation] Added lexical destroy folding.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -338,6 +338,10 @@ public:
   bool areUsesWithinBoundary(ArrayRef<Operand *> uses,
                              DeadEndBlocks *deadEndBlocks) const;
 
+  /// \p deadEndBlocks is optional.
+  bool areUsesOutsideBoundary(ArrayRef<Operand *> uses,
+                              DeadEndBlocks *deadEndBlocks) const;
+
   /// Compute liveness for a single SSA definition.
   void computeSSALiveness(SILValue def);
 };

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -43,7 +43,7 @@ namespace swift {
 ///
 ///   // Mark the beginning of a block reachable. Only called once per block.
 ///   // Typically a BasicBlockSet wrapper.
-///   boid markReachableBegin(SILBasicBlock *block);
+///   void markReachableBegin(SILBasicBlock *block);
 /// 
 ///   // Mark the end of a block reachable. Only called once per block.
 ///   // Typically a BasicBlockSet wrapper.

--- a/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
@@ -313,6 +313,23 @@ private:
   CanonicalOSSAConsumeInfo consumes;
 
 public:
+  /// When rewriting destroys, is this an instruction which destroys should not
+  /// be hoisted over to avoid churn and infinite looping.
+  static bool ignoredByDestroyHoisting(SILInstructionKind kind) {
+    switch (kind) {
+    case SILInstructionKind::DestroyValueInst:
+    case SILInstructionKind::CopyValueInst:
+    case SILInstructionKind::BeginBorrowInst:
+    case SILInstructionKind::EndBorrowInst:
+    case SILInstructionKind::FunctionRefInst:
+    case SILInstructionKind::EnumInst:
+    case SILInstructionKind::StructInst:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   void maybeNotifyMoveOnlyCopy(Operand *use) {
     if (!moveOnlyCopyValueNotification)
       return;

--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -151,6 +151,10 @@ bool shrinkBorrowScope(
     BeginBorrowInst *bbi, InstructionDeleter &deleter,
     SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts);
 
+bool foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,
+                                       DominanceInfo &dominanceTree,
+                                       InstructionDeleter &deleter);
+
 } // namespace swift
 
 #endif // SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEBORROWSCOPES_H

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -167,6 +167,20 @@ bool PrunedLiveness::areUsesWithinBoundary(ArrayRef<Operand *> uses,
   return true;
 }
 
+bool PrunedLiveness::areUsesOutsideBoundary(
+    ArrayRef<Operand *> uses, DeadEndBlocks *deadEndBlocks) const {
+  auto checkDeadEnd = [deadEndBlocks](SILInstruction *inst) {
+    return deadEndBlocks && deadEndBlocks->isDeadEnd(inst->getParent());
+  };
+
+  for (auto *use : uses) {
+    auto *user = use->getUser();
+    if (isWithinBoundary(user) || checkDeadEnd(user))
+      return false;
+  }
+  return true;
+}
+
 // An SSA def meets all the criteria for pruned liveness--def dominates all uses
 // with no holes in the liverange. The lifetime-ending uses are also
 // recorded--destroy_value or end_borrow. However destroy_values may not

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(swiftSILOptimizer PRIVATE
   InstructionDeleter.cpp
   InstOptUtils.cpp
   KeyPathProjector.cpp
+  LexicalDestroyFolding.cpp
   LoadStoreOptUtils.cpp
   LoopUtils.cpp
   OptimizerStatsUtils.cpp

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -492,9 +492,10 @@ void CanonicalizeOSSALifetime::findOrInsertDestroyInBlock(SILBasicBlock *bb) {
       return;
     }
     // This is not a potential last user. Keep scanning.
-    // Allow lifetimes to be artificially extended up to the next call. The goal
-    // is to prevent repeated destroy rewriting without inhibiting optimization.
-    if (ApplySite::isa(inst)) {
+    // Allow lifetimes to be artificially extended up to the next non-ignored
+    // instruction. The goal is to prevent repeated destroy rewriting without
+    // inhibiting optimization.
+    if (!ignoredByDestroyHoisting(inst->getKind())) {
       existingDestroy = nullptr;
     } else if (!existingDestroy) {
       if (auto *destroy = dyn_cast<DestroyValueInst>(inst)) {

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -1,0 +1,769 @@
+//===- LexicalDestroyFolding.cpp - Fold destroys into final owned applies -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+/// After ShrinkBorrowScope and CanonicalOSSALifetime both run, when a final use
+/// of the extended simple lifetime of a begin_borrow [lexical] is as an owned
+/// argument, we will have the following pattern:
+///
+/// %result = apply %fn(..., %copy, ...) : $... (..., @owned Ty, ...)
+/// end_borrow %lifetime : $Ty
+/// destroy_value %dvi
+///
+/// where %lifetime is the result of our begin_borrow [lexical]:
+///
+/// %lifetime = begin_borrow [lexical] %borrowee : $Ty
+///
+/// and %copy is a (transitive) copy of it
+///
+/// %copy = copy_value (copy_value (... %lifetime))
+///
+/// At that point, we want to fold the destroy_value, apply, and borrow into
+///
+/// end_borrow %lifetime : $Ty
+/// apply %fn(..., %move, ...) : $... (..., @owned Ty, ...)
+///
+/// where %move is a the result of a new instruction added above our scope:
+///
+/// %move = move_value [lexical] %borrowee : $Ty
+/// %lifetime = begin_borrow %move : $Ty
+///
+/// We only want to do this when it would mean allowing the callee to end a
+/// lifetime of a value that the caller owned--if we can transfer ownership from
+/// the caller to the callee.  In order to transfer ownership, the caller must
+/// first own the value, so we are only interested in borrows of owned values:
+///
+/// %borrowee : @owned $Ty
+/// %lifetime = begin_borrow [lexical] %borrowee
+///
+/// At the other end, we can only transfer ownership if there are no more
+/// interesting uses of the owned value after the apply.  Specifically, we
+/// require that the instruction after the end_borrow be a destroy_value of the
+/// borrowee.
+///
+/// The simplest example:
+///
+/// %copy = copy_value %lifetime : $Ty
+/// %result = apply %fn(..., %copy, ...) : $... (..., @owned Ty, ...)
+/// end_borrow %lifetime : $Ty
+/// destroy_value %borrowee : $Ty
+///
+/// Taken together, we get the simplest example of this transformation:
+///
+/// INPUT:
+///
+///     %borrowee : @owned
+///     %lifetime = begin_borrow [lexical] %owned
+///     %copy = copy_value %lifetime
+///     apply %fn(%copy) : $... (@owned)
+///     end_borrow %lifetime
+///     destroy_value %borrowee
+///
+/// OUTPUT:
+///
+///     %borrowee : @owned
+///     %move = move_value [lexical] %borrowee
+///     %lifetime = begin_borrow [lexical] %move
+///     end_borrow %lifetime
+///     apply %fn(%move) : $... (@owned)
+///
+/// TODO: Handle partial_apply, try_apply, and begin_apply.
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/GraphNodeWorklist.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/PrunedLiveness.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILNode.h"
+#include "swift/SILOptimizer/Analysis/Reachability.h"
+#include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+#include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
+#include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
+#include "llvm/ADT/SmallVector.h"
+
+#define DEBUG_TYPE "copy-propagation"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                       MARK: LexicalDestroyFolding
+//===----------------------------------------------------------------------===//
+
+class LexicalDestroyFolding {
+  // The instruction that begins the borrow scope.
+  BeginBorrowInst *const introducer;
+
+  // The function containing the introducer.
+  //
+  // introducer->getFunction()
+  SILFunction *const function;
+
+  // BorrowedValue(introducer)
+  BorrowedValue const borrowedValue;
+
+  // The value whose lifetime is guaranteed by the lexical borrow scope.
+  //
+  // introducer->getOperand()
+  SILValue const borrowee;
+
+  DominanceInfo &dominanceTree;
+
+  InstructionDeleter &deleter;
+
+public:
+  LexicalDestroyFolding(BeginBorrowInst *introducer,
+                        DominanceInfo &dominanceTree,
+                        InstructionDeleter &deleter)
+      : introducer(introducer), function(introducer->getFunction()),
+        borrowedValue(BorrowedValue(introducer)),
+        borrowee(introducer->getOperand()), dominanceTree(dominanceTree),
+        deleter(deleter) {
+    assert(introducer->isLexical());
+    assert(introducer->getOperand()->getOwnershipKind() ==
+           OwnershipKind::Owned);
+    assert(borrowedValue.isLocalScope());
+  }
+
+  bool run();
+
+private:
+  /// The consuming use pattern we are trying to match and transform.
+  struct Match {
+    ApplyInst *ai = nullptr;
+    EndBorrowInst *ebi = nullptr;
+    DestroyValueInst *dvi = nullptr;
+
+    /// Whether the match is a candidate for folding.
+    ///
+    /// A partial match--which has both the end_borrow and the destroy value
+    /// but no apply--cannot itself be folded but is not an obstruction to
+    /// folding other candidates.
+    bool isFullMatch() {
+      assert(ebi != nullptr);
+      assert(dvi != nullptr);
+      return ai != nullptr;
+    }
+  };
+  /// A sequence of instructions under consideration for folding
+  struct Candidate {
+    /// The instruction sequence itself.
+    Match match;
+    /// Whether the candidate could indeed be folded as determined by
+    /// isViableMatch.
+    bool viable;
+    /// The indices of the arguments of the apply to rewrite as determined by
+    /// rewritableArgumentIndicesForApply.
+    SmallVector<int, 2> argumentIndices;
+  };
+  /// The degree to which a match is a candidate for folding.
+  enum class MatchViability {
+    /// This match can be folded, supposing any can.
+    Viable,
+    /// This match cannot be folded, even if others can.
+    Nonviable,
+    /// Neither this match nor any other can be folded.
+    Illegal
+  };
+
+  /// Fast check for whether the given instruction is a candidate for folding.
+  ///
+  /// Tries to find patterns like
+  ///
+  ///     apply
+  ///     end_borrow
+  ///     ...           // instructions which CanonicalizeOSSALifetime will not
+  ///                   // hoist destroys over
+  ///     destroy_value %borrowee
+  ///
+  /// If None is returned, we can't do the transformation at any end_borrow.
+  /// If a Match WITHOUT an apply is returned, we can't do the transformation
+  /// on the provided instruction but we still might be able to do it on the
+  /// other scope ending instructions.
+  /// If a Match WITH an apply is returned, we might be able to transform this
+  /// instruction, so more expensive checks are in order.
+  Optional<Match> definesMatchingInstructionSequence(SILInstruction *) const;
+
+  /// Whether the specified instruction is or might be the beginning of a
+  /// sequence of "inconsequential" instructions the last of which destroys
+  /// %borrowee.
+  ///
+  /// CanonicalizeOSSALifetime will put destroy_value instructions after every
+  /// final non-consuming use of %borrowee.  So it will put a
+  /// destroy_value after an
+  ///     end_borrow %introducer
+  /// if there are no subsequent uses of %borrowee.  However, if there
+  /// is already one or more other instructions whose opcodes satisfy
+  /// CanonicalizeOSSALifetime::ignoredByDestroyHoisting just after
+  ///     end_borrow %introducer,
+  /// it won't hoist the
+  ///     destroy_value %borrowee
+  /// over them.
+  ///
+  /// Consequently, it's not good enough just to look at the instruction
+  /// immediately following
+  ///     end_borrow %introducer
+  /// Instead, we need to look over the sequence of them.
+  ///
+  /// To be certain that the sequence is valid, we need to check that none of
+  /// the instructions between the end_borrow and the destroy_value are users of
+  /// %borrowee.  That requires having a set of uses to check for membership
+  /// in, though, so that is postponed until isViableMatch.
+  ///
+  /// returns the destroy_value instruction in the sequence that destroys
+  ///         %borrowee or nullptr if there isn't one
+  DestroyValueInst *findNextBorroweeDestroy(SILInstruction *) const;
+
+  /// Slow check, dependent on finding users, that a Match found by
+  /// definesMatchingInstructionSequence can be folded.
+  MatchViability isViableMatch(Match &, SmallVectorImpl<int> &) const;
+
+  /// Find among the scope ending instructions of %lifetime any that match the
+  /// expected instruction sequence pattern.
+  ///
+  /// Uses definesMatchingInstructionSequence to determine whether an
+  /// instruction is a candidate for folding.
+  ///
+  /// Includes both full matches which could potentially be folded and partial
+  /// matches which need to be verified later aren't illegal in isViableMatch.
+  ///
+  /// returns true if any full matches are found
+  ///         false otherwise
+  bool findCandidates();
+
+  /// Identifies all the simple extended users of %introducer.
+  ///
+  /// Populates: users.
+  ///
+  /// returns true if none of the uses of %introducer escaped
+  ///         false otherwise
+  bool findUsers();
+
+  /// Find all uses of %borrowee that are dominated by introducer.
+  ///
+  /// We are only interested in those dominated by introducer because those are
+  /// the uses all of which must be "outside" the liveness boundary of
+  /// %introducer.  In detail, PrunedLiveness::isWithinBoundary relies on
+  /// clients to know that instructions are after the start of liveness.  We
+  /// determine this via the dominance tree.
+  ///
+  /// Populates: borroweeUses.
+  bool findDominatedUsesOfBorrowee();
+
+  /// Determines whether each candidate is viable for folding.
+  ///
+  /// Requiring findUsers to have been called, this uses the more expensive
+  /// isViableMatch.
+  ///
+  /// returns true if any candidates were viable
+  ///         false otherwise
+  bool filterCandidates();
+
+  /// Whether there are any uses of the borrowee within the borrow scope.
+  ///
+  /// If there are, we can't fold the apply.  Specifically, we can't introduce
+  /// a move_value [lexical] %borrowee because that value still needs to be used
+  /// in those locations.  While updateSSA would happily rewrite those uses to
+  /// be uses of the move, that is not a semantically valid transformation.
+  ///
+  /// For example, given the following SIL
+  ///     %borrowee : @owned
+  ///     %lifetime = begin_borrow [lexical] %borrowee
+  ///     apply %take_guaranteed(%borrowee)
+  ///     %copy = copy_value %lifetime
+  ///     apply %take_owned(%copy)
+  ///     end_borrow %lifetime
+  ///     destroy_value %borrowee
+  /// we can't rewrite like
+  ///     %borrowee : @owned
+  ///     %move = move_value [lexical] %borrowee
+  ///     %lifetime = begin_borrow [lexical] %move
+  ///     apply %take_guaranteed(??????)
+  ///     apply %take_owned(%move)
+  /// because there is no appropriate value to pass to %take_guaranteed.
+  /// Specifically, it's not legal to use %move there because that would make
+  /// the instruction a user of the lexical scope which it was not before.
+  bool borroweeHasUsesWithinBorrowScope();
+
+  /// Make all changes required to fold the viable candidates.
+  ///
+  /// Specifically:
+  /// - create a single move_value [lexical]
+  ///       %move = move_value [lexical] %borrowee
+  ///       %lifetime = begin_borrow [lexical] %move
+  /// - transform all the candidates from
+  ///       apply %fn(..., %copy, ...)
+  ///       end_borrow %lifetime
+  ///       ...
+  ///       destroy_value %borrowee
+  ///   to
+  ///       end_borrow %lifetime
+  ///       apply %fn(..., %move, ...)
+  ///       ...
+  /// - update SSA now that a second def has been introduced for
+  ///   %borrowee
+  void rewrite();
+
+  /// Add the new move_value [lexical] above the begin_borrow [lexical].
+  ///
+  /// At most one will be created per run of LexicalDestroyFolding.
+  ///
+  /// returns false if the move_value [lexical] instruction was added already
+  ///         true if the move_value [lexical] instruction was added just now
+  bool createMove();
+
+  /// Combine the matched instruction sequence
+  ///
+  ///   apply %fn(%copy)
+  ///   end_borrow %lifetime
+  ///   destroy_value %instance
+  ///
+  /// into
+  ///
+  ///   end_borrow %lifetime
+  ///   apply %fn(%move)
+  ///
+  /// This is done in three steps:
+  /// (1) rewrite the apply (and delete the copy_value that is fed to it if
+  ///     possible)
+  /// (2) hoist the end_borrow
+  /// (3) delete the destroy_value
+  void fold(Match, SmallVectorImpl<int> const &rewritableArgumentIndices);
+
+  // Update SSA to reflect that fact that %move and %borrowee are two
+  // defs for the "same value".
+  void updateSSA();
+
+  /// Whether the specified value is %introducer or its iterated copy_value.
+  ///
+  /// In other words, it has to be a simple extended def of %introducer.
+  bool isSimpleExtendedIntroducerDef(SILValue value) const;
+
+  /// Find the arguments in the specified apply that could be rewritten.
+  bool rewritableArgumentIndicesForApply(ApplySite,
+                                         SmallVectorImpl<int> &indices) const;
+
+private:
+  // State calculated over the course of the run.
+
+  /// The sequences of scope ending instructions that are under consideration
+  /// for folding.
+  llvm::SmallVector<Candidate, 4> candidates;
+  // The operands that are uses of the borrowee.
+  //
+  // Populated in findDominatedUsesOfBorrowee.
+  SmallVector<Operand *, 16> borroweeUses;
+  // The instructions that are users of the borrowee.
+  //
+  // A set of the users of borroweeUses for fast membership checking.
+  //
+  // Populated in findDominatedUsesOfBorrowee.
+  SmallPtrSet<SILInstruction *, 16> borroweeUsers;
+  // The operands that are uses of introducer.
+  //
+  // Populated in findUsers.
+  SmallPtrSet<Operand *, 16> uses;
+  // The instructions that are users of the simple extended borrow scope.
+  //
+  // Populated during findUsers.
+  SmallPtrSet<SILInstruction *, 16> users;
+  // The move_value [lexical] instruction that was added during the run.
+  //
+  // Defined during createMove.
+  MoveValueInst *mvi = nullptr;
+};
+
+//===----------------------------------------------------------------------===//
+//                             MARK: Driver
+//===----------------------------------------------------------------------===//
+
+/// Perform any possible folding.
+///
+/// Returns whether any change was made.
+bool LexicalDestroyFolding::run() {
+  // Do a cheap search for scope ending instructions that could potentially be
+  // candidates for folding.
+  if (!findCandidates())
+    return false;
+
+  // At least one full match was found and more expensive checks on the matches
+  // are in order.
+
+  // First, calculate a few values that are required to do the expensive checks:
+  // - borroweeUses
+  // - borroweeUsers
+  // - users
+  if (!findDominatedUsesOfBorrowee())
+    return false;
+  if (!findUsers())
+    return false;
+
+  // Now, filter the candidates using those values.
+  if (!filterCandidates())
+    return false;
+
+  // Finally, check that %borrowee has no uses within %introducer's
+  // borrow scope.
+  if (borroweeHasUsesWithinBorrowScope())
+    return false;
+
+  // It is safe to rewrite the viable candidates.  Do so.
+  rewrite();
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                             MARK: Rewriting
+//===----------------------------------------------------------------------===//
+
+void LexicalDestroyFolding::rewrite() {
+  bool foldedAny = false;
+  (void)foldedAny;
+  for (unsigned index = 0, count = candidates.size(); index < count; ++index) {
+    auto candidate = candidates[index];
+    if (!candidate.viable)
+      continue;
+    createMove();
+
+    fold(candidate.match, candidate.argumentIndices);
+#ifndef NDEBUG
+    foldedAny = true;
+#endif
+  }
+  assert(foldedAny && "rewriting without anything to rewrite!?");
+
+  // There are now "two defs for %borrowee":
+  // - %borrowee
+  // - %move
+  // We need to update SSA.
+  updateSSA();
+}
+
+bool LexicalDestroyFolding::createMove() {
+  // We only will create a single MoveValueInst.
+  if (mvi)
+    return false;
+
+  auto introducerBuilder = SILBuilderWithScope(introducer);
+  mvi = introducerBuilder.createMoveValue(
+      RegularLocation::getAutoGeneratedLocation(introducer->getLoc()), borrowee,
+      /*isLexical=*/true);
+  introducer->setOperand(mvi);
+  return true;
+}
+
+void LexicalDestroyFolding::fold(
+    Match candidate, SmallVectorImpl<int> const &rewritableArgumentIndices) {
+  // First, rewrite the apply in terms of the move_value.
+  unsigned argumentNumber = 0;
+  for (auto index : rewritableArgumentIndices) {
+    auto argument = candidate.ai->getArgument(index);
+    auto *cvi = cast<CopyValueInst>(argument);
+    if (argumentNumber == 0) {
+      candidate.ai->setArgument(index, mvi);
+      if (!deleter.deleteIfDead(cvi)) {
+        // We can't delete the copy_value because it has other users.  Instead,
+        // add a compensating destroy just before the apply.
+        auto applyBuilder = SILBuilderWithScope(candidate.ai);
+        applyBuilder.createDestroyValue(
+            RegularLocation::getAutoGeneratedLocation(candidate.ai->getLoc()),
+            cvi);
+      }
+    } else {
+      cvi->setOperand(mvi);
+    }
+    ++argumentNumber;
+  }
+
+  // At this point, we have something along the lines of
+  //
+  //   %move = move_value [lexical] %borrowee
+  //   %lifetime = begin_borrow [lexical] %move
+  //   ...
+  //   apply %fn(%move)
+  //   end_borrow %lifetime
+  //
+  // This isn't valid, though, because the apply consumes the the %move but
+  // the borrow scope guarantees it until the subsequent end_borrow.
+  //
+  // Fix this by hoisting the end_borrow above the apply.
+  auto applyBuilder = SILBuilderWithScope(candidate.ai);
+  applyBuilder.createEndBorrow(
+      RegularLocation::getAutoGeneratedLocation(candidate.ai->getLoc()),
+      introducer);
+  deleter.forceDelete(candidate.ebi);
+
+  // We have introduced a consuming use of %borrowee--the move_value-- and we
+  // just rewrote the apply to consume it.  Delete the old destroy_value.
+  deleter.forceDelete(candidate.dvi);
+}
+
+void LexicalDestroyFolding::updateSSA() {
+  SILSSAUpdater updater;
+  updater.initialize(borrowee->getType(), borrowee.getOwnershipKind());
+  updater.addAvailableValue(borrowee->getParentBlock(), borrowee);
+  updater.addAvailableValue(mvi->getParentBlock(), mvi);
+
+  SmallVector<Operand *> uses;
+  for (auto use : borrowee->getUses()) {
+    if (use->getUser() == mvi)
+      continue;
+    uses.push_back(use);
+  }
+
+  for (auto use : uses) {
+    updater.rewriteUse(*use);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                             MARK: Lookups
+//===----------------------------------------------------------------------===//
+
+bool LexicalDestroyFolding::findCandidates() {
+  llvm::SmallVector<SILInstruction *, 16> scopeEndingInsts;
+  borrowedValue.getLocalScopeEndingInstructions(scopeEndingInsts);
+
+  bool foundAnyFull = false;
+
+  for (auto *instruction : scopeEndingInsts) {
+    if (auto match = definesMatchingInstructionSequence(instruction)) {
+      assert(match->ebi->getOperand() == introducer);
+      assert(match->dvi->getOperand() == borrowee);
+      candidates.push_back({*match, false, {}});
+
+      foundAnyFull = foundAnyFull || match->isFullMatch();
+    } else {
+      // The instruction doesn't define even a partial match.  Either the scope
+      // ending instruction isn't an end_borrow or the subsequent instruction
+      // isn't a destroy_value.  We can't fold any applies.
+      return false;
+    }
+  }
+  return foundAnyFull;
+}
+
+bool LexicalDestroyFolding::findUsers() {
+  SmallVector<Operand *> useVector;
+  if (!findExtendedUsesOfSimpleBorrowedValue(borrowedValue, &useVector)) {
+    // If the value produced by begin_borrow escapes, don't shrink the borrow
+    // scope over the apply.
+    return false;
+  }
+  for (auto *use : useVector) {
+    uses.insert(use);
+    users.insert(use->getUser());
+  }
+  return true;
+}
+
+bool LexicalDestroyFolding::filterCandidates() {
+  bool anyViable = false;
+
+  // We have some end_borrows that might be candidates for folding.
+  for (unsigned index = 0, count = candidates.size(); index < count; ++index) {
+    auto &candidate = candidates[index];
+    SmallVector<int, 2> rewritableArgumentIndices;
+    auto viability = isViableMatch(candidate.match, candidate.argumentIndices);
+    switch (viability) {
+    case MatchViability::Viable:
+      candidate.viable = true;
+      anyViable = true;
+      break;
+    case MatchViability::Nonviable:
+      break;
+    case MatchViability::Illegal:
+      return false;
+      break;
+    }
+  }
+
+  return anyViable;
+}
+
+bool LexicalDestroyFolding::findDominatedUsesOfBorrowee() {
+  auto recordUse = [&](Operand *use) {
+    if (!dominanceTree.dominates(introducer, use->getUser()))
+      return;
+    borroweeUses.push_back(use);
+    borroweeUsers.insert(use->getUser());
+  };
+  for (auto *use : borrowee->getUses()) {
+    auto *user = use->getUser();
+    if (user == introducer)
+      continue;
+    if (use->getOperandOwnership() == OperandOwnership::Borrow) {
+      if (!BorrowingOperand(use).visitScopeEndingUses([&](Operand *end) {
+            if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
+              return false;
+            }
+            recordUse(end);
+            return true;
+          })) {
+        return false;
+      }
+    }
+    recordUse(use);
+  }
+  return true;
+}
+
+bool LexicalDestroyFolding::borroweeHasUsesWithinBorrowScope() {
+  PrunedLiveness liveness;
+  borrowedValue.computeLiveness(liveness);
+  DeadEndBlocks deadEndBlocks(function);
+  return !liveness.areUsesOutsideBoundary(borroweeUses, &deadEndBlocks);
+}
+
+//===----------------------------------------------------------------------===//
+//                             MARK: Predicates
+//===----------------------------------------------------------------------===//
+
+Optional<LexicalDestroyFolding::Match>
+LexicalDestroyFolding::definesMatchingInstructionSequence(
+    SILInstruction *inst) const {
+  // Look specifically for
+  //
+  //   apply
+  //   end_borrow // inst
+  //   ...
+  //   destroy_value %borrowee
+  auto *ebi = dyn_cast<EndBorrowInst>(inst);
+  if (!ebi)
+    return None;
+  auto *dvi = findNextBorroweeDestroy(ebi->getNextInstruction());
+  if (!dvi)
+    return None;
+  auto *ai = dyn_cast_or_null<ApplyInst>(ebi->getPreviousInstruction());
+  if (!ai)
+    return {{nullptr, ebi, dvi}};
+
+  return {{ai, ebi, dvi}};
+}
+
+DestroyValueInst *
+LexicalDestroyFolding::findNextBorroweeDestroy(SILInstruction *from) const {
+  for (auto *inst = from; inst; inst = inst->getNextInstruction()) {
+    if (!CanonicalizeOSSALifetime::ignoredByDestroyHoisting(inst->getKind())) {
+      // This is not an instruction that CanonicalOSSALifetime would not hoist a
+      // destroy above.  In other words, CanonicalOSSALifetime would have
+      // hoisted
+      //     destroy_value %borrowee
+      // over this instruction if it could have.  Stop looking.
+      return nullptr;
+    }
+    if (auto *dvi = dyn_cast<DestroyValueInst>(inst)) {
+      if (dvi->getOperand() == borrowee) {
+        return dvi;
+      }
+    }
+  }
+  return nullptr;
+}
+
+LexicalDestroyFolding::MatchViability LexicalDestroyFolding::isViableMatch(
+    Match &candidate, SmallVectorImpl<int> &rewritableArgumentIndices) const {
+  for (SILInstruction *inst = candidate.ebi; inst != candidate.dvi;
+       inst = inst->getNextInstruction()) {
+    if (borroweeUsers.contains(inst)) {
+      // In the sequence of instructions
+      //     end_borrow %lifetime
+      //     ...
+      //     destroy_value %borrowee
+      // we have found a user of %borrowee.  That existing means not
+      // only that this candidate is not viable but that NONE of the candidates
+      // are viable and we need to bail out completely.
+      return MatchViability::Illegal;
+    }
+  }
+
+  // Now that we've checked that this partial match isn't illegal, go ahead and
+  // discard it.
+  if (!candidate.isFullMatch())
+    return MatchViability::Nonviable;
+
+  // If the apply isn't a user of the extended simple value, then this
+  // transformation can't be done: the callee can't end the lexical lifetime
+  // of a value it doesn't see.  Presumably, this apply is a deinit barrier.
+  if (!users.contains(candidate.ai))
+    return MatchViability::Nonviable;
+
+  // We aren't able to rewrite every simple extended use of %introducer
+  // in the apply.
+  if (!rewritableArgumentIndicesForApply(candidate.ai,
+                                         rewritableArgumentIndices))
+    return MatchViability::Nonviable;
+
+  return MatchViability::Viable;
+}
+
+bool LexicalDestroyFolding::isSimpleExtendedIntroducerDef(
+    SILValue value) const {
+  while (true) {
+    auto *instruction = value.getDefiningInstruction();
+    if (!instruction)
+      return false;
+    if (instruction == introducer)
+      return true;
+    if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
+      value = cvi->getOperand();
+      continue;
+    }
+    return false;
+  }
+}
+
+bool LexicalDestroyFolding::rewritableArgumentIndicesForApply(
+    ApplySite apply, SmallVectorImpl<int> &indices) const {
+  for (auto &operand : apply->getAllOperands()) {
+    if (uses.contains(&operand)) {
+      if (apply.isArgumentOperand(operand)) {
+        auto convention = apply.getArgumentConvention(operand);
+        if (isSimpleExtendedIntroducerDef(operand.get()) &&
+            convention.isOwnedConvention()) {
+          indices.push_back(apply.getCalleeArgIndex(operand));
+        } else {
+          // This argument is a use of %introducer but not an owned use that we
+          // can rewrite.
+          return false;
+        }
+      } else {
+        // If %introducer is used in some non-argument position, e.g. as the
+        // callee, we can't fold.
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                             MARK: Entry Point
+//===----------------------------------------------------------------------===//
+
+/// The entry point.
+bool swift::foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,
+                                              DominanceInfo &dominanceTree,
+                                              InstructionDeleter &deleter) {
+  if (!bbi->isLexical())
+    return false;
+  if (bbi->getOperand()->getOwnershipKind() != OwnershipKind::Owned)
+    return false;
+  if (!dominanceTree.isReachableFromEntry(bbi->getParentBlock()))
+    return false;
+
+  auto folder = LexicalDestroyFolding(bbi, dominanceTree, deleter);
+  return folder.run();
+}

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -117,7 +117,7 @@ public:
            mayAccessPointer(instruction) || mayLoadWeakOrUnowned(instruction);
   }
 
-  bool canReplaceValueWithBorrowedValue(SILValue value) {
+  bool canReplaceValueWithBorrowee(SILValue value) {
     while (true) {
       auto *instruction = value.getDefiningInstruction();
       if (!instruction)
@@ -145,7 +145,7 @@ public:
     if (users.contains(instruction)) {
       if (auto *bbi = dyn_cast<BeginBorrowInst>(instruction)) {
         if (bbi->isLexical() &&
-            canReplaceValueWithBorrowedValue(bbi->getOperand())) {
+            canReplaceValueWithBorrowee(bbi->getOperand())) {
           if (rewrite) {
             auto borrowee = introducer->getOperand();
             bbi->setOperand(borrowee);
@@ -154,7 +154,7 @@ public:
           return true;
         }
       } else if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
-        if (canReplaceValueWithBorrowedValue(cvi->getOperand())) {
+        if (canReplaceValueWithBorrowee(cvi->getOperand())) {
           if (rewrite) {
             auto borrowee = introducer->getOperand();
             cvi->setOperand(borrowee);

--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -31,9 +31,10 @@ class Klass {}
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
-// CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: strong_release
+// CHECK-SIL-NEXT: debug_value [poison]
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADnF'
 func useMove(_ k: __owned Klass) -> Klass {
@@ -64,9 +65,10 @@ func useMove(_ k: __owned Klass) -> Klass {
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
-// CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: strong_release
+// CHECK-SIL-NEXT: debug_value [poison]
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxnRlzClF'
 func useMove<T : AnyObject>(_ k: __owned T) -> T {

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -1,0 +1,840 @@
+// RUN: %target-sil-opt -copy-propagation -enable-sil-verify-all %s | %FileCheck %s
+
+// =============================================================================
+// = DECLARATIONS                                                             {{
+// =============================================================================
+
+class C {}
+
+sil [ossa] @barrier : $@convention(thin) () -> ()
+sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
+sil [ossa] @callee_owned_owned : $@convention(thin) (@owned C, @owned C) -> ()
+sil [ossa] @callee_owned_guaranteed : $@convention(thin) (@owned C, @guaranteed C) -> ()
+sil [ossa] @get_owned : $@convention(thin) () -> @owned C
+
+// =============================================================================
+// = DECLARATIONS                                                             }}
+// =============================================================================
+
+// =============================================================================
+// TESTS                                                                      {{
+// =============================================================================
+
+// The simplest test for LexicalDestroyFolding.  Check that an outer lexical
+// owned lexical lifetime is added around the existing inner guaranteed lexical
+// lifetime.  The new lifetime should begin with a move_value [lexical] and end
+// with an apply.
+//
+// CHECK-LABEL: sil [ossa] @fold_simplest : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         apply [[CALEE_OWNED]]([[MOVE]])
+// CHECK-LABEL: } // end sil function 'fold_simplest'
+sil [ossa] @fold_simplest : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Fold when there is a use of %original_borrowee prior to the lexical lifetime.
+sil [ossa] @fold_prior_use : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold an apply where an owned value is passed to a guaranteed parameter.
+// The callee can't end ownership.
+//
+// CHECK-LABEL: sil [ossa] @nofold_owned_arg_to_guaranteed_param : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_owned_arg_to_guaranteed_param'
+sil [ossa] @nofold_owned_arg_to_guaranteed_param : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%copy) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %copy : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Enclose a single block guaranteed lexical scope ending in a consuming use
+// and destroy within a single block owned lexical scope, leaving the original
+// borrowee intact on other paths.
+//
+// CHECK-LABEL: sil [ossa] @fold_left_only : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_left_only'
+sil [ossa] @fold_left_only : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left, right
+
+left:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+
+}
+
+// Enclose two independent parallel guaranteed lexical scopes within two
+// independents owned lexical scopes.
+//
+// CHECK-LABEL: sil [ossa] @fold_two_independent_scopes : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[MOVE_LEFT:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE_LEFT]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[MOVE_RIGHT:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE_RIGHT]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_two_independent_scopes'
+sil [ossa] @fold_two_independent_scopes : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left, right
+
+left:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  %lifetime_1 = begin_borrow [lexical] %instance : $C
+  %copy_1 = copy_value %lifetime_1 : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime_1 : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+
+}
+
+// Enclose a single guaranteed lexical scope that contains two paralell
+// applies of owned arguments with the destroy at a NONcanonical position
+// within a single owned lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @fold_two_parallel_applies___noncanonical_destroys : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_two_parallel_applies___noncanonical_destroys'
+sil [ossa] @fold_two_parallel_applies___noncanonical_destroys : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %lifetime = begin_borrow [lexical] %instance : $C
+  cond_br undef, left, right
+
+left:
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+right:
+  %copy_2 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Enclose a single guaranteed lexical scope that contains two paralell
+// applies of owned arguments with the destroy at a noncanonical position
+// within a single owned lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @fold_two_parallel_applies___canonical_destroys : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]] : $C
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT:bb[0-9]+]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_two_parallel_applies___canonical_destroys'
+sil [ossa] @fold_two_parallel_applies___canonical_destroys : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %lifetime = begin_borrow [lexical] %instance : $C
+  cond_br undef, left, right
+
+left:
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  %copy_2 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Enclose a guaranteed lexical scope within an owned lexical scope when it
+// appears in a multiblock subgraph that is parallel to another apply use of the
+// borrowee that is not within the scope.
+//
+// CHECK-LABEL: sil [ossa] @fold_multiblock_borrow_single_apply_with_parallel_use : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT1:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT1]]:                                              
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[LEFT2:bb[0-9]+]], [[LEFT3:bb[0-9]+]]                         
+// CHECK:       [[LEFT2]]:                                              
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[LEFT3]]:                                              
+// CHECK:         destroy_value [[MOVE]]
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         apply [[CALLEE_OWNED]]([[INSTANCE]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[EXIT]]:                                              
+// CHECK-LABEL: } // end sil function 'fold_multiblock_borrow_single_apply_with_parallel_use'
+sil [ossa] @fold_multiblock_borrow_single_apply_with_parallel_use : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left1, right
+
+left1:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  cond_br undef, left2, left3
+
+left2:
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+left3:
+  destroy_value %copy : $C
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Enclose a guaranteed lexical scope within an owned lexical scope when it
+// appears in a multiblock subgraph that is parallel to another apply use of the
+// borrowee that is not within the scope.
+//
+// CHECK-LABEL: sil [ossa] @fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT1:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT1]]:                                              
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[LEFT2:bb[0-9]+]], [[LEFT3:bb[0-9]+]]                         
+// CHECK:       [[LEFT2]]:                                              
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[LEFT3]]:                                              
+// CHECK:         destroy_value [[MOVE]]
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         [[MOVE_2:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE_2]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[EXIT]]:                                              
+// CHECK-LABEL: } // end sil function 'fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow'
+sil [ossa] @fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left1, right
+
+left1:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  cond_br undef, left2, left3
+
+left2:
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+left3:
+  destroy_value %copy : $C
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  %lifetime_1 = begin_borrow [lexical] %instance : $C
+  %copy_1 = copy_value %lifetime_1 : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime_1 : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+
+}
+
+// Fold with an apply that takes the borrowee @owned twice and no use of the
+// guaranteed lifetime remains.
+//
+// CHECK-LABEL: sil [ossa] @fold_single_block_one_apply_double_use_all_owned : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_GUARANTEED:%[^,]+]] = begin_borrow [lexical] [[LIFETIME]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[LIFETIME_GUARANTEED]])
+// CHECK:         end_borrow [[LIFETIME_GUARANTEED]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CALLEE_OWNED_OWNED:%[^,]+]] = function_ref @callee_owned_owned
+// CHECK:         apply [[CALLEE_OWNED_OWNED]]([[LIFETIME]], [[COPY]])
+// CHECK-LABEL: } // end sil function 'fold_single_block_one_apply_double_use_all_owned'
+sil [ossa] @fold_single_block_one_apply_double_use_all_owned : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %copy_1 = copy_value %lifetime : $C
+  %copy_2 = copy_value %lifetime : $C
+  %callee_owned_owned = function_ref @callee_owned_owned : $@convention(thin) (@owned C, @owned C) -> ()
+  apply %callee_owned_owned(%copy_1, %copy_2) : $@convention(thin) (@owned C, @owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Fold with an apply that takes the borrowee @owned twice and a use of the
+// guaranteed lifetime remains.
+//
+// CHECK-LABEL: sil [ossa] @fold_single_block_one_apply_double_use_all_owned__no_remaining_uses : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[MOVE]]
+// CHECK:         [[CALLEE_OWNED_OWNED:%[^,]+]] = function_ref @callee_owned_owned
+// CHECK:         apply [[CALLEE_OWNED_OWNED]]([[MOVE]], [[COPY]])
+// CHECK-LABEL: } // end sil function 'fold_single_block_one_apply_double_use_all_owned__no_remaining_uses'
+sil [ossa] @fold_single_block_one_apply_double_use_all_owned__no_remaining_uses : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy_1 = copy_value %lifetime : $C
+  %copy_2 = copy_value %lifetime : $C
+  %callee_owned_owned = function_ref @callee_owned_owned : $@convention(thin) (@owned C, @owned C) -> ()
+  apply %callee_owned_owned(%copy_1, %copy_2) : $@convention(thin) (@owned C, @owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+} // end sil function 'test'
+
+// Do NOT fold with an apply that takes both a copy of the borrow @owned and
+// also the borrow itself @guaranteed.
+//
+// CHECK-LABEL: sil [ossa] @nofold_single_block_one_apply_double_use_one_guaranteed : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_single_block_one_apply_double_use_one_guaranteed'
+sil [ossa] @nofold_single_block_one_apply_double_use_one_guaranteed : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  %callee_owned_guaranteed = function_ref @callee_owned_guaranteed : $@convention(thin) (@owned C, @guaranteed C) -> ()
+  apply %callee_owned_guaranteed(%copy, %lifetime) : $@convention(thin) (@owned C, @guaranteed C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Do NOT fold an apply of an owned value when the borrowee is guaranteed.
+//
+// CHECK-LABEL: sil [ossa] @nofold_guaranteed_borrowee : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_guaranteed_borrowee'
+sil [ossa] @nofold_guaranteed_borrowee : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nofold_nonlexical : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_nonlexical'
+sil [ossa] @nofold_nonlexical : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %lifetime = begin_borrow %instance : $C
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Fold with the last consuming use but not with a previous consuming use.
+//
+// CHECK-LABEL: sil [ossa] @fold_single_block_two_applies_first_only : {{.*}} {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MOVE]]
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         tuple ()
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK-LABEL: } // end sil function 'fold_single_block_two_applies_first_only'
+sil [ossa] @fold_single_block_two_applies_first_only : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %copy_1 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  %retval = tuple ()
+  %copy_2 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  return %retval : $()
+}
+
+// Don't fold with apply when guaranteed lexical value used in one but not two
+// branches and the lexical scope ends after the use on the non-lexical branch.
+//
+// CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical'
+sil [ossa] @nofold_two_parallel_owned_uses_one_lexical : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left, right
+
+left:
+  %copy_1 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+right:
+  %copy_2 = copy_value %instance : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold with apply when guaranteed lexical value used in one but not two
+// branches and the lexical scope ends before the use on the non-lexical branch.
+//
+// CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
+sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %copy_2 = copy_value %instance : $C
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left, right
+
+left:
+  %copy_1 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  destroy_value %copy_2 : $C
+  br exit
+
+right:
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Fold even if there is a noncanonicalized copy which is otherwise used.
+// CHECK-LABEL: sil [ossa] @fold_noncanonical_copy_with_other_use : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MOVE]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[COPY]])
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[MOVE]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_noncanonical_copy_with_other_use'
+sil [ossa] @fold_noncanonical_copy_with_other_use : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %copy = copy_value %lifetime : $C
+  cond_br undef, left, right
+
+left:
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+right:
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%copy) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %copy : $C
+  br exit
+
+exit:
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Fold in the face of an unreachable block on one path so long as there is no
+// use of %original_borrowee in that unreachable-terminated branch.
+//
+// CHECK-LABEL: sil [ossa] @fold_unreachable : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         unreachable
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'fold_unreachable'
+sil [ossa] @fold_unreachable : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %lifetime = begin_borrow [lexical] %instance : $C
+  cond_br undef, left, right
+
+left:
+  unreachable
+
+right:
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold in the face of an unreachable block on one path so long as there
+// is no use of %original_borrowee in that "unterminated" branch.
+//
+// CHECK-LABEL: sil [ossa] @nofold_unreachable : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_unreachable'
+sil [ossa] @nofold_unreachable : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %lifetime = begin_borrow [lexical] %instance : $C
+  cond_br undef, left, right
+
+left:
+  apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
+  unreachable
+
+right:
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold if there's an outer borrow scope enclosing the guaranteed lexical
+// scope and it has a use within the lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @nofold_outer_borrow : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_outer_borrow'
+sil [ossa] @nofold_outer_borrow : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %outer = begin_borrow %instance : $C
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_guaranteed(%outer) : $@convention(thin) (@guaranteed C) -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  end_borrow %outer : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold if there's an outer borrow scope started in one block enclosing
+// the guaranteed lexical scope started in another block and it has a use
+// within the lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @nofold_outer_borrow__twoblock : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_outer_borrow__twoblock'
+sil [ossa] @nofold_outer_borrow__twoblock : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %outer = begin_borrow %instance : $C
+  br exit
+exit:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_guaranteed(%outer) : $@convention(thin) (@guaranteed C) -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  end_borrow %outer : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold if there are TWO layers of outer borrows, both started in one
+// block enclosing the guaranteed lexical scope started--all together in the
+// same block--and both have a use within the lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @nofold_outer_borrow_2x : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_outer_borrow_2x'
+sil [ossa] @nofold_outer_borrow_2x : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %outer = begin_borrow %instance : $C
+  %middle = begin_borrow %outer : $C
+  br exit
+exit:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_guaranteed(%outer) : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%middle) : $@convention(thin) (@guaranteed C) -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  end_borrow %middle : $C
+  end_borrow %outer : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold if there are TWO layers of outer borrows, both started in one
+// block, enclosing the guaranteed lexical scope started in another block and
+// both have a use within the lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @nofold_outer_borrow_2x__twoblock : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_outer_borrow_2x__twoblock'
+sil [ossa] @nofold_outer_borrow_2x__twoblock : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %outer = begin_borrow %instance : $C
+  %middle = begin_borrow %outer : $C
+  br exit
+exit:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_guaranteed(%outer) : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%middle) : $@convention(thin) (@guaranteed C) -> ()
+  apply %barrier() : $@convention(thin) () -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  end_borrow %middle : $C
+  end_borrow %outer : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold when a different borrow of the enclosing %original_borrowee end
+// in the middle of the lexical scope.
+//
+// CHECK-LABEL: sil [ossa] @nofold_outer_borrow_2x_end_inside__twoblock : {{.*}} {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_outer_borrow_2x_end_inside__twoblock'
+sil [ossa] @nofold_outer_borrow_2x_end_inside__twoblock : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %outer = begin_borrow %instance : $C
+  %middle = begin_borrow %outer : $C
+  br exit
+exit:
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_guaranteed(%outer) : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%middle) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %middle : $C
+  end_borrow %outer : $C
+  apply %barrier() : $@convention(thin) () -> ()
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold if the borrow scope begins in an unreachable-from-entry block.
+//
+// CHECK-LABEL: sil [ossa] @nofold_deadblock : $@convention(thin) () -> () {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_deadblock'
+sil [ossa] @nofold_deadblock : $@convention(thin) () -> () {
+entry:
+  br exit
+dead:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> @owned C
+  %instance = apply %get_owned() : $@convention(thin) () -> @owned C
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %copy = copy_value %lifetime : $C
+  apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't fold applies of the borrowed value.
+//
+// CHECK-LABEL: sil [ossa] @nofold_closure : $@convention(thin) (@owned () -> ()) -> () {
+// CHECK-NOT: move_value [lexical]
+// CHECK-LABEL: } // end sil function 'nofold_closure'
+sil [ossa] @nofold_closure : $@convention(thin) (@owned @convention(thick) () -> ()) -> () {
+entry(%instance : @owned $@convention(thick) () -> ()):
+  %lifetime = begin_borrow [lexical] %instance : $@convention(thick) () -> ()
+  apply %lifetime() : $@convention(thick) () -> ()
+  end_borrow %lifetime : $@convention(thick) () -> ()
+  destroy_value %instance : $@convention(thick) () -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// =============================================================================
+// TESTS                                                                      }}
+// =============================================================================

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -777,13 +777,14 @@ bad(%15 : @owned $Error):
 // CHECK:       [[LEFT]]:
 // CHECK:         [[REGISTER_3:%[^,]+]] = apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
 // CHECK:         [[REGISTER_6:%[^,]+]] = apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_up_to_two_barrier_applies'
 sil [ossa] @hoist_up_to_two_barrier_applies : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/shrink_borrow_scope.swift
+++ b/test/SILOptimizer/shrink_borrow_scope.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -c -O -enable-copy-propagation=true -enable-lexical-lifetimes=true -sil-verify-all -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
-// REQUIRES: rdar87255563
-
 // =============================================================================
 // = DECLARATIONS                                                             {{
 // =============================================================================
@@ -26,9 +24,10 @@ public func eliminate_copy_of_returned_then_consumed_owned_value(arg: __owned An
   // CHECK:       [[ARG_COPY:%[^,]+]] = copy_value [[ARG_LIFETIME]]
   let x = consumeAndProduce(arg)
   // CHECK:       [[X:%[^,]+]] = apply {{%[^,]+}}([[ARG_COPY]])
+  // CHECK:       [[MOVE_X:%[^,]+]] = move_value [lexical] [[X]]
   // no copy of 'x'
   _ = consumeAndProduce(x)
-  // CHECK:       [[RESULT:%[^,]+]] = apply {{%[^,]+}}([[X]])
+  // CHECK:       [[RESULT:%[^,]+]] = apply {{%[^,]+}}([[MOVE_X]])
   // CHECK:       end_borrow [[ARG_LIFETIME]]
   // release result
   // release arg


### PR DESCRIPTION
The new utility folds patterns like

```
// %borrowee is some owned value
%lifetime = begin_borrow %borrowee
...
// %copy is some transitive copy of %borrowee
apply %f(%copy)
end_borrow %lifetime
destroy_value %borrowee
```

into

```
%move = move_value [lexical] %borrowee
%lifetime begin_borrow [lexical] %move
...
end_borrow %lifetime
apply %f(%move)
```

It is intended to be run after ShrinkBorrowScope moves the end_borrow up to just before a relevant apply and after CanonicalizeOSSALifetime moves destroy_value instructions up to just after their last guaranteed use, at which point these patterns will exist.
