### PR TITLE
[5.6] Revert "[stdlib] fix another accidental infinite-recursion bug (#38950)"

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -757,23 +757,6 @@ extension RangeReplaceableCollection {
     self.replaceSubrange(subrange.relative(to: self), with: newElements)
   }
 
-  // This unavailable default implementation of
-  // `replaceSubrange<C: Collection>(_: Range<Index>, with: C)` prevents
-  // incomplete RangeReplaceableCollection implementations from satisfying
-  // the protocol through the use of the generic convenience implementation
-  // `replaceSubrange<C: Collection, R: RangeExpression>(_: R, with: C)`,
-  // If that were the case, at runtime the implementation generic over
-  // `RangeExpression` would call itself in an infinite recursion
-  // due to the absence of a better option.
-  @available(*, unavailable)
-  @_alwaysEmitIntoClient
-  public mutating func replaceSubrange<C>(
-    _ subrange: Range<Index>,
-    with newElements: C
-  ) where C: Collection, C.Element == Element {
-    fatalError()
-  }
-
   /// Removes the elements in the specified subrange from the collection.
   ///
   /// All the elements following the specified position are moved to close the

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -200,18 +200,6 @@ func subscriptMutableCollectionIgnored() {
   ds[3..<5] = goodSlice
 }
 
-// expected-error@+2 {{type 'IncompleteRangeReplaceableCollection' does not conform to protocol 'RangeReplaceableCollection'}}
-// expected-error@+1 {{unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'}}
-struct IncompleteRangeReplaceableCollection: RangeReplaceableCollection {
-  var startIndex: Int
-  var endIndex: Int
-
-  func index(after i: Int) -> Int { i+1 }
-  subscript(position: Int) -> Int { position }
-
-  init() { startIndex = 0; endIndex = 0 }
- }
-
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: possibly intended match
 // <unknown>:0: error: unexpected note produced: possibly intended match


### PR DESCRIPTION
**Explanation:** #38950 uncovered some incorrect conformances to RangeReplaceableCollection, which needed to be resolved on the adopter side. As a workaround, we've been reverting this change until adopters are updated. To avoid the continued application of the workaround, revert #38950 on 5.6 branch until adopters have adapted.
**Scope:** Delays the integration of #38950 to post-5.6.
**Radar/SR Issue:** rdar://88300345
**Risk:** Low.
**Testing:** PR and adopter testing.
**Original PR:** #38950, which is intended to remain in place on main.