### PR TITLE
skip implicit clang decls in the duplicate-decl assertion

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -963,6 +963,14 @@ void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
 #ifndef NDEBUG
   llvm::DenseSet<Decl *> visited;
   for (auto *D : Results) {
+    // decls synthesized from implicit clang decls may appear multiple times;
+    // e.g. if multiple modules with underlying clang modules are re-exported.
+    // including duplicates of these is harmless, so skip them when counting
+    // this assertion
+    if (const auto *CD = D->getClangDecl()) {
+      if (CD->isImplicit()) continue;
+    }
+
     auto inserted = visited.insert(D).second;
     assert(inserted && "there should be no duplicate decls");
   }

--- a/test/SymbolGraph/ClangImporter/Submodules.swift
+++ b/test/SymbolGraph/ClangImporter/Submodules.swift
@@ -1,5 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/Submodules -emit-module-path %t/Submodules.swiftmodule -enable-objc-interop -module-name Submodules %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %S/EmitWhileBuilding.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/Submodules -emit-module-path %t/Submodules.swiftmodule -enable-objc-interop -module-name Submodules -F %t %s -emit-symbol-graph -emit-symbol-graph-dir %t
 
 // REQUIRES: objc_interop
 
@@ -7,5 +9,7 @@
 
 @_exported import Mixed
 @_exported import Mixed.Submodule
+
+@_exported import EmitWhileBuilding
 
 public func someFunc() {}


### PR DESCRIPTION
Resolves SR-15801

The "duplicate decls" assertion added in https://github.com/apple/swift/pull/40810 (and re-added in https://github.com/apple/swift/pull/40860) trips on modules that re-export multiple modules that themselves have underlying Clang modules. This is because of decls added implicitly by Clang, such as `__NSConstantString`. These duplicate decls *should* be harmless to leave in, since they are usually filtered out by consumers of `getDisplayDecls` anyway.

I'm not totally sure this is the right approach, but these decls aren't as clear-cut as "importing multiple copies of the same underlying module", so i'm posting this as a potential solution and i would like to run as many tests as possible to make sure that my assumptions are correct.