### PR TITLE
[NFC][ClangImporter] Alter importDecl API to return an optional.

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -434,7 +434,7 @@ public:
 
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.
-  Decl *importDeclCached(const clang::NamedDecl *ClangDecl);
+  Optional<Decl *> importDeclCached(const clang::NamedDecl *ClangDecl);
 
   // Returns true if it is expected that the macro is ignored.
   bool shouldIgnoreMacro(StringRef Name, const clang::MacroInfo *Macro);

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -70,11 +70,11 @@ private:
       // The serialization code doesn't allow us to cross-reference
       // typealias declarations directly.  We could fix that, but it's
       // easier to just avoid doing so and fall into the external-path code.
-      if (!isa<TypeAliasDecl>(swiftDecl)) {
+      if (swiftDecl.hasValue() && !isa<TypeAliasDecl>(swiftDecl.getValue())) {
         // Only accept this declaration if it round-trips.
-        if (auto swiftClangDecl = swiftDecl->getClangDecl())
+        if (auto swiftClangDecl = swiftDecl.getValue()->getClangDecl())
           if (isSameDecl(decl, swiftClangDecl))
-            return swiftDecl;
+            return swiftDecl.getValue();
       }
     }
 


### PR DESCRIPTION
Inspired by #36747. I thought I'd go a little further. I have found
there is quite a lot of usage of dyn_cast_or_null in place of checking
for nullptr or using an optional. I think using an llvm::Optional<T> is
a lot cleaner.

Work in progress (Still doesn't compile), but I wanted to post this here for now so it doesn't get lost.

@zoecarver @hyp 
