### PR TITLE
[SIL] Allow giving debug names to SILBasicBlocks

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -107,6 +107,9 @@ public:
   ///          debug output.
   int getDebugID() const;
 
+  void setDebugName(llvm::StringRef name);
+  Optional<llvm::StringRef> getDebugName() const;
+
   SILFunction *getParent() { return Parent; }
   const SILFunction *getParent() const { return Parent; }
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -164,7 +164,7 @@ public:
   using CoverageMapCollectionType =
       llvm::MapVector<StringRef, SILCoverageMap *>;
   using BasicBlockNameMapType =
-      llvm::DenseMap<const SILBasicBlock *, llvm::StringRef>;
+      llvm::DenseMap<const SILBasicBlock *, std::string>;
 
   enum class LinkingMode : uint8_t {
     /// Link functions with non-public linkage. Used by the mandatory pipeline.
@@ -455,7 +455,7 @@ public:
 
   void setBasicBlockName(const SILBasicBlock *block, StringRef name) {
     #if NDEBUG
-    basicBlockNames[block] = name;
+    basicBlockNames[block] = name.str();
     #endif
   }
   Optional<StringRef> getBasicBlockName(const SILBasicBlock *block) {
@@ -464,7 +464,7 @@ public:
     if (Known == basicBlockNames.end())
       return None;
 
-    return Known->second;
+    return StringRef(Known->second);
     #else
     return None;
     #endif

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -67,6 +67,14 @@ int SILBasicBlock::getDebugID() const {
   llvm_unreachable("block not in function's block list");
 }
 
+void SILBasicBlock::setDebugName(llvm::StringRef name) {
+  getModule().setBasicBlockName(this, name);
+}
+
+Optional<llvm::StringRef> SILBasicBlock::getDebugName() const {
+  return getModule().getBasicBlockName(this);
+}
+
 SILModule &SILBasicBlock::getModule() const {
   return getParent()->getModule();
 }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -816,6 +816,12 @@ public:
       for (auto Id : PredIDs)
         *this << ' ' << Id;
     }
+
+    // If the basic block has a name available, print it as well
+    auto debugName = BB->getDebugName();
+    if (debugName.hasValue()) {
+      *this << " /// " << debugName.getValue();
+    }
     *this << '\n';
 
     const auto &SM = BB->getModule().getASTContext().SourceMgr;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -791,6 +791,12 @@ public:
     // the block header.
     printBlockArgumentUses(BB);
 
+    // If the basic block has a name available, print it as well
+    auto debugName = BB->getDebugName();
+    if (debugName.hasValue()) {
+      *this << "// " << debugName.getValue() << '\n';
+    }
+
     // Then print the name of our block, the arguments, and the block colon.
     *this << Ctx.getID(BB);
     printBlockArguments(BB);
@@ -815,12 +821,6 @@ public:
 
       for (auto Id : PredIDs)
         *this << ' ' << Id;
-    }
-
-    // If the basic block has a name available, print it as well
-    auto debugName = BB->getDebugName();
-    if (debugName.hasValue()) {
-      *this << " /// " << debugName.getValue();
     }
     *this << '\n';
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -818,6 +818,7 @@ public:
   /// are created by different emissions; it's just a little
   /// counter-intuitive within a single emission.)
   SILBasicBlock *createBasicBlock();
+  SILBasicBlock *createBasicBlock(llvm::StringRef debugName);
   SILBasicBlock *createBasicBlockAfter(SILBasicBlock *afterBB);
   SILBasicBlock *createBasicBlockBefore(SILBasicBlock *beforeBB);
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -58,6 +58,12 @@ SILBasicBlock *SILGenFunction::createBasicBlock() {
   }
 }
 
+SILBasicBlock *SILGenFunction::createBasicBlock(llvm::StringRef debugName) {
+  auto block = createBasicBlock();
+  block->setDebugName(debugName);
+  return block;
+}
+
 SILBasicBlock *SILGenFunction::createBasicBlock(FunctionSection section) {
   switch (section) {
   case FunctionSection::Ordinary: {


### PR DESCRIPTION
Resolves ancient issue rdar://19283513

It is very hard to wrap your head around more complex and dynamically generated basic block graphs without the ability to tag them with some human readable name.

This PR solves this, by allowing SILBasicBlock to have a "debug name". The names are stored in the Module, and are only available in `NDEBUG` builds.