### PR TITLE
Override -arch For Stdlib Targets

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -104,7 +104,6 @@ function(_add_target_variant_c_compile_link_flags)
     # of options by target_compile_options -- this way no undesired
     # side effects are introduced should a new search path be added.
     list(APPEND result
-      "-arch" "${CFLAGS_ARCH}"
       "-F${SWIFT_SDK_${CFLAGS_SDK}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
@@ -1202,6 +1201,10 @@ function(add_swift_target_library_single target name)
   endif()
 
   list(APPEND library_search_directories "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/usr/lib/swift")
+
+  # Override -arch on macOS. This is crucial for Apple Silicon, where CMake forces
+  # the *host* architecture to appear as the argument to -arch otherwise.
+  set_property(TARGET ${target} PROPERTY OSX_ARCHITECTURES "${SWIFTLIB_SINGLE_ARCHITECTURE}")
 
   # Add variant-specific flags.
   set(build_type "${SWIFT_STDLIB_BUILD_TYPE}")


### PR DESCRIPTION
On Apple Silicon hosts, CMake defaults OSX_ARCHITECTURES to the
host arch. When our cmake later explicitly provides -arch, clang
interprets two -arch flags as a directive to emit fat object files. When we go
to lipo them together, the host arches in the object files collide
and the build goes kaput.

In the same vein as https://github.com/apple/swift/pull/41059, stamp out the last place we were explicitly passing -arch.