### PR TITLE
Specify the segment name that contains the reflection sections.

### DIFF
--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -28,6 +28,9 @@ class SwiftObjectFileFormat {
 public:
   virtual ~SwiftObjectFileFormat() {}
   virtual llvm::StringRef getSectionName(ReflectionSectionKind section) = 0;
+  virtual llvm::Optional<llvm::StringRef> getSegmentName() {
+    return {};
+  }
 };
 
 /// Responsible for providing the Mach-O reflection section identifiers.
@@ -49,6 +52,9 @@ public:
       return "__swift5_reflstr";
     }
     llvm_unreachable("Section type not found.");
+  }
+  llvm::Optional<llvm::StringRef> getSegmentName() override {
+    return {"__TEXT"};
   }
 };
 


### PR DESCRIPTION
(cherry picked from commit 6e088c3863418c6752d356b92a6be4cda3184d8d)

<!-- What's in this pull request? -->
Specifies the segment name that contains the reflection sections (if it exists). This is necessary so LLDB knows how to extract reflection sections from an object file.

