### PR TITLE
Add DifferentiableProgrammingImplementation.md to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,7 +103,7 @@ documentation, please create a thread on the Swift forums under the
   Describes different kinds of dependencies across files in the same module,
   important for understanding incremental builds.
 - [DifferentiableProgrammingImplementation.md](/docs/DifferentiableProgrammingImplementation.md):
-  Explans how differentiation is implemented in the Swift compiler, stage by stage.
+  Describes how automatic differentiation is implemented in the Swift compiler.
 - C and ObjC interoperability: Clang Importer and PrintAsClang
   - [CToSwiftNameTranslation.md](/docs/CToSwiftNameTranslation.md):
     Describes how C and ObjC entities are imported into Swift

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,8 @@ documentation, please create a thread on the Swift forums under the
 - [DependencyAnalysis.md](/docs/DependencyAnalysis.md):
   Describes different kinds of dependencies across files in the same module,
   important for understanding incremental builds.
+- [DifferentiableProgrammingImplementation.md](/docs/DifferentiableProgrammingImplementation.md):
+  Explans how differentiation is implemented in the Swift compiler, stage by stage.
 - C and ObjC interoperability: Clang Importer and PrintAsClang
   - [CToSwiftNameTranslation.md](/docs/CToSwiftNameTranslation.md):
     Describes how C and ObjC entities are imported into Swift


### PR DESCRIPTION
<!-- What's in this pull request? -->
The new document has not yet been added. Currently, only `DifferentiableProgramming.md` is in there.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
