### PR TITLE
Use rsync for remote-run.

### DIFF
--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -3,30 +3,24 @@ RUN: %remote-run -n --remote-dir /xyz-REMOTE -o FIRST_OPT -o SECOND_OPT --output
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env'
+CHECK-SAME: '/bin/rm' '-rf' '{{.+}}-REMOTE/output'
 
 CHECK-NEXT: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env'
+CHECK-SAME: '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env'
+CHECK-SAME: 'cp'
 
-CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
+CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
 
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -o FIRST_OPT -o SECOND_OPT
+CHECK-NEXT: /usr/bin/rsync
+CHECK-DAG: '-p' '12345'
+CHECK-DAG: '-o' 'FIRST_OPT' '-o' 'SECOND_OPT'
 CHECK-SAME: some_user@some_host
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/output' '{{.+}}/nested/output'
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'

--- a/test/remote-run/dry-run-remote.test-sh
+++ b/test/remote-run/dry-run-remote.test-sh
@@ -1,25 +1,22 @@
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --input-prefix %S/Inputs/ some_user@some_host ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
 
-CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/input/upload'
-CHECK-INPUT-NEXT: /usr/bin/sftp
+CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/input'
+CHECK-INPUT-NEXT: /usr/bin/rsync
 CHECK-INPUT-SAME: some_user@some_host
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/1.txt' '/xyz-REMOTE/input/upload/1.txt'
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/2.txt' '/xyz-REMOTE/input/upload/2.txt'
-CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' 'ls'
+
+CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}}'ls'
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/nested)
 RUN: touch %t/nested/input %t/nested/BAD
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 
-CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
+CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output'
+CHECK-OUTPUT-NEXT: /usr/bin/rsync
 CHECK-OUTPUT-SAME: some_user@some_host
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
-CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' 'cp'
-CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
+
+CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
+CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}
+CHECK-OUTPUT-NEXT: /usr/bin/rsync
 CHECK-OUTPUT-SAME: some_user@some_host
-CHECK-OUTPUT-DAG: -get '/xyz-REMOTE/output/nested/output' '{{.+}}/nested/output'
-CHECK-OUTPUT-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'
+

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -5,11 +5,9 @@ RUN: %debug-remote-run -n --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S
 RUN: test -z "`ls %t`"
 RUN: test ! -e %t-REMOTE
 
-CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input/upload
-CHECK-INPUT-NEXT: /usr/bin/sftp
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/1.txt' '{{.+}}-REMOTE/input/upload/1.txt'
-CHECK-INPUT-DAG: -put '{{.+}}/Inputs/upload/2.txt' '{{.+}}-REMOTE/input/upload/2.txt'
-CHECK-INPUT: /usr/bin/env ls
+CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
+CHECK-INPUT-NEXT: /usr/bin/rsync
+CHECK-INPUT: /usr/bin/env {{.*}}ls
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/nested)
@@ -18,11 +16,8 @@ RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output
 RUN: test ! -e %t-REMOTE
 
 CHECK-OUTPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/output' '{{.+}}-REMOTE/output/nested/output'
-CHECK-OUTPUT-DAG: -put '{{.+}}/nested/input' '{{.+}}-REMOTE/output/nested/input'
-CHECK-OUTPUT: /usr/bin/env cp
-CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
-CHECK-OUTPUT-NEXT: /usr/bin/sftp
-CHECK-OUTPUT-DAG: -get '{{.+}}-REMOTE/output/nested/output' '{{.+}}/nested/output'
-CHECK-OUTPUT-DAG: -get '{{.+}}-REMOTE/output/nested/input' '{{.+}}/nested/input'
+CHECK-OUTPUT: /usr/bin/rsync
+CHECK-OUTPUT: /usr/bin/env {{.*}}cp
+CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}
+CHECK-OUTPUT-NEXT: /usr/bin/rsync
+

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -5,4 +5,4 @@ RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run -v 
 
 CHECK: {{^:foo: :bar:$}}
 
-VERBOSE: /usr/bin/env BAR=bar FOO=foo sh -c echo ":${FOO}:" ":${BAR}:"
+VERBOSE: /usr/bin/env BAR=bar FOO=foo {{.*}}sh -c echo ":${FOO}:" ":${BAR}:"

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -8,36 +8,31 @@ CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}-REMOTE
 CHECK-NEXT: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}'
 
 CHECK: /usr/bin/ssh -n
 CHECK-DAG: -p 12345
 CHECK-DAG: -i spiderman
-CHECK-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-SAME: some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
 
-CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
+CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
 
-CHECK-NEXT: /usr/bin/sftp
-CHECK-DAG: -P 12345
-CHECK-DAG: -i spiderman
+CHECK-NEXT: /usr/bin/rsync
+CHECK-DAG: '-p' '12345'
+CHECK-DAG: '-i' 'spiderman'
 CHECK-SAME: some_user@some_host
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/output' '{{.+}}/nested/output'
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'
 
 # Make sure things work without a port.
 RUN: %remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-PORTLESS %s
 
-CHECK-PORTLESS: /usr/bin/sftp
+CHECK-PORTLESS: /usr/bin/ssh -n
 CHECK-PORTLESS-SAME: -i spiderman
-CHECK-PORTLESS-SAME: some_user@some_host
+CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' '/bin/rm' '-rf' '{{.+}}'
 
 CHECK-PORTLESS: /usr/bin/ssh -n
 CHECK-PORTLESS-SAME: -i spiderman
-CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' 'cp'
+CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}'
+
+CHECK-PORTLESS: /usr/bin/ssh -n
+CHECK-PORTLESS-SAME: -i spiderman
+CHECK-PORTLESS-SAME: some_user@some_host -- '/usr/bin/env' {{.*}}'cp'

--- a/test/remote-run/lit.local.cfg
+++ b/test/remote-run/lit.local.cfg
@@ -2,6 +2,6 @@
 config.substitutions = list(config.substitutions)
 
 config.substitutions.insert(0, ('%debug-remote-run',
-                                r'%r %%utils/remote-run --debug-as-local %%sftp-server --remote-dir %%t-REMOTE' % (sys.executable,)))
+                                r'%r %%utils/remote-run --debug-as-local --remote-dir %%t-REMOTE' % (sys.executable,)))
 config.substitutions.insert(0, ('%remote-run',
                                 r'%r %%utils/remote-run' % (sys.executable,)))

--- a/test/remote-run/port.test-sh
+++ b/test/remote-run/port.test-sh
@@ -1,15 +1,8 @@
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
-CHECK-NEXT: /usr/bin/sftp
-CHECK-SAME: -P 12345
+CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
+CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
+CHECK-NEXT: /usr/bin/rsync
+CHECK-SAME: '-p' '12345'
 CHECK-SAME: some_user@some_host
-CHECK-DAG: -put '{{.+}}/nested/output' '/xyz-REMOTE/output/nested/output'
-CHECK-DAG: -put '{{.+}}/nested/input' '/xyz-REMOTE/output/nested/input'
-CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' 'cp'
-CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
-CHECK-NEXT: /usr/bin/sftp
-CHECK-SAME: -P 12345
-CHECK-SAME: some_user@some_host
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/output' '{{.+}}/nested/output'
-CHECK-DAG: -get '/xyz-REMOTE/output/nested/input' '{{.+}}/nested/input'

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -5,4 +5,4 @@ RUN: %debug-remote-run -v echo hello 2>&1 >/dev/null | %FileCheck -check-prefix 
 
 CHECK: {{^hello$}}
 
-VERBOSE: /usr/bin/env echo hello
+VERBOSE: /usr/bin/env {{.*}}echo hello

--- a/test/remote-run/upload-and-download.test-sh
+++ b/test/remote-run/upload-and-download.test-sh
@@ -27,26 +27,22 @@ RUN: ls %t-REMOTE/output/nested/ | %FileCheck -check-prefix CHECK-REMOTE %s
 RUN: %debug-remote-run -v --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s
 
 VERBOSE: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-VERBOSE-NEXT: /usr/bin/sftp
-VERBOSE-DAG: -put '{{.+}}/nested/output' '{{.+}}-REMOTE/output/nested/output'
-VERBOSE-DAG: -put '{{.+}}/nested/input' '{{.+}}-REMOTE/output/nested/input'
-VERBOSE: /usr/bin/env cp
-VERBOSE-NEXT: {{^}}/bin/mkdir -p {{.+}}/nested
-VERBOSE-NEXT: /usr/bin/sftp
-VERBOSE-DAG: -get '{{.+}}-REMOTE/output/nested/output' '{{.+}}/nested/output'
-VERBOSE-DAG: -get '{{.+}}-REMOTE/output/nested/input' '{{.+}}/nested/input'
+VERBOSE: /usr/bin/rsync
+VERBOSE: /usr/bin/env {{.*}}cp
+VERBOSE-NEXT: {{^}}/bin/mkdir -p {{.+}}
+VERBOSE-NEXT: /usr/bin/rsync
 
 RUN: %empty-directory(%t)
 RUN: touch %t/xyz-1before
 RUN: %debug-remote-run --output-prefix %t/xyz cp %t/xyz-1before %t/xyz-2after
 RUN: ls %t | %FileCheck -check-prefix CHECK-PREFIXED %s
-RUN: ls %t-REMOTE/ | %FileCheck -check-prefix CHECK-PREFIXED-REMOTE %s
+RUN: ls %t-REMOTE/output | %FileCheck -check-prefix CHECK-PREFIXED-REMOTE %s
 
 CHECK-PREFIXED: {{^xyz-1before$}}
 CHECK-PREFIXED: {{^xyz-2after$}}
 
-CHECK-PREFIXED-REMOTE: {{^output-1before$}}
-CHECK-PREFIXED-REMOTE: {{^output-2after$}}
+CHECK-PREFIXED-REMOTE: {{^xyz-1before$}}
+CHECK-PREFIXED-REMOTE: {{^xyz-2after$}}
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t-REMOTE)

--- a/test/remote-run/upload-stderr.test-sh
+++ b/test/remote-run/upload-stderr.test-sh
@@ -3,6 +3,6 @@ REQUIRES: sftp_server
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/REMOTE/input)
 RUN: chmod a-w %t/REMOTE/input
-RUN: %debug-remote-run --remote-dir %t/REMOTE --input-prefix %S/Inputs/upload/ true -- %S/Inputs/upload/1.txt 2>&1 | %FileCheck %s
+RUN: %debug-remote-run --ignore-rsync-failure --remote-dir %t/REMOTE --input-prefix %S/Inputs/upload/ true -- %S/Inputs/upload/1.txt 2>&1 | %FileCheck %s
 
 CHECK: Permission denied

--- a/test/remote-run/upload.test-sh
+++ b/test/remote-run/upload.test-sh
@@ -10,7 +10,7 @@ RUN: %debug-remote-run -v --input-prefix %S/Inputs/ ls %S/Inputs/upload/1.txt %S
 
 RUN: %empty-directory(%t-REMOTE)
 RUN: %debug-remote-run --input-prefix %S/Inputs/upload/1 ls %S/Inputs/upload/1.txt | %FileCheck -check-prefix CHECK-REMOTE-SINGLE-FILE %s
-RUN: test -f %t-REMOTE/input.txt
+RUN: test -f %t-REMOTE/input/1.txt
 
 RUN: %empty-directory(%t-REMOTE)
 RUN: %debug-remote-run --input-prefix %S/Inputs/upload/ --remote-input-prefix custom-input ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt | %FileCheck -check-prefix CHECK-REMOTE-CUSTOM %s
@@ -22,7 +22,7 @@ CHECK-REMOTE-NEXT: {{-REMOTE/input/2.txt$}}
 CHECK-REMOTE-NESTED: {{-REMOTE/input/upload/1.txt$}}
 CHECK-REMOTE-NESTED-NEXT: {{-REMOTE/input/upload/2.txt$}}
 
-CHECK-REMOTE-SINGLE-FILE: {{-REMOTE/input.txt$}}
+CHECK-REMOTE-SINGLE-FILE: {{-REMOTE/input/1.txt$}}
 
 CHECK-REMOTE-CUSTOM: {{-REMOTE/custom-input/1.txt$}}
 CHECK-REMOTE-CUSTOM-NEXT: {{-REMOTE/custom-input/2.txt$}}
@@ -32,8 +32,6 @@ CHECK: {{^1.txt$}}
 CHECK-NEXT: {{^2.txt$}}
 CHECK-NOT: BAD
 
-VERBOSE-NESTED: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input/upload
-VERBOSE-NESTED-NEXT: /usr/bin/sftp
-VERBOSE-NESTED-DAG: -put '{{.+}}/Inputs/upload/1.txt' '{{.+}}-REMOTE/input/upload/1.txt'
-VERBOSE-NESTED-DAG: -put '{{.+}}/Inputs/upload/2.txt' '{{.+}}-REMOTE/input/upload/2.txt'
-VERBOSE-NESTED: /usr/bin/env ls
+VERBOSE-NESTED: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
+VERBOSE-NESTED-NEXT: /usr/bin/rsync
+VERBOSE-NESTED: /usr/bin/env {{.*}}ls

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -18,6 +18,7 @@ import os
 import posixpath
 import subprocess
 import sys
+import shutil
 
 def quote(arg):
     return repr(arg)
@@ -26,6 +27,7 @@ class CommandRunner(object):
     def __init__(self):
         self.verbose = False
         self.dry_run = False
+        self.ignore_rsync_failure = False
 
     @staticmethod
     def _dirnames(files):
@@ -38,34 +40,26 @@ class CommandRunner(object):
             return None
         return subprocess.Popen(command, **kwargs)
 
-    def send(self, local_to_remote_files):
+    def mkdirs_remote(self, directories):
+        if directories:
+            mkdir_command = ['/bin/mkdir', '-p'] + directories
+            self.run_remote(mkdir_command)
+
+    def send(self, input_prefix, remote_prefix, local_to_remote_files):
         # Prepare the remote directory structure.
-        # FIXME: This could be folded into the sftp connection below.
-        dirs_to_make = self._dirnames(local_to_remote_files.values())
-        self.run_remote(['/bin/mkdir', '-p'] + dirs_to_make)
+        self.mkdirs_remote([remote_prefix])
 
-        # Send the local files.
-        sftp_commands = ("-put {0} {1}".format(quote(local_file), 
-                                               quote(remote_file))
-                         for local_file, remote_file
-                         in local_to_remote_files.items())
-        self.run_sftp(sftp_commands)
+        self.run_rsync_to(input_prefix, local_to_remote_files, remote_prefix)
 
-    def fetch(self, local_to_remote_files):
+    def fetch(self, output_prefix, remote_prefix, remote_to_local_files):
         # Prepare the local directory structure.
-        dirs_to_make = self._dirnames(local_to_remote_files.keys())
-        mkdir_command = ['/bin/mkdir', '-p'] + dirs_to_make
+        mkdir_command = ['/bin/mkdir', '-p', output_prefix]
         if self.verbose:
             print(' '.join(mkdir_command), file=sys.stderr)
         if not self.dry_run:
             subprocess.check_call(mkdir_command)
 
-        # Fetch the remote files.
-        sftp_commands = ("-get {0} {1}".format(quote(remote_file), 
-                                               quote(local_file))
-                         for local_file, remote_file
-                         in local_to_remote_files.items())
-        self.run_sftp(sftp_commands)
+        self.run_rsync_from(remote_prefix, remote_to_local_files, output_prefix)
 
     def run_remote(self, command, remote_env={}):
         env_strings = ['{0}={1}'.format(k,v) for k,v in sorted(remote_env.items())]
@@ -80,18 +74,25 @@ class CommandRunner(object):
             # FIXME: We may still want to fetch the output files to see what
             # went wrong.
             sys.exit(remote_proc.returncode)
-    
-    def run_sftp(self, commands):
-        sftp_proc = self.popen(self.sftp_invocation(), stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE, stderr=None)
-        concatenated_commands = '\n'.join(commands)
-        if self.verbose:
-            print(concatenated_commands, file=sys.stderr)
+
+    def run_rsync(self, invocation, sources):
+        rsync_proc = self.popen(invocation,
+                                stdin=subprocess.PIPE,
+                                stdout=None, stderr=None)
         if self.dry_run:
             return
-        _, _ = sftp_proc.communicate(concatenated_commands.encode('utf-8'))
-        if sftp_proc.returncode:
-            sys.exit(sftp_proc.returncode)
+        sources = '\n'.join(sources)
+        if self.verbose:
+            print(sources, file=sys.stderr)
+        _, _ = rsync_proc.communicate(sources.encode('utf-8'))
+        if not self.ignore_rsync_failure and rsync_proc.returncode:
+            sys.exit(rsync_proc.returncode)
+
+    def run_rsync_to(self, prefix, sources, dest):
+        self.run_rsync(self.rsync_to_invocation(prefix, dest), sources)
+
+    def run_rsync_from(self, prefix, sources, dest):
+        self.run_rsync(self.rsync_from_invocation(prefix, dest), sources)
 
 class RemoteCommandRunner(CommandRunner):
     def __init__(self, host, identity_path, ssh_options, config_file):
@@ -123,26 +124,109 @@ class RemoteCommandRunner(CommandRunner):
                 [self.remote_host, '--'] +
                 [quote(arg) for arg in command])
 
-    def sftp_invocation(self):
-        return (['/usr/bin/sftp', '-b', '-', '-q', '-r'] +
-                self.common_options(port_flag='-P') +
-                [self.remote_host])
+    def rsync_invocation(self, source, dest):
+        return ['/usr/bin/rsync', '-arRz', '--files-from=-',
+                '-e', ' '.join([quote(x) for x in
+                                ['/usr/bin/ssh'] +
+                                self.common_options(port_flag='-p')]),
+                source,
+                dest]
+
+    def rsync_from_invocation(self, source, dest):
+        return self.rsync_invocation(self.remote_host + ':' + source, dest)
+
+    def rsync_to_invocation(self, source, dest):
+        return self.rsync_invocation(source, self.remote_host + ':' + dest)
 
 class LocalCommandRunner(CommandRunner):
-    def __init__(self, sftp_server_path):
-        self.sftp_server_path = sftp_server_path
-
     def remote_invocation(self, command):
         return command
 
-    def sftp_invocation(self):
-        return ['/usr/bin/sftp', '-b', '-', '-q', '-D', self.sftp_server_path]
+    def rsync_invocation(self, source, dest):
+        return ['/usr/bin/rsync', '-arz', '--files-from=-', source, dest]
 
-def find_transfers(args, source_prefix, dest_prefix):
-    if source_prefix.endswith(posixpath.sep):
-        source_prefix = source_prefix[:-len(posixpath.sep)]
-    return dict((arg, dest_prefix + arg[len(source_prefix):])
-                for arg in args if arg.startswith(source_prefix))
+    def rsync_from_invocation(self, source, dest):
+        return self.rsync_invocation(source, dest)
+
+    def rsync_to_invocation(self, source, dest):
+        return self.rsync_invocation(source, dest)
+
+def strip_sep(name):
+    lsep = len(posixpath.sep)
+    while name.startswith(posixpath.sep):
+        name = name[lsep:]
+    return name
+
+class ArgumentProcessor(object):
+    def __init__(self,
+                 input_prefix, output_prefix,
+                 remote_dir, remote_input_prefix, remote_output_prefix,
+                 arguments):
+        assert not remote_input_prefix.startswith('..')
+        assert not remote_output_prefix.startswith('..')
+
+        self.input_prefix = input_prefix
+        self.output_prefix = output_prefix
+        self.remote_dir = remote_dir
+        self.remote_input_prefix = remote_input_prefix
+        self.remote_output_prefix = remote_output_prefix
+        self.original_args = arguments
+
+        if self.input_prefix:
+            while self.input_prefix.endswith(posixpath.sep):
+                self.input_prefix = self.input_prefix[:-len(posixpath.sep)]
+        if self.output_prefix:
+            while self.output_prefix.endswith(posixpath.sep):
+                self.output_prefix = self.output_prefix[:-len(posixpath.sep)]
+
+    def process_args(self):
+        self.args = []
+        self.inputs = set()
+        self.nodir_inputs = set()
+        self.existing_outputs = set()
+        self.outputs = set()
+        self.existing_nodir_outputs = set()
+        self.nodir_outputs = set()
+
+        iplen = 0
+        oplen = 0
+        if self.input_prefix:
+            iplen = len(self.input_prefix)
+            ipfxdir, ipfx = posixpath.split(self.input_prefix)
+        if self.output_prefix:
+            oplen = len(self.output_prefix)
+            opfxdir, opfx = posixpath.split(self.output_prefix)
+        for arg in self.original_args:
+            if iplen and arg.startswith(self.input_prefix):
+                name = arg[iplen:]
+                if not name.startswith(posixpath.sep):
+                    name = ipfx + name
+                    self.nodir_inputs.add(name)
+                else:
+                    name = strip_sep(name)
+                    self.inputs.add(name)
+
+                self.args.append(posixpath.join(self.remote_dir,
+                                                self.remote_input_prefix,
+                                                name))
+            elif oplen and arg.startswith(self.output_prefix):
+                name = arg[oplen:]
+                if not name.startswith(posixpath.sep):
+                    name = opfx + name
+                    self.nodir_outputs.add(name)
+                    if os.path.exists(arg):
+                        self.existing_nodir_outputs.add(name)
+                else:
+                    name = strip_sep(name)
+                    self.outputs.add(name)
+                    if os.path.exists(arg):
+                        self.existing_outputs.add(name)
+
+                self.args.append(posixpath.join(self.remote_dir,
+                                                self.remote_output_prefix,
+                                                name))
+            else:
+                self.args.append(arg)
 
 def collect_remote_env(local_env=os.environ, prefix='REMOTE_RUN_CHILD_'):
     return dict((key[len(prefix):], value)
@@ -179,10 +263,12 @@ def main():
     parser.add_argument('-o', '--ssh-option', action='append', default=[],
                         dest='ssh_options', metavar='OPTION',
                         help='extra SSH config options (man ssh_config)')
-    parser.add_argument('--debug-as-local', metavar='/PATH/TO/SFTP-SERVER',
+    parser.add_argument('--debug-as-local', action='store_true',
                         help='run commands locally instead of over SSH, for '
                              'debugging purposes. The "host" argument is '
                              'omitted.')
+    parser.add_argument('--ignore-rsync-failure', action='store_true',
+                        help='ignore rsync failures, for debugging.')
 
     parser.add_argument('host',
                         help='the host to connect to, in the form '
@@ -192,7 +278,7 @@ def main():
     args = parser.parse_args()
 
     if args.debug_as_local:
-        runner = LocalCommandRunner(args.debug_as_local)
+        runner = LocalCommandRunner()
         args.command.insert(0, args.host)
         del args.host
     else:
@@ -202,44 +288,56 @@ def main():
                                      args.config_file)
     runner.dry_run = args.dry_run
     runner.verbose = args.verbose or args.dry_run
+    runner.ignore_rsync_failure = args.ignore_rsync_failure
 
     assert not args.remote_dir == '/'
 
-    upload_files = dict()
-    download_files = dict()
-    remote_test_specific_dir = None
-    if args.input_prefix:
-        assert not args.remote_input_prefix.startswith("..")
-        remote_dir = posixpath.join(args.remote_dir, args.remote_input_prefix)
-        input_files = find_transfers(args.command, args.input_prefix, 
-                                     remote_dir)
-        assert not any(f in upload_files for f in input_files)
-        upload_files.update(input_files)
-    if args.output_prefix:
-        assert not args.remote_output_prefix.startswith("..")
-        remote_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
-        test_files = find_transfers(args.command, args.output_prefix, 
-                                    remote_dir)
-        assert not any(f in upload_files for f in test_files)
-        upload_files.update(test_files)
-        assert not any(f in download_files for f in test_files)
-        download_files.update(test_files)
-        remote_test_specific_dir = remote_dir
+    argproc = ArgumentProcessor(args.input_prefix,
+                                args.output_prefix,
+                                args.remote_dir,
+                                posixpath.normpath(args.remote_input_prefix),
+                                posixpath.normpath(args.remote_output_prefix),
+                                args.command)
 
-    if remote_test_specific_dir:
-        assert remote_test_specific_dir.startswith(args.remote_dir)
-        runner.run_remote(['/bin/rm', '-rf', remote_test_specific_dir])
-    if upload_files:
-        runner.send(upload_files)
+    argproc.process_args()
+
+    input_dir = posixpath.join(args.remote_dir, args.remote_input_prefix)
+    output_dir = posixpath.join(args.remote_dir, args.remote_output_prefix)
+
+    if args.output_prefix:
+        runner.run_remote(['/bin/rm', '-rf', output_dir])
+
+    dirs = set()
+    for output in argproc.outputs:
+        dirs.add(posixpath.join(output_dir, posixpath.dirname(output)))
+    for output in argproc.nodir_outputs:
+        dirs.add(posixpath.join(output_dir, posixpath.dirname(output)))
+    runner.mkdirs_remote(list(dirs))
+
+    if argproc.inputs:
+        runner.send(args.input_prefix, input_dir, argproc.inputs)
+
+    if argproc.nodir_inputs:
+        runner.send(posixpath.dirname(args.input_prefix),
+                    input_dir, argproc.nodir_inputs)
+
+    if argproc.existing_outputs:
+        runner.send(args.output_prefix, output_dir, argproc.existing_outputs)
+
+    if argproc.existing_nodir_outputs:
+        runner.send(posixpath.dirname(args.output_prefix),
+                    output_dir, argproc.existing_nodir_outputs)
 
     remote_env = collect_remote_env()
 
-    translated_command = [upload_files.get(arg, download_files.get(arg, arg))
-                          for arg in args.command]
-    runner.run_remote(translated_command, remote_env)
+    runner.run_remote(argproc.args, remote_env)
 
-    if download_files:
-        runner.fetch(download_files)
+    if argproc.outputs:
+        runner.fetch(args.output_prefix, output_dir, argproc.outputs)
+
+    if argproc.nodir_outputs:
+        runner.fetch(posixpath.dirname(args.output_prefix),
+                     output_dir, argproc.nodir_outputs)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Not only does this give us a huge speed-up, it also works around a problem where `sftp` doesn't always update the modification time, which causes random test failures.

rdar://88179140
