### PR TITLE
Make the environment_variables test less flaky.

### DIFF
--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -18,6 +18,9 @@
 // CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
 // CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
 
+// We need to do this because the DAG checks require a non-DAG check as an
+// anchor:
+
 // CHECK: Hello, world
 
 // We have to write this to stderr to avoid being dependent on the order of

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -18,5 +18,21 @@
 // CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
 // CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
 
-print("Hello, world")
 // CHECK: Hello, world
+
+// We have to write this to stderr to avoid being dependent on the order of
+// stdout vs stderr (the data can come in any order).
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif os(WASI)
+import WASILibc
+#elseif os(Windows)
+import CRT
+#else
+#error("Unsupported platform")
+#endif
+
+fputs("\nHello, world\n", stderr)
+


### PR DESCRIPTION
The test was inadvertently depending on the ordering of output between stderr and stdout, which makes it break particularly when being run remotely.

rdar://88335113
