### PR TITLE
[stdlib] Speed up `ObjectIdentifier`-keyed dictionaries

### DIFF
--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -95,6 +95,11 @@ extension ObjectIdentifier: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(Int(Builtin.ptrtoint_Word(_value)))
   }
+
+  @_alwaysEmitIntoClient // For back deployment
+  public func _rawHashValue(seed: Int) -> Int {
+    Int(Builtin.ptrtoint_Word(_value))._rawHashValue(seed: seed)
+  }
 }
 
 extension UInt {


### PR DESCRIPTION
`ObjectIdentifier` is used relatively frequently as the `Key` type for dictionaries, so it makes sense for it to implement single-shot hashing. This will lead to a measurable speedup in lookup/insertion performance.

rdar://88339458
