### PR TITLE
[Distributed] NFC: Disable remoteCall test on arm64_32 WatchOS simulator

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -7,6 +7,8 @@
 
 // rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
 // UNSUPPORTED: OS=watchos && CPU=i386
+// rdar://88340451 - segmentation fault on arm64_32 WatchOS simulator
+// UNSUPPORTED: OS=watchos && CPU=arm64_32
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Resolves: rdar://88340451

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
