### PR TITLE
Invoke correct CMake when building tsan libdispatch

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -48,7 +48,9 @@ class TSanLibDispatch(product.Product):
 
     def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""
-        rt_source_dir = join_path(self.source_dir, os.pardir, 'compiler-rt')
+        rt_source_dir = join_path(
+            self.source_dir, os.pardir,
+            'llvm-project', 'compiler-rt')
         toolchain_path = join_path(self.args.install_destdir, 'usr')
         clang = join_path(toolchain_path, 'bin', 'clang')
         clangxx = join_path(toolchain_path, 'bin', 'clang++')

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -54,7 +54,7 @@ class TSanLibDispatch(product.Product):
         clangxx = join_path(toolchain_path, 'bin', 'clang++')
 
         config_cmd = [
-            'cmake',
+            self.toolchain.cmake,
             '-GNinja',
             '-DCMAKE_PREFIX_PATH=%s' % toolchain_path,
             '-DCMAKE_C_COMPILER=%s' % clang,


### PR DESCRIPTION
This should address a build failure on TSAN - libdispatch Linux bots

Addresses rdar://88339546