### PR TITLE
ClangImporter: Import 'typedef id<P, Q> Foo' as a constraint type rather than an existential type

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2796,6 +2796,16 @@ namespace {
                                       SourceLoc(), Name,
                                       Loc,
                                       /*genericparams*/nullptr, DC);
+
+      // Unwrap an explicit ExistentialType around the underlying type so that
+      // the typealias can be used in a generic constraint context.
+      //
+      // FIXME: We might want to push this down further into importType(), and
+      // once ExistentialType becomes mandatory in the future we want to wrap
+      // references to imported typealiases in Sema's resolveType() as well.
+      if (auto *existentialType = SwiftType->getAs<ExistentialType>())
+        SwiftType = existentialType->getConstraintType();
+
       Result->setUnderlyingType(SwiftType);
       
       // Make Objective-C's 'id' unavailable.

--- a/test/ClangImporter/Inputs/explicit_existential.h
+++ b/test/ClangImporter/Inputs/explicit_existential.h
@@ -1,0 +1,13 @@
+@import Foundation;
+
+@protocol P
+@end
+
+@protocol Q
+@end
+
+typedef id<P, Q> PAndQ;
+
+@interface PAndQProcessor : NSObject
+- (void) takesPAndQExistential: (PAndQ)arg;
+@end

--- a/test/ClangImporter/explicit_existential.swift
+++ b/test/ClangImporter/explicit_existential.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -enable-objc-interop -import-objc-header %S/Inputs/explicit_existential.h
+
+// Make sure that 'typedef id<P, Q> PAndQ' imports as a typealias without
+// the ExistentialType wrapping the underlying type.
+
+protocol InheritsFromQAndQ : PAndQ {}
+
+func genericOverPAndQ<T : PAndQ>(_: T) {}
+
+func takesSequenceOfPAndQ<T : Sequence>(_: T) where T.Element : PAndQ {}
+
+func takesPAndQExistential(_ x: PAndQ) {
+  let b = PAndQProcessor()
+  b.takesPAndQExistential(x)
+}


### PR DESCRIPTION
We want to be able to use these typealiases both as existential types
and as generic constraints, so unwrap the ExistentialType explicitly
before setting the underlying type of the typealias.

This might not be the best long-term approach, so I added a FIXME
comment with my thoughts there.

Fixes rdar://problem/88208893.