### PR TITLE
[SymbolGraph] don't filter out all implicit decls

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -655,10 +655,6 @@ bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
     return false;
   }
 
-  if (D->isImplicit()) {
-    return false;
-  }
-
   if (!isa<ValueDecl>(D)) {
     return false;
   }

--- a/test/SymbolGraph/Symbols/Implicit.swift
+++ b/test/SymbolGraph/Symbols/Implicit.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Implicit -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name Implicit -I %t -pretty-print -output-dir %t -minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/Implicit.symbols.json
+
+// RUN: %target-swift-symbolgraph-extract -module-name Implicit -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Implicit.symbols.json --check-prefix PUBLIC
+
+public class SomeClass {}
+
+public struct SomeStruct {
+    let bar: Int
+    let other: String
+}
+
+// make sure that the implicitly-generated initializer appears when the access level is `internal`
+// CHECK-DAG: "precise": "s:8Implicit9SomeClassCACycfc"
+// CHECK-DAG: "precise": "s:8Implicit10SomeStructV3bar5otherACSi_SStcfc"
+
+// ...but that they don't show up when it's `public`, since they're marked `internal` to begin with
+// PUBLIC-NOT: "precise": "s:8Implicit9SomeClassCACycfc"
+// PUBLIC-NOT: "precise": "s:8Implicit10SomeStructV3bar5otherACSi_SStcfc"


### PR DESCRIPTION
Resolves rdar://86294494

When generating a symbol graph with minimum-access-level set to `internal`, implicitly-generated initializers are not included in the symbol graph, despite being available at that access level. This PR removes the filter in SymbolGraphGen that removes all implicit decls; most of them are being filtered in SourceEntityWalker anyway, so removing this check is harmless for the purposes of the symbol graph.