### PR TITLE
Make isVisibleFromModule accept TagDecl definitions that were demoted to declarations.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2706,9 +2706,12 @@ static bool isVisibleFromModule(const ClangModuleUnit *ModuleFilter,
 
     // For enums, structs, and unions, only count definitions when looking to
     // see what other modules they appear in.
-    if (IsTagDecl)
-      if (!cast<clang::TagDecl>(Redeclaration)->isCompleteDefinition())
+    if (IsTagDecl) {
+      auto TD = cast<clang::TagDecl>(Redeclaration);
+      if (!TD->isCompleteDefinition() &&
+          !TD->isThisDeclarationADemotedDefinition())
         continue;
+    }
 
     auto OwningClangModule = getClangTopLevelOwningModule(Redeclaration,
                                                           ClangASTContext);

--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -17,6 +17,5 @@ let encoding: UInt = NSUTF8StringEncoding
 let viaTypedef: Redeclaration.NSPoint = AppKit.NSPoint(x: 0, y: 0)
 Redeclaration.NSStringToNSString(AppKit.NSStringToNSString("abc")) // expected-warning {{result of call to 'NSStringToNSString' is unused}}
 
-/// The following error should soon be introduced by https://github.com/apple/llvm-project/pull/3497.
-let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1() // expected-error * {{module 'AppKit' has no member named 'FooStruct1'}}
+let viaStruct: Redeclaration.FooStruct1 = AppKit.FooStruct1()
 let forwardDecl: Redeclaration.Tribool = AppKit.Tribool() // expected-error {{no type named 'Tribool' in module 'Redeclaration'}}


### PR DESCRIPTION
Clang AST requires to have only a single definition in a redeclaration
chain, that's why it demotes duplicate definitions from other modules to
declarations. But on the Swift side it is important to know a module
contains a full definition and not just a forward declaration, even if
it was demoted to a declaration.