### PR TITLE
ConformanceChecker: Resolve value witnesses unless they depend on invalid type witnesses

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3149,8 +3149,9 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
           ProtocolConformanceState::Incomplete, /*isUnchecked=*/false);
       ConformanceChecker checker(getASTContext(), &conformance,
                                  missingWitnesses);
-      checker.resolveValueWitnesses();
+      // Type witnesses must be resolved first.
       checker.resolveTypeWitnesses();
+      checker.resolveValueWitnesses();
     }
 
     for (auto decl : missingWitnesses) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4847,12 +4847,6 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
 void ConformanceChecker::ensureRequirementsAreSatisfied() {
   Conformance->finishSignatureConformances();
   auto proto = Conformance->getProtocol();
-
-  if (CheckedRequirementSignature)
-    return;
-
-  CheckedRequirementSignature = true;
-
   auto &diags = proto->getASTContext().Diags;
 
   auto DC = Conformance->getDeclContext();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5080,10 +5080,6 @@ void ConformanceChecker::resolveValueWitnesses() {
       continue;
     }
 
-    // If this is an accessor for a storage decl, ignore it.
-    if (isa<AccessorDecl>(requirement))
-      continue;
-
     // If this requirement is part of a pair of imported async requirements,
     // where one has already been witnessed, we can skip it.
     //

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -788,6 +788,10 @@ private:
   ResolveWitnessResult resolveTypeWitnessViaLookup(
                          AssociatedTypeDecl *assocType);
 
+  /// Check whether all of the protocol's generic requirements are satisfied by
+  /// the chosen type witnesses.
+  void ensureRequirementsAreSatisfied();
+
   /// Diagnose or defer a diagnostic, as appropriate.
   ///
   /// \param requirement The requirement with which this diagnostic is
@@ -845,10 +849,6 @@ public:
   /// Resolve the type witness for the given associated type as
   /// directly as possible.
   void resolveSingleTypeWitness(AssociatedTypeDecl *assocType);
-
-  /// Check all of the protocols requirements are actually satisfied by a
-  /// the chosen type witnesses.
-  void ensureRequirementsAreSatisfied();
 
   /// Check the entire protocol conformance, ensuring that all
   /// witnesses are resolved and emitting any diagnostics.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -716,9 +716,6 @@ private:
   /// Whether we've already complained about problems with this conformance.
   bool AlreadyComplained = false;
 
-  /// Whether we checked the requirement signature already.
-  bool CheckedRequirementSignature = false;
-
   /// Mapping from Objective-C methods to the set of requirements within this
   /// protocol that have the same selector and instance/class designation.
   llvm::SmallDenseMap<ObjCMethodKey, TinyPtrVector<AbstractFunctionDecl *>, 4>

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -131,3 +131,119 @@ extension UInt32: ExpressibleByStringLiteral {}
 // the type actually conforming), do not crash when failing to find
 // the associated witness type.
 let diagnose: UInt32 = "reta"
+
+// Test that we attempt to resolve a value witness unless mapping its interface
+// type into the conformance context produces an invalid type.
+protocol P7 {
+  associatedtype A: Sequence // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+
+  subscript(subscript1 _: A) -> Never { get }
+  subscript<T>(subscript2 _: T) -> Never where T: Sequence, T.Element == A { get }
+  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'; do you want to add a stub?}}
+
+  func method1(_: A)
+  func method2() -> A.Element
+  func method3<T>(_: T) where T: Sequence, T.Element == A
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; do you want to add a stub?}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; do you want to add a stub?}}
+}
+do {
+  struct Conformer: P7 {} // expected-error {{type 'Conformer' does not conform to protocol 'P7'}}
+}
+
+protocol P8 {
+  associatedtype A: Sequence where A.Element == Never
+
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()'); do you want to add a stub?}}
+  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'; do you want to add a stub?}}
+  func method3<T>(_: T) where T: Sequence, T.Element == A
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; do you want to add a stub?}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; do you want to add a stub?}}
+}
+do {
+  struct Conformer: P8 {
+    // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P8'}}
+    // expected-error@-2 {{'P8' requires the types 'Bool' and 'Never' be equivalent}}
+    // expected-note@-3 {{requirement specified as 'Self.A.Element' == 'Never' [with Self = Conformer]}}
+    typealias A = Array<Bool>
+  }
+}
+
+protocol P9a {
+  associatedtype A
+}
+protocol P9b: P9a where A: Sequence {
+  subscript(subscript1 _: A.Element) -> Never { get }
+  subscript<T>(subscript2 _: T) -> Never where T: Sequence, T.Element == A.Element { get }
+  // expected-note@-1 {{protocol requires subscript with type '<T> (subscript2: T) -> Never'; do you want to add a stub?}}
+
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Bool) -> ()'); do you want to add a stub?}}
+  func method2() -> A.Element
+  func method3<T>(_: T) where T: Sequence, T.Element == A
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; do you want to add a stub?}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; do you want to add a stub?}}
+}
+do {
+  struct Conformer: P9b {
+    // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P9b'}}
+    // expected-error@-2 {{type 'Conformer.A' (aka 'Bool') does not conform to protocol 'Sequence'}}
+    typealias A = Bool
+  }
+}
+
+protocol P10a {
+  associatedtype A
+}
+protocol P10b: P10a where A: Sequence, A.Element == Never {
+  func method1(_: A) // expected-note {{protocol requires function 'method1' with type '(Conformer.A) -> ()' (aka '(Array<Bool>) -> ()'); do you want to add a stub?}}
+  func method2() -> A.Element // expected-note {{protocol requires function 'method2()' with type '() -> Bool'; do you want to add a stub?}}
+  func method3<T>(_: T) where T: Sequence, T.Element == A
+  // expected-note@-1 {{protocol requires function 'method3' with type '<T> (T) -> ()'; do you want to add a stub?}}
+  func method4(_: Never) // expected-note {{protocol requires function 'method4' with type '(Never) -> ()'; do you want to add a stub?}}
+}
+do {
+  struct Conformer: P10b {
+    // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P10b'}}
+    // expected-error@-2 {{'P10b' requires the types 'Bool' and 'Never' be equivalent}}
+    // expected-note@-3 {{requirement specified as 'Self.A.Element' == 'Never' [with Self = Conformer]}}
+    typealias A = Array<Bool>
+  }
+}
+
+protocol P11 {
+  associatedtype A: Equatable
+  // FIXME: Should not resolve witness for 'method', but Type::subst doesn't care
+  // about conditional requirements when querying type witnesses.
+  // expected-note@+1 {{protocol requires function 'method()' with type '() -> Conformer.A' (aka '() -> Array<P11>'); do you want to add a stub?}}
+  func method() -> A
+}
+do {
+  struct Conformer: P11 {
+    // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P11'}}
+    // expected-error@-2 {{type 'P11' does not conform to protocol 'Equatable'}} // FIXME: Crappy diagnostics
+    // expected-error@-3 {{'P11' requires that 'P11' conform to 'Equatable'}}
+    // expected-note@-4 {{requirement specified as 'P11' : 'Equatable'}}
+    // expected-note@-5 {{requirement from conditional conformance of 'Conformer.A' (aka 'Array<P11>') to 'Equatable'}}
+    typealias A = Array<any P11>
+  }
+}
+
+protocol P12 {
+  associatedtype A: Sequence where A.Element == Never // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  // FIXME: Should not resolve witness for 'prop', but getInterfaceType() returns
+  // '(Self) -> Never' instead of '(Self) -> Self.A.Element', and the invalid
+  // type parameter is never found (see 'hasInvalidTypeInConformanceContext').
+  // This happens because getInterfaceType() on properties returns contextual
+  // types that have been mapped out of context, but mapTypeOutOfContext() does
+  // not reconstitute type parameters that were substituted with concrete types.
+  // Instead, patterns should be refactored to use interface types, at least if
+  // they appear in type contexts.
+  //
+  // expected-note@+1 {{protocol requires property 'prop' with type '(Conformer) -> Never'; do you want to add a stub?}}
+  var prop: (Self) -> A.Element { get }
+}
+do {
+  struct Conformer: P12 { // expected-error {{type 'Conformer' does not conform to protocol 'P12'}}
+    typealias A = Bool // expected-note {{possibly intended match 'Conformer.A' (aka 'Bool') does not conform to 'Sequence'}}
+  }
+}

--- a/test/decl/protocol/conforms/fixit_stub.swift
+++ b/test/decl/protocol/conforms/fixit_stub.swift
@@ -162,17 +162,18 @@ protocol ProtocolChain2 : ProtocolChain1 {
 class Adopter15 : ProtocolChain2 {} //expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain2'}} expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain1'}}
 
 protocol ProtocolParallel1 {
-  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  func Foo4()
+  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  // FIXME: Why do we add stubs for all missing requirements when the note implies a single one?
+  func Foo4() // expected-note {{protocol requires function 'Foo4()' with type '() -> ()'; do you want to add a stub?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
 }
 
 protocol ProtocolParallel2 {
-  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  func Bar4()
+  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  func Bar4() // expected-note {{protocol requires function 'Bar4()' with type '() -> ()'; do you want to add a stub?}}{{57-57=\n    func Bar4() {\n        <#code#>\n    \}\n}}
 }
 
 class Adopter16 : ProtocolParallel1, ProtocolParallel2 {} // expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel1'}} expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel2'}}

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -20,11 +20,8 @@ distributed actor D2 {
 }
 
 distributed actor D3 {
-  // expected-error@-1{{protocol 'DistributedActor' is broken; cannot derive conformance for type 'D3'}}
-  // expected-error@-2{{protocol 'DistributedActor' is broken; cannot derive conformance for type 'D3'}} // FIXME(distributed): duplicate errors
-  // expected-error@-3{{type 'D3' does not conform to protocol 'Identifiable'}}
-  // expected-error@-4{{type 'D3' does not conform to protocol 'DistributedActor'}}
-  // expected-error@-5{{type 'D3' does not conform to protocol 'DistributedActor'}}
+  // expected-error@-1{{type 'D3' does not conform to protocol 'Identifiable'}}
+  // expected-error@-2{{type 'D3' does not conform to protocol 'DistributedActor'}}
 
   var id: Int { 0 }
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
@@ -36,11 +33,8 @@ struct OtherActorIdentity: Sendable, Hashable, Codable {}
 
 distributed actor D4 {
   // expected-error@-1{{actor 'D4' has no initializers}}
-  // expected-error@-2{{type 'D4' does not conform to protocol 'DistributedActor'}} // FIXME(distributed): duplicated errors
-  // expected-error@-3{{type 'D4' does not conform to protocol 'DistributedActor'}}
-  // expected-error@-4{{protocol 'DistributedActor' is broken; cannot derive conformance for type 'D4'}} // FIXME(distributed): duplicated errors
-  // expected-error@-5{{protocol 'DistributedActor' is broken; cannot derive conformance for type 'D4'}}
-  // expected-error@-6{{type 'D4' does not conform to protocol 'Identifiable'}}
+  // expected-error@-2{{type 'D4' does not conform to protocol 'DistributedActor'}}
+  // expected-error@-3{{type 'D4' does not conform to protocol 'Identifiable'}}
   let actorSystem: String
   // expected-error@-1{{invalid redeclaration of synthesized property 'actorSystem'}}
   // expected-error@-2{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}

--- a/test/refactoring/FillStubs/Outputs/basic/P19-8.swift.expected
+++ b/test/refactoring/FillStubs/Outputs/basic/P19-8.swift.expected
@@ -19,10 +19,6 @@ class C4 : P2 {}
 class C5 : P2 {
     typealias T2 = <#type#>
 
-    func foo1() {
-        <#code#>
-    }
-
   typealias T1 = Int
   func foo1() {}
 }

--- a/test/refactoring/FillStubs/Outputs/basic/P27-8.swift.expected
+++ b/test/refactoring/FillStubs/Outputs/basic/P27-8.swift.expected
@@ -27,10 +27,6 @@ class C6 : P2 {
 class C7 : P2 {
     typealias T1 = <#type#>
 
-    func foo1() {
-        <#code#>
-    }
-
   typealias T2 = Int
   func foo1() {}
 }

--- a/test/refactoring/FillStubs/Outputs/basic/P62-12.swift.expected
+++ b/test/refactoring/FillStubs/Outputs/basic/P62-12.swift.expected
@@ -62,10 +62,6 @@ extension C12 : P1 {
 extension C12 : P2 {
     typealias T2 = <#type#>
 
-    func foo1() {
-        <#code#>
-    }
-
   typealias T1 = Int
   func foo1() {}
 }

--- a/test/refactoring/FillStubs/Outputs/basic/P71-12.swift.expected
+++ b/test/refactoring/FillStubs/Outputs/basic/P71-12.swift.expected
@@ -71,10 +71,6 @@ extension C13 : P1 {
 extension C13 : P2 {
     typealias T2 = <#type#>
 
-    func foo1() {
-        <#code#>
-    }
-
   typealias T1 = Int
   func foo1() {}
 }


### PR DESCRIPTION
Rather than skipping value witness resolution altogether when a type witness failed to resolve or a generic requirement was not satisfied, conditionalize value witness resolution for a particular requirement on whether mapping its interface type into the conformance context produces a well-formed type.