### PR TITLE
[ClangImporter] Import `id<P>` as either `any P` or `P` based on context.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2796,16 +2796,6 @@ namespace {
                                       SourceLoc(), Name,
                                       Loc,
                                       /*genericparams*/nullptr, DC);
-
-      // Unwrap an explicit ExistentialType around the underlying type so that
-      // the typealias can be used in a generic constraint context.
-      //
-      // FIXME: We might want to push this down further into importType(), and
-      // once ExistentialType becomes mandatory in the future we want to wrap
-      // references to imported typealiases in Sema's resolveType() as well.
-      if (auto *existentialType = SwiftType->getAs<ExistentialType>())
-        SwiftType = existentialType->getConstraintType();
-
       Result->setUnderlyingType(SwiftType);
       
       // Make Objective-C's 'id' unavailable.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2796,6 +2796,16 @@ namespace {
                                       SourceLoc(), Name,
                                       Loc,
                                       /*genericparams*/nullptr, DC);
+
+      // Unwrap an explicit ExistentialType around the underlying type so that
+      // the typealias can be used in a generic constraint context.
+      //
+      // FIXME: We might want to push this down further into importType(), and
+      // once ExistentialType becomes mandatory in the future we want to wrap
+      // references to imported typealiases in Sema's resolveType() as well.
+      if (auto *existentialType = SwiftType->getAs<ExistentialType>())
+        SwiftType = existentialType->getConstraintType();
+
       Result->setUnderlyingType(SwiftType);
       
       // Make Objective-C's 'id' unavailable.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1835,8 +1835,7 @@ private:
 
   void visitExistentialType(ExistentialType *ET,
                             Optional<OptionalTypeKind> optionalKind) {
-    visitExistentialType(ET, optionalKind,
-        /*isMetatype=*/ET->getConstraintType()->is<AnyMetatypeType>());
+    visitPart(ET->getConstraintType(), optionalKind);
   }
 
   void visitExistentialMetatypeType(ExistentialMetatypeType *MT,

--- a/test/ClangImporter/Inputs/explicit_existential.h
+++ b/test/ClangImporter/Inputs/explicit_existential.h
@@ -1,0 +1,13 @@
+@import Foundation;
+
+@protocol P
+@end
+
+@protocol Q
+@end
+
+typedef id<P, Q> PAndQ;
+
+@interface PAndQProcessor : NSObject
+- (void) takesPAndQExistential: (PAndQ)arg;
+@end

--- a/test/ClangImporter/explicit_existential.swift
+++ b/test/ClangImporter/explicit_existential.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -enable-objc-interop -import-objc-header %S/Inputs/explicit_existential.h
+
+// Make sure that 'typedef id<P, Q> PAndQ' imports as a typealias without
+// the ExistentialType wrapping the underlying type.
+
+protocol InheritsFromQAndQ : PAndQ {}
+
+func genericOverPAndQ<T : PAndQ>(_: T) {}
+
+func takesSequenceOfPAndQ<T : Sequence>(_: T) where T.Element : PAndQ {}
+
+func takesPAndQExistential(_ x: PAndQ) {
+  let b = PAndQProcessor()
+  b.takesPAndQExistential(x)
+}


### PR DESCRIPTION
When `id<P>` is the underlying type of a typedef or on the right side of a generic constraint, it should be imported as a protocol or composition. Otherwise, it should be imported as an existential type. This is similar to how type resolution resolves existential types based on `TypeResolverContext`.

This PR subsumes https://github.com/apple/swift/pull/41138 and sinks the logic down into `importType()`.

Resolves: rdar://problem/88208893
