### PR TITLE
Add SWIFT_STDLIB_ENABLE_VECTOR_TYPES to take away support for SIMD

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -364,6 +364,10 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_STDLIB_SHORT_MANGLING_LOOKUPS")
   endif()
 
+  if(SWIFT_STDLIB_ENABLE_VECTOR_TYPES)
+    list(APPEND result "-DSWIFT_STDLIB_ENABLE_VECTOR_TYPES")
+  endif()
+
   if(SWIFT_STDLIB_HAS_TYPE_PRINTING)
     list(APPEND result "-DSWIFT_STDLIB_HAS_TYPE_PRINTING")
   endif()

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -101,6 +101,10 @@ option(SWIFT_STDLIB_SHORT_MANGLING_LOOKUPS
        "Build stdlib with fast-path context descriptor lookups based on well-known short manglings."
        TRUE)
 
+option(SWIFT_STDLIB_ENABLE_VECTOR_TYPES
+       "Build stdlib with support for SIMD and vector types"
+       TRUE)
+
 option(SWIFT_STDLIB_HAS_TYPE_PRINTING
        "Build stdlib with support for printing user-friendly type name as strings at runtime"
        TRUE)

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -10,6 +10,12 @@
 #
 #===----------------------------------------------------------------------===#
 
+if(SWIFT_STDLIB_ENABLE_VECTOR_TYPES)
+set(swiftDifferentiationSIMDFiles SIMDDifferentiation.swift.gyb)
+else()
+set(swiftDifferentiationSIMDFiles)
+endif()
+
 add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   Differentiable.swift
   DifferentialOperators.swift
@@ -23,7 +29,7 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
   GYB_SOURCES
     FloatingPointDifferentiation.swift.gyb
     TgmathDerivatives.swift.gyb
-    SIMDDifferentiation.swift.gyb
+    ${swiftDifferentiationSIMDFiles}
 
   SWIFT_MODULE_DEPENDS_OSX Darwin
   SWIFT_MODULE_DEPENDS_IOS Darwin

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -220,7 +220,6 @@ set(SWIFTLIB_SOURCES
   PlaygroundDisplay.swift
   CommandLine.swift
   SliceBuffer.swift
-  SIMDVector.swift
   UnfoldSequence.swift
   VarArgs.swift
   Zip.swift
@@ -229,10 +228,14 @@ set(SWIFTLIB_SOURCES
 
 set(SWIFTLIB_GYB_SOURCES
   ${SWIFTLIB_ESSENTIAL_GYB_SOURCES}
-  SIMDConcreteOperations.swift.gyb
-  SIMDVectorTypes.swift.gyb
   Tuple.swift.gyb
   )
+
+if(SWIFT_STDLIB_ENABLE_VECTOR_TYPES)
+  list(APPEND SWIFTLIB_SOURCES SIMDVector.swift)
+  list(APPEND SWIFTLIB_GYB_SOURCES SIMDConcreteOperations.swift.gyb SIMDVectorTypes.swift.gyb)
+endif()
+
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
 set(swift_core_link_flags "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
 set(swift_core_framework_depends)

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -240,6 +240,9 @@ _buildDemanglerForBuiltinType(const Metadata *type, Demangle::Demangler &Dem) {
 #define BUILTIN_TYPE(Symbol, Name) \
   if (type == &METADATA_SYM(Symbol).base) \
     return Dem.createNode(Node::Kind::BuiltinTypeName, Name);
+#if !SWIFT_STDLIB_ENABLE_VECTOR_TYPES
+#define BUILTIN_VECTOR_TYPE(ElementSymbol, ElementName, Width)
+#endif
 #include "swift/Runtime/BuiltinTypes.def"
   return nullptr;
 }

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -184,11 +184,15 @@ const ValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) =                     \
 const ValueWitnessTable swift::VALUE_WITNESS_SYM(Symbol) =     \
   ValueWitnessTableForBox<pointer_types::Symbol>::table;
 
+#if SWIFT_STDLIB_ENABLE_VECTOR_TYPES
 #define BUILTIN_VECTOR_TYPE(ElementSymbol, _, Width)                           \
   const ValueWitnessTable                                                      \
   swift::VALUE_WITNESS_SYM(VECTOR_BUILTIN_SYMBOL_NAME(ElementSymbol,Width)) =  \
   ValueWitnessTableForBox<NativeBox<SIMDVectorType<ctypes::ElementSymbol,      \
                                                    Width>>>::table;
+#else
+#define BUILTIN_VECTOR_TYPE(ElementSymbol, ElementName, Width)
+#endif
 
 #include "swift/Runtime/BuiltinTypes.def"
 
@@ -262,6 +266,9 @@ const ValueWitnessTable swift::VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING) =
   };
 #define BUILTIN_TYPE(Symbol, Name) \
   OPAQUE_METADATA(Symbol)
+#if !SWIFT_STDLIB_ENABLE_VECTOR_TYPES
+#define BUILTIN_VECTOR_TYPE(ElementSymbol, ElementName, Width)
+#endif
 #include "swift/Runtime/BuiltinTypes.def"
 
 /// The standard metadata for the empty tuple.

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1461,6 +1461,9 @@ public:
 #define BUILTIN_TYPE(Symbol, _) \
     if (mangledName.equals(#Symbol)) \
       return &METADATA_SYM(Symbol).base;
+#if !SWIFT_STDLIB_ENABLE_VECTOR_TYPES
+#define BUILTIN_VECTOR_TYPE(ElementSymbol, ElementName, Width)
+#endif
 #include "swift/Runtime/BuiltinTypes.def"
     return BuiltType();
   }


### PR DESCRIPTION
Intended for the "minimal" / "freestanding" presets to reduce codesize.