### PR TITLE
Make @preconcurrency suppress Sendable diagnostics more reliably. 

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -726,10 +726,13 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
   auto import = findImportFor(nominal, fromDC);
 
   // When the type is explicitly non-Sendable...
+  auto sourceFile = fromDC->getParentSourceFile();
   if (isExplicitlyNonSendable) {
     // @preconcurrency imports downgrade the diagnostic to a warning in Swift 6,
     if (import && import->options.contains(ImportFlags::Preconcurrency)) {
-      // FIXME: Note that this @preconcurrency import was "used".
+      if (sourceFile)
+        sourceFile->setImportUsedPreconcurrency(*import);
+
       return DiagnosticBehavior::Warning;
     }
 
@@ -741,7 +744,9 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
   // @preconcurrency suppresses the diagnostic in Swift 5.x, and
   // downgrades it to a warning in Swift 6 and later.
   if (import && import->options.contains(ImportFlags::Preconcurrency)) {
-    // FIXME: Note that this @preconcurrency import was "used".
+    if (sourceFile)
+      sourceFile->setImportUsedPreconcurrency(*import);
+
     return nominalModule->getASTContext().LangOpts.isSwiftVersionAtLeast(6)
         ? DiagnosticBehavior::Warning
         : DiagnosticBehavior::Ignore;
@@ -779,14 +784,6 @@ static bool diagnoseSingleNonSendableType(
 
   bool wasSuppressed = diagnose(type, behavior);
 
-  // If this type was imported from another module, try to find the
-  // corresponding import.
-  Optional<AttributedImport<swift::ImportedModule>> import;
-  SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
-  if (nominal && nominal->getParentModule() != module) {
-    import = findImportFor(nominal, fromContext.fromDC);
-  }
-
   if (behavior == DiagnosticBehavior::Ignore || wasSuppressed) {
     // Don't emit any other diagnostics.
   } else if (type->is<FunctionType>()) {
@@ -810,6 +807,14 @@ static bool diagnoseSingleNonSendableType(
         diag::non_sendable_nominal, nominal->getDescriptiveKind(),
         nominal->getName());
 
+    // This type was imported from another module; try to find the
+    // corresponding import.
+    Optional<AttributedImport<swift::ImportedModule>> import;
+    SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
+    if (sourceFile) {
+      import = findImportFor(nominal, fromContext.fromDC);
+    }
+
     // If we found the import that makes this nominal type visible, remark
     // that it can be @preconcurrency import.
     // Only emit this remark once per source file, because it can happen a
@@ -826,14 +831,6 @@ static bool diagnoseSingleNonSendableType(
 
       sourceFile->setImportUsedPreconcurrency(*import);
     }
-  }
-
-  // If we found an import that makes this nominal type visible, and that
-  // was a @preconcurrency import, note that we have made use of the
-  // attribute.
-  if (import && import->options.contains(ImportFlags::Preconcurrency) &&
-      sourceFile) {
-    sourceFile->setImportUsedPreconcurrency(*import);
   }
 
   return behavior == DiagnosticBehavior::Unspecified && !wasSuppressed;

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -29,7 +29,7 @@ struct S3_P1: P1 {
   nonisolated func onMainActor() { }
 }
 
-struct S4_P1_quitely: P1 {
+struct S4_P1_quietly: P1 {
   @SomeGlobalActor func onMainActor() { }
 }
 

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+@preconcurrency import NonStrictModule
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2: Sendable {
+  var nsc: NonStrictClass // no warning; @preconcurrency suppressed it
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+}
+
+struct MyType3 {
+  var nsc: NonStrictClass
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2)
+    print(mt3)
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }

--- a/test/Concurrency/sendable_preconcurrency_unused.swift
+++ b/test/Concurrency/sendable_preconcurrency_unused.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+@preconcurrency import NonStrictModule
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+func test(mt: MyType, nsc: NonStrictClass) {
+  Task {
+    print(mt)
+  }
+}

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+import NonStrictModule
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2 { // expected-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
+  var nsc: NonStrictClass
+  var ns: NS
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2) // expected-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+import NonStrictModule // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2: Sendable {
+  var nsc: NonStrictClass // expected-warning{{stored property 'nsc' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NonStrictClass'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2)
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }


### PR DESCRIPTION
Sendable diagnostics were firing a bit too eagerly because a suppressed
Sendable diagnostic for instance storage of a struct/enum would still
cause that type to not be implicitly Sendable. Additionally, a
`@preconcurrency` import would not always suppress the diagnostic when
there was an explicit Sendable conformance, which it should have.

Fixes rdar://88363542.