### PR TITLE
Make @preconcurrency suppress Sendable diagnostics more reliably.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -714,7 +714,6 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
   // Determine whether the type was explicitly non-Sendable.
   auto nominalModule = nominal->getParentModule();
   bool isExplicitlyNonSendable = nominalModule->isConcurrencyChecked() ||
-      isExplicitSendableConformance() ||
       hasExplicitSendableConformance(nominal);
 
   // Determine whether this nominal type is visible via a @preconcurrency
@@ -723,7 +722,7 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
 
   // When the type is explicitly non-Sendable...
   if (isExplicitlyNonSendable) {
-    // @preconcurrency imports downgrade the diagnostic to a warning.
+    // @preconcurrency imports downgrade the diagnostic to a warning in Swift 6,
     if (import && import->options.contains(ImportFlags::Preconcurrency)) {
       // FIXME: Note that this @preconcurrency import was "used".
       return DiagnosticBehavior::Warning;
@@ -743,7 +742,17 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
         : DiagnosticBehavior::Ignore;
   }
 
-  return defaultDiagnosticBehavior();
+  auto defaultBehavior = defaultDiagnosticBehavior();
+
+  // If we are checking an implicit Sendable conformance, don't suppress
+  // diagnostics for declarations in the same module. We want them so make
+  // enclosing inferred types non-Sendable.
+  if (defaultBehavior == DiagnosticBehavior::Ignore &&
+      nominal->getParentSourceFile() &&
+      conformanceCheck && *conformanceCheck == SendableCheck::Implicit)
+    return DiagnosticBehavior::Warning;
+
+  return defaultBehavior;
 }
 
 /// Produce a diagnostic for a single instance of a non-Sendable type where
@@ -3871,8 +3880,10 @@ static bool checkSendableInstanceStorage(
     bool operator()(VarDecl *property, Type propertyType) {
       // Classes with mutable properties are not Sendable.
       if (property->supportsMutation() && isa<ClassDecl>(nominal)) {
-        if (check == SendableCheck::Implicit)
+        if (check == SendableCheck::Implicit) {
+          invalid = true;
           return true;
+        }
 
         auto behavior = SendableCheckContext(
             dc, check).defaultDiagnosticBehavior();
@@ -3891,6 +3902,10 @@ static bool checkSendableInstanceStorage(
           propertyType, SendableCheckContext(dc, check), property->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
             if (check == SendableCheck::Implicit) {
+              // If we are to ignore this diagnose, just continue.
+              if (behavior == DiagnosticBehavior::Ignore)
+                return false;
+
               invalid = true;
               return true;
             }
@@ -3918,6 +3933,10 @@ static bool checkSendableInstanceStorage(
           elementType, SendableCheckContext(dc, check), element->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
             if (check == SendableCheck::Implicit) {
+              // If we are to ignore this diagnose, just continue.
+              if (behavior == DiagnosticBehavior::Ignore)
+                return false;
+
               invalid = true;
               return true;
             }

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+@preconcurrency import NonStrictModule
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2: Sendable {
+  var nsc: NonStrictClass // no warning; @preconcurrency suppressed it
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+}
+
+struct MyType3 {
+  var nsc: NonStrictClass
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2)
+    print(mt3)
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }

--- a/test/Concurrency/sendable_preconcurrency_unused.swift
+++ b/test/Concurrency/sendable_preconcurrency_unused.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+@preconcurrency import NonStrictModule
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+func test(mt: MyType, nsc: NonStrictClass) {
+  Task {
+    print(mt)
+  }
+}

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+import NonStrictModule
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2 { // expected-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
+  var nsc: NonStrictClass
+  var ns: NS
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2) // expected-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+import StrictModule
+import NonStrictModule // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+
+struct MyType {
+  var nsc: NonStrictClass
+}
+
+struct MyType2: Sendable {
+  var nsc: NonStrictClass // expected-warning{{stored property 'nsc' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NonStrictClass'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+}
+
+func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+  Task {
+    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
+    print(mt2)
+  }
+}
+
+extension NonStrictStruct: @unchecked Sendable { }


### PR DESCRIPTION
**Explanation**: Sendable diagnostics were firing a bit too eagerly because a suppressed `Sendable` diagnostic for instance storage of a struct/enum would still cause that type to not be implicitly `Sendable`.  This triggered an excessive number of warnings about, e.g., `Foundation.URL` not being `Sendable`.
**Scope**: Affects all code that adopted Swift concurrency.
**Radar/SR Issue**: rdar://88363542
**Risk**: Low. It's disabling warnings that were newly introduced in 5.6.
**Testing**: PR testing and CI .
**Original PR**: https://github.com/apple/swift/pull/41150