### PR TITLE
[Sema] Don't wrap class types in existential types.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4281,6 +4281,8 @@ Type ExistentialType::get(Type constraint) {
   if (constraint->is<ExistentialMetatypeType>())
     return constraint;
 
+  assert(constraint->isConstraintType());
+
   auto properties = constraint->getRecursiveProperties();
   auto arena = getArena(properties);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3362,6 +3362,13 @@ Type ArchetypeType::getExistentialType() const {
   auto constraint = ProtocolCompositionType::get(
      ctx, constraintTypes, requiresClass());
 
+  // If the archetype is only constrained to a class type,
+  // return the class type directly.
+  if (!constraint->isConstraintType()) {
+    assert(constraint->getClassOrBoundGenericClass());
+    return constraint;
+  }
+
   return ExistentialType::get(constraint);
 }
 

--- a/validation-test/compiler_crashers_2_fixed/rdar88296943.sil
+++ b/validation-test/compiler_crashers_2_fixed/rdar88296943.sil
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+import Swift
+
+class C {}
+sil_vtable C {}
+
+sil @repo: $@convention(c) @pseudogeneric <S, I where S : AnyObject, S : Hashable, I : C> (@inout_aliasable @block_storage @callee_guaranteed (@guaranteed S, Int, UnsafeMutablePointer<Bool>) -> (), S, Int, UnsafeMutablePointer<Bool>) -> () {
+bb0(%0 : $*@block_storage @callee_guaranteed (@guaranteed S, Int, UnsafeMutablePointer<Bool>) -> (), %1 : $S, %2 : $Int, %3 : $UnsafeMutablePointer<Bool>):
+  %9 = tuple ()                                   // user: %10
+  return %9 : $()                                 // id: %10
+}


### PR DESCRIPTION
This could happen previously when computing the existential type for a given archetype. In cases where an archetype is only constrained to a class, return the class type directly rather than wrapping it in an existential type.

Note: a better name for `isConstraintType()` is `isProtocolConstraintType()`, but I'll rename that in a follow-up to not cause conflicts with https://github.com/apple/swift/pull/41147

Resolves: rdar://88296943