### PR TITLE
[SymbolGraph] consider underscored symbols as `private` if they're `internal`

### DIFF
--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -1,29 +1,49 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name SkipsPublicUnderscore -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name SkipsPublicUnderscore -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/SkipsPublicUnderscore.symbols.json
+// RUN: %FileCheck %s --input-file %t/SkipsPublicUnderscore.symbols.json --check-prefix PUBLIC
+
+// RUN: %target-swift-symbolgraph-extract -module-name SkipsPublicUnderscore -I %t -pretty-print -output-dir %t -minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/SkipsPublicUnderscore.symbols.json --check-prefix INTERNAL
+
+// RUN: %target-swift-symbolgraph-extract -module-name SkipsPublicUnderscore -I %t -pretty-print -output-dir %t -minimum-access-level private
+// RUN: %FileCheck %s --input-file %t/SkipsPublicUnderscore.symbols.json --check-prefix PRIVATE
 
 public protocol PublicProtocol {}
 
-// CHECK-NOT: precise:{{.*}}_ProtocolShouldntAppear
-// CHECK-NOT: precise:{{.*}}PublicProtocol
+public class SomeClass {
+  // underscored names marked `internal` or tighter should be considered `private`
+
+  // PUBLIC-NOT: "precise": "s:21SkipsPublicUnderscore9SomeClassC12_InternalVarSSvp"
+  // INTERNAL-NOT: "precise": "s:21SkipsPublicUnderscore9SomeClassC12_InternalVarSSvp"
+  // PRIVATE: "precise": "s:21SkipsPublicUnderscore9SomeClassC12_InternalVarSSvp"
+  internal var _InternalVar: String = ""
+}
+
+// PUBLIC-NOT: precise:{{.*}}_ProtocolShouldntAppear
+// PUBLIC-NOT: precise:{{.*}}PublicProtocol
 @_show_in_interface
 public protocol _ProtocolShouldntAppear {}
 
-// CHECK-NOT: _ShouldntAppear
+// PUBLIC-NOT: _ShouldntAppear
+// INTERNAL-DAG: _ShouldntAppear
 
+// INTERNAL-DAG: "precise": "s:21SkipsPublicUnderscore23_ProtocolShouldntAppearP"
 public struct _ShouldntAppear: PublicProtocol, _ProtocolShouldntAppear {
   // Although these are public and not underscored,
   // they are inside an underscored type,
   // so shouldn't be allowed through.
 
-  // CHECK-NOT: shouldntAppear
+  // PUBLIC-NOT: shouldntAppear
+  // INTERNAL-DAG: shouldntAppear
   public var shouldntAppear: Int
 
-  // CHECK-NOT: InnerShouldntAppear
+  // PUBLIC-NOT: InnerShouldntAppear
+  // INTERNAL-DAG: InnerShouldntAppear
   public struct InnerShouldntAppear {
 
-  // CHECK-NOT: InnerInnerShouldntAppear
+  // PUBLIC-NOT: InnerInnerShouldntAppear
+  // INTERNAL-DAG: InnerInnerShouldntAppear
   public struct InnerInnerShouldntAppear {}
   }
 }
@@ -34,22 +54,27 @@ public struct ShouldAppear: _ProtocolShouldntAppear {}
 
 public struct PublicOuter {
   // Nor should an "internal" type's relationship to a "public" protocol.
-  // CHECK-NOT: _InnerShouldntAppear
+  // PUBLIC-NOT: _InnerShouldntAppear
+  // INTERNAL-DAG: _InnerShouldntAppear
   public struct _InnerShouldntAppear: PublicProtocol {}
 }
 
 extension PublicOuter {
-  // CHECK-NOT: _FromExtension
+  // PUBLIC-NOT: _FromExtension
+  // INTERNAL-DAG: _FromExtension
   public struct _FromExtension: PublicProtocol {
-    // CHECK-NOT: shouldntAppear
+    // PUBLIC-NOT: shouldntAppear
+    // INTERNAL-DAG: shouldntAppear
     public var shouldntAppear: Int
   }
 }
 
 extension _ShouldntAppear {
-  // CHECK-NOT: FromExtension
+  // PUBLIC-NOT: FromExtension
+  // INTERNAL-DAG: FromExtension
   public struct FromExtension: PublicProtocol {
-    // CHECK-NOT: shouldntAppear
+    // PUBLIC-NOT: shouldntAppear
+    // INTERNAL-DAG: shouldntAppear
     public var shouldntAppear: Int
   }
 }
@@ -60,4 +85,4 @@ extension _ShouldntAppear.InnerShouldntAppear {
 
 extension _ShouldntAppear.InnerShouldntAppear: Equatable {}
 
-// CHECK: "relationships": []
+// PUBLIC: "relationships": []


### PR DESCRIPTION
Resolves rdar://86294802

When generating a symbol graph, symbols that are prefixed with an underscore are always treated as `internal`, regardless of what their original access level is. However, there are more nuanced semantics for underscored symbols that are already `internal` or lower - these should be treated as `private` for the purposes of the `minimum-access-level` option. This PR updates the filtering logic to not emit `internal` underscored symbols unless you specifically request a `private`-level symbol graph.