### PR TITLE
RequirementMachine: Relate rules introduced by concrete type unification via rewrite loops

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2559,7 +2559,7 @@ WARNING(associated_type_override_typealias,none,
 
 ERROR(requirement_machine_completion_failed,none,
       "cannot build rewrite system for %select{generic signature|protocol}0; "
-      "%select{%error|rule count|rule length}1 limit exceeded",
+      "%select{%error|rule count|rule length|concrete nesting}1 limit exceeded",
       (unsigned, unsigned))
 
 ERROR(associated_type_objc,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2561,6 +2561,8 @@ ERROR(requirement_machine_completion_failed,none,
       "cannot build rewrite system for %select{generic signature|protocol}0; "
       "%select{%error|rule count|rule length|concrete nesting}1 limit exceeded",
       (unsigned, unsigned))
+NOTE(requirement_machine_completion_rule,none,
+     "failed rewrite rule is %0", (StringRef))
 
 ERROR(associated_type_objc,none,
       "associated type %0 cannot be declared inside '@objc' protocol %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2559,7 +2559,7 @@ WARNING(associated_type_override_typealias,none,
 
 ERROR(requirement_machine_completion_failed,none,
       "cannot build rewrite system for %select{generic signature|protocol}0; "
-      "%select{step|depth}1 limit exceeded",
+      "%select{%error|rule count|rule length}1 limit exceeded",
       (unsigned, unsigned))
 
 ERROR(associated_type_objc,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -518,6 +518,10 @@ namespace swift {
     /// algorithm.
     unsigned RequirementMachineMaxRuleLength = 12;
 
+    /// Maximum concrete type nesting depth for requirement machine property map
+    /// algorithm.
+    unsigned RequirementMachineMaxConcreteNesting = 30;
+
     /// Enable the new experimental protocol requirement signature minimization
     /// algorithm.
     RequirementMachineMode RequirementMachineProtocolSignatures =

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -510,13 +510,13 @@ namespace swift {
     /// Enables fine-grained debug output from the requirement machine.
     std::string DebugRequirementMachine;
 
-    /// Maximum iteration count for requirement machine Knuth-Bendix completion
+    /// Maximum rule count for requirement machine Knuth-Bendix completion
     /// algorithm.
-    unsigned RequirementMachineStepLimit = 4000;
+    unsigned RequirementMachineMaxRuleCount = 4000;
 
     /// Maximum term length for requirement machine Knuth-Bendix completion
     /// algorithm.
-    unsigned RequirementMachineDepthLimit = 12;
+    unsigned RequirementMachineMaxRuleLength = 12;
 
     /// Enable the new experimental protocol requirement signature minimization
     /// algorithm.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -351,6 +351,10 @@ def requirement_machine_max_rule_length : Joined<["-"], "requirement-machine-max
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the maximum rule length before giving up">;
 
+def requirement_machine_max_concrete_nesting : Joined<["-"], "requirement-machine-max-concrete-nesting=">,
+  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Set the maximum concrete type nesting depth before giving up">;
+
 def disable_requirement_machine_merged_associated_types : Flag<["-"], "disable-requirement-machine-merged-associated-types">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Disable merged associated types">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -343,13 +343,13 @@ def analyze_requirement_machine : Flag<["-"], "analyze-requirement-machine">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Print out requirement machine statistics at the end of the compilation job">;
 
-def requirement_machine_step_limit : Separate<["-"], "requirement-machine-step-limit">,
+def requirement_machine_max_rule_count : Joined<["-"], "requirement-machine-max-rule-count=">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Set the maximum steps before we give up on confluent completion">;
+  HelpText<"Set the maximum number of rules before giving up">;
 
-def requirement_machine_depth_limit : Separate<["-"], "requirement-machine-depth-limit">,
+def requirement_machine_max_rule_length : Joined<["-"], "requirement-machine-max-rule-length=">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Set the maximum depth before we give up on confluent completion">;
+  HelpText<"Set the maximum rule length before giving up">;
 
 def disable_requirement_machine_merged_associated_types : Flag<["-"], "disable-requirement-machine-merged-associated-types">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -91,6 +91,7 @@ add_swift_host_library(swiftAST STATIC
   RequirementMachine/RewriteSystem.cpp
   RequirementMachine/Symbol.cpp
   RequirementMachine/Term.cpp
+  RequirementMachine/TypeDifference.cpp
   SearchPathOptions.cpp
   SILLayout.cpp
   Stmt.cpp

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -458,17 +458,17 @@ void PropertyMap::recordConcreteConformanceRule(
       /*ruleID=*/concreteRuleID,
       /*inverse=*/true));
 
-  // Apply a concrete type adjustment to the concrete symbol if T' is shorter
-  // than T.
+  // If T' is a suffix of T, prepend the prefix to the concrete type's
+  // substitutions.
   auto concreteSymbol = *concreteRule.isPropertyRule();
-  unsigned adjustment = rhs.size() - concreteRule.getRHS().size();
+  unsigned prefixLength = rhs.size() - concreteRule.getRHS().size();
 
-  if (adjustment > 0 &&
+  if (prefixLength > 0 &&
       !concreteConformanceSymbol.getSubstitutions().empty()) {
-    path.add(RewriteStep::forAdjustment(adjustment, /*endOffset=*/1,
-                                        /*inverse=*/false));
+    path.add(RewriteStep::forPrefixSubstitutions(prefixLength, /*endOffset=*/1,
+                                                 /*inverse=*/false));
 
-    MutableTerm prefix(rhs.begin(), rhs.begin() + adjustment);
+    MutableTerm prefix(rhs.begin(), rhs.begin() + prefixLength);
     concreteSymbol = concreteSymbol.prependPrefixToConcreteSubstitutions(
         prefix, Context);
   }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -402,11 +402,8 @@ findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn,
 
     const auto &otherRule = getRule(found->second);
 
-    // If the new rule is conflicting, don't compare the rules at all
-    // and prefer to delete the new rule. Otherwise, prefer to delete
-    // the less canonical of the two rules.
     if (rule.isConflicting() ||
-        rule.compare(otherRule, Context) > 0) {
+        *rule.compare(otherRule, Context) > 0) {
       found = pair;
     }
   }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -94,7 +94,7 @@ RewriteLoop::findRulesAppearingOnceInEmptyContext(
       break;
     }
 
-    case RewriteStep::AdjustConcreteType:
+    case RewriteStep::PrefixSubstitutions:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
     case RewriteStep::Relation:
@@ -213,7 +213,7 @@ RewritePath RewritePath::splitCycleAtRule(unsigned ruleID) const {
       sawRule = true;
       continue;
     }
-    case RewriteStep::AdjustConcreteType:
+    case RewriteStep::PrefixSubstitutions:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
     case RewriteStep::Relation:
@@ -279,7 +279,7 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
         break;
       }
 
-      auto adjustStep = [&](RewriteStep newStep) {
+      auto recontextualizeStep = [&](RewriteStep newStep) {
         bool inverse = newStep.Inverse ^ step.Inverse;
 
         if (newStep.Kind == RewriteStep::Decompose && inverse) {
@@ -302,15 +302,15 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
 
       if (step.Inverse) {
         for (auto newStep : llvm::reverse(path))
-          adjustStep(newStep);
+          recontextualizeStep(newStep);
       } else {
         for (auto newStep : path)
-          adjustStep(newStep);
+          recontextualizeStep(newStep);
       }
 
       break;
     }
-    case RewriteStep::AdjustConcreteType:
+    case RewriteStep::PrefixSubstitutions:
     case RewriteStep::Shift:
     case RewriteStep::Decompose:
     case RewriteStep::Relation:

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -452,15 +452,15 @@ RewriteSystem::computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
                                          getRuleID(lhs),
                                          /*inverse=*/true));
 
-    // (2) Next, if the right hand side rule ends with a concrete type symbol,
-    // perform the concrete type adjustment:
+    // (2) Next, if the right hand side rule ends with a superclass or concrete
+    // type symbol, remove the prefix 'T' from each substitution in the symbol.
     //
     //     (σ - T)
     if (xv.back().hasSubstitutions() &&
         !xv.back().getSubstitutions().empty() &&
         t.size() > 0) {
-      path.add(RewriteStep::forAdjustment(t.size(), /*endOffset=*/0,
-                                          /*inverse=*/true));
+      path.add(RewriteStep::forPrefixSubstitutions(t.size(), /*endOffset=*/0,
+                                                   /*inverse=*/true));
 
       xv.back() = xv.back().prependPrefixToConcreteSubstitutions(
           t, Context);

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -90,7 +90,7 @@ Symbol RewriteContext::mergeAssociatedTypes(Symbol lhs, Symbol rhs) {
   assert(lhs.getKind() == Symbol::Kind::AssociatedType);
   assert(rhs.getKind() == Symbol::Kind::AssociatedType);
   assert(lhs.getName() == rhs.getName());
-  assert(lhs.compare(rhs, *this) > 0);
+  assert(*lhs.compare(rhs, *this) > 0);
 
   auto protos = lhs.getProtocols();
   auto otherProtos = rhs.getProtocols();
@@ -320,8 +320,8 @@ void RewriteSystem::checkMergedAssociatedType(Term lhs, Term rhs) {
     // We must have mergedSymbol <= rhs < lhs, therefore mergedSymbol != lhs.
     assert(lhs.back() != mergedSymbol &&
            "Left hand side should not already end with merged symbol?");
-    assert(mergedSymbol.compare(rhs.back(), Context) <= 0);
-    assert(rhs.back().compare(lhs.back(), Context) < 0);
+    assert(*mergedSymbol.compare(rhs.back(), Context) <= 0);
+    assert(*rhs.back().compare(lhs.back(), Context) < 0);
 
     // If the merge didn't actually produce a new symbol, there is nothing else
     // to do.

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -138,6 +138,7 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::Shift:
       case RewriteStep::Decompose:
       case RewriteStep::Relation:
+      case RewriteStep::DecomposeConcrete:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -139,6 +139,8 @@ void RewriteLoop::findProtocolConformanceRules(
       case RewriteStep::Decompose:
       case RewriteStep::Relation:
       case RewriteStep::DecomposeConcrete:
+      case RewriteStep::LeftConcreteProjection:
+      case RewriteStep::RightConcreteProjection:
         break;
       }
     }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -134,7 +134,7 @@ void RewriteLoop::findProtocolConformanceRules(
         break;
       }
 
-      case RewriteStep::AdjustConcreteType:
+      case RewriteStep::PrefixSubstitutions:
       case RewriteStep::Shift:
       case RewriteStep::Decompose:
       case RewriteStep::Relation:

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -435,7 +435,7 @@ void MinimalConformances::collectConformanceRules() {
               if (lhsRule.isExplicit() != rhsRule.isExplicit())
                 return !lhsRule.isExplicit();
 
-              return lhsRule.getLHS().compare(rhsRule.getLHS(), Context) > 0;
+              return *lhsRule.getLHS().compare(rhsRule.getLHS(), Context) > 0;
             });
 
   Context.ConformanceRulesHistogram.add(ConformanceRules.size());

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -401,6 +401,10 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
   // the concrete type witnesses in the concrete type's conformance.
   concretizeNestedTypesFromConcreteParents();
 
+  // Finally, a post-processing pass to reduce substitutions down to
+  // concrete types.
+  concretelySimplifyLeftHandSideSubstitutions();
+
   unsigned addedNewRules = System.getRules().size() - ruleCount;
   for (unsigned i = ruleCount, e = System.getRules().size(); i < e; ++i) {
     const auto &newRule = System.getRule(i);
@@ -415,6 +419,173 @@ PropertyMap::buildPropertyMap(unsigned maxIterations,
     return std::make_pair(CompletionResult::MaxIterations, addedNewRules);
 
   return std::make_pair(CompletionResult::Success, addedNewRules);
+}
+
+/// Similar to RewriteSystem::simplifySubstitutions(), but also replaces type
+/// parameters with concrete types and builds a type difference describing
+/// the transformation.
+///
+/// Returns None if the concrete type symbol cannot be simplified further.
+///
+/// Otherwise returns an index which can be passed to
+/// RewriteSystem::getTypeDifference().
+Optional<unsigned>
+PropertyMap::concretelySimplifySubstitutions(Symbol symbol,
+                                             RewritePath *path) const {
+  assert(symbol.hasSubstitutions());
+
+  // Fast path if the type is fully concrete.
+  auto substitutions = symbol.getSubstitutions();
+  if (substitutions.empty())
+    return None;
+
+  // Save the original rewrite path length so that we can reset if if we don't
+  // find anything to simplify.
+  unsigned oldSize = (path ? path->size() : 0);
+
+  if (path) {
+    // The term is at the top of the primary stack. Push all substitutions onto
+    // the primary stack.
+    path->add(RewriteStep::forDecompose(substitutions.size(),
+                                        /*inverse=*/false));
+
+    // Move all substitutions but the first one to the secondary stack.
+    for (unsigned i = 1; i < substitutions.size(); ++i)
+      path->add(RewriteStep::forShift(/*inverse=*/false));
+  }
+
+  // Simplify and collect substitutions.
+  llvm::SmallVector<std::pair<unsigned, Term>, 1> sameTypes;
+  llvm::SmallVector<std::pair<unsigned, Symbol>, 1> concreteTypes;
+
+  for (unsigned index : indices(substitutions)) {
+    // Move the next substitution from the secondary stack to the primary stack.
+    if (index != 0 && path)
+      path->add(RewriteStep::forShift(/*inverse=*/true));
+
+    auto term = symbol.getSubstitutions()[index];
+    MutableTerm mutTerm(term);
+
+    // Note that it's of course possible that the term both requires
+    // simplification, and the simplified term has a concrete type.
+    //
+    // This isn't handled with our current representation of
+    // TypeDifference, but that should be fine since the caller
+    // has to iterate until fixed point anyway.
+    //
+    // This should be rare in practice.
+    if (System.simplify(mutTerm, path)) {
+      // Record a mapping from this substitution to the simplified term.
+      sameTypes.emplace_back(index, Term::get(mutTerm, Context));
+    } else {
+      auto *props = lookUpProperties(mutTerm);
+
+      if (props && props->ConcreteType) {
+        // The property map entry might apply to a suffix of the substitution
+        // term, so prepend the appropriate prefix to its own substitutions.
+        auto prefix = props->getPrefixAfterStrippingKey(mutTerm);
+        auto concreteSymbol =
+          props->ConcreteType->prependPrefixToConcreteSubstitutions(
+              prefix, Context);
+
+        // Record a mapping from this substitution to the concrete type.
+        concreteTypes.emplace_back(index, concreteSymbol);
+
+        // If U.V is the substitution term and V is the property map key,
+        // apply the rewrite step U.(V => V.[concrete: C]) followed by
+        // prepending the prefix U to each substitution in the concrete type
+        // symbol if |U| > 0.
+        if (path) {
+          path->add(RewriteStep::forRewriteRule(/*startOffset=*/prefix.size(),
+                                                /*endOffset=*/0,
+                                                /*ruleID=*/*props->ConcreteTypeRule,
+                                                /*inverse=*/true));
+
+          path->add(RewriteStep::forPrefixSubstitutions(/*length=*/prefix.size(),
+                                                        /*endOffset=*/0,
+                                                        /*inverse=*/false));
+        }
+      }
+    }
+  }
+
+  // If nothing changed, we don't have to build the type difference.
+  if (sameTypes.empty() && concreteTypes.empty()) {
+    if (path) {
+      // The rewrite path should consist of a Decompose, followed by a number
+      // of Shifts, followed by a Compose.
+  #ifndef NDEBUG
+      for (auto iter = path->begin() + oldSize; iter < path->end(); ++iter) {
+        assert(iter->Kind == RewriteStep::Shift ||
+               iter->Kind == RewriteStep::Decompose);
+      }
+  #endif
+
+      path->resize(oldSize);
+    }
+    return None;
+  }
+
+  auto difference = buildTypeDifference(symbol, sameTypes, concreteTypes,
+                                        Context);
+  assert(difference.LHS != difference.RHS);
+
+  unsigned differenceID = System.recordTypeDifference(difference.LHS,
+                                                      difference.RHS,
+                                                      difference);
+
+  // All simplified substitutions are now on the primary stack. Collect them to
+  // produce the new term.
+  if (path) {
+    path->add(RewriteStep::forDecomposeConcrete(differenceID,
+                                                /*inverse=*/true));
+  }
+
+  return differenceID;
+}
+
+void PropertyMap::concretelySimplifyLeftHandSideSubstitutions() const {
+  for (unsigned ruleID = 0, e = System.getRules().size(); ruleID < e; ++ruleID) {
+    auto &rule = System.getRule(ruleID);
+    if (rule.isLHSSimplified() ||
+        rule.isRHSSimplified() ||
+        rule.isSubstitutionSimplified())
+      continue;
+
+    auto symbol = rule.getLHS().back();
+    if (!symbol.hasSubstitutions())
+      continue;
+
+    RewritePath path;
+
+    auto differenceID = concretelySimplifySubstitutions(symbol, &path);
+    if (!differenceID)
+      continue;
+
+    rule.markSubstitutionSimplified();
+
+    auto difference = System.getTypeDifference(*differenceID);
+    assert(difference.LHS == symbol);
+
+    // If the original rule is (T.[concrete: C] => T) and [concrete: C'] is
+    // the simplified symbol, then difference.LHS == [concrete: C] and
+    // difference.RHS == [concrete: C'], and the rewrite path we just
+    // built takes T.[concrete: C] to T.[concrete: C'].
+    //
+    // We want a path from T.[concrete: C'] to T, so invert the path to get
+    // a path from T.[concrete: C'] to T.[concrete: C], and add a final step
+    // applying the original rule (T.[concrete: C] => T).
+    path.invert();
+    path.add(RewriteStep::forRewriteRule(/*startOffset=*/0,
+                                         /*endOffset=*/0,
+                                         /*ruleID=*/ruleID,
+                                         /*inverted=*/false));
+    MutableTerm rhs(rule.getRHS());
+    MutableTerm lhs(rhs);
+    lhs.add(difference.RHS);
+
+    System.addRule(lhs, rhs, &path);
+  }
 }
 
 void PropertyMap::dump(llvm::raw_ostream &out) const {

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -245,6 +245,11 @@ private:
 
   void addProperty(Term key, Symbol property, unsigned ruleID);
 
+  void addConformanceProperty(Term key, Symbol property, unsigned ruleID);
+  void addLayoutProperty(Term key, Symbol property, unsigned ruleID);
+  void addSuperclassProperty(Term key, Symbol property, unsigned ruleID);
+  void addConcreteTypeProperty(Term key, Symbol property, unsigned ruleID);
+
   void checkConcreteTypeRequirements();
 
   void concretizeNestedTypesFromConcreteParents();

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -243,6 +243,11 @@ private:
 
   void addProperty(Term key, Symbol property, unsigned ruleID);
 
+  void processTypeDifference(const TypeDifference &difference,
+                             unsigned differenceID,
+                             unsigned lhsRuleID,
+                             unsigned rhsRuleID);
+
   void addConformanceProperty(Term key, Symbol property, unsigned ruleID);
   void addLayoutProperty(Term key, Symbol property, unsigned ruleID);
   void addSuperclassProperty(Term key, Symbol property, unsigned ruleID);

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -286,6 +286,11 @@ private:
     RequirementKind requirementKind,
     Symbol concreteConformanceSymbol) const;
 
+  Optional<unsigned> concretelySimplifySubstitutions(Symbol symbol,
+                                                     RewritePath *path) const;
+
+  void concretelySimplifyLeftHandSideSubstitutions() const;
+
   void verify() const;
 };
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -206,9 +206,7 @@ public:
                                 std::reverse_iterator<const Symbol *> end) const;
   PropertyBag *lookUpProperties(const MutableTerm &key) const;
 
-  std::pair<CompletionResult, unsigned>
-  buildPropertyMap(unsigned maxIterations,
-                   unsigned maxDepth);
+  void buildPropertyMap();
 
   void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -284,7 +284,8 @@ private:
     RequirementKind requirementKind,
     Symbol concreteConformanceSymbol) const;
 
-  Optional<unsigned> concretelySimplifySubstitutions(Symbol symbol,
+  Optional<unsigned> concretelySimplifySubstitutions(Term baseTerm,
+                                                     Symbol symbol,
                                                      RewritePath *path) const;
 
   void concretelySimplifyLeftHandSideSubstitutions() const;

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -458,7 +458,7 @@ void PropertyMap::addConcreteTypeProperty(
     for (const auto &pair : difference.SameTypes) {
       // Both sides are type parameters; add a same-type requirement.
       MutableTerm lhsTerm(difference.LHS.getSubstitutions()[pair.first]);
-      MutableTerm rhsTerm(difference.RHS.getSubstitutions()[pair.second]);
+      MutableTerm rhsTerm(pair.second);
 
       if (debug) {
         llvm::dbgs() << "%% Induced rule " << lhsTerm

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -518,6 +518,9 @@ void PropertyMap::addConcreteTypeProperty(
     assert(simplified);
     (void) simplified;
 
+    // FIXME: This is unsound! While 'key' was canonical at the time we
+    // started property map construction, we might have added other rules
+    // since then that made it non-canonical.
     assert(path.size() == 1);
     assert(path.begin()->Kind == RewriteStep::Rule);
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -404,7 +404,7 @@ void PropertyMap::processTypeDifference(const TypeDifference &difference,
 
   for (const auto &pair : difference.SameTypes) {
     // Both sides are type parameters; add a same-type requirement.
-    MutableTerm lhsTerm(difference.LHS.getSubstitutions()[pair.first]);
+    auto lhsTerm = difference.getOriginalSubstitution(pair.first);
     MutableTerm rhsTerm(pair.second);
 
     if (debug) {
@@ -419,7 +419,7 @@ void PropertyMap::processTypeDifference(const TypeDifference &difference,
   for (const auto &pair : difference.ConcreteTypes) {
     // A type parameter is equated with a concrete type; add a concrete
     // type requirement.
-    MutableTerm rhsTerm(difference.LHS.getSubstitutions()[pair.first]);
+    auto rhsTerm = difference.getOriginalSubstitution(pair.first);
     MutableTerm lhsTerm(rhsTerm);
     lhsTerm.add(pair.second);
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -586,28 +586,30 @@ void PropertyMap::addConcreteTypeProperty(
     //
     //    U.V.[concrete: G<...> with <U.X, U.Y>]
     //
-    // Record a loop relating the two rules via a concrete type adjustment.
+    // Record a loop relating the two rules via a rewrite step to prefix 'U' to
+    // the symbol's substitutions.
+    //
     // Since the new rule appears without context, it becomes redundant.
     if (checkRulePairOnce(*props->ConcreteTypeRule, ruleID)) {
       const auto &otherRule = System.getRule(*props->ConcreteTypeRule);
       assert(otherRule.getRHS().size() < key.size());
 
-      unsigned adjustment = (key.size() - otherRule.getRHS().size());
+      unsigned prefixLength = (key.size() - otherRule.getRHS().size());
 
       // Build a loop that rewrites U.V back into itself via the two rules,
-      // with a concrete type adjustment in the middle.
+      // with a prefix substitutions step in the middle.
       RewritePath path;
 
       // Add a rewrite step U.(V => V.[concrete: G<...> with <X, Y>]).
-      path.add(RewriteStep::forRewriteRule(/*startOffset=*/adjustment,
+      path.add(RewriteStep::forRewriteRule(/*startOffset=*/prefixLength,
                                            /*endOffset=*/0,
                                            *props->ConcreteTypeRule,
                                            /*inverse=*/true));
 
-      // Add a concrete type adjustment.
-      path.add(RewriteStep::forAdjustment(/*startOffset=*/adjustment,
-                                          /*endOffset=*/0,
-                                          /*inverse=*/false));
+      // Add a rewrite step to prefix 'U' to the substitutions.
+      path.add(RewriteStep::forPrefixSubstitutions(/*length=*/prefixLength,
+                                                   /*endOffset=*/0,
+                                                   /*inverse=*/false));
 
       // Add a rewrite step (U.V.[concrete: G<...> with <U.X, U.Y>] => U.V).
       path.add(RewriteStep::forRewriteRule(/*startOffset=*/0,

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -436,7 +436,8 @@ void PropertyMap::addConcreteTypeProperty(
   Optional<unsigned> lhsDifferenceID;
   Optional<unsigned> rhsDifferenceID;
 
-  bool conflict = System.computeTypeDifference(*props->ConcreteType, property,
+  bool conflict = System.computeTypeDifference(key,
+                                               *props->ConcreteType, property,
                                                lhsDifferenceID,
                                                rhsDifferenceID);
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -629,7 +629,7 @@ void PropertyMap::addConcreteTypeProperty(
     Term key, Symbol property, unsigned ruleID) {
   auto *props = getOrCreateProperties(key);
 
-  const auto &rule = System.getRule(ruleID);
+  auto &rule = System.getRule(ruleID);
   assert(rule.getRHS() == key);
 
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
@@ -782,6 +782,8 @@ void PropertyMap::addConcreteTypeProperty(
       buildRewritePathForUnifier(*props->ConcreteTypeRule, ruleID, System,
                                  path);
       System.recordRewriteLoop(MutableTerm(rule.getLHS()), path);
+
+      rule.markSubstitutionSimplified();
     }
   }
 }

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -351,117 +351,142 @@ static std::pair<Symbol, bool> unifySuperclasses(
   return std::make_pair(rhs, false);
 }
 
+void PropertyMap::addConformanceProperty(
+    Term key, Symbol property, unsigned ruleID) {
+  auto *props = getOrCreateProperties(key);
+  props->ConformsTo.push_back(property.getProtocol());
+  props->ConformsToRules.push_back(ruleID);
+}
+
+void PropertyMap::addLayoutProperty(
+    Term key, Symbol property, unsigned ruleID) {
+  auto *props = getOrCreateProperties(key);
+  bool debug = Debug.contains(DebugFlags::ConcreteUnification);
+
+  auto newLayout = property.getLayoutConstraint();
+
+  if (!props->Layout) {
+    // If we haven't seen a layout requirement before, just record it.
+    props->Layout = newLayout;
+    props->LayoutRule = ruleID;
+    return;
+  }
+
+  // Otherwise, compute the intersection.
+  assert(props->LayoutRule.hasValue());
+  auto mergedLayout = props->Layout.merge(property.getLayoutConstraint());
+
+  // If the intersection is invalid, we have a conflict.
+  if (!mergedLayout->isKnownLayout()) {
+    recordConflict(key, *props->LayoutRule, ruleID, System);
+    return;
+  }
+
+  // If the intersection is equal to the existing layout requirement,
+  // the new layout requirement is redundant.
+  if (mergedLayout == props->Layout) {
+    if (checkRulePairOnce(*props->LayoutRule, ruleID)) {
+      recordRelation(key, *props->LayoutRule, property, System, debug);
+    }
+
+  // If the intersection is equal to the new layout requirement, the
+  // existing layout requirement is redundant.
+  } else if (mergedLayout == newLayout) {
+    if (checkRulePairOnce(ruleID, *props->LayoutRule)) {
+      auto oldProperty = System.getRule(*props->LayoutRule).getLHS().back();
+      recordRelation(key, ruleID, oldProperty, System, debug);
+    }
+
+    props->LayoutRule = ruleID;
+  } else {
+    llvm::errs() << "Arbitrary intersection of layout requirements is "
+                 << "supported yet\n";
+    abort();
+  }
+}
+
+void PropertyMap::addSuperclassProperty(
+    Term key, Symbol property, unsigned ruleID) {
+  auto *props = getOrCreateProperties(key);
+  bool debug = Debug.contains(DebugFlags::ConcreteUnification);
+
+  if (checkRuleOnce(ruleID)) {
+    // A rule (T.[superclass: C] => T) induces a rule (T.[layout: L] => T),
+    // where L is either AnyObject or _NativeObject.
+    auto superclass =
+        property.getConcreteType()->getClassOrBoundGenericClass();
+    auto layout =
+        LayoutConstraint::getLayoutConstraint(
+          superclass->getLayoutConstraintKind(),
+          Context.getASTContext());
+    auto layoutSymbol = Symbol::forLayout(layout, Context);
+
+    recordRelation(key, ruleID, layoutSymbol, System, debug);
+  }
+
+  if (!props->Superclass) {
+    props->Superclass = property;
+    props->SuperclassRule = ruleID;
+    return;
+  }
+
+  assert(props->SuperclassRule.hasValue());
+  auto pair = unifySuperclasses(*props->Superclass, property,
+                                System, debug);
+  props->Superclass = pair.first;
+  bool conflict = pair.second;
+  if (conflict) {
+    recordConflict(key, *props->SuperclassRule, ruleID, System);
+  }
+}
+
+void PropertyMap::addConcreteTypeProperty(
+    Term key, Symbol property, unsigned ruleID) {
+  auto *props = getOrCreateProperties(key);
+  bool debug = Debug.contains(DebugFlags::ConcreteUnification);
+
+  if (!props->ConcreteType) {
+    props->ConcreteType = property;
+    props->ConcreteTypeRule = ruleID;
+    return;
+  }
+
+  assert(props->ConcreteTypeRule.hasValue());
+  bool conflict = unifyConcreteTypes(*props->ConcreteType, property,
+                                     System, debug);
+  if (conflict) {
+    recordConflict(key, *props->ConcreteTypeRule, ruleID, System);
+  }
+}
+
 /// Record a protocol conformance, layout or superclass constraint on the given
 /// key. Must be called in monotonically non-decreasing key order.
 void PropertyMap::addProperty(
     Term key, Symbol property, unsigned ruleID) {
   assert(property.isProperty());
   assert(*System.getRule(ruleID).isPropertyRule() == property);
-  auto *props = getOrCreateProperties(key);
-  bool debug = Debug.contains(DebugFlags::ConcreteUnification);
 
   switch (property.getKind()) {
   case Symbol::Kind::Protocol:
-    props->ConformsTo.push_back(property.getProtocol());
-    props->ConformsToRules.push_back(ruleID);
+    addConformanceProperty(key, property, ruleID);
     return;
 
-  case Symbol::Kind::Layout: {
-    auto newLayout = property.getLayoutConstraint();
-
-    if (!props->Layout) {
-      // If we haven't seen a layout requirement before, just record it.
-      props->Layout = newLayout;
-      props->LayoutRule = ruleID;
-    } else {
-      // Otherwise, compute the intersection.
-      assert(props->LayoutRule.hasValue());
-      auto mergedLayout = props->Layout.merge(property.getLayoutConstraint());
-
-      // If the intersection is invalid, we have a conflict.
-      if (!mergedLayout->isKnownLayout()) {
-        recordConflict(key, *props->LayoutRule, ruleID, System);
-        return;
-      }
-
-      // If the intersection is equal to the existing layout requirement,
-      // the new layout requirement is redundant.
-      if (mergedLayout == props->Layout) {
-        if (checkRulePairOnce(*props->LayoutRule, ruleID)) {
-          recordRelation(key, *props->LayoutRule, property, System, debug);
-        }
-
-      // If the intersection is equal to the new layout requirement, the
-      // existing layout requirement is redundant.
-      } else if (mergedLayout == newLayout) {
-        if (checkRulePairOnce(ruleID, *props->LayoutRule)) {
-          auto oldProperty = System.getRule(*props->LayoutRule).getLHS().back();
-          recordRelation(key, ruleID, oldProperty, System, debug);
-        }
-
-        props->LayoutRule = ruleID;
-      } else {
-        llvm::errs() << "Arbitrary intersection of layout requirements is "
-                     << "supported yet\n";
-        abort();
-      }
-    }
-
+  case Symbol::Kind::Layout:
+    addLayoutProperty(key, property, ruleID);
     return;
-  }
 
-  case Symbol::Kind::Superclass: {
-    if (checkRuleOnce(ruleID)) {
-      // A rule (T.[superclass: C] => T) induces a rule (T.[layout: L] => T),
-      // where L is either AnyObject or _NativeObject.
-      auto superclass =
-          property.getConcreteType()->getClassOrBoundGenericClass();
-      auto layout =
-          LayoutConstraint::getLayoutConstraint(
-            superclass->getLayoutConstraintKind(),
-            Context.getASTContext());
-      auto layoutSymbol = Symbol::forLayout(layout, Context);
-
-      recordRelation(key, ruleID, layoutSymbol, System, debug);
-    }
-
-    if (!props->Superclass) {
-      props->Superclass = property;
-      props->SuperclassRule = ruleID;
-    } else {
-      assert(props->SuperclassRule.hasValue());
-      auto pair = unifySuperclasses(*props->Superclass, property,
-                                    System, debug);
-      props->Superclass = pair.first;
-      bool conflict = pair.second;
-      if (conflict) {
-        recordConflict(key, *props->SuperclassRule, ruleID, System);
-        return;
-      }
-    }
-
+  case Symbol::Kind::Superclass:
+    addSuperclassProperty(key, property, ruleID);
     return;
-  }
 
-  case Symbol::Kind::ConcreteType: {
-    if (!props->ConcreteType) {
-      props->ConcreteType = property;
-      props->ConcreteTypeRule = ruleID;
-    } else {
-      assert(props->ConcreteTypeRule.hasValue());
-      bool conflict = unifyConcreteTypes(*props->ConcreteType, property,
-                                         System, debug);
-      if (conflict) {
-        recordConflict(key, *props->ConcreteTypeRule, ruleID, System);
-        return;
-      }
-    }
-
+  case Symbol::Kind::ConcreteType:
+    addConcreteTypeProperty(key, property, ruleID);
     return;
-  }
 
   case Symbol::Kind::ConcreteConformance:
-    // FIXME
+    // Concrete conformance rules are not recorded in the property map, since
+    // they're not needed for unification, and generic signature queries don't
+    // care about them.
     return;
 
   case Symbol::Kind::Name:

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -27,6 +27,7 @@ RequirementMachine::RequirementMachine(RewriteContext &ctx)
   Dump = langOpts.DumpRequirementMachine;
   MaxRuleCount = langOpts.RequirementMachineMaxRuleCount;
   MaxRuleLength = langOpts.RequirementMachineMaxRuleLength;
+  MaxConcreteNesting = langOpts.RequirementMachineMaxConcreteNesting;
   Stats = ctx.getASTContext().Stats;
 
   if (Stats)
@@ -48,6 +49,11 @@ static void checkCompletionResult(const RequirementMachine &machine,
 
   case CompletionResult::MaxRuleLength:
     llvm::errs() << "Rewrite system exceeded rule length limit\n";
+    machine.dump(llvm::errs());
+    abort();
+
+  case CompletionResult::MaxConcreteNesting:
+    llvm::errs() << "Rewrite system exceeded concrete type nesting depth limit\n";
     machine.dump(llvm::errs());
     abort();
   }
@@ -265,6 +271,8 @@ RequirementMachine::computeCompletion(RewriteSystem::ValidityPolicy policy) {
         const auto &newRule = System.getRule(ruleCount + i);
         if (newRule.getDepth() > MaxRuleLength)
           return CompletionResult::MaxRuleLength;
+        if (newRule.getNesting() > MaxConcreteNesting)
+          return CompletionResult::MaxConcreteNesting;
       }
 
       if (System.getRules().size() > MaxRuleCount)

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -65,6 +65,7 @@ class RequirementMachine final {
   /// Parameters to prevent runaway completion and property map construction.
   unsigned MaxRuleCount;
   unsigned MaxRuleLength;
+  unsigned MaxConcreteNesting;
 
   UnifiedStatsReporter *Stats;
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -88,17 +88,20 @@ class RequirementMachine final {
   RequirementMachine &operator=(RequirementMachine &&) = delete;
 
   void initWithGenericSignature(CanGenericSignature sig);
-  CompletionResult initWithProtocols(ArrayRef<const ProtocolDecl *> protos);
+  std::pair<CompletionResult, unsigned>
+  initWithProtocols(ArrayRef<const ProtocolDecl *> protos);
   void initWithAbstractRequirements(
       ArrayRef<GenericTypeParamType *> genericParams,
       ArrayRef<Requirement> requirements);
-  CompletionResult initWithWrittenRequirements(
+  std::pair<CompletionResult, unsigned>
+  initWithWrittenRequirements(
       ArrayRef<GenericTypeParamType *> genericParams,
       ArrayRef<StructuralRequirement> requirements);
 
   bool isComplete() const;
 
-  CompletionResult computeCompletion(RewriteSystem::ValidityPolicy policy);
+  std::pair<CompletionResult, unsigned>
+  computeCompletion(RewriteSystem::ValidityPolicy policy);
 
   MutableTerm getLongestValidPrefix(const MutableTerm &term) const;
 
@@ -141,6 +144,8 @@ public:
   computeMinimalProtocolRequirements();
 
   std::vector<Requirement> computeMinimalGenericSignatureRequirements();
+
+  std::string getRuleAsStringForDiagnostics(unsigned ruleID) const;
 
   bool hadError() const;
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -61,8 +61,10 @@ class RequirementMachine final {
 
   bool Dump = false;
   bool Complete = false;
-  unsigned RequirementMachineStepLimit;
-  unsigned RequirementMachineDepthLimit;
+
+  /// Parameters to prevent runaway completion and property map construction.
+  unsigned MaxRuleCount;
+  unsigned MaxRuleLength;
 
   UnifiedStatsReporter *Stats;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -266,7 +266,7 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
       ctx.Diags.diagnose(otherProto->getLoc(),
                          diag::requirement_machine_completion_failed,
                          /*protocol=*/1,
-                         status == CompletionResult::MaxIterations ? 0 : 1);
+                         unsigned(status));
 
       if (otherProto != proto) {
         ctx.evaluator.cacheOutput(
@@ -504,7 +504,7 @@ InferredGenericSignatureRequestRQM::evaluate(
     ctx.Diags.diagnose(loc,
                        diag::requirement_machine_completion_failed,
                        /*protocol=*/0,
-                       status == CompletionResult::MaxIterations ? 0 : 1);
+                       unsigned(status));
 
     auto result = GenericSignature::get(genericParams, {});
     return GenericSignatureWithError(result, /*hadError=*/true);

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -496,28 +496,6 @@ void RewritePathEvaluator::applyDecomposeConcrete(const RewriteStep &step,
 
   auto substitutions = difference.LHS.getSubstitutions();
 
-  auto getReplacementSubstitution = [&](unsigned n) -> MutableTerm {
-    for (const auto &pair : difference.SameTypes) {
-      if (pair.first == n) {
-        // Given a transformation Xn -> Xn', return the term Xn'.
-        return MutableTerm(pair.second);
-      }
-    }
-
-    for (const auto &pair : difference.ConcreteTypes) {
-      if (pair.first == n) {
-        // Given a transformation Xn -> [concrete: D], return the
-        // return Xn.[concrete: D].
-        MutableTerm result(substitutions[n]);
-        result.add(pair.second);
-        return result;
-      }
-    }
-
-    // Otherwise return the original substitution Xn.
-    return MutableTerm(substitutions[n]);
-  };
-
   if (!step.Inverse) {
     auto &term = getCurrentTerm();
 
@@ -531,7 +509,7 @@ void RewritePathEvaluator::applyDecomposeConcrete(const RewriteStep &step,
     term = newTerm;
 
     for (unsigned n : indices(substitutions))
-      Primary.push_back(getReplacementSubstitution(n));
+      Primary.push_back(difference.getReplacementSubstitution(n));
 
   } else {
     unsigned numSubstitutions = substitutions.size();
@@ -541,7 +519,7 @@ void RewritePathEvaluator::applyDecomposeConcrete(const RewriteStep &step,
 
     for (unsigned n : indices(substitutions)) {
       const auto &otherSubstitution = *(Primary.end() - numSubstitutions + n);
-      auto expectedSubstitution = getReplacementSubstitution(n);
+      auto expectedSubstitution = difference.getReplacementSubstitution(n);
       if (otherSubstitution != expectedSubstitution) {
         llvm::errs() << "Got: " << otherSubstitution << "\n";
         llvm::errs() << "Expected: " << expectedSubstitution << "\n";

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -85,8 +85,8 @@ void RewriteStep::dump(llvm::raw_ostream &out,
 
     break;
   }
-  case AdjustConcreteType: {
-    auto pair = evaluator.applyAdjustment(*this, system);
+  case PrefixSubstitutions: {
+    auto pair = evaluator.applyPrefixSubstitutions(*this, system);
 
     out << "(σ";
     out << (Inverse ? " - " : " + ");
@@ -260,11 +260,11 @@ RewritePathEvaluator::applyRewriteRule(const RewriteStep &step,
 }
 
 std::pair<MutableTerm, MutableTerm>
-RewritePathEvaluator::applyAdjustment(const RewriteStep &step,
-                                      const RewriteSystem &system) {
+RewritePathEvaluator::applyPrefixSubstitutions(const RewriteStep &step,
+                                               const RewriteSystem &system) {
   auto &term = getCurrentTerm();
 
-  assert(step.Kind == RewriteStep::AdjustConcreteType);
+  assert(step.Kind == RewriteStep::PrefixSubstitutions);
 
   auto &ctx = system.getRewriteContext();
   MutableTerm prefix(term.begin() + step.StartOffset,
@@ -451,8 +451,8 @@ void RewritePathEvaluator::apply(const RewriteStep &step,
     (void) applyRewriteRule(step, system);
     break;
 
-  case RewriteStep::AdjustConcreteType:
-    (void) applyAdjustment(step, system);
+  case RewriteStep::PrefixSubstitutions:
+    (void) applyPrefixSubstitutions(step, system);
     break;
 
   case RewriteStep::Shift:

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -550,7 +550,7 @@ RewritePathEvaluator::applyLeftConcreteProjection(const RewriteStep &step,
   const auto &difference = system.getTypeDifference(step.getTypeDifferenceID());
   unsigned index = step.getSubstitutionIndex();
 
-  MutableTerm leftProjection(difference.LHS.getSubstitutions()[index]);
+  auto leftProjection = difference.getOriginalSubstitution(index);
 
   MutableTerm leftBaseTerm(difference.BaseTerm);
   leftBaseTerm.add(difference.LHS);
@@ -607,7 +607,7 @@ RewritePathEvaluator::applyRightConcreteProjection(const RewriteStep &step,
   const auto &difference = system.getTypeDifference(step.getTypeDifferenceID());
   unsigned index = step.getSubstitutionIndex();
 
-  MutableTerm leftProjection(difference.LHS.getSubstitutions()[index]);
+  auto leftProjection = difference.getOriginalSubstitution(index);
   auto rightProjection = difference.getReplacementSubstitution(index);
 
   MutableTerm leftBaseTerm(difference.BaseTerm);

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -62,7 +62,7 @@ struct RewriteStep {
     /// If inverted: strip the prefix from each substitution.
     ///
     /// The StartOffset field encodes the length of the prefix.
-    AdjustConcreteType,
+    PrefixSubstitutions,
 
     ///
     /// *** Rewrite step kinds introduced by simplifySubstitutions() ***
@@ -130,10 +130,13 @@ struct RewriteStep {
 
   /// If Kind is Rule, the index of the rule in the rewrite system.
   ///
-  /// If Kind is AdjustConcreteType, the length of the prefix to add or remove
+  /// If Kind is PrefixSubstitutions, the length of the prefix to add or remove
   /// at the beginning of each concrete substitution.
   ///
-  /// If Kind is Concrete, the number of substitutions to push or pop.
+  /// If Kind is Decompose, the number of substitutions to push or pop.
+  ///
+  /// If Kind is Relation, the relation index returned from
+  /// RewriteSystem::recordRelation().
   unsigned Arg : 16;
 
   RewriteStep(StepKind kind, unsigned startOffset, unsigned endOffset,
@@ -154,10 +157,10 @@ struct RewriteStep {
     return RewriteStep(Rule, startOffset, endOffset, ruleID, inverse);
   }
 
-  static RewriteStep forAdjustment(unsigned offset, unsigned endOffset,
-                                   bool inverse) {
-    return RewriteStep(AdjustConcreteType, /*startOffset=*/0, endOffset,
-                       /*arg=*/offset, inverse);
+  static RewriteStep forPrefixSubstitutions(unsigned length, unsigned endOffset,
+                                            bool inverse) {
+    return RewriteStep(PrefixSubstitutions, /*startOffset=*/0, endOffset,
+                       /*arg=*/length, inverse);
   }
 
   static RewriteStep forShift(bool inverse) {
@@ -355,8 +358,8 @@ struct RewritePathEvaluator {
                                       const RewriteSystem &system);
 
   std::pair<MutableTerm, MutableTerm>
-  applyAdjustment(const RewriteStep &step,
-                  const RewriteSystem &system);
+  applyPrefixSubstitutions(const RewriteStep &step,
+                           const RewriteSystem &system);
 
   void applyShift(const RewriteStep &step,
                   const RewriteSystem &system);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -167,9 +167,9 @@ unsigned Rule::getNesting() const {
 }
 
 /// Linear order on rules; compares LHS followed by RHS.
-int Rule::compare(const Rule &other, RewriteContext &ctx) const {
-  int compare = LHS.compare(other.LHS, ctx);
-  if (compare != 0)
+Optional<int> Rule::compare(const Rule &other, RewriteContext &ctx) const {
+  Optional<int> compare = LHS.compare(other.LHS, ctx);
+  if (!compare.hasValue() || *compare != 0)
     return compare;
 
   return RHS.compare(other.RHS, ctx);
@@ -415,8 +415,8 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
 
   // If the left hand side and right hand side are already equivalent, we're
   // done.
-  int result = lhs.compare(rhs, Context);
-  if (result == 0) {
+  Optional<int> result = lhs.compare(rhs, Context);
+  if (*result == 0) {
     // If this rule is a consequence of existing rules, add a homotopy
     // generator.
     if (path) {
@@ -436,12 +436,12 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
 
   // Orient the two terms so that the left hand side is greater than the
   // right hand side.
-  if (result < 0) {
+  if (*result < 0) {
     std::swap(lhs, rhs);
     loop.invert();
   }
 
-  assert(lhs.compare(rhs, Context) > 0);
+  assert(*lhs.compare(rhs, Context) > 0);
 
   if (Debug.contains(DebugFlags::Add)) {
     llvm::dbgs() << "## Simplified and oriented rule " << lhs << " => " << rhs << "\n\n";

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -731,6 +731,12 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
     out << "- " << relation.first << " =>> " << relation.second << "\n";
   }
   out << "}\n";
+  out << "Type differences: {\n";
+  for (const auto &difference : Differences) {
+    difference.dump(out);
+    out << "\n";
+  }
+  out << "}\n";
   out << "Rewrite loops: {\n";
   for (const auto &loop : Loops) {
     if (loop.isDeleted())

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -183,7 +183,7 @@ public:
 
   unsigned getNesting() const;
 
-  int compare(const Rule &other, RewriteContext &ctx) const;
+  Optional<int> compare(const Rule &other, RewriteContext &ctx) const;
 
   void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -422,10 +422,10 @@ private:
   llvm::DenseMap<std::pair<Symbol, Symbol>, unsigned> DifferenceMap;
   std::vector<TypeDifference> Differences;
 
+public:
   unsigned recordTypeDifference(Symbol lhs, Symbol rhs,
                                 const TypeDifference &difference);
 
-public:
   bool
   computeTypeDifference(Symbol lhs, Symbol rhs,
                         Optional<unsigned> &lhsDifferenceID,

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -422,15 +422,14 @@ private:
   /// The map's values are indices into the vector. The map is used for
   /// uniquing, then the index is returned and lookups are performed into
   /// the vector.
-  llvm::DenseMap<std::pair<Symbol, Symbol>, unsigned> DifferenceMap;
+  llvm::DenseMap<std::tuple<Term, Symbol, Symbol>, unsigned> DifferenceMap;
   std::vector<TypeDifference> Differences;
 
 public:
-  unsigned recordTypeDifference(Symbol lhs, Symbol rhs,
-                                const TypeDifference &difference);
+  unsigned recordTypeDifference(const TypeDifference &difference);
 
   bool
-  computeTypeDifference(Symbol lhs, Symbol rhs,
+  computeTypeDifference(Term term, Symbol lhs, Symbol rhs,
                         Optional<unsigned> &lhsDifferenceID,
                         Optional<unsigned> &rhsDifferenceID);
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -192,18 +192,17 @@ public:
   }
 };
 
-/// Result type for RewriteSystem::computeConfluentCompletion() and
-/// PropertyMap::buildPropertyMap().
+/// Result type for RequirementMachine::computeCompletion().
 enum class CompletionResult {
-  /// Confluent completion was computed successfully.
+  /// Completion was successful.
   Success,
 
-  /// Maximum number of iterations reached.
-  MaxIterations,
+  /// Maximum number of rules exceeded.
+  MaxRuleCount,
 
-  /// Completion produced a rewrite rule whose left hand side has a length
-  /// exceeding the limit.
-  MaxDepth
+  /// Maximum rule length exceeded.
+  MaxRuleLength,
+
 };
 
 /// A term rewrite system for working with types in a generic signature.
@@ -322,9 +321,8 @@ public:
   /// Pairs of rules which have already been checked for overlap.
   llvm::DenseSet<std::pair<unsigned, unsigned>> CheckedOverlaps;
 
-  std::pair<CompletionResult, unsigned>
-  computeConfluentCompletion(unsigned maxIterations,
-                             unsigned maxDepth);
+  CompletionResult computeConfluentCompletion(unsigned maxRuleCount,
+                                              unsigned maxRuleLength);
 
   void simplifyLeftHandSides();
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -456,9 +456,6 @@ private:
   /// algorithms.
   std::vector<RewriteLoop> Loops;
 
-  void recordRewriteLoop(MutableTerm basepoint,
-                         RewritePath path);
-
   void propagateExplicitBits();
 
   Optional<unsigned>
@@ -474,6 +471,9 @@ private:
       llvm::DenseSet<unsigned> &redundantConformances);
 
 public:
+  void recordRewriteLoop(MutableTerm basepoint,
+                         RewritePath path);
+
   bool isInMinimizationDomain(ArrayRef<const ProtocolDecl *> protos) const;
 
   ArrayRef<RewriteLoop> getLoops() const {

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -21,6 +21,7 @@
 #include "Symbol.h"
 #include "Term.h"
 #include "Trie.h"
+#include "TypeDifference.h"
 
 namespace llvm {
   class raw_ostream;
@@ -389,6 +390,9 @@ public:
   using Relation = std::pair<Term, Term>;
 
 private:
+  /// The map's values are indices into the vector. The map is used for
+  /// uniquing, then the index is returned and lookups are performed into
+  /// the vector.
   llvm::DenseMap<Relation, unsigned> RelationMap;
   std::vector<Relation> Relations;
 
@@ -410,6 +414,24 @@ public:
   unsigned recordSameTypeWitnessRelation(
       Symbol concreteConformanceSymbol,
       Symbol associatedTypeSymbol);
+
+private:
+  /// The map's values are indices into the vector. The map is used for
+  /// uniquing, then the index is returned and lookups are performed into
+  /// the vector.
+  llvm::DenseMap<std::pair<Symbol, Symbol>, unsigned> DifferenceMap;
+  std::vector<TypeDifference> Differences;
+
+  unsigned recordTypeDifference(Symbol lhs, Symbol rhs,
+                                const TypeDifference &difference);
+
+public:
+  bool
+  computeTypeDifference(Symbol lhs, Symbol rhs,
+                        Optional<unsigned> &lhsDifferenceID,
+                        Optional<unsigned> &rhsDifferenceID);
+
+  const TypeDifference &getTypeDifference(unsigned index) const;
 
 private:
   //////////////////////////////////////////////////////////////////////////////

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -181,6 +181,8 @@ public:
 
   unsigned getDepth() const;
 
+  unsigned getNesting() const;
+
   int compare(const Rule &other, RewriteContext &ctx) const;
 
   void dump(llvm::raw_ostream &out) const;
@@ -203,6 +205,8 @@ enum class CompletionResult {
   /// Maximum rule length exceeded.
   MaxRuleLength,
 
+  /// Maximum concrete type nesting depth exceeded.
+  MaxConcreteNesting
 };
 
 /// A term rewrite system for working with types in a generic signature.

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -325,8 +325,9 @@ public:
   /// Pairs of rules which have already been checked for overlap.
   llvm::DenseSet<std::pair<unsigned, unsigned>> CheckedOverlaps;
 
-  CompletionResult computeConfluentCompletion(unsigned maxRuleCount,
-                                              unsigned maxRuleLength);
+  std::pair<CompletionResult, unsigned>
+  computeConfluentCompletion(unsigned maxRuleCount,
+                             unsigned maxRuleLength);
 
   void simplifyLeftHandSides();
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -461,9 +461,8 @@ private:
 
   void propagateExplicitBits();
 
-  Optional<unsigned>
-  findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn,
-                   RewritePath &replacementPath);
+  Optional<std::pair<unsigned, unsigned>>
+  findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn);
 
   void deleteRule(unsigned ruleID, const RewritePath &replacementPath);
 

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -223,7 +223,7 @@ public:
 
   ArrayRef<const ProtocolDecl *> getRootProtocols() const;
 
-  int compare(Symbol other, RewriteContext &ctx) const;
+  Optional<int> compare(Symbol other, RewriteContext &ctx) const;
 
   Symbol withConcreteSubstitutions(
       ArrayRef<Term> substitutions,

--- a/lib/AST/RequirementMachine/Term.cpp
+++ b/lib/AST/RequirementMachine/Term.cpp
@@ -128,9 +128,10 @@ bool Term::containsUnresolvedSymbols() const {
 ///
 /// This is used to implement Term::compare() and MutableTerm::compare()
 /// below.
-static int shortlexCompare(const Symbol *lhsBegin, const Symbol *lhsEnd,
-                           const Symbol *rhsBegin, const Symbol *rhsEnd,
-                           RewriteContext &ctx) {
+static Optional<int>
+shortlexCompare(const Symbol *lhsBegin, const Symbol *lhsEnd,
+                const Symbol *rhsBegin, const Symbol *rhsEnd,
+                RewriteContext &ctx) {
   unsigned lhsSize = (lhsEnd - lhsBegin);
   unsigned rhsSize = (rhsEnd - rhsBegin);
   if (lhsSize != rhsSize)
@@ -143,8 +144,8 @@ static int shortlexCompare(const Symbol *lhsBegin, const Symbol *lhsEnd,
     ++lhsBegin;
     ++rhsBegin;
 
-    int result = lhs.compare(rhs, ctx);
-    if (result != 0) {
+    Optional<int> result = lhs.compare(rhs, ctx);
+    if (!result.hasValue() || *result != 0) {
       assert(lhs != rhs);
       return result;
     }
@@ -155,13 +156,17 @@ static int shortlexCompare(const Symbol *lhsBegin, const Symbol *lhsEnd,
   return 0;
 }
 
-/// Shortlex order on terms.
-int Term::compare(Term other, RewriteContext &ctx) const {
+/// Shortlex order on terms. Returns None if the terms are identical except
+/// for an incomparable superclass or concrete type symbol at the end.
+Optional<int>
+Term::compare(Term other, RewriteContext &ctx) const {
   return shortlexCompare(begin(), end(), other.begin(), other.end(), ctx);
 }
 
-/// Shortlex order on mutable terms.
-int MutableTerm::compare(const MutableTerm &other, RewriteContext &ctx) const {
+/// Shortlex order on mutable terms. Returns None if the terms are identical
+/// except for an incomparable superclass or concrete type symbol at the end.
+Optional<int>
+MutableTerm::compare(const MutableTerm &other, RewriteContext &ctx) const {
   return shortlexCompare(begin(), end(), other.begin(), other.end(), ctx);
 }
 

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -79,7 +79,7 @@ public:
 
   void dump(llvm::raw_ostream &out) const;
 
-  int compare(Term other, RewriteContext &ctx) const;
+  Optional<int> compare(Term other, RewriteContext &ctx) const;
 
   friend bool operator==(Term lhs, Term rhs) {
     return lhs.Ptr == rhs.Ptr;
@@ -144,7 +144,7 @@ public:
     Symbols.append(from, to);
   }
 
-  int compare(const MutableTerm &other, RewriteContext &ctx) const;
+  Optional<int> compare(const MutableTerm &other, RewriteContext &ctx) const;
 
   bool empty() const { return Symbols.empty(); }
 

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -1,0 +1,514 @@
+//===--- TypeDifference.cpp - Utility for concrete type unification -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeDifference.h"
+#include "swift/AST/Types.h"
+#include "swift/AST/TypeMatcher.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+#include "RewriteContext.h"
+#include "RewriteSystem.h"
+#include "Term.h"
+
+using namespace swift;
+using namespace rewriting;
+
+void TypeDifference::dump(llvm::raw_ostream &out) const {
+  llvm::errs() << "LHS: " << LHS << "\n";
+  llvm::errs() << "RHS: " << RHS << "\n";
+
+  for (const auto &pair : SameTypes) {
+    out << "- " << LHS.getSubstitutions()[pair.first] << " (#";
+    out << pair.first << ") -> ";
+    out << RHS.getSubstitutions()[pair.second] << " (#";
+    out << pair.second << ")\n";
+  }
+
+  for (const auto &pair : ConcreteTypes) {
+    out << "- " << LHS.getSubstitutions()[pair.first] << " (#";
+    out << pair.first << ") -> " << pair.second << "\n";
+  }
+}
+
+void TypeDifference::verify(RewriteContext &ctx) const {
+#ifndef NDEBUG
+
+#define VERIFY(expr, str) \
+  if (!(expr)) { \
+    llvm::errs() << "TypeDifference::verify(): " << str << "\n"; \
+    dump(llvm::errs()); \
+    abort(); \
+  }
+
+  VERIFY(LHS.getKind() == RHS.getKind(), "Kind mismatch");
+
+  if (LHS == RHS) {
+    VERIFY(SameTypes.empty(), "Abstract substitutions with equal symbols");
+    VERIFY(ConcreteTypes.empty(), "Concrete substitutions with equal symbols");
+  } else {
+    VERIFY(!SameTypes.empty() || !ConcreteTypes.empty(),
+           "Missing substitutions with non-equal symbols");
+
+    llvm::DenseSet<unsigned> lhsVisited;
+    llvm::DenseSet<unsigned> rhsVisited;
+
+    for (const auto &pair : SameTypes) {
+      auto first = LHS.getSubstitutions()[pair.first];
+      auto second = RHS.getSubstitutions()[pair.second];
+      VERIFY(first.compare(second, ctx) > 0, "Order violation");
+
+      VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitutions");
+      VERIFY(rhsVisited.insert(pair.second).second, "Duplicate substitutions");
+    }
+
+    for (const auto &pair : ConcreteTypes) {
+      VERIFY(pair.first < LHS.getSubstitutions().size(),
+             "Out-of-bounds substitution");
+      VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitutions");
+      VERIFY(pair.second.getKind() == Symbol::Kind::ConcreteType, "Bad kind");
+    }
+  }
+
+#undef VERIFY
+#endif
+}
+
+namespace {
+  class ConcreteTypeMatcher : public TypeMatcher<ConcreteTypeMatcher> {
+    ArrayRef<Term> LHSSubstitutions;
+    ArrayRef<Term> RHSSubstitutions;
+    RewriteContext &Context;
+    
+  public:
+    /// Mismatches where both sides are type parameters and the left hand
+    /// side orders before the right hand side. The integers index the
+    /// LHSSubstitutions and RHSSubstitutions arrays, respectively.
+    SmallVector<std::pair<unsigned, unsigned>, 1> SameTypesOnLHS;
+
+    /// Mismatches where both sides are type parameters and the left hand
+    /// side orders after the right hand side. The integers index the
+    /// RHSSubstitutions and LHSSubstitutions arrays, respectively.
+    SmallVector<std::pair<unsigned, unsigned>, 1> SameTypesOnRHS;
+
+    /// Mismatches where the left hand side is concrete and the right hand
+    /// side is a type parameter. The integer is an index into the
+    /// RHSSubstitutions array.
+    SmallVector<std::pair<unsigned, Symbol>, 1> ConcreteTypesOnLHS;
+
+    /// Mismatches where the right hand side is concrete and the left hand
+    /// side is a type parameter. The integer is an index into the
+    /// LHSSubstitutions array.
+    SmallVector<std::pair<unsigned, Symbol>, 1> ConcreteTypesOnRHS;
+
+    /// Mismatches where both sides are concrete; the presence of at least
+    /// one such mismatch indicates a conflict.
+    SmallVector<std::pair<CanType, CanType>, 1> ConcreteConflicts;
+
+    ConcreteTypeMatcher(ArrayRef<Term> lhsSubstitutions,
+                        ArrayRef<Term> rhsSubstitutions,
+                        RewriteContext &ctx)
+        : LHSSubstitutions(lhsSubstitutions),
+          RHSSubstitutions(rhsSubstitutions),
+          Context(ctx) {}
+
+    bool alwaysMismatchTypeParameters() const { return true; }
+
+    bool mismatch(TypeBase *lhsType, TypeBase *rhsType,
+                  Type sugaredFirstType) {
+      bool lhsAbstract = lhsType->isTypeParameter();
+      bool rhsAbstract = rhsType->isTypeParameter();
+
+      if (lhsAbstract && rhsAbstract) {
+        unsigned lhsIndex = RewriteContext::getGenericParamIndex(lhsType);
+        unsigned rhsIndex = RewriteContext::getGenericParamIndex(rhsType);
+
+        auto lhsTerm = LHSSubstitutions[lhsIndex];
+        auto rhsTerm = RHSSubstitutions[rhsIndex];
+
+        int compare = lhsTerm.compare(rhsTerm, Context);
+        if (compare < 0) {
+          SameTypesOnLHS.emplace_back(rhsIndex, lhsIndex);
+        } else if (compare > 0) {
+          SameTypesOnRHS.emplace_back(lhsIndex, rhsIndex);
+        } else {
+          assert(lhsTerm == rhsTerm);
+        }
+        return true;
+      }
+
+      if (lhsAbstract) {
+        assert(!rhsAbstract);
+        unsigned lhsIndex = RewriteContext::getGenericParamIndex(lhsType);
+
+        SmallVector<Term, 2> result;
+        auto rhsSchema = Context.getRelativeSubstitutionSchemaFromType(
+            CanType(rhsType), RHSSubstitutions, result);
+        auto rhsSymbol = Symbol::forConcreteType(rhsSchema, result, Context);
+
+        ConcreteTypesOnRHS.emplace_back(lhsIndex, rhsSymbol);
+        return true;
+      }
+
+      if (rhsAbstract) {
+        assert(!lhsAbstract);
+        unsigned rhsIndex = RewriteContext::getGenericParamIndex(rhsType);
+
+        SmallVector<Term, 2> result;
+        auto lhsSchema = Context.getRelativeSubstitutionSchemaFromType(
+            CanType(lhsType), LHSSubstitutions, result);
+        auto lhsSymbol = Symbol::forConcreteType(lhsSchema, result, Context);
+
+        ConcreteTypesOnLHS.emplace_back(rhsIndex, lhsSymbol);
+        return true;
+      }
+
+      // Any other kind of type mismatch involves conflicting concrete types on
+      // both sides, which can only happen on invalid input.
+      assert(!lhsAbstract && !rhsAbstract);
+      ConcreteConflicts.emplace_back(CanType(lhsType), CanType(rhsType));
+      return true;
+    }
+
+    void verify() const {
+#ifndef NDEBUG
+
+#define VERIFY(expr, str) \
+  if (!(expr)) { \
+    llvm::errs() << "ConcreteTypeMatcher::verify(): " << str << "\n"; \
+    dump(llvm::errs()); \
+    abort(); \
+  }
+
+      llvm::DenseSet<unsigned> lhsVisited;
+      llvm::DenseSet<unsigned> rhsVisited;
+
+      for (const auto &pair : SameTypesOnLHS) {
+        auto first = RHSSubstitutions[pair.first];
+        auto second = LHSSubstitutions[pair.second];
+        VERIFY(first.compare(second, Context) > 0, "Order violation");
+
+        VERIFY(rhsVisited.insert(pair.first).second, "Duplicate substitution");
+        VERIFY(lhsVisited.insert(pair.second).second, "Duplicate substitution");
+      }
+
+      for (const auto &pair : SameTypesOnRHS) {
+        auto first = LHSSubstitutions[pair.first];
+        auto second = RHSSubstitutions[pair.second];
+        VERIFY(first.compare(second, Context) > 0, "Order violation");
+
+        VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitution");
+        VERIFY(rhsVisited.insert(pair.second).second, "Duplicate substitution");
+      }
+
+      for (const auto &pair : ConcreteTypesOnLHS) {
+      VERIFY(pair.first < RHSSubstitutions.size(),
+             "Out-of-bounds substitution");
+        VERIFY(rhsVisited.insert(pair.first).second, "Duplicate substitution");
+      }
+
+      for (const auto &pair : ConcreteTypesOnRHS) {
+        VERIFY(pair.first < LHSSubstitutions.size(),
+               "Out-of-bounds substitution");
+        VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitution");
+      }
+
+#undef VERIFY
+#endif
+    }
+
+    void dump(llvm::raw_ostream &out) const {
+      out << "Abstract differences with LHS < RHS:\n";
+      for (const auto &pair : SameTypesOnLHS) {
+        out << "- " << RHSSubstitutions[pair.first] << " (#";
+        out << pair.first << ") -> ";
+        out << LHSSubstitutions[pair.second] << " (#";
+        out << pair.second << ")\n";
+      }
+
+      out << "Abstract differences with RHS < LHS:\n";
+      for (const auto &pair : SameTypesOnRHS) {
+        out << "- " << LHSSubstitutions[pair.first] << " (#";
+        out << pair.first << ") -> ";
+        out << RHSSubstitutions[pair.second] << " (#";
+        out << pair.second << ")\n";
+      }
+
+      out << "Concrete differences with LHS < RHS:\n";
+      for (const auto &pair : ConcreteTypesOnLHS) {
+        out << "- " << RHSSubstitutions[pair.first] << " (#";
+        out << pair.first << ") -> " << pair.second << "\n";
+      }
+
+      out << "Concrete differences with RHS < LHS:\n";
+      for (const auto &pair : ConcreteTypesOnRHS) {
+        out << "- " << LHSSubstitutions[pair.first] << " (#";
+        out << pair.first << ") -> " << pair.second << "\n";
+      }
+
+      out << "Concrete conflicts:\n";
+      for (const auto &pair : ConcreteConflicts) {
+        out << "- " << pair.first << " vs " << pair.second << "\n";
+      }
+    }
+  };
+}
+
+static TypeDifference
+computeMeet(Symbol symbol, Symbol otherSymbol,
+            const llvm::SmallVector<std::pair<unsigned, unsigned>, 1> &sameTypes,
+            const llvm::SmallVector<std::pair<unsigned, Symbol>, 1> &concreteTypes,
+            RewriteContext &ctx) {
+  assert(symbol.getKind() == otherSymbol.getKind());
+
+  auto &astCtx = ctx.getASTContext();
+
+  SmallVector<Term, 2> resultSubstitutions;
+  SmallVector<std::pair<unsigned, unsigned>, 1> remappedSameTypes;
+
+  auto nextSubstitution = [&](Term t) -> Type {
+    unsigned index = resultSubstitutions.size();
+    resultSubstitutions.push_back(t);
+    return GenericTypeParamType::get(/*isTypeSequence=*/false,
+                                     /*depth=*/0, index, astCtx);
+  };
+
+  auto type = symbol.getConcreteType();
+  auto substitutions = symbol.getSubstitutions();
+  auto otherSubstitutions = otherSymbol.getSubstitutions();
+
+  Type resultType = type.transformRec([&](Type t) -> Optional<Type> {
+    if (t->is<GenericTypeParamType>()) {
+      unsigned index = RewriteContext::getGenericParamIndex(t);
+
+      for (const auto &pair : sameTypes) {
+        if (pair.first == index) {
+          remappedSameTypes.emplace_back(pair.first,
+                                         resultSubstitutions.size());
+          return nextSubstitution(otherSubstitutions[pair.second]);
+        }
+      }
+
+      for (const auto &pair : concreteTypes) {
+        if (pair.first == index) {
+          auto concreteSymbol = pair.second;
+          auto concreteType = concreteSymbol.getConcreteType();
+
+          return concreteType.transformRec([&](Type t) -> Optional<Type> {
+            if (t->is<GenericTypeParamType>()) {
+              unsigned index = RewriteContext::getGenericParamIndex(t);
+              Term substitution = concreteSymbol.getSubstitutions()[index];
+              return nextSubstitution(substitution);
+            }
+
+            assert(!t->is<DependentMemberType>());
+            return None;
+          });
+        }
+      }
+
+      assert(!t->is<DependentMemberType>());
+      return nextSubstitution(substitutions[index]);
+    }
+
+    return None;
+  });
+
+  auto resultSymbol = [&]() {
+    switch (symbol.getKind()) {
+    case Symbol::Kind::Superclass:
+      return Symbol::forSuperclass(CanType(resultType),
+                                   resultSubstitutions, ctx);
+    case Symbol::Kind::ConcreteType:
+      return Symbol::forConcreteType(CanType(resultType),
+                                     resultSubstitutions, ctx);
+    case Symbol::Kind::ConcreteConformance:
+      assert(symbol.getProtocol() == otherSymbol.getProtocol());
+      return Symbol::forConcreteConformance(CanType(resultType),
+                                            resultSubstitutions,
+                                            symbol.getProtocol(),
+                                            ctx);
+    default:
+      break;
+    }
+
+    llvm::report_fatal_error("Bad symbol kind");
+  }();
+
+  return {symbol, resultSymbol, remappedSameTypes, concreteTypes};
+}
+
+unsigned
+RewriteSystem::recordTypeDifference(Symbol lhs, Symbol rhs,
+                                    const TypeDifference &difference) {
+  assert(lhs == difference.LHS);
+  assert(rhs == difference.RHS);
+  assert(lhs != rhs);
+
+  auto key = std::make_pair(lhs, rhs);
+  auto found = DifferenceMap.find(key);
+  if (found != DifferenceMap.end())
+    return found->second;
+
+  unsigned index = Differences.size();
+  Differences.push_back(difference);
+
+  auto inserted = DifferenceMap.insert(std::make_pair(key, index));
+  assert(inserted.second);
+  (void) inserted;
+
+  return index;
+}
+
+const TypeDifference &RewriteSystem::getTypeDifference(unsigned index) const {
+  return Differences[index];
+}
+
+/// Computes the "meet" (LHS ∧ RHS) of two concrete type symbols (LHS and RHS
+/// respectively), together with a set of transformations that turn LHS into
+/// (LHS ∧ RHS) and RHS into (LHS ∧ RHS), respectively.
+///
+/// Returns 0, 1 or 2 transformations via the two Optional<unsigned>
+/// out parameters. The integer is an index that can be passed to
+/// RewriteSystem::getTypeDifference() to return a TypeDifference.
+///
+/// - If LHS == RHS, both lhsDifference and rhsDifference will be None.
+///
+/// - If LHS == (LHS ∧ RHS), then lhsTransform will be None. Otherwise,
+///   lhsTransform describes the transform from LHS to (LHS ∧ RHS).
+///
+/// - If RHS == (LHS ∧ RHS), then rhsTransform will be None. Otherwise,
+///   rhsTransform describes the transform from LHS to (LHS ∧ RHS).
+///
+/// - If (LHS ∧ RHS) is distinct from both LHS and RHS, then both
+///   lhsTransform and rhsTransform will be populated with a value.
+///
+/// Also returns a boolean indicating if there was a concrete type conflict,
+/// meaning that LHS and RHS had distinct concrete types at the same
+/// position (eg, if LHS == Array<Int> and RHS == Array<String>).
+///
+/// See the comment at the top of TypeDifference in TypeDifference.h for a
+/// description of the actual transformations.
+bool
+RewriteSystem::computeTypeDifference(Symbol lhs, Symbol rhs,
+                                     Optional<unsigned> &lhsDifferenceID,
+                                     Optional<unsigned> &rhsDifferenceID) {
+  assert(lhs.getKind() == rhs.getKind());
+
+  lhsDifferenceID = None;
+  rhsDifferenceID = None;
+
+  // Fast path if there's nothing to do.
+  if (lhs == rhs)
+    return false;
+
+  // Match the types to find differences.
+  ConcreteTypeMatcher matcher(lhs.getSubstitutions(),
+                              rhs.getSubstitutions(),
+                              Context);
+
+  bool success = matcher.match(lhs.getConcreteType(),
+                               rhs.getConcreteType());
+  assert(success);
+  (void) success;
+
+  matcher.verify();
+
+  auto lhsMeetRhs = computeMeet(lhs, rhs,
+                                matcher.SameTypesOnRHS,
+                                matcher.ConcreteTypesOnRHS,
+                                Context);
+  lhsMeetRhs.verify(Context);
+
+  auto rhsMeetLhs = computeMeet(rhs, lhs,
+                                matcher.SameTypesOnLHS,
+                                matcher.ConcreteTypesOnLHS,
+                                Context);
+  rhsMeetLhs.verify(Context);
+
+  bool isConflict = (matcher.ConcreteConflicts.size() > 0);
+
+#ifndef NDEBUG
+  if (!isConflict) {
+    // The meet operation should be commutative.
+    if (lhsMeetRhs.RHS != rhsMeetLhs.RHS) {
+      llvm::errs() << "Meet operation was not commutative:\n\n";
+
+      llvm::errs() << "LHS: " << lhs << "\n";
+      llvm::errs() << "RHS: " << rhs << "\n";
+      matcher.dump(llvm::errs());
+
+      llvm::errs() << "\n";
+      llvm::errs() << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
+      llvm::errs() << "RHS ∧ LHS: " << rhsMeetLhs.RHS << "\n";
+      abort();
+    }
+
+    // The meet operation should be idempotent.
+    {
+      // (LHS ∧ (LHS ∧ RHS)) == (LHS ∧ RHS)
+      auto lhsMeetLhsMeetRhs = computeMeet(lhs, lhsMeetRhs.RHS,
+                                           lhsMeetRhs.SameTypes,
+                                           lhsMeetRhs.ConcreteTypes,
+                                           Context);
+
+      lhsMeetLhsMeetRhs.verify(Context);
+
+      if (lhsMeetRhs.RHS != lhsMeetLhsMeetRhs.RHS) {
+        llvm::errs() << "Meet operation was not idempotent:\n\n";
+
+        llvm::errs() << "LHS: " << lhs << "\n";
+        llvm::errs() << "RHS: " << rhs << "\n";
+        matcher.dump(llvm::errs());
+
+        llvm::errs() << "\n";
+        llvm::errs() << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
+        llvm::errs() << "LHS ∧ (LHS ∧ RHS): " << lhsMeetLhsMeetRhs.RHS << "\n";
+        abort();
+      }
+    }
+
+    {
+      // (RHS ∧ (RHS ∧ LHS)) == (RHS ∧ LHS)
+      auto rhsMeetRhsMeetRhs = computeMeet(rhs, rhsMeetLhs.RHS,
+                                           rhsMeetLhs.SameTypes,
+                                           rhsMeetLhs.ConcreteTypes,
+                                           Context);
+
+      rhsMeetRhsMeetRhs.verify(Context);
+
+      if (lhsMeetRhs.RHS != rhsMeetRhsMeetRhs.RHS) {
+        llvm::errs() << "Meet operation was not idempotent:\n\n";
+
+        llvm::errs() << "LHS: " << lhs << "\n";
+        llvm::errs() << "RHS: " << rhs << "\n";
+        matcher.dump(llvm::errs());
+
+        llvm::errs() << "\n";
+        llvm::errs() << "RHS ∧ LHS: " << rhsMeetLhs.RHS << "\n";
+        llvm::errs() << "RHS ∧ (RHS ∧ LHS): " << rhsMeetRhsMeetRhs.RHS << "\n";
+        abort();
+      }
+    }
+  }
+#endif
+
+  if (lhs != lhsMeetRhs.RHS)
+    lhsDifferenceID = recordTypeDifference(lhs, lhsMeetRhs.RHS, lhsMeetRhs);
+
+  if (rhs != rhsMeetLhs.RHS)
+    rhsDifferenceID = recordTypeDifference(rhs, rhsMeetLhs.RHS, rhsMeetLhs);
+
+  return isConflict;
+}

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -63,7 +63,7 @@ void TypeDifference::verify(RewriteContext &ctx) const {
 
     for (const auto &pair : SameTypes) {
       auto first = LHS.getSubstitutions()[pair.first];
-      VERIFY(first.compare(pair.second, ctx) > 0, "Order violation");
+      VERIFY(*first.compare(pair.second, ctx) > 0, "Order violation");
       VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitutions");
     }
 
@@ -131,8 +131,8 @@ namespace {
         auto lhsTerm = LHSSubstitutions[lhsIndex];
         auto rhsTerm = RHSSubstitutions[rhsIndex];
 
-        int compare = lhsTerm.compare(rhsTerm, Context);
-        if (compare < 0) {
+        Optional<int> compare = lhsTerm.compare(rhsTerm, Context);
+        if (*compare < 0) {
           SameTypesOnLHS.emplace_back(rhsIndex, lhsTerm);
         } else if (compare > 0) {
           SameTypesOnRHS.emplace_back(lhsIndex, rhsTerm);
@@ -190,14 +190,14 @@ namespace {
 
       for (const auto &pair : SameTypesOnLHS) {
         auto first = RHSSubstitutions[pair.first];
-        VERIFY(first.compare(pair.second, Context) > 0, "Order violation");
+        VERIFY(*first.compare(pair.second, Context) > 0, "Order violation");
 
         VERIFY(rhsVisited.insert(pair.first).second, "Duplicate substitution");
       }
 
       for (const auto &pair : SameTypesOnRHS) {
         auto first = LHSSubstitutions[pair.first];
-        VERIFY(first.compare(pair.second, Context) > 0, "Order violation");
+        VERIFY(*first.compare(pair.second, Context) > 0, "Order violation");
 
         VERIFY(lhsVisited.insert(pair.first).second, "Duplicate substitution");
       }

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -251,8 +251,8 @@ namespace {
   };
 }
 
-static TypeDifference
-buildTypeDifference(
+TypeDifference
+swift::rewriting::buildTypeDifference(
     Symbol symbol,
     const llvm::SmallVector<std::pair<unsigned, Term>, 1> &sameTypes,
     const llvm::SmallVector<std::pair<unsigned, Symbol>, 1> &concreteTypes,

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -25,6 +25,10 @@
 using namespace swift;
 using namespace rewriting;
 
+MutableTerm TypeDifference::getOriginalSubstitution(unsigned index) const {
+  return MutableTerm(LHS.getSubstitutions()[index]);
+}
+
 MutableTerm TypeDifference::getReplacementSubstitution(unsigned index) const {
   for (const auto &pair : SameTypes) {
     if (pair.first == index) {
@@ -37,14 +41,14 @@ MutableTerm TypeDifference::getReplacementSubstitution(unsigned index) const {
     if (pair.first == index) {
       // Given a transformation Xn -> [concrete: D], return the
       // return Xn.[concrete: D].
-      MutableTerm result(LHS.getSubstitutions()[index]);
+      auto result = getOriginalSubstitution(index);
       result.add(pair.second);
       return result;
     }
   }
 
   // Otherwise return the original substitution Xn.
-  return MutableTerm(LHS.getSubstitutions()[index]);
+  return getOriginalSubstitution(index);
 }
 
 void TypeDifference::dump(llvm::raw_ostream &out) const {
@@ -53,12 +57,12 @@ void TypeDifference::dump(llvm::raw_ostream &out) const {
   llvm::errs() << "RHS: " << RHS << "\n";
 
   for (const auto &pair : SameTypes) {
-    out << "- " << LHS.getSubstitutions()[pair.first] << " (#";
+    out << "- " << getOriginalSubstitution(pair.first) << " (#";
     out << pair.first << ") -> " << pair.second << "\n";
   }
 
   for (const auto &pair : ConcreteTypes) {
-    out << "- " << LHS.getSubstitutions()[pair.first] << " (#";
+    out << "- " << getOriginalSubstitution(pair.first) << " (#";
     out << pair.first << ") -> " << pair.second << "\n";
   }
 }

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -25,6 +25,28 @@
 using namespace swift;
 using namespace rewriting;
 
+MutableTerm TypeDifference::getReplacementSubstitution(unsigned index) const {
+  for (const auto &pair : SameTypes) {
+    if (pair.first == index) {
+      // Given a transformation Xn -> Xn', return the term Xn'.
+      return MutableTerm(pair.second);
+    }
+  }
+
+  for (const auto &pair : ConcreteTypes) {
+    if (pair.first == index) {
+      // Given a transformation Xn -> [concrete: D], return the
+      // return Xn.[concrete: D].
+      MutableTerm result(LHS.getSubstitutions()[index]);
+      result.add(pair.second);
+      return result;
+    }
+  }
+
+  // Otherwise return the original substitution Xn.
+  return MutableTerm(LHS.getSubstitutions()[index]);
+}
+
 void TypeDifference::dump(llvm::raw_ostream &out) const {
   llvm::errs() << "Base term: " << BaseTerm << "\n";
   llvm::errs() << "LHS: " << LHS << "\n";

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -58,6 +58,7 @@ struct TypeDifference {
     : BaseTerm(baseTerm), LHS(lhs), RHS(rhs),
       SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
 
+  MutableTerm getOriginalSubstitution(unsigned index) const;
   MutableTerm getReplacementSubstitution(unsigned index) const;
 
   void dump(llvm::raw_ostream &out) const;

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "Symbol.h"
+#include "Term.h"
 
 #ifndef TYPE_DIFFERENCE_H_
 #define TYPE_DIFFERENCE_H_
@@ -30,7 +31,6 @@ namespace swift {
 namespace rewriting {
 
 class RewriteContext;
-class Term;
 
 /// Describes transformations that turn LHS into RHS. There are two kinds of
 /// transformations:
@@ -43,14 +43,14 @@ struct TypeDifference {
 
   /// A pair (N1, N2) where N1 is an index into LHS.getSubstitutions() and
   /// N2 is an index into RHS.getSubstitutions().
-  SmallVector<std::pair<unsigned, unsigned>, 1> SameTypes;
+  SmallVector<std::pair<unsigned, Term>, 1> SameTypes;
 
   /// A pair (N1, C2) where N1 is an index into LHS.getSubstitutions() and
   /// C2 is a concrete type symbol.
   SmallVector<std::pair<unsigned, Symbol>, 1> ConcreteTypes;
 
   TypeDifference(Symbol lhs, Symbol rhs,
-                 SmallVector<std::pair<unsigned, unsigned>, 1> sameTypes,
+                 SmallVector<std::pair<unsigned, Term>, 1> sameTypes,
                  SmallVector<std::pair<unsigned, Symbol>, 1> concreteTypes)
     : LHS(lhs), RHS(rhs), SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
 

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -32,12 +32,15 @@ namespace rewriting {
 
 class RewriteContext;
 
-/// Describes transformations that turn LHS into RHS. There are two kinds of
-/// transformations:
+/// Describes transformations that turn LHS into RHS, given that there are a
+/// pair of rules (BaseTerm.[LHS] => BaseTerm) and (BaseTerm.[RHS] => BaseTerm).
+///
+/// There are two kinds of transformations:
 ///
 /// - Replacing a type term T1 with another type term T2, where T2 < T1.
 /// - Replacing a type term T1 with a concrete type C2.
 struct TypeDifference {
+  Term BaseTerm;
   Symbol LHS;
   Symbol RHS;
 
@@ -49,10 +52,11 @@ struct TypeDifference {
   /// C2 is a concrete type symbol.
   SmallVector<std::pair<unsigned, Symbol>, 1> ConcreteTypes;
 
-  TypeDifference(Symbol lhs, Symbol rhs,
+  TypeDifference(Term baseTerm, Symbol lhs, Symbol rhs,
                  SmallVector<std::pair<unsigned, Term>, 1> sameTypes,
                  SmallVector<std::pair<unsigned, Symbol>, 1> concreteTypes)
-    : LHS(lhs), RHS(rhs), SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
+    : BaseTerm(baseTerm), LHS(lhs), RHS(rhs),
+      SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
 
   void dump(llvm::raw_ostream &out) const;
   void verify(RewriteContext &ctx) const;
@@ -60,7 +64,7 @@ struct TypeDifference {
 
 TypeDifference
 buildTypeDifference(
-    Symbol symbol,
+    Term baseTerm, Symbol symbol,
     const llvm::SmallVector<std::pair<unsigned, Term>, 1> &sameTypes,
     const llvm::SmallVector<std::pair<unsigned, Symbol>, 1> &concreteTypes,
     RewriteContext &ctx);

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -58,6 +58,13 @@ struct TypeDifference {
   void verify(RewriteContext &ctx) const;
 };
 
+TypeDifference
+buildTypeDifference(
+    Symbol symbol,
+    const llvm::SmallVector<std::pair<unsigned, Term>, 1> &sameTypes,
+    const llvm::SmallVector<std::pair<unsigned, Symbol>, 1> &concreteTypes,
+    RewriteContext &ctx);
+
 } // end namespace rewriting
 
 } // end namespace swift

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -58,6 +58,8 @@ struct TypeDifference {
     : BaseTerm(baseTerm), LHS(lhs), RHS(rhs),
       SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
 
+  MutableTerm getReplacementSubstitution(unsigned index) const;
+
   void dump(llvm::raw_ostream &out) const;
   void verify(RewriteContext &ctx) const;
 };

--- a/lib/AST/RequirementMachine/TypeDifference.h
+++ b/lib/AST/RequirementMachine/TypeDifference.h
@@ -1,0 +1,65 @@
+//===--- TypeDifference.h - Utility for concrete type unification ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Type.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
+#include "Symbol.h"
+
+#ifndef TYPE_DIFFERENCE_H_
+#define TYPE_DIFFERENCE_H_
+
+namespace llvm {
+
+class raw_ostream;
+
+} // end namespace llvm
+
+namespace swift {
+
+namespace rewriting {
+
+class RewriteContext;
+class Term;
+
+/// Describes transformations that turn LHS into RHS. There are two kinds of
+/// transformations:
+///
+/// - Replacing a type term T1 with another type term T2, where T2 < T1.
+/// - Replacing a type term T1 with a concrete type C2.
+struct TypeDifference {
+  Symbol LHS;
+  Symbol RHS;
+
+  /// A pair (N1, N2) where N1 is an index into LHS.getSubstitutions() and
+  /// N2 is an index into RHS.getSubstitutions().
+  SmallVector<std::pair<unsigned, unsigned>, 1> SameTypes;
+
+  /// A pair (N1, C2) where N1 is an index into LHS.getSubstitutions() and
+  /// C2 is a concrete type symbol.
+  SmallVector<std::pair<unsigned, Symbol>, 1> ConcreteTypes;
+
+  TypeDifference(Symbol lhs, Symbol rhs,
+                 SmallVector<std::pair<unsigned, unsigned>, 1> sameTypes,
+                 SmallVector<std::pair<unsigned, Symbol>, 1> concreteTypes)
+    : LHS(lhs), RHS(rhs), SameTypes(sameTypes), ConcreteTypes(concreteTypes) {}
+
+  void dump(llvm::raw_ostream &out) const;
+  void verify(RewriteContext &ctx) const;
+};
+
+} // end namespace rewriting
+
+} // end namespace swift
+
+#endif

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -950,6 +950,17 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_max_concrete_nesting)) {
+    unsigned limit;
+    if (StringRef(A->getValue()).getAsInteger(10, limit)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      HadError = true;
+    } else {
+      Opts.RequirementMachineMaxConcreteNesting = limit;
+    }
+  }
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -928,25 +928,25 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(OPT_debug_requirement_machine))
     Opts.DebugRequirementMachine = A->getValue();
 
-  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_step_limit)) {
+  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_max_rule_count)) {
     unsigned limit;
     if (StringRef(A->getValue()).getAsInteger(10, limit)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
       HadError = true;
     } else {
-      Opts.RequirementMachineStepLimit = limit;
+      Opts.RequirementMachineMaxRuleCount = limit;
     }
   }
 
-  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_depth_limit)) {
+  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_max_rule_length)) {
     unsigned limit;
     if (StringRef(A->getValue()).getAsInteger(10, limit)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
       HadError = true;
     } else {
-      Opts.RequirementMachineDepthLimit = limit;
+      Opts.RequirementMachineMaxRuleLength = limit;
     }
   }
 

--- a/test/Generics/canonical_concrete_substitutions_in_protocol.swift
+++ b/test/Generics/canonical_concrete_substitutions_in_protocol.swift
@@ -21,3 +21,37 @@ protocol R {
   associatedtype A
   associatedtype C: QQ where C.X == G<A>
 }
+
+// Make sure substitutions which are themselves concrete simplify recursively.
+
+// CHECK-LABEL: canonical_concrete_substitutions_in_protocol.(file).P1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P1]T == Int, Self.[P1]U == G<Int>>
+
+protocol P1 {
+  associatedtype T where T == Int
+  associatedtype U where U == G<T>
+}
+
+// CHECK-LABEL: canonical_concrete_substitutions_in_protocol.(file).P2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P2]T == Int, Self.[P2]U == G<Int>>
+
+protocol P2 {
+  associatedtype U where U == G<T>
+  associatedtype T where T == Int
+}
+
+// CHECK-LABEL: canonical_concrete_substitutions_in_protocol.(file).P3@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P3]T == G<Int>, Self.[P3]U == Int>
+
+protocol P3 {
+  associatedtype T where T == G<U>
+  associatedtype U where U == Int
+}
+
+// CHECK-LABEL: canonical_concrete_substitutions_in_protocol.(file).P4@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P4]T == G<Int>, Self.[P4]U == Int>
+
+protocol P4 {
+  associatedtype U where U == Int
+  associatedtype T where T == G<U>
+}

--- a/test/Generics/concrete_redundancy_via_adjustment.swift
+++ b/test/Generics/concrete_redundancy_via_adjustment.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+struct G<T> {}
+
+protocol P1 {
+  associatedtype X where X == G<Y>
+  associatedtype Y
+}
+
+// CHECK-LABEL: concrete_redundancy_via_adjustment.(file).P2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P2]T : P1>
+protocol P2 {
+  associatedtype T : P1 where T.X == G<T.Y>
+}

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+
+class G<T> {}
+
+protocol P1 { // expected-error {{cannot build rewrite system for protocol; concrete nesting limit exceeded}}
+  associatedtype A where A == G<B>
+  associatedtype B where B == G<A>
+}
+
+// The GenericSignatureBuilder rejected this protocol, but there's no real
+// reason to do that.
+protocol P2 {
+  associatedtype A where A : G<B>
+  associatedtype B where B : G<A>
+}
+
+func useP2<T : P2>(_: T) {
+  _ = T.A.self
+  _ = T.B.self
+}

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -3,6 +3,7 @@
 class G<T> {}
 
 protocol P1 { // expected-error {{cannot build rewrite system for protocol; concrete nesting limit exceeded}}
+// expected-note@-1 {{failed rewrite rule is [P1:A].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> with <[P1:A]>] => [P1:A]}}
   associatedtype A where A == G<B>
   associatedtype B where B == G<A>
 }

--- a/test/Generics/minimize_concrete_unification.swift
+++ b/test/Generics/minimize_concrete_unification.swift
@@ -1,0 +1,173 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+struct G<T> {}
+
+// Three requirements where any two imply the third:
+//
+// a) T == G<U>
+// b) T == G<Int>
+// c) U == Int
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pab@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pab]T == G<Int>, Self.[Pab]U == Int>
+
+protocol Pab {
+  associatedtype T where T == G<U>, T == G<Int>
+  associatedtype U
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pac@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pac]T == G<Int>, Self.[Pac]U == Int>
+
+protocol Pac {
+  associatedtype T where T == G<U>
+  associatedtype U where U == Int
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pbc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pbc]T == G<Int>, Self.[Pbc]U == Int>
+
+protocol Pbc {
+  associatedtype T where T == G<Int>
+  associatedtype U where U == Int
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pabc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pabc]T == G<Int>, Self.[Pabc]U == Int>
+
+protocol Pabc {
+  associatedtype T where T == G<U>, T == G<Int>
+  associatedtype U where U == Int
+}
+
+//
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pa@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pa]T == G<Self.[Pa]U>>
+
+protocol Pa {
+  associatedtype T where T == G<U>
+  associatedtype U
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PaQb@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PaQb]X : Pa, Self.[PaQb]X.[Pa]U == Int>
+
+protocol PaQb {
+  associatedtype X : Pa where X.T == G<Int>
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PaQc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PaQc]X : Pa, Self.[PaQc]X.[Pa]U == Int>
+
+protocol PaQc {
+  associatedtype X : Pa where X.U == Int
+}
+
+//
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pb@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pb]T == G<Int>>
+
+protocol Pb {
+  associatedtype T where T == G<Int>
+  associatedtype U
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PbQa@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PbQa]X : Pb, Self.[PbQa]X.[Pb]U == Int>
+
+protocol PbQa {
+  associatedtype X : Pb where X.T == G<X.U>
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PbQc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PbQc]X : Pb, Self.[PbQc]X.[Pb]U == Int>
+
+protocol PbQc {
+  associatedtype X : Pb where X.U == Int
+}
+
+//
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Pc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pc]U == Int>
+
+protocol Pc {
+  associatedtype T
+  associatedtype U where U == Int
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PcQa@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PcQa]X : Pc, Self.[PcQa]X.[Pc]T == G<Int>>
+
+protocol PcQa {
+  associatedtype X : Pc where X.T == G<X.U>
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).PcQb@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PcQb]X : Pc, Self.[PcQb]X.[Pc]T == G<Int>>
+
+protocol PcQb {
+  associatedtype X : Pc where X.T == G<Int>
+}
+
+//
+
+// CHECK-LABEL: minimize_concrete_unification.(file).Q1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Q1]V : Pa, Self.[Q1]W == Self.[Q1]V.[Pa]U>
+
+protocol Q1 {
+  associatedtype V where V : Pa, V.T == G<W>
+  associatedtype W
+}
+
+//
+
+// CHECK-LABEL: minimize_concrete_unification.(file).P1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P1]T == G<Self.[P1]U>>
+
+protocol P1 {
+  associatedtype T
+  associatedtype U where T == G<U>
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).P2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P2]T == G<Int>>
+
+protocol P2 {
+  associatedtype T where T == G<Int>
+  associatedtype U
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).P@
+// CHECK-NEXT: Requirement signature: <Self>
+
+protocol P {
+  associatedtype T
+  associatedtype U
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).R1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[R1]X : P, Self.[R1]X : Pa, Self.[R1]X.[P]U == Int>
+
+protocol R1 {
+  // The GSB would drop 'X.T == Int' from the minimal signature.
+  associatedtype X where X : P, X.T == G<Int>, X : Pa
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).R2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[R2]X : P, Self.[R2]X : Pb, Self.[R2]X.[P]U == Int>
+
+protocol R2 {
+  // The GSB would drop 'X.T == Int' from the minimal signature.
+  associatedtype X where X : P, X.T == G<X.U>, X : Pb
+}
+
+// CHECK-LABEL: minimize_concrete_unification.(file).R3@
+// CHECK-NEXT: Requirement signature: <Self where Self.[R3]X : Pa, Self.[R3]X : Pb>
+
+protocol R3 {
+  // The GSB would include a redundant 'X.T == Int' in the minimal signature.
+  associatedtype X where X : Pa, X.T == G<Int>, X : Pb
+}

--- a/test/Generics/non_confluent.swift
+++ b/test/Generics/non_confluent.swift
@@ -1,12 +1,12 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
-protocol ABA // expected-error {{cannot build rewrite system for protocol; depth limit exceeded}}
+protocol ABA // expected-error {{cannot build rewrite system for protocol; rule length limit exceeded}}
     where A.B == A.B.A { // expected-error *{{is not a member type}}
   associatedtype A : ABA
   associatedtype B : ABA
 }
 
-protocol Undecidable // expected-error {{cannot build rewrite system for protocol; depth limit exceeded}}
+protocol Undecidable // expected-error {{cannot build rewrite system for protocol; rule length limit exceeded}}
     where A.C == C.A, // expected-error *{{is not a member type}}
           A.D == D.A, // expected-error *{{is not a member type}}
           B.C == C.B, // expected-error *{{is not a member type}}
@@ -30,17 +30,17 @@ protocol P2 {
 }
 
 func foo<T : P1 & P2>(_: T) {}
-// expected-error@-1 {{cannot build rewrite system for generic signature; depth limit exceeded}}
+// expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
 
 extension P1 where Self : P2 {}
-// expected-error@-1 {{cannot build rewrite system for generic signature; depth limit exceeded}}
+// expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
 
 struct S<U : P1> : P1 {
   typealias T = S<S<U>>
 }
 
 protocol P3 {
-// expected-error@-1 {{cannot build rewrite system for protocol; depth limit exceeded}}
+// expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
   associatedtype T : P1 where T == S<U>
 // expected-error@-1 {{type 'Self.U' does not conform to protocol 'P1'}}
   associatedtype U : P1

--- a/test/Generics/non_confluent.swift
+++ b/test/Generics/non_confluent.swift
@@ -1,12 +1,14 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 protocol ABA // expected-error {{cannot build rewrite system for protocol; rule length limit exceeded}}
+// expected-note@-1 {{failed rewrite rule is [ABA:A].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:A] => [ABA:A].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B].[ABA:B]}}
     where A.B == A.B.A { // expected-error *{{is not a member type}}
   associatedtype A : ABA
   associatedtype B : ABA
 }
 
 protocol Undecidable // expected-error {{cannot build rewrite system for protocol; rule length limit exceeded}}
+// expected-note@-1 {{failed rewrite rule is [Undecidable:A].[Undecidable:B].[Undecidable:D].[Undecidable:C].[Undecidable:C].[Undecidable:C].[Undecidable:E].[Undecidable:B].[Undecidable:A].[Undecidable:A].[Undecidable:E].[Undecidable:C].[Undecidable:E] => [Undecidable:A].[Undecidable:B].[Undecidable:D].[Undecidable:C].[Undecidable:C].[Undecidable:C].[Undecidable:E].[Undecidable:B].[Undecidable:A].[Undecidable:A].[Undecidable:E].[Undecidable:C]}}
     where A.C == C.A, // expected-error *{{is not a member type}}
           A.D == D.A, // expected-error *{{is not a member type}}
           B.C == C.B, // expected-error *{{is not a member type}}
@@ -31,9 +33,11 @@ protocol P2 {
 
 func foo<T : P1 & P2>(_: T) {}
 // expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P2] => τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
 
 extension P1 where Self : P2 {}
 // expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P2] => τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
 
 struct S<U : P1> : P1 {
   typealias T = S<S<U>>
@@ -41,6 +45,8 @@ struct S<U : P1> : P1 {
 
 protocol P3 {
 // expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>> with <[P3:U]>] => [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
+
   associatedtype T : P1 where T == S<U>
 // expected-error@-1 {{type 'Self.U' does not conform to protocol 'P1'}}
   associatedtype U : P1

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -28,5 +28,4 @@ struct MergeTest<G : P1 & P2> {
 // CHECK:  [P1:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P1:Y1], [P1:Z1]>] }
 // CHECK:  [P2:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P2:Y2], [P2:Z2]>] }
 // CHECK:  τ_0_0 => { conforms_to: [P1 P2] }
-// CHECK:  τ_0_0.[P1:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <τ_0_0.[P1:Y1], τ_0_0.[P1:Z1]>] }
 // CHECK: }

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -34,8 +34,9 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
 // CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
 // CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-NEXT: - τ_0_0.B2 => τ_0_0.[P1:B1]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
@@ -45,5 +46,5 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
 // CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
-// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -38,8 +38,9 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
 // CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
 // CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
-// CHECK-NEXT: - τ_0_0.B2 => τ_0_0.[P1:B1]
 // CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK-NEXT: - τ_0_0.B2 => τ_0_0.[P1:B1]
+// CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }


### PR DESCRIPTION
The property map performed unification of concrete type terms, so that for example if you had `T == G<Int>` and `T == G<U>`, we would infer that `U == Int`. This worked for generic signature queries, however minimization did not understand concrete type unification because the new rules were not given a rewrite path expressing them in terms of existing rules.

In our example, any two of the requirements `T == G<Int>, T == G<U> and U == Int` imply the third. This means we need rewrite loops relating them. There are two loops:

1) The first loop has `U == Int` in empty context, and `T == G<Int>` and `T == G<U>` in non-empty context. This means if chosen, the first loop allows `U == Int` to be eliminated.
2) The second loop has `T == G<Int>` and `T == G<U>` in empty context, with `U == Int` appearing in context. This means that if chosen, the second loop allows either of those two rules can be eliminated.

The first loop is introduced when property unification records the rule `U == Int`.

The second loop is introduced by a new simplification pass that runs after property map construction. This pass replaces type parameters with concrete types in concrete type rules, so for example `T == G<U>` is simplified down to `T == G<Int>`. This will record the new rule `T == G<Int>` if it doesn't exist already, and record a rewrite loop relating `T == G<Int>` and `T == G<U>`.

A priori, there's no reason for homotopy reduction to pick either `T == G<Int>` or `T == G<U>` over the other for elimination, however the simplification pass marks `T == G<U>` as simplified, which means we try to eliminate it earlier.

The relation between two different instantiations of a concrete type symbol, like `G<U>` and `G<Int>` is recorded in a new uniqued TypeDifference object in the RewriteSystem. The TypeDifference describes a set of transformations for converting a less-specific left hand side (`G<U>`) into a more-specific right hand side (`G<Int>`) via a series of concrete type rules (in this case, `U == Int`).

The new `LeftConcreteProjection` and `RightConcreteProjection` rewrite steps relate the left hand side and right hand side of an induced rule with the two concrete type rules that induced it. This rewrite step kind appears in the first type of rewrite loop described above.

The new `DecomposeConcrete` rewrite step kind transforms the left hand side of a TypeDifference into the right hand side, or vice versa. This rewrite step kind appears in the second type of rewrite loop described above.

This is the concrete type part of rdar://problem/88134910. Superclass unification still needs additional work to model intersections between a derived class and a base class.