### PR TITLE
Consistently Reject Top-Level Placeholder Types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3746,6 +3746,8 @@ ERROR(placeholder_type_not_allowed_in_return_type,none,
       "type placeholder may not appear in function return type", ())
 ERROR(placeholder_type_not_allowed_in_parameter,none,
       "type placeholder may not appear in top-level parameter", ())
+ERROR(placeholder_type_not_allowed_in_pattern,none,
+      "placeholder type may not appear as type of a variable", ())
 NOTE(replace_placeholder_with_inferred_type,none,
      "replace the placeholder with the inferred type %0", (Type))
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -172,6 +172,14 @@ public:
   /// `OpaqueReturnTypeRepr`s.
   CollectedOpaqueReprs collectOpaqueReturnTypeReprs();
 
+  /// Retrieve the type repr without any parentheses around it.
+  ///
+  /// The use of this function must be restricted to contexts where
+  /// user-written types are provided, and a syntactic analysis is appropriate.
+  /// Most use cases should analyze the resolved \c Type instead and use
+  /// \c Type::getCanonicalType() or \c Type::getWithoutParens().
+  TypeRepr *getWithoutParens() const;
+
   //*** Allocation Routines ************************************************/
 
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -102,6 +102,16 @@ bool TypeRepr::hasOpaque() {
     findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
 }
 
+TypeRepr *TypeRepr::getWithoutParens() const {
+  auto *repr = const_cast<TypeRepr *>(this);
+  while (auto *tupleRepr = dyn_cast<TupleTypeRepr>(repr)) {
+    if (!tupleRepr->isParenType())
+      break;
+    repr = tupleRepr->getElementType(0);
+  }
+  return repr;
+}
+
 CollectedOpaqueReprs TypeRepr::collectOpaqueReturnTypeReprs() {
   class Walker : public ASTWalker {
     CollectedOpaqueReprs &Reprs;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1364,7 +1364,7 @@ namespace {
         return Type();
       }
       // Diagnose top-level usages of placeholder types.
-      if (isa<TopLevelCodeDecl>(CS.DC) && isa<PlaceholderTypeRepr>(repr)) {
+      if (isa<PlaceholderTypeRepr>(repr->getWithoutParens())) {
         CS.getASTContext().Diags.diagnose(repr->getLoc(),
                                           diag::placeholder_type_not_allowed);
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2061,15 +2061,9 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
   assert(typeRepr != nullptr && "Should call setSpecifier() on "
          "synthesized parameter declarations");
 
-  auto *nestedRepr = typeRepr;
-
   // Look through parens here; other than parens, specifiers
   // must appear at the top level of a parameter type.
-  while (auto *tupleRepr = dyn_cast<TupleTypeRepr>(nestedRepr)) {
-    if (!tupleRepr->isParenType())
-      break;
-    nestedRepr = tupleRepr->getElementType(0);
-  }
+  auto *nestedRepr = typeRepr->getWithoutParens();
 
   if (auto isolated = dyn_cast<IsolatedTypeRepr>(nestedRepr))
     nestedRepr = isolated->getBase();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2834,15 +2834,9 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
 
     ValueOwnership ownership = ValueOwnership::Default;
 
-    auto *nestedRepr = eltTypeRepr;
-
     // Look through parens here; other than parens, specifiers
     // must appear at the top level of a parameter type.
-    while (auto *tupleRepr = dyn_cast<TupleTypeRepr>(nestedRepr)) {
-      if (!tupleRepr->isParenType())
-        break;
-      nestedRepr = tupleRepr->getElementType(0);
-    }
+    auto *nestedRepr = eltTypeRepr->getWithoutParens();
 
     bool isolated = false;
     bool compileTimeConst = false;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1138,6 +1138,7 @@ func badTypes() {
 func unresolvedTypeExistential() -> Bool {
   return (Int.self==_{})
   // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-2 {{type placeholder not allowed here}}
 }
 
 do {

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -1,7 +1,10 @@
 // RUN: %target-typecheck-verify-swift
 
-let x: _ = 0
+let x: _ = 0 // expected-error {{placeholder type may not appear as type of a variable}} expected-note {{replace the placeholder with the inferred type 'Int'}} {{8-9=Int}}
 let x2 = x
+var x3: _ { // expected-error {{type placeholder not allowed here}}
+  get { 42 }
+}
 let dict1: [_: Int] = ["hi": 0]
 let dict2: [Character: _] = ["h": 0]
 
@@ -112,10 +115,10 @@ let _: () -> Int = { _() } // expected-error 2 {{type placeholder not allowed he
 let _: Int = _.init() // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 let _: () -> Int = { _.init() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 
-func returnsInt() -> Int { _() } // expected-error {{type of expression is ambiguous without more context}}
-func returnsIntClosure() -> () -> Int { { _() } } // expected-error {{unable to infer closure type in the current context}}
-func returnsInt2() -> Int { _.init() }  // expected-error {{could not infer type for placeholder}}
-func returnsIntClosure2() -> () -> Int { { _.init() } } // expected-error {{could not infer type for placeholder}}
+func returnsInt() -> Int { _() } // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
+func returnsIntClosure() -> () -> Int { { _() } } // expected-error 2 {{type placeholder not allowed here}} expected-error {{unable to infer closure type in the current context}}
+func returnsInt2() -> Int { _.init() }  // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
+func returnsIntClosure2() -> () -> Int { { _.init() } } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 
 let _: Int.Type = _ // expected-error {{'_' can only appear in a pattern or on the left side of an assignment}}
 let _: Int.Type = _.self // expected-error {{type placeholder not allowed here}}
@@ -144,13 +147,13 @@ let _ = [_].otherStaticMember.method()
 func f(x: Any, arr: [Int]) {
     // FIXME: Better diagnostics here. Maybe we should suggest replacing placeholders with 'Any'?
 
-    if x is _ {} // expected-error {{type of expression is ambiguous without more context}}
+    if x is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     if x is [_] {} // expected-error {{type of expression is ambiguous without more context}}
     if x is () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = x as? _ {} // expected-error {{type of expression is ambiguous without more context}}
+    if let y = x as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     if let y = x as? [_] {} // expected-error {{type of expression is ambiguous without more context}}
     if let y = x as? () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    let y1 = x as! _ // expected-error {{type of expression is ambiguous without more context}}
+    let y1 = x as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     let y2 = x as! [_] // expected-error {{type of expression is ambiguous without more context}}
     let y3 = x as! () -> _ // expected-error {{type of expression is ambiguous without more context}}
 
@@ -163,13 +166,13 @@ func f(x: Any, arr: [Int]) {
     case let y as () -> _: break // expected-error {{type placeholder not allowed here}}
     }
 
-    if arr is _ {} // expected-error {{type of expression is ambiguous without more context}}
+    if arr is _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     if arr is [_] {} // expected-error {{type of expression is ambiguous without more context}}
     if arr is () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    if let y = arr as? _ {} // expected-error {{type of expression is ambiguous without more context}}
+    if let y = arr as? _ {} // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     if let y = arr as? [_] {} // expected-error {{type of expression is ambiguous without more context}}
     if let y = arr as? () -> _ {} // expected-error {{type of expression is ambiguous without more context}}
-    let y1 = arr as! _ // expected-error {{type of expression is ambiguous without more context}}
+    let y1 = arr as! _ // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
     let y2 = arr as! [_] // expected-error {{type of expression is ambiguous without more context}}
     let y3 = arr as! () -> _ // expected-error {{type of expression is ambiguous without more context}}
 
@@ -208,8 +211,9 @@ let _: SetFailureType<Int, (String, Double)> = Just<Int>().setFailureType(to: (_
 // TODO: Better error message here? Would be nice if we could point to the placeholder...
 let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setFailureType(to: String.self) // expected-error {{type placeholder not allowed here}} expected-error {{generic parameter 'T' could not be inferred}}
 
-let _: (_) = 0 as Int
-let _: Int = 0 as (_)
+let _: (_) = 0 as Int // expected-error {{placeholder type may not appear as type of a variable}} expected-note {{replace the placeholder with the inferred type 'Int'}} {{9-10=Int}}
+let _: Int = 0 as (_) // expected-error {{type placeholder not allowed here}}
+let _: Int = 0 as (((((_))))) // expected-error {{type placeholder not allowed here}}
 
 _ = (1...10)
     .map {
@@ -254,3 +258,11 @@ enum EnumWithPlaceholders {
   // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
 }
 
+func deferredInit(_ c: Bool) {
+  let x: _ // expected-error {{type placeholder not allowed here}}
+  if c {
+    x = "Hello"
+  } else {
+    x = "Goodbye"
+  }
+}


### PR DESCRIPTION
Fix a regression introduced in #39627 where placeholders at the "top level" were mistaken for "placeholders in top level code".

This is done in two ways

- Restore diagnostics for usages of _ in expression position in all decl contexts
- Restore diagnostics for typed patterns and offer a replacement derived from the initializer expression's type if available. 