### PR TITLE
[debug-info] Use llvm.dbg.addr instead of llvm.dbg.declare and add support for working around coroutine issues.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1774,14 +1774,20 @@ public:
   }
 };
 
+struct SILDebugVariable;
+inline llvm::hash_code hash_value(const SILDebugVariable &P);
+
 /// Holds common debug information about local variables and function
 /// arguments that are needed by DebugValueInst, AllocStackInst,
 /// and AllocBoxInst.
 struct SILDebugVariable {
+  friend llvm::hash_code hash_value(const SILDebugVariable &P);
+
   StringRef Name;
   unsigned ArgNo : 16;
   unsigned Constant : 1;
   unsigned Implicit : 1;
+  unsigned isDenseMapSingleton : 2;
   Optional<SILType> Type;
   Optional<SILLocation> Loc;
   const SILDebugScope *Scope;
@@ -1791,17 +1797,28 @@ struct SILDebugVariable {
   SILDebugVariable(const SILDebugVariable &) = default;
   SILDebugVariable &operator=(const SILDebugVariable &) = default;
 
+  enum class IsDenseMapSingleton { No, IsEmpty, IsTombstone };
+  SILDebugVariable(IsDenseMapSingleton inputIsDenseMapSingleton)
+      : SILDebugVariable() {
+    assert(inputIsDenseMapSingleton != IsDenseMapSingleton::No &&
+           "Should only pass IsEmpty or IsTombstone");
+    isDenseMapSingleton = unsigned(inputIsDenseMapSingleton);
+  }
+
   SILDebugVariable()
-      : ArgNo(0), Constant(false), Implicit(false), Scope(nullptr) {}
+      : ArgNo(0), Constant(false), Implicit(false), isDenseMapSingleton(0),
+        Scope(nullptr) {}
   SILDebugVariable(bool Constant, uint16_t ArgNo)
-      : ArgNo(ArgNo), Constant(Constant), Implicit(false), Scope(nullptr) {}
+      : ArgNo(ArgNo), Constant(Constant), Implicit(false),
+        isDenseMapSingleton(0), Scope(nullptr) {}
   SILDebugVariable(StringRef Name, bool Constant, unsigned ArgNo,
                    bool IsImplicit = false, Optional<SILType> AuxType = {},
                    Optional<SILLocation> DeclLoc = {},
                    const SILDebugScope *DeclScope = nullptr,
                    llvm::ArrayRef<SILDIExprElement> ExprElements = {})
       : Name(Name), ArgNo(ArgNo), Constant(Constant), Implicit(IsImplicit),
-        Type(AuxType), Loc(DeclLoc), Scope(DeclScope), DIExpr(ExprElements) {}
+        isDenseMapSingleton(0), Type(AuxType), Loc(DeclLoc), Scope(DeclScope),
+        DIExpr(ExprElements) {}
 
   /// Created from either AllocStack or AllocBox instruction
   static Optional<SILDebugVariable>
@@ -1810,16 +1827,22 @@ struct SILDebugVariable {
   // We're not comparing DIExpr here because strictly speaking,
   // DIExpr is not part of the debug variable. We simply piggyback
   // it in this class so that's it's easier to carry DIExpr around.
-  bool operator==(const SILDebugVariable &V) {
+  bool operator==(const SILDebugVariable &V) const {
     return ArgNo == V.ArgNo && Constant == V.Constant && Name == V.Name &&
            Implicit == V.Implicit && Type == V.Type && Loc == V.Loc &&
-           Scope == V.Scope;
+           Scope == V.Scope && isDenseMapSingleton == V.isDenseMapSingleton;
   }
 
   bool isLet() const { return Name.size() && Constant; }
 
   bool isVar() const { return Name.size() && !Constant; }
 };
+
+/// Returns the hashcode for the new projection path.
+inline llvm::hash_code hash_value(const SILDebugVariable &P) {
+  return llvm::hash_combine(P.ArgNo, P.Constant, P.Name, P.Implicit,
+                            P.isDenseMapSingleton, P.Type, P.Loc, P.Scope);
+}
 
 /// A DebugVariable where storage for the strings has been
 /// tail-allocated following the parent SILInstruction.
@@ -9778,6 +9801,19 @@ public:
 
 private:
   void createNode(const SILInstruction &);
+};
+
+template <>
+struct DenseMapInfo<swift::SILDebugVariable> {
+  using KeyTy = swift::SILDebugVariable;
+  static inline KeyTy getEmptyKey() {
+    return KeyTy(KeyTy::IsDenseMapSingleton::IsEmpty);
+  }
+  static inline KeyTy getTombstoneKey() {
+    return KeyTy(KeyTy::IsDenseMapSingleton::IsTombstone);
+  }
+  static unsigned getHashValue(const KeyTy &Val) { return hash_value(Val); }
+  static bool isEqual(const KeyTy &LHS, const KeyTy &RHS) { return LHS == RHS; }
 };
 
 } // end llvm namespace

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -72,8 +72,10 @@ public:
       return line == rhs.line && column == rhs.column &&
              filename.equals(rhs.filename);
     }
+
     void dump() const;
     void print(raw_ostream &OS) const;
+    friend llvm::hash_code hash_value(const FilenameAndLocation &);
   };
 
 protected:
@@ -431,7 +433,18 @@ public:
   }
 
   inline bool operator!=(const SILLocation &R) const { return !(*this == R); }
+
+  friend llvm::hash_code hash_value(const SILLocation &);
 };
+
+inline llvm::hash_code hash_value(const SILLocation &R) {
+  return llvm::hash_combine(R.kindAndFlags.packedKindAndFlags,
+                            *R.storage.filePositionLoc);
+}
+
+inline llvm::hash_code hash_value(const SILLocation::FilenameAndLocation &R) {
+  return llvm::hash_combine(R.line, R.column, R.filename);
+}
 
 /// Allowed on any instruction.
 class RegularLocation : public SILLocation {

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -434,6 +434,8 @@ PASS(MoveKillsCopyableAddressesChecker, "sil-move-kills-copyable-addresses-check
 PASS(MoveFunctionCanonicalization, "sil-move-function-canon",
      "Pass that canonicalizes certain parts of the IR before we perform move "
      "function checking.")
+PASS(DebugInfoCanonicalizer, "sil-onone-debuginfo-canonicalizer",
+     "Canonicalize debug info at -Onone by propagating debug info into coroutine funclets")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5252,8 +5252,9 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
     return;
 
   VarDecl *Decl = i->getDecl();
-  // Describe the underlying alloca. This way an llvm.dbg.declare instrinsic
-  // is used, which is valid for the entire lifetime of the alloca.
+  // Describe the underlying alloca. This way an llvm.dbg.addr instrinsic is
+  // used, which assuming we do not invalidate it due to a move function is
+  // valid for the entire lifetime of the alloca.
   if (auto *BitCast = dyn_cast<llvm::BitCastInst>(addr)) {
     auto *Op0 = BitCast->getOperand(0);
     if (auto *Alloca = dyn_cast<llvm::AllocaInst>(Op0))

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(swiftSILOptimizer PRIVATE
   CapturePromotion.cpp
   ClosureLifetimeFixup.cpp
   ConstantPropagation.cpp
+  DebugInfoCanonicalizer.cpp
   DefiniteInitialization.cpp
   DIMemoryUseCollector.cpp
   DataflowDiagnostics.cpp

--- a/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
+++ b/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
@@ -1,0 +1,290 @@
+//===--- DebugInfoCanonicalizer.cpp ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file contains transformations that propagate debug info at the SIL
+/// level to make IRGen's job easier. The specific transformations that we
+/// perform is that we clone dominating debug_value for a specific
+/// SILDebugVariable after all coroutine-func-let boundary instructions. This in
+/// practice this as an algorithm works as follows:
+///
+/// 1. We walk the CFG along successors. By doing this we guarantee that we
+/// visit
+///    blocks after their dominators.
+///
+/// 2. When we visit a block, we walk the block from start->end. During this
+/// walk:
+///
+///    a. We grab a new block state from the centralized block->blockState map.
+///    This
+///       state is a [SILDebugVariable : DebugValueInst].
+///
+///    b. If we see a debug_value, we map blockState[debug_value.getDbgVar()] =
+///       debug_value. This ensures that when we get to the bottom of the block,
+///       we have pairs of SILDebugVariable + last debug_value on it.
+///
+///    c. If we see any coroutine funclet boundaries, we clone the current
+///    tracked
+///       set of our block state and then walk up the dom tree dumping in each
+///       block any debug_value with a SILDebugVariable that we have not already
+///       dumped. This is maintained by using a visited set of SILDebugVariable
+///       for each funclet boundary.
+///
+/// The end result is that at the beginning of each funclet we will basically
+/// declare the debug info for an addr.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-onone-debuginfo-canonicalizer"
+
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/FrozenMultiMap.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallSet.h"
+
+using namespace swift;
+
+namespace {
+
+struct BlockState {
+  llvm::SmallMapVector<SILDebugVariable, DebugValueInst *, 4> debugValues;
+};
+
+struct DebugInfoCanonicalizer {
+  SILFunction *fn;
+  DominanceAnalysis *da;
+  DominanceInfo *dt;
+  llvm::MapVector<SILBasicBlock *, BlockState> blockToBlockState;
+
+  DebugInfoCanonicalizer(SILFunction *fn, DominanceAnalysis *da)
+      : fn(fn), da(da), dt(nullptr) {}
+
+  // We only need the dominance info if we actually see a funclet boundary. So
+  // make this lazy so we only create the dom tree in functions that actually
+  // use coroutines.
+  DominanceInfo *getDominance() {
+    if (!dt)
+      dt = da->get(fn);
+    return dt;
+  }
+
+  bool process();
+
+  /// NOTE: insertPt->getParent() may not equal startBlock! This is b/c if we
+  /// are propagating from a yield, we want to begin in the yields block, not
+  /// the yield's insertion point successor block.
+  bool
+  propagateDebugValue(SILInstruction *insertPt, SILBasicBlock *startBlock,
+                      llvm::SmallDenseSet<SILDebugVariable, 8> &seenDebugVars) {
+    LLVM_DEBUG(llvm::dbgs() << "==> PROPAGATING VALUE\n");
+    LLVM_DEBUG(llvm::dbgs() << "Inst: " << *insertPt);
+
+    auto *dt = getDominance();
+    auto *domTreeNode = dt->getNode(startBlock);
+    auto *rootNode = dt->getRootNode();
+    if (domTreeNode == rootNode) {
+      LLVM_DEBUG(llvm::dbgs() << "Root node! Nothing to propagate!\n");
+      return false;
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Root Node: " << rootNode->getBlock()->getDebugID() << '\n');
+
+    // We already emitted in our caller all debug_value needed from the block we
+    // were processing. We just need to walk up the dominator tree until we
+    // process the root node.
+    bool madeChange = false;
+    do {
+      domTreeNode = domTreeNode->getIDom();
+      LLVM_DEBUG(llvm::dbgs() << "Visiting idom: "
+                              << domTreeNode->getBlock()->getDebugID() << '\n');
+      auto &domBlockState = blockToBlockState[domTreeNode->getBlock()];
+      for (auto &pred : domBlockState.debugValues) {
+        // If we see a nullptr, we had a SILUndef. Do not clone, but mark this
+        // as a debug var we have seen so if it is again defined in previous
+        // blocks, we don't clone.
+        if (!pred.second) {
+          seenDebugVars.insert(pred.first);
+          continue;
+        }
+
+        LLVM_DEBUG(llvm::dbgs() << "Has DebugValue: " << *pred.second);
+
+        // If we have already inserted something for this debug_value,
+        // continue.
+        if (!seenDebugVars.insert(pred.first).second) {
+          LLVM_DEBUG(llvm::dbgs() << "Already seen this one... skipping!\n");
+          continue;
+        }
+
+        // Otherwise do the clone.
+        LLVM_DEBUG(llvm::dbgs() << "Haven't seen this one... cloning!\n");
+        pred.second->clone(&*std::next(insertPt->getIterator()));
+        madeChange = true;
+      }
+    } while (domTreeNode != rootNode);
+
+    return madeChange;
+  }
+};
+
+} // namespace
+
+bool DebugInfoCanonicalizer::process() {
+  bool madeChange = false;
+
+  // We walk along successor edges depth first. This guarantees that we will
+  // visit any dominator of a specific block before we visit that block since
+  // any path to the block along successors by definition of dominators we must
+  // go through all such dominators.
+  BasicBlockWorklist worklist(&*fn->begin());
+  llvm::SmallDenseSet<SILDebugVariable, 8> seenDebugVars;
+
+  while (auto *block = worklist.pop()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "BB: Visiting. bb" << block->getDebugID() << '\n');
+    auto &state = blockToBlockState[block];
+
+    // Then for each inst in the block...
+    for (auto &inst : *block) {
+      LLVM_DEBUG(llvm::dbgs() << "    Inst: " << inst);
+      // If we have a debug_value, store state for it.
+      if (auto *dvi = dyn_cast<DebugValueInst>(&inst)) {
+        LLVM_DEBUG(llvm::dbgs() << "        Found DebugValueInst!\n");
+        auto debugInfo = dvi->getVarInfo();
+        if (!debugInfo) {
+          LLVM_DEBUG(llvm::dbgs() << "        Has no var info?! Skipping!\n");
+          continue;
+        }
+
+        // If we have a SILUndef, mark this debug info as being mapped to
+        // nullptr.
+        if (isa<SILUndef>(dvi->getOperand())) {
+          LLVM_DEBUG(llvm::dbgs() << "        SILUndef.\n");
+          auto iter = state.debugValues.insert({*debugInfo, nullptr});
+          if (!iter.second)
+            iter.first->second = nullptr;
+          continue;
+        }
+
+        // Otherwise, we may have a new debug_value to track. Try to begin
+        // tracking it...
+        auto iter = state.debugValues.insert({*debugInfo, dvi});
+
+        // If we already have one, we failed to insert... So update the iter
+        // by hand. We track the last instance always.
+        if (!iter.second) {
+          iter.first->second = dvi;
+        }
+        LLVM_DEBUG(llvm::dbgs() << "        ==> Updated Map.\n");
+        continue;
+      }
+
+      // Otherwise, check if we have a begin_apply or a yield walk up the idom
+      // tree dumping each seen debug_value once.
+      if (isa<BeginApplyInst>(&inst) || isa<EndApplyInst>(&inst) ||
+          isa<AbortApplyInst>(&inst)) {
+        LLVM_DEBUG(llvm::dbgs() << "        Found apply edge!.\n");
+        // Clone all of the debug_values that we are currently tracking both
+        // after the begin_apply,
+        SWIFT_DEFER { seenDebugVars.clear(); };
+
+        for (auto &pred : state.debugValues) {
+          // If we found a SILUndef, mark this debug var as seen but do not
+          // clone.
+          if (!pred.second) {
+            seenDebugVars.insert(pred.first);
+            continue;
+          }
+
+          pred.second->clone(&*std::next(inst.getIterator()));
+          // Inside our block, we know that we do not have any repeats since we
+          // always track the last debug var.
+          seenDebugVars.insert(pred.first);
+          madeChange = true;
+        }
+
+        // Then walk up the idoms until we reach the entry searching for
+        // seenDebugVars.
+        madeChange |=
+            propagateDebugValue(&inst, inst.getParent(), seenDebugVars);
+        continue;
+      }
+
+      if (auto *yi = dyn_cast<YieldInst>(&inst)) {
+        LLVM_DEBUG(llvm::dbgs() << "    Found Yield: " << *yi);
+
+        SWIFT_DEFER { seenDebugVars.clear(); };
+
+        // Duplicate all of our tracked debug values into our successor
+        // blocks.
+        for (auto *succBlock : yi->getSuccessorBlocks()) {
+          auto *inst = &*succBlock->begin();
+
+          LLVM_DEBUG(llvm::dbgs() << "        Visiting Succ: bb"
+                                  << succBlock->getDebugID() << '\n');
+          for (auto &pred : state.debugValues) {
+            if (!pred.second)
+              continue;
+            LLVM_DEBUG(llvm::dbgs() << "            Cloning: " << *pred.second);
+            pred.second->clone(inst);
+            madeChange = true;
+          }
+
+          // We start out dataflow in yi, not in inst, even though we use inst
+          // as the insert pt. This is b/c inst is in the successor block we
+          // haven't processed yet so we would emit any debug_value in the
+          // yields own block twice.
+          madeChange |=
+              propagateDebugValue(inst, yi->getParent(), seenDebugVars);
+        }
+      }
+    }
+
+    // Now add the block's successor to the worklist if we haven't visited them
+    // yet.
+    for (auto *succBlock : block->getSuccessorBlocks())
+      worklist.pushIfNotVisited(succBlock);
+  }
+
+  return madeChange;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class DebugInfoCanonicalizerTransform : public SILFunctionTransform {
+  void run() override {
+    DebugInfoCanonicalizer canonicalizer(getFunction(),
+                                         getAnalysis<DominanceAnalysis>());
+    if (canonicalizer.process()) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createDebugInfoCanonicalizer() {
+  return new DebugInfoCanonicalizerTransform();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -19,11 +19,12 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/SILOptions.h"
 #define DEBUG_TYPE "sil-passpipeline-plan"
+
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -919,6 +920,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");
   P.addSerializeSILPass();
+
+  // Fix up debug info by propagating dbg_values.
+  P.addDebugInfoCanonicalizer();
 
   // Now strip any transparent functions that still have ownership.
   P.addOwnershipModelEliminator();

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -334,15 +334,15 @@ func customFactoryMethodsInherited() {
 
 // CHECK-LABEL: define hidden swiftcc void @"$s7objc_ir30testCompatibilityAliasMangling3objySo13SwiftNameTestC_tF"
 func testCompatibilityAliasMangling(obj: SwiftNameAlias) {
-  // CHECK: call void @llvm.dbg.declare(metadata %TSo13SwiftNameTestC** {{%.+}}, metadata ![[SWIFT_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
+  // CHECK: call void @llvm.dbg.addr(metadata %TSo13SwiftNameTestC** {{%.+}}, metadata ![[SWIFT_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
 }
 
 func testGenericCompatibilityAliasMangling(generic_obj: SwiftGenericNameAlias<NSNumber>) {
-  // CHECK: call void @llvm.dbg.declare(metadata %TSo20SwiftGenericNameTestCySo8NSNumberCG** {{%.+}}, metadata ![[SWIFT_GENERIC_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
+  // CHECK: call void @llvm.dbg.addr(metadata %TSo20SwiftGenericNameTestCySo8NSNumberCG** {{%.+}}, metadata ![[SWIFT_GENERIC_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
 }
 
 func testConstrGenericCompatibilityAliasMangling(constr_generic_obj: SwiftConstrGenericNameAlias<NSNumber>) {
-  // CHECK: call void @llvm.dbg.declare(metadata %TSo26SwiftConstrGenericNameTestCySo8NSNumberCG** {{%.+}}, metadata ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
+  // CHECK: call void @llvm.dbg.addr(metadata %TSo26SwiftConstrGenericNameTestCySo8NSNumberCG** {{%.+}}, metadata ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
 }
 
 // CHECK-LABEL: s7objc_ir22testBlocksWithGenerics3hbaypSo13HasBlockArrayC_tF

--- a/test/DebugInfo/ErrorVar.swift
+++ b/test/DebugInfo/ErrorVar.swift
@@ -15,8 +15,8 @@ func simple(_ placeholder: Int64) throws -> () {
   // CHECK-SAME: i64
   // CHECK-SAME: %swift.refcounted* {{.*}}swiftself
   // CHECK-SAME: %swift.error** noalias nocapture dereferenceable(4)
-  // CHECK: call void @llvm.dbg.declare
-  // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata !DIExpression(DW_OP_deref))
+  // CHECK: call void @llvm.dbg.addr
+  // CHECK: call void @llvm.dbg.addr({{.*}}, metadata ![[ERROR:[0-9]+]], metadata !DIExpression(DW_OP_deref))
   // CHECK-DAG: ![[ERRTY:.*]] = !DICompositeType({{.*}}identifier: "$ss5Error_pD"
   // CHECK-DAG: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2, {{.*}}, type: ![[ERRTY]], flags: DIFlagArtificial)
   throw MyError.Simple

--- a/test/DebugInfo/LoadableByAddress.swift
+++ b/test/DebugInfo/LoadableByAddress.swift
@@ -12,7 +12,7 @@ public struct Continuation<A> {
 public typealias ContinuationU = Continuation<()>
 
 // CHECK: %2 = alloca %T1A12ContinuationV, align 8
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata %T1A12ContinuationV* %2,
+// CHECK-NEXT: call void @llvm.dbg.addr(metadata %T1A12ContinuationV* %2,
 // CHECK-SAME:    metadata ![[X:.*]], metadata !DIExpression())
 // CHECK: ![[X]] = !DILocalVariable(name: "x",
 

--- a/test/DebugInfo/ProtocolContainer.swift
+++ b/test/DebugInfo/ProtocolContainer.swift
@@ -14,7 +14,7 @@ class AClass : AProtocol {
 // CHECK: define hidden {{.*}}void @"$s17ProtocolContainer3foo{{[_0-9a-zA-Z]*}}F"
 // CHECK-NEXT: entry:
 // CHECK:      %[[X:.*]] = alloca %T17ProtocolContainer9AProtocolP, align {{(4|8)}}
-// CHECK:      call void @llvm.dbg.declare(metadata %T17ProtocolContainer9AProtocolP* %[[X]], metadata ![[XMD:.*]], metadata !DIExpression())
+// CHECK:      call void @llvm.dbg.addr(metadata %T17ProtocolContainer9AProtocolP* %[[X]], metadata ![[XMD:.*]], metadata !DIExpression())
 // CHECK-NOT: !DILocalVariable({{.*}} name: "x"
 // CHECK-NOT: !DILocalVariable({{.*}} name: "x"
 func foo (_ x : AProtocol) {

--- a/test/DebugInfo/any.swift
+++ b/test/DebugInfo/any.swift
@@ -3,7 +3,7 @@
 func markUsed<T>(_ t: T) {}
 
 func main() {
-  // CHECK: call void @llvm.dbg.declare(metadata %Any* {{.*}}, metadata ![[S:.*]], metadata !DIExpression()), !dbg ![[DBG:.*]]
+  // CHECK: call void @llvm.dbg.addr(metadata %Any* {{.*}}, metadata ![[S:.*]], metadata !DIExpression()), !dbg ![[DBG:.*]]
   // CHECK: ![[S]] = !DILocalVariable(name: "s", {{.*}}line: [[@LINE+2]]
   // CHECK: ![[DBG]] = !DILocation(line: [[@LINE+1]], column: 7,
   var s: Any = "hello world"

--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -10,18 +10,18 @@ func withGenericArg<T>(_ msg: T) async {
   // This odd debug info is part of a contract with CoroSplit/CoroFrame to fix
   // this up after coroutine splitting.
   // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalF"(%swift.context* swiftasync %0
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.context* %0
   // CHECK-SAME:   metadata ![[MSG:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, {{.*}}DW_OP_deref))
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.context* %0
   // CHECK-SAME:   metadata ![[TAU:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst,
 
   await forceSplit()
   // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalFTQ0_"(i8* swiftasync %0)
-  // CHECK: call void @llvm.dbg.declare(metadata i8* %0,
+  // CHECK: call void @llvm.dbg.addr(metadata i8* %0,
   // CHECK-SAME:   metadata ![[MSG_R:[0-9]+]], metadata !DIExpression(
   // CHECK-SAME:     DW_OP_plus_uconst, [[OFFSET:[0-9]+]],
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_deref))
-  // CHECK: call void @llvm.dbg.declare(metadata i8* %0,
+  // CHECK: call void @llvm.dbg.addr(metadata i8* %0,
   // CHECK-SAME:   metadata ![[TAU_R:[0-9]+]], metadata !DIExpression(DW_OP_deref,
   // CHECK-SAME:     DW_OP_plus_uconst, [[OFFSET]],
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}))

--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -9,11 +9,11 @@
 // argument.
 
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.0"
-// CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK: call void @llvm.dbg.addr
+// CHECK: call void @llvm.dbg.addr
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.1"
-// FIXME: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// FIXME: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP
 
 // CHECK: ![[X0]] = !DILocalVariable(name: "x"
 // FIXME: ![[X1]] = !DILocalVariable(name: "x"

--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -11,7 +11,7 @@ public func getVegetables() async -> [String] {
 public func chopVegetables() async throws -> [String] {
   let veggies = await getVegetables()
   // CHECK-NOT: {{^define }}
-  // CHECK:  call void @llvm.dbg.declare(metadata i8* %0, metadata ![[V:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_plus_uconst, {{[0-9]+}})
+  // CHECK:  call void @llvm.dbg.addr(metadata i8* %0, metadata ![[V:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_plus_uconst, {{[0-9]+}})
   // CHECK: ![[V]] = !DILocalVariable(name: "veggies"
   return veggies.map { "chopped \($0)" }
 }

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -8,10 +8,10 @@
 
 // CHECK-LABEL: define {{.*}} void @"$s1a4fiboyS2iYaFTY0_"
 // CHECK-NEXT: entryresume.0:
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NOT: {{ ret }}
 // CHECK: call void asm sideeffect ""
 // CHECK: ![[N]] = !DILocalVariable(name: "n"

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -16,7 +16,7 @@ public func makeDinner() async throws -> String {
 // CHECK-LABEL: define {{.*}} void @"$s1a10makeDinnerSSyYaKFTQ0_"
 // CHECK-NEXT: entryresume.0:
 // CHECK-NOT: {{ ret }}
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}})
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}%0, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}})
 // CHECK: ![[LOCAL]] = !DILocalVariable(name: "local"
   return local
 }

--- a/test/DebugInfo/autoclosure.swift
+++ b/test/DebugInfo/autoclosure.swift
@@ -2,7 +2,7 @@
 
 // CHECK: define{{.*}}@"$s11autoclosure7call_meyys5Int64VF"
 // CHECK-NOT: ret void
-// CHECK: call void @llvm.dbg.declare{{.*}}, !dbg
+// CHECK: call void @llvm.dbg.addr{{.*}}, !dbg
 // CHECK-NOT: ret void
 // CHECK: _value {{.*}}, !dbg ![[DBG:.*]]
 // CHECK: ret void

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -48,8 +48,8 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
      // CHECK-DAG: store i64 %1, i64* [[BADDR:.*]], align
      // CHECK-DAG: [[AVAL:%.*]] = getelementptr inbounds {{.*}}, [[AMEM:.*]], i32 0, i32 0
      // CHECK-DAG: [[BVAL:%.*]] = getelementptr inbounds {{.*}}, [[BMEM:.*]], i32 0, i32 0
-     // CHECK-DAG: call void @llvm.dbg.declare(metadata i64* [[AADDR]], metadata ![[AARG:.*]], metadata !DIExpression()), !dbg ![[ALOC]]
-     // CHECK-DAG: call void @llvm.dbg.declare(metadata i64* [[BADDR]], metadata ![[BARG:.*]], metadata !DIExpression())
+     // CHECK-DAG: call void @llvm.dbg.addr(metadata i64* [[AADDR]], metadata ![[AARG:.*]], metadata !DIExpression()), !dbg ![[ALOC]]
+     // CHECK-DAG: call void @llvm.dbg.addr(metadata i64* [[BADDR]], metadata ![[BARG:.*]], metadata !DIExpression())
      // CHECK-DAG: ![[AARG]] = !DILocalVariable(name: "a", arg: 1
      // CHECK-DAG: ![[BARG]] = !DILocalVariable(name: "b", arg: 2
      if b != 0 {

--- a/test/DebugInfo/byref-capture.swift
+++ b/test/DebugInfo/byref-capture.swift
@@ -5,7 +5,7 @@ func makeIncrementor(_ inc : Int64) -> () -> Int64
   var sum : Int64 = 0
   // CHECK: define {{.*}}5inner
   func inner() -> Int64 {
-    // CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V**
+    // CHECK: call void @llvm.dbg.addr(metadata %Ts5Int64V**
     // CHECK-SAME:                        metadata ![[SUM_CAPTURE:[0-9]+]],
     // CHECK-SAME:                        metadata !DIExpression(DW_OP_deref))
     // CHECK: ![[INOUTTY:[0-9]+]] = !DICompositeType({{.*}}identifier: "$ss5Int64VD"

--- a/test/DebugInfo/catch_let.swift
+++ b/test/DebugInfo/catch_let.swift
@@ -15,7 +15,7 @@ public func explicitBinding() {
     try throwing()
   }
   catch let error {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[EXPLICIT_ERROR:[0-9]+]],
+    // CHECK: call void @llvm.dbg.addr(metadata %swift.error** %{{.*}}, metadata ![[EXPLICIT_ERROR:[0-9]+]],
     use(error)
   }
 }
@@ -27,7 +27,7 @@ public func implicitBinding() {
     try throwing()
   }
   catch {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[IMPLICIT_ERROR:[0-9]+]],
+    // CHECK: call void @llvm.dbg.addr(metadata %swift.error** %{{.*}}, metadata ![[IMPLICIT_ERROR:[0-9]+]],
     use(error)
   }
 }
@@ -39,8 +39,8 @@ public func multiBinding() {
     try throwing()
   }
   catch let error as MyError, let error as MyError {
-    // CHECK: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}, metadata ![[MULTI_BINDING_ERROR:[0-9]+]],
-    // CHECK-NOT: call void @llvm.dbg.declare(metadata %swift.error** %{{.*}}
+    // CHECK: call void @llvm.dbg.addr(metadata %swift.error** %{{.*}}, metadata ![[MULTI_BINDING_ERROR:[0-9]+]],
+    // CHECK-NOT: call void @llvm.dbg.addr(metadata %swift.error** %{{.*}}
     use(error)
   } catch {
     use(error)

--- a/test/DebugInfo/closure-args.swift
+++ b/test/DebugInfo/closure-args.swift
@@ -17,7 +17,7 @@ func main() -> Void
     // value to be by-address. When that is fixed, remove the optional
     // DW_OP_deref below.
     //
-    // CHECK-NEXT: call void @llvm.dbg.declare(metadata %TSS** %[[RANDOM_STR_ADDR]], metadata !{{.*}}, metadata !DIExpression({{(DW_OP_deref)?}})), !dbg
+    // CHECK-NEXT: call void @llvm.dbg.addr(metadata %TSS** %[[RANDOM_STR_ADDR]], metadata !{{.*}}, metadata !DIExpression({{(DW_OP_deref)?}})), !dbg
 
     // CHECK: store %TSS* %{{.*}}, %TSS** %[[RANDOM_STR_ADDR]], align {{(4|8)}}
     // CHECK-DAG: !DILocalVariable(name: "lhs",{{.*}} line: [[@LINE+5]],

--- a/test/DebugInfo/dbgvalue-insertpt.swift
+++ b/test/DebugInfo/dbgvalue-insertpt.swift
@@ -3,7 +3,7 @@
 for i in 0 ..< 3 {
   // CHECK: %[[ALLOCA:[0-9]+]] = alloca %TSiSg
   // CHECK: %i.debug = alloca i{{32|64}}
-  // CHECK-NEXT: call void @llvm.dbg.declare(metadata i{{32|64}}* %i.debug,
+  // CHECK-NEXT: call void @llvm.dbg.addr(metadata i{{32|64}}* %i.debug,
   // CHECK-SAME:                           metadata ![[I:[0-9]+]],
   // CHECK: ![[I]] = !DILocalVariable(name: "i",
 }

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -19,9 +19,9 @@ sil hidden @test_fragment : $@convention(thin) () -> () {
 bb0:
   %2 = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":8:9, scope 1
   // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
-  // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
+  // CHECK: llvm.dbg.addr(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
   // CHECK: %[[SMALL_STRUCT:.+]] = alloca %{{.*}}SmallStruct
-  // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[SMALL_STRUCT]], metadata ![[SMALL_VAR_DECL_MD:[0-9]+]]
+  // CHECK: llvm.dbg.addr(metadata {{.*}}* %[[SMALL_STRUCT]], metadata ![[SMALL_VAR_DECL_MD:[0-9]+]]
   %3 = struct_element_addr %2 : $*MyStruct, #MyStruct.x, loc "file.swift":9:17, scope 1
   // CHECK: %[[FIELD_X:.*]] = getelementptr {{.*}} %[[MY_STRUCT]]
   // CHECK-SIL: debug_value %{{[0-9]+}} : $*Builtin.Int64
@@ -54,13 +54,13 @@ sil hidden @test_alloc_stack : $@convention(thin) () -> () {
 bb0:
   %my_struct = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":15:9, scope 2
   // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
-  // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
+  // CHECK: llvm.dbg.addr(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
   // CHECK-SIL: alloc_stack $Int, var
   // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9, scope {{[0-9]+}})
   // CHECK-SIL-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
   %field_x = alloc_stack $Int, var, (name "my_struct", loc "file.swift":15:9, scope 2), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":16:17, scope 2
   // CHECK: %[[FIELD_X:.+]] = alloca %TSi
-  // CHECK: llvm.dbg.declare(metadata %TSi* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
+  // CHECK: llvm.dbg.addr(metadata %TSi* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
   // CHECK-SAME:             !DIExpression(DW_OP_LLVM_fragment, 0, 64)
   dealloc_stack %field_x : $*Int
   dealloc_stack %my_struct: $*MyStruct

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -10,7 +10,7 @@
 // CHECK: define {{.*}}$s16debug_value_addr4testyyxlF
 // CHECK: entry:
 // CHECK-NEXT: %[[TADDR:.*]] = alloca
-// CHECK-NEXT: call void @llvm.dbg.declare({{.*}}%[[TADDR]]
+// CHECK-NEXT: call void @llvm.dbg.addr({{.*}}%[[TADDR]]
 // CHECK: store %swift.opaque* %0, %swift.opaque** %[[TADDR:.*]], align
 
 struct S<T> {

--- a/test/DebugInfo/debug_variable.sil
+++ b/test/DebugInfo/debug_variable.sil
@@ -6,14 +6,14 @@ import Swift
 
 sil_scope 2 { loc "simple.swift":1:2 parent @test_debug_value : $@convention(thin) (Int) -> () }
 
-// SR-14868: Incorrect source location on `llvm.dbg.declare` when the input
+// SR-14868: Incorrect source location on `llvm.dbg.addr` when the input
 // is SIL file.
 
 // CHECK: @test_debug_value
 // CHECK-SAME: !dbg ![[FUNC_DI:[0-9]+]]
 sil hidden @test_debug_value : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
-  // CHECK:      @llvm.dbg.declare(metadata i{{[0-9]+}}*
+  // CHECK:      @llvm.dbg.addr(metadata i{{[0-9]+}}*
   // CHECK-SAME:                   metadata ![[VAR_DI:[0-9]+]]
   // CHECK-SAME:                   ), !dbg ![[LOC_DI:[0-9]+]]
   debug_value %0 : $Int, let, name "x", argno 1, loc "simple.swift":3:4, scope 2

--- a/test/DebugInfo/dynamic_layout.swift
+++ b/test/DebugInfo/dynamic_layout.swift
@@ -10,10 +10,10 @@ class Class <T> {
   // Verify that the mangling of the type U is correct.
   // CHECK: define {{.*}}3foo
   // CHECK: %[[U1:.*]] = alloca %swift.type*
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.type** %[[U1]],
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.type** %[[U1]],
   // CHECK-SAME:                        metadata ![[U:[0-9]+]]
   // CHECK: %[[T2:.*]] = alloca %swift.type*
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.type** %[[T2]],
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.type** %[[T2]],
   // CHECK-SAME:                        metadata ![[T:[0-9]+]]
   // CHECK: ![[U]] = !DILocalVariable(name: "$\CF\84_1_0"
   // CHECK: ![[T]] = !DILocalVariable(name: "$\CF\84_0_0"

--- a/test/DebugInfo/generic_arg.swift
+++ b/test/DebugInfo/generic_arg.swift
@@ -3,10 +3,10 @@ import StdlibUnittest
 func foo<T>(_ x: T) -> () {
   // CHECK: define {{.*}} @"$s11generic_arg3fooyyxlF"
   // CHECK: %[[T:.*]] = alloca %swift.type*
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.type** %[[T]],
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.type** %[[T]],
   // CHECK-SAME:               metadata ![[T1:.*]], metadata !DIExpression())
   // CHECK: %[[X:.*]] = alloca %swift.opaque*
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[X]],
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.opaque** %[[X]],
   // CHECK-SAME: metadata ![[X1:.*]], metadata !DIExpression(DW_OP_deref))
   // CHECK: store %swift.type* %T, %swift.type** %[[T]],
   // CHECK: store %swift.opaque* %0, %swift.opaque** %[[X]],

--- a/test/DebugInfo/generic_arg2.swift
+++ b/test/DebugInfo/generic_arg2.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
 
 // CHECK: define hidden swiftcc void @"$s12generic_arg25ClassC3foo{{.*}}, %swift.type* %U
-// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %y.debug, metadata ![[U:.*]], metadata !DIExpression(DW_OP_deref))
+// CHECK: call void @llvm.dbg.addr(metadata %swift.opaque** %y.debug, metadata ![[U:.*]], metadata !DIExpression(DW_OP_deref))
 // Make sure there is no conflicting dbg.value for this variable.x
 // CHECK-NOT: dbg.value{{.*}}metadata ![[U]]
 class Class <T> {

--- a/test/DebugInfo/generic_arg3.swift
+++ b/test/DebugInfo/generic_arg3.swift
@@ -5,7 +5,7 @@ func apply<Type>(_ T : Type, fn: (Type) -> Type) -> Type { return fn(T) }
 public func f<Type>(_ value : Type)
 {
   // CHECK: define {{.*}}$s12generic_arg31fyyxlFxxXEfU_
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %[[ALLOCA:[^,]+]],
+  // CHECK: call void @llvm.dbg.addr(metadata %swift.opaque** %[[ALLOCA:[^,]+]],
   // CHECK-SAME: metadata ![[ARG:.*]], metadata !DIExpression(DW_OP_deref))
   // CHECK: store %swift.opaque* %1, %swift.opaque** %[[ALLOCA]], align
   // No deref here.

--- a/test/DebugInfo/generic_arg4.swift
+++ b/test/DebugInfo/generic_arg4.swift
@@ -4,8 +4,8 @@ public struct Q<T> {
   let x: T
 }
 // CHECK: define {{.*}}$s12generic_arg43fooyySayAA1QVyxGGlF
-// CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
+// CHECK: call void @llvm.dbg.addr
+// CHECK: call void @llvm.dbg.addr(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
 // CHECK-SAME:       metadata ![[ARG:.*]], metadata !DIExpression())
 // CHECK: store %[[TY]]* %0, %[[TY]]** %[[ALLOCA]], align
 // No deref here: the array argument is passed by value.

--- a/test/DebugInfo/generic_arg5.swift
+++ b/test/DebugInfo/generic_arg5.swift
@@ -7,8 +7,8 @@ public struct S<Type>
 public func foo<Type>(_ values : [S<Type>])
 {
   // CHECK: define {{.*}}$s12generic_arg53fooyySayAA1SVyxGGlFAESgAEXEfU_
-  // CHECK: call void @llvm.dbg.declare
-  // CHECK: call void @llvm.dbg.declare(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
+  // CHECK: call void @llvm.dbg.addr
+  // CHECK: call void @llvm.dbg.addr(metadata %[[TY:.*]]** %[[ALLOCA:[^,]+]],
   // CHECK-SAME:       metadata ![[ARG:[0-9]+]],
   // CHECK-SAME:       metadata !DIExpression(DW_OP_deref))
   // CHECK: store %[[TY]]* %1, %[[TY]]** %[[ALLOCA]], align

--- a/test/DebugInfo/generic_enum_closure.swift
+++ b/test/DebugInfo/generic_enum_closure.swift
@@ -8,9 +8,9 @@ struct CErrorOr<T>
     // CHECK: define hidden {{.*}}void @"$s20generic_enum_closure8CErrorOrV1xACyxGAA14__CurrentErrnoV_tcfC"
     // CHECK-NOT: define
     // This is a SIL-level debug_value_addr instruction.
-    // CHECK: call void @llvm.dbg.declare
+    // CHECK: call void @llvm.dbg.addr
     // Self is in a dynamic alloca, hence the shadow copy.
-    // CHECK: call void @llvm.dbg.declare(
+    // CHECK: call void @llvm.dbg.addr(
     // CHECK-SAME: metadata i8** %[[SHADOW:.*]], metadata ![[SELF:.*]], meta
     // CHECK-SAME: !DIExpression(DW_OP_deref))
     // CHECK-DAG: store i8* %[[DYN:.*]], i8** %[[SHADOW]]

--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -21,11 +21,11 @@ public func f(_ i : Int?)
 {
   // CHECK1-LABEL: define {{.*}}@"$s4main1fyySiSgF"
   // CHECK1: %i.debug = alloca %TSiSg
-  // CHECK1: @llvm.dbg.declare(metadata %TSiSg* %i.debug
+  // CHECK1: @llvm.dbg.addr(metadata %TSiSg* %i.debug
   // CHECK1: %[[BITCAST:.*]] = bitcast %TSiSg* %i.debug to i8*
   // CHECK1: call void @llvm.memset{{.*}}(i8* align {{(4|8)}} %[[BITCAST]],
   // CHECK1-SAME:                         i8 0, i64 {{(5|9)}}, i1 false){{$}}
-  // CHECK1: @llvm.dbg.declare(metadata {{(i32|i64)}}* %val.debug,
+  // CHECK1: @llvm.dbg.addr(metadata {{(i32|i64)}}* %val.debug,
   // CHECK1-SAME:              !dbg ![[DBG0:.*]]
   // CHECK1-LABEL: define {{.*}}@"$s4main1gyySSSgF"
   // CHECK1: ![[F:.*]] = distinct !DISubprogram(name: "f",
@@ -39,9 +39,9 @@ public func g(_ s : String?)
 {
   // CHECK2: define {{.*}}@"$s4main1gyySSSgF"
   // CHECK2: %s.debug = alloca %TSSSg
-  // CHECK2: @llvm.dbg.declare(metadata %TSSSg*
+  // CHECK2: @llvm.dbg.addr(metadata %TSSSg*
   // CHECK2: %val.debug = alloca %TSS
-  // CHECK2: @llvm.dbg.declare(metadata %TSS*
+  // CHECK2: @llvm.dbg.addr(metadata %TSS*
   // CHECK2: %[[BITCAST:.*]] = bitcast %TSS* %val.debug to i8*{{$}}
   // CHECK2: call void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[BITCAST]], i8 0
   // CHECK2: ![[G:.*]] = distinct !DISubprogram(name: "g"
@@ -53,9 +53,9 @@ public func h(_ s : String?)
 {
   // CHECK3: define {{.*}}@"$s4main1hyySSSgF"
   // CHECK3: %s.debug = alloca %TSSSg
-  // CHECK3: @llvm.dbg.declare(metadata %TSSSg*
+  // CHECK3: @llvm.dbg.addr(metadata %TSSSg*
   // CHECK3: %s.debug1 = alloca %TSS
-  // CHECK3: @llvm.dbg.declare(metadata %TSS*
+  // CHECK3: @llvm.dbg.addr(metadata %TSS*
   // CHECK3: %[[BITCAST:.*]] = bitcast %TSS* %s.debug1 to i8*{{$}}
   // CHECK3: call void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[BITCAST]], i8 0
   // CHECK3: ![[G:.*]] = distinct !DISubprogram(name: "h"

--- a/test/DebugInfo/inout.swift
+++ b/test/DebugInfo/inout.swift
@@ -10,12 +10,12 @@ typealias MyFloat = Float
 
 // CHECK: define hidden swiftcc void @"$s5inout13modifyFooHeap{{[_0-9a-zA-Z]*}}F"
 // CHECK: %[[ALLOCA:.*]] = alloca %Ts5Int64V*
-// CHECK: call void @llvm.dbg.declare(metadata
+// CHECK: call void @llvm.dbg.addr(metadata
 // CHECK-SAME:                        %[[ALLOCA]], metadata ![[A:[0-9]+]]
 
 // Closure with promoted capture.
 // PROMO-CHECK: define {{.*}}@"$s5inout13modifyFooHeapyys5Int64Vz_SftFADyXEfU_"
-// PROMO-CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V** %
+// PROMO-CHECK: call void @llvm.dbg.addr(metadata %Ts5Int64V** %
 // PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata !DIExpression(DW_OP_deref))
 
 // PROMO-CHECK: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "$ss5Int64VD"
@@ -36,7 +36,7 @@ func modifyFooHeap(_ a: inout Int64,
 
 // Inout reference type.
 // FOO-CHECK: define {{.*}}@"$s5inout9modifyFooyys5Int64Vz_SftF"
-// FOO-CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V** %
+// FOO-CHECK: call void @llvm.dbg.addr(metadata %Ts5Int64V** %
 // FOO-CHECK-SAME: metadata ![[U:[0-9]+]], metadata !DIExpression(DW_OP_deref))
 func modifyFoo(_ u: inout Int64,
 // FOO-CHECK-DAG: !DILocalVariable(name: "v", arg: 2{{.*}} line: [[@LINE+3]],{{.*}} type: ![[LET_MYFLOAT:[0-9]+]]

--- a/test/DebugInfo/iuo_arg.swift
+++ b/test/DebugInfo/iuo_arg.swift
@@ -17,7 +17,7 @@ class MyClass {
   func filterImage(_ image: UIImage!, _ doSomething:Bool) -> UIImage
 	{
     // Test that image is in an alloca, but not an indirect location.
-    // CHECK: call void @llvm.dbg.declare(metadata {{(i32|i64)}}* %[[ALLOCA:.*]], metadata ![[IMAGE:.*]], metadata !DIExpression())
+    // CHECK: call void @llvm.dbg.addr(metadata {{(i32|i64)}}* %[[ALLOCA:.*]], metadata ![[IMAGE:.*]], metadata !DIExpression())
     // CHECK: store {{(i32|i64)}} %0, {{(i32|i64)}}* %[[ALLOCA]], align
     // CHECK: ![[IMAGE]] = !DILocalVariable(name: "image", arg: 1
     // CHECK-NOT:                           flags:

--- a/test/DebugInfo/let.swift
+++ b/test/DebugInfo/let.swift
@@ -5,7 +5,7 @@ class DeepThought {
 }
 
 func foo() -> Int64 {
-  // CHECK: call void @llvm.dbg.declare(metadata %T3let11DeepThoughtC** {{.*}}, metadata ![[A:.*]], metadata !DIExpression())
+  // CHECK: call void @llvm.dbg.addr(metadata %T3let11DeepThoughtC** {{.*}}, metadata ![[A:.*]], metadata !DIExpression())
   // CHECK-DAG: !DILocalVariable(name: "machine",{{.*}}line: [[@LINE+1]], type: !{{[0-9]+}})
   let machine = DeepThought()
   // CHECK-DAG: !DILocalVariable(name: "a", {{.*}}line: [[@LINE+1]],

--- a/test/DebugInfo/letstring.swift
+++ b/test/DebugInfo/letstring.swift
@@ -13,12 +13,12 @@ class AppDelegate {
   // CHECK: define hidden {{.*}}i1 {{.*}}11AppDelegateC1f
   func f() -> Bool {
     // Test for -O0 shadow copies.
-    // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[SELF:.*]], metadata !DIExpression())
+    // CHECK: call void @llvm.dbg.addr({{.*}}, metadata ![[SELF:.*]], metadata !DIExpression())
     // CHECK-NOT: call void @llvm.dbg.value
-    // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[A:.*]], metadata !DIExpression())
+    // CHECK: call void @llvm.dbg.addr({{.*}}, metadata ![[A:.*]], metadata !DIExpression())
     let a = "let"
     // CHECK-NOT: call void @llvm.dbg.value
-    // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[B:.*]], metadata !DIExpression())
+    // CHECK: call void @llvm.dbg.addr({{.*}}, metadata ![[B:.*]], metadata !DIExpression())
     // CHECK-NOT: call void @llvm.dbg.value
     // CHECK: ret
     // CHECK-DAG: ![[SELF]] = !DILocalVariable(name: "self", arg: 1{{.*}} line: [[@LINE-10]],

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -54,7 +54,7 @@ func foo() {
 
 // func myLoop() {
   // CHECK: define {{.*}} @"$s4main6myLoopyyF"
-  // CHECK: call void @llvm.dbg.declare(metadata i64* %index.debug, {{.*}}), !dbg ![[FORLOOP:[0-9]+]]
+  // CHECK: call void @llvm.dbg.addr(metadata i64* %index.debug, {{.*}}), !dbg ![[FORLOOP:[0-9]+]]
   // CHECK: phi i64 [ %{{.[0-9]+}}, %{{.[0-9]+}} ], !dbg ![[FORLOOP]]
   // CHECK: call {{.*}} @"$s4main8markUsedyyxlF"{{.*}}, !dbg ![[FORBODY:[0-9]+]]
   // CHECK: ret void
@@ -70,7 +70,7 @@ func foo() {
 // func foo()
   // CHECK: define {{.*}} @"$s4main3fooyyF"
   // CHECK: %[[MYARRAY:.*]] = alloca
-  // CHECK: call void @llvm.dbg.declare(metadata %TSa* %[[MYARRAY]],
+  // CHECK: call void @llvm.dbg.addr(metadata %TSa* %[[MYARRAY]],
   // CHECK-SAME: !dbg ![[ARRAY:[0-9]+]]
   // CHECK: call swiftcc { {{.*}} } @"${{.*}}_allocateUninitializedArray{{.*}}"
   // CHECK-SAME: !dbg ![[ARRAY]]

--- a/test/DebugInfo/protocol-extension.swift
+++ b/test/DebugInfo/protocol-extension.swift
@@ -9,7 +9,7 @@ public extension P {
   public func f() -> Int32 {
     // CHECK-NEXT: entry:
     // CHECK-NEXT: %[[ALLOCA:.*]] = alloca %swift.type*,
-    // CHECK-NEXT: @llvm.dbg.declare(metadata %swift.type** %[[ALLOCA]],
+    // CHECK-NEXT: @llvm.dbg.addr(metadata %swift.type** %[[ALLOCA]],
     // CHECK-SAME:    metadata ![[SELFMETA:.*]], metadata !DIExpression())
     return v
   }

--- a/test/DebugInfo/protocol.swift
+++ b/test/DebugInfo/protocol.swift
@@ -23,7 +23,7 @@ class Point : PointUtils {
 func main() -> Int64 {
     var pt = Point(_x: 2.5, _y: 4.25)
 // CHECK: [[LOC2D:%[a-zA-Z0-9]+]] = alloca %T8protocol10PointUtilsP, align {{(4|8)}}
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}} [[LOC2D]], metadata ![[LOC:.*]], metadata !DIExpression())
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}} [[LOC2D]], metadata ![[LOC:.*]], metadata !DIExpression())
     var loc2d : PointUtils = pt
     var distance = loc2d.distanceFromOrigin()
 

--- a/test/DebugInfo/protocolarg.swift
+++ b/test/DebugInfo/protocolarg.swift
@@ -8,10 +8,10 @@ public protocol IGiveOutInts {
 }
 
 // CHECK: define {{.*}}@"$s11protocolarg16printSomeNumbersyyAA12IGiveOutInts_pF"
-// CHECK: @llvm.dbg.declare(metadata %T11protocolarg12IGiveOutIntsP** %
+// CHECK: @llvm.dbg.addr(metadata %T11protocolarg12IGiveOutIntsP** %
 // CHECK-SAME:              metadata ![[ARG:[0-9]+]],
 // CHECK-SAME:              metadata !DIExpression(DW_OP_deref))
-// CHECK: @llvm.dbg.declare(metadata %T11protocolarg12IGiveOutIntsP* %
+// CHECK: @llvm.dbg.addr(metadata %T11protocolarg12IGiveOutIntsP* %
 // CHECK-SAME:              metadata ![[VAR:.*]], metadata !DIExpression())
 
 public func printSomeNumbers(_ gen: IGiveOutInts) {

--- a/test/DebugInfo/self.swift
+++ b/test/DebugInfo/self.swift
@@ -18,7 +18,7 @@ public func f() {
 // CHECK: define {{.*}} @"$s4self11stuffStructVACycfC"(
 // CHECK-NEXT: entry:
 // CHECK: %[[ALLOCA:.*]] = alloca %T4self11stuffStructV, align {{(4|8)}}
-// CHECK: call void @llvm.dbg.declare(metadata %T4self11stuffStructV* %[[ALLOCA]],
+// CHECK: call void @llvm.dbg.addr(metadata %T4self11stuffStructV* %[[ALLOCA]],
 // CHECK-SAME: metadata ![[SELF:.*]], metadata !DIExpression()), !dbg
 // CHECK: ![[STUFFSTRUCT:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "stuffStruct", scope:{{.*}}identifier
 // CHECK: ![[SELF]] = !DILocalVariable(name: "self", scope

--- a/test/DebugInfo/shadowcopy-linetable.swift
+++ b/test/DebugInfo/shadowcopy-linetable.swift
@@ -7,7 +7,7 @@ func foo(_ x: inout Int64) {
   // line 0), but the code to load the value from the inout storage is
   // not.
   // CHECK: %[[X:.*]] = alloca %Ts5Int64V*, align {{(4|8)}}
-  // CHECK-NEXT: call void @llvm.dbg.declare
+  // CHECK-NEXT: call void @llvm.dbg.addr
   // CHECK-NEXT: %[[ZEROED:[0-9]+]] = bitcast %Ts5Int64V** %[[X]] to i8*{{$}}
   // CHECK-NEXT: call void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[ZEROED]], i8 0
   // CHECK: store %Ts5Int64V* %0, %Ts5Int64V** %[[X]], align {{(4|8)}}

--- a/test/DebugInfo/struct_resilience.swift
+++ b/test/DebugInfo/struct_resilience.swift
@@ -22,7 +22,7 @@ func f() {
   let s1 = Size(w: 1, h: 2)
   takesSize(s1)
   // CHECK: %[[ADDR:.*]] = alloca i8*
-  // CHECK: call void @llvm.dbg.declare(metadata i8** %[[ADDR]],
+  // CHECK: call void @llvm.dbg.addr(metadata i8** %[[ADDR]],
   // CHECK-SAME:                        metadata ![[V1:[0-9]+]],
   // CHECK-SAME:                        metadata !DIExpression(DW_OP_deref))
   // CHECK: %[[S1:.*]] = alloca i8,

--- a/test/DebugInfo/structs.swift
+++ b/test/DebugInfo/structs.swift
@@ -12,7 +12,7 @@ func test(_ x : A) {
 }
 // CHECK:    define hidden {{.*}}void @"$s7structs4test{{[_0-9a-zA-Z]*}}F"
 // CHECK: [[X_DBG:%.*]] = alloca
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}* [[X_DBG]], metadata [[X_MD:!.*]], metadata
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}* [[X_DBG]], metadata [[X_MD:!.*]], metadata
 // CHECK: ![[A:.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "A",
 // CHECK-SAME:                         identifier
 

--- a/test/DebugInfo/typearg.swift
+++ b/test/DebugInfo/typearg.swift
@@ -8,7 +8,7 @@ class AClass : AProtocol {
 }
 
 // CHECK: define hidden {{.*}}void @{{.*}}aFunction
-// CHECK:  call void @llvm.dbg.declare(metadata %swift.type** %{{.*}}, metadata ![[TYPEARG:.*]], metadata !DIExpression()),
+// CHECK:  call void @llvm.dbg.addr(metadata %swift.type** %{{.*}}, metadata ![[TYPEARG:.*]], metadata !DIExpression()),
 // CHECK: ![[TYPEARG]] = !DILocalVariable(name: "$\CF\84_0_0"
 // CHECK-SAME:                            type: ![[SWIFTMETATYPE:[^,)]+]]
 // CHECK-SAME:                            flags: DIFlagArtificial

--- a/test/DebugInfo/uninitialized.swift
+++ b/test/DebugInfo/uninitialized.swift
@@ -7,7 +7,7 @@ class MyClass {}
 public func f() {
   var object: MyClass
   // CHECK: %[[OBJ:.*]] = alloca %[[T1:.*]]*, align
-  // CHECK: call void @llvm.dbg.declare(metadata %[[T1]]** %[[OBJ]],
+  // CHECK: call void @llvm.dbg.addr(metadata %[[T1]]** %[[OBJ]],
   // CHECK: %[[BC1:.*]] = bitcast %[[T1]]** %[[OBJ]] to i8*{{$}}
   // CHECK: void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[BC1]], i8 0,
   // CHECK-SAME:                    ){{$}}
@@ -20,7 +20,7 @@ public func f() {
 public func g() {
   var dict: Dictionary<Int64, Int64>
   // CHECK: %[[DICT:.*]] = alloca %[[T2:.*]], align
-  // CHECK: call void @llvm.dbg.declare(metadata %[[T2]]* %[[DICT]],
+  // CHECK: call void @llvm.dbg.addr(metadata %[[T2]]* %[[DICT]],
   // CHECK: %[[BC2:.*]] = bitcast %[[T2]]* %[[DICT]] to i8*
   // CHECK: void @llvm.memset.{{.*}}(i8* align {{(4|8)}} %[[BC2]], i8 0,
   // CHECK-SAME:                    ){{$}}

--- a/test/DebugInfo/variables.swift
+++ b/test/DebugInfo/variables.swift
@@ -46,7 +46,7 @@ var unused: Int32 = -1
 
 // Stack variables.
 func foo(_ dt: Float) -> Float {
-  // CHECK-DAG: call void @llvm.dbg.declare
+  // CHECK-DAG: call void @llvm.dbg.addr
   // CHECK-DAG: !DILocalVariable(name: "f"
   let f: Float = 9.78
 

--- a/test/DebugInfo/weak-self-capture.swift
+++ b/test/DebugInfo/weak-self-capture.swift
@@ -16,4 +16,4 @@ public class ClosureMaker {
 }
 
 // CHECK: define {{.*}} @"$s4main12ClosureMakerC03getB0SiycyFSiycfU_"
-// CHECK: call void @llvm.dbg.declare(metadata %swift.weak** %{{.*}} !DIExpression(DW_OP_deref)),
+// CHECK: call void @llvm.dbg.addr(metadata %swift.weak** %{{.*}} !DIExpression(DW_OP_deref)),

--- a/test/SILOptimizer/debuginfo-canonicalizer.sil
+++ b/test/SILOptimizer/debuginfo-canonicalizer.sil
@@ -1,0 +1,143 @@
+// RUN: %target-sil-opt -sil-onone-debuginfo-canonicalizer -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+struct Int64 {
+  var value: Builtin.Int64
+}
+
+class Klass {
+  var value: Int64
+}
+
+// Since we only take the last debug_value associated with a SILDebugVariable,
+// we only should see someVar for debug_value %2.
+//
+// CHECK-LABEL: sil @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64 {
+// CHECK: bb0([[ARG:%.*]] : $Klass):
+// CHECK-NEXT: debug_value [[ARG]] : $Klass, let, name "someVar"
+// CHECK-NEXT: debug_value [[ARG]] : $Klass, let, name "otherName"
+// CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[ARG]] : $Klass
+// CHECK-NEXT: debug_value [[ADDR]] : $*Int64, let, name "someVar"
+// CHECK-NEXT: yield [[ADDR]] : $*Int64, resume bb1, unwind bb2
+//
+// CHECK: bb1:
+// CHECK-NEXT: debug_value [[ADDR]] : $*Int64, let, name "someVar"
+// CHECK-NEXT: debug_value [[ARG]] : $Klass, let, name "otherName"
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+//
+// CHECK: bb2:
+// CHECK-NEXT: debug_value [[ADDR]] : $*Int64, let, name "someVar"
+// CHECK-NEXT: debug_value [[ARG]] : $Klass, let, name "otherName"
+// CHECK-NEXT: unwind
+// CHECK: } // end sil function 'yieldOnceCoroutine'
+sil @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64 {
+bb0(%0 : $Klass):
+  debug_value %0 : $Klass, let, name "someVar"
+  debug_value %0 : $Klass, let, name "otherName"  
+  %1 = ref_element_addr %0 : $Klass, #Klass.value
+  debug_value %1 : $*Int64, let, name "someVar"
+  yield %1 : $*Int64, resume bb1, unwind bb2
+
+bb1:
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil @testSimple : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT:   debug_value [[ARG]]
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [[ARG]]
+// CHECK: } // end sil function 'testSimple'
+sil @testSimple : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %4) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  %9999 = tuple()
+  end_apply %4
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @testDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK:   cond_br undef, bb1, bb2
+//
+// CHECK: bb1:
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [[ARG]]
+// CHECK:   br bb3
+//
+// CHECK: bb2:
+// CHECK:   abort_apply
+// CHECK-NEXT:   debug_value [[ARG]]
+// CHECK: } // end sil function 'testDiamond'
+sil @testDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %token) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_apply %token
+  br bb3
+
+bb2:
+  abort_apply %token
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @testUndefDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK:   cond_br undef, bb1, bb2
+//
+// CHECK: bb1:
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [[ARG]]
+// CHECK:   br bb3
+//
+// CHECK: bb2:
+// CHECK-NEXT:   debug_value undef
+// CHECK-NEXT:   abort_apply
+// CHECK-NEXT:   br bb3
+// CHECK: } // end sil function 'testUndefDiamond'
+sil @testUndefDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %token) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_apply %token
+  br bb3
+
+bb2:
+  debug_value undef : $Klass, let, name "arg"
+  abort_apply %token
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/debuginfo_canonicalizer.sil
+++ b/test/SILOptimizer/debuginfo_canonicalizer.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-onone-debuginfo-canonicalizer -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -sil-verify-all %s 2>&1 | %FileCheck %s
 
 sil_stage canonical
 


### PR DESCRIPTION
Still a draft since I am still debugging the coroutine changes. But just wanted to create visibility.