### PR TITLE
Fix SR-15785 by adding a cached reference to the last linked list node, avoiding n^2 append scaling

### DIFF
--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -164,14 +164,19 @@ public:
 /// and are only tracked by their respective `TaskGroupTaskStatusRecord`.
 class TaskGroupTaskStatusRecord : public TaskStatusRecord {
   AsyncTask *FirstChild;
+  AsyncTask *LastChild;
 
 public:
   TaskGroupTaskStatusRecord()
-      : TaskStatusRecord(TaskStatusRecordKind::TaskGroup), FirstChild(nullptr) {
+      : TaskStatusRecord(TaskStatusRecordKind::TaskGroup),
+        FirstChild(nullptr),
+        LastChild(nullptr) {
   }
 
   TaskGroupTaskStatusRecord(AsyncTask *child)
-      : TaskStatusRecord(TaskStatusRecordKind::TaskGroup), FirstChild(child) {}
+      : TaskStatusRecord(TaskStatusRecordKind::TaskGroup),
+        FirstChild(child),
+        LastChild(child) {}
 
   TaskGroup *getGroup() { return reinterpret_cast<TaskGroup *>(this); }
 
@@ -185,38 +190,28 @@ public:
     assert(child->hasGroupChildFragment());
     assert(child->groupChildFragment()->getGroup() == getGroup());
 
+    auto oldLastChild = LastChild;
+    LastChild = child;
+    
     if (!FirstChild) {
       // This is the first child we ever attach, so store it as FirstChild.
       FirstChild = child;
       return;
     }
 
-    // We need to traverse the siblings to find the last one and add the child
-    // there.
-    // FIXME: just set prepend to the current head, no need to traverse.
-
-    auto cur = FirstChild;
-    while (cur) {
-      // no need to check hasChildFragment, all tasks we store here have them.
-      auto fragment = cur->childFragment();
-      if (auto next = fragment->getNextChild()) {
-        cur = next;
-      } else {
-        // we're done searching and `cur` is the last
-        break;
-      }
-    }
-
-    cur->childFragment()->setNextChild(child);
+    oldLastChild->childFragment()->setNextChild(child);
   }
 
   void detachChild(AsyncTask *child) {
     assert(child && "cannot remove a null child from group");
     if (FirstChild == child) {
       FirstChild = getNextChildTask(child);
+      if (FirstChild == nullptr) {
+        LastChild = nullptr;
+      }
       return;
     }
-
+    
     AsyncTask *prev = FirstChild;
     // Remove the child from the linked list, i.e.:
     //     prev -> afterPrev -> afterChild
@@ -230,6 +225,9 @@ public:
       if (afterPrev == child) {
         auto afterChild = getNextChildTask(child);
         prev->childFragment()->setNextChild(afterChild);
+        if (child == LastChild) {
+          LastChild = prev;
+        }
         return;
       }
 

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -176,7 +176,9 @@ public:
   TaskGroupTaskStatusRecord(AsyncTask *child)
       : TaskStatusRecord(TaskStatusRecordKind::TaskGroup),
         FirstChild(child),
-        LastChild(child) {}
+        LastChild(child) {
+    assert(!LastChild || !LastChild->childFragment()->getNextChild());
+  }
 
   TaskGroup *getGroup() { return reinterpret_cast<TaskGroup *>(this); }
 


### PR DESCRIPTION
Speeds up a trivial benchmark with 50,000 appends from 10+ seconds in a release build, to 0.2 seconds in a debug build, on my machine.

Fixes rdar://88219931