### PR TITLE
[5.6][SymbolGraph] don't filter out all implicit decls

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -655,10 +655,6 @@ bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
     return false;
   }
 
-  if (D->isImplicit()) {
-    return false;
-  }
-
   if (!isa<ValueDecl>(D)) {
     return false;
   }

--- a/test/SymbolGraph/Symbols/Implicit.swift
+++ b/test/SymbolGraph/Symbols/Implicit.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name Implicit -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name Implicit -I %t -pretty-print -output-dir %t -minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/Implicit.symbols.json
+
+// RUN: %target-swift-symbolgraph-extract -module-name Implicit -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Implicit.symbols.json --check-prefix PUBLIC
+
+public class SomeClass {}
+
+public struct SomeStruct {
+    let bar: Int
+    let other: String
+}
+
+// make sure that the implicitly-generated initializer appears when the access level is `internal`
+// CHECK-DAG: "precise": "s:8Implicit9SomeClassCACycfc"
+// CHECK-DAG: "precise": "s:8Implicit10SomeStructV3bar5otherACSi_SStcfc"
+
+// ...but that they don't show up when it's `public`, since they're marked `internal` to begin with
+// PUBLIC-NOT: "precise": "s:8Implicit9SomeClassCACycfc"
+// PUBLIC-NOT: "precise": "s:8Implicit10SomeStructV3bar5otherACSi_SStcfc"


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/41141

Explanation: Implicitly-generated initializers are not present in symbol graphs, even when the `-minimum-access-level` is set to `internal`. Other sources of symbol information, like SourceKit, properly show these initializers, so their absence in symbol graphs is an issue.

Scope: Only affects users of SymbolGraphGen who request symbol graphs with `internal` access or below.

Issue: rdar://86294494

Risk: Low. This change is limited to SymbolGraphGen, and does not affect normal compilation.

Testing: A new lit test, `SymbolGraph/Symbols/Implicit`, was added to verify the new behavior.