### PR TITLE
Enable -reflection-metadata-for-debugger-only for the freestanding stdlib

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -475,7 +475,7 @@ function(_compile_swift_files
   endif()
 
   if(NOT SWIFT_ENABLE_REFLECTION)
-    list(APPEND swift_flags "-Xfrontend" "-disable-reflection-metadata")
+    list(APPEND swift_flags "-Xfrontend" "-reflection-metadata-for-debugger-only")
   else()
     list(APPEND swift_flags "-D" "SWIFT_ENABLE_REFLECTION")
   endif()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1005,6 +1005,9 @@ if run_vendor == 'apple':
         if not config.swift_freestanding_is_darwin:
             swift_execution_tests_extra_flags += ' -Xfrontend -disable-preallocated-instantiation-caches'
 
+        if not config.swift_freestanding_is_darwin:
+            swift_execution_tests_extra_flags += ' -Xfrontend -reflection-metadata-for-debugger-only'
+
         # Build a resource dir for freestanding tests.
         new_resource_dir = os.path.join(config.test_exec_root, "resource_dir")
         if not os.path.exists(new_resource_dir): os.mkdir(new_resource_dir)


### PR DESCRIPTION
See <https://github.com/apple/swift/pull/40853> which introduced the flag.