### PR TITLE
[c++-interop] For failed imports in ClangImporter, cache them regardless.

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -441,9 +441,12 @@ public:
 
   std::string getClangModuleHash() const;
 
-  /// If we already imported a given decl, return the corresponding Swift decl.
-  /// Otherwise, return nullptr.
-  Decl *importDeclCached(const clang::NamedDecl *ClangDecl);
+  /// If we already imported a given decl successfully, return the corresponding
+  /// Swift decl as an Optional<Decl *>, but if we previously tried and failed
+  /// to import said decl then return nullptr.
+  /// Otherwise, if we have never encountered this decl previously then return
+  /// None.
+  Optional<Decl *> importDeclCached(const clang::NamedDecl *ClangDecl);
 
   // Returns true if it is expected that the macro is ignored.
   bool shouldIgnoreMacro(StringRef Name, const clang::MacroInfo *Macro);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3631,7 +3631,8 @@ std::string ClangImporter::getClangModuleHash() const {
   return Impl.Invocation->getModuleHash(Impl.Instance->getDiagnostics());
 }
 
-Decl *ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {
+Optional<Decl *>
+ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {
   return Impl.importDeclCached(ClangDecl, Impl.CurrentVersion);
 }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -958,8 +958,9 @@ public:
 
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.
-  Decl *importDeclCached(const clang::NamedDecl *ClangDecl, Version version,
-                         bool UseCanonicalDecl = true);
+  Optional<Decl *> importDeclCached(const clang::NamedDecl *ClangDecl,
+                                    Version version,
+                                    bool UseCanonicalDecl = true);
 
   Decl *importDeclImpl(const clang::NamedDecl *ClangDecl, Version version,
                        bool &TypedefIsSuperfluous, bool &HadForwardDeclaration);

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -66,7 +66,10 @@ private:
 
   StableSerializationPath findImportedPath(const clang::NamedDecl *decl) {
     // We've almost certainly imported this declaration, look for it.
-    if (auto swiftDecl = Impl.importDeclCached(decl, Impl.CurrentVersion)) {
+    Optional<Decl *> swiftDeclOpt =
+      Impl.importDeclCached(decl, Impl.CurrentVersion);
+    if (swiftDeclOpt.hasValue() && swiftDeclOpt.getValue()) {
+      auto swiftDecl = swiftDeclOpt.getValue();
       // The serialization code doesn't allow us to cross-reference
       // typealias declarations directly.  We could fix that, but it's
       // easier to just avoid doing so and fall into the external-path code.

--- a/test/ClangImporter/attr-swift_name.swift
+++ b/test/ClangImporter/attr-swift_name.swift
@@ -45,14 +45,6 @@ func test(_ i: Int) {
   // CHECK: SWIFT_NAME(MutuallyCircularNameA.Inner) @interface MutuallyCircularNameB : NSObject @end
   // CHECK-NOT: {{warning|note}}:
   // CHECK: note: please report this issue to the owners of 'ObjCIRExtras'
-  // CHECK-NOT: warning:
-
-  // CHECK: warning: cycle detected while resolving 'MutuallyCircularNameA' in swift_name attribute for 'MutuallyCircularNameB'
-  // CHECK: SWIFT_NAME(MutuallyCircularNameA.Inner) @interface MutuallyCircularNameB : NSObject @end
   // CHECK-NOT: {{warning|note}}:
-  // CHECK: note: while resolving 'MutuallyCircularNameB' in swift_name attribute for 'MutuallyCircularNameA'
   // CHECK: SWIFT_NAME(MutuallyCircularNameB.Inner) @interface MutuallyCircularNameA : NSObject @end
-  // CHECK-NOT: {{warning|note}}:
-  // CHECK: note: please report this issue to the owners of 'ObjCIRExtras'
-  // CHECK-NOT: warning:
 }


### PR DESCRIPTION
As per SR-14137 this caches entries in ImportedDecls even when the
import failed. The use of Optional<NullablePtr<Decl>> is employed here
as a better way to track this than a raw nullptr.

Also have to mention I did this based on Thomas's PR #36747.

This in theory should help us better handle complex templates and
dependant types.
