### PR TITLE
constant_vprintf: Add a mode where prints are silenced when -DPRINT_DISABLED is present on the client side

### DIFF
--- a/stdlib/public/core/StaticPrint.swift
+++ b/stdlib/public/core/StaticPrint.swift
@@ -849,10 +849,12 @@ internal func constant_vprintf_backend(
 @_semantics("oslog.requires_constant_arguments")
 @inlinable
 @_transparent
+@_alwaysEmitIntoClient
 @_optimize(none)
 public func constant_vprintf(_ message: ConstantVPrintFMessage) {
   let formatString = message.interpolation.formatString
   let argumentClosures = message.interpolation.arguments.argumentClosures
+  if Bool(_builtinBooleanLiteral: Builtin.ifdef_PRINT_DISABLED()) { return }
   let formatStringPointer = _getGlobalStringTablePointer(formatString)
   constant_vprintf_backend(
     fmt: formatStringPointer,

--- a/test/stdlib/StaticPrintDisabled.swift
+++ b/test/stdlib/StaticPrintDisabled.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s                   -I %t -o %t/a1.out -O && %target-run %t/a1.out | %FileCheck %s
+// RUN: %target-build-swift %s -D PRINT_DISABLED -I %t -o %t/a2.out -O && %target-run %t/a2.out | %FileCheck %s --check-prefix CHECK-PRINT-DISABLED --allow-empty
+
+// REQUIRES: executable_test
+// REQUIRES: stdlib_static_print
+
+let x = 42
+let s = "ABCDE"
+constant_vprintf("Hello World \(5) \(x) \(s)")
+
+// CHECK: Hello World 5 42 ABCDE
+// CHECK-PRINT-DISABLED-NOT: Hello World


### PR DESCRIPTION
Added a test that showcases that this actually works.