### PR TITLE
Fix missing argument in utils/swift-api-dump.py.

### DIFF
--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -106,6 +106,8 @@ def create_parser():
                         help='Enable experimental concurrency model.')
     parser.add_argument('--enable-experimental-distributed', action='store_true',
                         help='Enable experimental distributed actors.')
+    parser.add_argument('--enable-experimental-string-processing', action='store_true',
+                        help='Enable experimental string processing.')
     parser.add_argument('-swift-version', metavar='N',
                         help='the Swift version to use')
     parser.add_argument('-show-overlay', action='store_true',


### PR DESCRIPTION
`--enable-experimental-string-processing` argument was missing. `args.enable_experimental_string_processing` is being read at the bottom of the script.

Resolves rdar://88420489.