### PR TITLE
[Distributed] Check if not emitting message helps in IR issue

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -483,7 +483,7 @@ void DistributedAccessor::lookupWitnessTables(
     // then accessor should trap.
     {
       IGF.Builder.emitBlock(failBB);
-      IGF.emitTrap("missing witness table", /*EmitUnreachable=*/true);
+      IGF.emitTrap("", /*EmitUnreachable=*/true);
     }
 
     IGF.Builder.emitBlock(contBB);


### PR DESCRIPTION
Trying to see if this helps toolchain not weirdly crash.

This is supposed to avoid this call:

```
  if (EnableTrapDebugInfo && IGM.DebugInfo && !failureMsg.empty()) {
    IGM.DebugInfo->addFailureMessageToCurrentLoc(*this, failureMsg);
  }
```