### PR TITLE
Experimental support for implicitly opening existential arguments.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -313,6 +313,10 @@ namespace swift {
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;
 
+    /// Enable support for implicitly opening existential argument types
+    /// in calls to generic functions.
+    bool EnableOpenedExistentialTypes = false;
+
     /// Enable support for protocol types parameterized by primary
     /// associated type.
     bool EnableParameterizedProtocolTypes = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -514,6 +514,10 @@ def enable_parameterized_protocol_types :
   Flag<["-"], "enable-parameterized-protocol-types">,
   HelpText<"Enable experimental support for primary associated types and parameterized protocols">;
 
+def enable_experimental_opened_existential_types :
+  Flag<["-"], "enable-experimental-opened-existential-types">,
+  HelpText<"Enable experimental support for implicitly opened existentials">;
+
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -518,6 +518,10 @@ def enable_experimental_opened_existential_types :
   Flag<["-"], "enable-experimental-opened-existential-types">,
   HelpText<"Enable experimental support for implicitly opened existentials">;
 
+def disable_experimental_opened_existential_types :
+  Flag<["-"], "disble-experimental-opened-existential-types">,
+  HelpText<"Disable experimental support for implicitly opened existentials">;
+
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3353,6 +3353,11 @@ public:
   ConstraintLocator *getOpenOpaqueLocator(
       ConstraintLocatorBuilder locator, OpaqueTypeDecl *opaqueDecl);
 
+  /// Open the given existential type, recording the opened type in the
+  /// constraint system and returning both it and the root opened archetype.
+  std::pair<Type, OpenedArchetypeType *> openExistentialType(
+      Type type, ConstraintLocator *locator);
+
   /// Retrive the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags
   ConstraintLocator *
@@ -5506,19 +5511,15 @@ matchCallArguments(
     MatchCallArgumentListener &listener,
     Optional<TrailingClosureMatching> trailingClosureMatching);
 
-ConstraintSystem::TypeMatchResult
-matchCallArguments(ConstraintSystem &cs,
-                   FunctionType *contextualType,
-                   ArgumentList *argumentList,
-                   ArrayRef<AnyFunctionType::Param> args,
-                   ArrayRef<AnyFunctionType::Param> params,
-                   ConstraintKind subKind,
-                   ConstraintLocatorBuilder locator,
-                   Optional<TrailingClosureMatching> trailingClosureMatching);
-
 /// Given an expression that is the target of argument labels (for a call,
 /// subscript, etc.), find the underlying target expression.
 Expr *getArgumentLabelTargetExpr(Expr *fn);
+
+/// Given a type that includes an existential type that has been opened to
+/// the given type variable, type-erase occurences of that opened type
+/// variable and anything that depends on it to their non-dependent bounds.
+Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
+                                         TypeVariableType *openedTypeVar);
 
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3800,8 +3800,8 @@ void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,
   }
 }
 
-SelfReferenceInfo &
-SelfReferenceInfo::operator|=(const SelfReferenceInfo &other) {
+GenericParameterReferenceInfo &
+GenericParameterReferenceInfo::operator|=(const GenericParameterReferenceInfo &other) {
   hasCovariantSelfResult |= other.hasCovariantSelfResult;
   if (other.selfRef > selfRef) {
     selfRef = other.selfRef;
@@ -3812,23 +3812,25 @@ SelfReferenceInfo::operator|=(const SelfReferenceInfo &other) {
   return *this;
 }
 
-/// Report references to 'Self' within the given type using the given
-/// existential generic signature.
+/// Report references to the given generic parameter within the given type
+/// using the given existential generic signature.
 ///
 /// \param position The current position in terms of variance.
-static SelfReferenceInfo
-findExistentialSelfReferences(CanGenericSignature existentialSig, Type type,
-                              TypePosition position) {
+static GenericParameterReferenceInfo
+findGenericParameterReferences(CanGenericSignature existentialSig,
+                               GenericTypeParamType *genericParam,
+                               Type type,
+                               TypePosition position) {
   // If there are no type parameters, we're done.
   if (!type->hasTypeParameter())
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
 
   // Tuples preserve variance.
   if (auto tuple = type->getAs<TupleType>()) {
-    auto info = SelfReferenceInfo();
+    auto info = GenericParameterReferenceInfo();
     for (auto &elt : tuple->getElements()) {
-      info |= findExistentialSelfReferences(existentialSig, elt.getType(),
-                                            position);
+      info |= findGenericParameterReferences(existentialSig, genericParam,
+                                            elt.getType(), position);
     }
 
     // A covariant Self result inside a tuple will not be bona fide.
@@ -3840,23 +3842,25 @@ findExistentialSelfReferences(CanGenericSignature existentialSig, Type type,
   // Function types preserve variance in the result type, and flip variance in
   // the parameter type.
   if (auto funcTy = type->getAs<AnyFunctionType>()) {
-    auto inputInfo = SelfReferenceInfo();
+    auto inputInfo = GenericParameterReferenceInfo();
     for (auto param : funcTy->getParams()) {
       // inout parameters are invariant.
       if (param.isInOut()) {
-        inputInfo |= findExistentialSelfReferences(
-            existentialSig, param.getPlainType(), TypePosition::Invariant);
+        inputInfo |= findGenericParameterReferences(
+            existentialSig, genericParam, param.getPlainType(),
+            TypePosition::Invariant);
         continue;
       }
-      inputInfo |= findExistentialSelfReferences(
-          existentialSig, param.getParameterType(), position.flipped());
+      inputInfo |= findGenericParameterReferences(
+          existentialSig, genericParam, param.getParameterType(),
+          position.flipped());
     }
 
     // A covariant Self result inside a parameter will not be bona fide.
     inputInfo.hasCovariantSelfResult = false;
 
-    auto resultInfo = findExistentialSelfReferences(
-        existentialSig, funcTy->getResult(), position);
+    auto resultInfo = findGenericParameterReferences(
+        existentialSig, genericParam, funcTy->getResult(), position);
     if (resultInfo.selfRef == TypePosition::Covariant) {
       resultInfo.hasCovariantSelfResult = true;
     }
@@ -3865,48 +3869,52 @@ findExistentialSelfReferences(CanGenericSignature existentialSig, Type type,
 
   // Metatypes preserve variance.
   if (auto metaTy = type->getAs<MetatypeType>()) {
-    return findExistentialSelfReferences(existentialSig,
+    return findGenericParameterReferences(existentialSig, genericParam,
                                          metaTy->getInstanceType(), position);
   }
 
   // Optionals preserve variance.
   if (auto optType = type->getOptionalObjectType()) {
-    return findExistentialSelfReferences(existentialSig, optType, position);
+    return findGenericParameterReferences(
+        existentialSig, genericParam, optType, position);
   }
 
   // DynamicSelfType preserves variance.
   // FIXME: This shouldn't ever appear in protocol requirement
   // signatures.
   if (auto selfType = type->getAs<DynamicSelfType>()) {
-    return findExistentialSelfReferences(existentialSig,
+    return findGenericParameterReferences(existentialSig, genericParam,
                                          selfType->getSelfType(), position);
   }
 
   if (auto *const nominal = type->getAs<NominalOrBoundGenericNominalType>()) {
-    auto info = SelfReferenceInfo();
+    auto info = GenericParameterReferenceInfo();
 
     // Don't forget to look in the parent.
     if (const auto parent = nominal->getParent()) {
-      info |= findExistentialSelfReferences(existentialSig, parent, position);
+      info |= findGenericParameterReferences(
+          existentialSig, genericParam, parent, position);
     }
 
     // Most bound generic types are invariant.
     if (auto *const bgt = type->getAs<BoundGenericType>()) {
       if (bgt->isArray()) {
         // Swift.Array preserves variance in its 'Value' type.
-        info |= findExistentialSelfReferences(
-            existentialSig, bgt->getGenericArgs().front(), position);
+        info |= findGenericParameterReferences(
+            existentialSig, genericParam, bgt->getGenericArgs().front(),
+            position);
       } else if (bgt->isDictionary()) {
         // Swift.Dictionary preserves variance in its 'Element' type.
-        info |= findExistentialSelfReferences(existentialSig,
+        info |= findGenericParameterReferences(existentialSig, genericParam,
                                               bgt->getGenericArgs().front(),
                                               TypePosition::Invariant);
-        info |= findExistentialSelfReferences(
-            existentialSig, bgt->getGenericArgs().back(), position);
+        info |= findGenericParameterReferences(
+            existentialSig, genericParam, bgt->getGenericArgs().back(),
+            position);
       } else {
         for (auto paramType : bgt->getGenericArgs()) {
-          info |= findExistentialSelfReferences(existentialSig, paramType,
-                                                TypePosition::Invariant);
+          info |= findGenericParameterReferences(
+              existentialSig, genericParam, paramType, TypePosition::Invariant);
         }
       }
     }
@@ -3917,20 +3925,25 @@ findExistentialSelfReferences(CanGenericSignature existentialSig, Type type,
   // If the signature of an opaque result type has a same-type constraint
   // that refereces Self, it's invariant.
   if (auto opaque = type->getAs<OpaqueTypeArchetypeType>()) {
-    auto info = SelfReferenceInfo();
+    auto info = GenericParameterReferenceInfo();
     auto opaqueSig = opaque->getDecl()->getOpaqueInterfaceGenericSignature();
     for (const auto &req : opaqueSig.getRequirements()) {
       switch (req.getKind()) {
       case RequirementKind::Conformance:
       case RequirementKind::Layout:
-      case RequirementKind::Superclass:
         continue;
 
       case RequirementKind::SameType:
-        info |= findExistentialSelfReferences(
-            existentialSig, req.getFirstType(), TypePosition::Invariant);
-        info |= findExistentialSelfReferences(
-            existentialSig, req.getSecondType(), TypePosition::Invariant);
+        info |= findGenericParameterReferences(
+            existentialSig, genericParam, req.getFirstType(),
+            TypePosition::Invariant);
+
+        LLVM_FALLTHROUGH;
+
+      case RequirementKind::Superclass:
+        info |= findGenericParameterReferences(
+            existentialSig, genericParam, req.getSecondType(),
+            TypePosition::Invariant);
         break;
       }
     }
@@ -3945,72 +3958,81 @@ findExistentialSelfReferences(CanGenericSignature existentialSig, Type type,
     // 'Self' may be referenced only in an explicit superclass component.
     for (const auto member : comp->getMembers()) {
       if (member->getClassOrBoundGenericClass()) {
-        return findExistentialSelfReferences(existentialSig, member, position);
+        return findGenericParameterReferences(
+            existentialSig, genericParam, member, position);
       }
     }
 
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
   }
 
   if (!type->isTypeParameter()) {
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
   }
 
-  const auto selfTy = existentialSig.getGenericParams().front();
+  Type selfTy(genericParam);
   if (!type->getRootGenericParam()->isEqual(selfTy)) {
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
   }
 
   // A direct reference to 'Self'.
   if (selfTy->isEqual(type)) {
-    return SelfReferenceInfo::forSelfRef(position);
+    return GenericParameterReferenceInfo::forSelfRef(position);
   }
 
   // If the type parameter is beyond the domain of the existential generic
   // signature, ignore it.
   if (!existentialSig->isValidTypeInContext(type)) {
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
   }
 
   if (const auto concreteTy = existentialSig->getConcreteType(type)) {
-    return findExistentialSelfReferences(existentialSig, concreteTy, position);
+    return findGenericParameterReferences(
+        existentialSig, genericParam, concreteTy, position);
   }
 
   // A reference to an associated type rooted on 'Self'.
-  return SelfReferenceInfo::forAssocTypeRef(position);
+  return GenericParameterReferenceInfo::forAssocTypeRef(position);
 }
 
-SelfReferenceInfo ValueDecl::findExistentialSelfReferences(
-    Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const {
-  assert(baseTy->isExistentialType());
+GenericParameterReferenceInfo swift::findGenericParameterReferences(
+    const ValueDecl *value, CanGenericSignature sig,
+    GenericTypeParamType *genericParam,
+    bool treatNonResultCovarianceAsInvariant,
+    Optional<unsigned> skipParamIndex)  {
 
   // Types never refer to 'Self'.
-  if (isa<TypeDecl>(this))
-    return SelfReferenceInfo();
+  if (isa<TypeDecl>(value))
+    return GenericParameterReferenceInfo();
 
-  auto type = getInterfaceType();
+  auto type = value->getInterfaceType();
 
   // Skip invalid declarations.
   if (type->hasError())
-    return SelfReferenceInfo();
+    return GenericParameterReferenceInfo();
 
-  const auto sig = getASTContext().getOpenedArchetypeSignature(baseTy);
-
-  if (isa<AbstractFunctionDecl>(this) || isa<SubscriptDecl>(this)) {
+  if (isa<AbstractFunctionDecl>(value) || isa<SubscriptDecl>(value)) {
     // For a method, skip the 'self' parameter.
-    if (isa<AbstractFunctionDecl>(this))
+    if (value->hasCurriedSelf())
       type = type->castTo<AnyFunctionType>()->getResult();
 
-    auto inputInfo = SelfReferenceInfo();
-    for (auto param : type->castTo<AnyFunctionType>()->getParams()) {
+    auto inputInfo = GenericParameterReferenceInfo();
+    auto params = type->castTo<AnyFunctionType>()->getParams();
+    for (auto paramIdx : indices(params)) {
+      // If this is the parameter we were supposed to skip, do so.
+      if (skipParamIndex && paramIdx == *skipParamIndex)
+        continue;
+
+      const auto &param = params[paramIdx];
       // inout parameters are invariant.
       if (param.isInOut()) {
-        inputInfo |= ::findExistentialSelfReferences(sig, param.getPlainType(),
-                                                     TypePosition::Invariant);
+        inputInfo |= ::findGenericParameterReferences(
+            sig, genericParam, param.getPlainType(), TypePosition::Invariant);
         continue;
       }
-      inputInfo |= ::findExistentialSelfReferences(
-          sig, param.getParameterType(), TypePosition::Contravariant);
+      inputInfo |= ::findGenericParameterReferences(
+          sig, genericParam, param.getParameterType(),
+          TypePosition::Contravariant);
     }
 
     // A covariant Self result inside a parameter will not be bona fide.
@@ -4022,13 +4044,13 @@ SelfReferenceInfo ValueDecl::findExistentialSelfReferences(
     //
     // Methods of non-final classes can only contain a covariant 'Self'
     // as their result type.
-    if (treatNonResultCovariantSelfAsInvariant &&
+    if (treatNonResultCovarianceAsInvariant &&
         inputInfo.selfRef == TypePosition::Covariant) {
       inputInfo.selfRef = TypePosition::Invariant;
     }
 
-    auto resultInfo = ::findExistentialSelfReferences(
-        sig, type->castTo<AnyFunctionType>()->getResult(),
+    auto resultInfo = ::findGenericParameterReferences(
+        sig, genericParam, type->castTo<AnyFunctionType>()->getResult(),
         TypePosition::Covariant);
     if (resultInfo.selfRef == TypePosition::Covariant) {
       resultInfo.hasCovariantSelfResult = true;
@@ -4036,10 +4058,10 @@ SelfReferenceInfo ValueDecl::findExistentialSelfReferences(
 
     return inputInfo |= resultInfo;
   } else {
-    assert(isa<VarDecl>(this));
+    assert(isa<VarDecl>(value));
 
-    auto info =
-        ::findExistentialSelfReferences(sig, type, TypePosition::Covariant);
+    auto info = ::findGenericParameterReferences(
+        sig, genericParam, type, TypePosition::Covariant);
     if (info.selfRef == TypePosition::Covariant) {
       info.hasCovariantSelfResult = true;
     }
@@ -4047,7 +4069,27 @@ SelfReferenceInfo ValueDecl::findExistentialSelfReferences(
     return info;
   }
 
-  return SelfReferenceInfo();
+  return GenericParameterReferenceInfo();
+}
+
+GenericParameterReferenceInfo ValueDecl::findExistentialSelfReferences(
+    Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const {
+  assert(baseTy->isExistentialType());
+
+  // Types never refer to 'Self'.
+  if (isa<TypeDecl>(this))
+    return GenericParameterReferenceInfo();
+
+  auto type = getInterfaceType();
+
+  // Skip invalid declarations.
+  if (type->hasError())
+    return GenericParameterReferenceInfo();
+
+  const auto sig = getASTContext().getOpenedArchetypeSignature(baseTy);
+  auto genericParam = sig.getGenericParams().front();
+  return findGenericParameterReferences(
+      this, sig, genericParam, treatNonResultCovariantSelfAsInvariant, None);
 }
 
 Type TypeDecl::getDeclaredInterfaceType() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -451,6 +451,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableOpenedExistentialTypes |=
       Args.hasArg(OPT_enable_experimental_opened_existential_types);
 
+  // SwiftOnoneSupport produces different symbols when opening existentials,
+  // so disable it.
+  if (FrontendOpts.ModuleName == SWIFT_ONONE_SUPPORT)
+    Opts.EnableOpenedExistentialTypes = false;
+
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -448,8 +448,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableParameterizedProtocolTypes |=
       Args.hasArg(OPT_enable_parameterized_protocol_types);
 
-  Opts.EnableOpenedExistentialTypes |=
-      Args.hasArg(OPT_enable_experimental_opened_existential_types);
+  Opts.EnableOpenedExistentialTypes =
+    Args.hasFlag(OPT_enable_experimental_opened_existential_types,
+                 OPT_disable_experimental_opened_existential_types,
+                 false);
 
   // SwiftOnoneSupport produces different symbols when opening existentials,
   // so disable it.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -448,6 +448,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableParameterizedProtocolTypes |=
       Args.hasArg(OPT_enable_parameterized_protocol_types);
 
+  Opts.EnableOpenedExistentialTypes |=
+      Args.hasArg(OPT_enable_experimental_opened_existential_types);
+
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);
 

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -99,10 +99,10 @@ mapTypeOutOfOpenedExistentialContext(CanType t) {
         /*type sequence*/ false, /*depth*/ 0, /*index*/ i, ctx);
     params.push_back(param);
 
-    const auto constraintTy = openedTypes[i]
-                                  ->getExistentialType()
-                                  ->castTo<ExistentialType>()
-                                  ->getConstraintType();
+    Type constraintTy = openedTypes[i]->getExistentialType();
+    if (auto existentialTy = constraintTy->getAs<ExistentialType>())
+      constraintTy = existentialTy->getConstraintType();
+
     requirements.emplace_back(RequirementKind::Conformance, param,
                               constraintTy);
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1141,9 +1141,9 @@ namespace {
       return archetypeVal;
     }
 
-    /// Trying to close the active existential, if there is one.
+    /// Try to close the innermost active existential, if there is one.
     bool closeExistential(Expr *&result, ConstraintLocatorBuilder locator,
-                          bool force=false) {
+                          bool force) {
       if (OpenedExistentials.empty())
         return false;
 
@@ -1183,6 +1183,18 @@ namespace {
 
       OpenedExistentials.pop_back();
       return true;
+    }
+
+    /// Close any active existentials.
+    bool closeExistentials(Expr *&result, ConstraintLocatorBuilder locator,
+                           bool force=false) {
+      bool closedAny = false;
+      while (closeExistential(result, locator, force)) {
+        force = false;
+        closedAny = true;
+      }
+
+      return closedAny;
     }
 
     /// Determines if a partially-applied member reference should be
@@ -1706,7 +1718,7 @@ namespace {
 
         cs.setType(ref, refType);
 
-        closeExistential(ref, locator, /*force=*/openedExistential);
+        closeExistentials(ref, locator, /*force=*/openedExistential);
 
         // If this attribute was inferred based on deprecated Swift 3 rules,
         // complain.
@@ -1758,7 +1770,7 @@ namespace {
         cs.setType(memberRefExpr, refTy->castTo<FunctionType>()->getResult());
 
         Expr *result = memberRefExpr;
-        closeExistential(result, locator);
+        closeExistentials(result, locator);
 
         // If the property is of dynamic 'Self' type, wrap an implicit
         // conversion around the resulting expression, with the destination
@@ -1959,7 +1971,7 @@ namespace {
                                                               ref,
                                                               cs.getType(ref));
         cs.cacheType(result);
-        closeExistential(result, locator, /*force=*/openedExistential);
+        closeExistentials(result, locator, /*force=*/openedExistential);
         return forceUnwrapIfExpected(result, memberLocator);
       } else {
         assert((!baseIsInstance || member->isInstanceMember()) &&
@@ -2263,7 +2275,7 @@ namespace {
                && "open existential archetype in AnyObject subscript type?");
         cs.setType(subscriptExpr, resultTy);
         Expr *result = subscriptExpr;
-        closeExistential(result, locator);
+        closeExistentials(result, locator);
         return result;
       }
 
@@ -2305,7 +2317,7 @@ namespace {
                      : fullSubscriptTy->getResult());
 
       Expr *result = subscriptExpr;
-      closeExistential(result, locator);
+      closeExistentials(result, locator);
 
       // If the element is of dynamic 'Self' type, wrap an implicit conversion
       // around the resulting expression, with the destination type having
@@ -6029,6 +6041,22 @@ ArgumentList *ExprRewriter::coerceCallArguments(
       cs.cacheExprTypes(argExpr);
     }
 
+    auto argLoc = getArgLocator(argIdx, paramIdx, param.getParameterFlags());
+
+    // If the argument is an existential type that has been opened, perform
+    // the open operation.
+    if (argType->isAnyExistentialType() && paramType->hasOpenedExistential()) {
+      // FIXME: Look for an opened existential and use it. We need to
+      // know how far out we need to go to close the existentials. Huh.
+      auto knownOpened = solution.OpenedExistentialTypes.find(
+          cs.getConstraintLocator(argLoc));
+      if (knownOpened != solution.OpenedExistentialTypes.end()) {
+        argExpr = openExistentialReference(
+            argExpr, knownOpened->second, callee.getDecl());
+        argType = cs.getType(argExpr);
+      }
+    }
+
     if (argRequiresAutoClosureExpr(param, argType)) {
       assert(!param.isInOut());
 
@@ -6037,8 +6065,6 @@ ArgumentList *ExprRewriter::coerceCallArguments(
       //   - impilict autoclosure is created to wrap argument expression
       //   - new types are propagated to constraint system
       auto *closureType = param.getPlainType()->castTo<FunctionType>();
-
-      auto argLoc = getArgLocator(argIdx, paramIdx, param.getParameterFlags());
 
       argExpr = coerceToType(
           argExpr, closureType->getResult(),
@@ -6062,9 +6088,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
       convertedArg = cs.buildAutoClosureExpr(argExpr, closureType, dc);
     } else {
-      convertedArg = coerceToType(
-          argExpr, paramType,
-          getArgLocator(argIdx, paramIdx, param.getParameterFlags()));
+      convertedArg = coerceToType(argExpr, paramType, argLoc);
     }
 
     // Perform the wrapped value placeholder injection
@@ -7800,8 +7824,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
             result, covariantResultType));
     }
 
-    // Try closing the existential, if there is one.
-    closeExistential(result, locator);
+    // Try closing existentials, if there are any.
+    closeExistentials(result, locator);
 
     // We may also need to force the result for an IUO. We don't apply this on
     // SelfApplyExprs, as the force unwraps should be inserted at the result of

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1085,8 +1085,16 @@ namespace {
       // Dig out the base type.
       Type baseTy = cs.getType(base);
 
-      // Look through lvalues.
+      // Look through inout.
       bool isLValue = false;
+      InOutExpr *origInOutBase = dyn_cast<InOutExpr>(base);
+      if (origInOutBase) {
+        base = origInOutBase->getSubExpr();
+        baseTy = baseTy->getInOutObjectType();
+        isLValue = true;
+      }
+
+      // Look through lvalues.
       if (auto lvalueTy = baseTy->getAs<LValueType>()) {
         isLValue = true;
         baseTy = lvalueTy->getObjectType();
@@ -1104,7 +1112,7 @@ namespace {
       // If the base was an lvalue but it will only be treated as an
       // rvalue, turn the base into an rvalue now. This results in
       // better SILGen.
-      if (isLValue &&
+      if (isLValue && !origInOutBase &&
           (isNonMutatingMember(member) ||
            member->getDeclContext()->getDeclaredInterfaceType()
              ->hasReferenceSemantics())) {
@@ -1138,7 +1146,15 @@ namespace {
       // Record the opened existential.
       OpenedExistentials.push_back({archetype, base, archetypeVal, depth});
 
-      return archetypeVal;
+      // Re-apply inout if needed.
+      Expr *resultExpr = archetypeVal;
+      if (origInOutBase) {
+        resultExpr = new (ctx) InOutExpr(
+            origInOutBase->getLoc(), resultExpr, opaqueType->getRValueType());
+        cs.cacheType(resultExpr);
+      }
+
+      return resultExpr;
     }
 
     /// Try to close the innermost active existential, if there is one.
@@ -6045,7 +6061,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     // If the argument is an existential type that has been opened, perform
     // the open operation.
-    if (argType->isAnyExistentialType() && paramType->hasOpenedExistential()) {
+    if (argType->getInOutObjectType()->isAnyExistentialType() &&
+        paramType->hasOpenedExistential()) {
       // FIXME: Look for an opened existential and use it. We need to
       // know how far out we need to go to close the existentials. Huh.
       auto knownOpened = solution.OpenedExistentialTypes.find(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1354,6 +1354,11 @@ shouldOpenExistentialCallArgument(
     break;
   }
 
+  // C++ function templates require specialization, which is not possible with
+  // opened existential archetypes, so do not open.
+  if (isa_and_nonnull<clang::FunctionTemplateDecl>(callee->getClangDecl()))
+    return None;
+
   ASTContext &ctx = callee->getASTContext();
   if (!ctx.LangOpts.EnableOpenedExistentialTypes)
     return None;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1364,12 +1364,19 @@ shouldOpenExistentialCallArgument(
   if (param->isVariadic() && !param->getVarargBaseTy()->hasTypeSequence())
     return None;
 
+  // If the argument is of an existential metatype, look through the
+  // metatype on the parameter.
+  auto formalParamTy = param->getInterfaceType();
+  if (argTy->is<AnyMetatypeType>()) {
+    formalParamTy = formalParamTy->getMetatypeInstanceType();
+    paramTy = paramTy->getMetatypeInstanceType();
+  }
+
   // The parameter type must be a type variable.
   auto paramTypeVar = paramTy->getAs<TypeVariableType>();
   if (!paramTypeVar)
     return None;
 
-  auto formalParamTy = param->getInterfaceType();
   auto genericParam = formalParamTy->getAs<GenericTypeParamType>();
   if (!genericParam)
     return None;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1338,6 +1338,10 @@ shouldOpenExistentialCallArgument(
   if (!callee)
     return None;
 
+  // Only applies to functions and subscripts.
+  if (!isa<AbstractFunctionDecl>(callee) && !isa<SubscriptDecl>(callee))
+    return None;
+
   // Special semantics prohibit opening existentials.
   switch (TypeChecker::getDeclTypeCheckingSemantics(callee)) {
   case DeclTypeCheckingSemantics::OpenExistential:
@@ -1390,8 +1394,8 @@ shouldOpenExistentialCallArgument(
 
   // Ensure that the formal parameter is only used in covariant positions,
   // because it won't match anywhere else.
-  auto genericSig = callee->getAsGenericContext()->getGenericSignatureOfContext()
-      .getCanonicalSignature();
+  auto genericSig = callee->getInnermostDeclContext()
+      ->getGenericSignatureOfContext().getCanonicalSignature();
   auto referenceInfo = findGenericParameterReferences(
       callee, genericSig, genericParam,
       /*treatNonResultCovarianceAsInvariant=*/false,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1402,8 +1402,10 @@ shouldOpenExistentialCallArgument(
   if (param->isVariadic() && !param->getVarargBaseTy()->hasTypeSequence())
     return None;
 
-  // Look through an inout type on the formal type of the parameter.
-  auto formalParamTy = param->getInterfaceType()->getInOutObjectType();
+  // Look through an inout and optional types on the formal type of the
+  // parameter.
+  auto formalParamTy = param->getInterfaceType()->getInOutObjectType()
+      ->lookThroughSingleOptionalType();
 
   // If the argument is of an existential metatype, look through the
   // metatype on the parameter.
@@ -1412,8 +1414,8 @@ shouldOpenExistentialCallArgument(
     paramTy = paramTy->getMetatypeInstanceType();
   }
 
-  // Look through an inout type on the parameter.
-  paramTy = paramTy->getInOutObjectType();
+  // Look through an inout and optional types on the parameter.
+  paramTy = paramTy->getInOutObjectType()->lookThroughSingleOptionalType();
 
   // The parameter type must be a type variable.
   auto paramTypeVar = paramTy->getAs<TypeVariableType>();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1338,10 +1338,17 @@ shouldOpenExistentialCallArgument(
   if (!callee)
     return None;
 
-  // _openExistential handles its own opening.
-  if (TypeChecker::getDeclTypeCheckingSemantics(callee) ==
-        DeclTypeCheckingSemantics::OpenExistential)
+  // Special semantics prohibit opening existentials.
+  switch (TypeChecker::getDeclTypeCheckingSemantics(callee)) {
+  case DeclTypeCheckingSemantics::OpenExistential:
+  case DeclTypeCheckingSemantics::TypeOf:
+    // type(of:) and _openExistential handle their own opening.
     return None;
+
+  case DeclTypeCheckingSemantics::Normal:
+  case DeclTypeCheckingSemantics::WithoutActuallyEscaping:
+    break;
+  }
 
   ASTContext &ctx = callee->getASTContext();
   if (!ctx.LangOpts.EnableOpenedExistentialTypes)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1402,10 +1402,8 @@ shouldOpenExistentialCallArgument(
   if (param->isVariadic() && !param->getVarargBaseTy()->hasTypeSequence())
     return None;
 
-  // Look through an inout and optional types on the formal type of the
-  // parameter.
-  auto formalParamTy = param->getInterfaceType()->getInOutObjectType()
-      ->lookThroughSingleOptionalType();
+  // Look through an inout type on the formal type of the parameter.
+  auto formalParamTy = param->getInterfaceType()->getInOutObjectType();
 
   // If the argument is of an existential metatype, look through the
   // metatype on the parameter.
@@ -1414,8 +1412,8 @@ shouldOpenExistentialCallArgument(
     paramTy = paramTy->getMetatypeInstanceType();
   }
 
-  // Look through an inout and optional types on the parameter.
-  paramTy = paramTy->getInOutObjectType()->lookThroughSingleOptionalType();
+  // Look through an inout type on the parameter.
+  paramTy = paramTy->getInOutObjectType();
 
   // The parameter type must be a type variable.
   auto paramTypeVar = paramTy->getAs<TypeVariableType>();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1397,10 +1397,19 @@ shouldOpenExistentialCallArgument(
   if (!genericParam)
     return None;
 
-  // Ensure that the formal parameter is only used in covariant positions,
-  // because it won't match anywhere else.
+  // Only allow opening the innermost generic parameters.
+  auto genericContext = callee->getAsGenericContext();
+  if (!genericContext || !genericContext->isGeneric())
+    return None;
+
   auto genericSig = callee->getInnermostDeclContext()
       ->getGenericSignatureOfContext().getCanonicalSignature();
+  if (genericParam->getDepth() <
+          genericSig.getGenericParams().back()->getDepth())
+    return None;
+
+  // Ensure that the formal parameter is only used in covariant positions,
+  // because it won't match anywhere else.
   auto referenceInfo = findGenericParameterReferences(
       callee, genericSig, genericParam,
       /*treatNonResultCovarianceAsInvariant=*/false,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1813,7 +1813,7 @@ static Type typeEraseCovariantExistentialSelfReferences(Type refTy,
 
       // Opaque types whose substitutions involve this type parameter are
       // erased to their upper bound.
-      if (auto opaque = dyn_cast<OpaqueTypeArchetypeType>(type.getPointer())) {
+      if (auto opaque = dyn_cast<OpaqueTypeArchetypeType>(t)) {
         for (auto replacementType :
                  opaque->getSubstitutions().getReplacementTypes()) {
           if (hasErasedGenericParameter(replacementType)) {

--- a/test/Constraints/openExistential.swift
+++ b/test/Constraints/openExistential.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types
 
 protocol P { }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -159,16 +159,6 @@ func passesInOut(i: Int) {
   takesInOut(&p)
 }
 
-func takesOptional<T: P>(_ value: T?) { }
-// expected-note@-1{{required by global function 'takesOptional' where 'T' = 'P'}}
-
-func passesToOptional(p: any P, pOpt: (any P)?) {
-  takesOptional(p) // okay
-  takesOptional(pOpt) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}}
-  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
-}
-
-
 @available(SwiftStdlib 5.1, *)
 func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,0 +1,62 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types -enable-parameterized-protocol-types -enable-experimental-opaque-parameters
+
+protocol Q { }
+
+protocol P {
+  associatedtype A: Q
+}
+
+extension Int: P {
+  typealias A = Double
+}
+
+extension Array: P where Element: P {
+  typealias A = String
+}
+
+extension Double: Q { }
+extension String: Q { }
+
+func acceptGeneric<T: P>(_: T) -> T.A? { nil }
+func acceptCollection<C: Collection>(_ c: C) -> C.Element { c.first! }
+
+// --- Simple opening of existential values
+func testSimpleExistentialOpening(p: any P, pq: any P & Q, c: any Collection) {
+  let pa = acceptGeneric(p)
+  let _: Int = pa // expected-error{{cannot convert value of type 'Q?' to specified type 'Int'}}
+
+  let pqa = acceptGeneric(pq)
+  let _: Int = pqa  // expected-error{{cannot convert value of type 'Q?' to specified type 'Int'}}
+
+  let element = acceptCollection(c) 
+  let _: Int = element // expected-error{{cannot convert value of type 'Any' to specified type 'Int'}}
+}
+
+// --- Requirements on nested types
+protocol CollectionOfPs: Collection where Self.Element: P { }
+
+func takeCollectionOfPs<C: Collection>(_: C) -> C.Element.A?    
+  where C.Element: P
+{
+  nil
+}
+
+func testCollectionOfPs(cp: any CollectionOfPs) {
+  let e = takeCollectionOfPs(cp)
+  let _: Int = e // expected-error{{cannot convert value of type 'Q?' to specified type 'Int'}}
+}
+
+// --- Multiple opened existentials in the same expression
+func takeTwoGenerics<T1: P, T2: P>(_ a: T1, _ b: T2) -> (T1, T2) { (a, b) }
+
+extension P {
+  func combineThePs<T: P & Q>(_ other: T) -> (A, T.A)? { nil }
+}
+
+func testMultipleOpened(a: any P, b: any P & Q) {
+  let r1 = takeTwoGenerics(a, b)
+  let _: Int = r1  // expected-error{{cannot convert value of type '(P, P & Q)' to specified type 'Int'}}
+
+  let r2 = a.combineThePs(b)
+  let _: Int = r2  // expected-error{{cannot convert value of type '(Q, Q)?' to specified type 'Int'}}  
+}

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -159,6 +159,16 @@ func passesInOut(i: Int) {
   takesInOut(&p)
 }
 
+func takesOptional<T: P>(_ value: T?) { }
+// expected-note@-1{{required by global function 'takesOptional' where 'T' = 'P'}}
+
+func passesToOptional(p: any P, pOpt: (any P)?) {
+  takesOptional(p) // okay
+  takesOptional(pOpt) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}}
+  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
+}
+
+
 @available(SwiftStdlib 5.1, *)
 func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -152,6 +152,13 @@ func callVariadic(p1: any P, p2: any P) {
   // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
+func takesInOut<T: P>(_ value: inout T) { }
+
+func passesInOut(i: Int) {
+  var p: any P = i
+  takesInOut(&p)
+}
+
 @available(SwiftStdlib 5.1, *)
 func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types -enable-parametrized-protocol-types -enable-experimental-opaque-parameters
+// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types -enable-parameterized-protocol-types
 
 protocol Q { }
 
@@ -76,4 +76,23 @@ func reverseIt<T>(_ c: some CollectionOf<T>) -> some CollectionOf<T> {
 func useReverseIt(_ c: any CollectionOf) {
   let c = reverseIt(c)
   let _: Int = c // expected-error{{cannot convert value of type 'CollectionOf' to specified type 'Int'}}
+}
+
+/// --- Opening existentials when returning opaque types.
+extension P {
+  func getQ() -> some Q {
+    let a: A? = nil
+    return a!
+  }
+
+  func getCollectionOf() -> some CollectionOf<A> {
+    return [] as [A]
+  }
+}
+
+func testReturningOpaqueTypes(p: any P) {
+  let q = p.getQ()
+  let _: Int = q  // expected-error{{cannot convert value of type 'Q' to specified type 'Int'}}
+
+  p.getCollectionOf() // expected-error{{member 'getCollectionOf' cannot be used on value of protocol type 'P'; use a generic constraint instead}}
 }

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -140,6 +140,18 @@ func doNotOpenOuter(p: any P) {
   // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
+func takesVariadic<T: P>(_ args: T...) { }
+// expected-note@-1 2{{required by global function 'takesVariadic' where 'T' = 'P'}}
+// expected-note@-2{{in call to function 'takesVariadic'}}
+
+func callVariadic(p1: any P, p2: any P) {
+  takesVariadic() // expected-error{{generic parameter 'T' could not be inferred}}
+  takesVariadic(p1) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}}
+  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
+  takesVariadic(p1, p2) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}}
+  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
+}
+
 @available(SwiftStdlib 5.1, *)
 func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -126,11 +126,18 @@ func arrayOfOne<T: P>(_ value: T) -> [T] {
 }
 
 struct X<T: P> {
+  // expected-note@-1{{required by generic struct 'X' where 'T' = 'P'}}
+  func f(_: T) { }
 }
 
 // expected-note@+1{{required by global function 'createX' where 'T' = 'P'}}
 func createX<T: P>(_ value: T) -> X<T> {
   X<T>()
+}
+
+func doNotOpenOuter(p: any P) {
+  _ = X().f(p) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}}
+  // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -69,16 +69,19 @@ protocol CollectionOf: Collection {
 extension Array: CollectionOf { }
 extension Set: CollectionOf { }
 
+@available(SwiftStdlib 5.1, *)
 func reverseIt<T>(_ c: some CollectionOf<T>) -> some CollectionOf<T> {
   return c.reversed()
 }
 
+@available(SwiftStdlib 5.1, *)
 func useReverseIt(_ c: any CollectionOf) {
   let c = reverseIt(c)
   let _: Int = c // expected-error{{cannot convert value of type 'CollectionOf' to specified type 'Int'}}
 }
 
 /// --- Opening existentials when returning opaque types.
+@available(SwiftStdlib 5.1, *)
 extension P {
   func getQ() -> some Q {
     let a: A? = nil
@@ -90,6 +93,7 @@ extension P {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()
   let _: Int = q  // expected-error{{cannot convert value of type 'Q' to specified type 'Int'}}

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types -enable-parameterized-protocol-types -enable-experimental-opaque-parameters
+// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types -enable-parametrized-protocol-types -enable-experimental-opaque-parameters
 
 protocol Q { }
 
@@ -59,4 +59,21 @@ func testMultipleOpened(a: any P, b: any P & Q) {
 
   let r2 = a.combineThePs(b)
   let _: Int = r2  // expected-error{{cannot convert value of type '(Q, Q)?' to specified type 'Int'}}  
+}
+
+// --- With primary associated types and opaque parameter types
+protocol CollectionOf: Collection {
+  @_primaryAssociatedType associatedtype Element
+}
+
+extension Array: CollectionOf { }
+extension Set: CollectionOf { }
+
+func reverseIt<T>(_ c: some CollectionOf<T>) -> some CollectionOf<T> {
+  return c.reversed()
+}
+
+func useReverseIt(_ c: any CollectionOf) {
+  let c = reverseIt(c)
+  let _: Int = c // expected-error{{cannot convert value of type 'CollectionOf' to specified type 'Int'}}
 }

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -61,6 +61,16 @@ func testMultipleOpened(a: any P, b: any P & Q) {
   let _: Int = r2  // expected-error{{cannot convert value of type '(Q, Q)?' to specified type 'Int'}}  
 }
 
+// --- Opening existential metatypes
+func conjureValue<T: P>(of type: T.Type) -> T? {
+  nil
+}
+
+func testMagic(pt: any P.Type) {
+  let pOpt = conjureValue(of: pt)
+  let _: Int = pOpt // expected-error{{cannot convert value of type 'P?' to specified type 'Int'}}
+}
+
 // --- With primary associated types and opaque parameter types
 protocol CollectionOf: Collection {
   @_primaryAssociatedType associatedtype Element

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -enable-experimental-opened-existential-types
 
 // REQUIRES: OS=macosx
 

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,4 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -enable-experimental-opened-existential-types)
 //
 // REQUIRES: executable_test
 

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -343,7 +343,7 @@ do {
 
     arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     if #available(macOS 10.15, *) {
-      arg.invariantSelf1_1() // expected-error {{member 'invariantSelf1_1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+      _ = arg.invariantSelf1_1()
     }
     arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
@@ -392,7 +392,7 @@ do {
 
     arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     if #available(macOS 10.15, *) {
-      arg.invariantSelfProp1_1 // expected-error {{member 'invariantSelfProp1_1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+      _ = arg.invariantSelfProp1_1
     }
     arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
     arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -503,10 +503,11 @@ extension OpaqueProtocol {
 }
 
 func takesOpaqueProtocol(existential: OpaqueProtocol) {
-  // this is not allowed:
-  _ = existential.asSome // expected-error{{member 'asSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
-  _ = existential.getAsSome() // expected-error{{member 'getAsSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
-  _ = existential[0] // expected-error{{member 'subscript' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
+  // These are okay because we erase to the opaque type bound
+  let a = existential.asSome
+  let _: Int = a // expected-error{{cannot convert value of type 'OpaqueProtocol' to specified type 'Int'}}
+  _ = existential.getAsSome()
+  _ = existential[0]
 }
 
 func takesOpaqueProtocol<T : OpaqueProtocol>(generic: T) {


### PR DESCRIPTION
When calling a generic function with an argument of existential type,
implicitly "open" the existential type into a concrete archetype, which
can then be bound to the generic type. This extends the implicit
opening that is performed when accessing a member of an existential
type from the "self" parameter to all parameters. For example:

    func unsafeFirst<C: Collection>(_ c: C) -> C.Element { c.first! }

    func g(c: any Collection) {
      unsafeFirst(c)   // currently an error
                       // with this change, succeeds and produces an 'Any'
    }

This avoids many common sources of errors of the form

    protocol 'P' as a type cannot conform to the protocol itself

which come from calling generic functions with an existential, and
allows another way "out" if one has an existention and needs to treat
it generically.

This feature is behind a frontend flag
`-enable-experimental-opened-existential-types`.
