### PR TITLE
[cxx-interop] Fix crash when calling method that returns specialization of parent.

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2698,9 +2698,9 @@ public:
         TheDecl(decl), isMutating(isMutating) {}
   ParameterConvention
   getIndirectSelfParameter(const AbstractionPattern &type) const override {
-    llvm_unreachable(
-        "cxx functions do not have a Swift self parameter; "
-        "foreign self parameter is handled in getIndirectParameter");
+    if (isMutating)
+      return ParameterConvention::Indirect_Inout;
+    return ParameterConvention::Indirect_In_Guaranteed;
   }
 
   ParameterConvention
@@ -2708,9 +2708,7 @@ public:
                        const TypeLowering &substTL) const override {
     // `self` is the last parameter.
     if (index == TheDecl->getNumParams()) {
-      if (isMutating)
-        return ParameterConvention::Indirect_Inout;
-      return ParameterConvention::Indirect_In_Guaranteed;
+      return getIndirectSelfParameter(type);
     }
     return super::getIndirectParameter(index, type, substTL);
   }

--- a/test/Interop/Cxx/templates/Inputs/member-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/member-templates.h
@@ -28,6 +28,10 @@ template <class T> struct TemplateClassWithMemberTemplates {
 
   template <class U> void setValue(U val) { value = val; }
 
+  template<class U> TemplateClassWithMemberTemplates<U> toOtherSpec(const U& u) const {
+    return {u};
+  }
+
   TemplateClassWithMemberTemplates(T val) : value(val) {}
 };
 

--- a/test/Interop/Cxx/templates/member-templates.swift
+++ b/test/Interop/Cxx/templates/member-templates.swift
@@ -4,7 +4,6 @@
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc
-// REQUIRES: fixing-after-30630
 
 import MemberTemplates
 import StdlibUnittest
@@ -21,6 +20,13 @@ TemplatesTestSuite.test("Templated Add") {
   var h = HasMemberTemplates()
   expectEqual(h.addSameTypeParams(2, 1), 3)
   expectEqual(h.addMixedTypeParams(2, 1), 3)
+}
+
+TemplatesTestSuite.test("Returns other specialization") {
+  let t = TemplateClassWithMemberTemplates<CInt>(42)
+  var _5 = 5
+  let o = t.toOtherSpec(&_5)
+  // TODO: why is "o" Void here? rdar://88443730
 }
 
 runAllTests()


### PR DESCRIPTION
Also enables some more test coverage! 