### PR TITLE
Fix SILOptimizer crash for top-level async code

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1980,8 +1980,11 @@ public:
         // emitAsyncMainThreadStart will create argc and argv.
         // Just set the main actor as the expected executor; we should
         // already be running on it.
+        SILValue executor = sgm.TopLevelSGF->emitMainExecutor(prologueLoc);
         sgm.TopLevelSGF->ExpectedExecutor =
-          sgm.TopLevelSGF->emitMainExecutor(prologueLoc);
+            sgm.TopLevelSGF->B.createOptionalSome(
+                prologueLoc, executor,
+                SILType::getOptionalType(executor->getType()));
       } else {
         // Create the argc and argv arguments.
         auto entry = sgm.TopLevelSGF->B.getInsertionBB();

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -8,6 +8,7 @@
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[GET_MAIN:%.*]] = function_ref @swift_task_getMainExecutor
 // CHECK-NEXT: [[MAIN:%.*]] = apply [[GET_MAIN]]()
+// CHECK-NEXT: [[MAIN_OPTIONAL:%[0-9]+]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[MAIN]]
 
 actor MyActorImpl {}
 
@@ -67,7 +68,7 @@ await printFromMyActor(value: a)
 // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
 // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
 // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
-// CHECK: hop_to_executor [[MAIN]]
+// CHECK: hop_to_executor [[MAIN_OPTIONAL]]
 // CHECK: end_borrow [[ACTORREF]]
 
 if a < 10 {
@@ -121,6 +122,6 @@ if a < 10 {
     // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
     // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
     // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
-    // CHECK: hop_to_executor [[MAIN]]
+    // CHECK: hop_to_executor [[MAIN_OPTIONAL]]
     // CHECK: end_borrow [[ACTORREF]]
 }


### PR DESCRIPTION
Lowering hops to actors expected the executor to either be an optional
builtin executor type or an actor type. The type coming from
`getMainExecutor` is just a builtin executor, not an optional. As a
result, `LowerHopToActor::emitGetExecutor` would get called in
`LowerHopToActor::processHop`, and would try looking up the builtin
executor type, thinking it was an actor type. This would fail because we
didn't have an actor type.

```
auto actorConf = module->lookupConformance(actorType, actorProtocol);
assert(actorConf &&
           "hop_to_executor with actor that doesn't conform to Actor");
```

The end result was hitting this assert here, saying that the "actor"
doesn't conform to actor.

The fix is to wrap the executor in an optional.
