### PR TITLE
[build] Add Clang's features file to the toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -18,7 +18,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;s
 
 [preset: mixin_buildbot_install_components_with_clang]
 swift-install-components=back-deployment;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -807,7 +807,7 @@ no-swift-stdlib-assertions
 #===------------------------------------------------------------------------===#
 [preset: mixin_linux_install_components_with_clang]
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=
@@ -2618,7 +2618,7 @@ darwin-toolchain-display-name-short=Swift Development Snapshot
 darwin-toolchain-display-name=Swift Development Snapshot
 darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT
 darwin-toolchain-version=3.999.999
-llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libclang-headers;dsymutil
+llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libclang-headers;dsymutil;clang-features-file
 swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s


### PR DESCRIPTION
I confirmed that the toolchain contained the features file after LLVM
Project af7ae6adc695cb385f5c4834acfce950d09c17d6, not sure when it
disappeared.

Explicitly add it to the install components in the toolchain presets.

Resolves rdar://88446151.