### PR TITLE
[ConstraintSystem] Match trailing closures to implicit `.callAsFunction` when necessary

### DIFF
--- a/include/swift/AST/ArgumentList.h
+++ b/include/swift/AST/ArgumentList.h
@@ -249,11 +249,13 @@ public:
   static ArgumentList *
   createImplicit(ASTContext &ctx, SourceLoc lParenLoc, ArrayRef<Argument> args,
                  SourceLoc rParenLoc,
+                 Optional<unsigned> firstTrailingClosureIndex = None,
                  AllocationArena arena = AllocationArena::Permanent);
 
   /// Create a new implicit ArgumentList with a set of \p args.
   static ArgumentList *
   createImplicit(ASTContext &ctx, ArrayRef<Argument> args,
+                 Optional<unsigned> firstTrailingClosureIndex = None,
                  AllocationArena arena = AllocationArena::Permanent);
 
   /// Create a new implicit ArgumentList with a single labeled argument

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3488,6 +3488,11 @@ public:
   void recordMatchCallArgumentResult(ConstraintLocator *locator,
                                      MatchCallArgumentResult result);
 
+  /// Record implicitly generated `callAsFunction` with root at the
+  /// given expression, located at \c locator.
+  void recordCallAsFunction(UnresolvedDotExpr *root, ArgumentList *arguments,
+                            ConstraintLocator *locator);
+
   /// Walk a closure AST to determine its effects.
   ///
   /// \returns a function's extended info describing the effects, as

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5467,6 +5467,7 @@ matchCallArguments(
 ConstraintSystem::TypeMatchResult
 matchCallArguments(ConstraintSystem &cs,
                    FunctionType *contextualType,
+                   ArgumentList *argumentList,
                    ArrayRef<AnyFunctionType::Param> args,
                    ArrayRef<AnyFunctionType::Param> params,
                    ConstraintKind subKind,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1220,6 +1220,10 @@ public:
   /// constructions) to the argument lists for the call to that locator.
   llvm::MapVector<ConstraintLocator *, ArgumentList *> argumentLists;
 
+  /// The set of implicitly generated `.callAsFunction` root expressions.
+  llvm::DenseMap<ConstraintLocator *, UnresolvedDotExpr *>
+      ImplicitCallAsFunctionRoots;
+
   /// Record a new argument matching choice for given locator that maps a
   /// single argument to a single parameter.
   void recordSingleArgMatchingChoice(ConstraintLocator *locator);
@@ -2468,6 +2472,12 @@ public:
   /// types.
   llvm::DenseMap<CanType, DynamicCallableMethods> DynamicCallableCache;
 
+  /// A cache of implicitly generated dot-member expressions used as roots
+  /// for some `.callAsFunction` calls. The key here is "base" locator for
+  /// the `.callAsFunction` member reference.
+  llvm::SmallMapVector<ConstraintLocator *, UnresolvedDotExpr *, 2>
+      ImplicitCallAsFunctionRoots;
+
 private:
   /// Describe the candidate expression for partial solving.
   /// This class used by shrink & solve methods which apply
@@ -2950,6 +2960,9 @@ public:
 
     /// The length of \c ArgumentLists.
     unsigned numArgumentLists;
+
+    /// The length of \c ImplicitCallAsFunctionRoots.
+    unsigned numImplicitCallAsFunctionRoots;
 
     /// The previous score.
     Score PreviousScore;

--- a/lib/AST/ArgumentList.cpp
+++ b/lib/AST/ArgumentList.cpp
@@ -108,19 +108,22 @@ ArgumentList *ArgumentList::createTypeChecked(ASTContext &ctx,
                 originalArgs->isImplicit(), originalArgs);
 }
 
-ArgumentList *ArgumentList::createImplicit(ASTContext &ctx, SourceLoc lParenLoc,
-                                           ArrayRef<Argument> args,
-                                           SourceLoc rParenLoc,
-                                           AllocationArena arena) {
-  return create(ctx, lParenLoc, args, rParenLoc,
-                /*firstTrailingClosureIdx*/ None, /*implicit*/ true,
+ArgumentList *
+ArgumentList::createImplicit(ASTContext &ctx, SourceLoc lParenLoc,
+                             ArrayRef<Argument> args, SourceLoc rParenLoc,
+                             Optional<unsigned> firstTrailingClosureIndex,
+                             AllocationArena arena) {
+  return create(ctx, lParenLoc, args, rParenLoc, firstTrailingClosureIndex,
+                /*implicit*/ true,
                 /*originalArgs*/ nullptr, arena);
 }
 
-ArgumentList *ArgumentList::createImplicit(ASTContext &ctx,
-                                           ArrayRef<Argument> args,
-                                           AllocationArena arena) {
-  return createImplicit(ctx, SourceLoc(), args, SourceLoc(), arena);
+ArgumentList *
+ArgumentList::createImplicit(ASTContext &ctx, ArrayRef<Argument> args,
+                             Optional<unsigned> firstTrailingClosureIndex,
+                             AllocationArena arena) {
+  return createImplicit(ctx, SourceLoc(), args, SourceLoc(),
+                        firstTrailingClosureIndex, arena);
 }
 
 ArgumentList *ArgumentList::forImplicitSingle(ASTContext &ctx, Identifier label,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10696,16 +10696,10 @@ ConstraintSystem::simplifyApplicableFnConstraint(
         auto &ctx = getASTContext();
         auto numTrailing = argumentList->getNumTrailingClosures();
 
-        SmallVector<Argument, 4> newArguments;
-        SmallVector<Argument, 4> trailingClosures;
-
-        for (unsigned i = 0, n = argumentList->size(); i != n; ++i) {
-          if (argumentList->isTrailingClosureIndex(i)) {
-            trailingClosures.push_back(argumentList->get(i));
-          } else {
-            newArguments.push_back(argumentList->get(i));
-          }
-        }
+        SmallVector<Argument, 4> newArguments(
+            argumentList->getNonTrailingArgs());
+        SmallVector<Argument, 4> trailingClosures(
+            argumentList->getTrailingClosures());
 
         // Original argument list with all the trailing closures removed.
         auto *newArgumentList = ArgumentList::createParsed(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1321,6 +1321,7 @@ public:
 // Match the argument of a call to the parameter.
 ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
     ConstraintSystem &cs, FunctionType *contextualType,
+    ArgumentList *argList,
     ArrayRef<AnyFunctionType::Param> args,
     ArrayRef<AnyFunctionType::Param> params, ConstraintKind subKind,
     ConstraintLocatorBuilder locator,
@@ -1340,8 +1341,7 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
 
   ParameterListInfo paramInfo(params, callee, appliedSelf);
 
-  // Dig out the argument information.
-  auto *argList = cs.getArgumentList(loc);
+  // Make sure that argument list is available.
   assert(argList);
 
   // Apply labels to arguments.
@@ -10634,11 +10634,14 @@ ConstraintSystem::simplifyApplicableFnConstraint(
                               ? ConstraintKind::OperatorArgumentConversion
                               : ConstraintKind::ArgumentConversion);
 
+    auto *argumentsLoc = getConstraintLocator(
+        outerLocator.withPathElement(ConstraintLocator::ApplyArgument));
+
+    auto *argumentList = getArgumentList(argumentsLoc);
     // The argument type must be convertible to the input type.
     auto matchCallResult = ::matchCallArguments(
-        *this, func2, func1->getParams(), func2->getParams(), subKind,
-        outerLocator.withPathElement(ConstraintLocator::ApplyArgument),
-        trailingClosureMatching);
+        *this, func2, argumentList, func1->getParams(), func2->getParams(),
+        subKind, argumentsLoc, trailingClosureMatching);
 
     switch (matchCallResult) {
     case SolutionKind::Error:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10674,9 +10674,6 @@ ConstraintSystem::simplifyApplicableFnConstraint(
 
     switch (matchCallResult) {
     case SolutionKind::Error: {
-      if (shouldAttemptFixes())
-        return SolutionKind::Error;
-
       auto resultTy = func2->getResult();
 
       // If this is a call that constructs a callable type with

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10736,12 +10736,9 @@ ConstraintSystem::simplifyApplicableFnConstraint(
         if (matchCallResult != SolutionKind::Solved)
           return SolutionKind::Error;
 
-        // Note that `createImplicit` cannot be used here because it
-        // doesn't allow us to specify trailing closure index.
-        auto *implicitCallArgumentList = ArgumentList::createParsed(
-            ctx, /*LParen=*/SourceLoc(), trailingClosures,
-            /*RParen=*/SourceLoc(),
-            /*firstTrailingClosureIndex=*/0);
+        auto *implicitCallArgumentList =
+            ArgumentList::createImplicit(ctx, trailingClosures,
+                                         /*firstTrailingClosureIndex=*/0);
 
         auto *implicitRef = createImplicitRootForCallAsFunction(
             *this, callAsFunctionResultTy, implicitCallArgumentList, calleeLoc);
@@ -11720,6 +11717,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
     if (!ArgumentLists.count(memberLoc)) {
       auto *argList = ArgumentList::createImplicit(
           getASTContext(), {Argument(SourceLoc(), Identifier(), nullptr)},
+          /*firstTrailingClosureIndex=*/None,
           AllocationArena::ConstraintSolver);
       ArgumentLists.insert({memberLoc, argList});
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -201,6 +201,10 @@ Solution ConstraintSystem::finalize() {
     solution.argumentLists.insert(argListMapping);
   }
 
+  for (const auto &implicitRoot : ImplicitCallAsFunctionRoots) {
+    solution.ImplicitCallAsFunctionRoots.insert(implicitRoot);
+  }
+
   return solution;
 }
 
@@ -306,6 +310,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register the argument lists.
   for (auto &argListMapping : solution.argumentLists) {
     ArgumentLists.insert(argListMapping);
+  }
+
+  for (auto &implicitRoot : solution.ImplicitCallAsFunctionRoots) {
+    ImplicitCallAsFunctionRoots.insert(implicitRoot);
   }
 
   // Register any fixes produced along this path.
@@ -529,6 +537,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numIsolatedParams = cs.isolatedParams.size();
   numImplicitValueConversions = cs.ImplicitValueConversions.size();
   numArgumentLists = cs.ArgumentLists.size();
+  numImplicitCallAsFunctionRoots = cs.ImplicitCallAsFunctionRoots.size();
 
   PreviousScore = cs.CurrentScore;
 
@@ -642,6 +651,10 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any argument lists no longer in scope.
   truncate(cs.ArgumentLists, numArgumentLists);
+
+  // Remove any implicitly generated root expressions for `.callAsFunction`
+  // which are no longer in scope.
+  truncate(cs.ImplicitCallAsFunctionRoots, numImplicitCallAsFunctionRoots);
 
   // Reset the previous score.
   cs.CurrentScore = PreviousScore;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2714,6 +2714,7 @@ void ConstraintSystem::bindOverloadType(
     if (!argList) {
       argList = ArgumentList::createImplicit(
           ctx, {Argument(SourceLoc(), ctx.Id_dynamicMember, /*expr*/ nullptr)},
+          /*firstTrailingClosureIndex=*/None,
           AllocationArena::ConstraintSolver);
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3239,7 +3239,8 @@ size_t Solution::getTotalMemory() const {
          ConstraintRestrictions.getMemorySize() +
          llvm::capacity_in_bytes(Fixes) + DisjunctionChoices.getMemorySize() +
          OpenedTypes.getMemorySize() + OpenedExistentialTypes.getMemorySize() +
-         (DefaultedConstraints.size() * sizeof(void *));
+         (DefaultedConstraints.size() * sizeof(void *)) +
+         ImplicitCallAsFunctionRoots.getMemorySize();
 }
 
 DeclContext *Solution::getDC() const { return constraintSystem->DC; }

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://83717297
+//
+// Make sure that trailing closures are matches to the `callAsFunction`
+// when used in the same expression as `.init` of a callable type.
+
+protocol View {}
+struct EmptyView: View {}
+
+struct MyLayout {
+  func callAsFunction<V: View>(content: () -> V) -> MyLayout { .init() }
+  func callAsFunction<V: View>(answer: () -> Int,
+                               content: () -> V) -> MyLayout { .init() }
+}
+
+struct Test {
+  var body1: MyLayout {
+    MyLayout() {
+      EmptyView() // Ok
+    }
+  }
+
+  var body2: MyLayout {
+    MyLayout() {
+      42
+    } content: {
+      EmptyView() // Ok
+    }
+  }
+}


### PR DESCRIPTION
In situations like `T(...) { ... }` where `T` is a callable type,
it's not immediately clear whether trailing closures are associated
with `.init` of `T` or implicit `.callAsFunction`. So if constructor
didn't match trailing closures, let's attempt to split them off and
form an implicit `.callAsFunction` call with them as a fallback.

Resolves: rdar://83717297

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
