### PR TITLE
Disable `conformance_descriptors.swift` on Linux AArch64

### DIFF
--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -1,4 +1,5 @@
 // UNSUPPORTED: windows
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances


### PR DESCRIPTION
Test failure tracked in rdar://88451721.

Example failure: 
https://ci.swift.org/job/oss-swift-package-ubuntu-20_04-aarch64/712