### PR TITLE
Swift 6 mode is only available on asserts builds

### DIFF
--- a/test/Concurrency/property_initializers_swift6.swift
+++ b/test/Concurrency/property_initializers_swift6.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 6 -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
+// REQUIRES: asserts
 
 @MainActor
 func mainActorFn() -> Int { return 0 } // expected-note 2 {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 6 %s -verify
 
+// REQUIRES: asserts
+
 var a = 10
 // expected-note@-1 2 {{var declared here}}
 // expected-note@-2 2 {{mutation of this var is only permitted within the actor}}

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -1,6 +1,8 @@
 // RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 6 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift6-CHECK,CHECK'
 // RUN: not %target-swift-frontend -enable-experimental-async-top-level -swift-version 5 -typecheck %s %S/Inputs/foo.swift 2>&1 | %FileCheck %s --check-prefixes='Swift5-CHECK,CHECK'
 
+// REQUIRES: asserts
+
 var a = 10
 
 @MainActor

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -disable-availability-checking -enable-experimental-async-top-level -swift-version 6 %s -verify
 // RUN: %target-swift-frontend -typecheck -disable-availability-checking -swift-version 6 %s -verify
 
+// REQUIRES: asserts
+
 // Even though enable-experimental-async-top-level is enabled, there are no
 // 'await's made from the top-level, thus the top-level is not an asynchronous
 // context. `a` is just a normal top-level global variable with no actor


### PR DESCRIPTION
Any test using swift version 6 will only work on asserts builds of the
compiler to avoid seeing:

```
<unknown>:0: error: invalid value '6' in '-swift-version 6'
<unknown>:0: note: valid arguments to '-swift-version' are '4', '4.2', '5'
```

rdar://88087296