### PR TITLE
Lower non-optional executors

### DIFF
--- a/test/SILOptimizer/lower_hop_to_actor.sil
+++ b/test/SILOptimizer/lower_hop_to_actor.sil
@@ -221,3 +221,22 @@ bb0(%0 : @guaranteed $CustomActor):
   %r = tuple ()
   return %r : $()
 }
+
+sil @get_raw_executor : $@convention(thin) () -> Builtin.Executor
+
+// CHECK-LABEL: sil [ossa] @non_optional_executor :
+sil [ossa] @non_optional_executor : $@async () -> () {
+bb0:
+// CHECK: bb0:
+// CHECK:      [[GET_RAW_EXECUTOR:%.*]] = function_ref @get_raw_executor
+// CHECK-NEXT: [[EXECUTOR:%.*]] = apply [[GET_RAW_EXECUTOR]]()
+// CHECK-NEXT: [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT: hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT: [[RET:%.*]] = tuple ()
+// CHECK-NEXT: return [[RET]] : $()
+  %0 = function_ref @get_raw_executor : $@convention(thin) () -> Builtin.Executor
+  %1 = apply %0() : $@convention(thin) () -> Builtin.Executor
+  hop_to_executor %1 : $Builtin.Executor
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
Allow the `hop_to_executor` instruction to accept a non-optional executor without crashing in the lowering process.
IRGen still expects an optional executor, so to "lower" the executor, we construct an optional around it.