### PR TITLE
[Distributed] IRGen: Let debug info know about distributed accessor

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -277,7 +277,10 @@ DistributedAccessor::DistributedAccessor(IRGenFunction &IGF,
           IGM, AccessorType, AccessorType, SubstitutionMap(),
           /*suppress generics*/ true,
           FunctionPointer::Kind(
-              FunctionPointer::BasicKind::AsyncFunctionPointer))) {}
+              FunctionPointer::BasicKind::AsyncFunctionPointer))) {
+  if (IGM.DebugInfo)
+    IGM.DebugInfo->emitArtificialFunction(IGF, IGF.CurFn);
+}
 
 void DistributedAccessor::decodeArguments(llvm::Value *decoder,
                                           llvm::Value *argumentTypes,


### PR DESCRIPTION
Use `emitArtificialFunction` to let debug info know that compiler
is about to generate code for distributed accessor.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
