### PR TITLE
[SE-309] CSDiag: Add a fix-it that replaces an existential parameter type with its generic counterpart

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -140,8 +140,8 @@ ERROR(could_not_use_instance_member_on_type,none,
       "%select{| instance of nested}3 type %0",
       (Type, DeclNameRef, Type, bool))
 ERROR(could_not_use_member_on_existential,none,
-      "member %1 cannot be used on value of protocol type %0; use a generic"
-      " constraint instead",
+      "member %1 cannot be used on value of protocol type %0; consider using a"
+      " generic constraint instead",
       (Type, DeclNameRef))
 FIXIT(replace_with_type,"%0",(Type))
 FIXIT(insert_type_qualification,"%0.",(Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3933,19 +3933,145 @@ bool UnintendedExtraGenericParamMemberFailure::diagnoseAsError() {
 }
 
 bool InvalidMemberRefOnExistential::diagnoseAsError() {
-  auto anchor = getRawAnchor();
+  const auto Anchor = getRawAnchor();
 
-  DeclNameLoc nameLoc;
-  if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
-    nameLoc = UDE->getNameLoc();
-  } else if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor)) {
-    nameLoc = UME->getNameLoc();
+  DeclNameLoc NameLoc;
+  ParamDecl *PD = nullptr;
+  if (auto *UDE = getAsExpr<UnresolvedDotExpr>(Anchor)) {
+    NameLoc = UDE->getNameLoc();
+    if (auto *DRE = dyn_cast<DeclRefExpr>(UDE->getBase())) {
+      PD = dyn_cast<ParamDecl>(DRE->getDecl());
+    }
+  } else if (auto *UME = getAsExpr<UnresolvedMemberExpr>(Anchor)) {
+    NameLoc = UME->getNameLoc();
+  } else if (auto *SE = getAsExpr<SubscriptExpr>(Anchor)) {
+    if (auto *DRE = dyn_cast<DeclRefExpr>(SE->getBase())) {
+      PD = dyn_cast<ParamDecl>(DRE->getDecl());
+    }
   }
 
-  emitDiagnostic(diag::could_not_use_member_on_existential, getBaseType(),
-                 getName())
-      .highlight(nameLoc.getSourceRange())
-      .highlight(getSourceRange());
+  auto Diag = emitDiagnostic(diag::could_not_use_member_on_existential,
+                             getBaseType(), getName());
+  Diag.highlight(NameLoc.getSourceRange());
+  Diag.highlight(getSourceRange());
+
+  // If the base expression is a reference to a function or subscript
+  // parameter, offer a fixit that replaces the existential parameter type with
+  // its generic equivalent, e.g. func foo(p: any P) → func foo<T: P>(p: T).
+  // FIXME: Add an option to use 'some' vs. an explicit generic parameter.
+
+  if (!PD || !PD->getDeclContext()->getAsDecl())
+    return true;
+
+  // Code inside a subscript is bound against a duplicate set of implicit
+  // accessor parameters, which don't have a TypeRepr; dig out the corresponding
+  // explicit subscript parameter.
+  if (auto *const AD =
+          dyn_cast<AccessorDecl>(PD->getDeclContext()->getAsDecl())) {
+    auto *const SD = dyn_cast<SubscriptDecl>(AD->getStorage());
+    if (!SD)
+      return true;
+
+    const auto AccessorParams = AD->getParameters()->getArray();
+    const unsigned idx =
+        llvm::find(AccessorParams, PD) - AccessorParams.begin();
+
+    switch (AD->getAccessorKind()) {
+    case AccessorKind::Set:
+    case AccessorKind::WillSet:
+    case AccessorKind::DidSet:
+      // Ignore references to the 'newValue' or 'oldValue' parameters.
+      if (AccessorParams.front() == PD) {
+        return true;
+      }
+
+      PD = SD->getIndices()->get(idx - 1);
+      break;
+
+    case AccessorKind::Get:
+    case AccessorKind::Read:
+    case AccessorKind::Modify:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
+      PD = SD->getIndices()->get(idx);
+      break;
+    }
+  }
+
+  // Bail out in the absence of a TypeRepr.
+  if (!PD->getTypeRepr())
+    return true;
+
+  // Give up on 'inout' parameters. The intent is far more vague in this case,
+  // and applying the fix-it would invalidate mutations.
+  if (PD->isInOut())
+    return true;
+
+  constexpr StringRef GPNamePlaceholder = "<#generic parameter name#>";
+  SourceRange TyReplacementRange;
+  SourceRange RemoveAnyRange;
+  SourceLoc GPDeclLoc;
+  std::string GPDeclStr;
+  {
+    llvm::raw_string_ostream OS(GPDeclStr);
+    auto *const GC = PD->getDeclContext()->getAsDecl()->getAsGenericContext();
+    if (GC->getParsedGenericParams()) {
+      GPDeclLoc = GC->getParsedGenericParams()->getRAngleLoc();
+      OS << ", ";
+    } else {
+      GPDeclLoc =
+          isa<AbstractFunctionDecl>(GC)
+              ? cast<AbstractFunctionDecl>(GC)->getParameters()->getLParenLoc()
+              : cast<SubscriptDecl>(GC)->getIndices()->getLParenLoc();
+      OS << "<";
+    }
+    OS << GPNamePlaceholder << ": ";
+
+    auto *TR = PD->getTypeRepr()->getWithoutParens();
+    if (auto *STR = dyn_cast<SpecifierTypeRepr>(TR)) {
+      TR = STR->getBase()->getWithoutParens();
+    }
+    if (auto *ETR = dyn_cast<ExistentialTypeRepr>(TR)) {
+      TR = ETR->getConstraint();
+      RemoveAnyRange = SourceRange(ETR->getAnyLoc(), TR->getStartLoc());
+      TR = TR->getWithoutParens();
+    }
+    if (auto *MTR = dyn_cast<MetatypeTypeRepr>(TR)) {
+      TR = MTR->getBase();
+
+      // (P & Q).Type -> T.Type
+      // (P).Type -> (T).Type
+      // ((P & Q)).Type -> ((T)).Type
+      if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
+        assert(TTR->isParenType());
+        if (!isa<CompositionTypeRepr>(TTR->getElementType(0))) {
+          TR = TR->getWithoutParens();
+        }
+      }
+    }
+    TyReplacementRange = TR->getSourceRange();
+
+    // Strip any remaining parentheses and print the conformance constraint.
+    TR->getWithoutParens()->print(OS);
+
+    if (!GC->getParsedGenericParams()) {
+      OS << ">";
+    }
+  }
+
+  // First, replace the constraint type with the generic parameter type
+  // placeholder.
+  Diag.fixItReplace(TyReplacementRange, GPNamePlaceholder);
+
+  // Remove 'any' if needed, using a character-based removal to pick up
+  // whitespaces between it and its constraint repr.
+  if (RemoveAnyRange.isValid()) {
+    Diag.fixItRemoveChars(RemoveAnyRange.Start, RemoveAnyRange.End);
+  }
+
+  // Finally, insert the generic parameter declaration.
+  Diag.fixItInsert(GPDeclLoc, GPDeclStr);
+
   return true;
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1611,7 +1611,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   return requirementInfo.isContainedIn(witnessInfo);
 }
 
-// Returns 'nullptr' if this is the setter's 'newValue' parameter;
+// Returns 'nullptr' if this is the 'newValue' or 'oldValue' parameter;
 // otherwise, returns the corresponding parameter of the subscript
 // declaration.
 static ParamDecl *getOriginalParamFromAccessor(AbstractStorageDecl *storage,
@@ -1623,11 +1623,9 @@ static ParamDecl *getOriginalParamFromAccessor(AbstractStorageDecl *storage,
   switch (accessor->getAccessorKind()) {
   case AccessorKind::DidSet:
   case AccessorKind::WillSet:
-      return nullptr;
-
   case AccessorKind::Set:
     if (param == accessorParams->get(0)) {
-      // This is the 'newValue' parameter.
+      // This is the 'newValue' or 'oldValue' parameter.
       return nullptr;
     }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -164,7 +164,7 @@ func testReturningOpaqueTypes(p: any P) {
   let q = p.getQ()
   let _: Int = q  // expected-error{{cannot convert value of type 'Q' to specified type 'Int'}}
 
-  p.getCollectionOf() // expected-error{{member 'getCollectionOf' cannot be used on value of protocol type 'P'; use a generic constraint instead}}
+  p.getCollectionOf() // expected-error{{member 'getCollectionOf' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}}
 
   let q2 = getPQ(p)
   let _: Int = q2  // expected-error{{cannot convert value of type 'Q' to specified type 'Int'}}

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -370,8 +370,8 @@ func testClonableExistential(_ v: Clonable, _ vv: Clonable.Type) {
   let _: (Bool) -> Clonable? = id(vv.returnSelfIUOStatic as (Bool) -> Clonable?)
   let _: Clonable! = id(vv.returnSelfIUOStatic(true))
 
-  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of protocol type 'Clonable'; use a generic constraint instead}}
-  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; use a generic constraint instead}}
+  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of protocol type 'Clonable'; consider using a generic constraint instead}}
+  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; consider using a generic constraint instead}}
 
 }
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -38,7 +38,7 @@ func existential<T : EqualComparable, U : EqualComparable>(_ t1: T, t2: T, u: U)
   eqComp = u
   if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'EqualComparable' to expected argument type 'T'}}
   if eqComp.isEqual(t2) {}
-  // expected-error@-1 {{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; use a generic constraint instead}}
+  // expected-error@-1 {{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; consider using a generic constraint instead}}
 }
 
 protocol OtherEqualComparable {

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -318,143 +318,143 @@ do {
       { (_: () -> Any?) in }
     ]
 
-    arg.contravariantSelf1(0) // expected-error {{member 'contravariantSelf1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf2(0) // expected-error {{member 'contravariantSelf2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf3(0) // expected-error {{member 'contravariantSelf3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf4(0) // expected-error {{member 'contravariantSelf4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf5(0) // expected-error {{member 'contravariantSelf5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf6(0) // expected-error {{member 'contravariantSelf6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf7() // expected-error {{member 'contravariantSelf7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf8() // expected-error {{member 'contravariantSelf8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf9(0) // expected-error {{member 'contravariantSelf9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf10() // expected-error {{member 'contravariantSelf10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelf11(0) // expected-error {{member 'contravariantSelf11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc1(0) // expected-error {{member 'contravariantAssoc1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc2(0) // expected-error {{member 'contravariantAssoc2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc3(0) // expected-error {{member 'contravariantAssoc3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc4(0) // expected-error {{member 'contravariantAssoc4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc5(0) // expected-error {{member 'contravariantAssoc5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc6(0) // expected-error {{member 'contravariantAssoc6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc7() // expected-error {{member 'contravariantAssoc7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc8() // expected-error {{member 'contravariantAssoc8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc9(0) // expected-error {{member 'contravariantAssoc9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc10() // expected-error {{member 'contravariantAssoc10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssoc11(0) // expected-error {{member 'contravariantAssoc11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.contravariantSelf1(0) // expected-error {{member 'contravariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf2(0) // expected-error {{member 'contravariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf3(0) // expected-error {{member 'contravariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf4(0) // expected-error {{member 'contravariantSelf4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf5(0) // expected-error {{member 'contravariantSelf5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf6(0) // expected-error {{member 'contravariantSelf6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf7() // expected-error {{member 'contravariantSelf7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf8() // expected-error {{member 'contravariantSelf8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf9(0) // expected-error {{member 'contravariantSelf9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf10() // expected-error {{member 'contravariantSelf10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf11(0) // expected-error {{member 'contravariantSelf11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc1(0) // expected-error {{member 'contravariantAssoc1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc2(0) // expected-error {{member 'contravariantAssoc2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc3(0) // expected-error {{member 'contravariantAssoc3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc4(0) // expected-error {{member 'contravariantAssoc4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc5(0) // expected-error {{member 'contravariantAssoc5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc6(0) // expected-error {{member 'contravariantAssoc6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc7() // expected-error {{member 'contravariantAssoc7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc8() // expected-error {{member 'contravariantAssoc8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc9(0) // expected-error {{member 'contravariantAssoc9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc10() // expected-error {{member 'contravariantAssoc10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc11(0) // expected-error {{member 'contravariantAssoc11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
-    arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     if #available(macOS 10.15, *) {
       _ = arg.invariantSelf1_1()
     }
-    arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf4(0) // expected-error {{member 'invariantSelf4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf5() // expected-error {{member 'invariantSelf5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf6() // expected-error {{member 'invariantSelf6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf7(0) // expected-error {{member 'invariantSelf7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf8(0) // expected-error {{member 'invariantSelf8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf9(0) // expected-error {{member 'invariantSelf9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf10(0) // expected-error {{member 'invariantSelf10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelf11() // expected-error {{member 'invariantSelf11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc1(0) // expected-error {{member 'invariantAssoc1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc2(0) // expected-error {{member 'invariantAssoc2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc3(0) // expected-error {{member 'invariantAssoc3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc4(0) // expected-error {{member 'invariantAssoc4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc5() // expected-error {{member 'invariantAssoc5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc6() // expected-error {{member 'invariantAssoc6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc7(0) // expected-error {{member 'invariantAssoc7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc8(0) // expected-error {{member 'invariantAssoc8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc9(0) // expected-error {{member 'invariantAssoc9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc10(0) // expected-error {{member 'invariantAssoc10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssoc11() // expected-error {{member 'invariantAssoc11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf4(0) // expected-error {{member 'invariantSelf4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf5() // expected-error {{member 'invariantSelf5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf6() // expected-error {{member 'invariantSelf6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf7(0) // expected-error {{member 'invariantSelf7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf8(0) // expected-error {{member 'invariantSelf8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf9(0) // expected-error {{member 'invariantSelf9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf10(0) // expected-error {{member 'invariantSelf10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf11() // expected-error {{member 'invariantSelf11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc1(0) // expected-error {{member 'invariantAssoc1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc2(0) // expected-error {{member 'invariantAssoc2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc3(0) // expected-error {{member 'invariantAssoc3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc4(0) // expected-error {{member 'invariantAssoc4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc5() // expected-error {{member 'invariantAssoc5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc6() // expected-error {{member 'invariantAssoc6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc7(0) // expected-error {{member 'invariantAssoc7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc8(0) // expected-error {{member 'invariantAssoc8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc9(0) // expected-error {{member 'invariantAssoc9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc10(0) // expected-error {{member 'invariantAssoc10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc11() // expected-error {{member 'invariantAssoc11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
-    arg.contravariantSelfProp1 // expected-error {{member 'contravariantSelfProp1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp2 // expected-error {{member 'contravariantSelfProp2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp3 // expected-error {{member 'contravariantSelfProp3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp4 // expected-error {{member 'contravariantSelfProp4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp5 // expected-error {{member 'contravariantSelfProp5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp6 // expected-error {{member 'contravariantSelfProp6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp7 // expected-error {{member 'contravariantSelfProp7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp8 // expected-error {{member 'contravariantSelfProp8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp9 // expected-error {{member 'contravariantSelfProp9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp10 // expected-error {{member 'contravariantSelfProp10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantSelfProp11 // expected-error {{member 'contravariantSelfProp11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp1 // expected-error {{member 'contravariantAssocProp1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp2 // expected-error {{member 'contravariantAssocProp2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp3 // expected-error {{member 'contravariantAssocProp3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp4 // expected-error {{member 'contravariantAssocProp4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp5 // expected-error {{member 'contravariantAssocProp5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp6 // expected-error {{member 'contravariantAssocProp6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp7 // expected-error {{member 'contravariantAssocProp7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp8 // expected-error {{member 'contravariantAssocProp8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp9 // expected-error {{member 'contravariantAssocProp9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp10 // expected-error {{member 'contravariantAssocProp10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.contravariantAssocProp11 // expected-error {{member 'contravariantAssocProp11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.contravariantSelfProp1 // expected-error {{member 'contravariantSelfProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp2 // expected-error {{member 'contravariantSelfProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp3 // expected-error {{member 'contravariantSelfProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp4 // expected-error {{member 'contravariantSelfProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp5 // expected-error {{member 'contravariantSelfProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp6 // expected-error {{member 'contravariantSelfProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp7 // expected-error {{member 'contravariantSelfProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp8 // expected-error {{member 'contravariantSelfProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp9 // expected-error {{member 'contravariantSelfProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp10 // expected-error {{member 'contravariantSelfProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp11 // expected-error {{member 'contravariantSelfProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp1 // expected-error {{member 'contravariantAssocProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp2 // expected-error {{member 'contravariantAssocProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp3 // expected-error {{member 'contravariantAssocProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp4 // expected-error {{member 'contravariantAssocProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp5 // expected-error {{member 'contravariantAssocProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp6 // expected-error {{member 'contravariantAssocProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp7 // expected-error {{member 'contravariantAssocProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp8 // expected-error {{member 'contravariantAssocProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp9 // expected-error {{member 'contravariantAssocProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp10 // expected-error {{member 'contravariantAssocProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp11 // expected-error {{member 'contravariantAssocProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
-    arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     if #available(macOS 10.15, *) {
       _ = arg.invariantSelfProp1_1
     }
-    arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp4 // expected-error {{member 'invariantSelfProp4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp5 // expected-error {{member 'invariantSelfProp5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp6 // expected-error {{member 'invariantSelfProp6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp7 // expected-error {{member 'invariantSelfProp7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp8 // expected-error {{member 'invariantSelfProp8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp9 // expected-error {{member 'invariantSelfProp9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp10 // expected-error {{member 'invariantSelfProp10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantSelfProp11 // expected-error {{member 'invariantSelfProp11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp1 // expected-error {{member 'invariantAssocProp1' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp2 // expected-error {{member 'invariantAssocProp2' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp3 // expected-error {{member 'invariantAssocProp3' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp4 // expected-error {{member 'invariantAssocProp4' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp5 // expected-error {{member 'invariantAssocProp5' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp6 // expected-error {{member 'invariantAssocProp6' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp7 // expected-error {{member 'invariantAssocProp7' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp8 // expected-error {{member 'invariantAssocProp8' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp9 // expected-error {{member 'invariantAssocProp9' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp10 // expected-error {{member 'invariantAssocProp10' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg.invariantAssocProp11 // expected-error {{member 'invariantAssocProp11' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp4 // expected-error {{member 'invariantSelfProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp5 // expected-error {{member 'invariantSelfProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp6 // expected-error {{member 'invariantSelfProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp7 // expected-error {{member 'invariantSelfProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp8 // expected-error {{member 'invariantSelfProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp9 // expected-error {{member 'invariantSelfProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp10 // expected-error {{member 'invariantSelfProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp11 // expected-error {{member 'invariantSelfProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp1 // expected-error {{member 'invariantAssocProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp2 // expected-error {{member 'invariantAssocProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp3 // expected-error {{member 'invariantAssocProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp4 // expected-error {{member 'invariantAssocProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp5 // expected-error {{member 'invariantAssocProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp6 // expected-error {{member 'invariantAssocProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp7 // expected-error {{member 'invariantAssocProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp8 // expected-error {{member 'invariantAssocProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp9 // expected-error {{member 'invariantAssocProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp10 // expected-error {{member 'invariantAssocProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp11 // expected-error {{member 'invariantAssocProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
-    arg[contravariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantSelfSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[contravariantAssocSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg[contravariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
-    arg[invariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
-    arg[invariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; use a generic constraint instead}}
+    arg[invariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
   }
 }
 
@@ -484,7 +484,7 @@ do {
     protoMeta.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
     protoMeta[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
     _ = protoMeta.covariantSelfMethod // ok
-    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of protocol type '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'; use a generic constraint instead}}
+    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of protocol type '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'; consider using a generic constraint instead}}
     protoMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     protoMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
 
@@ -492,9 +492,9 @@ do {
     _ = existMeta.static_covariantSelfMethod // ok
     _ = existMeta.static_covariantSelfProp // ok
     _ = existMeta[static_covariantSelfSubscript: ()] // ok
-    existMeta.static_invariantSelfMethod // expected-error {{member 'static_invariantSelfMethod' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; use a generic constraint instead}}
-    existMeta.static_invariantSelfProp // expected-error {{member 'static_invariantSelfProp' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; use a generic constraint instead}}
-    existMeta[static_invariantSelfSubscript: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; use a generic constraint instead}}
+    existMeta.static_invariantSelfMethod // expected-error {{member 'static_invariantSelfMethod' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
+    existMeta.static_invariantSelfProp // expected-error {{member 'static_invariantSelfProp' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
+    existMeta[static_invariantSelfSubscript: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
     existMeta.invariantSelfMethod // expected-error {{instance member 'invariantSelfMethod' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     existMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     existMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
@@ -548,14 +548,14 @@ do {
   _ = exist.method3(false) // ok
   exist.method4(false)
   // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
-  // expected-error@-2 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; use a generic constraint instead}}
+  // expected-error@-2 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
   exist.method5(false)
   // expected-error@-1 {{instance method 'method5' requires that 'Bool' conform to 'Sequence'}}
-  // expected-error@-2 {{member 'method5' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; use a generic constraint instead}}
+  // expected-error@-2 {{member 'method5' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
 
   exist.method7(false)
   // expected-error@-1 {{instance method 'method7' requires that 'U' conform to 'UnfulfillableGenericRequirements'}}
-  // expected-error@-2 {{member 'method7' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; use a generic constraint instead}}
+  // expected-error@-2 {{member 'method7' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
 }
 protocol UnfulfillableGenericRequirementsDerived1: UnfulfillableGenericRequirements where A == Bool {}
 protocol UnfulfillableGenericRequirementsDerived2: UnfulfillableGenericRequirements where A == Class<Self> {}
@@ -567,7 +567,7 @@ do {
   exist1.method4(false)
   // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>}}
   exist2.method4(false)
-  // expected-error@-1 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived2'; use a generic constraint instead}}
+  // expected-error@-1 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived2'; consider using a generic constraint instead}}
   // expected-error@-2 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
 }
 protocol UnfulfillableGenericRequirementsDerived3: UnfulfillableGenericRequirements where A: Sequence, A.Element: Sequence {}
@@ -582,7 +582,7 @@ do {
   // expected-error@-2 {{instance method 'method6' requires that 'Self.A' conform to 'Sequence'}}
   // expected-error@-3 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
   exist2.method6(false)
-  // expected-error@-1 {{member 'method6' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived3'; use a generic constraint instead}}
+  // expected-error@-1 {{member 'method6' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived3'; consider using a generic constraint instead}}
   // expected-error@-2 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
 }
 
@@ -603,7 +603,7 @@ do {
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
-  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'InvalidTypeParameters'; use a generic constraint instead}}
+  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'InvalidTypeParameters'; consider using a generic constraint instead}}
 }
 
 protocol GenericRequirementFailures {
@@ -623,7 +623,7 @@ do {
   exist.method1() // expected-error {{referencing instance method 'method1()' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
   exist.method2() // expected-error {{referencing instance method 'method2()' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
   exist.method3(false) // expected-error {{referencing instance method 'method3' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
-  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'GenericRequirementFailures'; use a generic constraint instead}}
+  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'GenericRequirementFailures'; consider using a generic constraint instead}}
   exist.method4() // expected-error {{referencing instance method 'method4()' on 'GenericRequirementFailures' requires that 'Self.A' conform to 'GenericRequirementFailures'}}
 }
 protocol GenericRequirementFailuresDerived: GenericRequirementFailures where A: GenericRequirementFailures {}
@@ -642,9 +642,9 @@ protocol P2 {
 }
 func takesP2(p2: any P2) {
   _ = p2[]
-  // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P2'; use a generic constraint instead}}
+  // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P2'; consider using a generic constraint instead}}
   _ = p2.prop
-  // expected-error@-1{{member 'prop' cannot be used on value of protocol type 'P2'; use a generic constraint instead}}
+  // expected-error@-1{{member 'prop' cannot be used on value of protocol type 'P2'; consider using a generic constraint instead}}
 }
 
 protocol MiscTestsProto {
@@ -745,16 +745,16 @@ protocol ConcreteAssocTypes {
 }
 do {
   func test(arg: any ConcreteAssocTypes) {
-    _ = arg.method1 // expected-error {{member 'method1' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg.method2 // expected-error {{member 'method2' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
+    _ = arg.method1 // expected-error {{member 'method1' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.method2 // expected-error {{member 'method2' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
     // Covariant 'Self' erasure works in conjunction with concrete associated types.
     let _: (Bool, any ConcreteAssocTypes) = arg.property2 // ok
-    _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
-    _ = arg[subscript3: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; use a generic constraint instead}}
+    _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript3: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -225,11 +225,10 @@ protocol P1 {
   subscript(invariantAssocSubscript7 _: any P1 & Class<Q>) -> Void { get }
   subscript(invariantAssocSubscript8 _: Void) -> Struct<Q>.InnerGeneric<Void> { get }
 }
-@available(macOS 10.15, *)
 extension P1 {
-  func invariantSelf1_1() -> some P1 { self }
-  var invariantSelfProp1_1: some P1 { self }
-  subscript(invariantSelfSubscript1_1: Void) -> some P1 { self }
+  func opaqueResultTypeMethod() -> some P1 { self }
+  var opaqueResultTypeProp: some P1 { self }
+  subscript(opaqueResultTypeSubscript _: Bool) -> some P1 { self }
 }
 
 do {
@@ -318,6 +317,10 @@ do {
       { (_: () -> Any?) in }
     ]
 
+    let _: any P1 = arg.opaqueResultTypeMethod()
+    let _: any P1 = arg.opaqueResultTypeProp
+    let _: any P1 = arg[opaqueResultTypeSubscript: true]
+
     arg.contravariantSelf1(0) // expected-error {{member 'contravariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.contravariantSelf2(0) // expected-error {{member 'contravariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.contravariantSelf3(0) // expected-error {{member 'contravariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
@@ -342,9 +345,6 @@ do {
     arg.contravariantAssoc11(0) // expected-error {{member 'contravariantAssoc11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
     arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    if #available(macOS 10.15, *) {
-      _ = arg.invariantSelf1_1()
-    }
     arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.invariantSelf4(0) // expected-error {{member 'invariantSelf4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
@@ -391,9 +391,6 @@ do {
     arg.contravariantAssocProp11 // expected-error {{member 'contravariantAssocProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
 
     arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    if #available(macOS 10.15, *) {
-      _ = arg.invariantSelfProp1_1
-    }
     arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
     arg.invariantSelfProp4 // expected-error {{member 'invariantSelfProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
@@ -1,0 +1,206 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype A
+
+  func method(_: A)
+  subscript(_: A) -> A { get }
+  init(_: A)
+
+  static func staticMethod(_: A)
+}
+protocol Q {}
+
+do {
+  func test(p: P) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: ((P))) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:18--1:19=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: any P) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: (inout any P)) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+  }
+}
+do {
+  func test(p: __shared (any P)) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:30--1:31=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: ((any P))) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: any (P)) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P)'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: any   P) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: (any  (P))) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P)'; consider using a generic constraint instead}} {{-1:23--1:24=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: P.Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: (P).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P).Type'; consider using a generic constraint instead}} {{-1:17--1:18=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: any P.Type) {
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  func test(p: any ((P).Type)) {
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P).Type'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+
+do {
+  func test(p: P & Q) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:16--1:21=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: ((P & Q))) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: any P & Q) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: inout any P & Q) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{none}}
+  }
+}
+do {
+  func test(p: __shared (any P & Q)) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:30--1:35=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: ((any P & Q))) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: any (P & Q)) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P & Q)'; consider using a generic constraint instead}} {{-1:21--1:26=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: any   P & Q) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: (any  (P & Q))) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P & Q)'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: (P & Q).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P & Q).Type'; consider using a generic constraint instead}} {{-1:16--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: ((P & Q)).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '((P & Q)).Type'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: any (P & Q).Type) {
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P & Q).Type'; consider using a generic constraint instead}} {{-1:20--1:27=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+do {
+  func test(p: any (((P & Q)).Type)) {
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '((P & Q)).Type'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+  }
+}
+
+do {
+  // With an existing generic parameter list.
+  func test<T: Sequence>(t: T, p: any P) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:39--1:40=<#generic parameter name#>}} {{-1:35--1:39=}} {{-1:24--1:24=, <#generic parameter name#>: P}} {{none}}
+  }
+}
+do {
+  // With an subscript expression.
+  func test(p: any P) {
+    p[false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+do {
+  // With an initializer.
+  func test(p: any P.Type) {
+    p.init(false) // expected-error {{member 'init' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+  }
+}
+
+// Inside initializers, accessors and subscripts.
+struct Test {
+  init(p: any P) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:15--1:16=<#generic parameter name#>}} {{-1:11--1:15=}} {{-1:7--1:7=<<#generic parameter name#>: P>}} {{none}}
+  }
+
+  init<T: P>(p: any P, t: T) {
+    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:17--1:21=}} {{-1:12--1:12=, <#generic parameter name#>: P}} {{none}}
+  }
+
+  subscript(p: any P) -> any P {
+    p.method(false)  // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    return p
+  }
+
+  subscript<T: P>(p: any P, t: T) -> any P {
+    get {
+      p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-2:26--2:27=<#generic parameter name#>}} {{-2:22--2:26=}} {{-2:17--2:17=, <#generic parameter name#>: P}} {{none}}
+      return p
+    }
+    set(value) {
+      p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-6:26--6:27=<#generic parameter name#>}} {{-6:22--6:26=}} {{-6:17--6:17=, <#generic parameter name#>: P}} {{none}}
+      value.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+    }
+  }
+
+  subscript(p: any P & Q) -> any P {
+    _read { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    _modify { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-2:20--2:25=<#generic parameter name#>}} {{-2:16--2:20=}} {{-2:12--2:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    willSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-3:20--3:25=<#generic parameter name#>}} {{-3:16--3:20=}} {{-3:12--3:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    didSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-4:20--4:25=<#generic parameter name#>}} {{-4:16--4:20=}} {{-4:12--4:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    // expected-error@-2 {{'willSet' is not allowed in subscripts}}
+    // expected-error@-2 {{'didSet' is not allowed in subscripts}}
+  }
+
+  var property: any P {
+    get {}
+    set {
+      newValue.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+    }
+  }
+}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
@@ -189,10 +189,10 @@ struct Test {
   }
 
   subscript(p: any P & Q) -> any P {
-    _read { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    _read { p.method(false) }   // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
     _modify { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-2:20--2:25=<#generic parameter name#>}} {{-2:16--2:20=}} {{-2:12--2:12=<<#generic parameter name#>: P & Q>}} {{none}}
-    willSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-3:20--3:25=<#generic parameter name#>}} {{-3:16--3:20=}} {{-3:12--3:12=<<#generic parameter name#>: P & Q>}} {{none}}
-    didSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-4:20--4:25=<#generic parameter name#>}} {{-4:16--4:20=}} {{-4:12--4:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    willSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-3:20--3:25=<#generic parameter name#>}} {{-3:16--3:20=}} {{-3:12--3:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    didSet { p.method(false) }  // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-4:20--4:25=<#generic parameter name#>}} {{-4:16--4:20=}} {{-4:12--4:12=<<#generic parameter name#>: P & Q>}} {{none}}
     // expected-error@-2 {{'willSet' is not allowed in subscripts}}
     // expected-error@-2 {{'didSet' is not allowed in subscripts}}
   }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -165,18 +165,22 @@ protocol ProtocolWillSetDidSet4 {
 }
 
 class DidSetInSubscript {
-  subscript(_: Int) -> Int {
+  subscript(x: Int) -> Bool {
     didSet { // expected-error {{'didSet' is not allowed in subscripts}}
       print("eek")
+      // Make sure implicit observer parameters pick up the right type.
+      let _: Int = x
     }
     get {}
   }
 }
 
 class WillSetInSubscript {
-  subscript(_: Int) -> Int {
+  subscript(x: Int) -> Bool {
     willSet { // expected-error {{'willSet' is not allowed in subscripts}}
       print("eek")
+      // Make sure implicit observer parameters pick up the right type.
+      let _: Int = x
     }
     get {}
   }


### PR DESCRIPTION
If the base of an unsupported existential member access is a reference to a function/subscript parameter, offer a fix-it that replaces the existential parameter type with its generic counterpart, e.g. `func foo(p: any P) → func foo<T>(p: T)`.