### PR TITLE
Account for -disable-preallocated-instantiation-caches for non-dependent wtables in swift_getWitnessTable

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2462,7 +2462,8 @@ struct TargetGenericWitnessTable {
   using PrivateDataType = void *[swift::NumGenericMetadataPrivateDataWords];
 
   /// Private data for the instantiator.  Out-of-line so that the rest
-  /// of this structure can be constant.
+  /// of this structure can be constant. Might be null when building with
+  /// -disable-preallocated-instantiation-caches.
   RelativeDirectPointer<PrivateDataType> PrivateData;
 
   uint16_t getWitnessTablePrivateSizeInWords() const {
@@ -3536,7 +3537,8 @@ using OpaqueTypeDescriptor = TargetOpaqueTypeDescriptor<InProcess>;
 template <typename Runtime>
 struct TargetGenericMetadataInstantiationCache {
   /// Data that the runtime can use for its own purposes.  It is guaranteed
-  /// to be zero-filled by the compiler.
+  /// to be zero-filled by the compiler. Might be null when building with
+  /// -disable-preallocated-instantiation-caches.
   TargetPointer<Runtime, void>
   PrivateData[swift::NumGenericMetadataPrivateDataWords];
 };

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -4999,6 +4999,8 @@ WitnessTableCacheEntry::allocate(
 static WitnessTable *
 getNondependentWitnessTable(const ProtocolConformanceDescriptor *conformance,
                             const Metadata *type) {
+  assert(conformance->getGenericWitnessTable()->PrivateData != nullptr);
+
   // Check whether the table has already been instantiated.
   auto tablePtr = reinterpret_cast<std::atomic<WitnessTable*> *>(
                      conformance->getGenericWitnessTable()->PrivateData.get());
@@ -5065,7 +5067,8 @@ swift::swift_getWitnessTable(const ProtocolConformanceDescriptor *conformance,
   // least, not today). However, a generic type conformance may also be
   // nondependent if it 
   auto typeDescription = conformance->getTypeDescriptor();
-  if (typeDescription && !typeDescription->isGeneric()) {
+  if (typeDescription && !typeDescription->isGeneric() &&
+      genericTable->PrivateData != nullptr) {
     return getNondependentWitnessTable(conformance, type);
   }
 


### PR DESCRIPTION
Bugfix for <https://github.com/apple/swift/pull/41148>.