### PR TITLE
AST: Remove OpenedArchetypeType::getOpenedExistentialType()

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5770,9 +5770,6 @@ public:
 
   /// Retrieve the ID number of this opened existential.
   UUID getOpenedExistentialID() const;
-  
-  /// Retrieve the opened existential type
-  Type getOpenedExistentialType() const;
 
   /// Return the archetype that represents the root generic parameter of its
   /// interface type.
@@ -6412,8 +6409,7 @@ inline bool TypeBase::isOpenedExistentialWithError() {
 
   CanType T = getCanonicalType();
   if (auto archetype = dyn_cast<OpenedArchetypeType>(T)) {
-    auto openedExistentialType = archetype->getOpenedExistentialType();
-    return openedExistentialType->isExistentialWithError();
+    return archetype->getExistentialType()->isExistentialWithError();
   }
   return false;
 }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -249,7 +249,9 @@ public:
   }
 
   void remapOpenedType(CanOpenedArchetypeType archetypeTy) {
-    auto existentialTy = archetypeTy->getOpenedExistentialType()->getCanonicalType();
+    assert(archetypeTy->isRoot());
+
+    auto existentialTy = archetypeTy->getExistentialType()->getCanonicalType();
     auto replacementTy = OpenedArchetypeType::get(
         getOpASTType(existentialTy),
         archetypeTy->getInterfaceType());

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -248,7 +248,7 @@ public:
     return asImpl().remapASTType(ty);
   }
 
-  void remapOpenedType(CanOpenedArchetypeType archetypeTy) {
+  void remapRootOpenedType(CanOpenedArchetypeType archetypeTy) {
     assert(archetypeTy->isRoot());
 
     auto existentialTy = archetypeTy->getExistentialType()->getCanonicalType();
@@ -2201,7 +2201,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitOpenExistentialAddrInst(OpenExistentialAddrInst *Inst) {
   // Create a new archetype for this opened existential type.
-  remapOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
+  remapRootOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2214,7 +2214,7 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitOpenExistentialValueInst(
     OpenExistentialValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  remapOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
+  remapRootOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2237,7 +2237,7 @@ visitOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *Inst) {
     exType = exMetatype->getExistentialInstanceType()->getCanonicalType();
     openedType = cast<MetatypeType>(openedType).getInstanceType();
   }
-  remapOpenedType(cast<OpenedArchetypeType>(openedType));
+  remapRootOpenedType(cast<OpenedArchetypeType>(openedType));
 
   if (!Inst->getOperand()->getType().canUseExistentialRepresentation(
           ExistentialRepresentation::Class)) {
@@ -2261,7 +2261,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialRefInst(OpenExistentialRefInst *Inst) {
   // Create a new archetype for this opened existential type.
-  remapOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
+  remapRootOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2278,7 +2278,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxInst(OpenExistentialBoxInst *Inst) {
   // Create a new archetype for this opened existential type.
-  remapOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
+  remapRootOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createOpenExistentialBox(
@@ -2292,7 +2292,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxValueInst(OpenExistentialBoxValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  remapOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
+  remapRootOpenedType(Inst->getType().castTo<OpenedArchetypeType>());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4504,10 +4504,10 @@ CanOpenedArchetypeType OpenedArchetypeType::get(CanType existential,
     auto found = openedExistentialEnvironments.find(*knownID);
     
     if (found != openedExistentialEnvironments.end()) {
+      assert(found->second->getOpenedExistentialType()->isEqual(existential) &&
+             "Retrieved the wrong generic environment?");
       auto result = found->second->mapTypeIntoContext(interfaceType)
           ->castTo<OpenedArchetypeType>();
-      assert(result->getOpenedExistentialType()->isEqual(existential) &&
-             "Retrieved the wrong opened existential type?");
       return CanOpenedArchetypeType(result);
     }
   } else {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3743,7 +3743,8 @@ namespace {
     }
     void visitOpenedArchetypeType(OpenedArchetypeType *T, StringRef label) {
       printArchetypeCommon(T, "opened_archetype_type", label);
-      printRec("opened_existential", T->getOpenedExistentialType());
+      printRec("opened_existential",
+               T->getGenericEnvironment()->getOpenedExistentialType());
       printField("opened_existential_id", T->getOpenedExistentialID());
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -943,13 +943,10 @@ public:
         // so we can't use it for TypeTransformContext.
         // To work around this, replace the OpenedArchetypeType with the type of
         // the protocol itself.
-        CurrentType = CurrentType.transform([](Type T) -> Type {
-          if (auto *Opened = T->getAs<OpenedArchetypeType>()) {
-            return Opened->getOpenedExistentialType();
-          } else {
-            return T;
-          }
-        });
+        if (auto *Opened = CurrentType->getAs<OpenedArchetypeType>()) {
+          assert(Opened->isRoot());
+          CurrentType = Opened->getExistentialType();
+        }
         CurrentType = CurrentType->mapTypeOutOfContext();
       }
       setCurrentType(CurrentType);
@@ -5979,7 +5976,7 @@ public:
 
     if (Options.PrintForSIL)
       Printer << "@opened(\"" << T->getOpenedExistentialID() << "\") ";
-    visit(T->getOpenedExistentialType());
+    visit(T->getExistentialType());
   }
 
   void printArchetypeCommon(ArchetypeType *T,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -483,7 +483,7 @@ Type TypeBase::typeEraseOpenedArchetypesWithRoot(
     return type;
 
   const auto sig = root->getASTContext().getOpenedArchetypeSignature(
-      root->getOpenedExistentialType());
+      root->getExistentialType());
 
   unsigned metatypeDepth = 0;
 
@@ -519,7 +519,7 @@ Type TypeBase::typeEraseOpenedArchetypesWithRoot(
 
       Type erasedTy;
       if (root->isEqual(archetype)) {
-        erasedTy = root->getOpenedExistentialType();
+        erasedTy = root->getExistentialType();
       } else {
         erasedTy =
             sig->getNonDependentUpperBounds(archetype->getInterfaceType());
@@ -3346,9 +3346,12 @@ bool ArchetypeType::isRoot() const {
 
 Type ArchetypeType::getExistentialType() const {
   // Opened types hold this directly.
-  if (auto opened = dyn_cast<OpenedArchetypeType>(this))
-    return opened->getOpenedExistentialType();
-  
+  if (auto *opened = dyn_cast<OpenedArchetypeType>(this)) {
+    if (opened->isRoot()) {
+      return getGenericEnvironment()->getOpenedExistentialType();
+    }
+  }
+
   // Otherwise, compute it from scratch.
   SmallVector<Type, 4> constraintTypes;
   
@@ -3397,10 +3400,6 @@ OpenedArchetypeType::OpenedArchetypeType(
 
 UUID OpenedArchetypeType::getOpenedExistentialID() const {
   return getGenericEnvironment()->getOpenedExistentialUUID();
-}
-
-Type OpenedArchetypeType::getOpenedExistentialType() const {
-  return getGenericEnvironment()->getOpenedExistentialType();
 }
 
 OpaqueTypeArchetypeType::OpaqueTypeArchetypeType(

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1299,8 +1299,10 @@ void swift::ide::getReceiverType(Expr *Base,
     ReceiverTy = SelfT->getSelfType();
 
   // TODO: Handle generics and composed protocols
-  if (auto OpenedTy = ReceiverTy->getAs<OpenedArchetypeType>())
-    ReceiverTy = OpenedTy->getOpenedExistentialType();
+  if (auto OpenedTy = ReceiverTy->getAs<OpenedArchetypeType>()) {
+    assert(OpenedTy->isRoot());
+    ReceiverTy = OpenedTy->getExistentialType();
+  }
 
   if (auto TyD = ReceiverTy->getAnyNominal()) {
     Types.push_back(TyD);

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -100,7 +100,7 @@ mapTypeOutOfOpenedExistentialContext(CanType t) {
     params.push_back(param);
 
     const auto constraintTy = openedTypes[i]
-                                  ->getOpenedExistentialType()
+                                  ->getExistentialType()
                                   ->castTo<ExistentialType>()
                                   ->getConstraintType();
     requirements.emplace_back(RequirementKind::Conformance, param,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3049,7 +3049,8 @@ buildThunkSignature(SILGenFunction &SGF,
   auto *newGenericParam =
       GenericTypeParamType::get(/*type sequence*/ false, depth, 0, ctx);
 
-  auto constraint = openedExistential->getOpenedExistentialType();
+  assert(openedExistential->isRoot());
+  auto constraint = openedExistential->getExistentialType();
   if (auto existential = constraint->getAs<ExistentialType>())
     constraint = existential->getConstraintType();
 

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -67,7 +67,8 @@ CanGenericSignature buildThunkSignature(SILFunction *fn, bool inheritGenericSig,
   auto *newGenericParam =
       GenericTypeParamType::get(/*type sequence*/ false, depth, 0, ctx);
 
-  auto constraint = openedExistential->getOpenedExistentialType();
+  assert(openedExistential->isRoot());
+  auto constraint = openedExistential->getExistentialType();
   if (auto existential = constraint->getAs<ExistentialType>())
     constraint = existential->getConstraintType();
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -66,10 +66,10 @@ Type Solution::getFixedType(TypeVariableType *typeVar) const {
 /// members via dynamic lookup.
 static bool isOpenedAnyObject(Type type) {
   auto archetype = type->getAs<OpenedArchetypeType>();
-  if (!archetype)
+  if (!archetype || !archetype->isRoot())
     return false;
 
-  return archetype->getOpenedExistentialType()->isAnyObject();
+  return archetype->getExistentialType()->isAnyObject();
 }
 
 SubstitutionMap
@@ -7518,7 +7518,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
             ->getExistentialInstanceType();
         }
         assert(openedInstanceTy->castTo<OpenedArchetypeType>()
-                   ->getOpenedExistentialType()
+                   ->getExistentialType()
                    ->isEqual(existentialInstanceTy));
 
         auto opaqueValue =


### PR DESCRIPTION
Clients can explicitly ask for the opened existential type on the archetype's generic environment, or use `getExistentialType` to obtain a specific archetype's existential bounds .