### PR TITLE
[5.6] tsan libdispatch: invoke correct CMake, target proper sources

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -48,13 +48,15 @@ class TSanLibDispatch(product.Product):
 
     def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""
-        rt_source_dir = join_path(self.source_dir, os.pardir, 'compiler-rt')
+        rt_source_dir = join_path(
+            self.source_dir, os.pardir,
+            'llvm-project', 'compiler-rt')
         toolchain_path = join_path(self.args.install_destdir, 'usr')
         clang = join_path(toolchain_path, 'bin', 'clang')
         clangxx = join_path(toolchain_path, 'bin', 'clang++')
 
         config_cmd = [
-            'cmake',
+            self.toolchain.cmake,
             '-GNinja',
             '-DCMAKE_PREFIX_PATH=%s' % toolchain_path,
             '-DCMAKE_C_COMPILER=%s' % clang,


### PR DESCRIPTION
This addresses a build failure on TSAN - libdispatch Linux bots

Cherry-pick of #41135

Addresses rdar://88339546