### PR TITLE
[AST] only recurse getDisplayDecls in SymbolGraphGen

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -246,7 +246,7 @@ public:
   ///
   /// This can differ from \c getTopLevelDecls, e.g. it returns decls from a
   /// shadowed clang module.
-  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results) const {
+  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const {
     getTopLevelDecls(results);
   }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -780,7 +780,7 @@ public:
   /// shadowed clang module. It does not force synthesized top-level decls that
   /// should be printed to be added; use \c swift::getTopLevelDeclsForDisplay()
   /// for that.
-  void getDisplayDecls(SmallVectorImpl<Decl*> &results) const;
+  void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const;
 
   using LinkLibraryCallback = llvm::function_ref<void(LinkLibrary)>;
 

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -91,7 +91,7 @@ public:
 
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
-  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results) const override;
+  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const override;
 
   virtual void
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -145,7 +145,7 @@ namespace swift {
   /// \c ModuleDecl::getDisplayDecls() would only return if previous
   /// work happened to have synthesized them.
   void
-  getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results);
+  getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results, bool Recursive = false);
 
   struct ExtensionInfo {
     // The extension with the declarations to apply.

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -433,7 +433,7 @@ public:
   virtual void
   getOpaqueReturnTypeDecls(SmallVectorImpl<OpaqueTypeDecl*> &results) const override;
 
-  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results) const override;
+  virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const override;
 
   virtual void
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -949,30 +949,32 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
   return Result;
 }
 
-void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results) const {
-  if (isParsedModule(this)) {
+void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive) const {
+  if (Recursive && isParsedModule(this)) {
     SmallPtrSet<ModuleDecl *, 4> Modules;
     collectParsedExportedImports(this, Modules);
     for (const ModuleDecl *import : Modules) {
-      import->getDisplayDecls(Results);
+      import->getDisplayDecls(Results, Recursive);
     }
   }
   // FIXME: Should this do extra access control filtering?
   FORWARD(getDisplayDecls, (Results));
 
 #ifndef NDEBUG
-  llvm::DenseSet<Decl *> visited;
-  for (auto *D : Results) {
-    // decls synthesized from implicit clang decls may appear multiple times;
-    // e.g. if multiple modules with underlying clang modules are re-exported.
-    // including duplicates of these is harmless, so skip them when counting
-    // this assertion
-    if (const auto *CD = D->getClangDecl()) {
-      if (CD->isImplicit()) continue;
-    }
+  if (Recursive) {
+    llvm::DenseSet<Decl *> visited;
+    for (auto *D : Results) {
+      // decls synthesized from implicit clang decls may appear multiple times;
+      // e.g. if multiple modules with underlying clang modules are re-exported.
+      // including duplicates of these is harmless, so skip them when counting
+      // this assertion
+      if (const auto *CD = D->getClangDecl()) {
+        if (CD->isImplicit()) continue;
+      }
 
-    auto inserted = visited.insert(D).second;
-    assert(inserted && "there should be no duplicate decls");
+      auto inserted = visited.insert(D).second;
+      assert(inserted && "there should be no duplicate decls");
+    }
   }
 #endif
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3249,7 +3249,7 @@ static void getImportDecls(ClangModuleUnit *ClangUnit, const clang::Module *M,
   }
 }
 
-void ClangModuleUnit::getDisplayDecls(SmallVectorImpl<Decl*> &results) const {
+void ClangModuleUnit::getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive) const {
   if (clangModule)
     getImportDecls(const_cast<ClangModuleUnit *>(this), clangModule, results);
   getTopLevelDecls(results);

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -64,7 +64,7 @@ public:
   getTopLevelDecls(SmallVectorImpl<Decl *> &results) const override {}
 
   virtual void
-  getDisplayDecls(SmallVectorImpl<Decl *> &results) const override {}
+  getDisplayDecls(SmallVectorImpl<Decl *> &results, bool recursive = false) const override {}
 
   virtual void
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -35,9 +35,10 @@ using namespace swift;
 
 void
 swift::getTopLevelDeclsForDisplay(ModuleDecl *M,
-                                  SmallVectorImpl<Decl*> &Results) {
+                                  SmallVectorImpl<Decl*> &Results,
+                                  bool Recursive) {
   auto startingSize = Results.size();
-  M->getDisplayDecls(Results);
+  M->getDisplayDecls(Results, Recursive);
 
   // Force Sendable on all types, which might synthesize some extensions.
   // FIXME: We can remove this if @_nonSendable stops creating extensions.
@@ -49,7 +50,7 @@ swift::getTopLevelDeclsForDisplay(ModuleDecl *M,
   // Remove what we fetched and fetch again, possibly now with additional
   // extensions.
   Results.resize(startingSize);
-  M->getDisplayDecls(Results);
+  M->getDisplayDecls(Results, Recursive);
 }
 
 static bool shouldPrintAsFavorable(const Decl *D, const PrintOptions &Options) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -973,9 +973,9 @@ ModuleFile::getOpaqueReturnTypeDecls(SmallVectorImpl<OpaqueTypeDecl *> &results)
   }
 }
 
-void ModuleFile::getDisplayDecls(SmallVectorImpl<Decl *> &results) {
+void ModuleFile::getDisplayDecls(SmallVectorImpl<Decl *> &results, bool recursive) {
   if (UnderlyingModule)
-    UnderlyingModule->getDisplayDecls(results);
+    UnderlyingModule->getDisplayDecls(results, recursive);
 
   PrettyStackTraceModuleFile stackEntry(*this);
   getImportDecls(results);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -684,7 +684,7 @@ public:
   /// This includes all decls that should be displayed to clients of the module.
   /// This can differ from \c getTopLevelDecls, e.g. it returns decls from a
   /// shadowed clang module.
-  void getDisplayDecls(SmallVectorImpl<Decl*> &results);
+  void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false);
 
   StringRef getModuleFilename() const {
     if (!Core->ModuleInterfacePath.empty())

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1561,8 +1561,8 @@ SerializedASTFile::getOpaqueReturnTypeDecls(
 }
 
 void
-SerializedASTFile::getDisplayDecls(SmallVectorImpl<Decl*> &results) const {
-  File.getDisplayDecls(results);
+SerializedASTFile::getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive) const {
+  File.getDisplayDecls(results, recursive);
 }
 
 StringRef SerializedASTFile::getFilename() const {

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -57,7 +57,7 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
                                          const SymbolGraphOptions &Options) {
   SymbolGraphASTWalker Walker(*M, Options);
   SmallVector<Decl *, 64> ModuleDecls;
-  swift::getTopLevelDeclsForDisplay(M, ModuleDecls);
+  swift::getTopLevelDeclsForDisplay(M, ModuleDecls, /*recursive*/true);
 
   if (Options.PrintMessages)
     llvm::errs() << ModuleDecls.size()

--- a/test/ModuleInterface/exported-import.swift
+++ b/test/ModuleInterface/exported-import.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module-path %t/Other.swiftmodule -module-name Other %S/Inputs/other.swift
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module-path /dev/null -emit-module-interface-path %t/ExportedImport.swiftmodule -module-name ExportedImport %s -I %t
+
+// RUN: %FileCheck --input-file %t/ExportedImport.swiftmodule %s
+
+// CHECK-NOT: otherFileFunction
+
+@_exported import Other
+
+// CHECK: public struct SomeStruct
+public struct SomeStruct {}


### PR DESCRIPTION
This is a forward-port of part of https://github.com/apple/swift/pull/40866 from `release/5.6` to `main`, restricting the recursive parts of `ModuleDecl::getDisplayDecls` (and the associated assertions) behind a (new, optional) `recursive` parameter, which is only set to `true` when called from SymbolGraphGen. This restores the old "only this module" behavior for all other users of `getDisplayDecls`, while allowing the symbol graph to include re-exported symbols.