### PR TITLE
[Type Resolution] Allow imported existential typealiases to be used as constraints.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2796,16 +2796,6 @@ namespace {
                                       SourceLoc(), Name,
                                       Loc,
                                       /*genericparams*/nullptr, DC);
-
-      // Unwrap an explicit ExistentialType around the underlying type so that
-      // the typealias can be used in a generic constraint context.
-      //
-      // FIXME: We might want to push this down further into importType(), and
-      // once ExistentialType becomes mandatory in the future we want to wrap
-      // references to imported typealiases in Sema's resolveType() as well.
-      if (auto *existentialType = SwiftType->getAs<ExistentialType>())
-        SwiftType = existentialType->getConstraintType();
-
       Result->setUnderlyingType(SwiftType);
       
       // Make Objective-C's 'id' unavailable.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2796,6 +2796,16 @@ namespace {
                                       SourceLoc(), Name,
                                       Loc,
                                       /*genericparams*/nullptr, DC);
+
+      // Unwrap an explicit ExistentialType around the underlying type so that
+      // the typealias can be used in a generic constraint context.
+      //
+      // FIXME: We might want to push this down further into importType(), and
+      // once ExistentialType becomes mandatory in the future we want to wrap
+      // references to imported typealiases in Sema's resolveType() as well.
+      if (auto *existentialType = SwiftType->getAs<ExistentialType>())
+        SwiftType = existentialType->getConstraintType();
+
       Result->setUnderlyingType(SwiftType);
       
       // Make Objective-C's 'id' unavailable.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1835,7 +1835,8 @@ private:
 
   void visitExistentialType(ExistentialType *ET,
                             Optional<OptionalTypeKind> optionalKind) {
-    visitPart(ET->getConstraintType(), optionalKind);
+    visitExistentialType(ET, optionalKind,
+        /*isMetatype=*/ET->getConstraintType()->is<AnyMetatypeType>());
   }
 
   void visitExistentialMetatypeType(ExistentialMetatypeType *MT,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3499,6 +3499,17 @@ TypeResolver::resolveIdentifierType(IdentTypeRepr *IdType,
     return ExistentialType::get(result);
   }
 
+  if (!options.isConstraintImplicitExistential()) {
+    // Imported existential typealiases, e.g. id<P>, can be
+    // used as constraints by extracting the underlying protocol
+    // types.
+    auto *typeAlias = dyn_cast<TypeAliasType>(result.getPointer());
+    if (typeAlias && typeAlias->is<ExistentialType>() &&
+        typeAlias->getDecl()->hasClangNode()) {
+      return typeAlias->getAs<ExistentialType>()->getConstraintType();
+    }
+  }
+
   // Hack to apply context-specific @escaping to a typealias with an underlying
   // function type.
   if (result->is<FunctionType>())


### PR DESCRIPTION
Instead of importing `id<>` types as constraints, allow imported existential typealiases to be used in protocol constraint context.

Resolves: rdar://88490378