### PR TITLE
[Concurrency] Clear Slab's fake metadata pointer before freeing it.

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -61,6 +61,9 @@ else()
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
 endif()
 
+list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
+  "-D__STDC_WANT_LIB_EXT1__=1")
+
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ../CompatibilityOverride/CompatibilityOverride.cpp
   Actor.cpp

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -14,6 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Define __STDC_WANT_LIB_EXT1__ to get memset_s on platforms that have it.
+// Other files may have included string.h without it already, so we also set
+// this with a -D flag when building, but this allows tests to build without
+// additional trouble.
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
+
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Runtime/Debug.h"
 #include "llvm/Support/Alignment.h"
@@ -116,6 +123,22 @@ private:
     /// Return \p size with the added overhead of the slab header.
     static size_t includingHeader(size_t size) {
       return headerSize() + size;
+    }
+
+    /// Clear the fake metadata pointer. Call before freeing so that leftover
+    /// heap garbage doesn't have slab metadata pointers in it.
+    void clearMetadata() {
+      // Use memset_s or explicit_bzero where available. Fall back to a plain
+      // assignment on unknown platforms. This is not necessary for correctness,
+      // just as an aid to analysis tools, so it's OK if the fallback gets
+      // optimized out.
+#if defined(__APPLE__)
+      memset_s(&metadata, sizeof(metadata), 0, sizeof(metadata));
+#elif defined(__linux__)
+      explicit_bzero(&metadata, sizeof(metadata));
+#else
+      metadata = 0;
+#endif
     }
 
     /// Return the payload buffer address at \p atOffset.
@@ -247,6 +270,7 @@ private:
     while (slab) {
       Slab *next = slab->next;
       freedCapacity += slab->capacity;
+      slab->clearMetadata();
       free(slab);
       numAllocatedSlabs--;
       slab = next;
@@ -272,6 +296,8 @@ public:
   ~StackAllocator() {
     if (lastAllocation)
       SWIFT_FATAL_ERROR(0, "not all allocations are deallocated");
+    if (firstSlabIsPreallocated)
+      firstSlab->clearMetadata();
     (void)freeAllSlabs(firstSlabIsPreallocated ? firstSlab->next : firstSlab);
     assert(getNumAllocatedSlabs() == 0);
   }


### PR DESCRIPTION
This helps ensure that memory analysis tools don't get confused by leftover metadata pointers in reallocated memory that hasn't been initialized yet.

rdar://88494373