### PR TITLE
Reflection: adjust type definitions for `ConcurrentHashMap`

### DIFF
--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -49,8 +49,8 @@ template <typename Runtime> struct MetadataCacheNode {
 };
 
 template <typename Runtime> struct ConcurrentHashMap {
-  typename uint32_t ReaderCount;
-  typename uint32_t ElementCount;
+  uint32_t ReaderCount;
+  uint32_t ElementCount;
   typename Runtime::StoredPointer Elements;
   typename Runtime::StoredPointer Indices;
   // We'll ignore the remaining fields for now....

--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -49,8 +49,8 @@ template <typename Runtime> struct MetadataCacheNode {
 };
 
 template <typename Runtime> struct ConcurrentHashMap {
-  typename Runtime::StoredSize ReaderCount;
-  typename Runtime::StoredSize ElementCount;
+  typename uint32_t ReaderCount;
+  typename uint32_t ElementCount;
   typename Runtime::StoredPointer Elements;
   typename Runtime::StoredPointer Indices;
   // We'll ignore the remaining fields for now....


### PR DESCRIPTION
Adjust the types of `ConcurrentHashMap` to match the implementation.  This field is always a `uint32_t`, which would be misread previously.  Thanks to @mikeash for helping identify this.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
