### PR TITLE
[Distributed] IRGen: Fix loading of the witness tables

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -510,15 +510,17 @@ void DistributedAccessor::emitLoadOfWitnessTables(llvm::Value *witnessTables,
 
   IGF.Builder.emitBlock(contBB);
 
-  witnessTables = IGF.Builder.CreateBitCast(witnessTables, IGM.Int8PtrPtrTy);
+  witnessTables = IGF.Builder.CreateBitCast(witnessTables,
+                                            IGM.Int8PtrPtrTy->getPointerTo());
 
   for (unsigned i = 0, n = expectedWitnessTables; i != n; ++i) {
     auto offset = Size(i * IGM.getPointerSize());
     auto alignment = IGM.getPointerAlignment();
 
     auto witnessTableAddr = IGF.emitAddressAtOffset(
-        witnessTables, Offset(offset), IGM.Int8PtrTy, Alignment(alignment));
-    arguments.add(witnessTableAddr.getAddress());
+        witnessTables, Offset(offset), IGM.Int8PtrPtrTy, Alignment(alignment));
+
+    arguments.add(IGF.Builder.CreateLoad(witnessTableAddr));
   }
 }
 

--- a/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
@@ -386,11 +386,16 @@ public distributed actor MyOtherActor {
 // CHECK: incorrect-witness-tables:
 // CHECK-NEXT: unreachable
 
-// CHECK: [[WITNESS_BUF:%.*]] = bitcast i8* [[WITNESS_TABLES]] to i8**
-// CHECK-NEXT: [[T_ENCODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i32 0
-// CHECK-NEXT: [[T_DECODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i32 1
-// CHECK-NEXT: [[U_ENCODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i32 2
-// CHECK-NEXT: [[U_DECODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i32 3
+// CHECK: [[WITNESS_BUF:%.*]] = bitcast i8* [[WITNESS_TABLES]] to i8***
+// CHECK-NEXT: [[T_ENCODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i32 0
+// CHECK-NEXT: [[T_ENCODABLE:%.*]] = load i8**, i8*** [[T_ENCODABLE_ADDR]]
+// CHECK-NEXT: [[T_DECODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i32 1
+// CHECK-NEXT: [[T_DECODABLE:%.*]] = load i8**, i8*** [[T_DECODABLE_ADDR]]
+// CHECK-NEXT: [[U_ENCODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i32 2
+// CHECK-NEXT: [[U_ENCODABLE:%.*]] = load i8**, i8*** [[U_ENCODABLE_ADDR]]
+// CHECK-NEXT: [[U_DECODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i32 3
+// CHECK-NEXT: [[U_DECODABLE:%.*]] = load i8**, i8*** [[U_DECODABLE_ADDR]]
+
 
 /// ---> Check that distributed thunk code is formed correctly
 

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -366,11 +366,15 @@ public distributed actor MyOtherActor {
 // CHECK: incorrect-witness-tables:
 // CHECK-NEXT: unreachable
 
-// CHECK: [[WITNESS_BUF:%.*]] = bitcast i8* [[WITNESS_TABLES]] to i8**
-// CHECK-NEXT: [[T_ENCODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i64 0
-// CHECK-NEXT: [[T_DECODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i64 1
-// CHECK-NEXT: [[U_ENCODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i64 2
-// CHECK-NEXT: [[U_DECODABLE:%.*]] = getelementptr inbounds i8*, i8** [[WITNESS_BUF]], i64 3
+// CHECK: [[WITNESS_BUF:%.*]] = bitcast i8* [[WITNESS_TABLES]] to i8***
+// CHECK-NEXT: [[T_ENCODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i64 0
+// CHECK-NEXT: [[T_ENCODABLE:%.*]] = load i8**, i8*** [[T_ENCODABLE_ADDR]]
+// CHECK-NEXT: [[T_DECODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i64 1
+// CHECK-NEXT: [[T_DECODABLE:%.*]] = load i8**, i8*** [[T_DECODABLE_ADDR]]
+// CHECK-NEXT: [[U_ENCODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i64 2
+// CHECK-NEXT: [[U_ENCODABLE:%.*]] = load i8**, i8*** [[U_ENCODABLE_ADDR]]
+// CHECK-NEXT: [[U_DECODABLE_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[WITNESS_BUF]], i64 3
+// CHECK-NEXT: [[U_DECODABLE:%.*]] = load i8**, i8*** [[U_DECODABLE_ADDR]]
 
 /// ---> Check that distributed thunk code is formed correctly
 


### PR DESCRIPTION
The witness table is an array of pointers - `void **`,
which means that the list of the witnesses has type of `void ***`.

Instead of using result of `emitAddressAtOffset` accessor
should set the correct type for the list, which is `void ***`
and emit bit a lot for each of the witness table slots.

Resolves: rdar://87568630
Resolves: rdar://88340451

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
