### PR TITLE
Runtime: make padding explicit for `ElementStorage`

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -812,7 +812,7 @@ private:
   /// the first element of a variable-length array, whose size is determined by
   /// the allocation.
   struct ElementStorage {
-    uint32_t Capacity;
+    uintptr_t Capacity : 32;
     ElemTy Elem;
 
     static ElementStorage *allocate(size_t capacity) {


### PR DESCRIPTION
The `ElementStorage` member `Capacity` will be padded up to the next pointer alignment due to the storage of the `ElemTy` by C's struct layout rules.  However, this is implicit and not entirely guaranteed.  Instead, make the storage a pointer sized value, and then truncate to 32-bits to maintain ABI compatibility.  This becomes important as we expand on the runtime metadata handling.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
