### PR TITLE
Reflection: drop compatibility with old runtime layouts

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1190,28 +1190,7 @@ public:
     if (!ConformancesAddr)
       return "unable to read value of " + ConformancesPointerName;
 
-    auto Root = getReader().readPointer(ConformancesAddr->getResolvedAddress(),
-                                        sizeof(StoredPointer));
-    auto ReaderCount = Root->getResolvedAddress().getAddressData();
-
-    // ReaderCount will be the root pointer if the conformance cache is a
-    // ConcurrentMap. It's very unlikely that there would ever be more readers
-    // than the least valid pointer value, so compare with that to distinguish.
-    // TODO: once the old conformance cache is gone for good, remove that code.
-    uint64_t LeastValidPointerValue;
-    if (!getReader().queryDataLayout(
-            DataLayoutQueryType::DLQ_GetLeastValidPointerValue, nullptr,
-            &LeastValidPointerValue)) {
-      return std::string("unable to query least valid pointer value");
-    }
-
-    if (ReaderCount < LeastValidPointerValue)
-      IterateConformanceTable(ConformancesAddr->getResolvedAddress(), Call);
-    else {
-      // The old code has the root address at this location.
-      auto RootAddr = ReaderCount;
-      iterateConformanceTree(RootAddr, Call);
-    }
+    IterateConformanceTable(ConformancesAddr->getResolvedAddress(), Call);
     return llvm::None;
   }
   


### PR DESCRIPTION
This removes the compatibility code (which seems suspect) for the runtime datastructures.  Identified through Windows, this path will potentially misread the field and treat a pair of `uint32_t` as a pointer, which may succeed any way.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
