### PR TITLE
Reflection: correct conformance table iteration

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1157,7 +1157,7 @@ public:
         reinterpret_cast<const ConcurrentHashMap<Runtime> *>(MapBytes.get());
 
     auto Count = MapData->ElementCount;
-    auto Size = Count * sizeof(ConformanceCacheEntry<Runtime>);
+    auto Size = Count * sizeof(ConformanceCacheEntry<Runtime>) + sizeof(StoredPointer);
 
     auto ElementsBytes =
         getReader().readBytes(RemoteAddress(MapData->Elements), Size);
@@ -1165,7 +1165,7 @@ public:
       return;
     auto ElementsData =
         reinterpret_cast<const ConformanceCacheEntry<Runtime> *>(
-            ElementsBytes.get());
+            reinterpret_cast<const char *>(ElementsBytes.get()) + sizeof(StoredPointer));
 
     for (StoredSize i = 0; i < Count; i++) {
       auto &Element = ElementsData[i];


### PR DESCRIPTION
Adjust the iteration of the conformance table to match the current data structure layout.

`MapData` is a view into the `ConformanceState`:
~~~
[+0x00] Cache                 [Type: swift::ConcurrentReadableHashMap<ConformaanceCacheEntry, swift::StaticMutex>]
[+0x28] SectionsToScan        [Type: swift::ConcurrentReadableArray<ConformanceSection>]
[+0x50] scanSectionsBackwards [Type: bool]
~~~

`Cache` itself is a structure:
~~~
[+0x00] ReaderCount           [Type: std::atomic<uint32_t>]
[+0x04] ElementCount          [Type: std::atomic<uint32_t>]
[+0x08] Elements              [Type: std::atomic<swift::ConcurrentReadableHashMap<ConformanceCacheEntry, swift::staticMutex>::ElementStorage *>]
~~~

The `ElementStorage` backing `Elements` actually looks like:
~~~
[+0x00] Capacity              [Type: uint32_t]
[+0x08] Elem                  [Typwe: ConformanceCacheEntry]
~~~

The `Capacity` field will be pointer aligned (a previous change has changed this
to be explicitly pointer sized bit-sliced).  However, we would previously fail
to accomodate the `Capacity` field, and read the contents shifted by the size of
`Capacity`.  This repairs the iteration off the `ConformanceCache`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
