### PR TITLE
Runtime: change atomic implementation for `AllocationPool`

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -72,6 +72,13 @@ public:
     return value.compare_exchange_weak(oldValue, newValue, successOrder,
                                        failureOrder);
   }
+
+  bool compare_exchange_strong(Value &oldValue, Value newValue,
+                               std::memory_order successOrder,
+                               std::memory_order failureOrder) {
+    return value.compare_exchange_strong(oldValue, newValue, successOrder,
+                                         failureOrder);
+  }
 };
 
 #if defined(_WIN64)
@@ -128,11 +135,14 @@ public:
   bool compare_exchange_weak(Value &oldValue, Value newValue,
                              std::memory_order successOrder,
                              std::memory_order failureOrder) {
-    assert(failureOrder == std::memory_order_relaxed ||
-           failureOrder == std::memory_order_acquire ||
-           failureOrder == std::memory_order_consume);
-    assert(successOrder == std::memory_order_relaxed ||
-           successOrder == std::memory_order_release);
+    // We do not have weak CAS intrinsics, fallback to strong
+    return compare_exchange_strong(oldValue, newValue, successOrder,
+                                   failureOrder);
+  }
+
+  bool compare_exchange_strong(Value &oldValue, Value newValue,
+                               std::memory_order successOrder,
+                               std::memory_order failureOrder) {
 #if SWIFT_HAS_MSVC_ARM_ATOMICS
     if (successOrder == std::memory_order_relaxed &&
         failureOrder != std::memory_order_acquire) {
@@ -180,7 +190,7 @@ public:
 template <class T>
 class atomic : public impl::atomic_impl<T> {
 public:
-  atomic(T value) : impl::atomic_impl<T>(value) {}
+  constexpr atomic(T value) : impl::atomic_impl<T>(value) {}
 };
 
 } // end namespace swift


### PR DESCRIPTION
The `AllocationPool` type is reflected upon and inspected by debugging
tools.  This requires that the layout of the atomically wrapped type
must store the value at offset 0.  However, the `std::atomic` does not
make any such guarantees, and a layout differing would render debug
utilities useless.  Switch instead from a `std::atomic` to
`swift::atomic`.  In order to do so, we also need to introduce the
`compare_exchange_strong` helper which maps to
`compare_exchange_strong_explicit` mirroring `compare_exchange_weak`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
