### PR TITLE
Stop marking reflection metadata sections as 'no_dead_strip' on Darwin

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1284,7 +1284,7 @@ static std::string getReflectionSectionName(IRGenModule &IGM,
   case llvm::Triple::MachO:
     assert(LongName.size() <= 7 &&
            "Mach-O section name length must be <= 16 characters");
-    OS << "__TEXT,__swift5_" << LongName << ", regular, no_dead_strip";
+    OS << "__TEXT,__swift5_" << LongName << ", regular";
     break;
   }
   return std::string(OS.str());


### PR DESCRIPTION
I'm trying to expand dead-strippability to reflection metadata, part of the solution is <https://github.com/apple/swift/pull/40853>, this is another part -- currently IRGen marks all reflection metadata sections as 'no_dead_strip' (with a Darwin linker specific attribute). This seems unnecessarily conservative, and there seems to be no good reason why we need these entire sections to opt out of dead-strippability: The globals should either be "alive" (referenced by other globals/code), or if there's situations where there's actually a un-referenced global that still needs to survive into final binaries, we should use llvm.used on that particular global. Furthermore, we already do not use the equivalent of a section-wide dead-strippability opt-out for non-Mach-O targets, and also I tried to dig up why 'no_dead_strip' was added in git history, but I couldn't find anything -- seems like this has always been that way, with no explanation why.