### PR TITLE
[CSDiagnostics] Diagnose ambiguous empty closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -274,6 +274,8 @@ ERROR(cannot_infer_closure_parameter_type,none,
        (StringRef))
 ERROR(cannot_infer_closure_type,none,
       "unable to infer closure type in the current context", ())
+ERROR(cannot_infer_empty_closure_result_type,none,
+      "cannot infer return type of empty closure", ())
 ERROR(cannot_infer_closure_result_type,none,
       "cannot infer return type for closure with multiple statements; "
       "add explicit type to disambiguate", ())

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2335,6 +2335,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
 


### PR DESCRIPTION
- Allow `SpecifyClosureReturnType` to be diagnosed in ambiguous context
- Add a tailoed diagnostic for when it's impossible to infer a type of
  an empty closure

Resolves: rdar://88256059

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
