### PR TITLE
[SIL] Make owned function arguments lexical.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -234,8 +234,8 @@ inline bool accessKindMayConflict(SILAccessKind a, SILAccessKind b) {
 
 /// Return true if \p instruction is a deinitialization barrier.
 ///
-/// Deinitialization barriers constrain variable lifetimes. Lexical end_borrow
-/// and destroy_addr cannot be hoisted above them.
+/// Deinitialization barriers constrain variable lifetimes. Lexical end_borrow,
+/// destroy_value, and destroy_addr cannot be hoisted above them.
 bool isDeinitBarrier(SILInstruction *instruction);
 
 } // end namespace swift

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -169,6 +169,14 @@ bool findExtendedTransitiveGuaranteedUses(
   SILValue guaranteedValue,
   SmallVectorImpl<Operand *> &usePoints);
 
+/// Find non-transitive uses of a simple (i.e. without looking through
+/// reborrows) value.
+///
+/// The scope-ending use of borrows of the value are included.  If a borrow of
+/// the value is reborrowed, returns false.
+bool findUsesOfSimpleValue(SILValue value,
+                           SmallVectorImpl<Operand *> *usePoints = nullptr);
+
 /// An operand that forwards ownership to one or more results.
 class ForwardingOperand {
   Operand *use = nullptr;

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -212,7 +212,8 @@ public:
   /// their value ownership. This ignores any current uses of \p oldValue. To
   /// determine whether \p oldValue can be replaced as-is with it's existing
   /// uses, create an instance of OwnershipRAUWHelper and check its validity.
-  static bool hasValidRAUWOwnership(SILValue oldValue, SILValue newValue);
+  static bool hasValidRAUWOwnership(SILValue oldValue, SILValue newValue,
+                                    ArrayRef<Operand *> oldUses);
 
 private:
   OwnershipFixupContext *ctx;
@@ -282,6 +283,10 @@ private:
 
   SILValue getReplacementAddress();
 };
+
+/// Whether the provided uses lie within the current liveness of the
+/// specified lexical value.
+bool areUsesWithinLexicalValueLifetime(SILValue, ArrayRef<Operand *>);
 
 /// A utility composed ontop of OwnershipFixupContext that knows how to replace
 /// a single use of a value with another value with a different ownership. We

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -99,10 +99,8 @@ ValueBase::getDefiningInstructionResult() {
 }
 
 bool ValueBase::isLexical() const {
-  // TODO: Eventually, rather than SILGen'ing a borrow scope for owned 
-  //       arguments, we will just have this check here.
-  // if (auto *argument = dyn_cast<SILArgument>(this))
-  //   return argument->getOwnershipKind() == OwnershipKind::Owned;
+  if (auto *argument = dyn_cast<SILFunctionArgument>(this))
+    return argument->getOwnershipKind() == OwnershipKind::Owned;
   if (auto *bbi = dyn_cast<BeginBorrowInst>(this))
     return bbi->isLexical();
   if (auto *mvi = dyn_cast<MoveValueInst>(this))

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -406,7 +406,7 @@ private:
   ///     possible)
   /// (2) hoist the end_borrow
   /// (3) delete the destroy_value
-  void fold(Match, SmallVectorImpl<int> const &rewritableArgumentIndices);
+  void fold(Match, ArrayRef<int> rewritableArgumentIndices);
 
   // The move_value [lexical] instruction that was added during the run.
   //
@@ -503,8 +503,7 @@ bool Rewriter::createMove() {
   return true;
 }
 
-void Rewriter::fold(Match candidate,
-                    SmallVectorImpl<int> const &rewritableArgumentIndices) {
+void Rewriter::fold(Match candidate, ArrayRef<int> rewritableArgumentIndices) {
   // First, rewrite the apply in terms of the move_value.
   unsigned argumentNumber = 0;
   for (auto index : rewritableArgumentIndices) {

--- a/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyFolding.cpp
@@ -290,7 +290,7 @@ struct BorroweeUsage final {
 /// %lifetime.  In detail, PrunedLiveness::isWithinBoundary relies on
 /// clients to know that instructions are after the start of liveness.  We
 /// determine this via the dominance tree.
-bool findBorroweeUsage(Context &, BorroweeUsage &);
+bool findBorroweeUsage(Context const &, BorroweeUsage &);
 
 /// Sift scope ends of %lifetime for those that CAN be folded.
 class FilterCandidates final {
@@ -616,7 +616,7 @@ bool FilterCandidates::run(Candidates &candidates) {
   return anyViable;
 }
 
-bool findBorroweeUsage(Context &context, BorroweeUsage &usage) {
+bool findBorroweeUsage(Context const &context, BorroweeUsage &usage) {
   auto recordUse = [&](Operand *use) {
     // Ignore uses that aren't dominated by the introducer.  PrunedLiveness
     // relies on us doing this check.

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -297,13 +297,28 @@ static void cleanupOperandsBeforeDeletion(SILInstruction *oldValue,
 // directly checking ownership requirements. This does not determine whether the
 // scope of the newValue can be fully extended.
 bool OwnershipRAUWHelper::hasValidRAUWOwnership(SILValue oldValue,
-                                                SILValue newValue) {
+                                                SILValue newValue,
+                                                ArrayRef<Operand *> oldUses) {
   auto newOwnershipKind = newValue.getOwnershipKind();
 
   // If the either value is lexical, replacing its uses may result in
   // shortening or lengthening its lifetime in ways that don't respect lexical
   // scope and deinit barriers.
-  if (oldValue->isLexical() || newValue->isLexical())
+  //
+  // Specifically, we have the following cases:
+  //
+  // +--------+--------+
+  // |oldValue|newValue|
+  // +--------+--------+
+  // |  not   |  not   | legal
+  // +--------+--------+
+  // |lexical |  not   | illegal
+  // +--------+--------+
+  // |   *    |lexical | legal so long as it doesn't extend newValue's lifetime
+  // +--------+--------+
+  if ((oldValue->isLexical() && !newValue->isLexical()) ||
+      (newValue->isLexical() &&
+       !areUsesWithinLexicalValueLifetime(newValue, oldUses)))
     return false;
 
   // If our new kind is ValueOwnershipKind::None, then we are fine. We
@@ -353,20 +368,51 @@ bool OwnershipRAUWHelper::hasValidRAUWOwnership(SILValue oldValue,
 // extend the lifetime of \p oldValue to cover the new uses.
 static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue,
                                      OwnershipFixupContext &context) {
-  if (!OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue))
-    return false;
+  switch (oldValue.getOwnershipKind()) {
+  case OwnershipKind::Guaranteed:
+    // Check that the old lifetime can be extended and record the necessary
+    // book-keeping in the OwnershipFixupContext.
+    context.clear();
 
-  if (oldValue.getOwnershipKind() != OwnershipKind::Guaranteed)
+    // Check that no transitive uses have a PointerEscape, and record the leaf
+    // uses for liveness extension.
+    if (!findExtendedTransitiveGuaranteedUses(oldValue,
+                                              context.guaranteedUsePoints))
+      return false;
+    return OwnershipRAUWHelper::hasValidRAUWOwnership(
+        oldValue, newValue, context.guaranteedUsePoints);
+  default: {
+    SmallVector<Operand *, 8> ownedUsePoints;
+    // If newValue is lexical, find the uses of oldValue so that it can be
+    // determined whether the replacement would illegally extend the lifetime
+    // of newValue.
+    if (newValue->isLexical() &&
+        !findUsesOfSimpleValue(oldValue, &ownedUsePoints))
+      return false;
+    return OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue,
+                                                      ownedUsePoints);
+  }
+  }
+}
+
+bool swift::areUsesWithinLexicalValueLifetime(SILValue value,
+                                              ArrayRef<Operand *> uses) {
+  assert(value->isLexical());
+
+  // The lexical lifetime of a function argument is the whole body of the
+  // function.
+  if (isa<SILFunctionArgument>(value))
     return true;
 
-  // Check that the old lifetime can be extended and record the necessary
-  // book-keeping in the OwnershipFixupContext.
-  context.clear();
+  if (auto borrowedValue = BorrowedValue(value)) {
+    PrunedLiveness liveness;
+    auto *function = value->getFunction();
+    borrowedValue.computeLiveness(liveness);
+    DeadEndBlocks deadEndBlocks(function);
+    return liveness.areUsesWithinBoundary(uses, &deadEndBlocks);
+  }
 
-  // Check that no transitive uses have a PointerEscape, and record the leaf
-  // uses for liveness extension.
-  return findExtendedTransitiveGuaranteedUses(oldValue,
-                                              context.guaranteedUsePoints);
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1118,7 +1164,9 @@ SILValue OwnershipRAUWPrepare::prepareReplacement(SILValue newValue) {
   if (oldValue->use_empty())
     return newValue;
 
-  assert(OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue) &&
+  assert(
+      OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue,
+                                                 ctx.guaranteedUsePoints) &&
       "Should have checked if can perform this operation before calling it?!");
   // If our new value is just none, we can pass anything to it so just RAUW
   // and return.
@@ -1576,7 +1624,10 @@ OwnershipReplaceSingleUseHelper::OwnershipReplaceSingleUseHelper(
 
   // Otherwise, lets check if we can perform this RAUW operation. If we can't,
   // set ctx to nullptr to invalidate the helper and return.
-  if (!OwnershipRAUWHelper::hasValidRAUWOwnership(use->get(), newValue)) {
+  SmallVector<Operand *, 1> oldUses;
+  oldUses.push_back(use);
+  if (!OwnershipRAUWHelper::hasValidRAUWOwnership(use->get(), newValue,
+                                                  oldUses)) {
     invalidate();
     return;
   }

--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -31,10 +31,9 @@ class Klass {}
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: strong_release
-// CHECK-SIL-NEXT: debug_value [poison]
-// CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADnF'
 func useMove(_ k: __owned Klass) -> Klass {
@@ -65,10 +64,9 @@ func useMove(_ k: __owned Klass) -> Klass {
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: tuple
+// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: strong_release
-// CHECK-SIL-NEXT: debug_value [poison]
-// CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxnRlzClF'
 func useMove<T : AnyObject>(_ k: __owned T) -> T {

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -30,6 +30,7 @@ class C {
 sil [ossa] @dummy : $@convention(thin) () -> ()
 sil [ossa] @barrier : $@convention(thin) () -> ()
 sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
+sil [ossa] @getOwnedB : $@convention(thin) () -> (@owned B)
 sil [ossa] @takeOwnedC : $@convention(thin) (@owned C) -> ()
 sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
@@ -38,14 +39,17 @@ sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject)
 // -O ignores this because there's no copy_value
 // -Onone hoists the destroy and adds a poison flag.
 //
-// CHECK-LABEL: sil [ossa] @testDestroyAfterCall : $@convention(thin) (@owned B) -> () {
-// CHECK: bb0(%0 : @owned $B):
-// CHECK-ONONE:   destroy_value [poison] %0 : $B
+// CHECK-LABEL: sil [ossa] @testDestroyAfterCall : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[ARG:%.*]] = apply
+// CHECK-ONONE:   destroy_value [poison] [[ARG]] : $B
 // CHECK:   apply
-// CHECK-OPT:   destroy_value %0 : $B
+// CHECK-OPT:   destroy_value [[ARG]] : $B
 // CHECK-LABEL: } // end sil function 'testDestroyAfterCall'
-sil [ossa] @testDestroyAfterCall : $@convention(thin) (@owned B) -> () {
-bb0(%arg : @owned $B):
+sil [ossa] @testDestroyAfterCall : $@convention(thin) () -> () {
+bb0:
+  %getOwnedB = function_ref @getOwnedB : $@convention(thin) () -> (@owned B)
+  %arg = apply %getOwnedB() : $@convention(thin) () -> (@owned B)
   %f = function_ref @dummy : $@convention(thin) () -> ()
   %call = apply %f() : $@convention(thin) () -> ()
   destroy_value %arg : $B
@@ -57,19 +61,22 @@ bb0(%arg : @owned $B):
 // -Onone requres a destroy at the lifetime end. It reuses the
 // existing one without adding poison.
 //
-// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingStore : $@convention(thin) (@owned C) -> () {
-// CHECK: bb0(%0 : @owned $C):
+// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingStore : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[ARG:%.*]] = apply
 // CHECK: [[ADR:%.*]] = alloc_stack $C
 // CHECK-OPT-NOT: copy_value
-// CHECK-OPT: store %0 to [init] [[ADR]] : $*C
-// CHECK-ONONE: [[CP:%.*]] = copy_value %0 : $C
+// CHECK-OPT: store [[ARG]] to [init] [[ADR]] : $*C
+// CHECK-ONONE: [[CP:%.*]] = copy_value [[ARG]] : $C
 // CHECK-ONONE: store [[CP]] to [init] [[ADR]] : $*C
 // CHECK-OPT-NOT: destroy_value
-// CHECK-ONONE: destroy_value %0 : $C
+// CHECK-ONONE: destroy_value [[ARG]] : $C
 // CHECK: destroy_addr
 // CHECK-LABEL: } // end sil function 'testDestroyAfterConsumingStore'
-sil [ossa] @testDestroyAfterConsumingStore : $@convention(thin) (@owned C) -> () {
-bb0(%arg : @owned $C):
+sil [ossa] @testDestroyAfterConsumingStore : $@convention(thin) () -> () {
+bb0:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %arg = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %adr = alloc_stack $C
   %copy = copy_value %arg : $C
   store %copy to [init] %adr : $*C
@@ -83,19 +90,22 @@ bb0(%arg : @owned $C):
 // -O removes the copy/destroy
 // -Onone requres a destroy at the lifetime end. It creates a new poison one.
 //
-// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingStoreAndCall : $@convention(thin) (@owned C) -> () {
-// CHECK: bb0(%0 : @owned $C):
+// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingStoreAndCall : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[ARG:%.*]] = apply
 // CHECK: [[ADR:%.*]] = alloc_stack $C
 // CHECK-OPT-NOT: copy_value
-// CHECK-ONONE: copy_value %0 : $C
+// CHECK-ONONE: copy_value [[ARG]] : $C
 // CHECK: store %{{.*}} to [init] [[ADR]] : $*C
 // CHECK-OPT-NOT: destroy_value
-// CHECK-ONONE: destroy_value [poison] %0 : $C
+// CHECK-ONONE: destroy_value [poison] [[ARG]] : $C
 // CHECK: apply
 // CHECK: destroy_addr
 // CHECK-LABEL: } // end sil function 'testDestroyAfterConsumingStoreAndCall'
-sil [ossa] @testDestroyAfterConsumingStoreAndCall : $@convention(thin) (@owned C) -> () {
-bb0(%arg : @owned $C):
+sil [ossa] @testDestroyAfterConsumingStoreAndCall : $@convention(thin) () -> () {
+bb0:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %arg = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %adr = alloc_stack $C
   %copy = copy_value %arg : $C
   store %copy to [init] %adr : $*C
@@ -111,16 +121,19 @@ bb0(%arg : @owned $C):
 // -O removes the copy/destroy
 // -Onone reuses the existint lifetime-ending destroy.
 //
-// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingCall : $@convention(thin) (@owned C) -> () {
-// CHECK: bb0(%0 : @owned $C):
+// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingCall : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[ARG:%.*]] = apply
 // CHECK-OPT-NOT: copy_value
-// CHECK-ONONE:   %1 = copy_value %0 : $C
+// CHECK-ONONE:   copy_value [[ARG]] : $C
 // CHECK: apply {{.*}} : $@convention(thin) (@owned C) -> ()
 // CHECK-OPT-NOT: destroy_value
-// CHECK-ONONE:   destroy_value %0 : $C
+// CHECK-ONONE:   destroy_value [[ARG]] : $C
 // CHECK-LABEL: } // end sil function 'testDestroyAfterConsumingCall'
-sil [ossa] @testDestroyAfterConsumingCall : $@convention(thin) (@owned C) -> () {
-bb0(%arg : @owned $C):
+sil [ossa] @testDestroyAfterConsumingCall : $@convention(thin) () -> () {
+bb0:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %arg = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %copy = copy_value %arg : $C
   %f = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
   %call = apply %f(%copy) : $@convention(thin) (@owned C) -> ()
@@ -132,17 +145,20 @@ bb0(%arg : @owned $C):
 // -O removes the copy/destroy
 // -Onone requres a destroy at the lifetime end. It creates a new poison one.
 //
-// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingCallAndCall : $@convention(thin) (@owned C) -> () {
-// CHECK: bb0(%0 : @owned $C):
+// CHECK-LABEL: sil [ossa] @testDestroyAfterConsumingCallAndCall : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[ARG:%.*]] = apply
 // CHECK-OPT-NOT: copy_value
-// CHECK-ONONE: copy_value %0 : $C
+// CHECK-ONONE: copy_value [[ARG]] : $C
 // CHECK: apply %{{.*}}(%{{.*}}) : $@convention(thin) (@owned C) -> ()
 // CHECK-OPT-NOT: destroy_value
-// CHECK-ONONE:  destroy_value [poison] %0 : $C
+// CHECK-ONONE:  destroy_value [poison] [[ARG]] : $C
 // CHECK: apply
 // CHECK-LABEL: } // end sil function 'testDestroyAfterConsumingCallAndCall'
-sil [ossa] @testDestroyAfterConsumingCallAndCall : $@convention(thin) (@owned C) -> () {
-bb0(%arg : @owned $C):
+sil [ossa] @testDestroyAfterConsumingCallAndCall : $@convention(thin) () -> () {
+bb0:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %arg = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %copy = copy_value %arg : $C
   %f1 = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
   %call1 = apply %f1(%copy) : $@convention(thin) (@owned C) -> ()

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -21,6 +21,11 @@ class C {
 sil [ossa] @dummy : $@convention(thin) () -> ()
 sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
 sil [ossa] @takeOwnedC : $@convention(thin) (@owned C) -> ()
+sil [ossa] @getOwnedWrapper : $@convention(thin) () -> (@owned Wrapper)
+sil [ossa] @getOwnedMultiWrapper : $@convention(thin) () -> (@owned MultiWrapper)
+sil [ossa] @getOwnedHasObjectAndInt : $@convention(thin) () -> (@owned HasObjectAndInt)
+sil [ossa] @getOwnedString : $@convention(thin) () -> (@owned String)
+sil [ossa] @takeOwnedString : $@convention(thin) (@owned String) -> ()
 sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @accessRawP : $@convention(method) (Builtin.RawPointer) -> ()
@@ -147,15 +152,18 @@ bb0(%0 : @guaranteed $NativeObjectPair):
 
 // Test a basic copy with an outer use.
 //
-// CHECK-LABEL: sil [ossa] @testBorrowOuterUse : $@convention(thin) (@owned C) -> () {
-// CHECK: bb0(%0 : @owned $C):
+// CHECK-LABEL: sil [ossa] @testBorrowOuterUse : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
 // CHECK-NOT: begin_borrow
 // CHECK-NOT: copy
-// CHECK: apply %{{.*}}(%0) : $@convention(thin) (@owned C) -> ()
+// CHECK: apply %{{.*}}([[INSTANCE]]) : $@convention(thin) (@owned C) -> ()
 // CHECK-NOT: destroy
 // CHECK: } // end sil function 'testBorrowOuterUse'
-sil [ossa] @testBorrowOuterUse : $@convention(thin) (@owned C) -> () {
-bb0(%0 : @owned $C):
+sil [ossa] @testBorrowOuterUse : $@convention(thin) () -> () {
+bb0:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %0 = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %1 = begin_borrow %0 : $C
   %copy = copy_value %1 : $C
   end_borrow %1 : $C
@@ -792,21 +800,24 @@ bb0(%0 : @owned $Wrapper):
 // Test two inner forwards with one inner and one outer use.
 // Check that the destroy is removed after sinking the destructure.
 //
-// CHECK-LABEL: sil [ossa] @testForwardBorrow1 : $@convention(thin) (@owned Wrapper) -> () {
-// CHECK:       bb0(%0 : @owned $Wrapper):
-// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow %0 : $Wrapper
+// CHECK-LABEL: sil [ossa] @testForwardBorrow1 : {{.*}} {
+// CHECK:       bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
+// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow [[INSTANCE]] : $Wrapper
 // CHECK-NEXT:   [[DSIN1:%.*]] = destructure_struct [[BORROW]] : $Wrapper
 // CHECK-NEXT:   ([[DSIN2:%.*]], %{{.*}}) = destructure_struct [[DSIN1]] : $HasObjectAndInt
 // CHECK:        apply %{{.*}}([[DSIN2]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:   end_borrow [[BORROW]] : $Wrapper
-// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct [[INSTANCE]] : $Wrapper
 // CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
 // CHECK:        apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 // CHECK-LABEL: } // end sil function 'testForwardBorrow1'
-sil [ossa] @testForwardBorrow1 : $@convention(thin) (@owned Wrapper) -> () {
-bb0(%0 : @owned $Wrapper):
+sil [ossa] @testForwardBorrow1 : $@convention(thin) () -> () {
+bb0:
+  %getOwnedWrapper = function_ref @getOwnedWrapper : $@convention(thin) () -> (@owned Wrapper)
+  %0 = apply %getOwnedWrapper() : $@convention(thin) () -> (@owned Wrapper)
   %1 = begin_borrow %0 : $Wrapper
   %2 = destructure_struct %1 : $Wrapper
   (%3, %4) = destructure_struct %2 : $HasObjectAndInt
@@ -823,21 +834,24 @@ bb0(%0 : @owned $Wrapper):
 
 // Test two inner forwards where the copy has both and inner and outer uses.
 //
-// CHECK-LABEL: sil [ossa] @testForwardBorrow2 : $@convention(thin) (@owned Wrapper) -> () {
-// CHECK:       bb0(%0 : @owned $Wrapper):
-// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow %0 : $Wrapper
+// CHECK-LABEL: sil [ossa] @testForwardBorrow2 : {{.*}} {
+// CHECK:       bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
+// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow [[INSTANCE]] : $Wrapper
 // CHECK-NEXT:   [[DSIN1:%.*]] = destructure_struct [[BORROW]] : $Wrapper
 // CHECK-NEXT:   ([[DSIN2:%.*]], %{{.*}}) = destructure_struct [[DSIN1]] : $HasObjectAndInt
 // CHECK:        apply %{{.*}}([[DSIN2]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:   end_borrow [[BORROW]] : $Wrapper
-// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct [[INSTANCE]] : $Wrapper
 // CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
 // CHECK:        apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 // CHECK-LABEL: } // end sil function 'testForwardBorrow2'
-sil [ossa] @testForwardBorrow2 : $@convention(thin) (@owned Wrapper) -> () {
-bb0(%0 : @owned $Wrapper):
+sil [ossa] @testForwardBorrow2 : $@convention(thin) () -> () {
+bb0:
+  %getOwnedWrapper = function_ref @getOwnedWrapper : $@convention(thin) () -> (@owned Wrapper)
+  %0 = apply %getOwnedWrapper() : $@convention(thin) () -> (@owned Wrapper)
   %1 = begin_borrow %0 : $Wrapper
   %2 = destructure_struct %1 : $Wrapper
   (%3, %4) = destructure_struct %2 : $HasObjectAndInt
@@ -855,18 +869,21 @@ bb0(%0 : @owned $Wrapper):
 // Test two inner forwards with no inner use.
 // Remove the borrow and inner forwards.
 //
-// CHECK-LABEL: sil [ossa] @testForwardBorrow3 : $@convention(thin) (@owned Wrapper) -> () {
-// CHECK:       bb0(%0 : @owned $Wrapper):
+// CHECK-LABEL: sil [ossa] @testForwardBorrow3 : {{.*}} {
+// CHECK:       bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
 // CHECK-NOT:    borrow
 // CHECK-NOT:    copy
-// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct [[INSTANCE]] : $Wrapper
 // CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
 // CHECK-NEXT:   apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 // CHECK-LABEL: } // end sil function 'testForwardBorrow3'
-sil [ossa] @testForwardBorrow3 : $@convention(thin) (@owned Wrapper) -> () {
-bb0(%0 : @owned $Wrapper):
+sil [ossa] @testForwardBorrow3 : $@convention(thin) () -> () {
+bb0:
+  %getOwnedWrapper = function_ref @getOwnedWrapper : $@convention(thin) () -> (@owned Wrapper)
+  %0 = apply %getOwnedWrapper() : $@convention(thin) () -> (@owned Wrapper)
   %1 = begin_borrow %0 : $Wrapper
   %2 = destructure_struct %1 : $Wrapper
   (%3, %4) = destructure_struct %2 : $HasObjectAndInt
@@ -884,18 +901,21 @@ bb0(%0 : @owned $Wrapper):
 // Need to create two new destroys in this case.
 //
 //
-// CHECK-LABEL: sil [ossa] @testForwardBorrow4 : $@convention(thin) (@owned MultiWrapper) -> () {
-// CHECK: bb0(%0 : @owned $MultiWrapper):
-// CHECK-NEXT:   (%1, %2) = destructure_struct %0 : $MultiWrapper
-// CHECK-NEXT:   destroy_value %2 : $HasObjects
-// CHECK-NEXT:   ([[VAL:%.*]], %5) = destructure_struct %1 : $HasObjects
-// CHECK-NEXT:   destroy_value %5 : $C
+// CHECK-LABEL: sil [ossa] @testForwardBorrow4 : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
+// CHECK-NEXT:   ([[HASOBJECTS_0:%[^,]+]], [[HASOBJECTS_1:%[^,]+]]) = destructure_struct [[INSTANCE]] : $MultiWrapper
+// CHECK-NEXT:   destroy_value [[HASOBJECTS_1]] : $HasObjects
+// CHECK-NEXT:   ([[VAL:%.*]], [[OBJECT_1:%[^,]+]]) = destructure_struct [[HASOBJECTS_0]] : $HasObjects
+// CHECK-NEXT:   destroy_value [[OBJECT_1]] : $C
 // CHECK-NOT:    borrow
 // CHECK:        apply %{{.*}}([[VAL]]) : $@convention(thin) (@owned C) -> ()
 // CHECK-NOT:    destroy
 // CHECK-LABEL: } // end sil function 'testForwardBorrow4'
-sil [ossa] @testForwardBorrow4 : $@convention(thin) (@owned MultiWrapper) -> () {
-bb0(%0 : @owned $MultiWrapper):
+sil [ossa] @testForwardBorrow4 : $@convention(thin) () -> () {
+bb0:
+  %getOwnedMultiWrapper = function_ref @getOwnedMultiWrapper : $@convention(thin) () -> (@owned MultiWrapper)
+  %0 = apply %getOwnedMultiWrapper() : $@convention(thin) () -> (@owned MultiWrapper)
   %1 = begin_borrow %0 : $MultiWrapper
   (%2, %3) = destructure_struct %1 : $MultiWrapper
   (%4, %5) = destructure_struct %2 : $HasObjects
@@ -918,25 +938,28 @@ bb0(%0 : @owned $MultiWrapper):
 // with its source live range when the guaranteed uses are within the
 // outer scope. But that analysis needs to "see through" destructures.
 //
-// CHECK-LABEL: sil shared [ossa] @testForwardBorrow5 : $@convention(method) (@owned HasObjectAndInt) -> () {
-// CHECK: bb0(%0 : @owned $HasObjectAndInt):
-// CHECK-NEXT:  %1 = copy_value %0 : $HasObjectAndInt
-// CHECK-NEXT:  (%2, %3) = destructure_struct %1 : $HasObjectAndInt
-// CHECK-NEXT:  %4 = begin_borrow %2 : $C
-// CHECK-NEXT:  %5 = ref_tail_addr %4 : $C, $Builtin.Int8
-// CHECK-NEXT:  %6 = index_addr %5 : $*Builtin.Int8, undef : $Builtin.Word
-// CHECK-NEXT:  %7 = address_to_pointer %6 : $*Builtin.Int8 to $Builtin.RawPointer
-// CHECK-NEXT:  end_borrow %4 : $C
-// CHECK-NEXT:  destroy_value %2 : $C
-// CHECK:       apply %{{.*}}(%7) : $@convention(method) (Builtin.RawPointer) -> ()
-// CHECK-NEXT:  ([[OBJ:%.*]], %{{.*}}) = destructure_struct %0 : $HasObjectAndInt
+// CHECK-LABEL: sil shared [ossa] @testForwardBorrow5 : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
+// CHECK-NEXT:  [[COPY:%[^,]+]] = copy_value [[INSTANCE]] : $HasObjectAndInt
+// CHECK-NEXT:  ([[OBJECT:%[^,]+]], {{%[^,]+}}) = destructure_struct [[COPY]] : $HasObjectAndInt
+// CHECK-NEXT:  [[BORROW:%[^,]+]] = begin_borrow [[OBJECT]] : $C
+// CHECK-NEXT:  [[TAIL_ADDR:%[^,]+]] = ref_tail_addr [[BORROW]] : $C, $Builtin.Int8
+// CHECK-NEXT:  [[INDEX_ADDR:%[^,]+]] = index_addr [[TAIL_ADDR]] : $*Builtin.Int8, undef : $Builtin.Word
+// CHECK-NEXT:  [[POINTER:%[^,]+]] = address_to_pointer [[INDEX_ADDR]] : $*Builtin.Int8 to $Builtin.RawPointer
+// CHECK-NEXT:  end_borrow [[BORROW]] : $C
+// CHECK-NEXT:  destroy_value [[OBJECT]] : $C
+// CHECK:       apply %{{.*}}([[POINTER]]) : $@convention(method) (Builtin.RawPointer) -> ()
+// CHECK-NEXT:  ([[OBJ:%.*]], %{{.*}}) = destructure_struct [[INSTANCE]] : $HasObjectAndInt
 // CHECK-NEXT:  [[EXIS:%.*]] = init_existential_ref [[OBJ]] : $C : $C, $AnyObject
 // CHECK-NEXT:  fix_lifetime [[EXIS]] : $AnyObject
 // CHECK-NEXT:  destroy_value [[EXIS]] : $AnyObject
 // CHECK-NOT:   destroy
 // CHECK-LABEL: } // end sil function 'testForwardBorrow5'
-sil shared [ossa] @testForwardBorrow5 : $@convention(method) (@owned HasObjectAndInt) -> () {
-bb0(%0 : @owned $HasObjectAndInt):
+sil shared [ossa] @testForwardBorrow5 : $@convention(thin) () -> () {
+bb0:
+  %getOwnedHasObjectAndInt = function_ref @getOwnedHasObjectAndInt : $@convention(thin) () -> (@owned HasObjectAndInt)
+  %0 = apply %getOwnedHasObjectAndInt() : $@convention(thin) () -> (@owned HasObjectAndInt)
   %1 = begin_borrow %0 : $HasObjectAndInt
   %2 = struct_extract %1 : $HasObjectAndInt, #HasObjectAndInt.object
   %3 = copy_value %2 : $C
@@ -1045,9 +1068,10 @@ bb0(%0 : @owned $HasObject):
 // Removing this borrow scope will unblock removal of the final remaining copy_value:
 //    %_ = copy_value %_ : $String.UTF16View
 //
-// CHECK-LABEL: sil [ossa] @testUselessBorrowString : $@convention(thin) (@owned String) -> () {
-// CHECK: bb0(%0 : @owned $String):
-// CHECK-NEXT:   [[DESTRUCTURE:%.*]] = destructure_struct %0 : $String
+// CHECK-LABEL: sil [ossa] @testUselessBorrowString : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%.*]] = apply
+// CHECK-NEXT:   [[DESTRUCTURE:%.*]] = destructure_struct [[INSTANCE]] : $String
 // CHECK-NEXT:   [[UTF16:%.*]] = struct $String.UTF16View ([[DESTRUCTURE]] : $_StringGuts)
 // CHECK-NEXT:   br bb1
 // CHECK:      bb1:
@@ -1079,8 +1103,10 @@ bb0(%0 : @owned $HasObject):
 // CHECK:      bb8:
 // CHECK-NEXT:   destroy_value [[UTF16]] : $String.UTF16View
 // CHECK-LABEL: } // end sil function 'testUselessBorrowString'
-sil [ossa] @testUselessBorrowString : $@convention(thin) (@owned String) -> () {
-bb0(%0 : @owned $String):
+sil [ossa] @testUselessBorrowString : $@convention(thin) () -> () {
+bb0:
+  %getOwnedString = function_ref @getOwnedString : $@convention(thin) () -> (@owned String)
+  %0 = apply %getOwnedString() : $@convention(thin) () -> (@owned String)
   %1 = begin_borrow %0 : $String
   %2 = struct_extract %1 : $String, #String._guts
   %3 = copy_value %2 : $_StringGuts

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -17,6 +17,7 @@ sil_stage canonical
 import Builtin
 import Swift
 
+sil [ossa] @getOwnedT : $@convention(thin) <T> () -> (@owned T)
 sil [ossa] @takeOwned : $@convention(thin) <T> (@in T) -> ()
 sil [ossa] @takeMultipleOwned : $@convention(thin) <T> (@in T, @in T) -> ()
 sil [ossa] @takeGuaranteed : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -127,27 +128,30 @@ bb3(%11 : @owned $T):
   return %11 : $T
 }
 
-// CHECK-LABEL: sil [ossa] @testConsume : $@convention(thin) <T> (@in T, @inout T) -> () {
-// CHECK: bb0(%0 : @owned $T, %1 : $*T):
+// CHECK-LABEL: sil [ossa] @testConsume : {{.*}} {
+// CHECK: bb0([[ADDR:%[^,]+]] : $*T):
+// CHECK: [[INSTANCE:%[^,]+]] = apply
 //
 // TODO:  opt will reuse the original copy for the consuming store.
-// CHECK-DEBUG-NEXT:   [[STOREVAL:%.*]] = copy_value %0 : $T
+// CHECK-DEBUG-NEXT:   [[STOREVAL:%.*]] = copy_value [[INSTANCE]] : $T
 //
-// CHECK-NEXT:   debug_value %0 : $T
-// CHECK-DEBUG-NEXT: store [[STOREVAL]] to [assign] %1 : $*T
-// CHECK-NEXT:   store %0 to [assign] %1 : $*T
+// CHECK-NEXT:   debug_value [[INSTANCE]] : $T
+// CHECK-DEBUG-NEXT: store [[STOREVAL]] to [assign] [[ADDR]] : $*T
+// CHECK-NEXT:   store [[INSTANCE]] to [assign] [[ADDR]] : $*T
 //
 // The non-consuming use now uses the original value.
-// CHECK-DEBUG-NEXT:   debug_value %0 : $T
-// CHECK-NEXT:   debug_value %1 : $*T, expr op_deref
+// CHECK-DEBUG-NEXT:   debug_value [[INSTANCE]] : $T
+// CHECK-NEXT:   debug_value [[ADDR]] : $*T, expr op_deref
 //
 // The original destroy is deleted with optimizations enabled.
-// CHECK-DEBUG-NEXT: destroy_value %0 : $T
+// CHECK-DEBUG-NEXT: destroy_value [[INSTANCE]] : $T
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK-LABEL: // end sil function 'testConsume'
-sil [ossa] @testConsume : $@convention(thin) <T> (@in T, @inout T) -> () {
-bb0(%arg : @owned $T, %addr : $*T):
+sil [ossa] @testConsume : $@convention(thin) <T> (@inout T) -> () {
+bb0(%addr : $*T):
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy = copy_value %arg : $T
   debug_value %copy : $T
   store %copy to [assign] %addr : $*T
@@ -158,21 +162,22 @@ bb0(%arg : @owned $T, %addr : $*T):
   return %v : $()
 }
 
-// CHECK-LABEL: sil [ossa] @testDestroyEdge : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
-// CHECK: bb0(%0 : @owned $T, %1 : $Builtin.Int1):
-// CHECK-OPT-NEXT:   destroy_value %0 : $T
-// CHECK-ONONE-NEXT: destroy_value [poison] %0 : $T
-// CHECK-DEBUG-NEXT: cond_br %1, bb2, bb1
+// CHECK-LABEL: sil [ossa] @testDestroyEdge : {{.*}} {
+// CHECK: bb0([[BIT:%[^,]+]] : $Builtin.Int1):
+// CHECK: [[INSTANCE:%[^,]+]] = apply
+// CHECK-OPT-NEXT:   destroy_value [[INSTANCE]] : $T
+// CHECK-ONONE-NEXT: destroy_value [poison] [[INSTANCE]] : $T
+// CHECK-DEBUG-NEXT: cond_br [[BIT]], bb2, bb1
 //
 // CHECK: bb1:
 // Debug build inserts a new destroy
-// CHECK-DEBUG-NEXT: destroy_value %0 : $T
+// CHECK-DEBUG-NEXT: destroy_value [[INSTANCE]] : $T
 // CHECK-NEXT:     br bb3
 //
 // CHECK: bb2:
 // The original copy is deleted in both cases.
-// CHECK-DEBUG-NEXT:   debug_value %0 : $T
-// CHECK-DEBUG-NEXT:   destroy_value %0 : $T
+// CHECK-DEBUG-NEXT:   debug_value [[INSTANCE]] : $T
+// CHECK-DEBUG-NEXT:   destroy_value [[INSTANCE]] : $T
 // CHECK-NEXT:   br bb3
 //
 // CHECK: bb3:
@@ -180,8 +185,10 @@ bb0(%arg : @owned $T, %addr : $*T):
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK-LABEL: } // end sil function 'testDestroyEdge'
-sil [ossa] @testDestroyEdge : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
-bb0(%arg : @owned $T, %z : $Builtin.Int1):
+sil [ossa] @testDestroyEdge : $@convention(thin) <T> (Builtin.Int1) -> () {
+bb0(%z : $Builtin.Int1):
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   cond_br %z, bb2, bb1
 
 bb1:
@@ -224,23 +231,26 @@ bb(%0 : @owned $T):
 // Which copy is reused is unfortunately sensitive to the use list order.
 //
 // CHECK-TRACE-LABEL: CopyPropagation: testCopy2OperReuse
-// CHECK-TRACE:  Removing   destroy_value %0 : $T
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value %0 : $T
+// CHECK-TRACE:  Removing   destroy_value %1 : $T
+// CHECK-TRACE:  Removing   %{{.*}} = copy_value %1 : $T
 // CHECK-TRACE-NOT:  Removing
 //
-// CHECK-LABEL: sil [ossa] @testCopy2OperReuse : $@convention(thin) <T> (@in T) -> () {
-// CHECK: bb0(%0 : @owned $T):
-// CHECK-NEXT:  [[CP:%.*]] = copy_value %0 : $T
-// CHECK-ONONE-NEXT:  [[CP:%.*]] = copy_value %0 : $T
+// CHECK-LABEL: sil [ossa] @testCopy2OperReuse : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%[^,]+]] = apply
+// CHECK-NEXT:  [[CP:%.*]] = copy_value [[INSTANCE]] : $T
+// CHECK-ONONE-NEXT:  [[CP:%.*]] = copy_value [[INSTANCE]] : $T
 // CHECK-NEXT:  // function_ref takeMultipleOwned
 // CHECK-NEXT:  function_ref @takeMultipleOwned : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
-// CHECK-NEXT:  apply %{{.*}}<T>(%0, [[CP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
+// CHECK-NEXT:  apply %{{.*}}<T>([[INSTANCE]], [[CP]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
 // CHECK-ONONE-NEXT:  destroy_value
 // CHECK-NEXT:  tuple ()
 // CHECK-NEXT:  return
 // CHECK-LABEL: } // end sil function 'testCopy2OperReuse'
-sil [ossa] @testCopy2OperReuse : $@convention(thin) <T> (@in T) -> () {
-bb0(%arg : @owned $T):
+sil [ossa] @testCopy2OperReuse : $@convention(thin) <T> () -> () {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy1 = copy_value %arg : $T
   %copy2 = copy_value %arg : $T
   %f = function_ref @takeMultipleOwned : $@convention(thin) <T> (@in T, @in T) -> ()
@@ -253,23 +263,26 @@ bb0(%arg : @owned $T):
 // Reuse one copy and eliminate the other copy and destroy.
 //
 // CHECK-TRACE-LABEL: *** CopyPropagation: testCopy2CallReuse
-// CHECK-TRACE:  Removing   destroy_value %0 : $T
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value %0 : $T
+// CHECK-TRACE:  Removing   destroy_value %1 : $T
+// CHECK-TRACE:  Removing   %{{.*}} = copy_value %1 : $T
 // CHECK-TRACE-NOT:  Removing
 //
-// CHECK-LABEL: sil [ossa] @testCopy2CallReuse : $@convention(thin) <T> (@in T) -> () {
-// CHECK: bb0(%0 : @owned $T):
-// CHECK-NEXT:  [[CP:%.*]] = copy_value %0 : $T
-// CHECK-ONONE-NEXT:  [[CP:%.*]] = copy_value %0 : $T
+// CHECK-LABEL: sil [ossa] @testCopy2CallReuse : {{.*}} {
+// CHECK: bb0:
+// CHECK: [[INSTANCE:%[^,]+]] = apply
+// CHECK-NEXT:  [[CP:%.*]] = copy_value [[INSTANCE]] : $T
+// CHECK-ONONE-NEXT:  [[CP:%.*]] = copy_value [[INSTANCE]] : $T
 // CHECK-NEXT:  // function_ref
 // CHECK-NEXT:  function_ref
 // CHECK-NEXT:  apply %{{.*}}<T>([[CP]])
-// CHECK-NEXT:  apply %{{.*}}<T>(%0)
+// CHECK-NEXT:  apply %{{.*}}<T>([[INSTANCE]])
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return
 // CHECK-LABEL: } // end sil function 'testCopy2CallReuse'
-sil [ossa] @testCopy2CallReuse : $@convention(thin) <T> (@in T) -> () {
-bb0(%arg : @owned $T):
+sil [ossa] @testCopy2CallReuse : $@convention(thin) <T> () -> () {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy1 = copy_value %arg : $T
   %copy2 = copy_value %arg : $T
   %f = function_ref @takeOwned : $@convention(thin) <T> (@in T) -> ()
@@ -283,16 +296,17 @@ bb0(%arg : @owned $T):
 // bb1 has a consuming instruction but is also live-out. Reuse the copy in bb1.
 //
 // CHECK-TRACE-LABEL: *** CopyPropagation: liveoutConsume
-// CHECK-TRACE:  Removing   destroy_value %0 : $T
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value %0 : $T
+// CHECK-TRACE:  Removing   destroy_value %2 : $T
+// CHECK-TRACE:  Removing   %{{.*}} = copy_value %2 : $T
 // CHECK-TRACE-NOT:  Removing
 //
-// CHECK-LABEL: sil [ossa] @liveoutConsume : $@convention(thin) <T> (@owned T, Builtin.Int1) -> () {
-// CHECK: bb0(%0 : @owned $T, %1 : $Builtin.Int1):
+// CHECK-LABEL: sil [ossa] @liveoutConsume : {{.*}} {
+// CHECK: bb0([[BIT:%[^,]+]] : $Builtin.Int1):
+// CHECK: [[INSTANCE:%[^,]+]] = apply
 // CHECK-NOT: copy_value
-// CHECK: cond_br %1, bb2, bb1
+// CHECK: cond_br [[BIT]], bb2, bb1
 // CHECK: bb1:
-// CHECK: copy_value %0 : $T
+// CHECK: copy_value [[INSTANCE]] : $T
 // CHECK: apply
 // CHECK: br bb3
 // CHECK: bb3:
@@ -300,8 +314,10 @@ bb0(%arg : @owned $T):
 // CHECK: apply
 // CHECK-NOT: destroy_value
 // CHECK-LABEL: } // end sil function 'liveoutConsume'
-sil [ossa] @liveoutConsume : $@convention(thin) <T> (@owned T, Builtin.Int1) -> () {
-bb0(%arg : @owned $T, %z : $Builtin.Int1):
+sil [ossa] @liveoutConsume : $@convention(thin) <T> (Builtin.Int1) -> () {
+bb0(%z : $Builtin.Int1):
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy1 = copy_value %arg : $T
   cond_br %z, bb2, bb1
 
@@ -325,19 +341,21 @@ bb3:
 // The LiveWithin block has a destroy, but it's before the first use.
 //
 // CHECK-TRACE-LABEL: *** CopyPropagation: testDestroyBeforeUse
-// CHECK-TRACE:  Removing   destroy_value %1 : $T
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value %0 : $T
+// CHECK-TRACE:  Removing   destroy_value %2 : $T
+// CHECK-TRACE:  Removing   %{{.*}} = copy_value %1 : $T
 //
-// CHECK-LABEL: sil [ossa] @testDestroyBeforeUse : $@convention(thin) <T> (@in T) -> () {
-// CHECK: bb0(%0 : @owned $T):
+// CHECK-LABEL: sil [ossa] @testDestroyBeforeUse : {{.*}} {
+// CHECK: bb0:
 // CHECK-NOT: copy_value
 // CHECK-NOT: destroy_value
 // CHECK: apply
 // CHECK-NOT: destroy_value
 // CHECK: return
 // CHECK-LABEL: } // end sil function 'testDestroyBeforeUse'
-sil [ossa] @testDestroyBeforeUse : $@convention(thin) <T> (@in T) -> () {
-bb0(%arg : @owned $T):
+sil [ossa] @testDestroyBeforeUse : $@convention(thin) <T> () -> () {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy = copy_value %arg : $T
   destroy_value %copy : $T
   %f = function_ref @takeOwned : $@convention(thin) <T> (@in T) -> ()
@@ -369,18 +387,20 @@ bb0(%arg1 : @owned $T, %arg2 : @owned $T):
 // A copy may have multiple uses
 //
 // CHECK-TRACE-LABEL: *** CopyPropagation: testSharedCopy
-// CHECK-TRACE:  Removing   destroy_value %0 : $T
-// CHECK-TRACE:  Removing   %1 = copy_value %0 : $T
+// CHECK-TRACE:  Removing   destroy_value %1 : $T
+// CHECK-TRACE:  Removing   %2 = copy_value %1 : $T
 // CHECK-TRACE-NOT: Removing
 //
-// CHECK-LABEL: sil [ossa] @testSharedCopy : $@convention(thin) <T> (@in T) -> () {
+// CHECK-LABEL: sil [ossa] @testSharedCopy : {{.*}} {
 // CHECK-NOT: copy_value
 // CHECK: apply
 // CHECK: apply
 // CHECK-NOT: destroy_value
 // CHECK-LABEL: } // end sil function 'testSharedCopy'
-sil [ossa] @testSharedCopy : $@convention(thin) <T> (@in T) -> () {
-bb0(%arg : @owned $T):
+sil [ossa] @testSharedCopy : $@convention(thin) <T> () -> () {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %copy = copy_value %arg : $T
   %f1 = function_ref @takeGuaranteed : $@convention(thin) <T> (@in_guaranteed T) -> ()
   %call1 = apply %f1<T>(%copy) : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -392,23 +412,26 @@ bb0(%arg : @owned $T):
 }
 
 // CHECK-TRACE-LABEL: *** CopyPropagation: testBorrowCopy
-// CHECK-TRACE:        Canonicalizing: %0 = argument of bb0 : $T
-// CHECK-TRACE:        Removing   destroy_value [[REGISTER_1:%[^,]+]] : $T
-// CHECK-TRACE:        Removing   [[REGISTER_1]] = copy_value %0 : $T
+// CHECK-TRACE:        Canonicalizing: %1
+// CHECK-TRACE:        Removing   destroy_value %4 : $T
+// CHECK-TRACE:        Removing   %4 = copy_value %1 : $T
 //
-// CHECK-LABEL: sil [ossa] @testBorrowCopy : $@convention(thin) <T> (@in T) -> () {
-// CHECK-LABEL: bb0(%0 : @owned $T):
-// CHECK-NEXT:   destroy_value %0 : $T
+// CHECK-LABEL: sil [ossa] @testBorrowCopy : {{.*}} {
+// CHECK-LABEL: bb0:
+// CHECK:        [[INSTANCE:%[^,]+]] = apply
+// CHECK-NEXT:   destroy_value [[INSTANCE]] : $T
 // CHECK-NEXT:   tuple ()
 // CHECK-NEXT:   return
 // CHECK-LABEL: }
-sil [ossa] @testBorrowCopy : $@convention(thin) <T> (@in T) -> () {
-bb0(%0 : @owned $T):
-  %3 = begin_borrow %0 : $T
+sil [ossa] @testBorrowCopy : $@convention(thin) <T> () -> () {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %arg = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
+  %3 = begin_borrow %arg : $T
   %4 = copy_value %3 : $T
   end_borrow %3 : $T
   destroy_value %4 : $T
-  destroy_value %0 : $T
+  destroy_value %arg : $T
   %17 = tuple ()
   return %17 : $()
 }
@@ -436,23 +459,26 @@ sil @testThrows : $@convention(thin) <τ_0_0> (τ_0_0) -> (@error Error)
 
 // CHECK-TRACE-LABEL: *** CopyPropagation: testTryApply
 //
-// CHECK-LABEL: sil [ossa] @testTryApply : $@convention(thin) <T> (@in T) -> @error Error {
-// CHECK: bb0(%0 : @owned $T):
+// CHECK-LABEL: sil [ossa] @testTryApply : {{.*}} {
+// CHECK: bb0:
+// CHECK:   [[INSTANCE:%[^,]+]] = apply
 // CHECK:   function_ref @testThrows : $@convention(thin) <τ_0_0> (τ_0_0) -> @error Error
-// CHECK:   try_apply %{{.*}}<T>(%0) : $@convention(thin) <τ_0_0> (τ_0_0) -> @error Error, normal bb1, error bb2
-// CHECK: bb1(%3 : $()):
-// CHECK:   destroy_value %0 : $T
+// CHECK:   try_apply %{{.*}}<T>([[INSTANCE]]) : $@convention(thin) <τ_0_0> (τ_0_0) -> @error Error, normal bb1, error bb2
+// CHECK: bb1({{%[^,]+}} : $()):
+// CHECK:   destroy_value [[INSTANCE]] : $T
 // CHECK:   br bb3
 // CHECK: bb2(%{{.*}} : @owned $Error):
-// CHECK:   destroy_value %0 : $T
+// CHECK:   destroy_value [[INSTANCE]] : $T
 // CHECK:   destroy_value %{{.*}} : $Error
 // CHECK:   br bb3
 // CHECK: bb3:
 // CHECK-NOT: destroy
 // CHECK:   return
 // CHECK-LABEL: } // end sil function 'testTryApply'
-sil [ossa] @testTryApply : $@convention(thin) <T> (@in T) -> (@error Error) {
-bb0(%0 : @owned $T):
+sil [ossa] @testTryApply : $@convention(thin) <T> () -> (@error Error) {
+bb0:
+  %getOwnedT = function_ref @getOwnedT : $@convention(thin) <T> () -> (@owned T)
+  %0 = apply %getOwnedT<T>() : $@convention(thin) <T> () -> (@owned T)
   %1 = copy_value %0 : $T
   destroy_value %0 : $T
   %f = function_ref @testThrows : $@convention(thin) <τ_0_0> (τ_0_0) -> (@error Error)

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -166,7 +166,9 @@ exit:
 // within a single owned lexical scope.
 //
 // CHECK-LABEL: sil [ossa] @fold_two_parallel_applies___noncanonical_destroys : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
@@ -178,8 +180,10 @@ exit:
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_two_parallel_applies___noncanonical_destroys'
-sil [ossa] @fold_two_parallel_applies___noncanonical_destroys : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_two_parallel_applies___noncanonical_destroys : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   %lifetime = begin_borrow [lexical] %instance : $C
   cond_br undef, left, right
@@ -561,7 +565,9 @@ exit:
 
 // Fold even if there is a noncanonicalized copy which is otherwise used.
 // CHECK-LABEL: sil [ossa] @fold_noncanonical_copy_with_other_use : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]()
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MOVE]]
 // CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
@@ -581,8 +587,10 @@ exit:
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_noncanonical_copy_with_other_use'
-sil [ossa] @fold_noncanonical_copy_with_other_use : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_noncanonical_copy_with_other_use : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C
   %copy = copy_value %lifetime : $C
   cond_br undef, left, right

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -161,7 +161,7 @@ exit:
 
 }
 
-// Enclose a single guaranteed lexical scope that contains two paralell
+// Enclose a single guaranteed lexical scope that contains two parallel
 // applies of owned arguments with the destroy at a NONcanonical position
 // within a single owned lexical scope.
 //
@@ -514,11 +514,24 @@ exit:
   return %retval : $()
 }
 
-// Don't fold with apply when guaranteed lexical value used in one but not two
-// branches and the lexical scope ends before the use on the non-lexical branch.
+// Fold apply when guaranteed lexical value used in one but not two branches
+// and the lexical scope ends before the use on the non-lexical branch.
 //
 // CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : {{.*}} {
-// CHECK-NOT: move_value [lexical]
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[MOVE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
 sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -777,14 +777,13 @@ bad(%15 : @owned $Error):
 // CHECK:       [[LEFT]]:
 // CHECK:         [[REGISTER_3:%[^,]+]] = apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
 // CHECK:         [[REGISTER_6:%[^,]+]] = apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_up_to_two_barrier_applies'
 sil [ossa] @hoist_up_to_two_barrier_applies : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -83,6 +83,7 @@ sil [global_init] @global_init_fun : $@convention(thin) () -> Builtin.RawPointer
 sil [ossa] @user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 sil [ossa] @use_nativeobject_owned : $@convention(thin) (@owned Builtin.NativeObject) -> ()
 sil [ossa] @use_nativeobject_guaranteed : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+sil [ossa] @get_owned_klass : $@convention(thin) () -> (@owned Klass)
 sil @use_anyobject_guaranteed : $@convention(thin) (@guaranteed AnyObject) -> ()
 sil @use_generic_obj_guaranteed : $@convention(thin) <τ_0_0> (@guaranteed τ_0_0) -> ()
 sil [ossa] @unknown : $@convention(thin) () -> ()
@@ -5218,21 +5219,40 @@ bb0(%0 : $UnsafePointer<AnyObject>):
 // CHECK:   destroy_value [[CP1]] : $Klass
 // CHECK:   fix_lifetime %0 : $Klass
 // CHECK-LABEL: } // end sil function 'test_pointer_to_address'
-//
-// CHECK_COPYPROP-LABEL: sil [ossa] @test_pointer_to_address : $@convention(thin) (@owned Klass, Builtin.Word) -> @owned AnyObject {
-// CHECK_COPYPROP: bb0(%0 : @owned $Klass, %1 : $Builtin.Word):
-// CHECK_COPYPROP-NOT: copy_value
-// CHECK_COPYPROP:   [[BORROW:%.*]] = begin_borrow %0 : $Klass
-// CHECK_COPYPROP:   ref_tail_addr [[BORROW]] : $Klass, $AnyObject
-// CHECK_COPYPROP:   index_addr %{{.*}} : $*AnyObject, %1 : $Builtin.Word
-// CHECK_COPYPROP:   index_addr %{{.*}} : $*AnyObject, %1 : $Builtin.Word
-// CHECK_COPYPROP:   load [copy] %{{.*}} : $*AnyObject
-// CHECK_COPYPROP:   end_borrow [[BORROW]] : $Klass
-// CHECK_COPYPROP:   fix_lifetime %0 : $Klass
-// CHECK_COPYPROP:   destroy_value %0 : $Klass
-// CHECK_COPYPROP-LABEL: } // end sil function 'test_pointer_to_address'
 sil [ossa] @test_pointer_to_address : $@convention(thin) (@owned Klass, Builtin.Word) -> @owned AnyObject {
 bb0(%0 : @owned $Klass, %1 : $Builtin.Word):
+  %2 = begin_borrow %0 : $Klass
+  %3 = ref_tail_addr %2 : $Klass, $AnyObject
+  %4 = index_addr %3 : $*AnyObject, %1 : $Builtin.Word
+  %5 = address_to_pointer %4 : $*AnyObject to $Builtin.RawPointer
+  end_borrow %2 : $Klass
+  %7 = pointer_to_address %5 : $Builtin.RawPointer to [strict] $*AnyObject
+  %8 = index_addr %7 : $*AnyObject, %1 : $Builtin.Word
+  %9 = address_to_pointer %8 : $*AnyObject to $Builtin.RawPointer
+  %10 = pointer_to_address %9 : $Builtin.RawPointer to [strict] $*AnyObject
+  %11 = load [copy] %10 : $*AnyObject
+  fix_lifetime %0 : $Klass
+  destroy_value %0 : $Klass
+  return %11 : $AnyObject
+}
+
+// CHECK_COPYPROP-LABEL: sil [ossa] @test_pointer_to_address_copyprop : {{.*}} {
+// CHECK_COPYPROP: bb0([[WORD:%[^,]+]] :
+// CHECK_COPYPROP: [[INSTANCE:%[^,]+]] = apply
+// CHECK_COPYPROP-NOT: copy_value
+// CHECK_COPYPROP:   [[BORROW:%.*]] = begin_borrow [[INSTANCE]] : $Klass
+// CHECK_COPYPROP:   ref_tail_addr [[BORROW]] : $Klass, $AnyObject
+// CHECK_COPYPROP:   index_addr %{{.*}} : $*AnyObject, [[WORD]] : $Builtin.Word
+// CHECK_COPYPROP:   index_addr %{{.*}} : $*AnyObject, [[WORD]] : $Builtin.Word
+// CHECK_COPYPROP:   load [copy] %{{.*}} : $*AnyObject
+// CHECK_COPYPROP:   end_borrow [[BORROW]] : $Klass
+// CHECK_COPYPROP:   fix_lifetime [[INSTANCE]] : $Klass
+// CHECK_COPYPROP:   destroy_value [[INSTANCE]] : $Klass
+// CHECK_COPYPROP-LABEL: } // end sil function 'test_pointer_to_address_copyprop'
+sil [ossa] @test_pointer_to_address_copyprop : $@convention(thin) (Builtin.Word) -> @owned AnyObject {
+bb0(%1 : $Builtin.Word):
+  %f = function_ref @get_owned_klass : $@convention(thin) () -> (@owned Klass)
+  %0 = apply %f() : $@convention(thin) () -> (@owned Klass)
   %2 = begin_borrow %0 : $Klass
   %3 = ref_tail_addr %2 : $Klass, $AnyObject
   %4 = index_addr %3 : $*AnyObject, %1 : $Builtin.Word


### PR DESCRIPTION
The destroys of owned arguments must not be hoisted over deinit barriers to respect the semantics of lexical lifetimes.  Here, owned SILValues which are SILFunctionArguments are made to be lexical.  Code which hoists destroys will check this field and not hoist destroys.
