### PR TITLE
[cxx-interop] Add support for C++ increment decrement operations

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1802,6 +1802,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_GreaterEqual:
     case clang::OverloadedOperatorKind::OO_AmpAmp:
     case clang::OverloadedOperatorKind::OO_PipePipe:
+    case clang::OverloadedOperatorKind::OO_PlusPlus:
+    case clang::OverloadedOperatorKind::OO_MinusMinus:
       baseName = clang::getOperatorSpelling(op);
       isFunction = true;
       argumentNames.resize(

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -45,6 +45,14 @@ inline LoadableIntWrapper operator>>(LoadableIntWrapper lhs, LoadableIntWrapper 
   return LoadableIntWrapper{.value = lhs.value >> rhs.value};
 }
 
+inline LoadableIntWrapper operator++(LoadableIntWrapper lhs) {
+  return LoadableIntWrapper{.value = lhs.value++};
+}
+
+inline LoadableIntWrapper operator--(LoadableIntWrapper lhs) {
+  return LoadableIntWrapper{.value = lhs.value--};
+}
+
 inline bool operator<(LoadableIntWrapper lhs, LoadableIntWrapper rhs) { return lhs.value < rhs.value; }
 
 inline bool operator>(LoadableIntWrapper lhs, LoadableIntWrapper rhs) { return lhs.value > rhs.value; }

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -10,6 +10,8 @@
 // CHECK-NEXT: func | (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func << (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func >> (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func ++ (lhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func -- (lhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func < (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
 // CHECK-NEXT: func > (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
 // CHECK-NEXT: func == (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -21,6 +21,8 @@ let resultEqualEqual = lhs == rhs
 let resultExclaimEqual = lhs != rhs
 let resultLessEqual = lhs <= rhs
 let resultGreaterEqual = lhs >= rhs
+let reusltPlusPlus = lhs ++ rhs
+let reusltMinusMinus = lhs -- rhs
 
 var lhsBool = LoadableBoolWrapper(value: true)
 var rhsBool = LoadableBoolWrapper(value: false)

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -169,4 +169,22 @@ OperatorsTestSuite.test("pipe pipe (||)") {
   expectEqual(true, result.value)
 }
 
+OperatorsTestSuite.test("plus plus (++)") {
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 1)
+
+  let result = lhs ++ rhs
+
+  expectEqual(43, result.value)
+}
+
+OperatorsTestSuite.test("minus minus (--)") {
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 1)
+  
+  let result = lhs -- 1
+
+  expectEqual(41, result.value)
+}
+
 runAllTests()


### PR DESCRIPTION
Support imported C++ `++` and `--` operators in Swift.

Refs #32333