### PR TITLE
[Distributed] allow get only distributed computed properties

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -651,7 +651,7 @@ SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
 // 117 was 'spawn' and is now unused
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
-  DeclModifier | OnClass | OnFunc |
+  DeclModifier | OnClass | OnFunc | OnVar |
   DistributedOnly |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -144,6 +144,7 @@ enum class DescriptiveDeclKind : uint8_t {
   Property,
   StaticProperty,
   ClassProperty,
+  DistributedProperty,
   InfixOperator,
   PrefixOperator,
   PostfixOperator,
@@ -5239,6 +5240,9 @@ public:
 
   /// Is this an "async let" property?
   bool isAsyncLet() const;
+
+  /// Does this have a 'distributed' modifier?
+  bool isDistributed() const;
 
   /// Is this a stored property that will _not_ trigger any user-defined code
   /// upon any kind of access?

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4493,8 +4493,8 @@ ERROR(actor_isolated_non_self_reference,none,
         "from the main actor|from a non-isolated context}3",
         (DescriptiveDeclKind, DeclName, unsigned, unsigned, Type))
 ERROR(distributed_actor_isolated_non_self_reference,none,
-      "distributed actor-isolated %0 %1 can only be referenced inside the "
-      "distributed actor",
+      "distributed actor-isolated %0 %1 can not be accessed from a "
+      "non-isolated context",
       (DescriptiveDeclKind, DeclName))
 ERROR(distributed_actor_needs_explicit_distributed_import,none,
       "'_Distributed' module not imported, required for 'distributed actor'",
@@ -4568,9 +4568,9 @@ ERROR(distributed_actor_isolated_method,none,
 ERROR(distributed_actor_func_param_not_codable,none,
       "parameter '%0' of type %1 in %2 does not conform to '%3'",
       (StringRef, Type, DescriptiveDeclKind, StringRef))
-ERROR(distributed_actor_func_result_not_codable,none,
-      "result type %0 of %1 does not conform to '%2'",
-      (Type, DescriptiveDeclKind, StringRef))
+ERROR(distributed_actor_target_result_not_codable,none,
+      "result type %0 of %1 %2 does not conform to '%3'",
+      (Type, DescriptiveDeclKind, Identifier, StringRef))
 ERROR(distributed_actor_remote_func_implemented_manually,none,
       "distributed instance method's %0 remote counterpart %1 cannot not be implemented manually.",
       (Identifier, Identifier))
@@ -4761,9 +4761,19 @@ ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",
       (DeclName))
+ERROR(distributed_property_can_only_be_computed_get_only,none,
+      "'distributed' computed property %0 can only be have a 'get' implementation",
+      (DeclName))
+ERROR(distributed_property_cannot_be_static,none,
+      "'distributed' property %0 cannot be 'static'",
+      (DeclName))
+ERROR(distributed_property_can_only_be_computed,none,
+      "static property %0 cannot be 'distributed', because it is not a computed "
+      "get-only property",
+      (DeclName))
 NOTE(distributed_actor_isolated_property,none,
-      "distributed actor state is only available within the actor instance", // TODO: reword in terms of isolation
-      ())
+      "access to this property is only permitted within the distributed actor %0",
+      (DeclName))
 
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4566,10 +4566,10 @@ ERROR(distributed_actor_isolated_method,none,
       "only 'distributed' instance methods can be called on a potentially remote distributed actor",
       ())
 ERROR(distributed_actor_func_param_not_codable,none,
-      "parameter '%0' of type %1 in %2 does not conform to '%3'",
+      "parameter '%0' of type %1 in %2 does not conform to serialization requirement '%3'",
       (StringRef, Type, DescriptiveDeclKind, StringRef))
 ERROR(distributed_actor_target_result_not_codable,none,
-      "result type %0 of %1 %2 does not conform to '%3'",
+      "result type %0 of %1 %2 does not conform to serialization requirement '%3'",
       (Type, DescriptiveDeclKind, Identifier, StringRef))
 ERROR(distributed_actor_remote_func_implemented_manually,none,
       "distributed instance method's %0 remote counterpart %1 cannot not be implemented manually.",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4762,18 +4762,17 @@ ERROR(distributed_actor_user_defined_special_property,none,
       "distributed actor synthesized stored property",
       (DeclName))
 ERROR(distributed_property_can_only_be_computed_get_only,none,
-      "'distributed' computed property %0 can only be have a 'get' implementation",
+      "'distributed' computed property %0 cannot have setter",
       (DeclName))
 ERROR(distributed_property_cannot_be_static,none,
       "'distributed' property %0 cannot be 'static'",
       (DeclName))
 ERROR(distributed_property_can_only_be_computed,none,
-      "static property %0 cannot be 'distributed', because it is not a computed "
-      "get-only property",
-      (DeclName))
+      "%0 %1 cannot be 'distributed', only computed properties can",
+      (DescriptiveDeclKind, DeclName))
 NOTE(distributed_actor_isolated_property,none,
-      "access to this property is only permitted within the distributed actor %0",
-      (DeclName))
+      "access to %0 %1 is only permitted within distributed actor %2",
+      (DescriptiveDeclKind, DeclName, DeclName))
 
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -191,8 +191,13 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
      auto var = cast<VarDecl>(this);
      switch (var->getCorrectStaticSpelling()) {
      case StaticSpellingKind::None:
-       if (var->getDeclContext()->isTypeContext())
+       if (var->getDeclContext()->isTypeContext()) {
+         if (var->isDistributed() && !var->isLet()) {
+           return DescriptiveDeclKind::DistributedProperty;
+         }
+
          return DescriptiveDeclKind::Property;
+       }
        return var->isLet() ? DescriptiveDeclKind::Let
                            : DescriptiveDeclKind::Var;
      case StaticSpellingKind::KeywordStatic:
@@ -299,6 +304,7 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   ENTRY(Property, "property");
   ENTRY(StaticProperty, "static property");
   ENTRY(ClassProperty, "class property");
+  ENTRY(DistributedProperty, "distributed property");
   ENTRY(PrecedenceGroup, "precedence group");
   ENTRY(InfixOperator, "infix operator");
   ENTRY(PrefixOperator, "prefix operator");
@@ -6302,6 +6308,10 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
 
 bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>();
+}
+
+bool VarDecl::isDistributed() const {
+  return getAttrs().hasAttribute<DistributedActorAttr>();
 }
 
 bool VarDecl::isOrdinaryStoredProperty() const {

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -1155,14 +1155,14 @@ void SILGenFunction::emitDistributedThunk(SILDeclRef thunk) {
 
           // --- Codable: Decodable
           auto decodableRequirementTy =
-              ctx.getProtocol(KnownProtocolKind::Decodable); // FIXME: actually use SerializatioNRequirement
+              ctx.getProtocol(KnownProtocolKind::Decodable); // FIXME(distributed): actually use SerializationRequirement
           auto paramDecodableTypeConfRef = module->lookupConformance(
               paramTy, decodableRequirementTy);
           subConformances.push_back(paramDecodableTypeConfRef);
 
           // --- Codable: Encodable
           auto encodableRequirementTy = ctx.getProtocol(
-              KnownProtocolKind::Encodable); // FIXME: actually use SerializatioNRequirement
+              KnownProtocolKind::Encodable); // FIXME(distributed): actually use SerializationRequirement
           auto paramEncodableTypeConfRef = module->lookupConformance(
               paramTy, encodableRequirementTy);
           subConformances.push_back(paramEncodableTypeConfRef);

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -1154,15 +1154,17 @@ void SILGenFunction::emitDistributedThunk(SILDeclRef thunk) {
           subTypes.push_back(paramTy);
 
           // --- Codable: Decodable
-          auto decodableRequirementTy =
-              ctx.getProtocol(KnownProtocolKind::Decodable); // FIXME(distributed): actually use SerializationRequirement
+          auto decodableRequirementTy = ctx.getProtocol(
+              KnownProtocolKind::Decodable); // FIXME(distributed): actually use
+                                             // SerializationRequirement
           auto paramDecodableTypeConfRef = module->lookupConformance(
               paramTy, decodableRequirementTy);
           subConformances.push_back(paramDecodableTypeConfRef);
 
           // --- Codable: Encodable
           auto encodableRequirementTy = ctx.getProtocol(
-              KnownProtocolKind::Encodable); // FIXME(distributed): actually use SerializationRequirement
+              KnownProtocolKind::Encodable); // FIXME(distributed): actually use
+                                             // SerializationRequirement
           auto paramEncodableTypeConfRef = module->lookupConformance(
               paramTy, encodableRequirementTy);
           subConformances.push_back(paramEncodableTypeConfRef);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5539,9 +5539,14 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
 
   // distributed can be applied to actor definitions and their methods
   if (auto varDecl = dyn_cast<VarDecl>(D)) {
-    // distributed can not be applied to stored properties
-    diagnoseAndRemoveAttr(attr, diag::distributed_actor_property);
-    return;
+    if (varDecl->isDistributed()) {
+      if (checkDistributedActorProperty(varDecl, /*diagnose=*/true))
+        return;
+    } else {
+      // distributed can not be applied to stored properties
+      diagnoseAndRemoveAttr(attr, diag::distributed_actor_property);
+      return;
+    }
   }
 
   // distributed can only be declared on an `actor`

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1953,16 +1953,17 @@ namespace {
     void noteIsolatedActorMember(ValueDecl *decl, Expr *context) {
       // detect if it is a distributed actor, to provide better isolation notes
 
-      auto isDistributedActor = false;
-      if (auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl())
-        isDistributedActor = nominal->isDistributedActor();
+      auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl();
+      bool isDistributedActor = false;
+      if (nominal) isDistributedActor = nominal->isDistributedActor();
 
       // FIXME: Make this diagnostic more sensitive to the isolation context of
       // the declaration.
       if (isDistributedActor) {
         if (dyn_cast<VarDecl>(decl)) {
           // Distributed actor properties are never accessible externally.
-          decl->diagnose(diag::distributed_actor_isolated_property);
+          decl->diagnose(diag::distributed_actor_isolated_property,
+                         nominal->getName());
         } else {
           // it's a function or subscript
           decl->diagnose(diag::note_distributed_actor_isolated_method,
@@ -4705,9 +4706,9 @@ bool swift::isPotentiallyIsolatedActor(
 
   if (var->getName().str().equals("__secretlyKnownToBeLocal")) {
     // FIXME(distributed): we did a dynamic check and know that this actor is
-    // local,
-    //  but we can't express that to the type system; the real implementation
-    //  will have to mark 'self' as "known to be local" after an is-local check.
+    //   local, but we can't express that to the type system; the real
+    //   implementation will have to mark 'self' as "known to be local" after
+    //   an is-local check.
     return true;
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1960,9 +1960,10 @@ namespace {
       // FIXME: Make this diagnostic more sensitive to the isolation context of
       // the declaration.
       if (isDistributedActor) {
-        if (dyn_cast<VarDecl>(decl)) {
+        if (isa<VarDecl>(decl)) {
           // Distributed actor properties are never accessible externally.
           decl->diagnose(diag::distributed_actor_isolated_property,
+                         decl->getDescriptiveKind(), decl->getName(),
                          nominal->getName());
         } else {
           // it's a function or subscript

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -214,6 +214,67 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
   return false;
 }
 
+static bool checkDistributedTargetResultType(
+    ModuleDecl *module,
+    ValueDecl *valueDecl,
+    llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements,
+    bool diagnose) {
+  auto &C = valueDecl->getASTContext();
+
+  Type resultType;
+  if (auto func = dyn_cast<FuncDecl>(valueDecl)) {
+    resultType = func->mapTypeIntoContext(func->getResultInterfaceType());
+  } else if (auto var = dyn_cast<VarDecl>(valueDecl)) {
+    resultType = var->getInterfaceType();
+  } else {
+    assert(false && "Unsupported distributed target");
+  }
+
+  if (resultType->isVoid())
+    return false;
+
+  // If the serialization requirement is specifically `Codable`
+  // we can issue slightly better warnings
+  llvm::SmallPtrSet<ProtocolDecl *, 2> codableRequirements = {
+      C.getProtocol(swift::KnownProtocolKind::Encodable),
+      C.getProtocol(swift::KnownProtocolKind::Decodable),
+  };
+
+  auto isCodableRequirement =
+      serializationRequirements == codableRequirements;
+
+  for(auto serializationReq : serializationRequirements) {
+    auto conformance =
+        TypeChecker::conformsToProtocol(resultType, serializationReq, module);
+    if (conformance.isInvalid()) {
+      if (diagnose) {
+        serializationReq->dump();
+        llvm::StringRef conformanceToSuggest = isCodableRequirement ?
+            "Codable" : // Codable is a typealias, easier to diagnose like that
+            serializationReq->getNameStr();
+
+        auto diag = valueDecl->diagnose(
+            diag::distributed_actor_target_result_not_codable,
+            resultType,
+            valueDecl->getDescriptiveKind(),
+            valueDecl->getBaseIdentifier(),
+            conformanceToSuggest
+        );
+
+        if (isCodableRequirement) {
+          if (auto resultNominalType = resultType->getAnyNominal()) {
+            addCodableFixIt(resultNominalType, diag);
+          }
+        }
+
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 /// Check whether the function is a proper distributed function
 ///
 /// \param diagnose Whether to emit a diagnostic when a problem is encountered.
@@ -221,29 +282,35 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
 /// \returns \c true if there was a problem with adding the attribute, \c false
 /// otherwise.
 bool swift::checkDistributedFunction(FuncDecl *func, bool diagnose) {
-  // === All parameters and the result type must be Codable
+  // === All parameters and the result type must conform SerializationRequirement
 
-  auto &C = func->getASTContext();
-  auto encodableType = C.getProtocol(KnownProtocolKind::Encodable);
-  auto decodableType = C.getProtocol(KnownProtocolKind::Decodable);
+  auto actorDecl = func->getDeclContext()->getSelfNominalTypeDecl();
+
+  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationRequirements =
+      getDistributedSerializationRequirementProtocols(actorDecl);
 
   auto module = func->getParentModule();
 
   // --- Check parameters for 'Codable' conformance
   for (auto param : *func->getParameters()) {
     auto paramTy = func->mapTypeIntoContext(param->getInterfaceType());
-    if (TypeChecker::conformsToProtocol(paramTy, encodableType, module).isInvalid() ||
-        TypeChecker::conformsToProtocol(paramTy, decodableType, module).isInvalid()) {
-      if (diagnose) {
-        auto diag = func->diagnose(
-            diag::distributed_actor_func_param_not_codable,
-            param->getArgumentName().str(), param->getInterfaceType(),
-            func->getDescriptiveKind(), "Codable");
-        if (auto paramNominalTy = paramTy->getAnyNominal()) {
-          addCodableFixIt(paramNominalTy, diag);
-        } // else, no nominal type to suggest the fixit for, e.g. a closure
+
+    for (auto req : serializationRequirements) {
+      if (TypeChecker::conformsToProtocol(paramTy, req, module).isInvalid()) {
+        if (diagnose) {
+          auto diag = func->diagnose(
+              diag::distributed_actor_func_param_not_codable,
+              param->getArgumentName().str(),
+              param->getInterfaceType(),
+              func->getDescriptiveKind(),
+              req->getNameStr()); // TODO(distributed): handle Codable better
+
+          if (auto paramNominalTy = paramTy->getAnyNominal()) {
+            addCodableFixIt(paramNominalTy, diag);
+          } // else, no nominal type to suggest the fixit for, e.g. a closure
+        }
+        return true;
       }
-      return true;
     }
 
     if (param->isInOut()) {
@@ -267,22 +334,63 @@ bool swift::checkDistributedFunction(FuncDecl *func, bool diagnose) {
   }
 
   // --- Result type must be either void or a codable type
-  auto resultType = func->mapTypeIntoContext(func->getResultInterfaceType());
-  if (!resultType->isVoid()) {
-    if (TypeChecker::conformsToProtocol(resultType, decodableType, module).isInvalid() ||
-        TypeChecker::conformsToProtocol(resultType, encodableType, module).isInvalid()) {
-      if (diagnose) {
-        auto diag = func->diagnose(
-            diag::distributed_actor_func_result_not_codable,
-            func->getResultInterfaceType(), func->getDescriptiveKind(),
-            "Codable" // Codable is a typealias, easier to diagnose like that
-        );
-        if (auto resultNominalType = resultType->getAnyNominal()) {
-          addCodableFixIt(resultNominalType, diag);
-        }
-      }
+  if (checkDistributedTargetResultType(module, func, serializationRequirements, diagnose)) {
+    return true;
+  }
+
+  return false;
+}
+
+/// Check whether the function is a proper distributed computed property
+///
+/// \param diagnose Whether to emit a diagnostic when a problem is encountered.
+///
+/// \returns \c true if there was a problem with adding the attribute, \c false
+/// otherwise.
+bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
+  /// === Check if the declaration is a valid combination of attributes
+  if (var->isStatic()) {
+    var->diagnose(diag::distributed_property_cannot_be_static,
+                      var->getName());
+    // TODO(distributed): fixit, offer removing the static keyword
+    return true;
+  }
+
+  // only get-only computed properties are allowed to be distributed
+  if (var->getReadImpl() == swift::ReadImplKind::Get) {
+    if (var->getWriteImpl() != swift::WriteImplKind::Immutable) {
+      var->diagnose(
+          diag::distributed_property_can_only_be_computed_get_only,
+          var->getName());
       return true;
     }
+  } else {
+    // it is not a computed property
+    if (var->isLet()) {
+      var->diagnose(
+          diag::distributed_property_can_only_be_computed,
+          var->getName());
+      return true;
+    } else {
+      var->diagnose(
+          diag::distributed_property_can_only_be_computed_get_only,
+          var->getName());
+      return true;
+    }
+  }
+
+  // === Check the type of the property
+  auto serializationRequirements =
+      getDistributedSerializationRequirementProtocols(
+          var->getDeclContext()->getSelfNominalTypeDecl());
+
+  //  auto encodableType = C.getProtocol(KnownProtocolKind::Encodable);
+//  auto decodableType = C.getProtocol(KnownProtocolKind::Decodable);
+//  llvm::ArrayRef<ProtocolDecl*> serializationRequirements = {encodableType, decodableType};
+
+  auto module = var->getModuleContext();
+  if (checkDistributedTargetResultType(module, var, serializationRequirements, diagnose)) {
+    return true;
   }
 
   return false;
@@ -369,7 +477,6 @@ void TypeChecker::checkDistributedActor(ClassDecl *decl) {
   }
 
   // ==== Properties
-  // --- Check for any illegal re-definitions
   checkDistributedActorProperties(decl);
   // --- Synthesize the 'id' property here rather than via derived conformance
   //     because the 'DerivedConformanceDistributedActor' won't trigger for 'id'
@@ -410,6 +517,31 @@ static Type getAssociatedTypeOfDistributedSystem(NominalTypeDecl *actor,
 
   return dependentType.subst(SubstitutionMap::getProtocolSubstitutions(
       actorProtocol, selfType, conformance));
+}
+
+llvm::SmallPtrSet<ProtocolDecl *, 2>
+swift::getDistributedSerializationRequirementProtocols(NominalTypeDecl *nominal) {
+  auto &ctx = nominal->getASTContext();
+
+  auto serialReqType = ctx.getDistributedSerializationRequirementType(nominal)
+                            ->castTo<ExistentialType>()
+                            ->getConstraintType()
+                            ->getDesugaredType();
+
+  // TODO(distributed): check what happens with Any
+
+  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
+  if (auto composition = serialReqType->getAs<ProtocolCompositionType>()) {
+    for (auto member : composition->getMembers()) {
+      if (auto *protocol = member->getAs<ProtocolType>())
+        serializationReqs.insert(protocol->getDecl());
+    }
+  } else {
+    auto protocol = serialReqType->castTo<ProtocolType>()->getDecl();
+    serializationReqs.insert(protocol);
+  }
+
+  return serializationReqs;
 }
 
 Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
@@ -479,21 +611,23 @@ GetDistributedActorArgumentDecodingMethodRequest::evaluate(Evaluator &evaluator,
                                            DeclNameRef(ctx.Id_decodeNextArgument));
 
   // typealias SerializationRequirement = any ...
-  auto serializerType = ctx.getDistributedSerializationRequirementType(actor)
-                            ->castTo<ExistentialType>()
-                            ->getConstraintType()
-                            ->getDesugaredType();
-
-  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
-  if (auto composition = serializerType->getAs<ProtocolCompositionType>()) {
-    for (auto member : composition->getMembers()) {
-      if (auto *protocol = member->getAs<ProtocolType>())
-        serializationReqs.insert(protocol->getDecl());
-    }
-  } else {
-    auto protocol = serializerType->castTo<ProtocolType>()->getDecl();
-    serializationReqs.insert(protocol);
-  }
+  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs =
+      getDistributedSerializationRequirementProtocols(actor);
+//  auto serialReqType = ctx.getDistributedSerializationRequirementType(actor)
+//                            ->castTo<ExistentialType>()
+//                            ->getConstraintType()
+//                            ->getDesugaredType();
+//
+//  llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
+//  if (auto composition = serialReqType->getAs<ProtocolCompositionType>()) {
+//    for (auto member : composition->getMembers()) {
+//      if (auto *protocol = member->getAs<ProtocolType>())
+//        serializationReqs.insert(protocol->getDecl());
+//    }
+//  } else {
+//    auto protocol = serialReqType->castTo<ProtocolType>()->getDecl();
+//    serializationReqs.insert(protocol);
+//  }
 
   SmallVector<FuncDecl *, 2> candidates;
   // Looking for `decodeNextArgument<Arg: <SerializationReq>>() throws -> Arg`

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -84,6 +84,13 @@ llvm::SmallPtrSet<ProtocolDecl *, 2>
 flattenDistributedSerializationTypeToRequiredProtocols(
     TypeBase *serializationRequirement);
 
+/// Check if the `allRequirements` represent *exactly* the
+/// `Encodable & Decodable` (also known as `Codable`) requirement.
+/// If so, we can emit slightly nicer diagnostics.
+bool checkDistributedSerializationRequirementIsExactlyCodable(
+    ASTContext &C,
+    const llvm::SmallPtrSetImpl<ProtocolDecl *> &allRequirements);
+
 /// Given any set of generic requirements, locate those which are about the
 /// `SerializationRequirement`. Those need to be applied in the parameter and
 /// return type checking of distributed targets.

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -96,9 +96,7 @@ bool checkDistributedSerializationRequirementIsExactlyCodable(
 /// return type checking of distributed targets.
 llvm::SmallPtrSet<ProtocolDecl *, 2>
 extractDistributedSerializationRequirements(
-    ASTContext &C,
-    ArrayRef<Requirement> allRequirements);
-
+    ASTContext &C, ArrayRef<Requirement> allRequirements);
 
 /// Diagnose a distributed func declaration in a not-distributed actor protocol.
 void diagnoseDistributedFunctionInNonDistributedActorProtocol(

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -80,6 +80,19 @@ Type getDistributedSerializationRequirementType(NominalTypeDecl *nominal);
 llvm::SmallPtrSet<ProtocolDecl *, 2>
 getDistributedSerializationRequirementProtocols(NominalTypeDecl *decl);
 
+llvm::SmallPtrSet<ProtocolDecl *, 2>
+flattenDistributedSerializationTypeToRequiredProtocols(
+    TypeBase *serializationRequirement);
+
+/// Given any set of generic requirements, locate those which are about the
+/// `SerializationRequirement`. Those need to be applied in the parameter and
+/// return type checking of distributed targets.
+llvm::SmallPtrSet<ProtocolDecl *, 2>
+extractDistributedSerializationRequirements(
+    ASTContext &C,
+    ArrayRef<Requirement> allRequirements);
+
+
 /// Diagnose a distributed func declaration in a not-distributed actor protocol.
 void diagnoseDistributedFunctionInNonDistributedActorProtocol(
   const ProtocolDecl *proto, InFlightDiagnostic &diag);

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -56,6 +56,10 @@ bool checkDistributedActorSystemAdHocProtocolRequirements(
 /// Typecheck a distributed method declaration
 bool checkDistributedFunction(FuncDecl *decl, bool diagnose);
 
+/// Typecheck a distributed computed (get-only) property declaration.
+/// They are effectively checked the same way as argument-less methods.
+bool checkDistributedActorProperty(VarDecl *decl, bool diagnose);
+
 /// Determine the distributed actor transport type for the given actor.
 Type getDistributedActorSystemType(NominalTypeDecl *actor);
 
@@ -65,6 +69,16 @@ Type getDistributedActorIDType(NominalTypeDecl *actor);
 /// Determine the serialization requirement for the given actor, actor system
 /// or other type that has the SerializationRequirement associated type.
 Type getDistributedSerializationRequirementType(NominalTypeDecl *nominal);
+
+/// Get the specific protocols that the `SerializationRequirement` specifies,
+/// and all parameters / return types of distributed targets must conform to.
+///
+/// E.g. if a system declares `typealias SerializationRequirement = Codable`
+/// then this will return `{encodableProtocol, decodableProtocol}`.
+///
+/// Returns an empty set if the requirement was `Any`.
+llvm::SmallPtrSet<ProtocolDecl *, 2>
+getDistributedSerializationRequirementProtocols(NominalTypeDecl *decl);
 
 /// Diagnose a distributed func declaration in a not-distributed actor protocol.
 void diagnoseDistributedFunctionInNonDistributedActorProtocol(

--- a/test/Distributed/Inputs/FakeCodableForDistributedTests.swift
+++ b/test/Distributed/Inputs/FakeCodableForDistributedTests.swift
@@ -1,0 +1,369 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Fake encoder intended to serialize into a string representation easy to
+/// assert on.
+public final class FakeEncoder {
+  public func encode<T: Encodable>(_ value: T) throws -> String {
+    let stringsEncoding = StringsEncoding()
+    try value.encode(to: stringsEncoding)
+    return dotStringsFormat(from: stringsEncoding.data.strings)
+  }
+
+  private func dotStringsFormat(from strings: [String: String]) -> String {
+    var dotStrings = strings.map { k, v -> String in
+      if k.isEmpty {
+        return "\(v);"
+      } else {
+        return "\(k): \(v);"
+      }
+    }
+    return dotStrings.joined(separator: " ")
+  }
+}
+
+fileprivate struct StringsEncoding: Encoder {
+  fileprivate final class Storage {
+    private(set) var strings: [String: String] = [:]
+
+    func encode(key codingKey: [CodingKey], value: String) {
+      let key = codingKey.map { $0.stringValue }
+              .joined(separator: ".")
+      strings[key] = value
+    }
+  }
+
+  fileprivate var data: Storage
+
+  init(to encoded: Storage = Storage()) {
+    self.data = encoded
+  }
+
+  var codingPath: [CodingKey] = []
+
+  let userInfo: [CodingUserInfoKey: Any] = [:]
+
+  func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+    var container = StringsKeyedEncoding<Key>(to: data)
+    container.codingPath = codingPath
+    return KeyedEncodingContainer(container)
+  }
+
+  func unkeyedContainer() -> UnkeyedEncodingContainer {
+    var container = StringsUnkeyedEncoding(to: data)
+    container.codingPath = codingPath
+    return container
+  }
+
+  func singleValueContainer() -> SingleValueEncodingContainer {
+    var container = StringsSingleValueEncoding(to: data)
+    container.codingPath = codingPath
+    return container
+  }
+}
+
+fileprivate struct StringsKeyedEncoding<Key: CodingKey>: KeyedEncodingContainerProtocol {
+
+  private let data: StringsEncoding.Storage
+
+  init(to data: StringsEncoding.Storage) {
+    self.data = data
+  }
+
+  var codingPath: [CodingKey] = []
+
+  mutating func encodeNil(forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: "nil")
+  }
+
+  mutating func encode(_ value: Bool, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: String, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value)
+  }
+
+  mutating func encode(_ value: Double, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Float, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Int, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Int8, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Int16, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Int32, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: Int64, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt8, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt16, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt32, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt64, forKey key: Key) throws {
+    data.encode(key: codingPath + [key], value: value.description)
+  }
+
+  mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+    var stringsEncoding = StringsEncoding(to: data)
+    stringsEncoding.codingPath.append(key)
+    try value.encode(to: stringsEncoding)
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(
+    keyedBy keyType: NestedKey.Type,
+    forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+    var container = StringsKeyedEncoding<NestedKey>(to: data)
+    container.codingPath = codingPath + [key]
+    return KeyedEncodingContainer(container)
+  }
+
+  mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+    var container = StringsUnkeyedEncoding(to: data)
+    container.codingPath = codingPath + [key]
+    return container
+  }
+
+  mutating func superEncoder() -> Encoder {
+    let superKey = Key(stringValue: "super")!
+    return superEncoder(forKey: superKey)
+  }
+
+  mutating func superEncoder(forKey key: Key) -> Encoder {
+    var stringsEncoding = StringsEncoding(to: data)
+    stringsEncoding.codingPath = codingPath + [key]
+    return stringsEncoding
+  }
+}
+
+fileprivate struct StringsUnkeyedEncoding: UnkeyedEncodingContainer {
+  private let data: StringsEncoding.Storage
+
+  init(to data: StringsEncoding.Storage) {
+    self.data = data
+  }
+
+  var codingPath: [CodingKey] = []
+  private(set) var count: Int = 0
+
+  private mutating func nextIndexedKey() -> CodingKey {
+    let nextCodingKey = IndexedCodingKey(intValue: count)!
+    count += 1
+    return nextCodingKey
+  }
+
+  private struct IndexedCodingKey: CodingKey {
+    let intValue: Int?
+    let stringValue: String
+
+    init?(intValue: Int) {
+      self.intValue = intValue
+      self.stringValue = intValue.description
+    }
+
+    init?(stringValue: String) {
+      return nil
+    }
+  }
+
+  mutating func encodeNil() throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: "nil")
+  }
+
+  mutating func encode(_ value: Bool) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: String) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value)
+  }
+
+  mutating func encode(_ value: Double) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Float) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Int) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Int8) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Int16) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Int32) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: Int64) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt8) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt16) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt32) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode(_ value: UInt64) throws {
+    data.encode(key: codingPath + [nextIndexedKey()], value: value.description)
+  }
+
+  mutating func encode<T: Encodable>(_ value: T) throws {
+    var stringsEncoding = StringsEncoding(to: data)
+    stringsEncoding.codingPath = codingPath + [nextIndexedKey()]
+    try value.encode(to: stringsEncoding)
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(
+    keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+    var container = StringsKeyedEncoding<NestedKey>(to: data)
+    container.codingPath = codingPath + [nextIndexedKey()]
+    return KeyedEncodingContainer(container)
+  }
+
+  mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+    var container = StringsUnkeyedEncoding(to: data)
+    container.codingPath = codingPath + [nextIndexedKey()]
+    return container
+  }
+
+  mutating func superEncoder() -> Encoder {
+    var stringsEncoding = StringsEncoding(to: data)
+    stringsEncoding.codingPath.append(nextIndexedKey())
+    return stringsEncoding
+  }
+}
+
+fileprivate struct StringsSingleValueEncoding: SingleValueEncodingContainer {
+
+  private let data: StringsEncoding.Storage
+
+  init(to data: StringsEncoding.Storage) {
+    self.data = data
+  }
+
+  var codingPath: [CodingKey] = []
+
+  mutating func encodeNil() throws {
+    data.encode(key: codingPath, value: "nil")
+  }
+
+  mutating func encode(_ value: Bool) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: String) throws {
+    data.encode(key: codingPath, value: value)
+  }
+
+  mutating func encode(_ value: Double) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Float) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Int) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Int8) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Int16) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Int32) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: Int64) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: UInt) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: UInt8) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: UInt16) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: UInt32) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode(_ value: UInt64) throws {
+    data.encode(key: codingPath, value: value.description)
+  }
+
+  mutating func encode<T: Encodable>(_ value: T) throws {
+    var stringsEncoding = StringsEncoding(to: data)
+    stringsEncoding.codingPath = codingPath
+    try value.encode(to: stringsEncoding)
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_isRemote.swift
+++ b/test/Distributed/Runtime/distributed_actor_isRemote.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -1,4 +1,7 @@
-// RUN: %target-run-simple-swift( -Xfrontend -module-name=main -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -11,10 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
-// UNSUPPORTED: linux
-
-import Foundation
 import _Distributed
 
 final class Obj: @unchecked Sendable, Codable  {}
@@ -87,18 +86,17 @@ distributed actor Greeter {
     print("---> D = \(d), type(of:) = \(type(of: d))")
 
     // try encoding generic arguments to make sure that witness tables are passed correctly
-    let json = JSONEncoder()
+    let json = FakeEncoder()
 
-    let jsonA = try! String(data: json.encode(a), encoding: .utf8)
-    let jsonB = try! String(data: json.encode(b), encoding: .utf8)
-    let jsonC = try! String(data: json.encode(c), encoding: .utf8)
-    let jsonD = try! String(data: json.encode(d), encoding: .utf8)
+    let jsonA = try! json.encode(a)
+    let jsonB = try! json.encode(b)
+    let jsonC = try! json.encode(c)
+    let jsonD = try! json.encode(d)
 
-    print("---> A(JSON) = \(jsonA!)")
-    print("---> B(JSON) = \(jsonB!)")
-    print("---> C(JSON) = \(jsonC!)")
-    print("---> D(JSON) = \(jsonD!)")
-
+    print("---> A(SER) = \(jsonA)")
+    print("---> B(SER) = \(jsonB)")
+    print("---> C(SER) = \(jsonC)")
+    print("---> D(SER) = \(jsonD)")
   }
 
   distributed func genericOptional<T: Codable>(t: T?) {
@@ -275,6 +273,8 @@ struct FakeResultHandler: DistributedTargetInvocationResultHandler {
   }
 }
 
+// ==== ------------------------------------------------------------------------
+
 @available(SwiftStdlib 5.5, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
@@ -439,11 +439,11 @@ func test() async throws {
   try generic5Invocation.recordGenericSubstitution(Int.self)
   try generic5Invocation.recordGenericSubstitution(Int.self)
   try generic5Invocation.recordGenericSubstitution(String.self)
-  try generic5Invocation.recordGenericSubstitution([Double].self)
+  try generic5Invocation.recordGenericSubstitution([Int].self)
   try generic5Invocation.recordArgument(42)
   try generic5Invocation.recordArgument(S(data: 42))
   try generic5Invocation.recordArgument("Hello, World!")
-  try generic5Invocation.recordArgument([0.0, 0xdecafbad])
+  try generic5Invocation.recordArgument([0, 42])
   try generic5Invocation.doneRecording()
 
   let generic5Decoder = generic5Invocation.makeDecoder()
@@ -456,17 +456,17 @@ func test() async throws {
   // CHECK: ---> A = 42, type(of:) = Int
   // CHECK-NEXT: ---> B = S<Int>(data: 42), type(of:) = S<Int>
   // CHECK-NEXT: ---> C = Hello, World!, type(of:) = String
-  // CHECK-NEXT: ---> D = [0.0, 3737844653.0], type(of:) = Array<Double>
-  // CHECK-NEXT: ---> A(JSON) = 42
-  // CHECK-NEXT: ---> B(JSON) = {"data":42}
-  // CHECK-NEXT: ---> C(JSON) = "Hello, World!"
-  // CHECK-NEXT: ---> D(JSON) = [0,3737844653]
+  // CHECK-NEXT: ---> D = [0, 42], type(of:) = Array<Int>
+  // CHECK-NEXT: ---> A(SER) = 42;
+  // CHECK-NEXT: ---> B(SER) = data: 42;
+  // CHECK-NEXT: ---> C(SER) = Hello, World!;
+  // CHECK-NEXT: ---> D(SER) = 0: 0; 1: 42;
   // CHECK-NEXT: RETURN: ()
 
   var genericOptInvocation = system.makeInvocationEncoder()
 
-  try genericOptInvocation.recordGenericSubstitution([Double].self)
-  try genericOptInvocation.recordArgument([0.0, 0xdecafbad])
+  try genericOptInvocation.recordGenericSubstitution([Int].self)
+  try genericOptInvocation.recordArgument([0, 42])
   try genericOptInvocation.doneRecording()
 
   let genericOptDecoder = genericOptInvocation.makeDecoder()
@@ -476,7 +476,7 @@ func test() async throws {
     invocationDecoder: genericOptDecoder,
     handler: FakeResultHandler()
   )
-  // CHECK: ---> T = [0.0, 3737844653.0], type(of:) = Optional<Array<Double>>
+  // CHECK: ---> T = [0, 42], type(of:) = Optional<Array<Int>>
   // CHECK-NEXT: RETURN: ()
 
   var decodeErrInvocation = system.makeInvocationEncoder()

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -14,6 +14,9 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
+// FIXME(distributed): remote calls seem to hang on linux - rdar://87240034
+// UNSUPPORTED: linux
+
 import _Distributed
 
 final class Obj: @unchecked Sendable, Codable  {}

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --enable-var-scope --color
 
-// X: %target-run-simple-swift( -Xfrontend -module-name=main -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library -Xfrontend -I -Xfrontend %t ) | %FileCheck %s --dump-input=always
+// X: %target-run-simple-swift( -Xfrontend -module-name=main -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library -Xfrontend -I -Xfrontend %t ) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_fieldsDontCrashDeinit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Onone -Xfrontend -g -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_retains_system.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_func_metadata.swift
+++ b/test/Distributed/Runtime/distributed_func_metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/SIL/distributed_actor_remoteCall_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_remoteCall_sil.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -module-name remoteCall -primary-file %s -emit-sil -enable-experimental-distributed -disable-availability-checking -I %t | %FileCheck %s --enable-var-scope --color --dump-input=always
+// RUN: %target-swift-frontend -module-name remoteCall -primary-file %s -emit-sil -enable-experimental-distributed -disable-availability-checking -I %t | %FileCheck %s --enable-var-scope --color
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -58,12 +58,12 @@ distributed actor SomeDistributedActor_6 {
 }
 
 distributed actor BadValuesDistributedActor_7 {
-  distributed var varItNope: Int { 13 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-  distributed let letItNope: Int = 13 // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-  distributed lazy var lazyVarNope: Int = 13 // expected-error{{'distributed' modifier cannot be applied to this declaration}}
+  distributed var varItNope: Int { 13 } // we allow these
+  distributed let letItNope: Int = 13 // expected-error{{static property 'letItNope' cannot be 'distributed', because it is not a computed get-only property}}
+  distributed lazy var lazyVarNope: Int = 13 // expected-error{{'distributed' computed property 'lazyVarNope' can only be have a 'get' implementation}}
   distributed subscript(nope: Int) -> Int { nope * 2 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-  distributed static let staticLetNope: Int = 13 // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-  distributed static var staticVarNope: Int { 13 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
+  distributed static let staticLetNope: Int = 13 // expected-error{{'distributed' property 'staticLetNope' cannot be 'static'}}
+  distributed static var staticVarNope: Int { 13 } // expected-error{{'distributed' property 'staticVarNope' cannot be 'static'}}
   distributed static func staticNope() async throws -> Int { 13 } // expected-error{{'distributed' method cannot be 'static'}}
 }
 

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -59,8 +59,8 @@ distributed actor SomeDistributedActor_6 {
 
 distributed actor BadValuesDistributedActor_7 {
   distributed var varItNope: Int { 13 } // we allow these
-  distributed let letItNope: Int = 13 // expected-error{{static property 'letItNope' cannot be 'distributed', because it is not a computed get-only property}}
-  distributed lazy var lazyVarNope: Int = 13 // expected-error{{'distributed' computed property 'lazyVarNope' can only be have a 'get' implementation}}
+  distributed let letItNope: Int = 13 // expected-error{{property 'letItNope' cannot be 'distributed', only computed properties can}}
+  distributed lazy var lazyVarNope: Int = 13 // expected-error{{property 'lazyVarNope' cannot be 'distributed', only computed properties can}}
   distributed subscript(nope: Int) -> Int { nope * 2 } // expected-error{{'distributed' modifier cannot be applied to this declaration}}
   distributed static let staticLetNope: Int = 13 // expected-error{{'distributed' property 'staticLetNope' cannot be 'static'}}
   distributed static var staticVarNope: Int { 13 } // expected-error{{'distributed' property 'staticVarNope' cannot be 'static'}}

--- a/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
+++ b/test/Distributed/distributed_actor_is_experimental_enabled_missing_import.swift
@@ -16,8 +16,8 @@ actor A {
   distributed func dist() {} // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
   distributed func distAsync() async {} // expected-error{{'distributed' method can only be declared within 'distributed actor'}}
 
-  distributed var neverOk: String { // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-    "vars are not allowed to be distributed *ever* anyway"
+  distributed var neverOk: String {
+    ""
   }
 }
 
@@ -27,8 +27,8 @@ distributed actor DA2 {
   distributed func dist() {}
   distributed func distAsync() async {}
 
-  distributed var neverOk: String { // expected-error{{'distributed' modifier cannot be applied to this declaration}}
-    "vars are not allowed to be distributed *ever* anyway"
+  distributed var neverOk: String {
+    ""
   }
 }
 

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -28,8 +28,8 @@ struct NotCodableValue { }
 
 distributed actor DistributedActor_1 {
 
-  let name: String = "alice" // expected-note{{access to this property is only permitted within the distributed actor 'DistributedActor_1'}}
-  var mutable: String = "alice" // expected-note{{access to this property is only permitted within the distributed actor 'DistributedActor_1'}}
+  let name: String = "alice" // expected-note{{access to property 'name' is only permitted within distributed actor 'DistributedActor_1'}}
+  var mutable: String = "alice" // expected-note{{access to property 'mutable' is only permitted within distributed actor 'DistributedActor_1'}}
   var computedMutable: String {
     get {
       "hey"
@@ -39,8 +39,8 @@ distributed actor DistributedActor_1 {
     }
   }
 
-  distributed let letProperty: String = "" // expected-error{{static property 'letProperty' cannot be 'distributed', because it is not a computed get-only property}}
-  distributed var varProperty: String = "" // expected-error{{'distributed' computed property 'varProperty' can only be have a 'get' implementation}}
+  distributed let letProperty: String = "" // expected-error{{property 'letProperty' cannot be 'distributed', only computed properties can}}
+  distributed var varProperty: String = "" // expected-error{{property 'varProperty' cannot be 'distributed', only computed properties can}}
 
   distributed static func distributedStatic() {} // expected-error{{'distributed' method cannot be 'static'}}
   distributed class func distributedClass() {}

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -18,7 +18,7 @@ struct Logger {
 
 distributed actor Philosopher {
   let log: Logger
-  // expected-note@-1{{distributed actor state is only available within the actor instance}}
+  // expected-note@-1{{access to this property is only permitted within the distributed actor 'Philosopher'}}
   var variable = 12
   var variable_fromDetach = 12
   let INITIALIZED: Int
@@ -62,7 +62,7 @@ distributed actor Philosopher {
 
 func test_outside(system: FakeActorSystem) async throws {
   _ = try await Philosopher(system: system).dist()
-  _ = Philosopher(system: system).log // expected-error{{distributed actor-isolated property 'log' can only be referenced inside the distributed actor}}
+  _ = Philosopher(system: system).log // expected-error{{distributed actor-isolated property 'log' can not be accessed from a non-isolated context}}
 
   _ = Philosopher(system: system).id
   _ = Philosopher(system: system).actorSystem

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -18,7 +18,8 @@ struct Logger {
 
 distributed actor Philosopher {
   let log: Logger
-  // expected-note@-1{{access to this property is only permitted within the distributed actor 'Philosopher'}}
+  // expected-note@-1{{access to property 'log' is only permitted within distributed actor 'Philosopher'}}
+
   var variable = 12
   var variable_fromDetach = 12
   let INITIALIZED: Int

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -13,8 +13,8 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 distributed actor DA {
 
   let local: Int = 42
-  // expected-note@-1{{access to this property is only permitted within the distributed actor 'DA'}}
-  // expected-note@-2{{access to this property is only permitted within the distributed actor 'DA'}}
+  // expected-note@-1{{access to property 'local' is only permitted within distributed actor 'DA'}}
+  // expected-note@-2{{access to property 'local' is only permitted within distributed actor 'DA'}}
 
   nonisolated let nope: Int = 13
   // expected-error@-1{{'nonisolated' can not be applied to distributed actor stored properties}}

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -13,15 +13,15 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 distributed actor DA {
 
   let local: Int = 42
-  // expected-note@-1{{distributed actor state is only available within the actor instance}}
-  // expected-note@-2{{distributed actor state is only available within the actor instance}}
+  // expected-note@-1{{access to this property is only permitted within the distributed actor 'DA'}}
+  // expected-note@-2{{access to this property is only permitted within the distributed actor 'DA'}}
 
   nonisolated let nope: Int = 13
   // expected-error@-1{{'nonisolated' can not be applied to distributed actor stored properties}}
 
   nonisolated var computedNonisolated: Int {
     // nonisolated computed properties are outside of the actor and as such cannot access local
-    _ = self.local // expected-error{{distributed actor-isolated property 'local' can only be referenced inside the distributed actor}}
+    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a non-isolated context}}
 
     _ = self.id // ok, special handled and always available
     _ = self.actorSystem // ok, special handled and always available
@@ -34,7 +34,7 @@ distributed actor DA {
     _ = self.actorSystem // ok
     
     // self is a distributed actor self is NOT isolated
-    _ = self.local // expected-error{{distributed actor-isolated property 'local' can only be referenced inside the distributed actor}}
+    _ = self.local // expected-error{{distributed actor-isolated property 'local' can not be accessed from a non-isolated context}}
     _ = try await self.dist() // ok, was made implicitly throwing and async
     _ = self.computedNonisolated // it's okay, only the body of computedNonisolated is wrong
   }

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -38,7 +38,7 @@ distributed actor D {
     "nope!"
   }
 
-  // expected-error@+1{{result type 'NotCodable' of distributed property 'notCodable' does not conform to 'Codable'}}
+  // expected-error@+1{{result type 'NotCodable' of distributed property 'notCodable' does not conform to serialization requirement 'Codable'}}
   distributed var notCodable: NotCodable {
     .init()
   }

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-distributed -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+struct NotCodable {}
+
+distributed actor D {
+
+  // expected-note@+1{{access to this property is only permitted within the distributed actor 'D'}}
+  var normal: String = "normal"
+
+  // expected-note@+1{{access to this property is only permitted within the distributed actor 'D'}}
+  var computed: String  {
+    "normal"
+  }
+
+  // expected-error@+1{{property 'dlet' cannot be 'distributed', because it is not a computed get-only property}}
+  distributed let dlet: String = "illegal"
+
+  // expected-error@+1{{'distributed' computed property 'dletvar' can only be have a 'get' implementation}}
+  distributed var dletvar: String = "illegal"
+
+  // OK:
+  distributed var dist: String {
+    "dist"
+  }
+
+  // expected-error@+1{{'distributed' property 'hello' cannot be 'static'}}
+  static distributed var hello: String {
+    "nope!"
+  }
+
+  // expected-error@+1{{result type 'NotCodable' of distributed property 'notCodable' does not conform to 'Codable'}}
+  distributed var notCodable: NotCodable {
+    .init()
+  }
+
+  //expected-error@+1{{'distributed' computed property 'dist_nope' can only be have a 'get' implementation}}
+  distributed var dist_nope: String {
+    get {
+      "dist"
+    }
+    set {
+      // ignore
+    }
+  }
+
+}
+
+func test_outside(distributed: D) async throws {
+  _ = distributed.normal
+  // expected-error@-1{{distributed actor-isolated property 'normal' can not be accessed from a non-isolated context}}
+
+  _ = distributed.computed
+  // expected-error@-1{{distributed actor-isolated property 'computed' can not be accessed from a non-isolated context}}
+}
+

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -14,18 +14,18 @@ struct NotCodable {}
 
 distributed actor D {
 
-  // expected-note@+1{{access to this property is only permitted within the distributed actor 'D'}}
+  // expected-note@+1{{access to property 'normal' is only permitted within distributed actor 'D'}}
   var normal: String = "normal"
 
-  // expected-note@+1{{access to this property is only permitted within the distributed actor 'D'}}
+  // expected-note@+1{{access to property 'computed' is only permitted within distributed actor 'D'}}
   var computed: String  {
     "normal"
   }
 
-  // expected-error@+1{{property 'dlet' cannot be 'distributed', because it is not a computed get-only property}}
+  // expected-error@+1{{property 'dlet' cannot be 'distributed', only computed properties can}}
   distributed let dlet: String = "illegal"
 
-  // expected-error@+1{{'distributed' computed property 'dletvar' can only be have a 'get' implementation}}
+  // expected-error@+1{{distributed property 'dletvar' cannot be 'distributed', only computed properties can}}
   distributed var dletvar: String = "illegal"
 
   // OK:
@@ -43,7 +43,7 @@ distributed actor D {
     .init()
   }
 
-  //expected-error@+1{{'distributed' computed property 'dist_nope' can only be have a 'get' implementation}}
+  //expected-error@+1{{'distributed' computed property 'dist_nope' cannot have setter}}
   distributed var dist_nope: String {
     get {
       "dist"

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -196,12 +196,16 @@ protocol DistributedTacoMaker: DistributedActor, TacoPreparation {
 }
 
 extension DistributedTacoMaker {
-    distributed func makeTacos(with: Salsa) {}
+  distributed func makeTacos(with: Salsa) {}
 }
 
 extension TacoPreparation {
-    distributed func makeSalsa() -> Salsa {}
+  distributed func makeSalsa() -> Salsa {}
   // expected-error@-1{{'distributed' method can only be declared within 'distributed actor'}}
 }
 
 distributed actor TacoWorker: DistributedTacoMaker {} // implemented in extensions
+
+extension DistributedTacoMaker where SerializationRequirement == Codable {
+  distributed func makeGreatTacos(with: Salsa) {}
+}

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-distributed -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+import FakeDistributedActorSystems
+
+struct NotCodable {}
+
+protocol NoSerializationRequirementYet: DistributedActor {
+  // OK, no serialization requirement yet
+  distributed func test() -> NotCodable
+}
+
+distributed actor SpecifyRequirement: NoSerializationRequirementYet {
+  typealias ActorSystem = FakeActorSystem
+
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test' does not conform to serialization requirement 'Codable'}}
+  distributed func test() -> NotCodable {
+    .init()
+  }
+}
+
+extension NoSerializationRequirementYet {
+  // Still OK, we don't know if this will be implementable or not
+  distributed func test2() -> NotCodable {
+    .init()
+  }
+}
+
+extension NoSerializationRequirementYet
+  where SerializationRequirement == Codable {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test3' does not conform to serialization requirement 'Codable'}}
+  distributed func test3() -> NotCodable {
+    .init()
+  }
+}
+
+extension NoSerializationRequirementYet
+  where SerializationRequirement: Codable {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'test4' does not conform to serialization requirement 'Codable'}}
+  distributed func test4() -> NotCodable {
+    .init()
+  }
+}


### PR DESCRIPTION
The SE-0366 proposal said we'll support properties so start doing so by allowing to parse them.

The commit in the middle removes a Foundation dependency that's why the ad hoc Codable impl.