### PR TITLE
Platform: add a WinSDK submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -411,6 +411,13 @@ module WinSDK [system] {
     link "sensorsapi.lib"
   }
 
+  module ToolHelp {
+    header "TlHelp32.h"
+    export *
+
+    link "kernel32.Lib"
+  }
+
   module UI {
     module XAML {
       module Hosting {


### PR DESCRIPTION
This adds ToolHelp32 to the WinSDK module which is needed for
snapshotting process state.  This is useful for tooling like
swift-inspect.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
