### PR TITLE
[ClangImporter] Implement a wrapper for clang compiler.

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -196,7 +196,7 @@ void ClangImporter::recordModuleDependencies(
       fileDeps.push_back(fileDep.getKey().str());
     }
     // Inherit all Clang driver args when creating the clang importer.
-    ArrayRef<std::string> allArgs = Impl.ClangArgs;
+    ArrayRef<std::string> allArgs = Impl.DefaultCompiler.ClangArgs;
     ClangImporterOptions Opts;
 
     // Ensure the arguments we collected is sufficient to create a Clang

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9228,7 +9228,8 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   FrontendStatsTracer StatsTracer(SwiftContext.Stats,
                                   "import-clang-decl", ClangDecl);
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
-                                    Instance->getSourceManager(), "importing");
+                                    DefaultCompiler.Instance->getSourceManager(),
+                                    "importing");
 
   auto Canon = cast<clang::NamedDecl>(UseCanonicalDecl? ClangDecl->getCanonicalDecl(): ClangDecl);
 
@@ -9273,7 +9274,7 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
     return nullptr;
 
   clang::PrettyStackTraceDecl trace(decl, clang::SourceLocation(),
-                                    Instance->getSourceManager(),
+                                    DefaultCompiler.Instance->getSourceManager(),
                                     "importing (mirrored)");
 
   auto canon = decl->getCanonicalDecl();
@@ -10077,7 +10078,7 @@ static void loadMembersOfBaseImportedFromClang(ExtensionDecl *ext) {
 void ClangImporter::Implementation::loadAllMembersOfObjcContainer(
     Decl *D, const clang::ObjCContainerDecl *objcContainer) {
   clang::PrettyStackTraceDecl trace(objcContainer, clang::SourceLocation(),
-                                    Instance->getSourceManager(),
+                                    DefaultCompiler.Instance->getSourceManager(),
                                     "loading members for");
 
   assert(isa<ExtensionDecl>(D) || isa<NominalTypeDecl>(D));

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2854,7 +2854,7 @@ Type ClangImporter::Implementation::getNamedSwiftType(StringRef moduleName,
 }
 
 Decl *ClangImporter::Implementation::importDeclByName(StringRef name) {
-  auto &sema = Instance->getSema();
+  auto &sema = DefaultCompiler.Instance->getSema();
 
   // Map the name. If we can't represent the Swift name in Clang, bail out now.
   auto clangName = &getClangASTContext().Idents.get(name);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -456,25 +456,40 @@ private:
   /// Used to avoid running the AST verifier over the same declarations.
   size_t VerifiedDeclsCounter = 0;
 
-  /// Clang compiler invocation.
-  std::shared_ptr<clang::CompilerInvocation> Invocation;
+  /// A wrapper for clang compiler.
+  class ClangCompiler {
+    friend ClangImporter;
+    friend ClangImporter::Implementation;
 
-  /// Clang compiler instance, which is used to actually load Clang
-  /// modules.
-  std::unique_ptr<clang::CompilerInstance> Instance;
+    /// Clang compiler invocation.
+    std::shared_ptr<clang::CompilerInvocation> Invocation;
 
-  /// Clang compiler action, which is used to actually run the
-  /// parser.
-  std::unique_ptr<clang::FrontendAction> Action;
+    /// Clang compiler instance, which is used to actually load Clang
+    /// modules.
+    std::unique_ptr<clang::CompilerInstance> Instance;
 
-  /// Clang parser, which is used to load textual headers.
-  std::unique_ptr<clang::Parser> Parser;
+    /// Clang compiler action, which is used to actually run the
+    /// parser.
+    std::unique_ptr<clang::FrontendAction> Action;
 
-  /// Clang parser, which is used to load textual headers.
-  std::unique_ptr<clang::MangleContext> Mangler;
+    /// Clang parser, which is used to load textual headers.
+    std::unique_ptr<clang::Parser> Parser;
 
-  /// Clang arguments used to create the Clang invocation.
-  std::vector<std::string> ClangArgs;
+    /// Clang parser, which is used to load textual headers.
+    std::unique_ptr<clang::MangleContext> Mangler;
+
+    /// Clang arguments used to create the Clang invocation.
+    std::vector<std::string> ClangArgs;
+  };
+
+  ClangCompiler DefaultCompiler;
+
+  std::vector<ClangCompiler *> &getAllClangCompilers() {
+    auto allClangCompilers = new std::vector<ClangCompiler *> {
+      &DefaultCompiler,
+    };
+    return *allClangCompilers;
+  }
 
   /// Mapping from Clang swift_attr attribute text to the Swift source buffer
   /// IDs that contain that attribute text. These are re-used when parsing the
@@ -541,7 +556,7 @@ public:
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
 
   clang::CompilerInstance *getClangInstance() {
-    return Instance.get();
+    return DefaultCompiler.Instance.get();
   }
 
 private:
@@ -760,21 +775,21 @@ public:
 
   /// Retrieve the Clang AST context.
   clang::ASTContext &getClangASTContext() const {
-    return Instance->getASTContext();
+    return DefaultCompiler.Instance->getASTContext();
   }
 
   /// Retrieve the Clang Sema object.
   clang::Sema &getClangSema() const {
-    return Instance->getSema();
+    return DefaultCompiler.Instance->getSema();
   }
 
   /// Retrieve the Clang AST context.
   clang::Preprocessor &getClangPreprocessor() const {
-    return Instance->getPreprocessor();
+    return DefaultCompiler.Instance->getPreprocessor();
   }
   
   clang::CodeGenOptions &getClangCodeGenOpts() const {
-    return Instance->getCodeGenOpts();
+    return DefaultCompiler.Instance->getCodeGenOpts();
   }
 
   importer::ClangSourceBufferImporter &getBufferImporterForDiagnostics() {


### PR DESCRIPTION
Summary: This could be the first step to resolve SR-15822.

As mentioned in SR-15822 and [the related topic](https://forums.swift.org/t/55091), `ClangImporter` uses one instance of `clang::CompilerInstance` but it imports separately clang modules and textual headers. Such feature induces some bugs such as SR-15822.
This commit introduces a wrapper for clang compiler to let `ClangImporter` use other instances of `clang::CompilerInstance`.

Note: This commit has no functional changes, so it does NOT resolve any bugs. Just prepares resolution.

