### PR TITLE
[c++-interop] Adding operator~ support.

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1802,6 +1802,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_GreaterEqual:
     case clang::OverloadedOperatorKind::OO_AmpAmp:
     case clang::OverloadedOperatorKind::OO_PipePipe:
+    case clang::OverloadedOperatorKind::OO_Tilde:
       baseName = clang::getOperatorSpelling(op);
       isFunction = true;
       argumentNames.resize(

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -16,6 +16,10 @@ struct LoadableIntWrapper {
   int operator()(int x, int y) {
     return value + x * y;
   }
+
+  int operator~() {
+    return ~value;
+  }
 };
 
 struct AddressOnlyIntWrapper {

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -18,6 +18,12 @@ OperatorsTestSuite.test("LoadableIntWrapper.plus (inline)") {
 }
 #endif
 
+OperatorsTestSuite.test("LoadableIntWrapper.tilde (inline)") {
+  let wrapper = LoadableIntWrapper(value: 42)
+  let not42 = ~wrapper
+  expectEqual(~42, not42)
+}
+
 OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
   var wrapper = LoadableIntWrapper(value: 42)
 


### PR DESCRIPTION
This simply enables operator~.

More tests are coming. Prob will do operator! in a separate commit soon too.

@zoecarver @hyp 