### PR TITLE
Explicitly call `make_tuple`

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -385,7 +385,8 @@ describe(SILInstruction *blame) {
 
     // if we have no callee info, all we know is it's a call involving self.
     if (!callee)
-      return {"a call involving", "", ctx.Id_self};
+      return std::make_tuple<StringRef, StringRef, DeclName>("a call involving",
+                                                             "", ctx.Id_self);
 
     return {
       verbForInvoking(callee),
@@ -397,9 +398,11 @@ describe(SILInstruction *blame) {
   // handle non-call blames
   switch (blame->getKind()) {
     case SILInstructionKind::CopyValueInst:
-      return {"making a copy of", "", ctx.Id_self};
+      return std::make_tuple<StringRef, StringRef, DeclName>("making a copy of",
+                                                             "", ctx.Id_self);
     default:
-      return {"this use of", "", ctx.Id_self};
+      return std::make_tuple<StringRef, StringRef, DeclName>("this use of", "",
+                                                             ctx.Id_self);
   }
 }
 


### PR DESCRIPTION
Was hitting `chosen constructor is explicit in copy-initialization` on
these lines. Making the construction of the tuple explicit.

CI Failures:
 - https://ci.swift.org/job/apple-llvm-project-pr-linux/3351/
 - https://ci.swift.org/job/apple-llvm-project-pr-linux/3326/

rdar://88563859
