### PR TITLE
Audit and correct AsyncSequence Sendability

### DIFF
--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -45,7 +45,7 @@ extension AsyncSequence {
   ///   same or of a different type.
   /// - Returns: An asynchronous sequence that contains, in order, the
   ///   non-`nil` elements produced by the `transform` closure.
-  @preconcurrency 
+  @preconcurrency
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
     _ transform: @Sendable @escaping (Element) async -> ElementOfResult?
@@ -61,15 +61,13 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> ElementOfResult?
+  let transform: (Base.Element) async -> ElementOfResult?
 
-  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
+    transform: @escaping (Base.Element) async -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -93,15 +91,13 @@ extension AsyncCompactMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> ElementOfResult?
+    let transform: (Base.Element) async -> ElementOfResult?
 
-    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
+      transform: @escaping (Base.Element) async -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -136,13 +132,13 @@ extension AsyncCompactMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncCompactMapSequence: Sendable 
+extension AsyncCompactMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         ElementOfResult: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncCompactMapSequence.Iterator: Sendable 
+extension AsyncCompactMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         ElementOfResult: Sendable { }

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -47,7 +47,7 @@ extension AsyncSequence {
   ///   non-`nil` elements produced by the `transform` closure.
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @escaping (Element) async -> ElementOfResult?
+    _ transform: @Sendable @escaping (Element) async -> ElementOfResult?
   ) -> AsyncCompactMapSequence<Self, ElementOfResult> {
     return AsyncCompactMapSequence(self, transform: transform)
   }
@@ -61,12 +61,12 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async -> ElementOfResult?
+  let transform: @Sendable (Base.Element) async -> ElementOfResult?
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @escaping (Base.Element) async -> ElementOfResult?
+    transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -91,12 +91,12 @@ extension AsyncCompactMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async -> ElementOfResult?
+    let transform: @Sendable (Base.Element) async -> ElementOfResult?
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @escaping (Base.Element) async -> ElementOfResult?
+      transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -129,3 +129,13 @@ extension AsyncCompactMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+extension AsyncCompactMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable, 
+        ElementOfResult: Sendable { }
+
+extension AsyncCompactMapSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable, 
+        ElementOfResult: Sendable { }

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -130,11 +130,13 @@ extension AsyncCompactMapSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncCompactMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         ElementOfResult: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncCompactMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -47,7 +47,7 @@ extension AsyncSequence {
   ///   non-`nil` elements produced by the `transform` closure.
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @Sendable @escaping (Element) async -> ElementOfResult?
+    _ transform: @preconcurrency @Sendable @escaping (Element) async -> ElementOfResult?
   ) -> AsyncCompactMapSequence<Self, ElementOfResult> {
     return AsyncCompactMapSequence(self, transform: transform)
   }
@@ -61,12 +61,12 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> ElementOfResult?
+  let transform: @preconcurrency @Sendable (Base.Element) async -> ElementOfResult?
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -91,12 +91,12 @@ extension AsyncCompactMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> ElementOfResult?
+    let transform: @preconcurrency @Sendable (Base.Element) async -> ElementOfResult?
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -45,9 +45,10 @@ extension AsyncSequence {
   ///   same or of a different type.
   /// - Returns: An asynchronous sequence that contains, in order, the
   ///   non-`nil` elements produced by the `transform` closure.
+  @preconcurrency 
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async -> ElementOfResult?
+    _ transform: @Sendable @escaping (Element) async -> ElementOfResult?
   ) -> AsyncCompactMapSequence<Self, ElementOfResult> {
     return AsyncCompactMapSequence(self, transform: transform)
   }
@@ -60,13 +61,15 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async -> ElementOfResult?
+  let transform: @Sendable (Base.Element) async -> ElementOfResult?
 
+  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> ElementOfResult?
+    transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -90,13 +93,15 @@ extension AsyncCompactMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency 
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async -> ElementOfResult?
+    let transform: @Sendable (Base.Element) async -> ElementOfResult?
 
+    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> ElementOfResult?
+      transform: @Sendable @escaping (Base.Element) async -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -135,3 +135,11 @@ extension AsyncDropFirstSequence {
     return AsyncDropFirstSequence(base, dropping: self.count + count)
   }
 }
+
+extension AsyncDropFirstSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncDropFirstSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -136,10 +136,12 @@ extension AsyncDropFirstSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropFirstSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropFirstSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -43,7 +43,7 @@ extension AsyncSequence {
   ///   base sequence until the provided closure returns `false`.
   @inlinable
   public __consuming func drop(
-    while predicate: @escaping (Element) async -> Bool
+    while predicate: @Sendable @escaping (Element) async -> Bool
   ) -> AsyncDropWhileSequence<Self> {
     AsyncDropWhileSequence(self, predicate: predicate)
   }
@@ -58,12 +58,12 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: (Base.Element) async -> Bool
+  let predicate: @Sendable (Base.Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @escaping (Base.Element) async -> Bool
+    predicate: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -92,7 +92,7 @@ extension AsyncDropWhileSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @escaping (Base.Element) async -> Bool
+      predicate: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -127,3 +127,11 @@ extension AsyncDropWhileSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), predicate: predicate)
   }
 }
+
+extension AsyncDropWhileSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncDropWhileSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -128,10 +128,12 @@ extension AsyncDropWhileSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropWhileSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncDropWhileSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -41,9 +41,10 @@ extension AsyncSequence {
   ///   modified sequence.
   /// - Returns: An asynchronous sequence that skips over values from the
   ///   base sequence until the provided closure returns `false`.
+  @preconcurrency 
   @inlinable
   public __consuming func drop(
-    while predicate: @preconcurrency @Sendable @escaping (Element) async -> Bool
+    while predicate: @Sendable @escaping (Element) async -> Bool
   ) -> AsyncDropWhileSequence<Self> {
     AsyncDropWhileSequence(self, predicate: predicate)
   }
@@ -57,13 +58,15 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency 
   @usableFromInline
-  let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
+  let predicate: @Sendable (Base.Element) async -> Bool
 
+  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -86,13 +89,15 @@ extension AsyncDropWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency 
     @usableFromInline
-    var predicate: @preconcurrency (@Sendable (Base.Element) async -> Bool)?
+    var predicate: (@Sendable (Base.Element) async -> Bool)?
 
+    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -58,11 +58,9 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency 
   @usableFromInline
   let predicate: @Sendable (Base.Element) async -> Bool
 
-  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
@@ -89,11 +87,9 @@ extension AsyncDropWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency 
     @usableFromInline
     var predicate: (@Sendable (Base.Element) async -> Bool)?
 
-    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
@@ -134,11 +130,11 @@ extension AsyncDropWhileSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncDropWhileSequence: Sendable 
+extension AsyncDropWhileSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncDropWhileSequence.Iterator: Sendable 
+extension AsyncDropWhileSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -59,12 +59,12 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async -> Bool
+  let predicate: (Base.Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -88,12 +88,12 @@ extension AsyncDropWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    var predicate: (@Sendable (Base.Element) async -> Bool)?
+    var predicate: ((Base.Element) async -> Bool)?
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -43,7 +43,7 @@ extension AsyncSequence {
   ///   base sequence until the provided closure returns `false`.
   @inlinable
   public __consuming func drop(
-    while predicate: @Sendable @escaping (Element) async -> Bool
+    while predicate: @preconcurrency @Sendable @escaping (Element) async -> Bool
   ) -> AsyncDropWhileSequence<Self> {
     AsyncDropWhileSequence(self, predicate: predicate)
   }
@@ -58,12 +58,12 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async -> Bool
+  let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -87,12 +87,12 @@ extension AsyncDropWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    var predicate: ((Base.Element) async -> Bool)?
+    var predicate: @preconcurrency (@Sendable (Base.Element) async -> Bool)?
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -49,15 +49,13 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency 
   @usableFromInline
-  let isIncluded: @Sendable (Element) async -> Bool
+  let isIncluded: (Element) async -> Bool
 
-  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @Sendable @escaping (Base.Element) async -> Bool
+    isIncluded: @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -79,15 +77,13 @@ extension AsyncFilterSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency 
     @usableFromInline
-    let isIncluded: @Sendable (Base.Element) async -> Bool
+    let isIncluded: (Base.Element) async -> Bool
 
-    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @Sendable @escaping (Base.Element) async -> Bool
+      isIncluded: @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded
@@ -120,11 +116,11 @@ extension AsyncFilterSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncFilterSequence: Sendable 
+extension AsyncFilterSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncFilterSequence.Iterator: Sendable 
+extension AsyncFilterSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -33,9 +33,10 @@ extension AsyncSequence {
   ///   that indicates whether to include the element in the filtered sequence.
   /// - Returns: An asynchronous sequence that contains, in order, the elements
   ///   of the base sequence that satisfy the given predicate.
+  @preconcurrency 
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @preconcurrency @Sendable @escaping (Element) async -> Bool
+    _ isIncluded: @Sendable @escaping (Element) async -> Bool
   ) -> AsyncFilterSequence<Self> {
     return AsyncFilterSequence(self, isIncluded: isIncluded)
   }
@@ -48,13 +49,15 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency 
   @usableFromInline
-  let isIncluded: @preconcurrency Sendable (Element) async -> Bool
+  let isIncluded: @Sendable (Element) async -> Bool
 
+  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+    isIncluded: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -76,13 +79,15 @@ extension AsyncFilterSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency 
     @usableFromInline
-    let isIncluded: @preconcurrency @Sendable (Base.Element) async -> Bool
+    let isIncluded: @Sendable (Base.Element) async -> Bool
 
+    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+      isIncluded: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -114,10 +114,12 @@ extension AsyncFilterSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncFilterSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncFilterSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -35,7 +35,7 @@ extension AsyncSequence {
   ///   of the base sequence that satisfy the given predicate.
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @escaping (Element) async -> Bool
+    _ isIncluded: @Sendable @escaping (Element) async -> Bool
   ) -> AsyncFilterSequence<Self> {
     return AsyncFilterSequence(self, isIncluded: isIncluded)
   }
@@ -49,12 +49,12 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let isIncluded: (Element) async -> Bool
+  let isIncluded: @Sendable (Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @escaping (Base.Element) async -> Bool
+    isIncluded: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -82,7 +82,7 @@ extension AsyncFilterSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @escaping (Base.Element) async -> Bool
+      isIncluded: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded
@@ -113,3 +113,11 @@ extension AsyncFilterSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), isIncluded: isIncluded)
   }
 }
+
+extension AsyncFilterSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncFilterSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -35,7 +35,7 @@ extension AsyncSequence {
   ///   of the base sequence that satisfy the given predicate.
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @Sendable @escaping (Element) async -> Bool
+    _ isIncluded: @preconcurrency @Sendable @escaping (Element) async -> Bool
   ) -> AsyncFilterSequence<Self> {
     return AsyncFilterSequence(self, isIncluded: isIncluded)
   }
@@ -49,12 +49,12 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let isIncluded: @Sendable (Element) async -> Bool
+  let isIncluded: @preconcurrency Sendable (Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @Sendable @escaping (Base.Element) async -> Bool
+    isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -77,12 +77,12 @@ extension AsyncFilterSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let isIncluded: (Base.Element) async -> Bool
+    let isIncluded: @preconcurrency @Sendable (Base.Element) async -> Bool
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @Sendable @escaping (Base.Element) async -> Bool
+      isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -41,7 +41,7 @@ extension AsyncSequence {
   ///   elements in all the asychronous sequences produced by `transform`.
  @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
+    _ transform: @preconcurrency @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult> {
     return AsyncFlatMapSequence(self, transform: transform)
   }
@@ -55,12 +55,12 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> SegmentOfResult
+  let transform: @preconcurrency @Sendable (Base.Element) async -> SegmentOfResult
 
   @usableFromInline
   init(
     _ base: Base,
-    transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -83,7 +83,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> SegmentOfResult
+    let transform: @preconcurrency @Sendable (Base.Element) async -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -94,7 +94,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -163,7 +163,7 @@ extension AsyncFlatMapSequence: Sendable
         SegmentOfResult.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncFlatMapSequence: Sendable.Iterator 
+extension AsyncFlatMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -55,15 +55,13 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   @usableFromInline
   let base: Base
 
-  @preconcurrency 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> SegmentOfResult
+  let transform: (Base.Element) async -> SegmentOfResult
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base,
-    transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
+    transform: @escaping (Base.Element) async -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -85,9 +83,8 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> SegmentOfResult
+    let transform: (Base.Element) async -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -95,11 +92,10 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
+      transform: @escaping (Base.Element) async -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -161,14 +157,14 @@ extension AsyncFlatMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncFlatMapSequence: Sendable 
+extension AsyncFlatMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncFlatMapSequence.Iterator: Sendable 
+extension AsyncFlatMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -155,12 +155,14 @@ extension AsyncFlatMapSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncFlatMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncFlatMapSequence: Sendable.Iterator 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -39,9 +39,10 @@ extension AsyncSequence {
   ///   of this sequence as its parameter and returns an `AsyncSequence`.
   /// - Returns: A single, flattened asynchronous sequence that contains all
   ///   elements in all the asychronous sequences produced by `transform`.
- @inlinable
+  @preconcurrency 
+  @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async -> SegmentOfResult
+    _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult> {
     return AsyncFlatMapSequence(self, transform: transform)
   }
@@ -54,13 +55,15 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   @usableFromInline
   let base: Base
 
+  @preconcurrency 
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async -> SegmentOfResult
+  let transform: @Sendable (Base.Element) async -> SegmentOfResult
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base,
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> SegmentOfResult
+    transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -82,8 +85,9 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async -> SegmentOfResult
+    let transform: @Sendable (Base.Element) async -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -91,10 +95,11 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> SegmentOfResult
+      transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -41,7 +41,7 @@ extension AsyncSequence {
   ///   elements in all the asychronous sequences produced by `transform`.
  @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @escaping (Element) async -> SegmentOfResult
+    _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult> {
     return AsyncFlatMapSequence(self, transform: transform)
   }
@@ -55,12 +55,12 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async -> SegmentOfResult
+  let transform: @Sendable (Base.Element) async -> SegmentOfResult
 
   @usableFromInline
   init(
     _ base: Base,
-    transform: @escaping (Base.Element) async -> SegmentOfResult
+    transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -83,7 +83,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async -> SegmentOfResult
+    let transform: @Sendable (Base.Element) async -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -94,7 +94,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @escaping (Base.Element) async -> SegmentOfResult
+      transform: @Sendable @escaping (Base.Element) async -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -154,3 +154,16 @@ extension AsyncFlatMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+extension AsyncFlatMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable, 
+        SegmentOfResult: Sendable, 
+        SegmentOfResult.Element: Sendable { }
+
+extension AsyncFlatMapSequence: Sendable.Iterator 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable, 
+        SegmentOfResult: Sendable, 
+        SegmentOfResult.Element: Sendable, 
+        SegmentOfResult.AsyncIterator: Sendable { }

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -45,7 +45,7 @@ extension AsyncSequence {
   ///   produced by the `transform` closure.
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @escaping (Element) async -> Transformed
+    _ transform: @Sendable @escaping (Element) async -> Transformed
   ) -> AsyncMapSequence<Self, Transformed> {
     return AsyncMapSequence(self, transform: transform)
   }
@@ -59,12 +59,12 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async -> Transformed
+  let transform: @Sendable (Base.Element) async -> Transformed
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @escaping (Base.Element) async -> Transformed
+    transform: @Sendable @escaping (Base.Element) async -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -87,12 +87,12 @@ extension AsyncMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async -> Transformed
+    let transform: @Sendable (Base.Element) async -> Transformed
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @escaping (Base.Element) async -> Transformed
+      transform: @Sendable @escaping (Base.Element) async -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -117,3 +117,13 @@ extension AsyncMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+extension AsyncMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable, 
+        Transformed: Sendable { }
+
+extension AsyncMapSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable, 
+        Transformed: Sendable { }

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -43,9 +43,10 @@ extension AsyncSequence {
   ///   same or of a different type.
   /// - Returns: An asynchronous sequence that contains, in order, the elements
   ///   produced by the `transform` closure.
+  @preconcurrency 
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async -> Transformed
+    _ transform: @Sendable @escaping (Element) async -> Transformed
   ) -> AsyncMapSequence<Self, Transformed> {
     return AsyncMapSequence(self, transform: transform)
   }
@@ -58,13 +59,15 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency 
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async -> Transformed
+  let transform: @Sendable (Base.Element) async -> Transformed
 
+  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> Transformed
+    transform: @Sendable @escaping (Base.Element) async -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -86,13 +89,15 @@ extension AsyncMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency 
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async -> Transformed
+    let transform: @Sendable (Base.Element) async -> Transformed
 
+    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> Transformed
+      transform: @Sendable @escaping (Base.Element) async -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -45,7 +45,7 @@ extension AsyncSequence {
   ///   produced by the `transform` closure.
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @Sendable @escaping (Element) async -> Transformed
+    _ transform: @preconcurrency @Sendable @escaping (Element) async -> Transformed
   ) -> AsyncMapSequence<Self, Transformed> {
     return AsyncMapSequence(self, transform: transform)
   }
@@ -59,12 +59,12 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> Transformed
+  let transform: @preconcurrency @Sendable (Base.Element) async -> Transformed
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async -> Transformed
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -87,12 +87,12 @@ extension AsyncMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> Transformed
+    let transform: @preconcurrency @Sendable (Base.Element) async -> Transformed
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async -> Transformed
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -59,15 +59,13 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async -> Transformed
+  let transform: (Base.Element) async -> Transformed
 
-  @preconcurrency 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async -> Transformed
+    transform: @escaping (Base.Element) async -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -89,15 +87,13 @@ extension AsyncMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async -> Transformed
+    let transform: (Base.Element) async -> Transformed
 
-    @preconcurrency 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async -> Transformed
+      transform: @escaping (Base.Element) async -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -124,13 +120,13 @@ extension AsyncMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncMapSequence: Sendable 
+extension AsyncMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncMapSequence.Iterator: Sendable 
+extension AsyncMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -118,11 +118,13 @@ extension AsyncMapSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -109,3 +109,11 @@ extension AsyncPrefixSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), count: count)
   }
 }
+
+extension AsyncPrefixSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncPrefixSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -110,10 +110,12 @@ extension AsyncPrefixSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -121,10 +121,12 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixWhileSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncPrefixWhileSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -40,7 +40,7 @@ extension AsyncSequence {
   ///   elements that satisfy `predicate`.
   @inlinable
   public __consuming func prefix(
-    while predicate: @escaping (Element) async -> Bool
+    while predicate: @Sendable @escaping (Element) async -> Bool
   ) rethrows -> AsyncPrefixWhileSequence<Self> {
     return AsyncPrefixWhileSequence(self, predicate: predicate)
   }
@@ -54,12 +54,12 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: (Base.Element) async -> Bool
+  let predicate: @Sendable (Base.Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @escaping (Base.Element) async -> Bool
+    predicate: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -85,12 +85,12 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: (Base.Element) async -> Bool
+    let predicate: @Sendable (Base.Element) async -> Bool
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @escaping (Base.Element) async -> Bool
+      predicate: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -120,3 +120,11 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), predicate: predicate)
   }
 }
+
+extension AsyncPrefixWhileSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncPrefixWhileSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -50,19 +50,17 @@ extension AsyncSequence {
 /// An asynchronous sequence, containing the initial, consecutive
 /// elements of the base sequence that satisfy a given predicate.
 @available(SwiftStdlib 5.1, *)
-@preconcurrency
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async -> Bool
+  let predicate: (Base.Element) async -> Bool
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -87,15 +85,13 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async -> Bool
+    let predicate: (Base.Element) async -> Bool
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -127,11 +123,11 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncPrefixWhileSequence: Sendable 
+extension AsyncPrefixWhileSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncPrefixWhileSequence.Iterator: Sendable 
+extension AsyncPrefixWhileSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -40,7 +40,7 @@ extension AsyncSequence {
   ///   elements that satisfy `predicate`.
   @inlinable
   public __consuming func prefix(
-    while predicate: @Sendable @escaping (Element) async -> Bool
+    while predicate: @preconcurrency @Sendable @escaping (Element) async -> Bool
   ) rethrows -> AsyncPrefixWhileSequence<Self> {
     return AsyncPrefixWhileSequence(self, predicate: predicate)
   }
@@ -54,12 +54,12 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async -> Bool
+  let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -85,12 +85,12 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async -> Bool
+    let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -38,9 +38,10 @@ extension AsyncSequence {
   ///   included in the modified sequence.
   /// - Returns: An asynchronous sequence of the initial, consecutive
   ///   elements that satisfy `predicate`.
+  @preconcurrency
   @inlinable
   public __consuming func prefix(
-    while predicate: @preconcurrency @Sendable @escaping (Element) async -> Bool
+    while predicate: @Sendable @escaping (Element) async -> Bool
   ) rethrows -> AsyncPrefixWhileSequence<Self> {
     return AsyncPrefixWhileSequence(self, predicate: predicate)
   }
@@ -49,17 +50,19 @@ extension AsyncSequence {
 /// An asynchronous sequence, containing the initial, consecutive
 /// elements of the base sequence that satisfy a given predicate.
 @available(SwiftStdlib 5.1, *)
+@preconcurrency
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
   @usableFromInline
-  let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
+  let predicate: @Sendable (Base.Element) async -> Bool
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+    predicate: @Sendable @escaping (Base.Element) async -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -84,13 +87,15 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let predicate: @preconcurrency @Sendable (Base.Element) async -> Bool
+    let predicate: @Sendable (Base.Element) async -> Bool
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @preconcurrency @Sendable @escaping (Base.Element) async -> Bool
+      predicate: @Sendable @escaping (Base.Element) async -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -59,7 +59,7 @@ extension AsyncSequence {
   ///   error.
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @Sendable @escaping (Element) async throws -> ElementOfResult?
+    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> ElementOfResult?
   ) -> AsyncThrowingCompactMapSequence<Self, ElementOfResult> {
     return AsyncThrowingCompactMapSequence(self, transform: transform)
   }
@@ -73,12 +73,12 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
+  let transform: @preconcurrency @Sendable (Base.Element) async throws -> ElementOfResult?
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -103,7 +103,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
+    let transform: @preconcurrency @Sendable (Base.Element) async throws -> ElementOfResult?
 
     @usableFromInline
     var finished = false
@@ -111,7 +111,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -57,9 +57,10 @@ extension AsyncSequence {
   ///   non-`nil` elements produced by the `transform` closure. The sequence
   ///   ends either when the base sequence ends or when `transform` throws an
   ///   error.
+  @preconcurrency
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> ElementOfResult?
+    _ transform: @Sendable @escaping (Element) async throws -> ElementOfResult?
   ) -> AsyncThrowingCompactMapSequence<Self, ElementOfResult> {
     return AsyncThrowingCompactMapSequence(self, transform: transform)
   }
@@ -72,13 +73,15 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async throws -> ElementOfResult?
+  let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+    transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -102,16 +105,18 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async throws -> ElementOfResult?
+    let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
 
     @usableFromInline
     var finished = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+      transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -59,7 +59,7 @@ extension AsyncSequence {
   ///   error.
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
-    _ transform: @escaping (Element) async throws -> ElementOfResult?
+    _ transform: @Sendable @escaping (Element) async throws -> ElementOfResult?
   ) -> AsyncThrowingCompactMapSequence<Self, ElementOfResult> {
     return AsyncThrowingCompactMapSequence(self, transform: transform)
   }
@@ -73,12 +73,12 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async throws -> ElementOfResult?
+  let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @escaping (Base.Element) async throws -> ElementOfResult?
+    transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -103,7 +103,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async throws -> ElementOfResult?
+    let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
 
     @usableFromInline
     var finished = false
@@ -111,7 +111,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @escaping (Base.Element) async throws -> ElementOfResult?
+      transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -151,3 +151,12 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+extension AsyncThrowingCompactMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncThrowingCompactMapSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }
+

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -73,15 +73,13 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
+  let transform: (Base.Element) async throws -> ElementOfResult?
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+    transform: @escaping (Base.Element) async throws -> ElementOfResult?
   ) {
     self.base = base
     self.transform = transform
@@ -105,18 +103,16 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> ElementOfResult?
+    let transform: (Base.Element) async throws -> ElementOfResult?
 
     @usableFromInline
     var finished = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async throws -> ElementOfResult?
+      transform: @escaping (Base.Element) async throws -> ElementOfResult?
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -158,12 +154,12 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingCompactMapSequence: Sendable 
+extension AsyncThrowingCompactMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingCompactMapSequence.Iterator: Sendable 
+extension AsyncThrowingCompactMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }
 

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -152,10 +152,12 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingCompactMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingCompactMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -56,7 +56,7 @@ extension AsyncSequence {
   ///   provided closure returns `false` or throws an error.
   @inlinable
   public __consuming func drop(
-    while predicate: @Sendable @escaping (Element) async throws -> Bool
+    while predicate: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingDropWhileSequence<Self> {
     AsyncThrowingDropWhileSequence(self, predicate: predicate)
   }
@@ -71,12 +71,12 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async throws -> Bool
+  let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -99,7 +99,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async throws -> Bool
+    let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -110,7 +110,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -54,9 +54,10 @@ extension AsyncSequence {
   ///   element from the modified sequence.
   /// - Returns: An asynchronous sequence that skips over values until the
   ///   provided closure returns `false` or throws an error.
+  @preconcurrency
   @inlinable
   public __consuming func drop(
-    while predicate: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
+    while predicate: @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingDropWhileSequence<Self> {
     AsyncThrowingDropWhileSequence(self, predicate: predicate)
   }
@@ -70,13 +71,15 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
+  let predicate: @Sendable (Base.Element) async throws -> Bool
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -98,8 +101,9 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
+    let predicate: @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -107,10 +111,11 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     var doneDropping = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -56,7 +56,7 @@ extension AsyncSequence {
   ///   provided closure returns `false` or throws an error.
   @inlinable
   public __consuming func drop(
-    while predicate: @escaping (Element) async throws -> Bool
+    while predicate: @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingDropWhileSequence<Self> {
     AsyncThrowingDropWhileSequence(self, predicate: predicate)
   }
@@ -71,12 +71,12 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: (Base.Element) async throws -> Bool
+  let predicate: @Sendable (Base.Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @escaping (Base.Element) async throws -> Bool
+    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -99,7 +99,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: (Base.Element) async throws -> Bool
+    let predicate: @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -110,7 +110,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @escaping (Base.Element) async throws -> Bool
+      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -154,3 +154,11 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), predicate: predicate)
   }
 }
+
+extension AsyncThrowingDropWhileSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncThrowingDropWhileSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -71,15 +71,13 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async throws -> Bool
+  let predicate: (Base.Element) async throws -> Bool
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -101,9 +99,8 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async throws -> Bool
+    let predicate: (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -111,11 +108,10 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     var doneDropping = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -161,11 +157,11 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingDropWhileSequence: Sendable 
+extension AsyncThrowingDropWhileSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingDropWhileSequence.Iterator: Sendable 
+extension AsyncThrowingDropWhileSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -155,10 +155,12 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingDropWhileSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingDropWhileSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -45,9 +45,10 @@ extension AsyncSequence {
   ///   of the base sequence that satisfy the given predicate. If the predicate
   ///   throws an error, the sequence contains only values produced prior to
   ///   the error.
+  @preconcurrency
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
+    _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingFilterSequence<Self> {
     return AsyncThrowingFilterSequence(self, isIncluded: isIncluded)
   }
@@ -60,13 +61,15 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
   
+  @preconcurrency
   @usableFromInline
-  let isIncluded: @preconcurrency @Sendable (Element) async throws -> Bool
+  let isIncluded: @Sendable (Element) async throws -> Bool
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+    isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -88,16 +91,18 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let isIncluded: @preconcurrency @Sendable (Base.Element) async throws -> Bool
+    let isIncluded: @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+      isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -47,7 +47,7 @@ extension AsyncSequence {
   ///   the error.
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @escaping (Element) async throws -> Bool
+    _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingFilterSequence<Self> {
     return AsyncThrowingFilterSequence(self, isIncluded: isIncluded)
   }
@@ -61,12 +61,12 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   let base: Base
   
   @usableFromInline
-  let isIncluded: (Element) async throws -> Bool
+  let isIncluded: @Sendable (Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @escaping (Base.Element) async throws -> Bool
+    isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -89,7 +89,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let isIncluded: (Base.Element) async throws -> Bool
+    let isIncluded: @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -97,7 +97,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @escaping (Base.Element) async throws -> Bool
+      isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded
@@ -136,3 +136,11 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), isIncluded: isIncluded)
   }
 }
+
+extension AsyncThrowingFilterSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncThrowingFilterSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -137,10 +137,12 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFilterSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFilterSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -61,15 +61,13 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
   
-  @preconcurrency
   @usableFromInline
-  let isIncluded: @Sendable (Element) async throws -> Bool
+  let isIncluded: (Element) async throws -> Bool
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
+    isIncluded: @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -91,18 +89,16 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let isIncluded: @Sendable (Base.Element) async throws -> Bool
+    let isIncluded: (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
+      isIncluded: @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded
@@ -143,11 +139,11 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFilterSequence: Sendable 
+extension AsyncThrowingFilterSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFilterSequence.Iterator: Sendable 
+extension AsyncThrowingFilterSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -47,7 +47,7 @@ extension AsyncSequence {
   ///   the error.
   @inlinable
   public __consuming func filter(
-    _ isIncluded: @Sendable @escaping (Element) async throws -> Bool
+    _ isIncluded: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
   ) -> AsyncThrowingFilterSequence<Self> {
     return AsyncThrowingFilterSequence(self, isIncluded: isIncluded)
   }
@@ -61,12 +61,12 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   let base: Base
   
   @usableFromInline
-  let isIncluded: @Sendable (Element) async throws -> Bool
+  let isIncluded: @preconcurrency @Sendable (Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
+    isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.isIncluded = isIncluded
@@ -89,7 +89,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let isIncluded: @Sendable (Base.Element) async throws -> Bool
+    let isIncluded: @preconcurrency @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     var finished = false
@@ -97,7 +97,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      isIncluded: @Sendable @escaping (Base.Element) async throws -> Bool
+      isIncluded: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.isIncluded = isIncluded

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -55,7 +55,7 @@ extension AsyncSequence {
   ///   element from base sequence ends, or when `transform` throws an error.
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @escaping (Element) async throws -> SegmentOfResult
+    _ transform: @Sendable @escaping (Element) async throws -> SegmentOfResult
   ) -> AsyncThrowingFlatMapSequence<Self, SegmentOfResult> {
     return AsyncThrowingFlatMapSequence(self, transform: transform)
   }
@@ -69,12 +69,12 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async throws -> SegmentOfResult
+  let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
 
   @usableFromInline
   init(
     _ base: Base,
-    transform: @escaping (Base.Element) async throws -> SegmentOfResult
+    transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -97,7 +97,7 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async throws -> SegmentOfResult
+    let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -108,7 +108,7 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @escaping (Base.Element) async throws -> SegmentOfResult
+      transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -169,3 +169,18 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+
+extension AsyncThrowingFlatMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable, 
+        SegmentOfResult: Sendable, 
+        SegmentOfResult.Element: Sendable { }
+
+extension AsyncThrowingFlatMapSequence: Sendable.Iterator 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable, 
+        SegmentOfResult: Sendable, 
+        SegmentOfResult.Element: Sendable, 
+        SegmentOfResult.AsyncIterator: Sendable { }
+

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -170,13 +170,14 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
   }
 }
 
-
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFlatMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingFlatMapSequence: Sendable.Iterator 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -178,7 +178,7 @@ extension AsyncThrowingFlatMapSequence: Sendable
         SegmentOfResult.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFlatMapSequence: Sendable.Iterator 
+extension AsyncThrowingFlatMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -53,9 +53,10 @@ extension AsyncSequence {
   ///   elements in all the asychronous sequences produced by `transform`. The
   ///   sequence ends either when the the last sequence created from the last
   ///   element from base sequence ends, or when `transform` throws an error.
+  @preconcurrency
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> SegmentOfResult
+    _ transform: @Sendable @escaping (Element) async throws -> SegmentOfResult
   ) -> AsyncThrowingFlatMapSequence<Self, SegmentOfResult> {
     return AsyncThrowingFlatMapSequence(self, transform: transform)
   }
@@ -68,13 +69,15 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async throws -> SegmentOfResult
+  let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base,
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+    transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -96,8 +99,9 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async throws -> SegmentOfResult
+    let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -105,10 +109,11 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+      transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -55,7 +55,7 @@ extension AsyncSequence {
   ///   element from base sequence ends, or when `transform` throws an error.
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
-    _ transform: @Sendable @escaping (Element) async throws -> SegmentOfResult
+    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> SegmentOfResult
   ) -> AsyncThrowingFlatMapSequence<Self, SegmentOfResult> {
     return AsyncThrowingFlatMapSequence(self, transform: transform)
   }
@@ -69,12 +69,12 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
+  let transform: @preconcurrency @Sendable (Base.Element) async throws -> SegmentOfResult
 
   @usableFromInline
   init(
     _ base: Base,
-    transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -97,7 +97,7 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
+    let transform: @preconcurrency @Sendable (Base.Element) async throws -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -108,7 +108,7 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -69,15 +69,13 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
+  let transform: (Base.Element) async throws -> SegmentOfResult
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base,
-    transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+    transform: @escaping (Base.Element) async throws -> SegmentOfResult
   ) {
     self.base = base
     self.transform = transform
@@ -99,9 +97,8 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> SegmentOfResult
+    let transform: (Base.Element) async throws -> SegmentOfResult
 
     @usableFromInline
     var currentIterator: SegmentOfResult.AsyncIterator?
@@ -109,11 +106,10 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator,
-      transform: @Sendable @escaping (Base.Element) async throws -> SegmentOfResult
+      transform: @escaping (Base.Element) async throws -> SegmentOfResult
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -176,14 +172,14 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFlatMapSequence: Sendable 
+extension AsyncThrowingFlatMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 
         SegmentOfResult.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingFlatMapSequence.Iterator: Sendable 
+extension AsyncThrowingFlatMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         SegmentOfResult: Sendable, 

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -58,7 +58,7 @@ extension AsyncSequence {
   ///   produced by the `transform` closure.
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @Sendable @escaping (Element) async throws -> Transformed
+    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> Transformed
   ) -> AsyncThrowingMapSequence<Self, Transformed> {
     return AsyncThrowingMapSequence(self, transform: transform)
   }
@@ -72,12 +72,12 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   let base: Base
 
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> Transformed
+  let transform: @preconcurrency @Sendable (Base.Element) async throws -> Transformed
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async throws -> Transformed
+    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -100,7 +100,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> Transformed
+    let transform: @preconcurrency @Sendable (Base.Element) async throws -> Transformed
 
     @usableFromInline
     var finished = false
@@ -108,7 +108,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async throws -> Transformed
+      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -58,7 +58,7 @@ extension AsyncSequence {
   ///   produced by the `transform` closure.
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @escaping (Element) async throws -> Transformed
+    _ transform: @Sendable @escaping (Element) async throws -> Transformed
   ) -> AsyncThrowingMapSequence<Self, Transformed> {
     return AsyncThrowingMapSequence(self, transform: transform)
   }
@@ -72,12 +72,12 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   let base: Base
 
   @usableFromInline
-  let transform: (Base.Element) async throws -> Transformed
+  let transform: @Sendable (Base.Element) async throws -> Transformed
 
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @escaping (Base.Element) async throws -> Transformed
+    transform: @Sendable @escaping (Base.Element) async throws -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -100,7 +100,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let transform: (Base.Element) async throws -> Transformed
+    let transform: @Sendable (Base.Element) async throws -> Transformed
 
     @usableFromInline
     var finished = false
@@ -108,7 +108,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @escaping (Base.Element) async throws -> Transformed
+      transform: @Sendable @escaping (Base.Element) async throws -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -140,3 +140,14 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
+
+
+extension AsyncThrowingMapSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable, 
+        Transformed: Sendable { }
+
+extension AsyncThrowingMapSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable, 
+        Transformed: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -56,9 +56,10 @@ extension AsyncSequence {
   ///   ends the transformed sequence.
   /// - Returns: An asynchronous sequence that contains, in order, the elements
   ///   produced by the `transform` closure.
+  @preconcurrency
   @inlinable
   public __consuming func map<Transformed>(
-    _ transform: @preconcurrency @Sendable @escaping (Element) async throws -> Transformed
+    _ transform: @Sendable @escaping (Element) async throws -> Transformed
   ) -> AsyncThrowingMapSequence<Self, Transformed> {
     return AsyncThrowingMapSequence(self, transform: transform)
   }
@@ -71,13 +72,15 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let transform: @preconcurrency @Sendable (Base.Element) async throws -> Transformed
+  let transform: @Sendable (Base.Element) async throws -> Transformed
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Transformed
+    transform: @Sendable @escaping (Base.Element) async throws -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -99,16 +102,18 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let transform: @preconcurrency @Sendable (Base.Element) async throws -> Transformed
+    let transform: @Sendable (Base.Element) async throws -> Transformed
 
     @usableFromInline
     var finished = false
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Transformed
+      transform: @Sendable @escaping (Base.Element) async throws -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -141,12 +141,13 @@ extension AsyncThrowingMapSequence: AsyncSequence {
   }
 }
 
-
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingMapSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingMapSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -72,15 +72,13 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let transform: @Sendable (Base.Element) async throws -> Transformed
+  let transform: (Base.Element) async throws -> Transformed
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    transform: @Sendable @escaping (Base.Element) async throws -> Transformed
+    transform: @escaping (Base.Element) async throws -> Transformed
   ) {
     self.base = base
     self.transform = transform
@@ -102,18 +100,16 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let transform: @Sendable (Base.Element) async throws -> Transformed
+    let transform: (Base.Element) async throws -> Transformed
 
     @usableFromInline
     var finished = false
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      transform: @Sendable @escaping (Base.Element) async throws -> Transformed
+      transform: @escaping (Base.Element) async throws -> Transformed
     ) {
       self.baseIterator = baseIterator
       self.transform = transform
@@ -147,13 +143,13 @@ extension AsyncThrowingMapSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingMapSequence: Sendable 
+extension AsyncThrowingMapSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingMapSequence.Iterator: Sendable 
+extension AsyncThrowingMapSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable, 
         Transformed: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -52,7 +52,7 @@ extension AsyncSequence {
   ///   the error.
   @inlinable
   public __consuming func prefix(
-    while predicate: @Sendable @escaping (Element) async throws -> Bool
+    while predicate: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
   ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
     return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
   }
@@ -67,12 +67,12 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async throws -> Bool
+  let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -98,12 +98,12 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async throws -> Bool
+    let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -140,11 +140,12 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
   }
 }
 
-
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingPrefixWhileSequence: Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 extension AsyncThrowingPrefixWhileSequence.Iterator: Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -67,15 +67,13 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
-  @preconcurrency
   @usableFromInline
-  let predicate: @Sendable (Base.Element) async throws -> Bool
+  let predicate: (Base.Element) async throws -> Bool
 
-  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -100,15 +98,13 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
-    @preconcurrency
     @usableFromInline
-    let predicate: @Sendable (Base.Element) async throws -> Bool
+    let predicate: (Base.Element) async throws -> Bool
 
-    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -146,11 +142,11 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingPrefixWhileSequence: Sendable 
+extension AsyncThrowingPrefixWhileSequence: @unchecked Sendable 
   where Base: Sendable, 
         Base.Element: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-extension AsyncThrowingPrefixWhileSequence.Iterator: Sendable 
+extension AsyncThrowingPrefixWhileSequence.Iterator: @unchecked Sendable 
   where Base.AsyncIterator: Sendable, 
         Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -52,7 +52,7 @@ extension AsyncSequence {
   ///   the error.
   @inlinable
   public __consuming func prefix(
-    while predicate: @escaping (Element) async throws -> Bool
+    while predicate: @Sendable @escaping (Element) async throws -> Bool
   ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
     return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
   }
@@ -67,12 +67,12 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   let base: Base
 
   @usableFromInline
-  let predicate: (Base.Element) async throws -> Bool
+  let predicate: @Sendable (Base.Element) async throws -> Bool
 
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @escaping (Base.Element) async throws -> Bool
+    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -98,12 +98,12 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     var baseIterator: Base.AsyncIterator
 
     @usableFromInline
-    let predicate: (Base.Element) async throws -> Bool
+    let predicate: @Sendable (Base.Element) async throws -> Bool
 
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @escaping (Base.Element) async throws -> Bool
+      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate
@@ -139,3 +139,12 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     return Iterator(base.makeAsyncIterator(), predicate: predicate)
   }
 }
+
+
+extension AsyncThrowingPrefixWhileSequence: Sendable 
+  where Base: Sendable, 
+        Base.Element: Sendable { }
+
+extension AsyncThrowingPrefixWhileSequence.Iterator: Sendable 
+  where Base.AsyncIterator: Sendable, 
+        Base.Element: Sendable { }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -50,9 +50,10 @@ extension AsyncSequence {
   ///   of the base sequence that satisfy the given predicate. If the predicate
   ///   throws an error, the sequence contains only values produced prior to
   ///   the error.
+  @preconcurrency
   @inlinable
   public __consuming func prefix(
-    while predicate: @preconcurrency @Sendable @escaping (Element) async throws -> Bool
+    while predicate: @Sendable @escaping (Element) async throws -> Bool
   ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
     return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
   }
@@ -66,13 +67,15 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
 
+  @preconcurrency
   @usableFromInline
-  let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
+  let predicate: @Sendable (Base.Element) async throws -> Bool
 
+  @preconcurrency
   @usableFromInline
   init(
     _ base: Base, 
-    predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+    predicate: @Sendable @escaping (Base.Element) async throws -> Bool
   ) {
     self.base = base
     self.predicate = predicate
@@ -97,13 +100,15 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 
+    @preconcurrency
     @usableFromInline
-    let predicate: @preconcurrency @Sendable (Base.Element) async throws -> Bool
+    let predicate: @Sendable (Base.Element) async throws -> Bool
 
+    @preconcurrency
     @usableFromInline
     init(
       _ baseIterator: Base.AsyncIterator, 
-      predicate: @preconcurrency @Sendable @escaping (Base.Element) async throws -> Bool
+      predicate: @Sendable @escaping (Base.Element) async throws -> Bool
     ) {
       self.baseIterator = baseIterator
       self.predicate = predicate

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -986,7 +986,7 @@ extension AsyncSequence where Element: Equatable {
     }
 
     AsyncFlatMapSequenceTests.test("flat map throwing inner") {
-      func buildSubSequence(
+      @Sendable func buildSubSequence(
         _ start: Int
       ) -> AsyncThrowingMapSequence<AsyncLazySequence<Range<Int>>, Int> {
         return (start..<4).async.map { (value: Int) throws -> Int in
@@ -1020,7 +1020,7 @@ extension AsyncSequence where Element: Equatable {
     }
 
     AsyncFlatMapSequenceTests.test("flat map throwing inner on throwing outer") {
-      func buildSubSequence(
+      @Sendable func buildSubSequence(
         _ start: Int
       ) throws -> AsyncThrowingMapSequence<AsyncLazySequence<Range<Int>>, Int> {
         return (start..<4).async.map { (value: Int) throws -> Int in

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -50,6 +50,12 @@
 // UNSUPPORTED: swift_evolve
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
+Func AsyncSequence.compactMap(_:) is now with @preconcurrency
+Func AsyncSequence.drop(while:) is now with @preconcurrency
+Func AsyncSequence.filter(_:) is now with @preconcurrency
+Func AsyncSequence.flatMap(_:) is now with @preconcurrency
+Func AsyncSequence.map(_:) is now with @preconcurrency
+Func AsyncSequence.prefix(while:) is now with @preconcurrency
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
 Struct CheckedContinuation has removed conformance to UnsafeSendable


### PR DESCRIPTION
This corrects Sendable annotations for the following types (and their iterators and closures):

AsyncCompactMapSequence
AsyncDropFirstSequence
AsyncDropWhileSequence
AsyncFilterSequence
AsyncFlatMapSequence
AsyncMapSequence
AsyncPrefixSequence
AsyncPrefixWhileSequence
AsyncThrowingCompactMapSequence
AsyncThrowingDropWhileSequence
AsyncThrowingFilterSequence
AsyncThrowingMapSequence
AsyncThrowingPrefixWhileSequence

Conditionally, if an AsyncSequence is based on a Sendable AsyncSequence and the produced element is Sendable then that composed AsyncSequence should be Sendable. Same applies to the iterator.