### PR TITLE
GSB: Fix null pointer dereference in involvesNonSelfSubjectTypes() [5.6]

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5834,7 +5834,7 @@ void GenericSignatureBuilder::checkIfRequirementCanBeDerived(
 }
 
 static bool involvesNonSelfSubjectTypes(const RequirementSource *source) {
-  while (source->kind != RequirementSource::RequirementSignatureSelf) {
+  while (source && source->kind != RequirementSource::RequirementSignatureSelf) {
     if (source->isProtocolRequirement() &&
         !source->getStoredType()->is<GenericTypeParamType>())
       return true;

--- a/test/Generics/sr15792.swift
+++ b/test/Generics/sr15792.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift %s
+
+protocol Collection {
+  associatedtype SubSequence: Collection
+}
+
+protocol BidirectionalCollection: Collection where SubSequence: BidirectionalCollection {}
+
+struct Slice<Base : Collection> : Collection {
+  typealias SubSequence = Slice<Base>
+}
+
+extension Slice: BidirectionalCollection where Base : BidirectionalCollection {}
+
+protocol SlicedCollection: BidirectionalCollection where SubSequence == Slice<Self> {}


### PR DESCRIPTION
If we have a RequirementSource here that's not rooted in a
RequirementSignatureSelf, we would dereference a null pointer
instead of ending the loop early.

The only way such a RequirementSource can appear is from
inferConditionalRequirements().

This crash does not occur on the main branch, because
inferConditionalRequirements() is no longer performed inside
protocols there because the RequirementMachine can't support it.

A better fix would be to change inferConditionalRequirements() to
build the proper RequirementSource in this case, but I'm going
with a narrow fix since the GenericSignatureBuilder is going away
on the main branch at some point.

Fixes <rdar://problem/88474300> and <https://bugs.swift.org/browse/SR-15792>.
