### PR TITLE
Turn build-swift-stdlib-static-print on for freestanding preset

### DIFF
--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -14,6 +14,10 @@ if(SWIFT_ENABLE_REFLECTION)
   list(APPEND swift_stdlib_unittest_compile_flags "-DSWIFT_ENABLE_REFLECTION")
 endif()
 
+if(SWIFT_STDLIB_STATIC_PRINT)
+  list(APPEND swift_stdlib_unittest_compile_flags "-D" "SWIFT_STDLIB_STATIC_PRINT")
+endif()
+
 set(swift_stdlib_unittest_link_libraries "")
 set(swift_stdlib_unittest_modules "")
 if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -304,3 +304,16 @@ public func dump<T, TargetStream: TextOutputStream>(_ value: T, to target: inout
 }
 
 #endif
+
+#if SWIFT_STDLIB_STATIC_PRINT
+
+public func print(_ s: Any, terminator: String = "\n") {
+  let data = Array("\(s)\(terminator)".utf8)
+  write(STDOUT_FILENO, data, data.count)
+}
+
+public func print<Target>(_ s: Any, terminator: String = "\n", to output: inout Target) where Target : TextOutputStream {
+  output.write("\(s)\(terminator)")
+}
+
+#endif

--- a/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
+++ b/stdlib/private/SwiftPrivateLibcExtras/CMakeLists.txt
@@ -3,6 +3,10 @@ if(SWIFT_STDLIB_HAS_ENVIRON)
   set(swift_private_libc_extras_flags "-D" "SWIFT_STDLIB_HAS_ENVIRON")
 endif()
 
+if(SWIFT_STDLIB_STATIC_PRINT)
+  list(APPEND swift_private_libc_extras_flags "-D" "SWIFT_STDLIB_STATIC_PRINT")
+endif()
+
 set(swift_private_libc_extras_incorporate_object_libraries)
 if(SWIFT_STDLIB_HAS_COMMANDLINE)
   list(APPEND swift_private_libc_extras_flags "-D" "SWIFT_STDLIB_HAS_COMMANDLINE")

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -244,6 +244,13 @@ var environ: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?> {
 }
 #endif
 
+#if SWIFT_STDLIB_STATIC_PRINT
+func print(_ s: String) {
+  let data = Array("\(s)\n".utf8)
+  write(STDOUT_FILENO, data, data.count)
+}
+#endif
+
 /// Start the same executable as a child process, redirecting its stdout and
 /// stderr.
 public func spawnChild(_ args: [String])

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -98,6 +98,7 @@ extension Collection {
   internal func _makeCollectionDescription(
     withTypeName type: String? = nil
   ) -> String {
+#if !SWIFT_STDLIB_STATIC_PRINT
     var result = ""
     if let type = type {
       result += "\(type)(["
@@ -116,6 +117,9 @@ extension Collection {
     }
     result += type != nil ? "])" : "]"
     return result
+#else
+    return "(collection printing not available)"
+#endif
   }
 }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1677,6 +1677,7 @@ extension Collection {
   internal func _makeKeyValuePairDescription<K, V>(
     withTypeName type: String? = nil
   ) -> String where Element == (key: K, value: V) {
+#if !SWIFT_STDLIB_STATIC_PRINT
     if self.isEmpty {
       return "[:]"
     }
@@ -1695,6 +1696,9 @@ extension Collection {
     }
     result += "]"
     return result
+#else
+    return "(collection printing not available)"
+#endif
   }
 }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -295,10 +295,14 @@ extension Optional: CustomDebugStringConvertible {
   public var debugDescription: String {
     switch self {
     case .some(let value):
+#if !SWIFT_STDLIB_STATIC_PRINT
       var result = "Optional("
       debugPrint(value, terminator: "", to: &result)
       result += ")"
       return result
+#else
+    return "(optional printing not available)"
+#endif
     case .none:
       return "nil"
     }

--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !SWIFT_STDLIB_STATIC_PRINT
+
 /// Writes the textual representations of the given items into the standard
 /// output.
 ///
@@ -247,3 +249,5 @@ internal func _debugPrint<Target: TextOutputStream>(
   }
   output.write(terminator)
 }
+
+#endif

--- a/stdlib/public/core/REPL.swift
+++ b/stdlib/public/core/REPL.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !SWIFT_STDLIB_STATIC_PRINT
+
 /// Print a string as is to stdout.
 public // COMPILER_INTRINSIC
 func _replPrintLiteralString(_ text: String) {
@@ -22,3 +24,5 @@ public // COMPILER_INTRINSIC
 func _replDebugPrintln<T>(_ value: T) {
   debugPrint(value)
 }
+
+#endif

--- a/test/SILOptimizer/StaticVPrintFMandatoryOptTest.swift
+++ b/test/SILOptimizer/StaticVPrintFMandatoryOptTest.swift
@@ -14,7 +14,7 @@ import Foundation
 // CHECK-LABEL: @${{.*}}testSimpleInterpolationyy
 func testSimpleInterpolation() {
   let x = "World"
-  constant_vprintf("Hello \(5) \(x)")
+  print("Hello \(5) \(x)")
   // Match the format string. For now we don't expect all allocations to be avoided
   // CHECK: string_literal utf8 "Hello %ld %s"
 }

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -3,6 +3,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// UNSUPPORTED: freestanding
 
 import StdlibUnittest
 

--- a/test/stdlib/Map.swift
+++ b/test/stdlib/Map.swift
@@ -39,18 +39,29 @@ print("testing...")
 // Test mapping a collection
 // CHECK-NEXT: [6, 9, 12, 15, 18, 21]
 let a = Array((2..<8).lazy.map { $0 * 3 })
-print(a)
+do {
+  var output = ""
+  var prefix = ""
+  for x in a {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
+
 
 // Test mapping a sequence
 let s = a.makeIterator().lazy.map { $0 / 3 }
 // CHECK-NEXT: <2, 3, 4, 5, 6, 7>
-print("<", terminator: "")
-var prefix = ""
-for x in s {
-  print("\(prefix)\(x)", terminator: "")
-  prefix = ", "
+do {
+  var output = ""
+  var prefix = ""
+  for x in s {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("<\(output)>")
 }
-print(">")
 
 //===--- Avoid creating gratuitously self-destructive sequences -----------===//
 
@@ -94,11 +105,27 @@ struct IntRange : Sequence {
 // consuming it.
 let m1 = IntRange(start: 1, end: 5).lazy.map { $0 * 2 }
 // CHECK-NEXT: [2, 4, 6, 8]
-print(Array(m1))
+do {
+  var output = ""
+  var prefix = ""
+  for x in m1 {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
 
 // A second iteration produces the same result.
 // CHECK-NEXT: [2, 4, 6, 8]
-print(Array(m1))
+do {
+  var output = ""
+  var prefix = ""
+  for x in m1 {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
 
 // CHECK-NEXT: all done.
 print("all done.")

--- a/test/stdlib/Reduce.swift
+++ b/test/stdlib/Reduce.swift
@@ -22,19 +22,27 @@ let numberSum = numbers.reduce(0, { x, y in
   x + y
 })
 // CHECK-NEXT: 10
-print(numberSum)
+print("\(numberSum)")
 
 let letters = "abracadabra"
 let letterCount = letters.reduce(into: [:]) { counts, letter in
   counts[letter, default: 0] += 1
 }
 // CHECK-NEXT: ["a", "b", "c", "d", "r"]
-print(letterCount.keys.sorted())
-print(letterCount["a"]!) // CHECK: 5
-print(letterCount["b"]!) // CHECK: 2
-print(letterCount["c"]!) // CHECK: 1
-print(letterCount["d"]!) // CHECK: 1
-print(letterCount["r"]!) // CHECK: 2
+do {
+  var output = ""
+  var prefix = ""
+  for x in letterCount.keys.sorted() {
+    output += "\(prefix)\"\(x)\""
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
+print("\(letterCount["a"]!)") // CHECK: 5
+print("\(letterCount["b"]!)") // CHECK: 2
+print("\(letterCount["c"]!)") // CHECK: 1
+print("\(letterCount["d"]!)") // CHECK: 1
+print("\(letterCount["r"]!)") // CHECK: 2
 
 
 // Test the two reduce methods with different levels of inference
@@ -43,36 +51,36 @@ let numbers2 = Array(2..<7)
 // Test reduce(_:_:)
 // CHECK-NEXT: 20
 let sum1 = numbers2.reduce(0) { (x: Int, y: Int) -> Int in x + y }
-print(sum1)
+print("\(sum1)")
 
 // CHECK-NEXT: 20
 let sum2 = numbers2.reduce(0) { (x, y) in x + y }
-print(sum2)
+print("\(sum2)")
 
 // CHECK-NEXT: 20
 let sum3 = numbers2.reduce(0) { $0 + $1 }
-print(sum3)
+print("\(sum3)")
 
 // CHECK-NEXT: 20
 let sum4 = numbers2.reduce(0, +)
-print(sum4)
+print("\(sum4)")
 
 // Test reduce(into:_:)
 // CHECK-NEXT: 20
 let sum5 = numbers2.reduce(into: 0) { (x: inout Int, y: Int) in x += y }
-print(sum5)
+print("\(sum5)")
 
 // CHECK-NEXT: 20
 let sum6 = numbers2.reduce(into: 0) { x, y in x += y }
-print(sum6)
+print("\(sum6)")
 
 // CHECK-NEXT: 20
 let sum7 = numbers2.reduce(into: 0) { $0 += $1 }
-print(sum7)
+print("\(sum7)")
 
 // CHECK-NEXT: 20
 let sum8 = numbers2.reduce(into: 0, +=)
-print(sum8)
+print("\(sum8)")
 
 
 // Test that the initial value remains unmodified
@@ -81,9 +89,25 @@ let result = numbers2.reduce(into: original) { acc, x in
   acc.append(x)
 }
 // CHECK-NEXT: [0, 1]
-print(original)
+do {
+  var output = ""
+  var prefix = ""
+  for x in original {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
 // CHECK-NEXT: [0, 1, 2, 3, 4, 5, 6]
-print(result)
+do {
+  var output = ""
+  var prefix = ""
+  for x in result {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
+}
 
 
 // CHECK: all done.

--- a/test/stdlib/StaticPrint.swift
+++ b/test/stdlib/StaticPrint.swift
@@ -18,14 +18,14 @@ let PrintTests = TestSuite("StaticPrint")
 // CHECK: string_literal utf8 ", world"
 // CHECK: string_literal utf8 "hello, world 5"
 PrintTests.test("StringInterpolation") {
-  constant_vprintf("")
-  constant_vprintf("hello")
-  constant_vprintf("\(5)")
+  print("")
+  print("hello")
+  print("\(5)")
   let x = 5
-  constant_vprintf("\(x)")
+  print("\(x)")
   let y = ", world"
-  constant_vprintf("\(y)")
-  constant_vprintf("hello \(y)\(x)")
+  print("\(y)")
+  print("hello \(y)\(x)")
 }
 
 runAllTests()

--- a/test/stdlib/StaticPrintDisabled.swift
+++ b/test/stdlib/StaticPrintDisabled.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s                   -I %t -o %t/a1.out -O && %target-run %t/a1.out | %FileCheck %s
-// RUN: %target-build-swift %s -D PRINT_DISABLED -I %t -o %t/a2.out -O && %target-run %t/a2.out | %FileCheck %s --check-prefix CHECK-PRINT-DISABLED --allow-empty
+// RUN: %target-build-swift %s                                -I %t -o %t/a1.out -O && %target-run %t/a1.out | %FileCheck %s
+// RUN: %target-build-swift %s -D SWIFT_STDLIB_PRINT_DISABLED -I %t -o %t/a2.out -O && %target-run %t/a2.out | %FileCheck %s --check-prefix CHECK-PRINT-DISABLED --allow-empty
 
 // REQUIRES: executable_test
 // REQUIRES: stdlib_static_print
 
 let x = 42
 let s = "ABCDE"
-constant_vprintf("Hello World \(5) \(x) \(s)")
+print("Hello World \(5) \(x) \(s)")
 
 // CHECK: Hello World 5 42 ABCDE
 // CHECK-PRINT-DISABLED-NOT: Hello World

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -171,4 +171,4 @@ test_varArgs6()
 
 
 // CHECK: done.
-print("done.")
+my_printf("done.")

--- a/test/stdlib/builtin-ifdef.swift
+++ b/test/stdlib/builtin-ifdef.swift
@@ -22,7 +22,7 @@
   @_cdecl("main")
   func main() -> Int32 {
     print("Hello")
-    print(Bool(_builtinBooleanLiteral: ifdefFooBar()))
+    print("\(Bool(_builtinBooleanLiteral: ifdefFooBar()))")
     // CHECK: Hello
     // CHECK: false
 

--- a/test/stdlib/sort_integers.swift
+++ b/test/stdlib/sort_integers.swift
@@ -49,7 +49,13 @@ func randomize(_ size: Int, _ verify: ([Int]) -> Void) {
 
 // Verify the permute method itself:
 let printer: ([Int]) -> Void = {
-  print($0)
+  var output = ""
+  var prefix = ""
+  for x in $0 {
+    output += "\(prefix)\(x)"
+    prefix = ", "
+  }
+  print("[\(output)]")
 }
 //CHECK: [0, 1, 2]
 //CHECK: [0, 2, 1]
@@ -86,7 +92,7 @@ let partition_verifier: ([Int]) -> Void = {
     // the pivot value.
     for i in 0..<idx {
       if y[i] >= first! {
-        print("Error!\n", terminator: "")
+        print("Error!")
         return
       }
     }
@@ -94,7 +100,7 @@ let partition_verifier: ([Int]) -> Void = {
     // equal to the pivot value.
     for i in idx..<y.count - 1 {
       if y[i] < first! {
-        print("Error!\n", terminator: "")
+        print("Error!")
         return
       }
     }

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2506,6 +2506,7 @@ verbose-build
 
 [preset: mixin_stdlib_minimal]
 enable-experimental-differentiable-programming=0
+swift-enable-experimental-string-processing=0
 enable-experimental-concurrency=1
 enable-experimental-distributed=0
 build-swift-dynamic-sdk-overlay=0
@@ -2537,6 +2538,7 @@ swift-stdlib-experimental-hermetic-seal-at-link=1
 swift-stdlib-disable-instantiation-caches=1
 swift-stdlib-has-type-printing=0
 build-swift-stdlib-unicode-data=0
+build-swift-stdlib-static-print=1
 
 [preset: stdlib_S_standalone_minimal_macho_x86_64,build]
 mixin-preset=

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -990,7 +990,7 @@ def create_argument_parser():
            help='Build optional StdlibUnittest components')
 
     option('--build-swift-stdlib-static-print', toggle_true,
-           help='Build constant_vprintf support')
+           help='Build constant-folding print() support')
 
     option('--build-swift-stdlib-unicode-data', toggle_true,
            default=True,

--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -48,7 +48,7 @@ common_expected_dependencies = [
     "_malloc_size", "_memchr", "_memcmp", "_memcpy", "_memmove", "_memset",
     "_posix_memalign", "_putc", "_read", "_realloc", "_snprintf", "_strchr",
     "_strcmp", "_strdup", "_strlen", "_strncmp", "_strtod", "_strtof",
-    "_strtol", "_strtold", "_vsnprintf", "_write",
+    "_strtol", "_strtold", "_vprintf", "_vsnprintf", "_write",
 ] + cxx_dependencies + math_dependencies
 vendor_apple_specific_dependencies = [
     "___stack_chk_fail", "___stack_chk_guard",


### PR DESCRIPTION
Several small independent changes here:
- Turn build-swift-stdlib-static-print=1 for freestanding preset.
- Make constant_vprintf append "\n" to the end of each print.
- Fix a bug in constant_vprintf_backend where it wouldn't print if there are 0 argument closures.
- Rename constant_vprintf() to just print().
- Ifdef out other instances of stdlib using print() or debugPrint().
- Change the "PRINT_DISABLED" client side flag that disables printing into a more verbose "SWIFT_STDLIB_PRINT_DISABLED".
- Since the "regular" print() is now gone from the stdlib on freestanding, add private implementations into testing libraries (StdlibUnittest, SwiftPrivateLibcExtras)
- Add vprintf as an allowed dependency for freestanding.
