### PR TITLE
Implicitly set -enable-lexical-lifetimes=false for the Swift standard library

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1560,8 +1560,15 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     }
   }
 
-  // Implicitly disable lexical lifetimes for the Swift module.
-  if (!enableLexicalLifetimesFlag && FEOpts.ModuleName == "Swift") {
+  // Implicitly disable lexical lifetimes for the Swift modules and helpers.
+  if (!enableLexicalLifetimesFlag &&
+      (FEOpts.ModuleName == "Swift" ||
+       FEOpts.ModuleName == "_Concurrency" ||
+       FEOpts.ModuleName == "_Distributed" ||
+       FEOpts.ModuleName == "_MatchingEngine" ||
+       FEOpts.ModuleName == "_StringProcessing" ||
+       FEOpts.ModuleName == "SwiftOnoneSupport" ||
+       FEOpts.ModuleName == "OSLogTestHelper")) {
     enableLexicalLifetimesFlag = false;
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1560,6 +1560,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     }
   }
 
+  // Implicitly disable lexical lifetimes for the Swift module.
+  if (!enableLexicalLifetimesFlag && FEOpts.ModuleName == "Swift") {
+    enableLexicalLifetimesFlag = false;
+  }
+
   if (enableLexicalLifetimesFlag.getValueOr(false) &&
       !enableLexicalBorrowScopesFlag.getValueOr(true)) {
     // Error if lexical lifetimes have been enabled but lexical borrow scopes--

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1723,7 +1723,6 @@ function(add_swift_target_library name)
   if (SWIFTLIB_IS_STDLIB)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
-    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
   endif()
 
   if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER AND NOT BUILD_STANDALONE AND


### PR DESCRIPTION
Older compilers cannot handle this flag.

Fixes rdar://88605521