### PR TITLE
build-presets: remove -sil-verify-all from PR testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1600,9 +1600,6 @@ skip-build-tvos
 skip-test-tvos
 skip-test-tvos-host
 
-# Run the SIL verifier after each transform when building swift files
-sil-verify-all
-
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
 skip-test-ios-host


### PR DESCRIPTION
Building the stdlibs with -sil-verify-all takes a very long time. To speed up PR testing, don't build with -sil-verify-all.
Note that we still have pther jobs with -sil-verify-all to catch seldom regressions which are not caught with the standard verification.
