### PR TITLE
[Build System] Don't clean sourcekit-lsp prior to running tests

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -76,7 +76,7 @@ class IndexStoreDB(product.Product):
 
 
 def run_build_script_helper(action, host_target, product, args,
-                            sanitize_all=False):
+                            sanitize_all=False, clean=True):
     script_path = os.path.join(
         product.source_dir, 'Utilities', 'build-script-helper.py')
 
@@ -104,6 +104,9 @@ def run_build_script_helper(action, host_target, product, args,
         helper_cmd.extend(['--sanitize', 'undefined'])
     elif args.enable_tsan:
         helper_cmd.extend(['--sanitize', 'thread'])
+
+    if not clean:
+        helper_cmd.append('--no-clean')
 
     if not product.is_darwin_host(
             host_target) and product.is_cross_compile_target(host_target):

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -50,14 +50,14 @@ class SourceKitLSP(product.Product):
     def test(self, host_target):
         indexstoredb.run_build_script_helper(
             'test', host_target, self, self.args,
-            self.args.test_sourcekitlsp_sanitize_all)
+            self.args.test_sourcekitlsp_sanitize_all, clean=False)
 
     def should_install(self, host_target):
         return self.args.install_sourcekitlsp
 
     def install(self, host_target):
         indexstoredb.run_build_script_helper(
-            'install', host_target, self, self.args)
+            'install', host_target, self, self.args, clean=False)
 
     @classmethod
     def get_dependencies(cls):


### PR DESCRIPTION
Previously, we were always cleaning the sourcekit-lsp build directory prior to running tests and installing. That’s a waste of time. Only clean prior to the first build.

rdar://82448307