### PR TITLE
[5.6] Propagate response files correctly to the new driver.

### DIFF
--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -184,7 +184,8 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
 }
 
 static int run_driver(StringRef ExecName,
-                       const ArrayRef<const char *> argv) {
+                       const ArrayRef<const char *> argv,
+                       const ArrayRef<const char *> originalArgv) {
   // This is done here and not done in FrontendTool.cpp, because
   // FrontendTool.cpp is linked to tools, which don't use libswift.
   initializeLibSwift();
@@ -244,7 +245,8 @@ static int run_driver(StringRef ExecName,
       subCommandArgs.push_back(NewDriverPath.c_str());
 
       // Push on the source program arguments
-      subCommandArgs.insert(subCommandArgs.end(), argv.begin() + 1, argv.end());
+      subCommandArgs.insert(subCommandArgs.end(),
+                            originalArgv.begin() + 1, originalArgv.end());
 
       // Execute the subcommand.
       subCommandArgs.push_back(nullptr);
@@ -393,12 +395,13 @@ int swift::mainEntry(int argc_, const char **argv_) {
     return 2;
   }
 
+  ArrayRef<const char *> originalArgv(argv_, &argv_[argc_]);
   if (isRepl) {
     // Preserve argv for the stack trace.
     SmallVector<const char *, 256> replArgs(argv.begin(), argv.end());
     replArgs.erase(&replArgs[1]);
-    return run_driver(ExecName, replArgs);
+    return run_driver(ExecName, replArgs, originalArgv);
   } else {
-    return run_driver(ExecName, argv);
+    return run_driver(ExecName, argv, originalArgv);
   }
 }

--- a/test/Driver/LegacyDriver/Inputs/print-args.sh
+++ b/test/Driver/LegacyDriver/Inputs/print-args.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+for arg in "$@" ; do
+  echo "$arg"
+done

--- a/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
+++ b/test/Driver/LegacyDriver/legacy-driver-propagates-response-file-to-new-driver.swift
@@ -1,0 +1,17 @@
+// Verify that when the legacy driver (swift-frontend executable invoked as
+// swiftc) spawns the new driver, it passes the original arguments (i.e.,
+// preserving response files) instead of trying to spawn the process with the
+// expansion, which may exceed `ARG_MAX`.
+
+// REQUIRES: shell
+// RUN: %{python} -c 'for i in range(500001): print("-DTEST5_" + str(i))' > %t.resp
+// RUN: cp %S/Inputs/print-args.sh %swift_obj_root/bin/legacy-driver-propagates-response-file.sh
+// RUN: env SWIFT_USE_NEW_DRIVER=legacy-driver-propagates-response-file.sh %swiftc_driver_plain %s @%t.resp | %FileCheck %s
+// RUN: rm %swift_obj_root/bin/legacy-driver-propagates-response-file.sh
+
+// CHECK:      -Xfrontend
+// CHECK-NEXT: -new-driver-path
+// CHECK-NEXT: -Xfrontend
+// CHECK-NEXT: legacy-driver-propagates-response-file.sh
+// CHECK:      @{{.*}}.resp
+// CHECK-NOT:  -DTEST5_{{.*}}

--- a/test/Driver/LegacyDriver/lit.local.cfg
+++ b/test/Driver/LegacyDriver/lit.local.cfg
@@ -1,0 +1,7 @@
+# Make a local copy of the environment.
+config.environment = dict(config.environment)
+
+# Remove the settings that force tests to use the old driver so that tests
+# in this directory can set `SWIFT_USE_NEW_DRIVER` to test those code paths.
+del config.environment['SWIFT_USE_OLD_DRIVER']
+del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']


### PR DESCRIPTION
Cherry pick of #39493 for Swift 5.6.

Summary from original PR:

> If a response file is being passed to the legacy driver because it is too large to fit on the system's command line, then it should also be passed when spawning the new driver. Currently, however, the legacy driver attempts to pass the expanded arguments to the new driver, which can cause the invocation to fail, requiring the new driver to be disabled in order to compile.

[The corresponding change in apple/swift-driver](https://github.com/apple/swift-driver/pull/854/commits/df0e9e195f844d5700225445465346324b594376) was landed early enough that it's already in the 5.6 release branch.

@DougGregor, can you please take a look?