### PR TITLE
[swift-inspect] Fix errors when targeting 32-bit.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
@@ -26,7 +26,7 @@ struct Backtrace {
     ptr: swift_reflection_ptr_t,
     inspector: Inspector
   ) -> String {
-    let symbol = inspector.getSymbol(address: ptr)
+    let symbol = inspector.getSymbol(address: swift_addr_t(ptr))
     let name = symbol.name ?? "<unknown>"
     let library = symbol.library ?? "<unknown>"
     return "\(hex: ptr) (\(library)) \(name)"

--- a/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Inspector.swift
@@ -52,6 +52,12 @@ class Inspector {
       return 0
     }
 
+#if os(tvOS) || os(watchOS)
+    if tryForkCorpse {
+      print("warning: unable to generate corpse on this OS")
+    }
+    return task
+#else
     if !tryForkCorpse {
       return task
     }
@@ -66,6 +72,7 @@ class Inspector {
       print("warning: unable to generate corpse for pid \(pid): \(machErrStr(kr))", to: &Std.err)
       return task
     }
+#endif
   }
   
   func passContext() -> UnsafeMutableRawPointer {
@@ -129,7 +136,7 @@ class Inspector {
       }
 
       // Deallocate the thread list.
-      let ptr = vm_address_t(bitPattern: threadList)
+      let ptr = vm_address_t(truncatingIfNeeded: Int(bitPattern: threadList))
       let size = vm_size_t(MemoryLayout<thread_t>.size) * vm_size_t(threadCount)
       vm_deallocate(mach_task_self_, ptr, size);
     }

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirrorExtensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirrorExtensions.swift
@@ -62,7 +62,7 @@ extension SwiftReflectionContextRef {
     reader: (swift_addr_t, Int) -> UnsafeRawPointer?
   ) -> UInt? {
     let size = MemoryLayout<UInt>.stride * 3
-    guard let ptr = reader(array, size) else { return nil }
+    guard let ptr = reader(swift_addr_t(array), size) else { return nil }
     let typedPtr = ptr.bindMemory(to: UInt.self, capacity: 3)
     // Array layout goes: metadata, refcount, count
     return typedPtr[2]

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -100,9 +100,9 @@ func dumpArrays(
     guard metadata != 0 else { return }
     guard context.isAContiguousArray(metadata: metadata) else { return }
     let isClass = context.isAContiguousArrayOfClassElementType(metadata: metadata)
-    let count = context.arrayCount(array: pointer, reader: inspector.read)
+    let count = context.arrayCount(array: swift_reflection_ptr_t(pointer), reader: inspector.read)
     let countStr = count.map({ String($0) }) ?? "<unknown>"
-    print("\(hex: pointer)\t\(size)\t\(countStr)\t\(isClass)")
+    print("\(hex: swift_reflection_ptr_t(pointer))\t\(size)\t\(countStr)\t\(isClass)")
   })
 }
 


### PR DESCRIPTION
The C APIs are somewhat inconsistent about what kind of integers they use, so we need a bunch of conversions when targeting 32-bit.