### PR TITLE
Disable IRGen/async/protocol_req_descriptor.swift on arm64e

### DIFF
--- a/test/IRGen/async/protocol_req_descriptor.swift
+++ b/test/IRGen/async/protocol_req_descriptor.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir  -disable-availability-checking %s | %FileCheck -check-prefix CHECK -check-prefix CHECK-%target-cpu -check-prefix CHECK-%target-import-type %s
 // REQUIRES: concurrency
 
+// UNSUPPORTED: CPU=arm64e
+
 // Make sure that the protocol requirement descriptor includes the async flag.
 // CHECK: @"$s23protocol_req_descriptor12RepoProtocolMp" = {{.*}}%swift.protocol_requirement { i32 34, i32 0 }, %swift.protocol_requirement { i32 49, i32 0 } }>
 protocol RepoProtocol {


### PR DESCRIPTION
I would need to test for a different pattern on arm64e.

rdar://88636399