### PR TITLE
Introduce @_backDeploy attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -39,6 +39,15 @@ Most notably, default argument expressions are implicitly
 `@_alwaysEmitIntoClient`, which means that adding a default argument to a
 function which did not have one previously does not break ABI.
 
+## `@_backDeploy(availabilitySpec ...)`
+
+Causes the body of a function to be emitted into the module interface to be
+available for inlining in clients with deployment targets lower than the formal
+availability of the function. When inlined, the body of the function is
+transformed such that it calls the library's copy of the function if it is
+available at runtime. Otherwise, the copy of the original function body is
+executed.
+
 ## `@_assemblyVision`
 
 Forces emission of assembly vision remarks for a function or method, showing

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -713,6 +713,12 @@ DECL_ATTR(exclusivity, Exclusivity,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   128)
 
+DECL_ATTR(_backDeploy, BackDeploy,
+  OnAbstractFunction |
+  AllowMultipleAttributes | LongAttribute | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
+  129)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2172,6 +2172,30 @@ public:
   }
 };
 
+/// The @_backDeploy(...) attribute, used to make function declarations available
+/// for back deployment to older OSes via emission into the client binary.
+class BackDeployAttr: public DeclAttribute {
+public:
+  BackDeployAttr(SourceLoc AtLoc, SourceRange Range,
+                 PlatformKind Platform,
+                 const llvm::VersionTuple Version,
+                 bool Implicit)
+    : DeclAttribute(DAK_BackDeploy, AtLoc, Range, Implicit),
+      Platform(Platform),
+      Version(Version) {}
+
+  /// The platform the symbol is available for back deployment on.
+  const PlatformKind Platform;
+
+  /// The earliest platform version that may use the back deployed implementation.
+  const llvm::VersionTuple Version;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_BackDeploy;
+  }
+};
+
+
 /// Attributes that may be applied to declarations.
 class DeclAttributes {
   /// Linked list of declaration attributes.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1531,6 +1531,15 @@ WARNING(attr_availability_nonspecific_platform_unexpected_version,none,
       "unexpected version number in '%0' attribute for non-specific platform "
       "'*'", (StringRef))
 
+WARNING(attr_availability_wildcard_ignored,none,
+        "* as platform name has no effect in '%0' attribute", (StringRef))
+
+ERROR(attr_availability_need_platform_version,none,
+     "expected at least one platform version in in '%0' attribute", (StringRef))
+
+WARNING(attr_availability_platform_version_major_minor_only,none,
+        "'%0' only uses major and minor version number", (StringRef))
+
 // availability macro
 ERROR(attr_availability_wildcard_in_macro, none,
       "future platforms identified by '*' cannot be used in "
@@ -1548,12 +1557,15 @@ ERROR(attr_availability_duplicate,none,
       (StringRef, StringRef))
 
 // originallyDefinedIn
+// FIXME: Refactor to share between attributes
 ERROR(originally_defined_in_missing_rparen,none,
       "expected ')' in @_originallyDefinedIn argument list", ())
 
+// FIXME: Refactor to share between attributes
 ERROR(originally_defined_in_unrecognized_platform,none,
       "unrecognized platform name in @_originallyDefinedIn argument list", ())
 
+// FIXME: This is unused and can be removed
 ERROR(originally_defined_in_unrecognized_property,none,
       "unrecognized property in @_originallyDefinedIn argument list", ())
 
@@ -1564,15 +1576,19 @@ ERROR(originally_defined_in_need_original_module_name,none,
 ERROR(originally_defined_in_need_nonempty_module_name,none,
       "original module name cannot be empty in @_originallyDefinedIn", ())
 
+// FIXME: Refactor to share between attributes
 ERROR(originally_defined_in_need_platform_version,none,
      "expected at least one platform version in @_originallyDefinedIn", ())
 
+// FIXME: Refactor to share between attributes
 WARNING(originally_defined_in_major_minor_only,none,
         "@_originallyDefinedIn only uses major and minor version number", ())
 
+// FIXME: Refactor to share between attributes
 WARNING(originally_defined_in_missing_platform_name,none,
         "* as platform name has no effect", ())
 
+// FIXME: Refactor to share between attributes
 WARNING(originally_defined_in_swift_version, none,
         "Swift language version checks has no effect "
         "in @_originallyDefinedIn", ())
@@ -1580,6 +1596,10 @@ WARNING(originally_defined_in_swift_version, none,
 WARNING(originally_defined_in_package_description, none,
         "PackageDescription version checks has no effect "
         "in @_originallyDefinedIn", ())
+
+// backDeploy
+ERROR(attr_back_deploy_missing_rparen,none,
+      "expected ')' in '@_backDeploy' argument list", ())
 
 // convention
 ERROR(convention_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1503,6 +1503,8 @@ WARNING(attr_availability_invalid_duplicate,none,
         "'%0' argument has already been specified", (StringRef))
 WARNING(attr_availability_unknown_platform,none,
       "unknown platform '%0' for attribute '%1'", (StringRef, StringRef))
+ERROR(attr_availability_expected_platform,none,
+      "expected platform in '%0' attribute", (StringRef))
 ERROR(attr_availability_invalid_renamed,none,
       "'renamed' argument of '%0' attribute must be an operator, identifier, "
       "or full function name, optionally prefixed by a type name", (StringRef))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1537,7 +1537,7 @@ WARNING(attr_availability_wildcard_ignored,none,
         "* as platform name has no effect in '%0' attribute", (StringRef))
 
 ERROR(attr_availability_need_platform_version,none,
-     "expected at least one platform version in in '%0' attribute", (StringRef))
+     "expected at least one platform version in '%0' attribute", (StringRef))
 
 WARNING(attr_availability_platform_version_major_minor_only,none,
         "'%0' only uses major and minor version number", (StringRef))

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1559,11 +1559,11 @@ ERROR(attr_availability_duplicate,none,
       (StringRef, StringRef))
 
 // originallyDefinedIn
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_defined_in_missing_rparen,none,
       "expected ')' in @_originallyDefinedIn argument list", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_defined_in_unrecognized_platform,none,
       "unrecognized platform name in @_originallyDefinedIn argument list", ())
 
@@ -1578,19 +1578,19 @@ ERROR(originally_defined_in_need_original_module_name,none,
 ERROR(originally_defined_in_need_nonempty_module_name,none,
       "original module name cannot be empty in @_originallyDefinedIn", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_defined_in_need_platform_version,none,
      "expected at least one platform version in @_originallyDefinedIn", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 WARNING(originally_defined_in_major_minor_only,none,
         "@_originallyDefinedIn only uses major and minor version number", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 WARNING(originally_defined_in_missing_platform_name,none,
         "* as platform name has no effect", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 WARNING(originally_defined_in_swift_version, none,
         "Swift language version checks has no effect "
         "in @_originallyDefinedIn", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1597,18 +1597,21 @@ WARNING(option_set_zero_constant,none,
 NOTE(option_set_empty_set_init,none,
      "use [] to silence this warning", ())
 
+// FIXME: Refactor to share between attributes
 ERROR(originally_defined_in_dupe_platform,none,
       "duplicate version number for platform %0", (StringRef))
 
 ERROR(originally_definedin_topleve_decl,none,
       "@%0 is only applicable to top-level decl", (StringRef))
 
+// FIXME: Refactor to share between attributes
 ERROR(originally_definedin_need_available,none,
       "need @available attribute for @%0", (StringRef))
 
 ERROR(originally_definedin_must_not_before_available_version,none,
       "symbols are moved to the current module before they were available in the OSs", (StringRef))
 
+// FIXME: Refactor to share between attributes
 WARNING(originally_defined_in_on_non_public,
        none, "@%0 does not have any effect on "
        "%select{private|fileprivate|internal|%error|%error}1 declarations",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1597,21 +1597,21 @@ WARNING(option_set_zero_constant,none,
 NOTE(option_set_empty_set_init,none,
      "use [] to silence this warning", ())
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_defined_in_dupe_platform,none,
       "duplicate version number for platform %0", (StringRef))
 
 ERROR(originally_definedin_topleve_decl,none,
       "@%0 is only applicable to top-level decl", (StringRef))
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_definedin_need_available,none,
       "need @available attribute for @%0", (StringRef))
 
 ERROR(originally_definedin_must_not_before_available_version,none,
       "symbols are moved to the current module before they were available in the OSs", (StringRef))
 
-// FIXME: Refactor to share between attributes
+// FIXME(backDeploy): Refactor to share with back deployment attr
 WARNING(originally_defined_in_on_non_public,
        none, "@%0 does not have any effect on "
        "%select{private|fileprivate|internal|%error|%error}1 declarations",

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1846,6 +1846,16 @@ public:
                     bool &DiscardAttribute, SourceRange &attrRange,
                     SourceLoc AtLoc, SourceLoc Loc,
                     llvm::function_ref<void(AvailableAttr *)> addAttribute);
+
+  using PlatformAndVersion = std::pair<PlatformKind, llvm::VersionTuple>;
+
+  /// Parse a platform and version tuple (e.g. "macOS 12.0") and append it to the
+  /// given vector. Wildcards ('*') parse successfully but are ignored. Assumes
+  /// that the tuples are part of a comma separated list ending with a trailing
+  /// ')'.
+  ParserStatus parsePlatformVersionInList(StringRef AttrName,
+      llvm::SmallVector<PlatformAndVersion, 4> &PlatformAndVersions);
+
   //===--------------------------------------------------------------------===//
   // Code completion second pass.
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1188,6 +1188,16 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_BackDeploy: {
+    Printer.printAttrName("@_backDeploy");
+    Printer << "(";
+    auto Attr = cast<BackDeployAttr>(this);
+    Printer << platformString(Attr->Platform) << " " <<
+      Attr->Version.getAsString();
+    Printer << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -1356,6 +1366,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_typeSequence";
   case DAK_UnavailableFromAsync:
     return "_unavailableFromAsync";
+  case DAK_BackDeploy:
+    return "_backDeploy";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1300,9 +1300,8 @@ StringRef DeclAttribute::getAttrName() const {
       return "exclusivity(checked)";
     case ExclusivityAttr::Unchecked:
       return "exclusivity(unchecked)";
-    default:
-      llvm_unreachable("Invalid optimization kind");
     }
+    llvm_unreachable("Invalid optimization kind");
   }
   case DAK_Effects:
     switch (cast<EffectsAttr>(this)->getKind()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -118,6 +118,7 @@ public:
   IGNORED_ATTR(InheritActorContext)
   IGNORED_ATTR(Isolated)
   IGNORED_ATTR(Preconcurrency)
+  IGNORED_ATTR(BackDeploy)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {
@@ -275,6 +276,8 @@ public:
   void visitUnavailableFromAsyncAttr(UnavailableFromAsyncAttr *attr);
 
   void visitPrimaryAssociatedTypeAttr(PrimaryAssociatedTypeAttr *attr);
+
+  void checkBackDeployAttrs(Decl *D, ArrayRef<BackDeployAttr *> Attrs);
 };
 
 } // end anonymous namespace
@@ -3458,6 +3461,11 @@ void AttributeChecker::checkOriginalDefinedInAttrs(Decl *D,
       return;
     }
   }
+}
+
+void AttributeChecker::checkBackDeployAttrs(Decl *D,
+    ArrayRef<BackDeployAttr *> Attrs) {
+  // FIXME(backDeploy): Diagnose incompatible uses of `@_backDeploy
 }
 
 Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1567,6 +1567,8 @@ namespace  {
 
     UNINTERESTING_ATTR(PrimaryAssociatedType)
 
+    UNINTERESTING_ATTR(BackDeploy)
+
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4772,6 +4772,21 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::BackDeploy_DECL_ATTR: {
+        bool isImplicit;
+        unsigned Platform;
+        DEF_VER_TUPLE_PIECES(Version);
+        serialization::decls_block::BackDeployDeclAttrLayout::readRecord(
+            scratch, isImplicit, LIST_VER_TUPLE_PIECES(Version), Platform);
+        llvm::VersionTuple Version;
+        DECODE_VER_TUPLE(Version)
+        Attr = new (ctx) BackDeployAttr(SourceLoc(), SourceRange(),
+                                        (PlatformKind)Platform,
+                                        Version,
+                                        isImplicit);
+        break;
+      }
+
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 666; // mark_must_check initial
+const uint16_t SWIFTMODULE_VERSION_MINOR = 667; // @_backDeploy
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2042,6 +2042,13 @@ namespace decls_block {
     UnavailableFromAsync_DECL_ATTR,
     BCFixed<1>, // Implicit flag
     BCBlob      // Message
+  >;
+
+  using BackDeployDeclAttrLayout = BCRecordLayout<
+    BackDeploy_DECL_ATTR,
+    BCFixed<1>,     // implicit flag
+    BC_AVAIL_TUPLE, // OS version
+    BCVBR<5>        // platform
   >;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2581,6 +2581,18 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_BackDeploy: {
+      auto *theAttr = cast<BackDeployAttr>(DA);
+      ENCODE_VER_TUPLE(Version, llvm::Optional<llvm::VersionTuple>(theAttr->Version));
+      auto abbrCode = S.DeclTypeAbbrCodes[BackDeployDeclAttrLayout::Code];
+      BackDeployDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode,
+          theAttr->isImplicit(),
+          LIST_VER_TUPLE_PIECES(Version),
+          static_cast<unsigned>(theAttr->Platform));
+      return;
+    }
+
     case DAK_ObjC: {
       auto *theAttr = cast<ObjCAttr>(DA);
       SmallVector<IdentifierID, 4> pieces;

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -2,8 +2,11 @@
 
 // Ensure @_backDeploy attributes and function bodies are printed in
 // swiftinterface files.
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test %s
+// RUN: %swiftc_driver -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -enable-library-evolution -verify-emitted-module-interface -module-name Test %s
 // RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+
+// FIXME(backDeploy): Remove this step in favor of a test that exercises using
+// a back deployed API from a test library so that we can avoid -merge-modules
 
 // Ensure @_backDeploy attributes and function bodies are present after
 // deserializing .swiftmodule files.

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+
+// Ensure @_backDeploy attributes and function bodies are printed in
+// swiftinterface files.
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test %s
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+
+// Ensure @_backDeploy attributes and function bodies are present after
+// deserializing .swiftmodule files.
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test
+// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
+
+// FIXME(backDeploy): Verify that function bodies are emitted
+
+public struct TopLevelStruct {
+  // CHECK: @_backDeploy(macOS 11.0)
+  // CHECK: public func backDeployedFunc1_SinglePlatform() -> Swift.Int
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0)
+  public func backDeployedFunc1_SinglePlatform() -> Int {
+    return 42
+  }
+  
+  // CHECK: @_backDeploy(macOS 11.0)
+  // CHECK: @_backDeploy(iOS 14.0)
+  // CHECK: public func backDeployedFunc2_MultiPlatform() -> Swift.Int
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0, iOS 14.0)
+  public func backDeployedFunc2_MultiPlatform() -> Int {
+    return 43
+  }
+}
+
+// CHECK: @_backDeploy(macOS 11.0)
+// CHECK: public func backDeployTopLevelFunc() -> Swift.Int
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0)
+public func backDeployTopLevelFunc() -> Int {
+  return 42
+}

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -4,8 +4,6 @@
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
-// FIXME: These shouldn't be different, or we'll get different output from
-// WMO and non-WMO builds.
 // CHECK-LABEL: public struct Foo : Swift.Hashable {
 public struct Foo: Hashable {
   // CHECK: public var inlinableGetPublicSet: Swift.Int {

--- a/test/attr/backDeploy.swift
+++ b/test/attr/backDeploy.swift
@@ -1,0 +1,112 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library
+
+// MARK: - Valid declarations
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0)
+public func backDeployedTopLevelFunc() {}
+
+// FIXME(backDeploy): Availability macros should be supported
+
+public class TopLevelClass {
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0)
+  public func backDeployedMemberFunc() {}
+
+  // FIXME(backDeploy): Computed properties should be supported
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+  public var backDeployedComputedProperty: Int { 98 }
+
+  // FIXME(backDeploy): Subscripts should be supported
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+  subscript(index: Int) -> Int {
+    get { return 1 }
+    set(newValue) {}
+  }
+}
+
+// MARK: - Unsupported declaration types
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+public class CannotBackDeployClass {
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+  public var cannotBackDeploystoredProperty: Int = 83
+}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+public struct CannotBackDeployStruct {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+public enum CannotBackDeployEnum {
+  @available(macOS 12.0, *)
+  @_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+  case cannotBackDeployEnumCase
+}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+public var cannotBackDeployTopLevelVar = 79
+
+// MARK: - Incompatible declarations
+
+// FIXME(backDeploy): Test explicit @available is required
+// FIXME(backDeploy): Test @available is compatible
+// FIXME(backDeploy): Test public is required
+// FIXME(backDeploy): Test @inlinable, @_alwaysEmitIntoClient, @transparent are rejected
+
+// MARK: - Attribute parsing
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
+public func unknownOSFunc() {}
+
+// FIXME(backDeploy): The error here should be specific about the missing version for iOS
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, iOS) // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
+public func missingVersionForPlatformFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, iOS 14.0,) // expected-error {{unexpected ',' separator}}
+public func unexpectedSeparatorFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0.1) // expected-warning {{'@_backDeploy' only uses major and minor version number}}
+public func patchVersionFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, * 9.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+public func wildcardPlatformNameFunc() {}
+
+// FIXME(backDeploy): The error here should be about * being ignored
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, *) // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
+public func trailingWildcardPlatformFunc() {}
+
+// FIXME(backDeploy): Expect error for duplicate platforms in same attribute
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, macOS 10.0)
+public func duplicatePlatformsFunc1() {}
+
+// FIXME(backDeploy): Expect error for duplicate platforms accross multiple attributes
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0)
+@_backDeploy(macOS 10.0)
+public func duplicatePlatformsFunc2() {}
+
+@available(macOS 12.0, *)
+@_backDeploy() // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
+public func zeroPlatformVersionsFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy // expected-error {{expected '(' in '_backDeploy' attribute}}
+public func expectedLeftParenFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0 // expected-note {{to match this opening '('}}
+public func expectedRightParenFunc() {} // expected-error {{expected ')' in '@_backDeploy' argument list}}

--- a/test/attr/backDeploy.swift
+++ b/test/attr/backDeploy.swift
@@ -66,10 +66,25 @@ public var cannotBackDeployTopLevelVar = 79
 @_backDeploy(macOS 11.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
 public func unknownOSFunc() {}
 
-// FIXME(backDeploy): The error here should be specific about the missing version for iOS
 @available(macOS 12.0, *)
-@_backDeploy(macOS 11.0, iOS) // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
-public func missingVersionForPlatformFunc() {}
+@_backDeploy(@) // expected-error {{expected platform in '@_backDeploy' attribute}}
+public func badPlatformFunc1() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(@ 12.0) // expected-error {{expected platform in '@_backDeploy' attribute}}
+public func badPlatformFunc2() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
+public func missingVersionFunc1() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, iOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
+public func missingVersionFunc2() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS, iOS) // expected-error 2{{expected version number in '@_backDeploy' attribute}}
+public func missingVersionFunc3() {}
 
 @available(macOS 12.0, *)
 @_backDeploy(macOS 11.0, iOS 14.0,) // expected-error {{unexpected ',' separator}}
@@ -81,12 +96,15 @@ public func patchVersionFunc() {}
 
 @available(macOS 12.0, *)
 @_backDeploy(macOS 11.0, * 9.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
-public func wildcardPlatformNameFunc() {}
+public func wildcardWithVersionFunc() {}
 
-// FIXME(backDeploy): The error here should be about * being ignored
 @available(macOS 12.0, *)
-@_backDeploy(macOS 11.0, *) // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
-public func trailingWildcardPlatformFunc() {}
+@_backDeploy(macOS 11.0, *) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+public func trailingWildcardFunc() {}
+
+@available(macOS 12.0, *)
+@_backDeploy(macOS 11.0, *, iOS 14.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+public func embeddedWildcardFunc() {}
 
 // FIXME(backDeploy): Expect error for duplicate platforms in same attribute
 @available(macOS 12.0, *)

--- a/test/attr/backDeploy.swift
+++ b/test/attr/backDeploy.swift
@@ -118,7 +118,7 @@ public func duplicatePlatformsFunc1() {}
 public func duplicatePlatformsFunc2() {}
 
 @available(macOS 12.0, *)
-@_backDeploy() // expected-error {{expected at least one platform version in in '@_backDeploy' attribute}}
+@_backDeploy() // expected-error {{expected at least one platform version in '@_backDeploy' attribute}}
 public func zeroPlatformVersionsFunc() {}
 
 @available(macOS 12.0, *)


### PR DESCRIPTION
Introduces the `@_backDeploy` attribute for use on function declarations. The purpose and desired semantics of this attribute are documented in UnderscoredAttributes.md.

This PR implements parsing and serialization and upcoming PRs will implement the semantics as well as additional diagnostics. Aspects of the parsing have been designed to be reused by `@_originallyDefinedIn` in the future.

Resolves rdar://88453905