### PR TITLE
Disable `conformance_descriptors.swift` on arm64e

### DIFF
--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -1,5 +1,8 @@
 // UNSUPPORTED: windows
+// rdar://88451721
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// rdar://88579818
+// UNSUPPORTED: CPU=arm64e
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances


### PR DESCRIPTION
We do not seem to handle something specific to this arch when extracting protocol names.
Test failure tracked in rdar://88579818

Example failure:
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable/724/