### PR TITLE
[ConstraintSystem] Adjust expression complexity computation to account for multi-statement closures

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -199,13 +199,19 @@ public:
     return endTime.getProcessTime() - StartTime.getProcessTime();
   }
 
+  /// Return the remaining process time in milliseconds until the
+  /// threshold specified during construction is reached.
+  unsigned getRemainingProcessTimeInMillis() const {
+    auto elapsed = unsigned(getElapsedProcessTimeInFractionalSeconds());
+    return elapsed >= ThresholdInMillis ? 0 : ThresholdInMillis - elapsed;
+  }
+
   // Disable emission of warnings about expressions that take longer
   // than the warning threshold.
   void disableWarning() { PrintWarning = false; }
 
   bool isExpired() const {
-    auto elapsed = getElapsedProcessTimeInFractionalSeconds();
-    return unsigned(elapsed) > ThresholdInMillis;
+    return getRemainingProcessTimeInMillis() == 0;
   }
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -167,7 +167,9 @@ public:
 
 
 class ExpressionTimer {
-  Expr* E;
+  using AnchorType = llvm::PointerUnion<Expr *, ConstraintLocator *>;
+
+  AnchorType Anchor;
   ASTContext &Context;
   llvm::TimeRecord StartTime;
 
@@ -181,8 +183,8 @@ class ExpressionTimer {
 public:
   /// This constructor sets a default threshold defined for all expressions
   /// via compiler flag `solver-expression-time-threshold`.
-  ExpressionTimer(Expr *E, ConstraintSystem &CS);
-  ExpressionTimer(Expr *E, ConstraintSystem &CS, unsigned thresholdInMillis);
+  ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS);
+  ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS, unsigned thresholdInMillis);
 
   ~ExpressionTimer();
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -167,8 +167,10 @@ public:
 
 
 class ExpressionTimer {
+public:
   using AnchorType = llvm::PointerUnion<Expr *, ConstraintLocator *>;
 
+private:
   AnchorType Anchor;
   ASTContext &Context;
   llvm::TimeRecord StartTime;
@@ -187,6 +189,8 @@ public:
   ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS, unsigned thresholdInMillis);
 
   ~ExpressionTimer();
+
+  AnchorType getAnchor() const { return Anchor; }
 
   unsigned getWarnLimit() const {
     return Context.TypeCheckerOpts.WarnLongExpressionTypeChecking;
@@ -5680,6 +5684,8 @@ public:
   ConjunctionElement(Constraint *element) : Element(element) {}
 
   bool attempt(ConstraintSystem &cs) const;
+
+  ConstraintLocator *getLocator() const { return Element->getLocator(); }
 
   void print(llvm::raw_ostream &Out, SourceManager *SM) const {
     Out << "conjunction element ";

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -816,6 +816,10 @@ bool ConjunctionStep::attempt(const ConjunctionElement &element) {
   // by dropping all scoring information.
   CS.CurrentScore = Score();
 
+  // Reset the scope counter to avoid "too complex" failures
+  // when closure has a lot of elements in the body.
+  CS.CountScopes = 0;
+
   auto success = element.attempt(CS);
 
   // If element attempt has failed, mark whole conjunction

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -820,6 +820,14 @@ bool ConjunctionStep::attempt(const ConjunctionElement &element) {
   // when closure has a lot of elements in the body.
   CS.CountScopes = 0;
 
+  // If timer is enabled, let's reset it so that each element
+  // (expression) gets a fresh time slice to get solved. This
+  // is important for closures with large number of statements
+  // in them.
+  if (CS.Timer) {
+    CS.Timer.emplace(element.getLocator(), CS);
+  }
+
   auto success = element.attempt(CS);
 
   // If element attempt has failed, mark whole conjunction

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -857,6 +857,10 @@ class ConjunctionStep : public BindingStep<ConjunctionElementProducer> {
   /// The score established before conjunction is attempted.
   Score CurrentScore;
 
+  /// The number of constraint solver scopes already explored
+  /// before accepting this conjunction.
+  llvm::SaveAndRestore<unsigned> OuterScopeCount;
+
   /// Conjunction constraint associated with this step.
   Constraint *Conjunction;
   /// Position of the conjunction in the inactive constraints
@@ -889,8 +893,8 @@ public:
       : BindingStep(cs, {cs, conjunction},
                     conjunction->isIsolated() ? IsolatedSolutions : solutions),
         BestScore(getBestScore()), CurrentScore(getCurrentScore()),
-        Conjunction(conjunction), AfterConjunction(erase(conjunction)),
-        OuterSolutions(solutions) {
+        OuterScopeCount(cs.CountScopes, 0), Conjunction(conjunction),
+        AfterConjunction(erase(conjunction)), OuterSolutions(solutions) {
     assert(conjunction->getKind() == ConstraintKind::Conjunction);
 
     // Make a snapshot of the constraint system state before conjunction.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -44,12 +44,17 @@ using namespace inference;
 #define DEBUG_TYPE "ConstraintSystem"
 
 ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS)
-  : E(E),
-      Context(CS.getASTContext()),
+    : ExpressionTimer(
+          E, CS,
+          CS.getASTContext().TypeCheckerOpts.ExpressionTimeoutThreshold) {}
+
+ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS,
+                                 unsigned thresholdInMillis)
+    : E(E), Context(CS.getASTContext()),
       StartTime(llvm::TimeRecord::getCurrentTime()),
+      ThresholdInMillis(thresholdInMillis),
       PrintDebugTiming(CS.getASTContext().TypeCheckerOpts.DebugTimeExpressions),
-      PrintWarning(true) {
-}
+      PrintWarning(true) {}
 
 ExpressionTimer::~ExpressionTimer() {
   auto elapsed = getElapsedProcessTimeInFractionalSeconds();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -43,14 +43,14 @@ using namespace inference;
 
 #define DEBUG_TYPE "ConstraintSystem"
 
-ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS)
+ExpressionTimer::ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS)
     : ExpressionTimer(
-          E, CS,
+          Anchor, CS,
           CS.getASTContext().TypeCheckerOpts.ExpressionTimeoutThreshold) {}
 
-ExpressionTimer::ExpressionTimer(Expr *E, ConstraintSystem &CS,
+ExpressionTimer::ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS,
                                  unsigned thresholdInMillis)
-    : E(E), Context(CS.getASTContext()),
+    : Anchor(Anchor), Context(CS.getASTContext()),
       StartTime(llvm::TimeRecord::getCurrentTime()),
       ThresholdInMillis(thresholdInMillis),
       PrintDebugTiming(CS.getASTContext().TypeCheckerOpts.DebugTimeExpressions),
@@ -64,20 +64,38 @@ ExpressionTimer::~ExpressionTimer() {
     // Round up to the nearest 100th of a millisecond.
     llvm::errs() << llvm::format("%0.2f", ceil(elapsed * 100000) / 100)
                  << "ms\t";
-    E->getLoc().print(llvm::errs(), Context.SourceMgr);
+    if (auto *E = Anchor.dyn_cast<Expr *>()) {
+      E->getLoc().print(llvm::errs(), Context.SourceMgr);
+    } else {
+      auto *locator = Anchor.get<ConstraintLocator *>();
+      locator->dump(&Context.SourceMgr, llvm::errs());
+    }
     llvm::errs() << "\n";
   }
 
   if (!PrintWarning)
     return;
 
-  const auto WarnLimit = getWarnLimit();
-  if (WarnLimit != 0 && elapsedMS >= WarnLimit && E->getLoc().isValid())
-    Context.Diags.diagnose(E->getLoc(), diag::debug_long_expression,
-                           elapsedMS, WarnLimit)
-      .highlight(E->getSourceRange());
-}
+  ASTNode anchor;
+  if (auto *locator = Anchor.dyn_cast<ConstraintLocator *>()) {
+    anchor = simplifyLocatorToAnchor(locator);
+    // If locator couldn't be simplified down to a single AST
+    // element, let's warn about its root.
+    if (!anchor)
+      anchor = locator->getAnchor();
+  } else {
+    anchor = Anchor.get<Expr *>();
+  }
 
+  const auto WarnLimit = getWarnLimit();
+  if (WarnLimit != 0 && elapsedMS >= WarnLimit &&
+      anchor.getStartLoc().isValid()) {
+    Context.Diags
+        .diagnose(anchor.getStartLoc(), diag::debug_long_expression, elapsedMS,
+                  WarnLimit)
+        .highlight(anchor.getSourceRange());
+  }
+}
 
 ConstraintSystem::ConstraintSystem(DeclContext *dc,
                                    ConstraintSystemOptions options)


### PR DESCRIPTION
Each conjunction element should get their own number of scopes and time slice,
otherwise the larger the closure the sooner constraint solver would trigger
'too complex' incorrectly.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
