### PR TITLE
Pass in `libswiftCore.dylib` as input to `conformance_descriptors.swift`

### DIFF
--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances
-// RUN: %target-swift-reflection-dump -binary-filename %t/Conformances | %FileCheck %s
+// RUN: %target-swift-reflection-dump -binary-filename %t/Conformances -binary-filename %platform-module-dir/%target-library-name(swiftCore) | %FileCheck %s
 
 // CHECK: CONFORMANCES:
 // CHECK: =============


### PR DESCRIPTION
This will make the test more robust in being able to read out the conformances we are looking for (Hashable, Equatable)

Resolves rdar://88579818
