### PR TITLE
Shop the Wording of @usableFromInline Redundancy Diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5670,7 +5670,8 @@ ERROR(usable_from_inline_attr_with_explicit_access,
       (DeclName, AccessLevel))
 
 WARNING(inlinable_implies_usable_from_inline,none,
-        "'@inlinable' declaration is already '@usableFromInline'",())
+        "'@usableFromInline' attribute has no effect on '@inlinable' %0 %1",
+        (DescriptiveDeclKind, DeclName))
 
 ERROR(usable_from_inline_attr_in_protocol,none,
       "'@usableFromInline' attribute cannot be used in protocols", ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2414,7 +2414,8 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
     if (Ctx.isSwiftVersionAtLeast(4,2))
-      diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
+      diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline,
+                            VD->getDescriptiveKind(), VD->getName());
     return;
   }
 }

--- a/test/Compatibility/attr_inlinable_old_spelling_42.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_42.swift
@@ -9,4 +9,4 @@
 // expected-warning@-1 {{'@_versioned' has been renamed to '@usableFromInline'}}{{2-12=usableFromInline}}
 
 @inlinable @usableFromInline func redundantAttribute() {}
-// expected-warning@-1 {{'@inlinable' declaration is already '@usableFromInline'}}
+// expected-warning@-1 {{'@usableFromInline' attribute has no effect on '@inlinable' global function 'redundantAttribute()'}}

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -6,7 +6,7 @@
 // expected-error@-1 {{'@inlinable' attribute cannot be applied to this declaration}}
 
 @inlinable @usableFromInline func redundantAttribute() {}
-// expected-warning@-1 {{'@inlinable' declaration is already '@usableFromInline'}}
+// expected-warning@-1 {{'@usableFromInline' attribute has no effect on '@inlinable' global function 'redundantAttribute()'}} {{12-30=}}
 
 private func privateFunction() {}
 // expected-note@-1 2{{global function 'privateFunction()' is not '@usableFromInline' or public}}


### PR DESCRIPTION
- Explicitly call out the decl kind
- Clearly state the exact issue at hand
- Correct the tests to check for the fixit

rdar://88527799