### PR TITLE
Don't terminate ReplaceOpaqueTypesWithUnderlyingTypes if same opaque type is substituted with different substitution arguments.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5672,9 +5672,12 @@ enum class OpaqueSubstitutionKind {
 /// archetypes with underlying types visible at a given resilience expansion
 /// to their underlying types.
 class ReplaceOpaqueTypesWithUnderlyingTypes {
+public:
+  using SeenDecl = std::pair<OpaqueTypeDecl *, SubstitutionMap>;
+private:
   ResilienceExpansion contextExpansion;
   llvm::PointerIntPair<const DeclContext *, 1, bool> inContextAndIsWholeModule;
-  llvm::SmallPtrSetImpl<OpaqueTypeDecl *> *seenDecls;
+  llvm::DenseSet<SeenDecl> *seenDecls;
 
 public:
   ReplaceOpaqueTypesWithUnderlyingTypes(const DeclContext *inContext,
@@ -5686,7 +5689,7 @@ public:
 
   ReplaceOpaqueTypesWithUnderlyingTypes(
       const DeclContext *inContext, ResilienceExpansion contextExpansion,
-      bool isWholeModuleContext, llvm::SmallPtrSetImpl<OpaqueTypeDecl *> &seen);
+      bool isWholeModuleContext, llvm::DenseSet<SeenDecl> &seen);
 
   /// TypeSubstitutionFn
   Type operator()(SubstitutableType *maybeOpaqueType) const;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3449,7 +3449,8 @@ ReplaceOpaqueTypesWithUnderlyingTypes::shouldPerformSubstitution(
 
 static Type substOpaqueTypesWithUnderlyingTypesRec(
     Type ty, const DeclContext *inContext, ResilienceExpansion contextExpansion,
-    bool isWholeModuleContext, SmallPtrSetImpl<OpaqueTypeDecl *> &decls) {
+    bool isWholeModuleContext,
+    llvm::DenseSet<ReplaceOpaqueTypesWithUnderlyingTypes::SeenDecl> &decls) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion,
                                                  isWholeModuleContext, decls);
   return ty.subst(replacer, replacer, SubstFlags::SubstituteOpaqueArchetypes);
@@ -3513,7 +3514,7 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
 
 ReplaceOpaqueTypesWithUnderlyingTypes::ReplaceOpaqueTypesWithUnderlyingTypes(
     const DeclContext *inContext, ResilienceExpansion contextExpansion,
-    bool isWholeModuleContext, llvm::SmallPtrSetImpl<OpaqueTypeDecl *> &seen)
+    bool isWholeModuleContext, llvm::DenseSet<SeenDecl> &seen)
     : contextExpansion(contextExpansion),
       inContextAndIsWholeModule(inContext, isWholeModuleContext),
       seenDecls(&seen) {}
@@ -3565,24 +3566,25 @@ operator()(SubstitutableType *maybeOpaqueType) const {
 
   // If the type changed, but still contains opaque types, recur.
   if (!substTy->isEqual(maybeOpaqueType) && substTy->hasOpaqueArchetype()) {
+    SeenDecl seenKey(opaqueRoot->getDecl(), opaqueRoot->getSubstitutions());
     if (auto *alreadySeen = this->seenDecls) {
       // Detect substitution loops. If we find one, just bounce the original
       // type back to the caller. This substitution will fail at runtime
       // instead.
-      if (!alreadySeen->insert(opaqueRoot->getDecl()).second) {
+      if (!alreadySeen->insert(seenKey).second) {
         return maybeOpaqueType;
       }
 
       auto res = ::substOpaqueTypesWithUnderlyingTypesRec(
           substTy, inContext, contextExpansion, isContextWholeModule,
           *alreadySeen);
-      alreadySeen->erase(opaqueRoot->getDecl());
+      alreadySeen->erase(seenKey);
       return res;
     } else {
       // We're the top of the stack for the recursion check. Allocate a set of
       // opaque result type decls we've already seen for the rest of the check.
-      SmallPtrSet<OpaqueTypeDecl *, 8> seenDecls;
-      seenDecls.insert(opaqueRoot->getDecl());
+      llvm::DenseSet<SeenDecl> seenDecls;
+      seenDecls.insert(seenKey);
       return ::substOpaqueTypesWithUnderlyingTypesRec(
           substTy, inContext, contextExpansion, isContextWholeModule,
           seenDecls);
@@ -3595,7 +3597,7 @@ operator()(SubstitutableType *maybeOpaqueType) const {
 static ProtocolConformanceRef substOpaqueTypesWithUnderlyingTypesRec(
     ProtocolConformanceRef ref, Type origType, const DeclContext *inContext,
     ResilienceExpansion contextExpansion, bool isWholeModuleContext,
-    SmallPtrSetImpl<OpaqueTypeDecl *> &decls) {
+    llvm::DenseSet<ReplaceOpaqueTypesWithUnderlyingTypes::SeenDecl> &decls) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion,
                                                  isWholeModuleContext, decls);
   return ref.subst(origType, replacer, replacer,
@@ -3679,24 +3681,26 @@ operator()(CanType maybeOpaqueType, Type replacementType,
 
   // If the type still contains opaque types, recur.
   if (substTy->hasOpaqueArchetype()) {
+    SeenDecl seenKey(opaqueRoot->getDecl(), opaqueRoot->getSubstitutions());
+    
     if (auto *alreadySeen = this->seenDecls) {
       // Detect substitution loops. If we find one, just bounce the original
       // type back to the caller. This substitution will fail at runtime
       // instead.
-      if (!alreadySeen->insert(opaqueRoot->getDecl()).second) {
+      if (!alreadySeen->insert(seenKey).second) {
         return abstractRef;
       }
 
       auto res = ::substOpaqueTypesWithUnderlyingTypesRec(
           substRef, substTy, inContext, contextExpansion, isContextWholeModule,
           *alreadySeen);
-      alreadySeen->erase(opaqueRoot->getDecl());
+      alreadySeen->erase(seenKey);
       return res;
     } else {
       // We're the top of the stack for the recursion check. Allocate a set of
       // opaque result type decls we've already seen for the rest of the check.
-      SmallPtrSet<OpaqueTypeDecl *, 8> seenDecls;
-      seenDecls.insert(opaqueRoot->getDecl());
+      llvm::DenseSet<SeenDecl> seenDecls;
+      seenDecls.insert(seenKey);
       return ::substOpaqueTypesWithUnderlyingTypesRec(
           substRef, substTy, inContext, contextExpansion, isContextWholeModule,
           seenDecls);

--- a/test/SILGen/opaque_type_repeat_application.swift
+++ b/test/SILGen/opaque_type_repeat_application.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-sil -disable-availability-checking -verify %s
+
+// rdar://88120984
+
+protocol P {}
+
+private struct Wrapped<T: P>: P { var x: T }
+
+extension P {
+    func wrapped() -> some P {
+        return Wrapped(x: self)
+    }
+}
+
+class CWrap<T: P> { init(x: T) {} }
+
+func foo<T: P>(x: T) {
+    let y = x.wrapped().wrapped().wrapped().wrapped()
+
+    _ = CWrap(x: y)
+}


### PR DESCRIPTION
A finite opaque type can still be composed of multiple references to the same
declaration's opaque type. Change the occurs check here to account for both
substitution map and opaque type decl instead of just the decl.
Fixes rdar://88120984.