### PR TITLE
ModuleInterface: properly handle equal-joined arguments in the ignorable flags field

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1086,12 +1086,19 @@ bool swift::extractCompilerFlagsFromInterface(StringRef interfacePath,
     // options and input-like options.
     if (!parse->getOption().hasFlag(options::FrontendOption))
       continue;
-    // Push the supported option and its value to the list.
-    // We shouldn't need to worry about cases like -tbd-install_name=Foo because
-    // the parsing function should have droped alias options already.
-    SubArgs.push_back(ArgSaver.save(parse->getSpelling()).data());
-    for (auto value: parse->getValues())
-      SubArgs.push_back(value);
+    auto spelling = ArgSaver.save(parse->getSpelling());
+    auto &values = parse->getValues();
+    if (spelling.endswith("=")) {
+      // Handle the case like -tbd-install_name=Foo. This should be rare because
+      // most equal-separated arguments are alias to the separate form.
+      assert(values.size() == 1);
+      SubArgs.push_back(ArgSaver.save((llvm::Twine(spelling) + values[0]).str()).data());
+    } else {
+      // Push the supported option and its value to the list.
+      SubArgs.push_back(spelling.data());
+      for (auto value: values)
+        SubArgs.push_back(value);
+    }
   }
 
   return false;


### PR DESCRIPTION
Previously, we have an assumption that all equal-joined arguments are alias to the
separate forms, e.g. `-tbd-install_name=Foo` is an alias to `-tbd-install_name Foo`. However,
it seems having only the equal-joined version of an argument is possible. This PR adds
support to that scenario.
