### PR TITLE
Downgrade concurrency-related error to a warning.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2580,7 +2580,8 @@ namespace {
         ctx.Diags.diagnose(
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),
-            var->getDescriptiveKind(), var->getName());
+            var->getDescriptiveKind(), var->getName())
+          .warnUntilSwiftVersion(6);
         return true;
       }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -114,7 +114,7 @@ func testSendable(fn: () -> Void) {
 func testSendableInAsync() async {
   var x = 17
   doSomethingConcurrentlyButUnsafe {
-    x = 42 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 42 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -309,8 +309,8 @@ extension MyActor {
       acceptInout(&self.mutable) // expected-error{{actor-isolated property 'mutable' can not be used 'inout' from a Sendable closure}}
       _ = self.immutable
       _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a Sendable closure}}
-      _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-      localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+      _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+      localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
       _ = localConstant
 
       _ = otherLocalVar
@@ -341,8 +341,8 @@ extension MyActor {
     @Sendable func localFn1() {
       _ = self.text[0] // expected-error{{actor-isolated property 'text' can not be referenced from a Sendable function}}
       _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a Sendable function}}
-      _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-      localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+      _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+      localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
       _ = localConstant
     }
 
@@ -350,8 +350,8 @@ extension MyActor {
       acceptClosure {
         _ = text[0]  // expected-error{{actor-isolated property 'text' can not be referenced from a non-isolated context}}
         _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a non-isolated context}}
-        _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-        localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+        _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+        localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
         _ = localConstant
       }
     }
@@ -624,8 +624,8 @@ func testGlobalRestrictions(actor: MyActor) async {
   // code.
   var i = 17
   acceptConcurrentClosure {
-    _ = i // expected-error{{reference to captured var 'i' in concurrently-executing code}}
-    i = 42 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
+    _ = i // expected-warning{{reference to captured var 'i' in concurrently-executing code}}
+    i = 42 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
   }
   print(i)
 
@@ -722,7 +722,7 @@ func checkLocalFunctions() async {
   }
 
   func local3() { // expected-error{{concurrently-executed local function 'local3()' must be marked as '@Sendable'}}
-    k = 25 // expected-error{{mutation of captured var 'k' in concurrently-executing code}}
+    k = 25 // expected-warning{{mutation of captured var 'k' in concurrently-executing code}}
   }
 
   print(k)
@@ -1141,12 +1141,12 @@ extension MyActor {
       _ = synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}
       // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
 
-      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+      counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosure {
       _ = await synchronous() // ok
-      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+      counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosureInheriting {
@@ -1167,13 +1167,12 @@ func testGlobalActorInheritance() {
   var counter = 0
 
   acceptAsyncSendableClosure {
-    counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+    counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
   }
 
   acceptAsyncSendableClosure { @SomeGlobalActor in
     counter += 1 // ok
   }
-
 
   acceptAsyncSendableClosureInheriting {
     counter += 1 // ok

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -16,7 +16,7 @@ actor MyActor {
     async let z = synchronous()
 
     var localText = text
-    async let w = localText.removeLast() // expected-error{{mutation of captured var 'localText' in concurrently-executing code}}
+    async let w = localText.removeLast() // expected-warning{{mutation of captured var 'localText' in concurrently-executing code}}
 
     _ = await x
     _ = await y

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -165,7 +165,7 @@ func testConcurrency() {
   acceptConcurrent {
     print(x) // expected-warning{{capture of 'x' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
     print(y) // expected-warning{{capture of 'y' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
-    // expected-error@-1{{reference to captured var 'y' in concurrently-executing code}}
+    // expected-warning@-1{{reference to captured var 'y' in concurrently-executing code}}
   }
 }
 
@@ -182,7 +182,7 @@ func testUnsafeSendableNothing() {
 func testUnsafeSendableInAsync() async {
   var x = 5
   acceptUnsafeSendable {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -17,7 +17,7 @@ func testMe() {
 func testUnsafeSendableInMainAsync() async {
   var x = 5
   DispatchQueue.main.async {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }
@@ -25,7 +25,7 @@ func testUnsafeSendableInMainAsync() async {
 func testUnsafeSendableInAsync(queue: DispatchQueue) async {
   var x = 5
   queue.async {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -80,12 +80,12 @@ func mutationOfLocal() {
     }()
 
     // Mutations of captured variables executing concurrently are bad.
-    localInt = 17 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
-    localInt += 1 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
-    localInt.makeNegative() // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt = 17 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt += 1 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt.makeNegative() // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
 
     _ = {
-      localInt = localInt + 12 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
+      localInt = localInt + 12 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
     }()
 
     return i + localInt
@@ -110,8 +110,8 @@ func testCaseNonTrivialValue() {
     print(i.optArray?[j] ?? 0)
     print(i.optArray![j])
 
-    i.int = 5 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
-    i.array[0] = 5 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
+    i.int = 5 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
+    i.array[0] = 5 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
 
     return value
   }


### PR DESCRIPTION
We are diagnosing this condition more completely now, so downgrade
from an error to a warning to not break existing code.

Fixes rdar://88649197.
