### PR TITLE
[debug-info] Add DIExpr to SILDebugVariable::operator== for real.

### DIFF
--- a/include/swift/SIL/SILDebugVariable.h
+++ b/include/swift/SIL/SILDebugVariable.h
@@ -62,6 +62,12 @@ struct SILDebugVariable {
            Scope == V.Scope && DIExpr == V.DIExpr;
   }
 
+  SILDebugVariable withoutDIExpr() const {
+    auto result = *this;
+    result.DIExpr = {};
+    return result;
+  }
+
   bool isLet() const { return Name.size() && Constant; }
 
   bool isVar() const { return Name.size() && !Constant; }

--- a/include/swift/SIL/SILDebugVariable.h
+++ b/include/swift/SIL/SILDebugVariable.h
@@ -1,0 +1,72 @@
+//===--- SILDebugVariable.h -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILDEBUGVARIABLE_H
+#define SWIFT_SIL_SILDEBUGVARIABLE_H
+
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILDebugInfoExpression.h"
+#include "swift/SIL/SILLocation.h"
+#include "swift/SIL/SILType.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+class AllocationInst;
+
+/// Holds common debug information about local variables and function
+/// arguments that are needed by DebugValueInst, AllocStackInst,
+/// and AllocBoxInst.
+struct SILDebugVariable {
+  StringRef Name;
+  unsigned ArgNo : 16;
+  unsigned Constant : 1;
+  unsigned Implicit : 1;
+  Optional<SILType> Type;
+  Optional<SILLocation> Loc;
+  const SILDebugScope *Scope;
+  SILDebugInfoExpression DIExpr;
+
+  // Use vanilla copy ctor / operator
+  SILDebugVariable(const SILDebugVariable &) = default;
+  SILDebugVariable &operator=(const SILDebugVariable &) = default;
+
+  SILDebugVariable()
+      : ArgNo(0), Constant(false), Implicit(false), Scope(nullptr) {}
+  SILDebugVariable(bool Constant, uint16_t ArgNo)
+      : ArgNo(ArgNo), Constant(Constant), Implicit(false), Scope(nullptr) {}
+  SILDebugVariable(StringRef Name, bool Constant, unsigned ArgNo,
+                   bool IsImplicit = false, Optional<SILType> AuxType = {},
+                   Optional<SILLocation> DeclLoc = {},
+                   const SILDebugScope *DeclScope = nullptr,
+                   llvm::ArrayRef<SILDIExprElement> ExprElements = {})
+      : Name(Name), ArgNo(ArgNo), Constant(Constant), Implicit(IsImplicit),
+        Type(AuxType), Loc(DeclLoc), Scope(DeclScope), DIExpr(ExprElements) {}
+
+  /// Created from either AllocStack or AllocBox instruction
+  static Optional<SILDebugVariable>
+  createFromAllocation(const AllocationInst *AI);
+
+  bool operator==(const SILDebugVariable &V) {
+    return ArgNo == V.ArgNo && Constant == V.Constant && Name == V.Name &&
+           Implicit == V.Implicit && Type == V.Type && Loc == V.Loc &&
+           Scope == V.Scope && DIExpr == V.DIExpr;
+  }
+
+  bool isLet() const { return Name.size() && Constant; }
+
+  bool isVar() const { return Name.size() && !Constant; }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1811,7 +1811,7 @@ struct SILDebugVariable {
   bool operator==(const SILDebugVariable &V) {
     return ArgNo == V.ArgNo && Constant == V.Constant && Name == V.Name &&
            Implicit == V.Implicit && Type == V.Type && Loc == V.Loc &&
-           Scope == V.Scope && DIExpr == DIExpr;
+           Scope == V.Scope && DIExpr == V.DIExpr;
   }
 
   bool isLet() const { return Name.size() && Constant; }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -33,6 +33,7 @@
 #include "swift/SIL/SILAllocated.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILDebugInfoExpression.h"
+#include "swift/SIL/SILDebugVariable.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILLocation.h"
@@ -1773,50 +1774,6 @@ public:
   MutableArrayRef<Operand> getTypeDependentOperands() {
     return this->getAllOperands().slice(1);
   }
-};
-
-/// Holds common debug information about local variables and function
-/// arguments that are needed by DebugValueInst, AllocStackInst,
-/// and AllocBoxInst.
-struct SILDebugVariable {
-  StringRef Name;
-  unsigned ArgNo : 16;
-  unsigned Constant : 1;
-  unsigned Implicit : 1;
-  Optional<SILType> Type;
-  Optional<SILLocation> Loc;
-  const SILDebugScope *Scope;
-  SILDebugInfoExpression DIExpr;
-
-  // Use vanilla copy ctor / operator
-  SILDebugVariable(const SILDebugVariable &) = default;
-  SILDebugVariable &operator=(const SILDebugVariable &) = default;
-
-  SILDebugVariable()
-      : ArgNo(0), Constant(false), Implicit(false), Scope(nullptr) {}
-  SILDebugVariable(bool Constant, uint16_t ArgNo)
-      : ArgNo(ArgNo), Constant(Constant), Implicit(false), Scope(nullptr) {}
-  SILDebugVariable(StringRef Name, bool Constant, unsigned ArgNo,
-                   bool IsImplicit = false, Optional<SILType> AuxType = {},
-                   Optional<SILLocation> DeclLoc = {},
-                   const SILDebugScope *DeclScope = nullptr,
-                   llvm::ArrayRef<SILDIExprElement> ExprElements = {})
-      : Name(Name), ArgNo(ArgNo), Constant(Constant), Implicit(IsImplicit),
-        Type(AuxType), Loc(DeclLoc), Scope(DeclScope), DIExpr(ExprElements) {}
-
-  /// Created from either AllocStack or AllocBox instruction
-  static Optional<SILDebugVariable>
-  createFromAllocation(const AllocationInst *AI);
-
-  bool operator==(const SILDebugVariable &V) {
-    return ArgNo == V.ArgNo && Constant == V.Constant && Name == V.Name &&
-           Implicit == V.Implicit && Type == V.Type && Loc == V.Loc &&
-           Scope == V.Scope && DIExpr == V.DIExpr;
-  }
-
-  bool isLet() const { return Name.size() && Constant; }
-
-  bool isVar() const { return Name.size() && !Constant; }
 };
 
 /// A DebugVariable where storage for the strings has been

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -97,8 +97,12 @@ ArchetypeToConcreteConvertUInt8(t: c)
 ArchetypeToConcreteConvertUInt8(t: f)
 
 // x -> x where x is not a class.
+//
+// TODO: Why is the optimizer cloning twice here.
+//
 // CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ArchetypeToConcreteConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK: bb0
+// CHECK-NEXT: debug_value %0
 // CHECK-NEXT: debug_value %0
 // CHECK-NEXT: return %0
 
@@ -119,6 +123,7 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // x -> x where x is a class.
 // CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C) -> @owned C {
 // CHECK: bb0([[ARG:%.*]] : $C)
+// CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: strong_retain [[ARG]]
 // CHECK-NEXT: return [[ARG]]

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -97,12 +97,8 @@ ArchetypeToConcreteConvertUInt8(t: c)
 ArchetypeToConcreteConvertUInt8(t: f)
 
 // x -> x where x is not a class.
-//
-// TODO: Why is the optimizer cloning twice here.
-//
 // CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast31ArchetypeToConcreteConvertUInt8{{[_0-9a-zA-Z]*}}3Not{{.*}}Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
 // CHECK: bb0
-// CHECK-NEXT: debug_value %0
 // CHECK-NEXT: debug_value %0
 // CHECK-NEXT: return %0
 
@@ -123,7 +119,6 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // x -> x where x is a class.
 // CHECK-LABEL: sil shared [noinline] @$s37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C) -> @owned C {
 // CHECK: bb0([[ARG:%.*]] : $C)
-// CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: debug_value [[ARG]]
 // CHECK-NEXT: strong_retain [[ARG]]
 // CHECK-NEXT: return [[ARG]]


### PR DESCRIPTION
I in a previous commit attempted to do this but I thinkoed. I did this again and
at the same time also refactored SILDebugVariable into its own header. Just
combining two NFC commits into one.
