### PR TITLE
[ClangImporter] SR-15822: Let it have separate compiler instances.

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -196,7 +196,7 @@ void ClangImporter::recordModuleDependencies(
       fileDeps.push_back(fileDep.getKey().str());
     }
     // Inherit all Clang driver args when creating the clang importer.
-    ArrayRef<std::string> allArgs = Impl.ClangArgs;
+    ArrayRef<std::string> allArgs = Impl.DefaultCompiler.ClangArgs;
     ClangImporterOptions Opts;
 
     // Ensure the arguments we collected is sufficient to create a Clang

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9228,7 +9228,8 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   FrontendStatsTracer StatsTracer(SwiftContext.Stats,
                                   "import-clang-decl", ClangDecl);
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
-                                    Instance->getSourceManager(), "importing");
+                                    DefaultCompiler.Instance->getSourceManager(),
+                                    "importing");
 
   auto Canon = cast<clang::NamedDecl>(UseCanonicalDecl? ClangDecl->getCanonicalDecl(): ClangDecl);
 
@@ -9273,7 +9274,7 @@ ClangImporter::Implementation::importMirroredDecl(const clang::NamedDecl *decl,
     return nullptr;
 
   clang::PrettyStackTraceDecl trace(decl, clang::SourceLocation(),
-                                    Instance->getSourceManager(),
+                                    DefaultCompiler.Instance->getSourceManager(),
                                     "importing (mirrored)");
 
   auto canon = decl->getCanonicalDecl();
@@ -10077,7 +10078,7 @@ static void loadMembersOfBaseImportedFromClang(ExtensionDecl *ext) {
 void ClangImporter::Implementation::loadAllMembersOfObjcContainer(
     Decl *D, const clang::ObjCContainerDecl *objcContainer) {
   clang::PrettyStackTraceDecl trace(objcContainer, clang::SourceLocation(),
-                                    Instance->getSourceManager(),
+                                    DefaultCompiler.Instance->getSourceManager(),
                                     "loading members for");
 
   assert(isa<ExtensionDecl>(D) || isa<NominalTypeDecl>(D));

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2825,7 +2825,7 @@ Type ClangImporter::Implementation::getNamedSwiftType(StringRef moduleName,
 }
 
 Decl *ClangImporter::Implementation::importDeclByName(StringRef name) {
-  auto &sema = Instance->getSema();
+  auto &sema = DefaultCompiler.Instance->getSema();
 
   // Map the name. If we can't represent the Swift name in Clang, bail out now.
   auto clangName = &getClangASTContext().Idents.get(name);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -456,11 +456,13 @@ private:
   /// Used to avoid running the AST verifier over the same declarations.
   size_t VerifiedDeclsCounter = 0;
 
+public:
   /// A wrapper for clang compiler.
   class ClangCompiler {
     friend ClangImporter;
     friend ClangImporter::Implementation;
 
+  private:
     /// Clang compiler invocation.
     std::shared_ptr<clang::CompilerInvocation> Invocation;
 
@@ -480,13 +482,47 @@ private:
 
     /// Clang arguments used to create the Clang invocation.
     std::vector<std::string> ClangArgs;
+
+  public:
+    bool addSearchPath(StringRef newSearchPath, bool isFramework, bool isSystem);
+
+    /// Retrieve the Clang AST context.
+    clang::ASTContext &getASTContext() const {
+      return Instance->getASTContext();
+    }
+
+    /// Retrieve the Clang Sema object.
+    clang::Sema &getSema() const {
+      return Instance->getSema();
+    }
+
+    /// Retrieve the Clang Preprocessor.
+    clang::Preprocessor &getPreprocessor() const {
+      return Instance->getPreprocessor();
+    }
+
+    clang::PreprocessorOptions &getPreprocessorOpts() const {
+      return Instance->getPreprocessorOpts();
+    }
+
+    clang::CodeGenOptions &getCodeGenOpts() const {
+      return Instance->getCodeGenOpts();
+    }
+
+    clang::SourceManager &getSourceManager() const {
+      return Instance->getSourceManager();
+    }
   };
 
+private:
   ClangCompiler DefaultCompiler;
+
+  ClangCompiler BridgingHeaderCompiler;
 
   std::vector<ClangCompiler *> &getAllClangCompilers() {
     auto allClangCompilers = new std::vector<ClangCompiler *> {
       &DefaultCompiler,
+      &BridgingHeaderCompiler,
     };
     return *allClangCompilers;
   }
@@ -557,6 +593,10 @@ public:
 
   clang::CompilerInstance *getClangInstance() {
     return DefaultCompiler.Instance.get();
+  }
+
+  clang::CompilerInstance *getBridgingHeaderCompilerInstance() {
+    return BridgingHeaderCompiler.Instance.get();
   }
 
 private:

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -456,25 +456,40 @@ private:
   /// Used to avoid running the AST verifier over the same declarations.
   size_t VerifiedDeclsCounter = 0;
 
-  /// Clang compiler invocation.
-  std::shared_ptr<clang::CompilerInvocation> Invocation;
+  /// A wrapper for clang compiler.
+  class ClangCompiler {
+    friend ClangImporter;
+    friend ClangImporter::Implementation;
 
-  /// Clang compiler instance, which is used to actually load Clang
-  /// modules.
-  std::unique_ptr<clang::CompilerInstance> Instance;
+    /// Clang compiler invocation.
+    std::shared_ptr<clang::CompilerInvocation> Invocation;
 
-  /// Clang compiler action, which is used to actually run the
-  /// parser.
-  std::unique_ptr<clang::FrontendAction> Action;
+    /// Clang compiler instance, which is used to actually load Clang
+    /// modules.
+    std::unique_ptr<clang::CompilerInstance> Instance;
 
-  /// Clang parser, which is used to load textual headers.
-  std::unique_ptr<clang::Parser> Parser;
+    /// Clang compiler action, which is used to actually run the
+    /// parser.
+    std::unique_ptr<clang::FrontendAction> Action;
 
-  /// Clang parser, which is used to load textual headers.
-  std::unique_ptr<clang::MangleContext> Mangler;
+    /// Clang parser, which is used to load textual headers.
+    std::unique_ptr<clang::Parser> Parser;
 
-  /// Clang arguments used to create the Clang invocation.
-  std::vector<std::string> ClangArgs;
+    /// Clang parser, which is used to load textual headers.
+    std::unique_ptr<clang::MangleContext> Mangler;
+
+    /// Clang arguments used to create the Clang invocation.
+    std::vector<std::string> ClangArgs;
+  };
+
+  ClangCompiler DefaultCompiler;
+
+  std::vector<ClangCompiler *> &getAllClangCompilers() {
+    auto allClangCompilers = new std::vector<ClangCompiler *> {
+      &DefaultCompiler,
+    };
+    return *allClangCompilers;
+  }
 
   /// Mapping from Clang swift_attr attribute text to the Swift source buffer
   /// IDs that contain that attribute text. These are re-used when parsing the
@@ -541,7 +556,7 @@ public:
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
 
   clang::CompilerInstance *getClangInstance() {
-    return Instance.get();
+    return DefaultCompiler.Instance.get();
   }
 
 private:
@@ -760,21 +775,21 @@ public:
 
   /// Retrieve the Clang AST context.
   clang::ASTContext &getClangASTContext() const {
-    return Instance->getASTContext();
+    return DefaultCompiler.Instance->getASTContext();
   }
 
   /// Retrieve the Clang Sema object.
   clang::Sema &getClangSema() const {
-    return Instance->getSema();
+    return DefaultCompiler.Instance->getSema();
   }
 
   /// Retrieve the Clang AST context.
   clang::Preprocessor &getClangPreprocessor() const {
-    return Instance->getPreprocessor();
+    return DefaultCompiler.Instance->getPreprocessor();
   }
   
   clang::CodeGenOptions &getClangCodeGenOpts() const {
-    return Instance->getCodeGenOpts();
+    return DefaultCompiler.Instance->getCodeGenOpts();
   }
 
   importer::ClangSourceBufferImporter &getBufferImporterForDiagnostics() {

--- a/test/ClangImporter/MixedSource/Inputs/SR15822.h
+++ b/test/ClangImporter/MixedSource/Inputs/SR15822.h
@@ -1,0 +1,4 @@
+#ifndef SR15822_H__________
+#define SR15822_H__________
+typedef struct {} SR15822CStruct;
+#endif

--- a/test/ClangImporter/MixedSource/Inputs/SR15822ClangModule/module.modulemap
+++ b/test/ClangImporter/MixedSource/Inputs/SR15822ClangModule/module.modulemap
@@ -1,0 +1,5 @@
+// SR-15822: Only existence of this module does matter.
+module SR15822ClangModule {
+  header "../SR15822.h"
+  export *
+}

--- a/test/ClangImporter/MixedSource/Inputs/SR15822Library.swift
+++ b/test/ClangImporter/MixedSource/Inputs/SR15822Library.swift
@@ -1,0 +1,6 @@
+public typealias SwiftyName = SR15822CStruct
+extension SwiftyName {
+  public var foo: String {
+    return "foo"
+  }
+}

--- a/test/ClangImporter/MixedSource/SR15822-Dont_conceal_C_decls.swift
+++ b/test/ClangImporter/MixedSource/SR15822-Dont_conceal_C_decls.swift
@@ -1,0 +1,13 @@
+// Confirm that SR-15822 is resolved.
+
+// RUN: %empty-directory(%t)
+// RUN: cd "%t"
+// RUN: %target-swiftc_driver "%S/Inputs/SR15822Library.swift" -import-objc-header "%S/Inputs/SR15822.h" -emit-module -emit-library -module-name SR15822Library
+// RUN: %target-swiftc_driver "%s" -o ./main -I"%t" -I"%S/Inputs" -L"%t" -lSR15822Library
+// RUN: LD_LIBRARY_PATH="%t" ./main | %FileCheck %s
+
+import SR15822ClangModule
+import SR15822Library
+let instance = SwiftyName()
+print(instance.foo)
+// CHECK: {{^foo$}}


### PR DESCRIPTION
This PR includes more aggressive steps beyond #41237 to resolve SR-15822.
Because `ClangImporter` imports separately clang modules and bridging headers, we could let it have separate instances to parse them.

Related thread: https://forums.swift.org/t/55091
Resolves SR-15822.