### PR TITLE
[SR-15049][Diagnostics] Infer throwing in async let patter synthesized auto closure for SelfCallExpr initialization

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -369,10 +369,14 @@ public:
 /// bind a name to it.  This is spelled "_".
 class AnyPattern : public Pattern {
   SourceLoc Loc;
+  /// Flag representing if this is an "async let _: Type" pattern since 
+  /// `async let _` is a subPattern of a \c TypedPattern represented 
+  /// as \c AnyPattern
+  bool IsAsyncLet;
 
 public:
-  explicit AnyPattern(SourceLoc Loc)
-      : Pattern(PatternKind::Any), Loc(Loc) { }
+  explicit AnyPattern(SourceLoc Loc, bool IsAsyncLet = false)
+      : Pattern(PatternKind::Any), Loc(Loc), IsAsyncLet(IsAsyncLet) {}
 
   static AnyPattern *createImplicit(ASTContext &Context) {
     auto *AP = new (Context) AnyPattern(SourceLoc());
@@ -382,6 +386,8 @@ public:
 
   SourceLoc getLoc() const { return Loc; }
   SourceRange getSourceRange() const { return Loc; }
+
+  bool isAsyncLet() const { return IsAsyncLet; }
 
   static bool classof(const Pattern *P) {
     return P->getKind() == PatternKind::Any;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -160,6 +160,9 @@ public:
     IVOLP_InLet
   } InVarOrLetPattern = IVOLP_NotInVarOrLet;
 
+  /// Whether this context has an async attribute.
+  bool InPatternWithAsyncAttribute = false;
+
   bool InPoundLineEnvironment = false;
   bool InPoundIfEnvironment = false;
   /// Do not call \c addUnvalidatedDeclWithOpaqueResultType when in an inactive

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1727,6 +1727,12 @@ bool PatternBindingDecl::isAsyncLet() const {
   if (auto var = getAnchoringVarDecl(0))
     return var->isAsyncLet();
 
+  // Check for "async let _: <Type> = <expression>" pattern.
+  auto *pattern = getPatternList()[0].getPattern();
+  if (auto *typedPattern = dyn_cast<TypedPattern>(pattern)) {
+    auto *anyPattern = dyn_cast<AnyPattern>(typedPattern->getSubPattern());
+    return anyPattern && anyPattern->isAsyncLet();
+  }
   return false;
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6851,6 +6851,10 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
                      SourceLoc TryLoc,
                      bool HasLetOrVarKeyword) {
   assert(StaticLoc.isInvalid() || StaticSpelling != StaticSpellingKind::None);
+  // Track whether we are parsing an 'async let' pattern.
+  const auto hasAsyncAttr = Attributes.hasAttribute<AsyncAttr>();
+  llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute,
+                                       hasAsyncAttr);
 
   if (StaticLoc.isValid()) {
     if (!Flags.contains(PD_HasContainerType)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6851,10 +6851,6 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
                      SourceLoc TryLoc,
                      bool HasLetOrVarKeyword) {
   assert(StaticLoc.isInvalid() || StaticSpelling != StaticSpellingKind::None);
-  // Track whether we are parsing an 'async let' pattern.
-  const auto hasAsyncAttr = Attributes.hasAttribute<AsyncAttr>();
-  llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute,
-                                       hasAsyncAttr);
 
   if (StaticLoc.isValid()) {
     if (!Flags.contains(PD_HasContainerType)) {
@@ -6949,6 +6945,11 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       // In our recursive parse, remember that we're in a var/let pattern.
       llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
       T(InVarOrLetPattern, isLet ? IVOLP_InLet : IVOLP_InVar);
+
+      // Track whether we are parsing an 'async let' pattern.
+      const auto hasAsyncAttr = Attributes.hasAttribute<AsyncAttr>();
+      llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute,
+                                           hasAsyncAttr);
 
       auto patternRes = parseTypedPattern();
       if (patternRes.hasCodeCompletion())
@@ -7630,7 +7631,11 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
         llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
         T(InVarOrLetPattern, Parser::IVOLP_InMatchingPattern);
         parseMatchingPattern(/*isExprBasic*/false);
-        
+
+        // Reset async attribute in parser context.
+        llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute,
+                                             false);
+
         if (consumeIf(tok::colon)) {
           backtrack.cancelBacktrack();
           diagnose(CaseLoc, diag::case_outside_of_switch, "case");

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2846,7 +2846,10 @@ ParserResult<Expr> Parser::parseExprClosure() {
   // reset our state to not be in a pattern for any recursive pattern parses.
   llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
   T(InVarOrLetPattern, IVOLP_NotInVarOrLet);
-  
+
+  // Reset async attribute in parser context.
+  llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
+
   // Parse the opening left brace.
   SourceLoc leftBrace = consumeToken();
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1111,8 +1111,8 @@ ParserResult<Pattern> Parser::parsePattern() {
   switch (Tok.getKind()) {
   case tok::l_paren:
     return parsePatternTuple();
-    
-  case tok::kw__:
+
+  case tok::kw__: {
     // Normally, '_' is invalid in type context for patterns, but they show up
     // in interface files as the name for type members that are non-public.
     // Treat them as an implicitly synthesized NamedPattern with a nameless
@@ -1126,8 +1126,12 @@ ParserResult<Pattern> Parser::parsePattern() {
       return makeParserResult(NamedPattern::createImplicit(Context, VD));
     }
     PatternCtx.setCreateSyntax(SyntaxKind::WildcardPattern);
-    return makeParserResult(new (Context) AnyPattern(consumeToken(tok::kw__)));
-    
+
+    const auto isAsyncLet =
+        InPatternWithAsyncAttribute && introducer == VarDecl::Introducer::Let;
+    return makeParserResult(
+        new (Context) AnyPattern(consumeToken(tok::kw__), isAsyncLet));
+  }
   case tok::identifier: {
     PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1170,7 +1170,10 @@ ParserResult<Pattern> Parser::parsePattern() {
     // In our recursive parse, remember that we're in a var/let pattern.
     llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
     T(InVarOrLetPattern, isLet ? IVOLP_InLet : IVOLP_InVar);
-    
+
+    // Reset async attribute in parser context.
+    llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
+
     ParserResult<Pattern> subPattern = parsePattern();
     if (subPattern.hasCodeCompletion())
       return makeParserCodeCompletionResult<Pattern>();
@@ -1379,6 +1382,9 @@ ParserResult<Pattern> Parser::parseMatchingPatternAsLetOrVar(bool isLet,
   // In our recursive parse, remember that we're in a var/let pattern.
   llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
     T(InVarOrLetPattern, isLet ? IVOLP_InLet : IVOLP_InVar);
+
+  // Reset async attribute in parser context.
+  llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
 
   ParserResult<Pattern> subPattern = parseMatchingPattern(isExprBasic);
   if (subPattern.isNull())

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1563,6 +1563,10 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     // In our recursive parse, remember that we're in a matching pattern.
     llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
       T(InVarOrLetPattern, IVOLP_InMatchingPattern);
+
+    // Reset async attribute in parser context.
+    llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
+
     ThePattern = parseMatchingPattern(/*isExprBasic*/ true);
   } else if (Tok.is(tok::kw_case)) {
     ConditionCtxt.setCreateSyntax(SyntaxKind::Unknown);
@@ -1581,7 +1585,10 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     // In our recursive parse, remember that we're in a var/let pattern.
     llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
       T(InVarOrLetPattern, wasLet ? IVOLP_InLet : IVOLP_InVar);
-    
+
+    // Reset async attribute in parser context.
+    llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
+
     ThePattern = parseMatchingPattern(/*isExprBasic*/ true);
     
     if (ThePattern.isNonNull()) {
@@ -2213,6 +2220,10 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
   if (consumeIf(tok::kw_case)) {
     llvm::SaveAndRestore<decltype(InVarOrLetPattern)>
       T(InVarOrLetPattern, Parser::IVOLP_InMatchingPattern);
+
+    // Reset async attribute in parser context.
+    llvm::SaveAndRestore<bool> AsyncAttr(InPatternWithAsyncAttribute, false);
+
     pattern = parseMatchingPattern(/*isExprBasic*/true);
     pattern = parseOptionalPatternTypeAnnotation(pattern);
   } else if (!IsCStyleFor || Tok.is(tok::kw_var)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1523,6 +1523,11 @@ namespace {
       if (!isSendableClosure(closure, /*forActorIsolation=*/false))
         return;
 
+      // Skip this warning for implicit closures such as async let
+      // implicit generated autoclosures.
+      if (closure->isImplicit())
+        return;
+
       SmallVector<CapturedValue, 2> captures;
       closure->getCaptureInfo().getLocalCaptures(captures);
       for (const auto &capture : captures) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -724,6 +724,12 @@ public:
   DeclContext *RethrowsDC = nullptr;
   DeclContext *ReasyncDC = nullptr;
 
+  // Indicates if `classifyApply` will attempt to classify SelfApplyExpr
+  // because that should be done only in certain contexts like when infering
+  // if "async let" implicit auto closure wrapping initialize expression can
+  // throw.
+  bool ClassifySelfApplyExpr = false;
+
   DeclContext *getPolymorphicEffectDeclContext(EffectKind kind) const {
     switch (kind) {
     case EffectKind::Throws: return RethrowsDC;
@@ -745,15 +751,23 @@ public:
 
   /// Check to see if the given function application throws or is async.
   Classification classifyApply(ApplyExpr *E) {
-    if (isa<SelfApplyExpr>(E)) {
-      assert(!E->isImplicitlyAsync());
-      return Classification();
-    }
-
     // An apply expression is a potential throw site if the function throws.
     // But if the expression didn't type-check, suppress diagnostics.
     if (!E->getType() || E->getType()->hasError())
       return Classification::forInvalidCode();
+
+    if (auto *SAE = dyn_cast<SelfApplyExpr>(E)) {
+      assert(!E->isImplicitlyAsync());
+
+      if (ClassifySelfApplyExpr && !SAE->getBase()->isImplicit()) {
+        auto fnType = E->getType()->getAs<AnyFunctionType>();
+        if (fnType && fnType->isThrowing()) {
+          return Classification::forUnconditional(
+              EffectKind::Throws, PotentialEffectReason::forApply());
+        }
+      }
+      return Classification();
+    }
 
     auto type = E->getFn()->getType();
     if (!type) return Classification::forInvalidCode();
@@ -2967,6 +2981,8 @@ void TypeChecker::checkPropertyWrapperEffects(
 }
 
 bool TypeChecker::canThrow(Expr *expr) {
-  return (ApplyClassifier().classifyExpr(expr, EffectKind::Throws)
-          == ConditionalEffectKind::Always);
+  ApplyClassifier classifier;
+  classifier.ClassifySelfApplyExpr = true;
+  return (classifier.classifyExpr(expr, EffectKind::Throws) ==
+          ConditionalEffectKind::Always);
 }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -759,7 +759,7 @@ public:
     if (auto *SAE = dyn_cast<SelfApplyExpr>(E)) {
       assert(!E->isImplicitlyAsync());
 
-      if (ClassifySelfApplyExpr && !SAE->getBase()->isImplicit()) {
+      if (ClassifySelfApplyExpr) {
         auto fnType = E->getType()->getAs<AnyFunctionType>();
         if (fnType && fnType->isThrowing()) {
           return Classification::forUnconditional(

--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// REQUIRES: concurrency
+
+func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
+   // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
+}
+
+func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
async let pattern is wrapped in an synthesized auto closure by the rewriter and those implicit auto closure are being considered in effects diagnostics which leads to unwanted errors and misleading `autoclosure` messages. 
This PR is basically:
* Tracking `async let _:<Type>` as async let pattern binding declaration. (The current logic doesn't account this as being an async let pattern)
* Making implicit synthesized auto closure transparent to some effects diagnostic heuristics.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15049.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
