### PR TITLE
Remove ActorIsolation::DistributedActorInstance.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -55,10 +55,6 @@ public:
     /// For example, a mutable stored property or synchronous function within
     /// the actor is isolated to the instance of that actor.
     ActorInstance,
-    /// The declaration is isolated to a (potentially) distributed actor.
-    /// Distributed actors may access _their_ state (same as 'ActorInstance')
-    /// however others may not access any properties on other distributed actors.
-    DistributedActorInstance,
     /// The declaration is explicitly specified to be independent of any actor,
     /// meaning that it can be used from any actor but is also unable to
     /// refer to the isolated state of any given actor.
@@ -99,10 +95,6 @@ public:
     return ActorIsolation(ActorInstance, actor);
   }
 
-  static ActorIsolation forDistributedActorInstance(NominalTypeDecl *actor) {
-    return ActorIsolation(DistributedActorInstance, actor);
-  }
-
   static ActorIsolation forGlobalActor(Type globalActor, bool unsafe) {
     return ActorIsolation(
         unsafe ? GlobalActorUnsafe : GlobalActor, globalActor);
@@ -117,7 +109,7 @@ public:
   bool isIndependent() const { return kind == Independent; }
 
   NominalTypeDecl *getActor() const {
-    assert(getKind() == ActorInstance || getKind() == DistributedActorInstance);
+    assert(getKind() == ActorInstance);
     return actor;
   }
 
@@ -151,7 +143,6 @@ public:
       return true;
 
     case ActorInstance:
-    case DistributedActorInstance:
       return lhs.actor == rhs.actor;
 
     case GlobalActor:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2013,14 +2013,13 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
           return true;
 
         switch (getActorIsolation(type)) {
-          case swift::ActorIsolation::Unspecified:
-          case swift::ActorIsolation::GlobalActorUnsafe:
+          case ActorIsolation::Unspecified:
+          case ActorIsolation::GlobalActorUnsafe:
             break;
 
-          case swift::ActorIsolation::ActorInstance:
-          case swift::ActorIsolation::DistributedActorInstance:
-          case swift::ActorIsolation::Independent:
-          case swift::ActorIsolation::GlobalActor:
+          case ActorIsolation::ActorInstance:
+          case ActorIsolation::Independent:
+          case ActorIsolation::GlobalActor:
             return true;
         }
       }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -832,10 +832,6 @@ static void formatDiagnosticArgument(StringRef Modifier,
       Out << "actor-isolated";
       break;
 
-    case ActorIsolation::DistributedActorInstance:
-      Out << "distributed actor-isolated";
-      break;
-
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe: {
       Type globalActor = isolation.getGlobalActor();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1488,7 +1488,6 @@ void CustomAttrTypeRequest::cacheResult(Type value) const {
 bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
   case ActorInstance:
-  case DistributedActorInstance:
   case Independent:
   case Unspecified:
     return false;
@@ -1503,7 +1502,6 @@ bool ActorIsolation::requiresSubstitution() const {
 ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
-  case DistributedActorInstance:
   case Independent:
   case Unspecified:
     return *this;
@@ -1521,10 +1519,6 @@ void swift::simple_display(
   switch (state) {
     case ActorIsolation::ActorInstance:
       out << "actor-isolated to instance of " << state.getActor()->getName();
-      break;
-
-    case ActorIsolation::DistributedActorInstance:
-      out << "distributed-actor-isolated to instance of " << state.getActor()->getName();
       break;
 
     case ActorIsolation::Independent:

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2627,11 +2627,8 @@ public:
     auto isolation = getActorIsolation(const_cast<ValueDecl *>(VD));
 
     switch (isolation.getKind()) {
-    case ActorIsolation::DistributedActorInstance: {
-      // TODO: implicitlyThrowing here for distributed
-      LLVM_FALLTHROUGH; // continue the ActorInstance checks
-    }
     case ActorIsolation::ActorInstance: {
+        // TODO: implicitlyThrowing here for distributed
       if (IsCrossActorReference) {
         implicitlyAsync = true;
         // TODO: 'NotRecommended' if this is a r-value reference.

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -343,7 +343,6 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
   // must be instance isolated
   switch (isolation) {
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::DistributedActorInstance:
       return true;
 
     case ActorIsolation::Unspecified:

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -568,7 +568,7 @@ void SILGenFunction::emitDistributedActorClassMemberDestruction(
     B.emitBlock(remoteMemberDestroyBB);
 
     for (VarDecl *vd : cd->getStoredProperties()) {
-      if (getActorIsolation(vd) == ActorIsolation::DistributedActorInstance)
+      if (getActorIsolation(vd) == ActorIsolation::ActorInstance)
         continue;
 
       destroyClassMember(cleanupLoc, selfValue, vd);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -532,7 +532,6 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
       if (auto destructor = dyn_cast<DestructorDecl>(dc)) {
         switch (getActorIsolation(destructor)) {
         case ActorIsolation::ActorInstance:
-        case ActorIsolation::DistributedActorInstance:
           return true;
 
         case ActorIsolation::GlobalActor:
@@ -600,11 +599,6 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
         }
       }
       break;
-
-    case ActorIsolation::DistributedActorInstance: {
-      // TODO: perhaps here we can emit our special handling to make a message?
-      LLVM_FALLTHROUGH;
-    }
 
     case ActorIsolation::ActorInstance: {
       // Only produce an executor for actor-isolated functions that are async
@@ -804,8 +798,7 @@ Optional<SILValue> SILGenFunction::emitExecutor(
   case ActorIsolation::Independent:
     return None;
 
-  case ActorIsolation::ActorInstance:
-  case ActorIsolation::DistributedActorInstance: {
+  case ActorIsolation::ActorInstance: {
     // "self" here means the actor instance's "self" value.
     assert(maybeSelf.hasValue() && "actor-instance but no self provided?");
     auto self = maybeSelf.getValue();

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -925,7 +925,6 @@ void LifetimeChecker::injectActorHops() {
   // Must be an initializer that is isolated to self.
   switch (getActorIsolation(ctor)) {
     case ActorIsolation::ActorInstance:
-    case ActorIsolation::DistributedActorInstance:
       break;
 
     case ActorIsolation::Unspecified:

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -89,7 +89,6 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   // The property must not be isolated to an actor instance.
   switch (auto isolation = getActorIsolation(var)) {
   case ActorIsolation::ActorInstance:
-  case ActorIsolation::DistributedActorInstance:
     var->diagnose(
         diag::actor_instance_property_wrapper, var->getName(),
         nominal->getName());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2937,12 +2937,13 @@ bool ConformanceChecker::checkActorIsolation(
 
     // An actor-isolated witness can only conform to an actor-isolated
     // requirement.
-    if (requirementIsolation == ActorIsolation::ActorInstance) {
+    auto requirementFunc = dyn_cast<AbstractFunctionDecl>(requirement);
+    if (requirementIsolation == ActorIsolation::ActorInstance &&
+        !(requirementFunc && requirementFunc->isDistributed())) {
       return false;
     }
 
     auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness);
-    auto requirementFunc = dyn_cast<AbstractFunctionDecl>(requirement);
     auto nominal = dyn_cast<NominalTypeDecl>(witness->getDeclContext());
     auto witnessClass = dyn_cast<ClassDecl>(witness->getDeclContext());
     if (auto extension = dyn_cast<ExtensionDecl>(witness->getDeclContext())) {
@@ -3170,11 +3171,6 @@ bool ConformanceChecker::checkActorIsolation(
   switch (auto requirementIsolation = getActorIsolation(requirement)) {
   case ActorIsolation::ActorInstance:
     llvm_unreachable("There are not actor protocols");
-  case ActorIsolation::DistributedActorInstance:
-    // A requirement inside a distributed actor, where it has a protocol that was
-    // bound requiring a `DistributedActor` conformance (`protocol D: DistributedActor`),
-    // results in the requirement being isolated to given distributed actor.
-    break;
 
   case ActorIsolation::GlobalActorUnsafe:
     requirementIsUnsafe = true;


### PR DESCRIPTION
The distributed case is distinguishable from the non-distributed case
based on the actor type itself for those rare cases where we care. The
vast majority of code is simplified by treating this identically to
`ActorInstance`.
