### PR TITLE
[cmake] Allow overriding Clang resource symlink target

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -205,20 +205,23 @@ endif()
 if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER OR SWIFT_PREBUILT_CLANG)
   # This will still link against the Swift-forked clang headers if the Swift
   # toolchain was built with SWIFT_INCLUDE_TOOLS.
-  set(symlink_dir ${clang_headers_location})
+  set(SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET_default ${clang_headers_location})
 else()
-  set(symlink_dir "../clang/${CLANG_VERSION}")
+  set(SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET_default "../clang/${CLANG_VERSION}")
 endif()
+
+set(SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET
+  ${SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET_default} CACHE STRING "The target of the installed symlink at lib/swift/clang")
 
 swift_install_symlink_component(clang-resource-dir-symlink
   LINK_NAME clang
-  TARGET ${symlink_dir}
+  TARGET ${SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET}
   DESTINATION "lib/swift")
 
 if(SWIFT_BUILD_STATIC_STDLIB)
   swift_install_symlink_component(clang-resource-dir-symlink
     LINK_NAME clang
-    TARGET ${symlink_dir}
+    TARGET ${SWIFT_CLANG_RESOURCE_DIR_SYMLINK_INSTALL_TARGET}
     DESTINATION "lib/swift_static")
 endif()
 


### PR DESCRIPTION
When building with a prebuilt Clang, the changes introduced in #40707
supposed that the toolchain was in its final path.

When building in stages (first the toolchain, then the standard
library), the toolchain might not be in the final path, and the created
symlink will point to a machine-local path that does not make sense.

The changes introduced should not modify the existing behaviour
introduced by #40707, but should allow customizing the final
installation target using the CMake cached variable for those setups
that need the flexibility.

/cc @buttaface 