### PR TITLE
Ensure that async/synchronous overloading works in implicit-async closures

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2724,13 +2724,11 @@ bool ConstraintSystem::isAsynchronousContext(DeclContext *dc) {
   if (auto func = dyn_cast<AbstractFunctionDecl>(dc))
     return func->isAsyncContext();
 
-  if (auto abstractClosure = dyn_cast<AbstractClosureExpr>(dc)) {
-    if (Type type = GetClosureType{*this}(abstractClosure)) {
-      if (auto fnType = type->getAs<AnyFunctionType>())
-        return fnType->isAsync();
-    }
-
-    return abstractClosure->isBodyAsync();
+  if (auto closure = dyn_cast<ClosureExpr>(dc)) {
+    return evaluateOrDefault(
+        getASTContext().evaluator,
+        ClosureEffectsRequest{const_cast<ClosureExpr *>(closure)},
+        FunctionType::ExtInfo()).isAsync();
   }
 
   return false;

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -163,3 +163,20 @@ func testAsyncWithConversions() async {
   // expected-error@-1:7{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   // expected-note@-2:7{{call is 'async'}}
 }
+
+// rdar://88692889 - make sure overload resolution cues off the presence of
+// 'await' in the body to determine whether to prefer async functions, not
+// whether the closure is in a context where it will be converted to async.
+@available(SwiftStdlib 5.1, *)
+struct OverloadInImplicitAsyncClosure {
+  init(int: Int) async throws {
+    let task = Task { () -> Self in
+      let result = try Self(int: int)
+      return result
+    }
+
+    self = try await task.value
+  }
+
+  init(int: Int) throws { }
+}


### PR DESCRIPTION
When we are within a closure that is not required to be asynchronous
(i.e., it has no `await` in it), make sure that we prefer synchronous
functions to asynchronous ones, even if this closure will later be
converted to `async` and the constraint system knows that.

Fixes rdar://88692889.
