### PR TITLE
RequirementMachine: Record rewrite loops during superclass unification

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4026,7 +4026,7 @@ public:
   ClassDecl *getSuperclassDecl() const;
 
   /// Check if this class is a superclass or equal to the given class.
-  bool isSuperclassOf(ClassDecl *other) const;
+  bool isSuperclassOf(const ClassDecl *other) const;
 
   /// Set the superclass of this class.
   void setSuperclass(Type superclass);
@@ -4121,7 +4121,7 @@ public:
 
   /// Whether the class uses the ObjC object model (reference counting,
   /// allocation, etc.), the Swift model, or has no reference counting at all.
-  ReferenceCounting getObjectModel() {
+  ReferenceCounting getObjectModel() const {
     if (isForeignReferenceType())
       return ReferenceCounting::None;
 
@@ -4131,7 +4131,7 @@ public:
     return ReferenceCounting::Native;
   }
 
-  LayoutConstraintKind getLayoutConstraintKind() {
+  LayoutConstraintKind getLayoutConstraintKind() const {
     if (getObjectModel() == ReferenceCounting::ObjC)
       return LayoutConstraintKind::Class;
 
@@ -4261,7 +4261,7 @@ public:
   /// Used to determine if this class decl is a foriegn reference type. I.e., a
   /// non-reference-counted swift reference type that was imported from a C++
   /// record.
-  bool isForeignReferenceType();
+  bool isForeignReferenceType() const;
 };
 
 /// The set of known protocols for which derived conformances are supported.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4937,7 +4937,7 @@ void swift::simple_display(llvm::raw_ostream &out, AncestryFlags value) {
   out << " }";
 }
 
-bool ClassDecl::isSuperclassOf(ClassDecl *other) const {
+bool ClassDecl::isSuperclassOf(const ClassDecl *other) const {
   llvm::SmallPtrSet<const ClassDecl *, 8> visited;
 
   do {
@@ -5082,7 +5082,7 @@ bool ClassDecl::walkSuperclasses(
   return false;
 }
 
-bool ClassDecl::isForeignReferenceType() {
+bool ClassDecl::isForeignReferenceType() const {
   return getClangDecl() && isa<clang::RecordDecl>(getClangDecl());
 }
 

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -63,12 +63,13 @@ void PropertyMap::concretizeNestedTypesFromConcreteParents() {
         llvm::dbgs() << "- via superclass requirement\n";
       }
 
+      const auto &superclassReq = props->getSuperclassRequirement();
       concretizeNestedTypesFromConcreteParent(
           props->getKey(),
           RequirementKind::Superclass,
-          *props->SuperclassRule,
-          props->Superclass->getConcreteType(),
-          props->Superclass->getSubstitutions(),
+          *superclassReq.SuperclassRule,
+          superclassReq.SuperclassType->getConcreteType(),
+          superclassReq.SuperclassType->getSubstitutions(),
           props->ConformsToRules,
           props->ConformsTo,
           props->SuperclassConformances);

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -115,11 +115,12 @@ void PropertyBag::dump(llvm::raw_ostream &out) const {
     out << " layout: " << Layout;
   }
 
-  if (Superclass) {
-    out << " superclass: " << *Superclass;
+  if (hasSuperclassBound()) {
+    const auto &superclassReq = getSuperclassRequirement();
+    out << " superclass: " << *superclassReq.SuperclassType;
   }
 
-  if (ConcreteType) {
+  if (isConcreteType()) {
     out << " concrete_type: " << *ConcreteType;
   }
 
@@ -154,8 +155,10 @@ Type PropertyBag::getSuperclassBound(
     const MutableTerm &lookupTerm,
     const PropertyMap &map) const {
   MutableTerm prefix = getPrefixAfterStrippingKey(lookupTerm);
-  return map.getTypeFromSubstitutionSchema(Superclass->getConcreteType(),
-                                           Superclass->getSubstitutions(),
+
+  const auto &req = getSuperclassRequirement();
+  return map.getTypeFromSubstitutionSchema(req.SuperclassType->getConcreteType(),
+                                           req.SuperclassType->getSubstitutions(),
                                            genericParams, prefix);
 }
 
@@ -199,16 +202,22 @@ void PropertyBag::copyPropertiesFrom(const PropertyBag *next,
   // T := UV should have substitutions {UX1, ..., UXn}.
   MutableTerm prefix(Key.begin(), Key.begin() + prefixLength);
 
-  if (next->Superclass) {
-    Superclass = next->Superclass->prependPrefixToConcreteSubstitutions(
-        prefix, ctx);
-    SuperclassRule = next->SuperclassRule;
-  }
-
   if (next->ConcreteType) {
     ConcreteType = next->ConcreteType->prependPrefixToConcreteSubstitutions(
         prefix, ctx);
     ConcreteTypeRule = next->ConcreteTypeRule;
+  }
+
+  // Copy over class hierarchy information.
+  SuperclassDecl = next->SuperclassDecl;
+  if (!next->Superclasses.empty()) {
+    Superclasses = next->Superclasses;
+
+    for (auto &pair : Superclasses) {
+      pair.second.SuperclassType =
+          pair.second.SuperclassType->prependPrefixToConcreteSubstitutions(
+              prefix, ctx);
+    }
   }
 }
 
@@ -221,11 +230,18 @@ void PropertyBag::verify(const RewriteSystem &system) const {
     assert(symbol.getProtocol() == ConformsTo[i]);
   }
 
-  // FIXME: Once unification introduces new rules, add asserts requiring
-  // that the layout, superclass and concrete type symbols match, as above
+  // FIXME: Add asserts requiring that the layout, superclass and
+  // concrete type symbols match, as above
   assert(!Layout.isNull() == LayoutRule.hasValue());
-  assert(Superclass.hasValue() == SuperclassRule.hasValue());
   assert(ConcreteType.hasValue() == ConcreteTypeRule.hasValue());
+
+  assert((SuperclassDecl == nullptr) == Superclasses.empty());
+  for (const auto &pair : Superclasses) {
+    const auto &req = pair.second;
+    assert(req.SuperclassType.hasValue());
+    assert(req.SuperclassRule.hasValue());
+  }
+
 #endif
 }
 

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -250,6 +250,13 @@ private:
 
   void addConformanceProperty(Term key, Symbol property, unsigned ruleID);
   void addLayoutProperty(Term key, Symbol property, unsigned ruleID);
+
+  void unifyConcreteTypes(Term key,
+                          Optional<Symbol> &existingProperty,
+                          Optional<unsigned> &existingRuleID,
+                          Symbol property,
+                          unsigned ruleID);
+
   void addSuperclassProperty(Term key, Symbol property, unsigned ruleID);
   void addConcreteTypeProperty(Term key, Symbol property, unsigned ruleID);
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -47,7 +47,8 @@ bool PropertyMap::checkRulePairOnce(unsigned firstRuleID,
 /// This is used to define rewrite loops for relating pairs of rules where
 /// one implies another:
 ///
-/// - a more specific layout constraint implies a general layout constraint5
+/// - a more specific layout constraint implies a general layout constraint
+/// - a more specific superclass bound implies a less specific superclass bound
 /// - a superclass bound implies a layout constraint
 /// - a concrete type that is a class implies a superclass bound
 /// - a concrete type that is a class implies a layout constraint
@@ -64,6 +65,8 @@ static void recordRelation(Term key,
 
   assert((lhsProperty.getKind() == Symbol::Kind::Layout &&
           rhsProperty.getKind() == Symbol::Kind::Layout) ||
+         (lhsProperty.getKind() == Symbol::Kind::Superclass &&
+          rhsProperty.getKind() == Symbol::Kind::Superclass) ||
          (lhsProperty.getKind() == Symbol::Kind::Superclass &&
           rhsProperty.getKind() == Symbol::Kind::Layout) ||
          (lhsProperty.getKind() == Symbol::Kind::ConcreteType &&
@@ -138,184 +141,6 @@ static void recordConflict(Term key,
   newRule.markConflicting();
 }
 
-namespace {
-  /// Utility class used by unifyConcreteTypes() and unifySuperclasses()
-  /// to walk two concrete types in parallel. Any time there is a mismatch,
-  /// records a new induced rule.
-  class ConcreteTypeMatcher : public TypeMatcher<ConcreteTypeMatcher> {
-    ArrayRef<Term> lhsSubstitutions;
-    ArrayRef<Term> rhsSubstitutions;
-    RewriteContext &ctx;
-    RewriteSystem &system;
-    bool debug;
-
-  public:
-    ConcreteTypeMatcher(ArrayRef<Term> lhsSubstitutions,
-                        ArrayRef<Term> rhsSubstitutions,
-                        RewriteSystem &system,
-                        bool debug)
-        : lhsSubstitutions(lhsSubstitutions),
-          rhsSubstitutions(rhsSubstitutions),
-          ctx(system.getRewriteContext()), system(system),
-          debug(debug) {}
-
-    bool alwaysMismatchTypeParameters() const { return true; }
-
-    bool mismatch(TypeBase *firstType, TypeBase *secondType,
-                  Type sugaredFirstType) {
-      bool firstAbstract = firstType->isTypeParameter();
-      bool secondAbstract = secondType->isTypeParameter();
-
-      if (firstAbstract && secondAbstract) {
-        // Both sides are type parameters; add a same-type requirement.
-        auto lhsTerm = ctx.getRelativeTermForType(CanType(firstType),
-                                                  lhsSubstitutions);
-        auto rhsTerm = ctx.getRelativeTermForType(CanType(secondType),
-                                                  rhsSubstitutions);
-        if (lhsTerm != rhsTerm) {
-          if (debug) {
-            llvm::dbgs() << "%% Induced rule " << lhsTerm
-                         << " == " << rhsTerm << "\n";
-          }
-
-          // FIXME: Need a rewrite path here.
-          (void) system.addRule(lhsTerm, rhsTerm);
-        }
-        return true;
-      }
-
-      if (firstAbstract && !secondAbstract) {
-        // A type parameter is equated with a concrete type; add a concrete
-        // type requirement.
-        auto subjectTerm = ctx.getRelativeTermForType(CanType(firstType),
-                                                      lhsSubstitutions);
-
-        SmallVector<Term, 3> result;
-        auto concreteType = ctx.getRelativeSubstitutionSchemaFromType(
-            CanType(secondType), rhsSubstitutions, result);
-
-        MutableTerm constraintTerm(subjectTerm);
-        constraintTerm.add(Symbol::forConcreteType(concreteType, result, ctx));
-
-        if (debug) {
-          llvm::dbgs() << "%% Induced rule " << subjectTerm
-                       << " == " << constraintTerm << "\n";
-        }
-
-        // FIXME: Need a rewrite path here.
-        (void) system.addRule(subjectTerm, constraintTerm);
-        return true;
-      }
-
-      if (!firstAbstract && secondAbstract) {
-        // A concrete type is equated with a type parameter; add a concrete
-        // type requirement.
-        auto subjectTerm = ctx.getRelativeTermForType(CanType(secondType),
-                                                      rhsSubstitutions);
-
-        SmallVector<Term, 3> result;
-        auto concreteType = ctx.getRelativeSubstitutionSchemaFromType(
-            CanType(firstType), lhsSubstitutions, result);
-
-        MutableTerm constraintTerm(subjectTerm);
-        constraintTerm.add(Symbol::forConcreteType(concreteType, result, ctx));
-
-        if (debug) {
-          llvm::dbgs() << "%% Induced rule " << subjectTerm
-                       << " == " << constraintTerm << "\n";
-        }
-
-        // FIXME: Need a rewrite path here.
-        (void) system.addRule(subjectTerm, constraintTerm);
-        return true;
-      }
-
-      // Any other kind of type mismatch involves conflicting concrete types on
-      // both sides, which can only happen on invalid input.
-      return false;
-    }
-  };
-}
-
-/// When a type parameter has two superclasses, we have to both unify the
-/// type constructor arguments, and record the most derived superclass.
-///
-/// For example, if we have this setup:
-///
-///   class Base<T, T> {}
-///   class Middle<U> : Base<T, T> {}
-///   class Derived : Middle<Int> {}
-///
-///   T : Base<U, V>
-///   T : Derived
-///
-/// The most derived superclass requirement is 'T : Derived'.
-///
-/// The corresponding superclass of 'Derived' is 'Base<Int, Int>', so we
-/// unify the type constructor arguments of 'Base<U, V>' and 'Base<Int, Int>',
-/// which generates two induced rules:
-///
-///   U.[concrete: Int] => U
-///   V.[concrete: Int] => V
-///
-/// Returns the most derived superclass, which becomes the new superclass
-/// that gets recorded in the property map.
-static std::pair<Symbol, bool> unifySuperclasses(
-    Symbol lhs, Symbol rhs, RewriteSystem &system,
-    bool debug) {
-  if (debug) {
-    llvm::dbgs() << "% Unifying " << lhs << " with " << rhs << "\n";
-  }
-
-  auto lhsType = lhs.getConcreteType();
-  auto rhsType = rhs.getConcreteType();
-
-  auto *lhsClass = lhsType.getClassOrBoundGenericClass();
-  assert(lhsClass != nullptr);
-
-  auto *rhsClass = rhsType.getClassOrBoundGenericClass();
-  assert(rhsClass != nullptr);
-
-  // First, establish the invariant that lhsClass is either equal to, or
-  // is a superclass of rhsClass.
-  if (lhsClass == rhsClass ||
-      lhsClass->isSuperclassOf(rhsClass)) {
-    // Keep going.
-  } else if (rhsClass->isSuperclassOf(lhsClass)) {
-    std::swap(rhs, lhs);
-    std::swap(rhsType, lhsType);
-    std::swap(rhsClass, lhsClass);
-  } else {
-    // FIXME: Diagnose the conflict.
-    if (debug) {
-      llvm::dbgs() << "%% Unrelated superclass types\n";
-    }
-
-    return std::make_pair(lhs, true);
-  }
-
-  if (lhsClass != rhsClass) {
-    // Get the corresponding substitutions for the right hand side.
-    assert(lhsClass->isSuperclassOf(rhsClass));
-    rhsType = rhsType->getSuperclassForDecl(lhsClass)
-                     ->getCanonicalType();
-  }
-
-  // Unify type contructor arguments.
-  ConcreteTypeMatcher matcher(lhs.getSubstitutions(),
-                              rhs.getSubstitutions(),
-                              system, debug);
-  if (!matcher.match(lhsType, rhsType)) {
-    if (debug) {
-      llvm::dbgs() << "%% Superclass conflict\n";
-    }
-    return std::make_pair(rhs, true);
-  }
-
-  // Record the more specific class.
-  return std::make_pair(rhs, false);
-}
-
 void PropertyMap::addConformanceProperty(
     Term key, Symbol property, unsigned ruleID) {
   auto *props = getOrCreateProperties(key);
@@ -370,38 +195,172 @@ void PropertyMap::addLayoutProperty(
   }
 }
 
+/// Given a term T == U.V, an existing rule (V.[superclass: C] => V), and
+/// a superclass declaration D of C, record a new rule (T.[superclass: C'] => T)
+/// where C' is the substituted superclass type of C for D.
+///
+/// For example, suppose we have
+///
+///    class Derived : Base<Int> {}
+///    class Base<T> {}
+///
+/// Given C == Derived and D == Base, then C' == Base<Int>.
+void PropertyMap::recordSuperclassRelation(Term key,
+                                           Symbol superclassType,
+                                           unsigned superclassRuleID,
+                                           const ClassDecl *otherClass) {
+  auto derivedType = superclassType.getConcreteType();
+  assert(otherClass->isSuperclassOf(derivedType->getClassOrBoundGenericClass()));
+
+  auto baseType = derivedType->getSuperclassForDecl(otherClass)
+      ->getCanonicalType();
+
+  SmallVector<Term, 3> baseSubstitutions;
+  auto baseSchema = Context.getRelativeSubstitutionSchemaFromType(
+      baseType, superclassType.getSubstitutions(),
+      baseSubstitutions);
+
+  auto baseSymbol = Symbol::forSuperclass(baseSchema, baseSubstitutions,
+                                          Context);
+
+  bool debug = Debug.contains(DebugFlags::ConcreteUnification);
+  recordRelation(key, superclassRuleID, baseSymbol, System, debug);
+}
+
+/// When a type parameter has two superclasses, we have to both unify the
+/// type constructor arguments, and record the most derived superclass.
+///
+/// For example, if we have this setup:
+///
+///   class Base<T, T> {}
+///   class Middle<U> : Base<T, T> {}
+///   class Derived : Middle<Int> {}
+///
+///   T : Base<U, V>
+///   T : Derived
+///
+/// The most derived superclass requirement is 'T : Derived'.
+///
+/// The corresponding superclass of 'Derived' is 'Base<Int, Int>', so we
+/// unify the type constructor arguments of 'Base<U, V>' and 'Base<Int, Int>',
+/// which generates two induced rules:
+///
+///   U.[concrete: Int] => U
+///   V.[concrete: Int] => V
 void PropertyMap::addSuperclassProperty(
     Term key, Symbol property, unsigned ruleID) {
   auto *props = getOrCreateProperties(key);
+  auto &newRule = System.getRule(ruleID);
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
+
+  const auto *superclassDecl = property.getConcreteType()
+      ->getClassOrBoundGenericClass();
+  assert(superclassDecl != nullptr);
 
   if (checkRuleOnce(ruleID)) {
     // A rule (T.[superclass: C] => T) induces a rule (T.[layout: L] => T),
     // where L is either AnyObject or _NativeObject.
-    auto superclass =
-        property.getConcreteType()->getClassOrBoundGenericClass();
     auto layout =
         LayoutConstraint::getLayoutConstraint(
-          superclass->getLayoutConstraintKind(),
+          superclassDecl->getLayoutConstraintKind(),
           Context.getASTContext());
     auto layoutSymbol = Symbol::forLayout(layout, Context);
 
     recordRelation(key, ruleID, layoutSymbol, System, debug);
   }
 
-  if (!props->Superclass) {
-    props->Superclass = property;
-    props->SuperclassRule = ruleID;
+  if (debug) {
+    llvm::dbgs() << "% New superclass " << superclassDecl->getName()
+                 << " for " << key << " is ";
+  }
+
+  // If this is the first superclass requirement we've seen for this term,
+  // just record it and we're done.
+  if (!props->SuperclassDecl) {
+    props->SuperclassDecl = superclassDecl;
+
+    assert(props->Superclasses.empty());
+    auto &req = props->Superclasses[superclassDecl];
+
+    assert(!req.SuperclassType.hasValue());
+    assert(!req.SuperclassRule.hasValue());
+
+    req.SuperclassType = property;
+    req.SuperclassRule = ruleID;
     return;
   }
 
-  assert(props->SuperclassRule.hasValue());
-  auto pair = unifySuperclasses(*props->Superclass, property,
-                                System, debug);
-  props->Superclass = pair.first;
-  bool conflict = pair.second;
-  if (conflict) {
-    recordConflict(key, *props->SuperclassRule, ruleID, System);
+  // Otherwise, we compare it against the existing superclass requirement.
+  assert(!props->Superclasses.empty());
+
+  if (superclassDecl == props->SuperclassDecl) {
+    if (debug) {
+      llvm::dbgs() << "equal to existing superclass\n";
+    }
+
+    // Perform concrete type unification at this level of the class
+    // hierarchy.
+    auto &req = props->Superclasses[superclassDecl];
+    assert(req.SuperclassType.hasValue());
+    assert(req.SuperclassRule.hasValue());
+
+    unifyConcreteTypes(key, req.SuperclassType, req.SuperclassRule,
+                       property, ruleID);
+
+  } else if (superclassDecl->isSuperclassOf(props->SuperclassDecl)) {
+    if (debug) {
+      llvm::dbgs() << "less specific than existing superclass "
+                   << props->SuperclassDecl->getName() << "\n";
+    }
+
+    // Record a relation where existing superclass implies the new superclass.
+    const auto &existingReq = props->Superclasses[props->SuperclassDecl];
+    if (checkRulePairOnce(*existingReq.SuperclassRule, ruleID)) {
+      recordSuperclassRelation(key,
+                               *existingReq.SuperclassType,
+                               *existingReq.SuperclassRule,
+                               superclassDecl);
+    }
+
+    // Record the new rule at the less specific level of the class
+    // hierarchy, performing concrete type unification if we've
+    // already seen another rule at that level.
+    auto &req = props->Superclasses[superclassDecl];
+
+    unifyConcreteTypes(key, req.SuperclassType, req.SuperclassRule,
+                       property, ruleID);
+
+  } else if (props->SuperclassDecl->isSuperclassOf(superclassDecl)) {
+    if (debug) {
+      llvm::dbgs() << "more specific than existing superclass "
+                   << props->SuperclassDecl->getName() << "\n";
+    }
+
+    // Record a relation where new superclass implies the existing superclass.
+    const auto &existingReq = props->Superclasses[props->SuperclassDecl];
+    if (checkRulePairOnce(*existingReq.SuperclassRule, ruleID)) {
+      recordSuperclassRelation(key, property, ruleID,
+                               props->SuperclassDecl);
+    }
+
+    // Record the new rule at the more specific level of the class
+    // hierarchy.
+    auto &req = props->Superclasses[superclassDecl];
+    assert(!req.SuperclassType.hasValue());
+    assert(!req.SuperclassRule.hasValue());
+
+    req.SuperclassType = property;
+    req.SuperclassRule = ruleID;
+
+    props->SuperclassDecl = superclassDecl;
+
+  } else {
+    if (debug) {
+      llvm::dbgs() << "not related to existing superclass "
+                   << props->SuperclassDecl->getName() << "\n";
+    }
+
+    newRule.markConflicting();
   }
 }
 
@@ -851,7 +810,7 @@ void PropertyMap::checkConcreteTypeRequirements() {
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
 
   for (auto *props : Entries) {
-    if (props->ConcreteTypeRule) {
+    if (props->isConcreteType()) {
       auto concreteType = props->ConcreteType->getConcreteType();
 
       // A rule (T.[concrete: C] => T) where C is a class type induces a rule
@@ -866,10 +825,11 @@ void PropertyMap::checkConcreteTypeRequirements() {
 
       // If the concrete type is not a class and we have a superclass
       // requirement, we have a conflict.
-      } else if (props->SuperclassRule) {
+      } else if (props->hasSuperclassBound()) {
+        const auto &req = props->getSuperclassRequirement();
         recordConflict(props->getKey(),
                        *props->ConcreteTypeRule,
-                       *props->SuperclassRule, System);
+                       *req.SuperclassRule, System);
       }
 
       // A rule (T.[concrete: C] => T) where C is a class type induces a rule

--- a/test/Generics/minimize_superclass_unification_generic.swift
+++ b/test/Generics/minimize_superclass_unification_generic.swift
@@ -1,0 +1,488 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+class A<T, U, V> {}
+
+class B<X, Y, Z, W> : A<X, (Y) -> Z, Int> {}
+
+class C<I, J : Sequence, K> : B<String, I, [J.Element], K> {}
+
+
+// ---------------------------------------------- //
+// Unifying two requirements in the same protocol //
+// ---------------------------------------------- //
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pab@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pab]A1 == Self.[Pab]B1,
+// CHECK-SAME: Self.[Pab]A2 == (Self.[Pab]B2) -> Self.[Pab]B3,
+// CHECK-SAME: Self.[Pab]A3 == Int,
+
+// CHECK-SAME: Self.[Pab]T : B<Self.[Pab]A1, Self.[Pab]B2, Self.[Pab]B3, Self.[Pab]B4>>
+
+protocol Pab {
+  associatedtype T where T : A<A1, A2, A3>, T : B<B1, B2, B3, B4>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pba@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pba]A1 == Self.[Pba]B1,
+// CHECK-SAME: Self.[Pba]A2 == (Self.[Pba]B2) -> Self.[Pba]B3,
+// CHECK-SAME: Self.[Pba]A3 == Int,
+
+// CHECK-SAME: Self.[Pba]T : B<Self.[Pba]A1, Self.[Pba]B2, Self.[Pba]B3, Self.[Pba]B4>>
+
+protocol Pba {
+  associatedtype T where T : B<B1, B2, B3, B4>, T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pac@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pac]A1 == String,
+// CHECK-SAME: Self.[Pac]A2 == (Self.[Pac]C1) -> Array<Self.[Pac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pac]A3 == Int,
+
+// CHECK-SAME: Self.[Pac]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pac]T : C<Self.[Pac]C1, Self.[Pac]C2, Self.[Pac]C3>>
+
+protocol Pac {
+  associatedtype T where T : A<A1, A2, A3>, T : C<C1, C2, C3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pca@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pca]A1 == String,
+// CHECK-SAME: Self.[Pca]A2 == (Self.[Pca]C1) -> Array<Self.[Pca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pca]A3 == Int,
+
+// CHECK-SAME: Self.[Pca]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pca]T : C<Self.[Pca]C1, Self.[Pca]C2, Self.[Pca]C3>>
+
+protocol Pca {
+  associatedtype T where T : C<C1, C2, C3>, T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pbc@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pbc]B1 == String,
+// CHECK-SAME: Self.[Pbc]B2 == Self.[Pbc]C1,
+// CHECK-SAME: Self.[Pbc]B3 == Array<Self.[Pbc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbc]B4 == Self.[Pbc]C3,
+
+// CHECK-SAME: Self.[Pbc]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pbc]T : C<Self.[Pbc]B2, Self.[Pbc]C2, Self.[Pbc]B4>>
+
+protocol Pbc {
+  associatedtype T where T : B<B1, B2, B3, B4>, T : C<C1, C2, C3>
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pcb@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pcb]B1 == String,
+// CHECK-SAME: Self.[Pcb]B2 == Self.[Pcb]C1,
+// CHECK-SAME: Self.[Pcb]B3 == Array<Self.[Pcb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcb]B4 == Self.[Pcb]C3,
+
+// CHECK-SAME: Self.[Pcb]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pcb]T : C<Self.[Pcb]B2, Self.[Pcb]C2, Self.[Pcb]B4>>
+
+protocol Pcb {
+  associatedtype T where T : C<C1, C2, C3>, T : B<B1, B2, B3, B4>
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+
+// ------------------------------------------------ //
+// Unifying three requirements in the same protocol //
+// ------------------------------------------------ //
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pabc@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pabc]A1 == String,
+// CHECK-SAME: Self.[Pabc]A2 == (Self.[Pabc]B2) -> Array<Self.[Pabc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pabc]A3 == Int,
+
+// CHECK-SAME: Self.[Pabc]B1 == String,
+// CHECK-SAME: Self.[Pabc]B2 == Self.[Pabc]C1,
+// CHECK-SAME: Self.[Pabc]B3 == Array<Self.[Pabc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pabc]B4 == Self.[Pabc]C3,
+
+// CHECK-SAME: Self.[Pabc]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pabc]T : C<Self.[Pabc]B2, Self.[Pabc]C2, Self.[Pabc]B4>>
+
+protocol Pabc {
+  associatedtype T where T : A<A1, A2, A3>, T : B<B1, B2, B3, B4>, T : C<C1, C2, C3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pacb@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pacb]A1 == String,
+// CHECK-SAME: Self.[Pacb]A2 == (Self.[Pacb]B2) -> Array<Self.[Pacb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pacb]A3 == Int,
+
+// CHECK-SAME: Self.[Pacb]B1 == String,
+// CHECK-SAME: Self.[Pacb]B2 == Self.[Pacb]C1,
+// CHECK-SAME: Self.[Pacb]B3 == Array<Self.[Pacb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pacb]B4 == Self.[Pacb]C3,
+
+// CHECK-SAME: Self.[Pacb]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pacb]T : C<Self.[Pacb]B2, Self.[Pacb]C2, Self.[Pacb]B4>>
+
+protocol Pacb {
+  associatedtype T where T : A<A1, A2, A3>, T : C<C1, C2, C3>, T : B<B1, B2, B3, B4>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pbac@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pbac]A1 == String,
+// CHECK-SAME: Self.[Pbac]A2 == (Self.[Pbac]B2) -> Array<Self.[Pbac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbac]A3 == Int,
+
+// CHECK-SAME: Self.[Pbac]B1 == String,
+// CHECK-SAME: Self.[Pbac]B2 == Self.[Pbac]C1,
+// CHECK-SAME: Self.[Pbac]B3 == Array<Self.[Pbac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbac]B4 == Self.[Pbac]C3,
+
+// CHECK-SAME: Self.[Pbac]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pbac]T : C<Self.[Pbac]B2, Self.[Pbac]C2, Self.[Pbac]B4>>
+
+protocol Pbac {
+  associatedtype T where T : B<B1, B2, B3, B4>, T : A<A1, A2, A3>, T : C<C1, C2, C3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pbca@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pbca]A1 == String,
+// CHECK-SAME: Self.[Pbca]A2 == (Self.[Pbca]B2) -> Array<Self.[Pbca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbca]A3 == Int,
+
+// CHECK-SAME: Self.[Pbca]B1 == String,
+// CHECK-SAME: Self.[Pbca]B2 == Self.[Pbca]C1,
+// CHECK-SAME: Self.[Pbca]B3 == Array<Self.[Pbca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbca]B4 == Self.[Pbca]C3,
+
+// CHECK-SAME: Self.[Pbca]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pbca]T : C<Self.[Pbca]B2, Self.[Pbca]C2, Self.[Pbca]B4>>
+
+protocol Pbca {
+  associatedtype T where T : B<B1, B2, B3, B4>, T : C<C1, C2, C3>, T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pcab@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pcab]A1 == String,
+// CHECK-SAME: Self.[Pcab]A2 == (Self.[Pcab]B2) -> Array<Self.[Pcab]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcab]A3 == Int,
+
+// CHECK-SAME: Self.[Pcab]B1 == String,
+// CHECK-SAME: Self.[Pcab]B2 == Self.[Pcab]C1,
+// CHECK-SAME: Self.[Pcab]B3 == Array<Self.[Pcab]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcab]B4 == Self.[Pcab]C3,
+
+// CHECK-SAME: Self.[Pcab]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pcab]T : C<Self.[Pcab]B2, Self.[Pcab]C2, Self.[Pcab]B4>>
+
+protocol Pcab {
+  associatedtype T where T : C<C1, C2, C3>, T : A<A1, A2, A3>, T : B<B1, B2, B3, B4>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).Pcba@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[Pcba]A1 == String,
+// CHECK-SAME: Self.[Pcba]A2 == (Self.[Pcba]B2) -> Array<Self.[Pcba]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcba]A3 == Int,
+
+// CHECK-SAME: Self.[Pcba]B1 == String,
+// CHECK-SAME: Self.[Pcba]B2 == Self.[Pcba]C1,
+// CHECK-SAME: Self.[Pcba]B3 == Array<Self.[Pcba]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcba]B4 == Self.[Pcba]C3,
+
+// CHECK-SAME: Self.[Pcba]C2 : Sequence,
+
+// CHECK-SAME: Self.[Pcba]T : C<Self.[Pcba]B2, Self.[Pcba]C2, Self.[Pcba]B4>>
+
+protocol Pcba {
+  associatedtype T where T : C<C1, C2, C3>, T : B<B1, B2, B3, B4>, T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+
+// --------------------------------------------------------- //
+// Unifying two requirements in another and current protocol //
+// --------------------------------------------------------- //
+
+protocol Pa {
+  associatedtype T where T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+}
+
+protocol Pb {
+  associatedtype T where T : B<B1, B2, B3, B4>
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+}
+
+protocol Pc {
+  associatedtype T where T : C<C1, C2, C3>
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PaQb@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PaQb]T : Pa,
+
+// CHECK-SAME: Self.[PaQb]T.[Pa]T : B<Self.[PaQb]B1, Self.[PaQb]B2, Self.[PaQb]B3, Self.[PaQb]B4>>
+
+protocol PaQb {
+  associatedtype T : Pa where T.T : B<B1, B2, B3, B4>
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PbQa@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PbQa]A1 == Self.[PbQa]T.[Pb]B1,
+// CHECK-SAME: Self.[PbQa]A2 == (Self.[PbQa]T.[Pb]B2) -> Self.[PbQa]T.[Pb]B3,
+// CHECK-SAME: Self.[PbQa]A3 == Int,
+
+// CHECK-SAME: Self.[PbQa]T : Pb>
+
+protocol PbQa {
+  associatedtype T : Pb where T.T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PaQc@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PaQc]C2 : Sequence,
+
+// CHECK-SAME: Self.[PaQc]T : Pa,
+
+// CHECK-SAME: Self.[PaQc]T.[Pa]T : C<Self.[PaQc]C1, Self.[PaQc]C2, Self.[PaQc]C3>>
+
+protocol PaQc {
+  associatedtype T : Pa where T.T : C<C1, C2, C3>
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PcQa@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PcQa]A1 == String,
+// CHECK-SAME: Self.[PcQa]A2 == (Self.[PcQa]T.[Pc]C1) -> Array<Self.[PcQa]T.[Pc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[PcQa]A3 == Int,
+
+// CHECK-SAME: Self.[PcQa]T : Pc>
+
+protocol PcQa {
+  associatedtype T : Pc where T.T : A<A1, A2, A3>
+
+  associatedtype A1
+  associatedtype A2
+  associatedtype A3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PbQc@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PbQc]C2 : Sequence,
+
+// CHECK-SAME: Self.[PbQc]T : Pb,
+
+// CHECK-SAME: Self.[PbQc]T.[Pb]T : C<Self.[PbQc]C1, Self.[PbQc]C2, Self.[PbQc]C3>>
+
+protocol PbQc {
+  associatedtype T : Pb where T.T : C<C1, C2, C3>
+
+  associatedtype C1
+  associatedtype C2 : Sequence
+  associatedtype C3
+}
+
+// CHECK-LABEL: minimize_superclass_unification_generic.(file).PcQb@
+// CHECK-NEXT: Requirement signature: <Self where
+
+// CHECK-SAME: Self.[PcQb]B1 == String,
+// CHECK-SAME: Self.[PcQb]B2 == Self.[PcQb]T.[Pc]C1,
+// CHECK-SAME: Self.[PcQb]B3 == Array<Self.[PcQb]T.[Pc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[PcQb]B4 == Self.[PcQb]T.[Pc]C3,
+
+// CHECK-SAME: Self.[PcQb]T : Pc>
+
+protocol PcQb {
+  associatedtype T : Pc where T.T : B<B1, B2, B3, B4>
+
+  associatedtype B1
+  associatedtype B2
+  associatedtype B3
+  associatedtype B4
+}

--- a/test/Generics/minimize_superclass_unification_non_generic.swift
+++ b/test/Generics/minimize_superclass_unification_non_generic.swift
@@ -1,0 +1,61 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+class A {}
+class B : A {}
+class C : B {}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pabc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pabc]T : C>
+protocol Pabc {
+  associatedtype T where T : A, T : B, T : C
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pacb@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pacb]T : C>
+protocol Pacb {
+  associatedtype T where T : A, T : C, T : B
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pbac@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pbac]T : C>
+protocol Pbac {
+  associatedtype T where T : B, T : A, T : C
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pbca@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pbca]T : C>
+protocol Pbca {
+  associatedtype T where T : B, T : C, T : A
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pcab@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pcab]T : C>
+protocol Pcab {
+  associatedtype T where T : C, T : A, T : B
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).Pcba@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Pcba]T : C>
+protocol Pcba {
+  associatedtype T where T : C, T : B, T : A
+}
+
+protocol Pa {
+  associatedtype T where T : A
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).PaQc@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PaQc]T : Pa, Self.[PaQc]T.[Pa]T : C>
+protocol PaQc {
+  associatedtype T where T : Pa, T.T : C
+}
+
+protocol Pc {
+  associatedtype T where T : C
+}
+
+// CHECK-LABEL: minimize_superclass_unification_non_generic.(file).PcQa@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PcQa]T : Pc>
+protocol PcQa {
+  associatedtype T where T : Pc, T.T : A
+}

--- a/test/Generics/rdar25065503.swift
+++ b/test/Generics/rdar25065503.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+class Base<T> {}
+class Derived : Base<Int> {}
+
+struct Holder<A : Base<B>, B> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Holder
+// CHECK-NEXT: Generic signature: <A, B where A : Derived, B == Int>
+extension Holder where A : Derived {
+
+  // Make sure that 'B == Int' is implied by 'A : Base<B>' together with
+  // 'A : Derived', since 'Derived : Base<Int>'.
+  func returnInt(_ b: B) -> Int { return b }
+}

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -31,12 +31,12 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-NEXT: Rewrite system: {
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
-// CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
-// CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
-// CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
-// CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
-// CHECK-NEXT: - τ_0_0.B2 => τ_0_0.[P1:B1]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P2:B2]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
+// CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
+// CHECK:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK:      - τ_0_0.B2 => τ_0_0.[P1:B1]
 // CHECK:      }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
@@ -44,7 +44,7 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
-// CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
-// CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
 // CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
+// CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -35,20 +35,20 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
 // CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
-// CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
-// CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
-// CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
-// CHECK-NEXT: - τ_0_0.B2 => τ_0_0.[P1:B1]
-// CHECK-NEXT: - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
-// CHECK-NEXT: }
+// CHECK:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
+// CHECK:      - τ_0_0.B2 => τ_0_0.[P1:B1]
+// CHECK:      }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
 // CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
+// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
 // CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
 // CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
-// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -39,9 +39,10 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      - [P2:X].[superclass: Derived<τ_0_0> with <[P2:A2]>] => [P2:X] [explicit]
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Derived<τ_0_0> with <τ_0_0.[P2:A2]>] => τ_0_0.[P1:X]
-// CHECK-NEXT: - [P1:X].[layout: _NativeClass] => [P1:X]
-// CHECK-NEXT: - [P2:X].[layout: _NativeClass] => [P2:X]
-// CHECK-NEXT: - τ_0_0.[P2:A2].[Q:T] => τ_0_0.[P1:A1]
+// CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
+// CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Base<τ_0_0> with <τ_0_0.[P2:A2].[Q:T]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P2:A2].[Q:T] => τ_0_0.[P1:A1]
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }


### PR DESCRIPTION
Reuses the new concrete unification mechanism from https://github.com/apple/swift/pull/41159 for superclass requirements where both requirements reference the same class declaration.

When they reference different class declarations, introduce a relation for the implication going from the more specific class to the less specific class, ensuring that the less specific class requirement is minimized away.

This obsoletes the old ConcreteTypeMatcher mechanism in PropertyMap.cpp that predates the RewriteLoop stuff, since it's no longer needed.

This is the second half of rdar://problem/88134910.

Also addresses rdar://problem/25065503.