### PR TITLE
Workaround clang backend bug 

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -202,6 +202,12 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define SWIFT_ASYNC_CONTEXT
 #endif
 
+#if __has_attribute(optnone)
+#define SWIFT_OPTNONE __attribute__((optnone))
+#else
+#define SWIFT_OPTNONE
+#endif
+
 // SWIFT_CC(swiftasync) is the Swift async calling convention.
 // We assume that it supports mandatory tail call elimination.
 #if __has_feature(swiftasynccc) && __has_attribute(swiftasynccall)

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1564,10 +1564,13 @@ static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
     asImpl(executor.getDefaultActor())->giveUpThread(runner);
 }
 
+// TODO (rokhinip): Workaround rdar://88700717. To be removed with
+// rdar://88711954
 SWIFT_CC(swiftasync)
 static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
                                   TaskContinuationFunction *resumeFunction,
-                                  ExecutorRef newExecutor) {
+                                  ExecutorRef newExecutor) SWIFT_OPTNONE {
+
   auto trackingInfo = ExecutorTrackingInfo::current();
   auto currentExecutor =
     (trackingInfo ? trackingInfo->getActiveExecutor()


### PR DESCRIPTION
This is a workaround for a bug that was causing clang to fail to build Actor.cpp