### PR TITLE
permit isolated-member references in actor deinits with warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4479,7 +4479,9 @@ NOTE(note_distributed_actor_system_conformance_missing_adhoc_requirement,none,
 ERROR(override_implicit_unowned_executor,none,
       "cannot override an actor's 'unownedExecutor' property that wasn't "
       "explicitly defined", ())
-
+ERROR(actor_isolated_from_deinit,none,
+      "actor-isolated %0 %1 can not be referenced from a non-isolated deinit",
+      (DescriptiveDeclKind, DeclName))
 ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can not be "
         "%select{referenced|mutated|used 'inout'}2 "

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2676,12 +2676,14 @@ namespace {
     /// \param refCxt the context in which the member reference happens.
     /// \param baseActor the actor referenced in the base of the member access.
     /// \param member the declaration corresponding to the accessed member.
+    /// \param memberLoc the source location of the reference to the member.
     ///
     /// \returns true iff the member access is permitted in Sema because it will
     /// be verified later by flow-isolation.
     bool checkedByFlowIsolation(DeclContext const *refCxt,
                                 ReferencedActor &baseActor,
-                                ValueDecl const *member) {
+                                ValueDecl const *member,
+                                SourceLoc memberLoc) {
 
       // base of member reference must be `self`
       if (!baseActor.isActorSelf())
@@ -2716,6 +2718,18 @@ namespace {
       if (auto *var = dyn_cast<VarDecl>(member))
         if (var->hasStorage() && var->isInstanceMember())
           return true;
+
+      // In Swift 5, we were allowing all members to be referenced from a
+      // deinit, but that will not be valid in Swift 6+, so warn about it.
+      if (!refCxt->getASTContext().isSwiftVersionAtLeast(6)) {
+        if (isa<DestructorDecl>(fnDecl) && member->isInstanceMember()) {
+          auto &diags = refCxt->getASTContext().Diags;
+          diags.diagnose(memberLoc, diag::actor_isolated_from_deinit,
+                         member->getDescriptiveKind(),
+                         member->getName()).warnUntilSwiftVersion(6);
+          return true;
+        }
+      }
 
       return false;
     }
@@ -2820,7 +2834,7 @@ namespace {
         // access an isolated member on `self`. If that case applies, then we
         // can skip checking.
         if (checkedByFlowIsolation(getDeclContext(), isolatedActor,
-                                          member))
+                                          member, memberLoc))
           return false;
 
         // An escaping partial application of something that is part of

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -844,7 +844,7 @@ actor SomeActorWithInits {
     let _ = self.nonSendable // OK only through typechecking, not SIL.
 
     defer {
-      isolated() // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated deinit; this is an error in Swift 6}}
       mutableState += 1 // okay
       nonisolated()
     }
@@ -860,7 +860,7 @@ actor SomeActorWithInits {
   }
 
 
-  func isolated() { } // expected-note 9 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
+  func isolated() { } // expected-note 8 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func nonisolated() {}
 }
 


### PR DESCRIPTION
This capability was available in Swift 5.5, but with flow-isolation
it's not safe to do so in general. When I initially implemented
flow-isolation, I intended for it to not break too much existing
code, and emit warnings about things changing in Swift 6. But
I missed this case, where we have just a simple method call in
a deinit, which is likely to be common:

```swift
actor A {
  func cleanup() { ... }
  deinit {
    cleanup()
  }
}
```

Instead of rejecting that call to `cleanup`, we now warn that it's
not going to be allowed in Swift 6, because `cleanup` is isolated
and the deinit is not.

resolves rdar://88666799
