### PR TITLE
Permit redeclaration of superclass's Sendable-ness

### DIFF
--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -151,3 +151,17 @@ actor A10: AsyncThrowingProtocolWithNotSendable {
 class Klass<Output: Sendable>: Sendable {}
 final class SubKlass: Klass<[S]> {}
 public struct S {}
+
+// rdar://88700507 - redundant conformance of @MainActor-isolated subclass to 'Sendable'
+@MainActor class MainSuper {}
+class MainSub: MainSuper, @unchecked Sendable {}
+
+class SendableSuper: @unchecked Sendable {}
+class SendableSub: SendableSuper, @unchecked Sendable {}
+
+class SendableExtSub: SendableSuper {}
+extension SendableExtSub: @unchecked Sendable {}
+
+// Still want to know about same-class redundancy
+class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
+extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}


### PR DESCRIPTION
A recent change to `Sendable` conformance handling resulted in subclasses of global-actor-confined classes being rejected if they explicitly declared a conformance to `Sendable`.

This behavior is technically correct because actor-isolated types are implicitly `Sendable`, but the source compatibility regression was not desirable. We are also considering requiring subclasses to explicitly repeat their superclass's `Sendable` conformance, so it makes sense to allow these redundant conformances in the general case to ease that potential transition.

Fixes rdar://88700507.