### PR TITLE
[cxx Interop] Disambiguate methods within the same class with same name but differing "constness"

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -569,6 +569,10 @@ public:
   llvm::MapVector<std::pair<NominalTypeDecl *, Type>,
                   std::pair<FuncDecl *, FuncDecl *>> cxxSubscripts;
 
+  /// Keep track of cxx function names, params etc in order to
+  /// allow for de-duping functions that differ strictly on "constness".
+  llvm::DenseMap<llvm::StringRef, std::pair<llvm::DenseSet<clang::FunctionDecl *>, llvm::DenseSet<clang::FunctionDecl *>>> cxxMethods;
+
   /// Keeps track of the Clang functions that have been turned into
   /// properties.
   llvm::DenseMap<const clang::FunctionDecl *, VarDecl *> FunctionsAsProperties;

--- a/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
@@ -1,0 +1,48 @@
+#ifndef TEST_INTEROP_CXX_CLASS_AMBIGUOUS_METHOD_METHODS_H
+#define TEST_INTEROP_CXX_CLASS_AMBIGUOUS_METHOD_METHODS_H
+
+struct HasAmbiguousMethods {
+
+  // No input
+  void ping() { ++mutableMethodsCalledCount; }
+  void ping() const {}
+
+  // One input
+  int increment(int a) {
+    ++mutableMethodsCalledCount;
+    return a + 1;
+  }
+
+  int increment(int a) const {
+    return a + 1;
+  }
+
+  // Multiple input with out param
+  void increment(int a, int b, int &c) {
+    ++mutableMethodsCalledCount;
+    c = a + b;
+  }
+
+  void increment(int a, int b, int &c) const {
+    c = a + b;
+  }
+
+  // Multiple input with inout param
+  void increment(int &a, int b) {
+    ++mutableMethodsCalledCount;
+    a += b;
+  }
+
+  void increment(int &a, int b) const {
+    a += b;
+  }
+
+  // No input with output
+  int numberOfMutableMethodsCalled() { return ++mutableMethodsCalledCount; }
+  int numberOfMutableMethodsCalled() const { return mutableMethodsCalledCount; }
+
+private:
+  int mutableMethodsCalledCount = 0;
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_AMBIGUOUS_METHOD_METHODS_H

--- a/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
@@ -7,13 +7,13 @@ struct HasAmbiguousMethods {
   void ping() { ++mutableMethodsCalledCount; }
   void ping() const {}
 
-  // One input
-  int increment(int a) {
-    ++mutableMethodsCalledCount;
+  // One input (const first)
+  int increment(int a) const {
     return a + 1;
   }
 
-  int increment(int a) const {
+  int increment(int a) {
+    ++mutableMethodsCalledCount;
     return a + 1;
   }
 
@@ -37,9 +37,9 @@ struct HasAmbiguousMethods {
     a += b;
   }
 
-  // No input with output
-  int numberOfMutableMethodsCalled() { return ++mutableMethodsCalledCount; }
+  // No input with output (const first)
   int numberOfMutableMethodsCalled() const { return mutableMethodsCalledCount; }
+  int numberOfMutableMethodsCalled() { return ++mutableMethodsCalledCount; }
 
 private:
   int mutableMethodsCalledCount = 0;

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -25,6 +25,9 @@ struct HasMethods {
 
   NonTrivialInWrapper nonConstPassThroughAsWrapper(int a) { return {a}; }
   NonTrivialInWrapper constPassThroughAsWrapper(int a) const { return {a}; }
+
+  int increment(int a) { return a + 1; }
+  int increment(int a) const { return a + 1; }
 };
 
 #endif // TEST_INTEROP_CXX_CLASS_METHOD_METHODS_H

--- a/test/Interop/Cxx/class/method/Inputs/methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/methods.h
@@ -25,9 +25,6 @@ struct HasMethods {
 
   NonTrivialInWrapper nonConstPassThroughAsWrapper(int a) { return {a}; }
   NonTrivialInWrapper constPassThroughAsWrapper(int a) const { return {a}; }
-
-  int increment(int a) { return a + 1; }
-  int increment(int a) const { return a + 1; }
 };
 
 #endif // TEST_INTEROP_CXX_CLASS_METHOD_METHODS_H

--- a/test/Interop/Cxx/class/method/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/method/Inputs/module.modulemap
@@ -2,3 +2,8 @@ module Methods {
   header "methods.h"
   requires cplusplus
 }
+
+module AmbiguousMethods {
+  header "ambiguous_methods.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=AmbiguousMethods -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: mutating func pingMutating()
+// CHECK: func ping()
+
+// CHECK: mutating func incrementMutating(_ a: Int32) -> Int32
+// CHECK: func increment(_ a: Int32) -> Int32
+
+// CHECK: mutating func incrementMutating(_ a: Int32, _ b: Int32, _ c: inout Int32)
+// CHECK: func increment(_ a: Int32, _ b: Int32, _ c: inout Int32)
+
+// CHECK: mutating func incrementMutating(_ a: inout Int32, _ b: Int32)
+// CHECK: func increment(_ a: inout Int32, _ b: Int32)
+
+// CHECK: mutating func numberOfMutableMethodsCalledMutating() -> Int32
+// CHECK: func numberOfMutableMethodsCalled() -> Int32

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -3,8 +3,8 @@
 // CHECK: mutating func pingMutating()
 // CHECK: func ping()
 
-// CHECK: mutating func incrementMutating(_ a: Int32) -> Int32
 // CHECK: func increment(_ a: Int32) -> Int32
+// CHECK: mutating func incrementMutating(_ a: Int32) -> Int32
 
 // CHECK: mutating func incrementMutating(_ a: Int32, _ b: Int32, _ c: inout Int32)
 // CHECK: func increment(_ a: Int32, _ b: Int32, _ c: inout Int32)
@@ -12,5 +12,5 @@
 // CHECK: mutating func incrementMutating(_ a: inout Int32, _ b: Int32)
 // CHECK: func increment(_ a: inout Int32, _ b: Int32)
 
-// CHECK: mutating func numberOfMutableMethodsCalledMutating() -> Int32
 // CHECK: func numberOfMutableMethodsCalled() -> Int32
+// CHECK: mutating func numberOfMutableMethodsCalledMutating() -> Int32

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -1,0 +1,80 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// Crash when running on windows: rdar://88391102
+// XFAIL: OS=windows-msvc
+
+import StdlibUnittest
+import AmbiguousMethods
+
+var CxxAmbiguousMethodTestSuite = TestSuite("CxxAmbiguousMethods")
+
+CxxAmbiguousMethodTestSuite.test("numberOfMutableMethodsCalled: () -> Int") {
+  var instance = HasAmbiguousMethods()
+
+  // Sanity check. Make sure we start at 0
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  // Make sure calling numberOfMutableMethodsCalled above didn't
+  // change the count
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  // Check that mutable version _does_ change the mutable call count
+  expectEqual(1, instance.numberOfMutableMethodsCalledMutating())
+
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
+CxxAmbiguousMethodTestSuite.test("Basic Increment: (Int) -> Int") {
+  var instance = HasAmbiguousMethods()
+  var a: Int32 = 0
+
+  // Sanity check. Make sure we start at 0
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  // Non mutable version should NOT change count
+  a = instance.increment(a);
+  expectEqual(1, a)
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  a = instance.incrementMutating(a);
+  expectEqual(2, a)
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
+CxxAmbiguousMethodTestSuite.test("Out Param Increment: (Int, Int, inout Int) -> Void") {
+  var instance = HasAmbiguousMethods()
+  var out: Int32 = 0
+
+  // Sanity check. Make sure we start at 0
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  // Non mutable version should NOT change count
+  instance.increment(0, 1, &out);
+  expectEqual(1, out)
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  instance.incrementMutating(5, 2, &out);
+  expectEqual(7, out)
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
+CxxAmbiguousMethodTestSuite.test("Inout Param Increment: (inout Int, Int) -> Void") {
+  var instance = HasAmbiguousMethods()
+  var inoutVal: Int32 = 0
+
+  // Sanity check. Make sure we start at 0
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  // Non mutable version should NOT change count
+  instance.increment(&inoutVal, 1);
+  expectEqual(1, inoutVal)
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
+
+  instance.incrementMutating(&inoutVal, 2);
+  expectEqual(3, inoutVal)
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -2,8 +2,6 @@
 //
 // REQUIRES: executable_test
 //
-// Crash when running on windows: rdar://88391102
-// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import AmbiguousMethods

--- a/test/Interop/Cxx/class/method/methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/methods-module-interface.swift
@@ -17,9 +17,3 @@
 
 // CHECK: mutating func nonConstPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
 // CHECK: func constPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
-
-// CHECK: mutating func incrementMutable(_ a: Int32) -> Int32
-// CHECK: func incrementMutable(_ a: Int32) -> Int32
-
-// CHECK: const func increment(_ a: Int32) -> Int32
-// CHECK: func increment(_ a: Int32) -> Int32

--- a/test/Interop/Cxx/class/method/methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/methods-module-interface.swift
@@ -17,3 +17,9 @@
 
 // CHECK: mutating func nonConstPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
 // CHECK: func constPassThroughAsWrapper(_ a: Int32) -> NonTrivialInWrapper
+
+// CHECK: mutating func incrementMutable(_ a: Int32) -> Int32
+// CHECK: func incrementMutable(_ a: Int32) -> Int32
+
+// CHECK: const func increment(_ a: Int32) -> Int32
+// CHECK: func increment(_ a: Int32) -> Int32


### PR DESCRIPTION
<!-- What's in this pull request? -->
When importing CXX methods into Swift the compiler had issues with classes (Records) that contained 2+ methods that differed in "constness" but had the same name

Example:
```cpp
int increment(int a);
int increment(int a) const;
```

This PR appends "Mutating" to the end of the mutable function to disambiguate when importing into swift.

the result of the above would then be:

```swift
func incrementMutating(_ a: Int32) -> Int32
func increment(_ a: Int32) -> Int32
```

Determining when 2 methods conflict is a seemingly hard problem. Name alone is not enough to get it right 100% of the time since you could have a class with:

```cpp
int increment(int a);
int increment(int a, int b) const;
```

That said, such patterns seem less common and so this PR uses name alone to disambiguate, recognizing that it may result in some confusing outputs in more uncommon circumstances

The above example would result in:

```swift
func incrementMutating(_ a: Int32) -> Int32
func increment(_ a: Int32, _ b: Int32) -> Int32
```

even though the 2 methods do NOT conflict.