### PR TITLE
[CS] Don't apply compatibility logic to collection literals

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9555,17 +9555,17 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
   // we generated somewhat reasonable code that performed a force cast. To
   // maintain compatibility with that behavior, allow the coercion between
   // two collections, but add a warning fix telling the user to use as! or as?
-  // instead.
+  // instead. In Swift 6 mode, this becomes an error.
   //
   // We only need to perform this compatibility logic if this is a coercion of
   // something that isn't a collection expr (as collection exprs would have
   // crashed in codegen due to CSApply peepholing them). Additionally, the LHS
   // type must be a (potentially optional) type variable, as only such a
   // constraint could have been previously been left unsolved.
-  //
-  // FIXME: Once we get a new language version, change this condition to only
-  // preserve compatibility for Swift 5.x mode.
   auto canUseCompatFix = [&]() {
+    if (Context.isSwiftVersionAtLeast(6))
+      return false;
+
     if (!rawType1->lookThroughAllOptionalTypes()->isTypeVariableOrMember())
       return false;
 

--- a/test/Constraints/casts_swift6.swift
+++ b/test/Constraints/casts_swift6.swift
@@ -1,0 +1,78 @@
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -swift-version 6
+
+// -swift-version 6 is currently asserts-only
+// REQUIRES: asserts
+
+func id<T>(_ x: T) -> T { x }
+func ohno<T>(_ x: T) -> T? { nil }
+
+// Swift 6 version of the test in casts.swift
+func test_compatibility_coercions(_ arr: [Int], _ optArr: [Int]?, _ dict: [String: Int], _ set: Set<Int>, _ i: Int, _ stringAnyDict: [String: Any]) {
+  // These have always been fine.
+  _ = arr as [Any]?
+  _ = dict as [String: Int]?
+  _ = set as Set<Int>
+
+  // These have always been errors.
+  _ = arr as [String] // expected-error {{cannot convert value of type '[Int]' to type '[String]' in coercion}}
+  // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+  _ = dict as [String: String] // expected-error {{cannot convert value of type '[String : Int]' to type '[String : String]' in coercion}}
+  // expected-note@-1 {{arguments to generic parameter 'Value' ('Int' and 'String') are expected to be equal}}
+  _ = dict as [String: String]? // expected-error {{'[String : Int]' is not convertible to '[String : String]?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{12-14=as!}}
+  _ = (dict as [String: Int]?) as [String: Int] // expected-error {{value of optional type '[String : Int]?' must be unwrapped to a value of type '[String : Int]'}}
+  // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  _ = set as Set<String>  // expected-error {{cannot convert value of type 'Set<Int>' to type 'Set<String>' in coercion}}
+   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
+
+  // Make sure we error on the following in Swift 6 mode.
+
+  // FIXME: Bad diagnostics (SR-15843)
+  _ = id(arr) as [String] // expected-error {{type of expression is ambiguous without more context}}
+  _ = (arr ?? []) as [String] // expected-error {{type of expression is ambiguous without more context}}
+  _ = (arr ?? [] ?? []) as [String] // expected-error {{type of expression is ambiguous without more context}}
+  _ = (optArr ?? []) as [String] // expected-error {{type of expression is ambiguous without more context}}
+
+  _ = (arr ?? []) as [String]? // expected-error {{'[Int]' is not convertible to '[String]?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+  _ = (arr ?? []) as [String?]? // expected-error {{'[Int]' is not convertible to '[String?]?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+  _ = (arr ?? []) as [String??]?? // expected-error {{'[Int]' is not convertible to '[String??]??'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+  _ = (dict ?? [:]) as [String: String?]? // expected-error {{'[String : Int]' is not convertible to '[String : String?]?'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+  _ = (set ?? []) as Set<String>?? // expected-error {{'Set<Int>' is not convertible to 'Set<String>??'}}
+  // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
+
+  _ = ohno(ohno(ohno(arr))) as [String] // expected-error {{cannot convert value of type '[Int]???' to type '[String]' in coercion}}
+  _ = ohno(ohno(ohno(arr))) as [Int] // expected-error {{cannot convert value of type '[Int]???' to type '[Int]' in coercion}}
+  _ = ohno(ohno(ohno(Set<Int>()))) as Set<String> // expected-error {{cannot convert value of type 'Set<Int>???' to type 'Set<String>' in coercion}}
+  _ = ohno(ohno(ohno(["": ""]))) as [Int: String] // expected-error {{cannot convert value of type '[String : String]???' to type '[Int : String]' in coercion}}
+  _ = ohno(ohno(ohno(dict))) as [String: Int] // expected-error {{cannot convert value of type '[String : Int]???' to type '[String : Int]' in coercion}}
+
+  // In this case the array literal can be inferred to be [String], so totally
+  // valid.
+  _ = ([] ?? []) as [String] // expected-warning {{left side of nil coalescing operator '??' has non-optional type '[String]', so the right side is never used}}
+  _ = (([] as Optional) ?? []) as [String]
+
+  // The array can also be inferred to be [Any].
+  _ = ([] ?? []) as Array // expected-warning {{left side of nil coalescing operator '??' has non-optional type '[Any]', so the right side is never used}}
+
+  // Cases from rdar://88334481
+  typealias Magic<T> = T
+  _ = [i] as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = [i] as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = ([i]) as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _  = [i: i] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+  _  = ([i: i]) as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+  _  = [i: stringAnyDict] as [String: Any] // expected-error {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+
+  _ = [i].self as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  _ = (try [i]) as Magic as [String] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+  // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
+
+  // These are wrong, but make sure we don't warn about the value cast always succeeding.
+  _  = [i: i] as! [String: Any]
+  _  = [i: stringAnyDict] as! [String: Any]
+}

--- a/test/SILGen/collection_downcast.swift
+++ b/test/SILGen/collection_downcast.swift
@@ -242,8 +242,8 @@ func testSetDowncastBridgedConditional(_ dict: Set<NSObject>)
 
 func promote<T>(_ x: T) -> T? { nil }
 
-// CHECK-LABEL: sil hidden [ossa] @$s19collection_downcast36testCollectionCompatibilityCoercionsyySaySiG_SayypGSgShySSGSDySSSiGtF
-func testCollectionCompatibilityCoercions(_ arr: [Int], _ optArr: [Any]?, _ set: Set<String>, _ dict: [String: Int]) {
+// CHECK-LABEL: sil hidden [ossa] @$s19collection_downcast36testCollectionCompatibilityCoercionsyySaySiG_SayypGSgShySSGSDySSSiGSitF
+func testCollectionCompatibilityCoercions(_ arr: [Int], _ optArr: [Any]?, _ set: Set<String>, _ dict: [String: Int], _ i: Int) {
   // Make sure we generate reasonable code for all of the below examples.
 
   // CHECK: [[CAST_FN:%.+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -297,4 +297,15 @@ func testCollectionCompatibilityCoercions(_ arr: [Int], _ optArr: [Any]?, _ set:
   // CHECK: [[CAST_FN:%.+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
   // CHECK: apply [[CAST_FN]]<String, Int, Int, String>([[DICT]]) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
   _ = promote(promote(promote(dict))) as [Int: String]
+
+  typealias Magic<T> = T
+
+  // These are currently not peepholed.
+  // CHECK: [[CAST_FN:%.+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: apply [[CAST_FN]]<Int, String>
+  [i].self as Magic as [String]
+
+  // CHECK: [[CAST_FN:%.+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
+  // CHECK: apply [[CAST_FN]]<Int, String>
+  (try [i]) as Magic as [String]
 }


### PR DESCRIPTION
We currently permit (but warn on) coercions of collections with unrelated element types in certain cases. This is done in an effort to preserve compatibility with pre-5.3 compilers that may have allowed such code to compile due to dropping constraints while solving (#30886).

This is limited to collection coercions as we emit somewhat reasonable code for them that performs a force cast of the elements at runtime. However, it turns out that in the case of collection literals, we peephole the element conversions in CSApply, leading to codegen crashes. As such, narrow down the condition of this compatibility logic to not apply to collection literals, as this never would have compiled properly.

Additionally, disable the compatability logic altogether in Swift 6 mode.

rdar://88334481