### PR TITLE
PerformanceDiagnostics: don't issue a metatype diagnostics when using MemoryLayout

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -812,7 +812,7 @@ def CrossModuleOptimization : Flag<["-"], "cross-module-optimization">,
 
 def ExperimentalPerformanceAnnotations : Flag<["-"], "experimental-performance-annotations">,
   Flags<[HelpHidden, FrontendOption]>,
-  HelpText<"Perform cross-module optimization">;
+  HelpText<"Enable experimental performance annotations">;
 
 def RemoveRuntimeAsserts : Flag<["-"], "remove-runtime-asserts">,
   Flags<[FrontendOption]>,

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -667,10 +667,9 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       if (auto selfType = instTy->getAs<DynamicSelfType>())
         instTy = selfType->getSelfType();
       auto *cl = instTy->getClassOrBoundGenericClass();
-      bool isForeign =
-          cl->getObjectModel() == ReferenceCounting::ObjC ||
-          cl->isForeign();
-      if ((cl && isForeign) || instTy->isAnyObject())
+      bool isForeign = cl && (cl->getObjectModel() == ReferenceCounting::ObjC ||
+                              cl->isForeign());
+      if (isForeign || instTy->isAnyObject())
         return RuntimeEffect::MetaData | RuntimeEffect::ObjectiveC;
       return RuntimeEffect::MetaData;
     }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -85,6 +85,11 @@ func testUnsafePerformance(_ idx: Int) -> [Int] {
   return _unsafePerformance { [10, 20, 30, 40] }
 }
 
+@_noAllocation
+func testMemoryLayout() -> Int {
+  return MemoryLayout<Int>.size + MemoryLayout<Int>.stride + MemoryLayout<Int>.alignment
+}
+
 class MyError : Error {}
 
 @_noLocks


### PR DESCRIPTION
The metatype is not code-gend for the memory layout builtins.
Also fix the wrong help test for the -experimental-performance-annotations option.

rdar://88641277