### PR TITLE
[Distributed] NFC: Remove obsolete remoteCall test XFAILs on 32-bit W…

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// rdar://87568630 - segmentation fault on 32-bit WatchOS simulator
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import _Distributed
 import FakeDistributedActorSystems
 


### PR DESCRIPTION
…atchOS

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
