### PR TITLE
Rather than turning off sil-verify-all on all stdlib builds... Re-enable it only on the macOS x86_64 platform.

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -459,8 +459,8 @@ function(_compile_swift_files
 
   if(SWIFT_SIL_VERIFY_ALL_MACOS_ONLY)
     # Only add if we have a macOS build triple
-    if (STREQUAL "${SWIFTFILE_SDK}" "OSX" AND
-        STREQUAL "${SWIFTFILE_ARCHITECTURE}" "x86_64")
+    if ("${SWIFTFILE_SDK}" STREQUAL "OSX" AND
+        "${SWIFTFILE_ARCHITECTURE}" STREQUAL "x86_64")
       list(APPEND swift_flags "-Xfrontend" "-sil-verify-all")
     endif()
   endif()

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1602,6 +1602,9 @@ skip-build-tvos
 skip-test-tvos
 skip-test-tvos-host
 
+# Run the SIL verifier after each transform when building swift files
+sil-verify-all-macos-only
+
 # Don't run host tests for iOS, tvOS and watchOS platforms to make the build
 # faster.
 skip-test-ios-host


### PR DESCRIPTION
Most of the stdlibs at the SIL level are the same so by not verifying them all,
we aren't losing that much coverage. This gives us back some of the coverage we
lost when we disabled -sil-verify-all everywhere without causing us to have the
huge slow down when building multiple stdlibs.

----

NOTE: I checked locally that this only causes the x86_64 macOS stdlib to verify using ninja -t commands.