### PR TITLE
[Concurrency] Remove explicit_bzero call on Linux.

### DIFF
--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -128,14 +128,12 @@ private:
     /// Clear the fake metadata pointer. Call before freeing so that leftover
     /// heap garbage doesn't have slab metadata pointers in it.
     void clearMetadata() {
-      // Use memset_s or explicit_bzero where available. Fall back to a plain
-      // assignment on unknown platforms. This is not necessary for correctness,
-      // just as an aid to analysis tools, so it's OK if the fallback gets
-      // optimized out.
+      // Use memset_s on Apple platforms. Fall back to a plain
+      // assignment on other platforms. This is not necessary for
+      // correctness, just as an aid to analysis tools, so it's OK if
+      // the fallback gets optimized out.
 #if defined(__APPLE__)
       memset_s(&metadata, sizeof(metadata), 0, sizeof(metadata));
-#elif defined(__linux__)
-      explicit_bzero(&metadata, sizeof(metadata));
 #else
       metadata = 0;
 #endif


### PR DESCRIPTION
Clearing memory before freeing it is difficult to do portably. The Linux version didn't build on CentOS. Have Linux use `= 0` for now.