### PR TITLE
runtime: enable shims for Float16 on Linux (armv7)

### DIFF
--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -29,7 +29,7 @@
 
 // Android NDK <r21 do not provide `__aeabi_d2h` in the compiler runtime,
 // provide shims in that case.
-#if (defined(__ANDROID__) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
+#if ((defined(__ANDROID__) || defined(__linux__)) && defined(__ARM_ARCH_7A__) && defined(__ARM_EABI__)) || \
   ((defined(__i386__) || defined(__i686__) || defined(__x86_64__)) && !defined(__APPLE__))
 
 #include "../SwiftShims/Visibility.h"


### PR DESCRIPTION
<!-- What's in this pull request? -->
GNU's C library is missing `__aeabi_d2h()` when cross compiling for Linux armv7. Without this shim, the std lib will compile but crash at runtime. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
