### PR TITLE
Sema: Fix request cycle involving protocol typealiases in preparation for RequirementMachine support

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -874,6 +874,7 @@ private:
 public:
   // Caching.
   bool isCached() const { return true; }
+  void diagnoseCycle(DiagnosticEngine &diags) const;
 };
 
 /// Request the fragile function kind for the context.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1468,10 +1468,9 @@ CanType TypeBase::computeCanonicalType() {
     // If we haven't set a depth for this generic parameter, try to do so.
     // FIXME: This is a dreadful hack.
     if (gpDecl->getDepth() == GenericTypeParamDecl::InvalidDepth) {
-      if (auto decl =
-            gpDecl->getDeclContext()->getInnermostDeclarationDeclContext())
-        if (auto valueDecl = decl->getAsGenericContext())
-          (void)valueDecl->getGenericSignature();
+      auto *dc = gpDecl->getDeclContext();
+      auto *gpList = dc->getAsDecl()->getAsGenericContext()->getGenericParams();
+      gpList->setDepth(dc->getGenericContextDepth());
     }
 
     assert(gpDecl->getDepth() != GenericTypeParamDecl::InvalidDepth &&

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -820,6 +820,17 @@ void UnderlyingTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
 }
 
 //----------------------------------------------------------------------------//
+// StructuralTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+void StructuralTypeRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto aliasDecl = std::get<0>(getStorage());
+  diags.diagnose(aliasDecl, diag::recursive_decl_reference,
+                 aliasDecl->getDescriptiveKind(),
+                 aliasDecl->getName());
+}
+
+//----------------------------------------------------------------------------//
 // EnumRawValuesRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -827,9 +827,6 @@ Type TypeResolution::applyUnboundGenericArguments(
         genericArgs.size() >= decl->getGenericParams()->size() - 1)) &&
       "invalid arguments, use applyGenericArguments for diagnostic emitting");
 
-  auto genericSig = decl->getGenericSignature();
-  assert(!genericSig.isNull());
-
   TypeSubstitutionMap subs;
 
   // Get the interface type for the declaration. We will be substituting
@@ -855,6 +852,7 @@ Type TypeResolution::applyUnboundGenericArguments(
       if (!resultType->hasTypeParameter())
         return resultType;
 
+      auto genericSig = decl->getGenericSignature();
       auto parentSig = decl->getDeclContext()->getGenericSignatureOfContext();
       for (auto gp : parentSig.getGenericParams())
         subs[gp->getCanonicalType()->castTo<GenericTypeParamType>()] =
@@ -864,18 +862,18 @@ Type TypeResolution::applyUnboundGenericArguments(
     }
 
     skipRequirementsCheck |= parentTy->hasTypeVariable();
-  } else if (auto genericSig =
+  } else if (auto parentSig =
                  decl->getDeclContext()->getGenericSignatureOfContext()) {
-    for (auto gp : genericSig.getGenericParams()) {
+    for (auto gp : parentSig.getGenericParams()) {
       subs[gp->getCanonicalType()->castTo<GenericTypeParamType>()] = gp;
     }
   }
 
   // Realize the types of the generic arguments and add them to the
   // substitution map.
-  auto innerParams = genericSig.getInnermostGenericParams();
-  for (unsigned i = 0; i < innerParams.size(); ++i) {
-    auto origTy = innerParams[i];
+  auto innerParams = decl->getGenericParams()->getParams();
+  for (unsigned i : indices(innerParams)) {
+    auto origTy = innerParams[i]->getDeclaredInterfaceType();
     auto origGP = origTy->getCanonicalType()->castTo<GenericTypeParamType>();
 
     if (!origGP->isTypeSequence()) {
@@ -894,7 +892,8 @@ Type TypeResolution::applyUnboundGenericArguments(
     // types we can bind to this type sequence parameter.
     unsigned tail;
     for (tail = 1; tail <= innerParams.size(); ++tail) {
-      auto tailTy = innerParams[innerParams.size() - tail];
+      auto tailTy = innerParams[innerParams.size() - tail]
+          ->getDeclaredInterfaceType();
       auto tailGP = tailTy->getCanonicalType()->castTo<GenericTypeParamType>();
       if (tailGP->isTypeSequence()) {
         assert(tailGP->isEqual(origGP) &&
@@ -943,6 +942,7 @@ Type TypeResolution::applyUnboundGenericArguments(
     if (noteLoc.isInvalid())
       noteLoc = loc;
 
+    auto genericSig = decl->getGenericSignature();
     auto result = TypeChecker::checkGenericArguments(
         module, loc, noteLoc,
         UnboundGenericType::get(decl, parentTy, getASTContext()),

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -230,9 +230,7 @@ class Top {}
 class Bottom<T : Bottom<Top>> {}
 // expected-error@-1 {{'Bottom' requires that 'Top' inherit from 'Bottom<Top>'}}
 // expected-note@-2 {{requirement specified as 'T' : 'Bottom<Top>' [with T = Top]}}
-// expected-error@-3 4{{generic class 'Bottom' has self-referential generic requirements}}
-// expected-note@-4 {{while resolving type 'Bottom<Top>'}}
-// expected-note@-5 {{through reference here}}
+// expected-error@-3 3{{generic class 'Bottom' has self-referential generic requirements}}
 
 // Invalid inheritance clause
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -45,8 +45,7 @@ public protocol P {
 }
 
 public struct S<A: P> where A.T == S<A> {
-// expected-error@-1 4{{generic struct 'S' has self-referential generic requirements}}
-// expected-note@-2 {{while resolving type 'S<A>'}}
+// expected-error@-1 3{{generic struct 'S' has self-referential generic requirements}}
   func f(a: A.T) {
     g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
     _ = A.T.self
@@ -71,8 +70,7 @@ protocol PI {
 }
 
 struct SI<A: PI> : I where A : I, A.T == SI<A> {
-// expected-error@-1 4{{generic struct 'SI' has self-referential generic requirements}}
-// expected-note@-2 {{while resolving type 'SI<A>'}}
+// expected-error@-1 3{{generic struct 'SI' has self-referential generic requirements}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }

--- a/validation-test/compiler_crashers_2_fixed/sr-10612.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr-10612.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck %s
+// RUN: %target-swift-frontend -typecheck %s
 
 protocol P1: class {
     associatedtype P1P1: P1


### PR DESCRIPTION
The RequirementMachine eagerly resolves protocol typealiases while building a rewrite system. This was causing a request cycle because structural type resolution would request the generic signature of a type unnecessarily, and that generic signature could then reference the protocol itself.

Here is an example (my next PR actually adds an explicit test case, but there are a bunch of examples in the test suite already that boil down to this and fail with -requirement-machine-protocol-signatures=on):

```swift
protocol P where A == B {
  associatedtype A
  typealias B = Foo<Self>
}

struct Foo<T : P> {}
```

While building the requirement signature of `P` we resolve the structural type of `B`, which would previously trigger the computation of the generic signature of `Foo`, which would ask for the requirement signature of `P`. However structural type resolution doesn't check generic requirements on the bound generic type, so it need the generic signature except for in a couple of specific cases (which will still cause a cycle with an example like the above, but that's okay).