### PR TITLE
[SymbolGraph] Don't emit symbols that are unavailable on all platforms

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -661,6 +661,17 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
   return false;
 }
 
+bool SymbolGraph::isUnconditionallyUnavailableOnAllPlatforms(const Decl *D) const {
+  return llvm::any_of(D->getAttrs(), [](const auto *Attr) { 
+    if (const auto *AvAttr = dyn_cast<AvailableAttr>(Attr)) {
+      return !AvAttr->hasPlatform()
+        && AvAttr->isUnconditionallyUnavailable();
+    }
+
+    return false;
+  });
+}
+
 /// Returns `true` if the symbol should be included as a node in the graph.
 bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
   // If this decl isn't in this module, don't record it,
@@ -672,5 +683,6 @@ bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
   if (!isa<ValueDecl>(D)) {
     return false;
   }
-  return !isImplicitlyPrivate(cast<ValueDecl>(D));
+  return !isImplicitlyPrivate(cast<ValueDecl>(D)) 
+    && !isUnconditionallyUnavailableOnAllPlatforms(cast<ValueDecl>(D));
 }

--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -226,6 +226,11 @@ struct SymbolGraph {
   bool isImplicitlyPrivate(const Decl *D,
                            bool IgnoreContext = false) const;
 
+  /// Returns `true` if the declaration has an availability attribute
+  /// that marks it as unconditionally unavailable on all platforms (i.e., where
+  /// the platform is marked '*').
+  bool isUnconditionallyUnavailableOnAllPlatforms(const Decl *D) const;
+
   /// Returns `true` if the declaration should be included as a node
   /// in the graph.
   bool canIncludeDeclAsNode(const Decl *D) const;

--- a/test/SymbolGraph/Symbols/UnavailableOnAllPlatforms.swift
+++ b/test/SymbolGraph/Symbols/UnavailableOnAllPlatforms.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnavailableOnAllPlatforms -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnavailableOnAllPlatforms -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/UnavailableOnAllPlatforms.symbols.json
+
+// REQUIRES: OS=macosx
+
+// CHECK: ShouldAppear
+@available(Linux, unavailable)
+public struct ShouldAppear {}
+
+// CHECK-NOT: ShouldntAppear
+@available(*, unavailable)
+public struct ShouldntAppear {
+
+    // CHECK-NOT: shouldntAppearFunc
+    public func shouldntAppearFunc() {}
+}
+
+// CHECK-NOT: shouldntAppearGlobalFunc
+@available(*, unavailable)
+public func shouldntAppearGlobalFunc() {}


### PR DESCRIPTION
Make SymbolGraphGen skip symbols that are marked unconditionally unavailable on all platforms (`@available(*, unavailable)`). Since these APIs cannot be used, they're not relevant to clients.

Resolves rdar://88807294.