### PR TITLE
Remove disable-objc-interop from test hermetic-seal-exec.swift

### DIFF
--- a/test/IRGen/hermetic-seal-exec.swift
+++ b/test/IRGen/hermetic-seal-exec.swift
@@ -4,7 +4,7 @@
 
 // (1) Build library swiftmodule
 // RUN: %target-build-swift %s -DLIBRARY -module-name Library -experimental-hermetic-seal-at-link -lto=llvm-full %lto_flags \
-// RUN:     -Xfrontend -disable-reflection-metadata -Xfrontend -disable-reflection-names -Xfrontend -disable-objc-interop \
+// RUN:     -Xfrontend -disable-reflection-metadata -Xfrontend -disable-reflection-names \
 // RUN:     -emit-library -static -o %t/libLibrary.a \
 // RUN:     -emit-module -emit-module-path %t/Library.swiftmodule
 
@@ -13,7 +13,7 @@
 
 // (3) Build client
 // RUN: %target-build-swift %s -DCLIENT -parse-as-library -module-name Main -experimental-hermetic-seal-at-link -lto=llvm-full %lto_flags \
-// RUN:     -Xfrontend -disable-reflection-metadata -Xfrontend -disable-reflection-names -Xfrontend -disable-objc-interop \
+// RUN:     -Xfrontend -disable-reflection-metadata -Xfrontend -disable-reflection-names \
 // RUN:     -I%t -L%t -lLibrary -o %t/main
 
 // (4) Check that unused symbols are not present in final executable


### PR DESCRIPTION
This test uses the stdlib build from the current build which typically
will have objc interop enabled.

If disable-objc-interop is enabled we make different layout assumptions
so mixing build products with the flag enabled/disabled is not supported.

This will get exposed when by running the test in optimize mode after PR #41338.

rdar://88827015