### PR TITLE
[CSClosure] SE-0326: Type-checker statement conditions individually

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -43,11 +43,9 @@ namespace swift {
   enum class PatternKind : uint8_t;
   enum class StmtKind;
 
-  using StmtCondition = llvm::MutableArrayRef<StmtConditionElement>;
-
   struct ASTNode
       : public llvm::PointerUnion<Expr *, Stmt *, Decl *, Pattern *, TypeRepr *,
-                                  StmtCondition *, CaseLabelItem *> {
+                                  StmtConditionElement *, CaseLabelItem *> {
     // Inherit the constructors from PointerUnion.
     using PointerUnion::PointerUnion;
 

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -395,7 +395,7 @@ public:
 /// the "x" binding, one for the "y" binding, one for the where clause, one for
 /// "z"'s binding.  A simple "if" statement is represented as a single binding.
 ///
-class StmtConditionElement {
+class alignas(1 << PatternAlignInBits) StmtConditionElement {
   /// If this is a pattern binding, it may be the first one in a declaration, in
   /// which case this is the location of the var/let/case keyword.  If this is
   /// the second pattern (e.g. for 'y' in "var x = ..., y = ...") then this
@@ -818,7 +818,7 @@ public:
 };
 
 /// A pattern and an optional guard expression used in a 'case' statement.
-class CaseLabelItem {
+class alignas(1 << PatternAlignInBits) CaseLabelItem {
   enum class Kind {
     /// A normal pattern
     Normal = 0,

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -61,6 +61,7 @@ namespace swift {
   class TypeRepr;
   class ValueDecl;
   class CaseLabelItem;
+  class StmtConditionElement;
 
   /// We frequently use three tag bits on all of these types.
   constexpr size_t AttrAlignInBits = 3;
@@ -154,6 +155,9 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::AttributeBase, swift::AttrAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeRepr, swift::TypeReprAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::CaseLabelItem, swift::PatternAlignInBits)
+
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::StmtConditionElement,
+                            swift::PatternAlignInBits)
 
 static_assert(alignof(void*) >= 2, "pointer alignment is too small");
 

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1036,7 +1036,7 @@ public:
     if (auto *repr = node.dyn_cast<TypeRepr *>())
       return repr;
 
-    if (auto *cond = node.dyn_cast<StmtCondition *>())
+    if (auto *cond = node.dyn_cast<StmtConditionElement *>())
       return cond;
 
     if (auto *caseItem = node.dyn_cast<CaseLabelItem *>())

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -35,15 +35,8 @@ SourceRange ASTNode::getSourceRange() const {
     return P->getSourceRange();
   if (const auto *T = this->dyn_cast<TypeRepr *>())
     return T->getSourceRange();
-  if (const auto *C = this->dyn_cast<StmtCondition *>()) {
-    if (C->empty())
-      return SourceRange();
-
-    auto first = C->front();
-    auto last = C->back();
-
-    return {first.getStartLoc(), last.getEndLoc()};
-  }
+  if (const auto *C = this->dyn_cast<StmtConditionElement *>())
+    return C->getSourceRange();
   if (const auto *I = this->dyn_cast<CaseLabelItem *>()) {
     return I->getSourceRange();
   }
@@ -85,7 +78,7 @@ bool ASTNode::isImplicit() const {
     return P->isImplicit();
   if (const auto *T = this->dyn_cast<TypeRepr*>())
     return false;
-  if (const auto *C = this->dyn_cast<StmtCondition *>())
+  if (const auto *C = this->dyn_cast<StmtConditionElement *>())
     return false;
   if (const auto *I = this->dyn_cast<CaseLabelItem *>())
     return false;
@@ -103,10 +96,9 @@ void ASTNode::walk(ASTWalker &Walker) {
     P->walk(Walker);
   else if (auto *T = this->dyn_cast<TypeRepr*>())
     T->walk(Walker);
-  else if (auto *C = this->dyn_cast<StmtCondition *>()) {
-    for (auto &elt : *C)
-      elt.walk(Walker);
-  } else if (auto *I = this->dyn_cast<CaseLabelItem *>()) {
+  else if (auto *C = this->dyn_cast<StmtConditionElement *>())
+    C->walk(Walker);
+  else if (auto *I = this->dyn_cast<CaseLabelItem *>()) {
     if (auto *P = I->getPattern())
       P->walk(Walker);
 
@@ -127,9 +119,9 @@ void ASTNode::dump(raw_ostream &OS, unsigned Indent) const {
     P->dump(OS, Indent);
   else if (auto T = dyn_cast<TypeRepr*>())
     T->print(OS);
-  else if (auto C = dyn_cast<StmtCondition *>()) {
-    OS.indent(Indent) << "(statement conditions)";
-  } else if (auto *I = dyn_cast<CaseLabelItem *>()) {
+  else if (auto *C = dyn_cast<StmtConditionElement *>())
+    OS.indent(Indent) << "(statement condition)";
+  else if (auto *I = dyn_cast<CaseLabelItem *>()) {
     OS.indent(Indent) << "(case label item)";
   } else
     llvm_unreachable("unsupported AST node");

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6050,8 +6050,8 @@ SourceLoc constraints::getLoc(ASTNode anchor) {
     return S->getStartLoc();
   } else if (auto *P = anchor.dyn_cast<Pattern *>()) {
     return P->getLoc();
-  } else if (auto *C = anchor.dyn_cast<StmtCondition *>()) {
-    return C->front().getStartLoc();
+  } else if (auto *C = anchor.dyn_cast<StmtConditionElement *>()) {
+    return C->getStartLoc();
   } else {
     auto *I = anchor.get<CaseLabelItem *>();
     return I->getStartLoc();


### PR DESCRIPTION
Instead of referencing whole statement condition, break it down to
individual elements and solve them separately.

Resolves: rdar://88720312

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
