### PR TITLE
[Runtime] Improve deallocation performance of linked structures

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -232,6 +232,14 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 // so changing this value is not sufficient.
 #define SWIFT_DEFAULT_LLVM_CC llvm::CallingConv::C
 
+// Annotation to force a call in tail position to be tail call optimized.
+// If the compiler does not support this, it will be a no-op.
+#if __has_attribute(musttail)
+#define SWIFT_MUSTTAIL __attribute__((musttail))
+#else
+#define SWIFT_MUSTTAIL
+#endif
+
 // SWIFT_FORMAT(fmt,first) marks a function as taking a format string argument
 // at argument `fmt`, with the first argument for the format string as `first`.
 #if __has_attribute(format)

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -181,8 +181,8 @@ namespace swift {
 }
 
 // FIXME: HACK: copied from HeapObject.cpp
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED void
-_swift_release_dealloc(swift::HeapObject *object);
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED __attribute__((swiftcall)) void
+_swift_release_dealloc(SWIFT_CONTEXT swift::HeapObject *object);
 
 namespace swift {
 
@@ -988,6 +988,7 @@ class RefCounts {
   // First slow path of doDecrement, where the object may need to be deinited.
   // Side table is handled in the second slow path, doDecrementSideTable().
   template <PerformDeinit performDeinit>
+  SWIFT_ALWAYS_INLINE
   bool doDecrementSlow(RefCountBits oldbits, uint32_t dec) {
     RefCountBits newbits;
     

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -181,7 +181,7 @@ namespace swift {
 }
 
 // FIXME: HACK: copied from HeapObject.cpp
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED __attribute__((swiftcall)) void
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED SWIFT_CC(swift) void
 _swift_release_dealloc(SWIFT_CONTEXT swift::HeapObject *object);
 
 namespace swift {

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -682,7 +682,13 @@ SWIFT_CC(swift)
 void _swift_release_dealloc(SWIFT_CONTEXT HeapObject *object) {
   // We are forcing `destroy` to be tail called to prevent creation of a
   // new stack frame and reduce overhead of frame pointer authentication.
+#if defined(__arm64__) && !defined(__LP64__)
+  // FIXME: rdar://89699064 - There is a bug in LLVM preventing this call
+  //        from being tail call optimized on arm64_32.
+  return asFullMetadata(object->metadata)->destroy(object);
+#else
   SWIFT_MUSTTAIL return asFullMetadata(object->metadata)->destroy(object);
+#endif
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -680,7 +680,9 @@ void swift::swift_unownedCheck(HeapObject *object) {
 
 SWIFT_CC(swift)
 void _swift_release_dealloc(SWIFT_CONTEXT HeapObject *object) {
-  __attribute__((musttail)) return asFullMetadata(object->metadata)->destroy(object);
+  // We are forcing `destroy` to be tail called to prevent creation of a
+  // new stack frame and reduce overhead of frame pointer authentication.
+  SWIFT_MUSTTAIL return asFullMetadata(object->metadata)->destroy(object);
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -332,8 +332,8 @@ HeapObject *swift::swift_allocEmptyBox() {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED void
-_swift_release_dealloc(HeapObject *object);
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED __attribute__((swiftcall)) void
+_swift_release_dealloc(SWIFT_CONTEXT HeapObject *object);
 
 SWIFT_ALWAYS_INLINE
 static HeapObject *_swift_retain_(HeapObject *object) {
@@ -678,8 +678,9 @@ void swift::swift_unownedCheck(HeapObject *object) {
     swift::swift_abortRetainUnowned(object);
 }
 
-void _swift_release_dealloc(HeapObject *object) {
-  asFullMetadata(object->metadata)->destroy(object);
+__attribute__((swiftcall))
+void _swift_release_dealloc(SWIFT_CONTEXT HeapObject *object) {
+  __attribute__((musttail)) return asFullMetadata(object->metadata)->destroy(object);
 }
 
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -332,7 +332,7 @@ HeapObject *swift::swift_allocEmptyBox() {
 }
 
 // Forward-declare this, but define it after swift_release.
-extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED __attribute__((swiftcall)) void
+extern "C" SWIFT_LIBRARY_VISIBILITY SWIFT_NOINLINE SWIFT_USED SWIFT_CC(swift) void
 _swift_release_dealloc(SWIFT_CONTEXT HeapObject *object);
 
 SWIFT_ALWAYS_INLINE
@@ -678,7 +678,7 @@ void swift::swift_unownedCheck(HeapObject *object) {
     swift::swift_abortRetainUnowned(object);
 }
 
-__attribute__((swiftcall))
+SWIFT_CC(swift)
 void _swift_release_dealloc(SWIFT_CONTEXT HeapObject *object) {
   __attribute__((musttail)) return asFullMetadata(object->metadata)->destroy(object);
 }


### PR DESCRIPTION
Forced inlining of `doDecrementSlow` and tail call of `destroy` in `_swift_release_dealloc`.

rdar://88695181