### PR TITLE
Emit function bodies for functions annotated with @_backDeploy

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -201,6 +201,7 @@ struct FragileFunctionKind {
     AlwaysEmitIntoClient,
     DefaultArgument,
     PropertyInitializer,
+    BackDeploy,
     None
   };
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -320,6 +320,7 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
   case FragileFunctionKind::AlwaysEmitIntoClient:
   case FragileFunctionKind::DefaultArgument:
   case FragileFunctionKind::PropertyInitializer:
+  case FragileFunctionKind::BackDeploy:
     return ResilienceExpansion::Minimal;
   case FragileFunctionKind::None:
     return ResilienceExpansion::Maximal;
@@ -415,6 +416,11 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
 
       if (AFD->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
         return {FragileFunctionKind::AlwaysEmitIntoClient,
+                /*allowUsableFromInline=*/true};
+      }
+
+      if (AFD->getAttrs().hasAttribute<BackDeployAttr>()) {
+        return {FragileFunctionKind::BackDeploy,
                 /*allowUsableFromInline=*/true};
       }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -560,6 +560,9 @@ void swift::simple_display(llvm::raw_ostream &out,
   case FragileFunctionKind::PropertyInitializer:
     out << "propertyInitializer";
     break;
+  case FragileFunctionKind::BackDeploy:
+    out << "backDeploy";
+    break;
   case FragileFunctionKind::None:
     out << "none";
     break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2927,7 +2927,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     StringRef AttrName = "@_backDeploy";
     ParserStatus Status = parseList(tok::r_paren, LeftLoc, RightLoc, false,
                                     diag::attr_back_deploy_missing_rparen,
-                                    SyntaxKind::Unknown, [&]() -> ParserStatus {
+                                    SyntaxKind::AvailabilitySpecList,
+                                    [&]() -> ParserStatus {
       ParserStatus ListItemStatus =
           parsePlatformVersionInList(AttrName, PlatformAndVersions);
       if (ListItemStatus.isErrorOrHasCompletion())

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -17,27 +17,24 @@
 
 public struct TopLevelStruct {
   // CHECK: @_backDeploy(macOS 11.0)
-  // CHECK: public func backDeployedFunc1_SinglePlatform() -> Swift.Int
+  // FROMSOURCE: public func backDeployedFunc1_SinglePlatform() -> Swift.Int { return 42 }
+  // FROMMODULE: public func backDeployedFunc1_SinglePlatform() -> Swift.Int
   @available(macOS 12.0, *)
   @_backDeploy(macOS 11.0)
-  public func backDeployedFunc1_SinglePlatform() -> Int {
-    return 42
-  }
+  public func backDeployedFunc1_SinglePlatform() -> Int { return 42 }
   
   // CHECK: @_backDeploy(macOS 11.0)
   // CHECK: @_backDeploy(iOS 14.0)
-  // CHECK: public func backDeployedFunc2_MultiPlatform() -> Swift.Int
+  // FROMSOURCE: public func backDeployedFunc2_MultiPlatform() -> Swift.Int { return 43 }
+  // FROMMODULE: public func backDeployedFunc2_MultiPlatform() -> Swift.Int
   @available(macOS 12.0, *)
   @_backDeploy(macOS 11.0, iOS 14.0)
-  public func backDeployedFunc2_MultiPlatform() -> Int {
-    return 43
-  }
+  public func backDeployedFunc2_MultiPlatform() -> Int { return 43 }
 }
 
 // CHECK: @_backDeploy(macOS 11.0)
-// CHECK: public func backDeployTopLevelFunc() -> Swift.Int
+// FROMSOURCE: public func backDeployTopLevelFunc() -> Swift.Int { return 44 }
+// FROMMODULE: public func backDeployTopLevelFunc() -> Swift.Int
 @available(macOS 12.0, *)
 @_backDeploy(macOS 11.0)
-public func backDeployTopLevelFunc() -> Int {
-  return 42
-}
+public func backDeployTopLevelFunc() -> Int { return 44 }

--- a/test/SILGen/back_deploy_attribute.swift
+++ b/test/SILGen/back_deploy_attribute.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s21back_deploy_attribute0A12DeployedFuncyyF : $@convention(thin) () -> ()
+@available(macOS 10.51, *)
+@_backDeploy(macOS 10.50)
+public func backDeployedFunc() {}
+
+@available(macOS 10.50, *)
+public struct TopLevelStruct {
+  // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s21back_deploy_attribute14TopLevelStructV0a8DeployedF4FuncyyF : $@convention(method) (TopLevelStruct) -> ()
+  @available(macOS 10.51, *)
+  @_backDeploy(macOS 10.50)
+  public func backDeployedStructFunc() {}
+}
+
+
+// FIXME(backDeploy): Verify SIL in a caller that requires back deployment
+
+
+// CHECK-LABLEL: sil hidden [available 10.51] [ossa] @$s21back_deploy_attribute21alwaysAvailableCalleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK: bb0(%0 : $TopLevelStruct):
+@available(macOS 10.51, *)
+func alwaysAvailableCaller(_ s: TopLevelStruct) {
+  /// This function's availability meets the minimum availability of the APIs, so
+  /// no back deployment logic is required.
+
+  // CHECK: %2 = function_ref @$s21back_deploy_attribute0A12DeployedFuncyyF : $@convention(thin) () -> ()
+  // CHECK: %3 = apply %2() : $@convention(thin) () -> ()
+  backDeployedFunc()
+  // CHECK: %4 = function_ref @$s21back_deploy_attribute14TopLevelStructV0a8DeployedF4FuncyyF : $@convention(method) (TopLevelStruct) -> ()
+  // CHECK: %5 = apply %4(%0) : $@convention(method) (TopLevelStruct) -> ()
+  s.backDeployedStructFunc()
+}


### PR DESCRIPTION
Emit function bodies for functions with `@_backDeploy` into `.swiftinterface` files. Also, add a basic SILGen test for the `@_backDeploy` attribute and fix parsing for the attribute so that `-verify-syntax-tree` passes. The SILGen test will become more interesting when thunks are generated for the back deployed calls.

Resolves rdar://88650341