### PR TITLE
[build-script] Add support for building the benchmark test suite only for macos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ option(SWIFT_BUILD_PERF_TESTSUITE
     "Create in-tree targets for building swift performance benchmarks."
     FALSE)
 
+option(SWIFT_BENCHMARK_MACOS_ONLY
+    "When SWIFT_BUILD_PERF_TESTSUITE is set, only build for macOS"
+    FALSE)
+
 option(SWIFT_INCLUDE_TESTS "Create targets for building/running tests." TRUE)
 
 option(SWIFT_INCLUDE_TEST_BINARIES

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -19,6 +19,10 @@ if(SWIFT_BENCHMARK_SUBCMAKE_BUILD)
     MESSAGE "If we are a subcmake build, we must be built standalone")
 endif()
 
+if(SWIFT_BENCHMARK_MACOS_ONLY)
+  set(ONLY_PLATFORMS "macosx")
+endif()
+
 include(AddSwiftBenchmarkSuite)
 
 #===-----------------------------------------------------------------------===#

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1051,6 +1051,11 @@ def create_argument_parser():
     option('--skip-build-benchmarks', toggle_false('build_benchmarks'),
            help='skip building Swift Benchmark Suite')
 
+    option('--swift-benchmark-macos-only', toggle_true,
+           default=False,
+           help='Build the swift benchmark suite only for macOS to save '
+                'compile time')
+
     option('--build-external-benchmarks', toggle_true,
            help='skip building Swift Benchmark Suite')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -276,6 +276,7 @@ EXPECTED_DEFAULTS = {
     'watchos_all': False,
     'llvm_install_components': defaults.llvm_install_components(),
     'clean_install_destdir': False,
+    'swift_benchmark_macos_only': False,
 }
 
 
@@ -712,6 +713,7 @@ EXPECTED_OPTIONS = [
 
     IntOption('--benchmark-num-o-iterations'),
     IntOption('--benchmark-num-onone-iterations'),
+    EnableOption('--swift-benchmark-macos-only'),
     IntOption('--jobs', dest='build_jobs'),
     IntOption('--llvm-max-parallel-lto-link-jobs'),
     IntOption('--swift-tools-max-parallel-lto-link-jobs'),

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -68,6 +68,9 @@ class Swift(product.Product):
         self.cmake_options.extend(
             self._swift_tools_ld64_lto_codegen_only_for_supporting_targets)
 
+        self.cmake_options.extend(
+            self._swift_benchmark_macos_only)
+
     @classmethod
     def is_build_script_impl_product(cls):
         """is_build_script_impl_product -> bool
@@ -191,6 +194,11 @@ updated without updating swift.py?")
     def _swift_tools_ld64_lto_codegen_only_for_supporting_targets(self):
         return [('SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL',
                  self.args.swift_tools_ld64_lto_codegen_only_for_supporting_targets)]
+
+    @property
+    def _swift_benchmark_macos_only(self):
+        return [('SWIFT_BENCHMARK_MACOS_ONLY:BOOL',
+                 self.args.swift_benchmark_macos_only)]
 
     @classmethod
     def get_dependencies(cls):

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -65,7 +65,8 @@ class SwiftTestCase(unittest.TestCase):
             build_swift_stdlib_unicode_data=True,
             swift_freestanding_is_darwin=False,
             build_swift_private_stdlib=True,
-            swift_tools_ld64_lto_codegen_only_for_supporting_targets=False)
+            swift_tools_ld64_lto_codegen_only_for_supporting_targets=False,
+            swift_benchmark_macos_only=False)
 
         # Setup shell
         shell.dry_run = True
@@ -104,6 +105,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
+            '-DSWIFT_BENCHMARK_MACOS_ONLY:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -127,6 +129,7 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=TRUE',
             '-DSWIFT_STDLIB_ENABLE_UNICODE_DATA=TRUE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
+            '-DSWIFT_BENCHMARK_MACOS_ONLY:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 
@@ -404,3 +407,16 @@ class SwiftTestCase(unittest.TestCase):
              'TRUE'],
             [x for x in swift.cmake_options
                 if 'SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS' in x])
+
+    def test_swift_benchmark_macos_only(self):
+        self.args.swift_benchmark_macos_only = True
+        swift = Swift(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir='/path/to/src',
+            build_dir='/path/to/build')
+        self.assertEqual(
+            ['-DSWIFT_BENCHMARK_MACOS_ONLY:BOOL='
+             'TRUE'],
+            [x for x in swift.cmake_options
+                if 'SWIFT_BENCHMARK_MACOS_ONLY' in x])


### PR DESCRIPTION
Just trying to save compile time in the full test.

----

I am going to add a test for this before it lands.