### PR TITLE
Limit inference of Sendable for public, frozen types relying on preconcurrency

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -267,7 +267,24 @@ enum class SendableCheck {
 
   /// Implicit conformance to Sendable.
   Implicit,
+
+  /// Implicit conformance to Sendable that would be externally-visible, i.e.,
+  /// for a public @_frozen type.
+  ImplicitForExternallyVisible,
 };
+
+/// Whether this sendable check is implicit.
+static inline bool isImplicitSendableCheck(SendableCheck check) {
+  switch (check) {
+  case SendableCheck::Explicit:
+  case SendableCheck::ImpliedByStandardProtocol:
+    return false;
+
+  case SendableCheck::Implicit:
+  case SendableCheck::ImplicitForExternallyVisible:
+    return true;
+  }
+}
 
 /// Describes the context in which a \c Sendable check occurs.
 struct SendableCheckContext {

--- a/test/ModuleInterface/Inputs/preconcurrency.swift
+++ b/test/ModuleInterface/Inputs/preconcurrency.swift
@@ -1,0 +1,1 @@
+public class NotSendable { }

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -1,14 +1,17 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency %s
+// RUN: %target-swift-frontend -emit-module -o %t/Preconcurrency.swiftmodule -module-name Preconcurrency %S/Inputs/preconcurrency.swift
+
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency -I %t %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %FileCheck %s -check-prefix SYNTHESIZED < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface -I %t 
 
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency -I %t 
 // RUN: %FileCheck %s < %t/TestFromModule.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface
+// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface -I %t 
 
 // REQUIRES: concurrency
+import Preconcurrency
 
 // CHECK: public actor SomeActor
 
@@ -95,6 +98,13 @@ public protocol P2 {
 public class C8 : P2 {
   // CHECK: @{{(Test.)?}}SomeGlobalActor public func method()
   public func method() {}
+}
+
+// CHECK-NOT: StructWithImplicitlyNonSendable{{.*}}Sendable
+@available(SwiftStdlib 5.1, *)
+@_frozen
+public struct StructWithImplicitlyNonSendable {
+  var ns: NotSendable? = nil
 }
 
 // FIXME: Work around a bug where module printing depends on the "synthesized"


### PR DESCRIPTION
When inferring Sendable for a public, frozen type, that Sendable conformance
becomes part of the contract. Therefore, don't infer this conformance
when any of instance storage is implicitly non-Sendable.

Fixes rdar://88652324.
