### PR TITLE
Fix the signature of Builtin.Once() to take callback with an argument, to match swift_once()

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1834,17 +1834,14 @@ static ValueDecl *getUnreachableOperation(ASTContext &Context,
 static ValueDecl *getOnceOperation(ASTContext &Context,
                                    Identifier Id,
                                    bool withContext) {
-  // (RawPointer, @convention(c) ([Context]) -> ()[, Context]) -> ()
+  // (RawPointer, @convention(c) (Context) -> ()[, Context]) -> ()
   
   auto HandleTy = Context.TheRawPointerType;
   auto VoidTy = Context.TheEmptyTupleType;
   SmallVector<AnyFunctionType::Param, 1> CFuncParams;
-  swift::CanType ContextTy;
-  if (withContext) {
-    ContextTy = Context.TheRawPointerType;
-    auto ContextArg = FunctionType::Param(ContextTy);
-    CFuncParams.push_back(ContextArg);
-  }
+  swift::CanType ContextTy = Context.TheRawPointerType;
+  auto ContextArg = FunctionType::Param(ContextTy);
+  CFuncParams.push_back(ContextArg);
   auto Rep = FunctionTypeRepresentation::CFunctionPointer;
   auto ClangType = Context.getClangFunctionType(CFuncParams, VoidTy, Rep);
   auto Thin =

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -381,7 +381,7 @@ func testCondFail(_ b: Bool, c: Bool) {
 // CHECK:         call void @swift_once([[WORD]]* [[PRED_PTR]], i8* %1, i8* undef)
 // CHECK-objc:    br label %[[DONE]]
 
-func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(c) () -> ()) {
+func testOnce(_ p: Builtin.RawPointer, f: @escaping @convention(c) (Builtin.RawPointer) -> ()) {
   Builtin.once(p, f)
 }
 

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -859,11 +859,11 @@ func release(ptr: Builtin.NativeObject) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-func once_helper() {}
+func once_helper(_ context: Builtin.RawPointer) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins4once7controlyBp_tF
-// CHECK:      [[T0:%.*]] = function_ref @$s8builtins11once_helperyyFTo : $@convention(c) () -> ()
-// CHECK-NEXT: builtin "once"(%0 : $Builtin.RawPointer, [[T0]] : $@convention(c) () -> ())
+// CHECK:      [[T0:%.*]] = function_ref @$s8builtins11once_helperyyBpFTo : $@convention(c) (Builtin.RawPointer) -> ()
+// CHECK-NEXT: builtin "once"(%0 : $Builtin.RawPointer, [[T0]] : $@convention(c) (Builtin.RawPointer) -> ())
 func once(control: Builtin.RawPointer) {
   Builtin.once(control, once_helper)
 }


### PR DESCRIPTION
This is to fix a ptrauth mismatch when the callee, swift_once, expected a `void(*)(void*)` argument, but currently Builtin.Once is passing the callback as a `void(*)()`.