### PR TITLE
[ShrinkBorrowScope] Adopt BackwardReachability.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -426,6 +426,12 @@ public:
   /// the debug scope for newly created instructions.
   const SILDebugScope *getScopeOfFirstNonMetaInstruction();
 
+  /// Whether the block has any phi arguments.
+  ///
+  /// Note that a block could have an argument and still return false.  The
+  /// argument must also satisfy SILPhiArgument::isPhiArgument.
+  bool hasPhi() const;
+
   //===--------------------------------------------------------------------===//
   // Debugging
   //===--------------------------------------------------------------------===//

--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -148,7 +148,7 @@ protected:
 };
 
 bool shrinkBorrowScope(
-    BeginBorrowInst *bbi, InstructionDeleter &deleter,
+    BeginBorrowInst const &bbi, InstructionDeleter &deleter,
     SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts);
 
 bool foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -395,6 +395,15 @@ bool SILBasicBlock::isLegalToHoistInto() const {
   return true;
 }
 
+bool SILBasicBlock::hasPhi() const {
+  if (getArguments().size() == 0)
+    return false;
+  // It is sufficient to check whether the first argument is a phi.  A block
+  // can't have both phis and terminator results.
+  auto *argument = getArguments()[0];
+  return argument->isPhiArgument();
+}
+
 const SILDebugScope *SILBasicBlock::getScopeOfFirstNonMetaInstruction() {
   for (auto &Inst : *this)
     if (Inst.isMetaInstruction())

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -451,7 +451,7 @@ void CopyPropagation::run() {
     // at least once and then until each stops making changes.
     while (true) {
       SmallVector<CopyValueInst *, 4> modifiedCopyValueInsts;
-      auto shrunk = shrinkBorrowScope(bbi, deleter, modifiedCopyValueInsts);
+      auto shrunk = shrinkBorrowScope(*bbi, deleter, modifiedCopyValueInsts);
       for (auto *cvi : modifiedCopyValueInsts)
         defWorklist.updateForCopy(cvi);
       changed |= shrunk;

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -1,20 +1,30 @@
+//=====-- ShrinkBorrowScope.cpp - Hoist end_borrows to deinit barriers. -=====//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
+//===----------------------------------------------------------------------===//
+/// Shrink borrow scopes by hoisting end_borrows up to deinit barriers.  After
+/// this is done, CanonicalOSSALifetime is free to hoist the destroys of the
+/// owned value up to the end_borrow.  In this way, the lexical lifetime of
+/// guaranteed values is preserved.
+//===----------------------------------------------------------------------===//
 
 #include "swift/AST/Builtins.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/Reachability.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "llvm/ADT/STLExtras.h"
 
 #define DEBUG_TYPE "copy-propagation"
 
@@ -24,295 +34,409 @@ using namespace swift;
 //                       MARK: ShrinkBorrowScope
 //===----------------------------------------------------------------------===//
 
-class ShrinkBorrowScope {
-  // The instruction that begins this borrow scope.
-  BeginBorrowInst *introducer;
+namespace ShrinkBorrowScope {
+
+/// The environment within which to hoist.
+struct Context final {
+  /// The instruction that begins the borrow scope.
+  BeginBorrowInst const &introducer;
+
+  /// BorrowedValue(introducer)
+  BorrowedValue const borrowedValue;
+
+  /// The value whose lifetime is guaranteed by the lexical borrow scope.
+  ///
+  /// introducer->getOperand()
+  SILValue const borrowee;
+
+  SILFunction &function;
+
+  /// The copy_value instructions that the utility creates or changes.
+  ///
+  /// Clients provide this so that they can update worklists in respons.
+  SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts;
 
   InstructionDeleter &deleter;
 
-  SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts;
+  Context(BeginBorrowInst const &introducer,
+          SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts,
+          InstructionDeleter &deleter)
+      : introducer(introducer), borrowedValue(BorrowedValue(&introducer)),
+        borrowee(introducer.getOperand()), function(*introducer.getFunction()),
+        modifiedCopyValueInsts(modifiedCopyValueInsts), deleter(deleter) {}
+  Context(Context const &) = delete;
+  Context &operator=(Context const &) = delete;
+};
 
+/// How %lifetime gets used.
+struct Usage final {
   /// Instructions which are users of the simple (i.e. not reborrowed) extended
   /// i.e. copied lifetime of the introducer.
   SmallPtrSet<SILInstruction *, 16> users;
-
-  /// Deinit barriers that obstruct hoisting end_borrow instructions.
-  llvm::SmallVector<std::pair<SILBasicBlock *, SILInstruction *>>
-      barrierInstructions;
-
-  /// Blocks above which the borrow scope cannot be hoisted.
-  ///
-  /// Consequently, these blocks must begin with end_borrow %borrow.
-  ///
-  /// Note: These blocks aren't barrier blocks.  Rather the borrow scope is
-  ///       barred from being hoisted out of them.  That could happen because
-  ///       one of its predecessors is a barrier block (i.e. has a successor
-  ///       which is live) or because one of its predecessors has a terminator
-  ///       which is itself a deinit barrier.
-  SmallPtrSet<SILBasicBlock *, 8> barredBlocks;
-
-  // The list of blocks to look for new points at which to insert end_borrows
-  // in.  A block must not be processed if all of its successors have not yet
-  // been.  For that reason, it is necessary to allow the same block to be
-  // visited multiple times, at most once for each successor.
-  SmallVector<SILBasicBlock *, 8> worklist;
   // The instructions from which the shrinking starts, the scope ending
   // instructions, keyed off the block in which they appear.
-  llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *> startingInstructions;
-  // The end _borrow instructions for this borrow scope that existed before
-  // ShrinkBorrowScope ran and which were not modified.
-  llvm::SmallPtrSet<SILInstruction *, 8> reusedEndBorrowInsts;
+  llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *> ends;
 
-  // Whether ShrinkBorrowScope made any changes to the function.
-  //
-  // It could have made one of the following sorts of changes:
-  // - deleted an end_borrow
-  // - created an end_borrow
-  // - rewrote the operand of an instruction
-  //   - ApplySite
-  //   - begin_borrow
-  //   - copy_value
-  bool madeChange;
+  bool containsEnd(SILInstruction *end) const {
+    auto iterator = ends.find(end->getParent());
+    return iterator != ends.end() && iterator->second == end;
+  };
 
-public:
-  ShrinkBorrowScope(BeginBorrowInst *bbi, InstructionDeleter &deleter,
-                    SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts)
-      : introducer(bbi), deleter(deleter),
-        modifiedCopyValueInsts(modifiedCopyValueInsts), madeChange(false) {}
-
-  bool run();
-
-  bool populateUsers();
-  bool initializeWorklist();
-  void findBarriers();
-  bool rewrite();
-  bool createEndBorrow(SILInstruction *insertionPoint);
-
-  bool canReplaceValueWithBorrowee(SILValue value) {
-    while (true) {
-      auto *instruction = value.getDefiningInstruction();
-      if (!instruction)
-        return false;
-      if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
-        value = cvi->getOperand();
-        continue;
-      } else if (auto *bbi = dyn_cast<BeginBorrowInst>(instruction)) {
-        if (bbi == introducer) {
-          return true;
-        }
-      }
-      return false;
-    }
-  }
-
-  bool canHoistOverInstruction(SILInstruction *instruction) {
-    return tryHoistOverInstruction(instruction, /*rewrite=*/false);
-  }
-
-  bool tryHoistOverInstruction(SILInstruction *instruction, bool rewrite = true) {
-    if (instruction == introducer) {
-      return false;
-    }
-    if (users.contains(instruction)) {
-      if (auto *bbi = dyn_cast<BeginBorrowInst>(instruction)) {
-        if (bbi->isLexical() &&
-            canReplaceValueWithBorrowee(bbi->getOperand())) {
-          if (rewrite) {
-            auto borrowee = introducer->getOperand();
-            bbi->setOperand(borrowee);
-            madeChange = true;
-          }
-          return true;
-        }
-      } else if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
-        if (canReplaceValueWithBorrowee(cvi->getOperand())) {
-          if (rewrite) {
-            auto borrowee = introducer->getOperand();
-            cvi->setOperand(borrowee);
-            madeChange = true;
-            modifiedCopyValueInsts.push_back(cvi);
-          }
-          return true;
-        }
-      }
-      return false;
-    }
-    return !isDeinitBarrier(instruction);
-  }
+  Usage(){};
+  Usage(Usage const &) = delete;
+  Usage &operator=(Usage const &) = delete;
 };
 
-//===----------------------------------------------------------------------===//
-//                        MARK: Rewrite borrow scopes
-//===----------------------------------------------------------------------===//
+/// Identify scope ending uses and extended users of %lifetime.
+///
+/// returns true if all uses were found
+///         false otherwise
+bool findUsage(Context const &context, Usage &usage) {
+  llvm::SmallVector<SILInstruction *, 16> scopeEndingInsts;
+  context.borrowedValue.getLocalScopeEndingInstructions(scopeEndingInsts);
 
-bool ShrinkBorrowScope::run() {
-  if (!BorrowedValue(introducer).isLocalScope())
-    return false;
-  if (!populateUsers())
-    return false;
-  if (!initializeWorklist())
-    return false;
+  // Form a map of the scopeEndingInsts, keyed off the block they occur in.
+  for (auto *instruction : scopeEndingInsts) {
+    // If a scope ending instruction is not an end_borrow, bail out.
+    if (!isa<EndBorrowInst>(instruction))
+      return false;
+    auto *block = instruction->getParent();
+    usage.ends[block] = instruction;
+  }
 
-  findBarriers();
-
-  madeChange |= rewrite();
-
-  return madeChange;
-}
-
-bool ShrinkBorrowScope::populateUsers() {
   SmallVector<Operand *, 16> uses;
-  if (!findExtendedUsesOfSimpleBorrowedValue(BorrowedValue(introducer),
-                                             &uses)) {
+  if (!findExtendedUsesOfSimpleBorrowedValue(context.borrowedValue, &uses)) {
     // If the value produced by begin_borrow escapes, don't shrink the borrow
     // scope.
     return false;
   }
   for (auto *use : uses) {
-    auto *user = use->getUser();
-    users.insert(user);
+    usage.users.insert(use->getUser());
   }
   return true;
 }
 
-bool ShrinkBorrowScope::initializeWorklist() {
-  llvm::SmallVector<SILInstruction *, 16> scopeEndingInsts;
-  BorrowedValue(introducer).getLocalScopeEndingInstructions(scopeEndingInsts);
+/// How end_borrow hoisting is obstructed.
+struct DeinitBarriers final {
+  /// Blocks up to "before the beginning" of which hoisting was able to proceed.
+  BasicBlockSetVector hoistingReachesBeginBlocks;
 
-  // Form a map of the scopeEndingInsts, keyed off the block they occur in.  If
-  // a scope ending instruction is not an end_borrow, bail out.
-  for (auto *instruction : scopeEndingInsts) {
-    if (!isa<EndBorrowInst>(instruction))
+  /// Blocks to "after the end" of which hoisting was able to proceed.
+  BasicBlockSet hoistingReachesEndBlocks;
+
+  /// Borrows to be rewritten as borrows of %borrowee.
+  SmallVector<BeginBorrowInst *, 4> borrows;
+
+  /// Copies to be rewritten as copies of %borrowee.
+  SmallVector<CopyValueInst *, 4> copies;
+
+  /// Instructions above which end_borrows cannot be hoisted.
+  SmallVector<SILInstruction *, 4> barriers;
+
+  /// Blocks one of whose phis is a barrier and consequently out of which
+  /// end_borrows cannot be hoisted.
+  SmallVector<SILBasicBlock *, 4> phiBarriers;
+
+  DeinitBarriers(Context &context)
+      : hoistingReachesBeginBlocks(&context.function),
+        hoistingReachesEndBlocks(&context.function) {}
+  DeinitBarriers(DeinitBarriers const &) = delete;
+  DeinitBarriers &operator=(DeinitBarriers const &) = delete;
+};
+
+/// Works backwards from the current location of end_borrows to the earliest
+/// place they can be hoisted to.
+///
+/// Implements BackwardReachability::BlockReachability.
+class DataFlow final {
+  Context const &context;
+  Usage const &uses;
+  DeinitBarriers &result;
+
+  enum class Classification { Barrier, Borrow, Copy, Other };
+
+  BackwardReachability<DataFlow> reachability;
+
+public:
+  DataFlow(Context const &context, Usage const &uses, DeinitBarriers &result)
+      : context(context), uses(uses), result(result),
+        reachability(&context.function, *this) {
+    // Seed reachability with the scope ending uses from which the backwards
+    // data flow will begin.
+    for (auto pair : uses.ends) {
+      reachability.initLastUse(pair.second);
+    }
+  }
+  DataFlow(DataFlow const &) = delete;
+  DataFlow &operator=(DataFlow const &) = delete;
+
+  void run() { reachability.solveBackward(); }
+
+private:
+  friend class BackwardReachability<DataFlow>;
+
+  bool hasReachableBegin(SILBasicBlock *block) {
+    return result.hoistingReachesBeginBlocks.contains(block);
+  }
+
+  void markReachableBegin(SILBasicBlock *block) {
+    result.hoistingReachesBeginBlocks.insert(block);
+  }
+
+  void markReachableEnd(SILBasicBlock *block) {
+    result.hoistingReachesEndBlocks.insert(block);
+  }
+
+  Classification classifyInstruction(SILInstruction *);
+
+  bool classificationIsBarrier(Classification);
+
+  void visitedInstruction(SILInstruction *, Classification);
+
+  bool checkReachableBarrier(SILInstruction *);
+
+  bool checkReachablePhiBarrier(SILBasicBlock *);
+};
+
+/// Whether the specified value is %lifetime or its iterated copy_value.
+///
+/// In other words, it has to be a simple extended def of %lifetime.
+bool isSimpleExtendedIntroducerDef(Context const &context, SILValue value) {
+  while (true) {
+    auto *instruction = value.getDefiningInstruction();
+    if (!instruction)
       return false;
-    auto *block = instruction->getParent();
-    worklist.push_back(block);
-    startingInstructions[block] = instruction;
-  }
-
-  return true;
-}
-
-void ShrinkBorrowScope::findBarriers() {
-  // Walk the cfg backwards from the blocks containing scope ending
-  // instructions, visiting only the initial blocks (which contained those
-  // instructions) and those blocks all of whose successors have already been
-  // visited.
-  //
-  // TODO: Handle loops.
-
-  // Blocks to the top of which the borrow scope has been shrunk.
-  SmallPtrSet<SILBasicBlock *, 8> deadBlocks;
-  auto hasOnlyDeadSuccessors =
-      [&deadBlocks](SILBasicBlock *block) -> bool {
-    return llvm::all_of(block->getSuccessorBlocks(), [=](auto *successor) {
-      return deadBlocks.contains(successor);
-    });
-  };
-
-  while (!worklist.empty()) {
-    auto *block = worklist.pop_back_val();
-    auto *startingInstruction = startingInstructions.lookup(block);
-    if (!startingInstruction && !hasOnlyDeadSuccessors(block)) {
+    if (instruction == &context.introducer)
+      return true;
+    if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
+      value = cvi->getOperand();
       continue;
     }
-    for (auto *successor : block->getSuccessorBlocks()) {
-      barredBlocks.erase(successor);
-    }
-
-    // We either have processed all successors of block or else it is a block
-    // which contained one of the original scope-ending instructions.  Scan the
-    // block backwards, looking for the first deinit barrier.  If we've visited
-    // all successors, start scanning from the terminator.  If the block
-    // contained an original scope-ending instruction, start scanning from it.
-    SILInstruction *instruction =
-        startingInstruction ? startingInstruction : block->getTerminator();
-    if (!startingInstruction) {
-      // That there's no starting instruction means that this this block did not
-      // contain an original introducer.  It was added to the worklist later.
-      // At that time, it was checked that this block (along with all that
-      // successor's other predecessors) had a terminator over which the borrow
-      // scope could be shrunk.  Shrink it now.
-      bool hoisted = tryHoistOverInstruction(block->getTerminator());
-      assert(hoisted);
-      (void)hoisted;
-    }
-    SILInstruction *barrier = nullptr;
-    while ((instruction = instruction->getPreviousInstruction())) {
-      if (!tryHoistOverInstruction(instruction)) {
-        barrier = instruction;
-        break;
-      }
-    }
-
-    if (barrier) {
-      barrierInstructions.push_back({block, barrier});
-    } else {
-      deadBlocks.insert(block);
-      barredBlocks.insert(block);
-      // If any of block's predecessor has a terminator over which the scope 
-      // can't be shrunk, the scope is barred from shrinking out of this block.
-      if (llvm::all_of(block->getPredecessorBlocks(), [&](auto *block) {
-            return canHoistOverInstruction(block->getTerminator());
-            })) {
-        // Otherwise, add all predecessors to the worklist and attempt to shrink
-        // the borrow scope through them.
-        for (auto *predecessor : block->getPredecessorBlocks()) {
-          worklist.push_back(predecessor);
-        }
-      }
-    }
+    return false;
   }
 }
 
-bool ShrinkBorrowScope::rewrite() {
-  bool createdBorrow = false;
+DataFlow::Classification
+DataFlow::classifyInstruction(SILInstruction *instruction) {
+  if (instruction == &context.introducer) {
+    return Classification::Barrier;
+  }
+  if (auto *bbi = dyn_cast<BeginBorrowInst>(instruction)) {
+    if (bbi->isLexical() &&
+        isSimpleExtendedIntroducerDef(context, bbi->getOperand())) {
+      return Classification::Borrow;
+    }
+  } else if (auto *cvi = dyn_cast<CopyValueInst>(instruction)) {
+    if (isSimpleExtendedIntroducerDef(context, cvi->getOperand())) {
+      return Classification::Copy;
+    }
+  }
+  if (uses.users.contains(instruction)) {
+    return Classification::Barrier;
+  }
+  if (isDeinitBarrier(instruction)) {
+    return Classification::Barrier;
+  }
+  return Classification::Other;
+}
 
-  // Insert the new end_borrow instructions that occur after deinit barriers.
-  for (auto pair : barrierInstructions) {
-    auto *insertionPoint = pair.second->getNextInstruction();
-    createdBorrow |= createEndBorrow(insertionPoint);
+bool DataFlow::classificationIsBarrier(Classification classification) {
+  switch (classification) {
+  case Classification::Barrier:
+    return true;
+  case Classification::Borrow:
+  case Classification::Copy:
+  case Classification::Other:
+    return false;
+  }
+  llvm_unreachable("exhaustive switch not exhaustive?!");
+}
+
+void DataFlow::visitedInstruction(SILInstruction *instruction,
+                                  Classification classification) {
+  assert(classifyInstruction(instruction) == classification);
+  switch (classification) {
+  case Classification::Barrier:
+    result.barriers.push_back(instruction);
+    return;
+  case Classification::Borrow:
+    result.borrows.push_back(cast<BeginBorrowInst>(instruction));
+    return;
+  case Classification::Copy:
+    result.copies.push_back(cast<CopyValueInst>(instruction));
+    return;
+  case Classification::Other:
+    return;
+  }
+  llvm_unreachable("exhaustive switch not exhaustive?!");
+}
+
+bool DataFlow::checkReachableBarrier(SILInstruction *instruction) {
+  auto classification = classifyInstruction(instruction);
+  visitedInstruction(instruction, classification);
+  return classificationIsBarrier(classification);
+}
+
+bool DataFlow::checkReachablePhiBarrier(SILBasicBlock *block) {
+  assert(llvm::all_of(block->getArguments(),
+                      [&](auto argument) { return PhiValue(argument); }));
+
+  bool isBarrier =
+      llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
+        return classificationIsBarrier(
+            classifyInstruction(predecessor->getTerminator()));
+      });
+  if (isBarrier) {
+    result.phiBarriers.push_back(block);
+  }
+  return isBarrier;
+}
+
+/// Hoist the scope ends of %lifetime, rewriting copies and borrows along the
+/// way.
+class Rewriter final {
+  Context &context;
+  Usage const &uses;
+  DeinitBarriers const &barriers;
+
+  // The end _borrow instructions for this borrow scope that existed before
+  // ShrinkBorrowScope ran and which were not modified.
+  llvm::SmallPtrSet<SILInstruction *, 8> reusedEndBorrowInsts;
+
+public:
+  Rewriter(Context &context, Usage const &uses, DeinitBarriers const &barriers)
+      : context(context), uses(uses), barriers(barriers) {}
+  Rewriter(Rewriter const &) = delete;
+  Rewriter &operator=(Rewriter const &) = delete;
+
+  bool run();
+
+private:
+  bool createEndBorrow(SILInstruction *insertionPoint);
+};
+
+bool Rewriter::run() {
+  bool madeChange = false;
+
+  for (auto *bbi : barriers.borrows) {
+    bbi->setOperand(context.borrowee);
+    madeChange = true;
+  }
+  for (auto *cvi : barriers.copies) {
+    cvi->setOperand(context.borrowee);
+    context.modifiedCopyValueInsts.push_back(cvi);
+    madeChange = true;
   }
 
-  // Insert the new end_borrow instructions that occur at the beginning of
-  // blocks which we couldn't hoist out of.
-  for (auto *block : barredBlocks) {
-    auto *insertionPoint = &*block->begin();
-    createdBorrow |= createEndBorrow(insertionPoint);
+  // Add end_borrows for phi barrier boundaries.
+  //
+  // A block is a phi barrier iff any of its predecessors' terminators get
+  // classified as barriers.  That happens when a copy of %lifetime is passed
+  // to a phi.
+  for (auto *block : barriers.phiBarriers) {
+    madeChange |= createEndBorrow(&block->front());
   }
 
-  if (createdBorrow) {
+  // Add end_borrows for barrier boundaries.
+  //
+  // Insert end_borrows after every non-terminator barrier.
+  //
+  // For terminator barriers, add end_borrows at the beginning of the successor
+  // blocks.  But only if all of its parent block P's successors S in succ(P)
+  // had reachable beginnings.  If any one of them didn't, then this isn't a
+  // barrier boundary but actually a control flow boundary, and will be handled
+  // below.  We witness that all of its successors had reachable beginnings by
+  // way of parent block P having a reachable end.
+  //
+  // terminator-boundary(B) := isBarrier(P->getTerminator()) && end-reachable(P)
+  //                           where P := pred(B)
+  for (auto instruction : barriers.barriers) {
+    if (auto *terminator = dyn_cast<TermInst>(instruction)) {
+      auto successors = terminator->getParentBlock()->getSuccessorBlocks();
+      if (!barriers.hoistingReachesEndBlocks.contains(
+              terminator->getParentBlock())) {
+        // If reachability didn't make it to the begin of any one of this
+        // block's successors, then this isn't a terminator boundary, and will
+        // be handled below.
+        assert(successors.size() > 1);
+        continue;
+      }
+      for (auto *successor : successors) {
+        madeChange |= createEndBorrow(&successor->front());
+      }
+    } else {
+      auto *next = instruction->getNextInstruction();
+      assert(next);
+      madeChange |= createEndBorrow(next);
+    }
+  }
+
+  // Add end_borrows for control-flow boundaries.
+  //
+  // Insert end_borrows at the beginning of blocks which were preceded by a
+  // control flow branch (and which, thanks to the lack of critical edges,
+  // don't have multiple predecessors) whose end was not reachable (because
+  // reachability was not able to make it to the top of some other successor).
+  //
+  // In other words, a control flow boundary is the target edge from a block B
+  // to its single predecessor P not all of whose successors S in succ(P) had
+  // reachable beginnings.  We witness that fact about P's successors by way of
+  // P not having a reachable end--see BackwardReachability::meetOverSuccessors.
+  //
+  // control-flow-boundary(B) := beginning-reachable(B) && !end-reachable(P)
+  for (auto *block : barriers.hoistingReachesBeginBlocks) {
+    if (auto *predecessor = block->getSinglePredecessorBlock()) {
+      if (!barriers.hoistingReachesEndBlocks.contains(predecessor)) {
+        madeChange |= createEndBorrow(&block->front());
+      }
+    }
+  }
+
+  if (madeChange) {
     // Remove all the original end_borrow instructions.
-    for (auto pair : startingInstructions) {
+    for (auto pair : uses.ends) {
       if (reusedEndBorrowInsts.contains(pair.second)) {
         continue;
       }
-      deleter.forceDelete(pair.getSecond());
+      context.deleter.forceDelete(pair.getSecond());
     }
   }
 
-  return createdBorrow;
+  return madeChange;
 }
 
-bool ShrinkBorrowScope::createEndBorrow(SILInstruction *insertionPoint) {
+bool Rewriter::createEndBorrow(SILInstruction *insertionPoint) {
   if (auto *ebi = dyn_cast<EndBorrowInst>(insertionPoint)) {
-    llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *>::iterator location;
-    if ((location = llvm::find_if(startingInstructions, [&](auto pair) -> bool {
-           return pair.second == insertionPoint;
-         })) != startingInstructions.end()) {
-      reusedEndBorrowInsts.insert(location->second);
+    if (uses.containsEnd(insertionPoint)) {
+      reusedEndBorrowInsts.insert(insertionPoint);
       return false;
     }
   }
   auto builder = SILBuilderWithScope(insertionPoint);
   builder.createEndBorrow(
       RegularLocation::getAutoGeneratedLocation(insertionPoint->getLoc()),
-      introducer);
+      &context.introducer);
   return true;
 }
 
+bool run(Context &context) {
+  Usage usage;
+  if (!findUsage(context, usage))
+    return false;
+
+  DeinitBarriers barriers(context);
+  DataFlow flow(context, usage, barriers);
+  flow.run();
+
+  Rewriter rewriter(context, usage, barriers);
+
+  return rewriter.run();
+}
+} // end namespace ShrinkBorrowScope
+
 bool swift::shrinkBorrowScope(
-    BeginBorrowInst *bbi, InstructionDeleter &deleter,
+    BeginBorrowInst const &bbi, InstructionDeleter &deleter,
     SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts) {
-  ShrinkBorrowScope borrowShrinker(bbi, deleter, modifiedCopyValueInsts);
-  return borrowShrinker.run();
+  ShrinkBorrowScope::Context context(bbi, modifiedCopyValueInsts, deleter);
+  return ShrinkBorrowScope::run(context);
 }

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -30,10 +30,13 @@ class PointerWrapper {
 enum OneOfThree { case one, two, three }
 
 sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @get_owned_c : $@convention(thin) () -> (@owned C)
 sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 sil [ossa] @callee_optional_d_guaranteed: $@convention(thin) (@guaranteed Optional<D>) -> ()
 sil [ossa] @synchronization_point : $@convention(thin) () -> ()
 sil [ossa] @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
+sil [ossa] @barrier : $@convention(thin) () -> ()
+
 
 // =============================================================================
 // = DECLARATIONS                                                             }}
@@ -232,11 +235,11 @@ exit:
 // CHECK:         switch_enum [[MAYBE]] : $Optional<C>, case #Optional.some!enumelt: [[SOME_DEST:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_DEST:bb[0-9]+]] 
 // CHECK:       [[SOME_DEST]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
 // CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         br [[BASIC_BLOCK3:bb[0-9]+]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[NONE_DEST]]:
 // CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         br [[BASIC_BLOCK3]]
-// CHECK:       [[BASIC_BLOCK3]]:
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
 // CHECK:         return [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_over_terminator_2'
 sil [ossa] @hoist_over_terminator_2 : $@convention(thin) (@owned C) -> @owned C {
@@ -256,9 +259,10 @@ exit:
     return %instance_c : $C
 }
 
-// Hoist over transformation terminator which forwards ownership of guaranteed
-// value which itself had forwarding ownership of the original borrow.
-// CHECK-LABEL: sil [ossa] @hoist_over_terminator_3 : {{.*}} {
+// Don't hoist over transformation terminator which forwards ownership of
+// guaranteed value which itself had forwarding ownership of the original
+// borrow.
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_terminator_3 : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         [[MAYBE:%[^,]+]] = enum $Optional<C>, #Optional.some!enumelt, [[LIFETIME]]
@@ -271,8 +275,8 @@ exit:
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK:         return [[INSTANCE]]
-// CHECK-LABEL: } // end sil function 'hoist_over_terminator_3'
-sil [ossa] @hoist_over_terminator_3 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_terminator_3'
+sil [ossa] @dont_hoist_over_terminator_3 : $@convention(thin) (@owned C) -> @owned C {
 entry(%instance_c : @owned $C):
     %lifetime_c = begin_borrow %instance_c : $C
     %maybe_c = enum $Optional<C>, #Optional.some!enumelt, %lifetime_c : $C
@@ -283,6 +287,45 @@ some_dest(%lifetime_c_2 : @guaranteed $C):
     br exit
 
 none_dest:
+    end_borrow %lifetime_c : $C
+    br exit
+
+exit:
+    return %instance_c : $C
+}
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_terminator_3__barrier : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[MAYBE_C:%[^,]+]] = enum $Optional<C>, #Optional.some!enumelt, [[LIFETIME]]
+// CHECK:         switch_enum [[MAYBE_C]] : $Optional<C>, case #Optional.some!enumelt: [[SOME_DEST:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_DEST:bb[0-9]+]]
+// CHECK:       [[SOME_DEST]]({{%[^,]+}} :
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         tuple ()
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[NONE_DEST]]:
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         tuple ()
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_terminator_3__barrier'
+sil [ossa] @dont_hoist_over_terminator_3__barrier : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance_c : @owned $C):
+    %lifetime_c = begin_borrow %instance_c : $C
+    %maybe_c = enum $Optional<C>, #Optional.some!enumelt, %lifetime_c : $C
+    switch_enum %maybe_c : $Optional<C>, case #Optional.some!enumelt: some_dest, case #Optional.none!enumelt: none_dest
+
+some_dest(%lifetime_c_2 : @guaranteed $C):
+    %tuple = tuple ()
+    end_borrow %lifetime_c : $C
+    br exit
+
+none_dest:
+    %barrier = function_ref @barrier : $@convention(thin) () -> ()
+    apply %barrier() : $@convention(thin) () -> ()
+    %tuple_2 = tuple ()
     end_borrow %lifetime_c : $C
     br exit
 
@@ -355,6 +398,40 @@ exit(%thing : @owned $C):
     destroy_value %thing : $C
     destroy_value %instance : $C
     %retval = tuple ()
+    return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_some_barred_blocks__2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         br [[TRAMPOLINE:bb[0-9]+]](undef : $C)
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]] : $C
+// CHECK:         br [[TRAMPOLINE]]([[COPY]] : $C)
+// CHECK:       [[TRAMPOLINE]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_some_barred_blocks__2'
+sil [ossa] @dont_hoist_over_some_barred_blocks__2 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    %lifetime = begin_borrow [lexical] %instance : $C
+    cond_br undef, left, right
+
+left:
+    br trampoline(undef : $C)
+
+right:
+    %copy = copy_value %lifetime : $C
+    br trampoline(%copy : $C)
+
+trampoline(%copy_1 : @owned $C):
+    end_borrow %lifetime : $C
+    br exit
+
+exit:
+    %retval = tuple ()
+    destroy_value %copy_1 : $C
+    destroy_value %instance : $C
     return %retval : $()
 }
 
@@ -457,7 +534,7 @@ exit:
 // CHECK:         [[LIFETIME_C:%[^,]+]] = begin_borrow [[INSTANCE_C]]
 // CHECK:         [[COPY_C:%[^,]+]] = copy_value [[LIFETIME_C]]
 // CHECK:         [[LIFETIME_D:%[^,]+]] = begin_borrow [[INSTANCE_D]]
-// CHECK:         [[REGISTER_4:%[^,]+]] = struct $CDCase ([[LIFETIME_C]] : $C, [[LIFETIME_D]] : $D)
+// CHECK:         struct $CDCase ([[LIFETIME_C]] : $C, [[LIFETIME_D]] : $D)
 // CHECK:         end_borrow [[LIFETIME_C]]
 // CHECK:         end_borrow [[LIFETIME_D]]
 // CHECK:         destroy_value [[INSTANCE_D]]
@@ -744,7 +821,7 @@ bad(%15 : @owned $Error):
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         try_apply undef() : {{.*}}, normal [[GOOD:bb[0-9]+]], error [[BAD:bb[0-9]+]]
-// CHECK:       [[GOOD]]([[REGISTER_3:%[^,]+]] : $()):
+// CHECK:       [[GOOD]]({{%[^,]+}} : $()):
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         destroy_value [[INSTANCE]]
 // CHECK:       [[BAD]]([[ERROR:%[^,]+]] : @owned $Error):
@@ -777,11 +854,11 @@ bad(%15 : @owned $Error):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:
-// CHECK:         [[REGISTER_3:%[^,]+]] = apply undef()
+// CHECK:         apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
-// CHECK:         [[REGISTER_6:%[^,]+]] = apply undef()
+// CHECK:         apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
@@ -828,6 +905,53 @@ entry(%instance : @owned $C, %input : $S):
     return %retval : $()
 }
 
+// Don't hoist out of a block when one of its predecessors has a terminator that
+// is a use of the end_borrow.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_user_br__other_br_multiple_preds : {{.*}} {
+// CHECK: {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:   cond_br undef, {{bb[0-9]+}}, [[RIGHT:bb[0-9]+]]
+// CHECK: [[RIGHT]]:
+// CHECK:   [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:   br [[EXIT:bb[0-9]+]]([[COPY]] :
+// CHECK: [[EXIT]]({{%[^,]+}} :
+// CHECK:   end_borrow [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_user_br__other_br_multiple_preds'
+sil [ossa] @dont_hoist_over_user_br__other_br_multiple_preds : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    %lifetime = begin_borrow [lexical] %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, left1, right
+
+left1:
+    cond_br undef, left2, left3
+
+left2:
+    br left4
+
+left3:
+    br left4
+
+left4:
+    %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
+    %owned_c = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
+    br exit(%owned_c : $C)
+
+right:
+    %barrier = function_ref @barrier : $@convention(thin) () -> ()
+    apply %barrier() : $@convention(thin) () -> ()
+    %copy = copy_value %lifetime : $C
+    br exit(%copy : $C)
+
+exit(%value : @owned $C):
+    destroy_value %value : $C
+    end_borrow %lifetime : $C
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
 
 // =============================================================================
 // instruction tests                                                          }}


### PR DESCRIPTION
Replaced ShrinkBorrowScope's own data flow with the general BackwardReachability.

Took this opportunity to refactor and document the utility.

Taken together these changes make ShrinkBorrowScope serve as a template for a future LexicalDestroyHoisting which will operate on owned lexical values (rather than guaranteed as here) and hoist destroy_values (rather than end_borrows as here) but should otherwise be quite similar.
