### PR TITLE
Platform: add submodule to WinSDK for ProcessAPI

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -398,6 +398,13 @@ module WinSDK [system] {
     link "WinSpool.Lib"
   }
 
+  module PSAPI {
+    header "Psapi.h"
+    export *
+
+    link "psapi.lib"
+  }
+
   module RichEdit {
     header "Richedit.h"
     export *


### PR DESCRIPTION
This adds the PSAPI submodule to WinSDK for use in swift-inspect.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
