### PR TITLE
Priority inversion avoidance in Actor Runtime

### DIFF
--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -96,7 +96,7 @@ struct StackAllocator {
 template <typename Runtime>
 struct ActiveTaskStatusWithEscalation {
   uint32_t Flags;
-  uint32_t DrainLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
+  uint32_t ExecutionLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
   typename Runtime::StoredPointer Record;
 };
 
@@ -150,10 +150,22 @@ struct FutureAsyncContextPrefix {
 };
 
 template <typename Runtime>
+struct ActiveActorStatusWithEscalation {
+  uint32_t Flags;
+  uint32_t DrainLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
+  typename Runtime::StoredPointer FirstJob;
+};
+
+template <typename Runtime>
+struct ActiveActorStatusWithoutEscalation {
+  uint32_t Flags[sizeof(typename Runtime::StoredPointer) == 8 ? 2 : 1];
+  typename Runtime::StoredPointer FirstJob;
+};
+
+template <typename Runtime, typename ActiveActorStatus>
 struct DefaultActorImpl {
   HeapObject<Runtime> HeapObject;
-  typename Runtime::StoredPointer FirstJob;
-  typename Runtime::StoredSize Flags;
+  ActiveActorStatus Status;
 };
 
 template <typename Runtime>

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -16,6 +16,7 @@
 ///===----------------------------------------------------------------------===///
 
 #include "swift/Runtime/Concurrency.h"
+#include <atomic>
 
 #ifdef _WIN32
 // On Windows, an include below triggers an indirect include of minwindef.h
@@ -33,6 +34,7 @@
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/ThreadLocal.h"
 #include "swift/Runtime/ThreadLocalStorage.h"
+#include "swift/Runtime/DispatchShims.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Actor.h"
 #include "swift/Basic/ListMerger.h"
@@ -88,7 +90,7 @@ using namespace swift;
 
 /// Should we yield the thread?
 static bool shouldYieldThread() {
-  // FIXME: system scheduler integration
+  // return dispatch_swift_job_should_yield();
   return false;
 }
 
@@ -453,22 +455,17 @@ struct RunningJobInfo {
     Inline, Other
   };
   KindType Kind;
-  JobPriority Priority;
 
   bool wasInlineJob() const {
     return Kind == Inline;
   }
 
-  static RunningJobInfo forOther(JobPriority priority) {
-    return {Other, priority};
+  static RunningJobInfo forOther() {
+    return {Other};
   }
-  static RunningJobInfo forInline(JobPriority priority) {
-    return {Inline, priority};
+  static RunningJobInfo forInline() {
+    return {Inline};
   }
-
-  void setAbandoned();
-  void setRunning();
-  bool waitForActivation();
 };
 
 class JobRef {
@@ -531,6 +528,119 @@ public:
   }
 };
 
+/// This is designed to fit into two words, which can generally be
+/// done lock-free on all our supported platforms.
+class alignas(sizeof(void *) * 2) ActiveActorStatus {
+  enum : uint32_t {
+    // Bits 0-2: Actor state
+    //
+    // Possible state transitions for an actor:
+    //
+    // Idle -> Running
+    // Running -> Idle
+    // Running -> Scheduled
+    // Scheduled -> Running
+    // Idle -> Deallocated
+    // Running -> Zombie_ReadyForDeallocation
+    //
+    // It is possible for an actor to be in Running and yet completely released
+    // by clients. However, the actor needs to be kept alive until it is done
+    // executing the task that is running on it and gives it up. It is only
+    // after that that we can safely deallocate it.
+    ActorStateMask = 0x7,
+
+    /// The actor is not currently scheduled.  Completely redundant
+    /// with the job list being empty.
+    Idle = 0x0,
+    /// There actor is scheduled
+    Scheduled = 0x1,
+    /// There is currently a thread running the actor.
+    Running = 0x2,
+    /// The actor is ready for deallocation once it stops running
+    Zombie_ReadyForDeallocation = 0x3,
+
+    // Bit 3
+    DistributedRemote = 0x8,
+
+    // Bits 8 - 15. We only need 8 bits of the whole size_t to represent Job
+    // Priority
+    PriorityMask = 0xFF00,
+    PriorityShift = 0x8,
+  };
+  uint32_t Flags;
+  JobRef FirstJob;
+
+  ActiveActorStatus(uint32_t flags, JobRef job)
+    : Flags(flags), FirstJob(job) {}
+
+public:
+  constexpr ActiveActorStatus()
+      : Flags(), FirstJob(JobRef()) {}
+
+  bool isDistributedRemote() const { return Flags & DistributedRemote; }
+  ActiveActorStatus withDistributedRemote() const {
+    return ActiveActorStatus(Flags | DistributedRemote, FirstJob);
+  }
+
+  bool isIdle() const {
+    bool isIdle = ((Flags & ActorStateMask) == Idle);
+    if (isIdle) {
+      assert(FirstJob == NULL);
+    }
+    return isIdle;
+  }
+  ActiveActorStatus withIdle() const {
+    return ActiveActorStatus((Flags & ~ActorStateMask) | Idle, FirstJob);
+  }
+
+  bool isAnyRunning() const {
+    uint32_t state = Flags & ActorStateMask;
+    return (state == Running) || (state == Zombie_ReadyForDeallocation);
+  }
+  bool isRunning() const {
+    return (Flags & ActorStateMask) == Running;
+  }
+  ActiveActorStatus withRunning() const {
+    uint32_t flags = (Flags & ~ActorStateMask) | Running;
+    return ActiveActorStatus(flags, FirstJob);
+  }
+
+  bool isScheduled() const {
+    return (Flags & ActorStateMask) == Scheduled;
+  }
+  ActiveActorStatus withScheduled() const {
+    return ActiveActorStatus((Flags & ~ActorStateMask) | Scheduled, FirstJob);
+  }
+
+  bool isZombie_ReadyForDeallocation() const {
+    return (Flags & ActorStateMask) == Zombie_ReadyForDeallocation;
+  }
+  ActiveActorStatus withZombie_ReadyForDeallocation() const {
+    return ActiveActorStatus((Flags & ~ActorStateMask) | Zombie_ReadyForDeallocation, FirstJob);
+  }
+
+  JobPriority getMaxPriority() const {
+    return (JobPriority) ((Flags & PriorityMask) >> PriorityShift);
+  }
+  ActiveActorStatus withMaxPriority(JobPriority priority) const {
+    return ActiveActorStatus((Flags & ~PriorityMask) | (uint32_t(priority) << PriorityShift) , FirstJob);
+  }
+
+  JobRef getFirstJob() const {
+    return FirstJob;
+  }
+  ActiveActorStatus withFirstJob(JobRef firstJob) const {
+    return ActiveActorStatus(Flags, firstJob);
+  }
+
+  uint32_t getOpaqueFlags() const {
+    return Flags;
+  }
+};
+
+static_assert(sizeof(ActiveActorStatus) == 2 * sizeof(uintptr_t),
+  "ActiveTaskStatus is 2 words large");
+
 /// The default actor implementation.
 ///
 /// Ownership of the actor is subtle.  Jobs are assumed to keep the actor
@@ -543,7 +653,9 @@ public:
 ///
 /// - Let R be 1 if there are jobs enqueued on the actor or if a job
 ///   is currently running on the actor; otherwise let R be 0.
-/// - Let N be the number of active processing jobs for the actor.
+/// - Let N be the number of active processing jobs for the actor. N may be > 1
+///   because we may have stealers for actors if we have to escalate the max
+///   priority of the actor
 /// - N >= R
 /// - There are N - R extra retains of the actor.
 ///
@@ -554,118 +666,32 @@ public:
 ///
 /// We then have the following ownership rules:
 ///
-/// - When we enqueue the first job on an actor, then R becomes 1, and
-///   we must create a processing job so that N >= R.  We do not need to
-///   retain the actor.
-/// - When we create an extra job to process an actor (e.g. because of
-///   priority overrides), N increases but R remains the same.  We must
-///   retain the actor.
-/// - When we start running an actor, our job definitively becomes the
-///   owning job, but neither N nor R changes.  We do not need to retain
-///   the actor.
-/// - When we go to start running an actor and for whatever reason we
-///   don't actually do so, we are eliminating an extra processing job,
-///   and so N decreases but R remains the same.  We must release the
-///   actor.
-/// - When we are running an actor and give it up, and there are no
-///   remaining jobs on it, then R becomes 0 and N decreases by 1.
-///   We do not need to release the actor.
-/// - When we are running an actor and give it up, and there are jobs
-///   remaining on it, then R remains 1 but N is decreasing by 1.
-///   We must either release the actor or create a new processing job
-///   for it to maintain the balance.
+/// (1) When we enqueue the first job on an actor, then R becomes 1, and
+///     we must create a processing job so that N >= R.  We do not need to
+///     retain the actor.
+/// (2) When we create an extra job to process an actor (e.g. because of
+///     priority overrides), N increases but R remains the same.  We must
+///     retain the actor - ie stealer for actor has a reference on the actor
+/// (3) When we start running an actor, our job definitively becomes the
+///     owning job, but neither N nor R changes.  We do not need to retain
+///     the actor.
+/// (4) When we go to start running an actor and for whatever reason we
+///     don't actually do so, we are eliminating an extra processing job,
+///     and so N decreases but R remains the same.  We must release the
+///     actor.
+/// (5) When we are running an actor and give it up, and there are no
+///     remaining jobs on it, then R becomes 0 and N decreases by 1.
+///     We do not need to release the actor.
+/// (6) When we are running an actor and give it up, and there are jobs
+///     remaining on it, then R remains 1 but N is decreasing by 1.
+///     We must either release the actor or create a new processing job
+///     for it to maintain the balance.
+///
+/// The current behaviour of actors is such that we only use the inline
+/// processing job to schedule the actor and not OOL jobs. As a result, the
+/// subset of rules that currently apply are (1), (3), (5), (6).
 class DefaultActorImpl : public HeapObject {
-  enum class Status {
-    /// The actor is not currently scheduled.  Completely redundant
-    /// with the job list being empty.
-    Idle,
-
-    /// There is currently a job scheduled to process the actor at the
-    /// stored max priority.
-    Scheduled,
-
-    /// There is currently a thread processing the actor at the stored
-    /// max priority.
-    Running,
-
-    /// The actor is a zombie that's been fully released but is still
-    /// running.  We delay deallocation until its running thread gives
-    /// it up, which fortunately doesn't touch anything in the
-    /// actor except for the DefaultActorImpl.
-    ///
-    /// To coordinate between the releasing thread and the running
-    /// thread, we have a two-stage "latch".  This is because the
-    /// releasing thread does not atomically decide to not deallocate.
-    /// Fortunately almost all of the overhead here is only incurred
-    /// when we actually do end up in the zombie state.
-    Zombie_Latching,
-    Zombie_ReadyForDeallocation
-  };
-
-  struct Flags : public FlagSet<size_t> {
-    enum : size_t {
-      Status_offset = 0,
-      Status_width = 3,
-
-      HasActiveInlineJob = 3,
-
-      IsDistributedRemote = 4,
-
-      MaxPriority = 8,
-      MaxPriority_width = JobFlags::Priority_width,
-
-      // FIXME: add a reference to the running thread ID so that we
-      // can boost priorities.
-    };
-
-    /// What is the current high-level status of this actor?
-    FLAGSET_DEFINE_FIELD_ACCESSORS(Status_offset, Status_width, Status,
-                                   getStatus, setStatus)
-
-    bool isAnyRunningStatus() const {
-      auto status = getStatus();
-      return status == Status::Running ||
-             status == Status::Zombie_Latching ||
-             status == Status::Zombie_ReadyForDeallocation;
-    }
-
-    bool isAnyZombieStatus() const {
-      auto status = getStatus();
-      return status == Status::Zombie_Latching ||
-             status == Status::Zombie_ReadyForDeallocation;
-    }
-
-    /// Is there currently an active processing job allocated inline
-    /// in the actor?
-    FLAGSET_DEFINE_FLAG_ACCESSORS(HasActiveInlineJob,
-                                  hasActiveInlineJob, setHasActiveInlineJob)
-
-    /// Is the actor a distributed 'remote' actor?
-    /// I.e. it does not have storage for user-defined properties and all
-    /// function call must be transformed into $distributed_ function calls.
-    FLAGSET_DEFINE_FLAG_ACCESSORS(IsDistributedRemote,
-                                  isDistributedRemote, setIsDistributedRemote)
-
-    /// What is the maximum priority of jobs that are currently running
-    /// or enqueued on this actor?
-    ///
-    /// Note that the above isn't quite correct: we don't actually
-    /// lower this after we finish processing higher-priority tasks.
-    /// (Doing so introduces some subtleties around kicking off
-    /// lower-priority processing jobs.)
-    FLAGSET_DEFINE_FIELD_ACCESSORS(MaxPriority, MaxPriority_width,
-                                   JobPriority,
-                                   getMaxPriority, setMaxPriority)
-  };
-
-  /// This is designed to fit into two words, which can generally be
-  /// done lock-free on all our supported platforms.
-  struct alignas(2 * sizeof(void*)) State {
-    JobRef FirstJob;
-    struct Flags Flags;
-  };
-
-  swift::atomic<State> CurrentState;
+  swift::atomic<ActiveActorStatus> CurrentState;
 
   friend class ProcessInlineJob;
   union {
@@ -681,9 +707,13 @@ class DefaultActorImpl : public HeapObject {
 public:
   /// Properly construct an actor, except for the heap header.
   void initialize(bool isDistributedRemote = false) {
-    auto flags = Flags();
-    flags.setIsDistributedRemote(isDistributedRemote);
-    new (&CurrentState) swift::atomic<State>(State{JobRef(), flags});
+    ActiveActorStatus status = ActiveActorStatus();
+    if (isDistributedRemote) {
+      status = status.withDistributedRemote();
+    }
+    new (&CurrentState) swift::atomic<ActiveActorStatus>(status);
+
+    SWIFT_TASK_DEBUG_LOG("Creating default actor %p", this);
     JobStorageHeapObject.metadata = nullptr;
     concurrency::trace::actor_create(this);
   }
@@ -696,17 +726,18 @@ public:
   /// we reach this point.
   void deallocate();
 
-  /// Add a job to this actor.
-  void enqueue(Job *job);
+  /// Try to lock the actor, if it is already running or scheduled, fail
+  bool tryLock(bool asDrainer);
 
-  /// Take over running this actor in the current thread, if possible.
-  bool tryAssumeThread(RunningJobInfo runner);
+  /// Enqueue a job onto the actor. This typically means that the actor hit
+  /// contention during the tryLock and so we're taking the slow path
+  void enqueue(Job *job, JobPriority priority);
 
-  /// Give up running this actor in the current thread.
-  void giveUpThread(RunningJobInfo runner);
+  /// Unlock an actor
+  bool unlock(bool forceUnlock);
 
-  /// Claim the next job off the actor or give it up.
-  Job *claimNextJobOrGiveUp(bool actorIsOwned, RunningJobInfo runner);
+  // The calling thread must be holding the actor lock while calling this
+  Job *drainOne();
 
   /// Check if the actor is actually a distributed *remote* actor.
   ///
@@ -721,7 +752,7 @@ private:
   /// done if we know nobody else is trying to do it at the same time,
   /// e.g. if this thread just sucessfully transitioned the actor from
   /// Idle to Scheduled.
-  void scheduleNonOverrideProcessJob(JobPriority priority,
+  void scheduleActorProcessJob(JobPriority priority,
                                      bool hasActiveInlineJob);
 
   static DefaultActorImpl *fromInlineJob(Job *job) {
@@ -749,107 +780,16 @@ static DefaultActor *asAbstract(DefaultActorImpl *actor) {
 }
 
 /*****************************************************************************/
-/*********************** DEFAULT ACTOR IMPLEMENTATION ************************/
+/******************** NEW DEFAULT ACTOR IMPLEMENTATION ***********************/
 /*****************************************************************************/
-
-void DefaultActorImpl::destroy() {
-  auto oldState = CurrentState.load(std::memory_order_relaxed);
-  while (true) {
-    assert(!oldState.FirstJob && "actor has queued jobs at destruction");
-    if (oldState.Flags.getStatus() == Status::Idle) return;
-
-    assert(oldState.Flags.getStatus() == Status::Running &&
-           "actor scheduled but not running at destruction");
-
-    // If the actor is currently running, set it to zombie status
-    // so that we know to deallocate it when it's given up.
-    auto newState = oldState;
-    newState.Flags.setStatus(Status::Zombie_Latching);
-    if (CurrentState.compare_exchange_weak(oldState, newState,
-                                           std::memory_order_relaxed,
-                                           std::memory_order_relaxed)) {
-      concurrency::trace::actor_destroy(this);
-      return;
-    }
-  }
-}
-
-void DefaultActorImpl::deallocate() {
-  // If we're in a zombie state waiting to latch, put the actor in the
-  // ready-for-deallocation state, but don't actually deallocate yet.
-  // Note that we should never see the actor already in the
-  // ready-for-deallocation state; giving up the actor while in the
-  // latching state will always put it in Idle state.
-  auto oldState = CurrentState.load(std::memory_order_relaxed);
-  while (oldState.Flags.getStatus() == Status::Zombie_Latching) {
-    auto newState = oldState;
-    newState.Flags.setStatus(Status::Zombie_ReadyForDeallocation);
-    if (CurrentState.compare_exchange_weak(oldState, newState,
-                                           std::memory_order_relaxed,
-                                           std::memory_order_relaxed))
-      return;
-  }
-
-  assert(oldState.Flags.getStatus() == Status::Idle);
-
-  deallocateUnconditional();
-}
-
-void DefaultActorImpl::deallocateUnconditional() {
-  concurrency::trace::actor_deallocate(this);
-
-  if (JobStorageHeapObject.metadata != nullptr)
-    JobStorage.~ProcessInlineJob();
-  auto metadata = cast<ClassMetadata>(this->metadata);
-  swift_deallocObject(this, metadata->getInstanceSize(),
-                      metadata->getInstanceAlignMask());
-}
 
 /// Given that a job is enqueued normally on a default actor, get/set
 /// the next job in the actor's queue.
-///
-/// Note that this must not be used on the message jobs that can appear
-/// in the queue; those jobs are not actually in the actor's queue (they're
-/// on the global execution queues).  So the actor's actual queue flows
-/// through the NextJob field on those objects rather than through
-/// the SchedulerPrivate fields.
 static JobRef getNextJobInQueue(Job *job) {
   return *reinterpret_cast<JobRef*>(job->SchedulerPrivate);
 }
 static void setNextJobInQueue(Job *job, JobRef next) {
   *reinterpret_cast<JobRef*>(job->SchedulerPrivate) = next;
-}
-
-/// Schedule a processing job that doesn't have to be an override job.
-///
-/// We can either do this with inline storage or heap-allocated.
-/// To ues inline storage, we need to verify that the hasActiveInlineJob
-/// flag is not set in the state and then successfully set it.  The
-/// argument reports that this has happened correctly.
-///
-/// We should only schedule a non-override processing job at all if
-/// we're transferring ownership of the jobs in it; see the ownership
-/// comment on DefaultActorImpl.
-void DefaultActorImpl::scheduleNonOverrideProcessJob(JobPriority priority,
-                                                     bool hasActiveInlineJob) {
-  Job *job;
-  if (hasActiveInlineJob) {
-    job = new ProcessOutOfLineJob(this, priority);
-  } else {
-    if (JobStorageHeapObject.metadata != nullptr)
-      JobStorage.~ProcessInlineJob();
-    job = new (&JobStorage) ProcessInlineJob(priority);
-  }
-  swift_task_enqueueGlobal(job);
-}
-
-/// Flag that the current processing job has been abandoned
-/// and will not be running the actor.
-void RunningJobInfo::setAbandoned() {
-}
-
-/// Flag that the current processing job is now running the actor.
-void RunningJobInfo::setRunning() {
 }
 
 namespace {
@@ -868,65 +808,102 @@ struct JobQueueTraits {
 
 } // end anonymous namespace
 
-/// Preprocess the prefix of the actor's queue that hasn't already
-/// been preprocessed:
-///
-/// - Split the jobs into messages and actual jobs.
-/// - Append the actual jobs to any already-preprocessed job list.
-///
-/// The returned job should become the new root of the job queue
-/// (or may be immediately dequeued, in which its successor should).
-static Job *preprocessQueue(JobRef first,
-                            JobRef previousFirst,
-                            Job *previousFirstNewJob) {
-  assert(previousFirst || previousFirstNewJob == nullptr);
 
-  if (!first.needsPreprocessing())
-    return first.getAsPreprocessedJob();
+// Called with the actor drain lock held
+//
+// This function is called when we hit a conflict between preprocessQueue and
+// a concurrent enqueuer resulting in unprocessed jobs being queued up in the
+// middle.
+//
+// We need to find the unprocessed jobs enqueued by the enqueuer and process
+// them - We know that these unprocessed jobs must exist between the new head
+// and the previous start. We can then process these jobs and merge them into
+// the already processed list of jobs from the previous iteration of
+// preprocessQueue
+static Job *
+preprocessQueue(JobRef unprocessedStart, JobRef unprocessedEnd, Job *existingProcessedJobsToMergeInto)
+{
+  assert(existingProcessedJobsToMergeInto != NULL);
 
+  // Build up a list of jobs we need to preprocess
   using ListMerger = swift::ListMerger<Job*, JobQueueTraits>;
-  ListMerger newJobs;
+  ListMerger jobsToProcess;
 
-  while (first != previousFirst) {
-    // If we find something that doesn't need preprocessing, it must've
-    // been left by a previous queue-processing, which means that
-    // this must be our first attempt to preprocess in this processing.
-    // Just treat the queue from this point as a well-formed whole
-    // to which we need to add any new items we might've just found.
-    if (!first.needsPreprocessing()) {
-      assert(!previousFirst && !previousFirstNewJob);
-      previousFirstNewJob = first.getAsPreprocessedJob();
+  // Get just the prefix list of unprocessed jobs
+  auto current = unprocessedStart;
+  while (current != unprocessedEnd) {
+    assert(current.needsPreprocessing());
+    // Advance current to next pointer and process current unprocessed job
+    auto job = current.getAsJob();
+    current = getNextJobInQueue(job);
+
+    jobsToProcess.insertAtFront(job);
+  }
+
+  // Finish processing the unprocessed jobs
+  Job *newProcessedJobs = jobsToProcess.release();
+  assert(newProcessedJobs);
+
+  ListMerger mergedList(existingProcessedJobsToMergeInto);
+  mergedList.merge(newProcessedJobs);
+  return mergedList.release();
+}
+
+// Called with the actor drain lock held.
+//
+// Preprocess the queue starting from the top
+static Job *
+preprocessQueue(JobRef start) {
+  if (start == NULL) {
+    return NULL;
+  }
+
+  // Entire queue is well formed, no pre-processing needed
+  if (!start.needsPreprocessing()) {
+    return start.getAsPreprocessedJob();
+  }
+
+  // There exist some jobs which haven't been preprocessed
+
+  // Build up a list of jobs we need to preprocess
+  using ListMerger = swift::ListMerger<Job*, JobQueueTraits>;
+  ListMerger jobsToProcess;
+
+  Job *wellFormedListStart = NULL;
+
+  auto current = start;
+  while (current != NULL) {
+    if (!current.needsPreprocessing()) {
+      // We can assume that everything from here onwards as being well formed
+      // and sorted
+      wellFormedListStart = current.getAsPreprocessedJob();
       break;
     }
 
-    // If the job is a message, add it to the list of messages we need
-    // to process.
-    if (first.isMessage()) {
-      swift_unreachable("no messages currently supported");
-    }
+    // Advance current to next pointer and insert current fella to jobsToProcess
+    // list
+    auto job = current.getAsJob();
+    current = getNextJobInQueue(job);
 
-    // If the job isn't a message, add it to the front of the list of
-    // jobs we're building up.  Note that this reverses the order of
-    // jobs; since enqueue() always adds jobs to the front, reversing
-    // the order effectively makes the actor queue FIFO, which is what
-    // we want.
-    auto job = first.getAsJob();
-    first = getNextJobInQueue(job);
-    newJobs.insertAtFront(job);
+    jobsToProcess.insertAtFront(job);
   }
 
-  // If there are jobs already in the queue, put the new jobs at the end.
-  auto firstNewJob = newJobs.release();
-  if (!firstNewJob) {
-    firstNewJob = previousFirstNewJob;
-  } else if (previousFirstNewJob) {
-    // Merge the jobs we just processed into the existing job list.
-    ListMerger merge(previousFirstNewJob);
-    merge.merge(firstNewJob);
-    firstNewJob = merge.release();
+  // Finish processing the unprocessed jobs
+  auto processedJobHead = jobsToProcess.release();
+  assert(processedJobHead);
+
+  Job *firstJob = NULL;
+  if (wellFormedListStart) {
+    // Merge it with already known well formed list if we have one.
+    ListMerger mergedList(wellFormedListStart);
+    mergedList.merge(processedJobHead);
+    firstJob = mergedList.release();
+  } else {
+    // Nothing to merge with, just return the head we already have
+    firstJob = processedJobHead;
   }
 
-  return firstNewJob;
+  return firstJob;
 }
 
 static void traceJobQueue(DefaultActorImpl *actor, Job *first) {
@@ -935,258 +912,348 @@ static void traceJobQueue(DefaultActorImpl *actor, Job *first) {
   });
 }
 
-void DefaultActorImpl::giveUpThread(RunningJobInfo runner) {
-  SWIFT_TASK_DEBUG_LOG("giving up thread for actor %p", this);
-  auto oldState = CurrentState.load(std::memory_order_acquire);
-  assert(oldState.Flags.isAnyRunningStatus());
+static SWIFT_ATTRIBUTE_ALWAYS_INLINE void traceActorStateTransition(DefaultActorImpl *actor,
+    ActiveActorStatus oldState, ActiveActorStatus newState) {
 
-  auto firstNewJob = preprocessQueue(oldState.FirstJob, JobRef(), nullptr);
-  traceJobQueue(this, firstNewJob);
+  SWIFT_TASK_DEBUG_LOG("Actor %p transitioned from %zx to %zx (%s)\n", actor,
+    oldState.getOpaqueFlags(), newState.getOpaqueFlags(), __FUNCTION__);
+  concurrency::trace::actor_state_changed(actor,
+        newState.getFirstJob().getRawJob(), newState.getFirstJob().needsPreprocessing(),
+        newState.getOpaqueFlags());
+}
 
-  _swift_tsan_release(this);
-  while (true) {
-    // In Zombie_ReadyForDeallocation state, nothing else should
-    // be touching the atomic, and there's no point updating it.
-    if (oldState.Flags.getStatus() == Status::Zombie_ReadyForDeallocation) {
-      deallocateUnconditional();
+void DefaultActorImpl::destroy() {
+  auto oldState = CurrentState.load(std::memory_order_relaxed);
+  // Tasks on an actor are supposed to keep the actor alive until they start
+  // running and we can only get here if ref count of the object = 0 which means
+  // there should be no more tasks enqueued on the actor.
+  assert(!oldState.getFirstJob() && "actor has queued jobs at destruction");
+
+  if (oldState.isIdle()) {
       return;
-    }
+  }
+  assert(oldState.isRunning() && "actor scheduled but not running at destruction");
+}
 
-    // In Zombie_Latching state, we should try to update to Idle;
-    // if we beat the releasing thread, it'll deallocate.
-    // In Running state, we may need to schedule a processing job.
+void DefaultActorImpl::deallocate() {
+  // If we're running, mark ourselves as ready for deallocation but don't
+  // deallocate yet. When we stop running the actor - at unlock() time - we'll
+  // do the actual deallocation.
+  //
+  // If we're idle, just deallocate immediately
+  auto oldState = CurrentState.load(std::memory_order_relaxed);
+  while (oldState.isRunning()) {
+    auto newState = oldState.withZombie_ReadyForDeallocation();
+    if (CurrentState.compare_exchange_weak(oldState, newState,
+                                           std::memory_order_relaxed,
+                                           std::memory_order_relaxed))
+      return;
+  }
 
-    State newState = oldState;
-    newState.FirstJob = JobRef::getPreprocessed(firstNewJob);
-    if (firstNewJob) {
-      assert(oldState.Flags.getStatus() == Status::Running);
-      newState.Flags.setStatus(Status::Scheduled);
+  assert(oldState.isIdle());
+  deallocateUnconditional();
+}
+
+void DefaultActorImpl::deallocateUnconditional() {
+  concurrency::trace::actor_deallocate(this);
+
+  if (JobStorageHeapObject.metadata != nullptr)
+    JobStorage.~ProcessInlineJob();
+  auto metadata = cast<ClassMetadata>(this->metadata);
+  swift_deallocObject(this, metadata->getInstanceSize(),
+                      metadata->getInstanceAlignMask());
+}
+
+void DefaultActorImpl::scheduleActorProcessJob(JobPriority priority, bool useInlineJob) {
+  Job *job;
+  if (useInlineJob) {
+    if (JobStorageHeapObject.metadata != nullptr)
+      JobStorage.~ProcessInlineJob();
+    job = new (&JobStorage) ProcessInlineJob(priority);
+  } else {
+    assert(false && "Should not be here - we don't have support for any OOL actor process jobs yet");
+    // TODO (rokhinip): Don't we need to take a +1 per ref count rules specified?
+    swift_retain(this);
+    job = new ProcessOutOfLineJob(this, priority);
+  }
+  SWIFT_TASK_DEBUG_LOG("Scheduling processing job %p for actor %p at priority %#x", job, this, priority);
+  swift_task_enqueueGlobal(job);
+}
+
+
+bool DefaultActorImpl::tryLock(bool asDrainer) {
+  SWIFT_TASK_DEBUG_LOG("Attempting to jump onto %p, as drainer = %d", this, asDrainer);
+  auto oldState = CurrentState.load(std::memory_order_relaxed);
+
+  while (true) {
+    if (asDrainer) {
+      // TODO (rokhinip): Once we have OOL process job support, this assert can
+      // potentially fail due to a race with an actor stealer that might have
+      // won the race and started running the actor
+      assert(oldState.isScheduled());
     } else {
-      newState.Flags.setStatus(Status::Idle);
+      // We're trying to take the lock in an uncontended manner
+      if (oldState.isRunning() || oldState.isScheduled()) {
+        SWIFT_TASK_DEBUG_LOG("Failed to jump to %p in fast path", this);
+        return false;
+      }
+
+      assert(oldState.getMaxPriority() == JobPriority::Unspecified);
+      assert(oldState.getFirstJob() == NULL);
     }
 
-    // If the runner was an inline job, it's no longer active.
-    if (runner.wasInlineJob()) {
-      newState.Flags.setHasActiveInlineJob(false);
+    auto newState = oldState.withRunning();
+    if (CurrentState.compare_exchange_weak(oldState, newState,
+                                 std::memory_order_relaxed,
+                                 std::memory_order_relaxed)) {
+      _swift_tsan_acquire(this);
+      traceActorStateTransition(this, oldState, newState);
+      return true;
     }
-
-    bool hasMoreJobs = (bool) newState.FirstJob;
-    bool hasActiveInlineJob = newState.Flags.hasActiveInlineJob();
-    bool needsNewProcessJob = hasMoreJobs;
-
-    // If we want to create a new inline job below, be sure to claim that
-    // in the new state.
-    if (needsNewProcessJob && !hasActiveInlineJob) {
-      newState.Flags.setHasActiveInlineJob(true);
-    }
-
-    auto firstPreprocessed = oldState.FirstJob;
-    if (!CurrentState.compare_exchange_weak(oldState, newState,
-                    /*success*/ std::memory_order_release,
-                    /*failure*/ std::memory_order_acquire)) {
-      // Preprocess any new queue items.
-      firstNewJob = preprocessQueue(oldState.FirstJob,
-                                    firstPreprocessed,
-                                    firstNewJob);
-      traceJobQueue(this, firstNewJob);
-
-      // Try again.
-      continue;
-    }
-
-#define ACTOR_STATE_TRANSITION                                                 \
-  do {                                                                         \
-    SWIFT_TASK_DEBUG_LOG("actor %p transitioned from %zx to %zx (%s)\n", this, \
-                         oldState.Flags.getOpaqueValue(),                      \
-                         newState.Flags.getOpaqueValue(), __FUNCTION__);       \
-    concurrency::trace::actor_state_changed(                                   \
-        this, newState.FirstJob.getRawJob(),                                   \
-        newState.FirstJob.needsPreprocessing(),                                \
-        newState.Flags.getOpaqueValue());                                      \
-  } while (0)
-    ACTOR_STATE_TRANSITION;
-
-    // The priority of the remaining work.
-    auto newPriority = newState.Flags.getMaxPriority();
-
-    // This is the actor's owning job; per the ownership rules (see
-    // the comment on DefaultActorImpl), if there are remaining
-    // jobs, we need to balance out our ownership one way or another.
-    // We also, of course, need to ensure that there's a thread that's
-    // actually going to process the actor.
-    if (hasMoreJobs) {
-      // Enqueue a job that will try to take over running with the
-      // new priority.  This also ensures that there's a job at that
-      // priority which will actually take over the actor.
-      scheduleNonOverrideProcessJob(newPriority, hasActiveInlineJob);
-    }
-
-    return;
   }
 }
 
-/// Claim the next job on the actor or give it up forever.
-///
-/// The running thread doesn't need to already own the actor to do this.
-/// It does need to be participating correctly in the ownership
-/// scheme as a "processing job"; see the comment on DefaultActorImpl.
-Job *DefaultActorImpl::claimNextJobOrGiveUp(bool actorIsOwned,
-                                            RunningJobInfo runner) {
-  auto oldState = CurrentState.load(std::memory_order_acquire);
+void DefaultActorImpl::enqueue(Job *job, JobPriority priority) {
+  // We can do relaxed loads here, we are just using the current head in the
+  // atomic state and linking that into the new job we are inserting, we don't
+  // need acquires
+  SWIFT_TASK_DEBUG_LOG("Enqueueing job %p onto actor %p at priority %#x", job, this, priority);
+  auto oldState = CurrentState.load(std::memory_order_relaxed);
+  while (true) {
+    auto newState = oldState;
 
-  // The status had better be Running unless we're trying to acquire
-  // our first job.
-  assert(oldState.Flags.isAnyRunningStatus() || !actorIsOwned);
+    // Link this into the queue in the atomic state
+    JobRef currentHead = oldState.getFirstJob();
+    setNextJobInQueue(job, currentHead);
+    JobRef newHead = JobRef::getUnpreprocessed(job);
 
-  // If we don't yet own the actor, we need to try to claim the actor
-  // first; we cannot safely access the queue memory yet because other
-  // threads may concurrently be trying to do this.
-  if (!actorIsOwned) {
-    // We really shouldn't ever be in a state where we're trying to take
-    // over a non-running actor if the actor is in a zombie state.
-    assert(!oldState.Flags.isAnyZombieStatus());
+    newState = newState.withFirstJob(newHead);
 
-    while (true) {
-      // A helper function when the only change we need to try is to
-      // update for an inline runner.
-      auto tryUpdateForInlineRunner = [&]{
-        if (!runner.wasInlineJob()) return true;
+    if (oldState.isIdle()) {
+      // Someone gave up the actor lock after we failed fast path.
+      // Schedule the actor
+      newState = newState.withScheduled();
+      newState = newState.withMaxPriority(priority);
 
-        auto newState = oldState;
-        newState.Flags.setHasActiveInlineJob(false);
-        auto success = CurrentState.compare_exchange_weak(oldState, newState,
-                            /*success*/ std::memory_order_relaxed,
-                            /*failure*/ std::memory_order_acquire);
-        if (success)
-          ACTOR_STATE_TRANSITION;
-        return success;
-      };
+    } else {
+      if (priority > oldState.getMaxPriority()) {
+        newState = newState.withMaxPriority(priority);
+      }
+    }
 
-      // If the actor is out of work, or its priority doesn't match our
-      // priority, don't try to take over the actor.
-      if (!oldState.FirstJob) {
+    if (CurrentState.compare_exchange_weak(oldState, newState,
+                   /* success */ std::memory_order_release,
+                   /* failure */ std::memory_order_relaxed)) {
+      traceActorStateTransition(this, oldState, newState);
 
-        // The only change we need here is inline-runner bookkeeping.
-        if (!tryUpdateForInlineRunner())
-          continue;
-
-        // We're eliminating a processing thread; balance ownership.
-        swift_release(this);
-        runner.setAbandoned();
-        return nullptr;
+      if (!oldState.isScheduled() && newState.isScheduled()) {
+        // We took responsibility to schedule the actor for the first time. See
+        // also ownership rule (1)
+        return scheduleActorProcessJob(newState.getMaxPriority(), true);
       }
 
-      // If the actor is currently running, we'd need to wait for
-      // it to stop; just exit.
-      if (oldState.Flags.getStatus() == Status::Running) {
-        // The only change we need here is inline-runner bookkeeping.
-        if (!tryUpdateForInlineRunner())
-          continue;
-
-        swift_release(this);
-        return nullptr;
+      if (oldState.getMaxPriority() != newState.getMaxPriority()) {
+        if (newState.isRunning()) {
+          // TODO (rokhinip): Override the thread running the actor
+          return;
+        } else {
+          // TODO (rokhinip): Schedule the stealer
+        }
       }
-
-      // Try to set the state as Running.
-      assert(oldState.Flags.getStatus() == Status::Scheduled);
-      auto newState = oldState;
-      newState.Flags.setStatus(Status::Running);
-
-      // Also do our inline-runner bookkeeping.
-      if (runner.wasInlineJob())
-        newState.Flags.setHasActiveInlineJob(false);
-
-      if (!CurrentState.compare_exchange_weak(oldState, newState,
-                              /*success*/ std::memory_order_relaxed,
-                              /*failure*/ std::memory_order_acquire))
-        continue;
-      ACTOR_STATE_TRANSITION;
-      _swift_tsan_acquire(this);
-
-      // If that succeeded, we can proceed to the main body.
-      oldState = newState;
-      runner.setRunning();
-      break;
+      return;
     }
   }
+}
 
-  assert(oldState.Flags.isAnyRunningStatus());
-
-  // We should have taken care of the inline-job bookkeeping now.
-  assert(!oldState.Flags.hasActiveInlineJob() || !runner.wasInlineJob());
-
-  // Okay, now it's safe to look at queue state.
-  // Preprocess any queue items at the front of the queue.
-  auto newFirstJob = preprocessQueue(oldState.FirstJob, JobRef(), nullptr);
-  traceJobQueue(this, newFirstJob);
+/* This can be called in 2 ways:
+ *    * force_unlock = true: Thread is following task and therefore wants to
+ *    give up the current actor since task is switching away.
+ *    * force_unlock = false: Thread is not necessarily following the task, it
+ *    may want to follow actor if there is more work on it.
+ *
+ *    Returns true if we managed to unlock the actor, false if we didn't. If the
+ *    actor has more jobs remaining on it during unlock, this method will
+ *    schedule the actor
+ */
+bool DefaultActorImpl::unlock(bool forceUnlock)
+{
+  auto oldState = CurrentState.load(std::memory_order_relaxed);
+  SWIFT_TASK_DEBUG_LOG("Try unlock-ing actor %p with forceUnlock = %d", this, forceUnlock);
 
   _swift_tsan_release(this);
   while (true) {
-    // In Zombie_ReadyForDeallocation state, nothing else should
-    // be touching the atomic, and there's no point updating it.
-    if (oldState.Flags.getStatus() == Status::Zombie_ReadyForDeallocation) {
+    assert(oldState.isAnyRunning());
+    // TODO (rokhinip): Further assert that the current thread is the one
+    // running the actor
+
+    if (oldState.isZombie_ReadyForDeallocation()) {
+      // TODO (rokhinip): This is where we need to reset any override the thread
+      // might have as a result of this actor
       deallocateUnconditional();
-      return nullptr;
+      SWIFT_TASK_DEBUG_LOG("Unlock-ing actor %p succeeded with full deallocation", this);
+      return true;
     }
 
-    State newState = oldState;
+    auto newState = oldState;
+    if (oldState.getFirstJob() != NULL) {
+      // There is work left to do
+      if (!forceUnlock) {
+        SWIFT_TASK_DEBUG_LOG("Unlock-ing actor %p failed", this);
+        return false;
+      }
 
-    // If the priority we're currently running with is adqeuate for
-    // all the remaining jobs, try to dequeue something.
-    // FIXME: should this be an exact match in priority instead of
-    // potentially running jobs with too high a priority?
-    Job *jobToRun;
-    if (newFirstJob) {
-      jobToRun = newFirstJob;
-      newState.FirstJob = getNextJobInQueue(newFirstJob);
-      newState.Flags.setStatus(Status::Running);
-
-    // Otherwise, we should give up the thread.
+      newState = newState.withScheduled();
     } else {
-      jobToRun = nullptr;
-      newState.FirstJob = JobRef::getPreprocessed(newFirstJob);
-      newState.Flags.setStatus(newFirstJob ? Status::Scheduled
-                                           : Status::Idle);
+      // There is no work left to do - actor goes idle
+      newState = newState.withIdle();
+      newState = newState.withMaxPriority(JobPriority::Unspecified);
     }
 
-    // Try to update the queue.  The changes we've made to the queue
-    // structure need to be made visible even if we aren't dequeuing
-    // anything.
-    auto firstPreprocessed = oldState.FirstJob;
-    if (!CurrentState.compare_exchange_weak(oldState, newState,
-                     /*success*/ std::memory_order_release,
-                     /*failure*/ std::memory_order_acquire)) {
-      // Preprocess any new queue items, which will have been formed
-      // into a linked list leading to the last head we observed.
-      // (The fact that that job may not be the head anymore doesn't
-      // matter; we're looking for an exact match with that.)
-      newFirstJob = preprocessQueue(oldState.FirstJob,
-                                    firstPreprocessed,
-                                    newFirstJob);
-      traceJobQueue(this, newFirstJob);
+    if (CurrentState.compare_exchange_weak(oldState, newState,
+                      /* success */ std::memory_order_relaxed,
+                      /* failure */ std::memory_order_relaxed)) {
+      traceActorStateTransition(this, oldState, newState);
 
-      // Loop to retry updating the state.
-      continue;
+      if (newState.isScheduled()) {
+        // See ownership rule (6) in DefaultActorImpl
+        assert(newState.getFirstJob() != NULL);
+        scheduleActorProcessJob(newState.getMaxPriority(), true);
+      } else {
+        // See ownership rule (5) in DefaultActorImpl
+        SWIFT_TASK_DEBUG_LOG("Actor %p is idle now", this);
+      }
+
+      // TODO (rokhinip): Reset any overrides the thread might have had as a
+      // result of the actor
+
+      return true;
     }
-    ACTOR_STATE_TRANSITION;
-
-    // We successfully updated the state.
-
-    // If we're giving up the thread with jobs remaining, we need
-    // to release the actor.
-    Optional<JobPriority> remainingJobPriority;
-    if (!jobToRun && newFirstJob) {
-      remainingJobPriority = newState.Flags.getMaxPriority();
-    }
-
-    // Per the ownership rules (see the comment on DefaultActorImpl),
-    // release the actor if we're giving up the thread with jobs
-    // remaining.
-    if (remainingJobPriority)
-      swift_release(this);
-
-    return jobToRun;
   }
+}
+
+// Called with actor lock held on current thread
+Job * DefaultActorImpl::drainOne() {
+  SWIFT_TASK_DEBUG_LOG("Draining one job from default actor %p", this);
+
+  auto oldState = CurrentState.load(std::memory_order_acquire);
+
+  auto jobToPreprocessFrom = oldState.getFirstJob();
+  Job *firstJob = preprocessQueue(jobToPreprocessFrom);
+  traceJobQueue(this, firstJob);
+
+  _swift_tsan_release(this);
+  while (true) {
+    assert(oldState.isAnyRunning());
+
+    if (!firstJob) {
+      // Nothing to drain, short circuit
+      SWIFT_TASK_DEBUG_LOG("No jobs to drain on actor %p", this);
+      return NULL;
+    }
+
+    auto newState = oldState;
+    // Dequeue the first job and set up a new head
+    newState = newState.withFirstJob(getNextJobInQueue(firstJob));
+    if (CurrentState.compare_exchange_weak(oldState, newState,
+                            /* sucess */ std::memory_order_release,
+                            /* failure */ std::memory_order_acquire)) {
+      SWIFT_TASK_DEBUG_LOG("Drained first job %p from actor %p", firstJob, this);
+      traceActorStateTransition(this, oldState, newState);
+      return firstJob;
+    }
+
+    // There were new items concurrently added to the queue. We need to
+    // preprocess the newly added unprocessed items and merge them to the already
+    // preprocessed list.
+    //
+    // The newly merged items that need to be preprocessed, are between the head
+    // of the linked list, and the last job we did the previous preprocessQueue
+    // on
+    firstJob = preprocessQueue(oldState.getFirstJob(), jobToPreprocessFrom, firstJob);
+    jobToPreprocessFrom = oldState.getFirstJob();
+    traceJobQueue(this, firstJob);
+  }
+}
+
+// Called from processing jobs which are created to drain an actor. We need to
+// reason about this function together with swift_task_switch because threads
+// can switch from "following actors" to "following tasks" and vice versa.
+//
+// The way this function works is as following:
+//
+// 1. We grab the actor lock for the actor we were scheduled to drain.
+// 2. Drain the first task out of the actor and run it. Henceforth, the thread
+// starts executing the task and following it around. It is no longer a
+// processing job for the actor. Note that it will hold the actor lock until it
+// needs to hop off the actor but conceptually, it is now a task executor as well.
+// 3. When the thread needs to hop off the actor, it is done deep in the
+// callstack of this function with an indirection through user code:
+// defaultActorDrain -> runJobInEstablishedExecutorContext ->  user
+// code -> a call to swift_task_switch to hop out of actor
+// 4. This call to swift_task_switch() will attempt to hop off the existing
+// actor and jump to the new one. There are 2 possible outcomes at that point:
+//   (a) We were able to hop to the new actor and so thread continues executing
+//   task. We then schedule a job for the old actor to continue if it has
+//   pending work
+//   (b) We were not able to take the fast path to the new actor, the task gets
+//   enqueued onto the new actor it is going to, and the thread now follows the
+//   actor we were trying to hop off. At this point, note that we don't give up
+//   the actor lock in `swift_task_switchImpl` so we will come back to
+//   defaultActorDrain with the actor lock still held.
+//
+// At the point of return from the job execution, we may not be holding the lock
+// of the same actor that we had started off with, so we need to reevaluate what
+// the current actor is
+static void defaultActorDrain(DefaultActorImpl *actor) {
+  SWIFT_TASK_DEBUG_LOG("Draining default actor %p", actor);
+  DefaultActorImpl *currentActor = actor;
+
+  bool actorLockAcquired = actor->tryLock(true);
+  // We always must succeed in taking the actor lock that we are draining
+  // because we don't have to compete with OOL jobs. See ownership rule (3)
+  assert(actorLockAcquired);
+
+  // Setup a TSD for tracking current execution info
+  ExecutorTrackingInfo trackingInfo;
+  trackingInfo.enterAndShadow(
+    ExecutorRef::forDefaultActor(asAbstract(currentActor)));
+
+  while (true) {
+    if (shouldYieldThread()) {
+      currentActor->unlock(true);
+      break;
+    }
+
+    Job *job = currentActor->drainOne();
+    if (job == NULL) {
+      // No work left to do, try unlocking the actor. This may fail if there is
+      // work concurrently enqueued in which case, we'd try again in the loop
+      if (!currentActor->unlock(false)) {
+        continue;
+      }
+      break;
+    }
+
+    // This thread is now going to follow the task on this actor. It may hop off
+    // the actor
+    runJobInEstablishedExecutorContext(job);
+
+    // We could have come back from the job on a generic executor and not as
+    // part of a default actor. If so, there is no more work left for us to do
+    // here.
+    auto currentExecutor = trackingInfo.getActiveExecutor();
+    if (!currentExecutor.isDefaultActor()) {
+      currentActor = nullptr;
+      break;
+    }
+    currentActor = asImpl(currentExecutor.getDefaultActor());
+  }
+
+  // Leave the tracking info.
+  trackingInfo.leave();
+
+  // Balances with the retain taken in Process{Inline,OutOfLine}Job::process
+  swift_release(actor);
 }
 
 SWIFT_CC(swift)
@@ -1213,208 +1280,28 @@ static void swift_job_runImpl(Job *job, ExecutorRef executor) {
   // executor) and we've switched to a default actor.
   auto currentExecutor = trackingInfo.getActiveExecutor();
   if (trackingInfo.allowsSwitching() && currentExecutor.isDefaultActor()) {
-    // Use an underestimated priority; if this means we create an
-    // extra processing job in some cases, that's probably okay.
-    auto runner = RunningJobInfo::forOther(JobPriority(0));
-    asImpl(currentExecutor.getDefaultActor())->giveUpThread(runner);
+    asImpl(currentExecutor.getDefaultActor())->unlock(true);
   }
-}
-
-/// The primary function for processing an actor on a thread.  Start
-/// processing the given default actor as the active default actor on
-/// the current thread, and keep processing whatever actor we're
-/// running when code returns back to us until we're not processing
-/// any actors anymore.
-///
-/// \param currentActor is expected to be passed in as retained to ensure that
-///                     the actor lives for the duration of job execution.
-///                     Note that this may conflict with the retain/release
-///                     design in the DefaultActorImpl, but it does fix bugs!
-SWIFT_CC(swiftasync)
-static void processDefaultActor(DefaultActorImpl *currentActor,
-                                RunningJobInfo runner) {
-  SWIFT_TASK_DEBUG_LOG("processDefaultActor %p", currentActor);
-  DefaultActorImpl *actor = currentActor;
-
-  // If we actually have work to do, we'll need to set up tracking info.
-  // Optimistically assume that we will; the alternative (an override job
-  // took over the actor first) is rare.
-  ExecutorTrackingInfo trackingInfo;
-  trackingInfo.enterAndShadow(
-    ExecutorRef::forDefaultActor(asAbstract(currentActor)));
-
-  // Remember whether we've already taken over the actor.
-  bool threadIsRunningActor = false;
-  while (true) {
-    assert(currentActor);
-
-    // Immediately check if we've been asked to yield the thread.
-    if (shouldYieldThread())
-      break;
-
-    // Try to claim another job from the current actor, taking it over
-    // if we haven't already.
-    auto job = currentActor->claimNextJobOrGiveUp(threadIsRunningActor,
-                                                  runner);
-
-    SWIFT_TASK_DEBUG_LOG("processDefaultActor %p claimed job %p", currentActor,
-                         job);
-    concurrency::trace::actor_dequeue(currentActor, job);
-
-    // If we failed to claim a job, we have nothing to do.
-    if (!job) {
-      // We also gave up the actor as part of failing to claim it.
-      // Make sure we don't try to give up the actor again.
-      currentActor = nullptr;
-      break;
-    }
-
-    // This thread now owns the current actor.
-    threadIsRunningActor = true;
-
-    // Run the job.
-    runJobInEstablishedExecutorContext(job);
-
-    // The current actor may have changed after the job.
-    // If it's become nil, or not a default actor, we have nothing to do.
-    auto currentExecutor = trackingInfo.getActiveExecutor();
-
-    SWIFT_TASK_DEBUG_LOG("processDefaultActor %p current executor now %p",
-                         currentActor, currentExecutor.getIdentity());
-
-    if (!currentExecutor.isDefaultActor()) {
-      // The job already gave up the thread for us.
-      // Make sure we don't try to give up the actor again.
-      currentActor = nullptr;
-      break;
-    }
-    currentActor = asImpl(currentExecutor.getDefaultActor());
-  }
-
-  // Leave the tracking info.
-  trackingInfo.leave();
-
-  // If we still have an active actor, we should give it up.
-  if (threadIsRunningActor && currentActor) {
-    currentActor->giveUpThread(runner);
-  }
-
-  swift_release(actor);
 }
 
 SWIFT_CC(swiftasync)
 void ProcessInlineJob::process(Job *job) {
   DefaultActorImpl *actor = DefaultActorImpl::fromInlineJob(job);
 
-  // Pull the priority out of the job before we do anything that might
-  // invalidate it.
-  auto targetPriority = job->getPriority();
-  auto runner = RunningJobInfo::forInline(targetPriority);
-
   swift_retain(actor);
-  return processDefaultActor(actor, runner); // 'return' forces tail call
+  return defaultActorDrain(actor); // 'return' forces tail call
 }
 
+// Currently unused
 SWIFT_CC(swiftasync)
 void ProcessOutOfLineJob::process(Job *job) {
   auto self = cast<ProcessOutOfLineJob>(job);
   DefaultActorImpl *actor = self->Actor;
 
-  // Pull the priority out of the job before we do anything that might
-  // invalidate it.
-  auto targetPriority = job->getPriority();
-  auto runner = RunningJobInfo::forOther(targetPriority);
-
   delete self;
 
   swift_retain(actor);
-  return processDefaultActor(actor, runner); // 'return' forces tail call
-}
-
-void DefaultActorImpl::enqueue(Job *job) {
-  auto oldState = CurrentState.load(std::memory_order_relaxed);
-
-  while (true) {
-    assert(!oldState.Flags.isAnyZombieStatus() &&
-           "enqueuing work on a zombie actor");
-    auto newState = oldState;
-
-    // Put the job at the front of the job list (which will get
-    // reversed during preprocessing).
-    setNextJobInQueue(job, oldState.FirstJob);
-    newState.FirstJob = JobRef::getUnpreprocessed(job);
-
-    auto oldStatus = oldState.Flags.getStatus();
-    bool wasIdle = oldStatus == Status::Idle;
-
-    // Update the priority: the priority of the job we're adding
-    // if the actor was idle, or the max if not.  Only the running
-    // thread can decrease the actor's priority once it's non-idle.
-    // (But note that the job we enqueue can still observe a
-    // lowered priority.)
-    auto oldPriority = oldState.Flags.getMaxPriority();
-    auto newPriority =
-      wasIdle ? job->getPriority()
-              : std::max(oldPriority, job->getPriority());
-    newState.Flags.setMaxPriority(newPriority);
-
-    // We might be able to create an inline job; flag that.
-    bool hasActiveInlineJob = newState.Flags.hasActiveInlineJob();
-    if (wasIdle && !hasActiveInlineJob)
-      newState.Flags.setHasActiveInlineJob(true);
-
-    // Make sure the status is at least Scheduled.  We'll actually
-    // schedule the job below, if we succeed at this.
-    if (wasIdle) {
-      newState.Flags.setStatus(Status::Scheduled);
-    }
-
-    // Try the compare-exchange, and try again if it fails.
-    if (!CurrentState.compare_exchange_weak(oldState, newState,
-          /*success*/ std::memory_order_release,
-          /*failure*/ std::memory_order_relaxed))
-      continue;
-    ACTOR_STATE_TRANSITION;
-    concurrency::trace::actor_enqueue(this, job);
-
-    // Okay, we successfully updated the status.  Schedule a job to
-    // process the actor if necessary.
-
-    // If the actor is currently idle, schedule it using the
-    // invasive job.
-    if (wasIdle) {
-      scheduleNonOverrideProcessJob(newPriority, hasActiveInlineJob);
-    }
-
-    return;
-  }
-}
-
-bool DefaultActorImpl::tryAssumeThread(RunningJobInfo runner) {
-  // We have to load-acquire in order to properly order accesses to
-  // the actor's state for the new task.
-  auto oldState = CurrentState.load(std::memory_order_acquire);
-
-  // If the actor is currently idle, try to mark it as running.
-  while (oldState.Flags.getStatus() == Status::Idle) {
-    assert(!oldState.FirstJob);
-    auto newState = oldState;
-    newState.Flags.setStatus(Status::Running);
-    newState.Flags.setMaxPriority(runner.Priority);
-
-    if (CurrentState.compare_exchange_weak(oldState, newState,
-                              /*success*/ std::memory_order_relaxed,
-                              /*failure*/ std::memory_order_acquire)) {
-      ACTOR_STATE_TRANSITION;
-      _swift_tsan_acquire(this);
-      return true;
-    }
-  }
-
-  assert(!oldState.Flags.isAnyZombieStatus() &&
-         "trying to assume a zombie actor");
-
-  return false;
+  return defaultActorDrain(actor); // 'return' forces tail call
 }
 
 void swift::swift_defaultActor_initialize(DefaultActor *_actor) {
@@ -1426,7 +1313,7 @@ void swift::swift_defaultActor_destroy(DefaultActor *_actor) {
 }
 
 void swift::swift_defaultActor_enqueue(Job *job, DefaultActor *_actor) {
-  asImpl(_actor)->enqueue(job);
+  asImpl(_actor)->enqueue(job, job->getPriority());
 }
 
 void swift::swift_defaultActor_deallocate(DefaultActor *_actor) {
@@ -1493,12 +1380,13 @@ static bool canGiveUpThreadForSwitch(ExecutorTrackingInfo *trackingInfo,
 ///
 /// Note that we don't update DefaultActorProcessingFrame here; we'll
 /// do that in runOnAssumedThread.
-static void giveUpThreadForSwitch(ExecutorRef currentExecutor,
-                                  RunningJobInfo runner) {
-  if (currentExecutor.isGeneric())
+static void giveUpThreadForSwitch(ExecutorRef currentExecutor) {
+  if (currentExecutor.isGeneric()) {
+    SWIFT_TASK_DEBUG_LOG("Giving up current generic executor %p", currentExecutor);
     return;
+  }
 
-  asImpl(currentExecutor.getDefaultActor())->giveUpThread(runner);
+  asImpl(currentExecutor.getDefaultActor())->unlock(true);
 }
 
 /// Try to assume control of the current thread for the given executor
@@ -1508,8 +1396,7 @@ static void giveUpThreadForSwitch(ExecutorRef currentExecutor,
 ///
 /// Note that we don't update DefaultActorProcessingFrame here; we'll
 /// do that in runOnAssumedThread.
-static bool tryAssumeThreadForSwitch(ExecutorRef newExecutor,
-                                     RunningJobInfo runner) {
+static bool tryAssumeThreadForSwitch(ExecutorRef newExecutor) {
   // If the new executor is generic, we don't need to do anything.
   if (newExecutor.isGeneric()) {
     return true;
@@ -1517,7 +1404,7 @@ static bool tryAssumeThreadForSwitch(ExecutorRef newExecutor,
 
   // If the new executor is a default actor, ask it to assume the thread.
   if (newExecutor.isDefaultActor()) {
-    return asImpl(newExecutor.getDefaultActor())->tryAssumeThread(runner);
+    return asImpl(newExecutor.getDefaultActor())->tryLock(false);
   }
 
   return false;
@@ -1527,8 +1414,7 @@ static bool tryAssumeThreadForSwitch(ExecutorRef newExecutor,
 /// continue to run the given task on it.
 SWIFT_CC(swiftasync)
 static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
-                               ExecutorTrackingInfo *oldTracking,
-                               RunningJobInfo runner) {
+                               ExecutorTrackingInfo *oldTracking) {
   // Note that this doesn't change the active task and so doesn't
   // need to either update ActiveTask or flagAsRunning/flagAsSuspended.
 
@@ -1561,7 +1447,7 @@ static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
                        executor.getIdentity());
 
   if (executor.isDefaultActor())
-    asImpl(executor.getDefaultActor())->giveUpThread(runner);
+    asImpl(executor.getDefaultActor())->unlock(true);
 }
 
 // TODO (rokhinip): Workaround rdar://88700717. To be removed with
@@ -1570,12 +1456,14 @@ SWIFT_CC(swiftasync)
 static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
                                   TaskContinuationFunction *resumeFunction,
                                   ExecutorRef newExecutor) SWIFT_OPTNONE {
+  auto task = swift_task_getCurrent();
+  assert(task && "no current task!");
 
   auto trackingInfo = ExecutorTrackingInfo::current();
   auto currentExecutor =
     (trackingInfo ? trackingInfo->getActiveExecutor()
                   : ExecutorRef::generic());
-  SWIFT_TASK_DEBUG_LOG("trying to switch from executor %p to %p",
+  SWIFT_TASK_DEBUG_LOG("Task %p trying to switch from executor %p to %p", task,
                        currentExecutor.getIdentity(),
                        newExecutor.getIdentity());
 
@@ -1586,29 +1474,23 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
     return resumeFunction(resumeContext); // 'return' forces tail call
   }
 
-  auto task = swift_task_getCurrent();
-  assert(task && "no current task!");
-
   // Park the task for simplicity instead of trying to thread the
   // initial resumption information into everything below.
   task->ResumeContext = resumeContext;
   task->ResumeTask = resumeFunction;
-
-  // Okay, we semantically need to switch.
-  auto runner = RunningJobInfo::forOther(task->getPriority());
 
   // If the current executor can give up its thread, and the new executor
   // can take over a thread, try to do so; but don't do this if we've
   // been asked to yield the thread.
   if (canGiveUpThreadForSwitch(trackingInfo, currentExecutor) &&
       !shouldYieldThread() &&
-      tryAssumeThreadForSwitch(newExecutor, runner)) {
+      tryAssumeThreadForSwitch(newExecutor)) {
     SWIFT_TASK_DEBUG_LOG(
         "switch succeeded, task %p assumed thread for executor %p", task,
         newExecutor.getIdentity());
-    giveUpThreadForSwitch(currentExecutor, runner);
+    giveUpThreadForSwitch(currentExecutor);
     // 'return' forces tail call
-    return runOnAssumedThread(task, newExecutor, trackingInfo, runner);
+    return runOnAssumedThread(task, newExecutor, trackingInfo);
   }
 
   // Otherwise, just asynchronously enqueue the task on the given
@@ -1645,7 +1527,7 @@ static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
     return swift_task_enqueueGlobal(job);
 
   if (executor.isDefaultActor())
-    return asImpl(executor.getDefaultActor())->enqueue(job);
+    return asImpl(executor.getDefaultActor())->enqueue(job, job->getPriority());
 
   auto wtable = executor.getSerialExecutorWitnessTable();
   auto executorObject = executor.getIdentity();
@@ -1694,5 +1576,5 @@ bool swift::swift_distributed_actor_is_remote(DefaultActor *_actor) {
 
 bool DefaultActorImpl::isDistributedRemote() {
   auto state = CurrentState.load(std::memory_order_relaxed);
-  return state.Flags.isDistributedRemote();
+  return state.isDistributedRemote();
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -47,7 +47,6 @@ namespace swift {
 // Set to 1 to enable helpful debug spew to stderr
 // If this is enabled, tests with `swift_task_debug_log` requirement can run.
 #if 0
-
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
   fprintf(stderr, "[%lu] [%s:%d](%s) " fmt "\n",                               \
           (unsigned long)_swift_get_thread_id(),                               \

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -50,8 +50,8 @@ using namespace swift;
 // Check to make sure the runtime is being built with a compiler that
 // supports the Swift calling convention.
 //
-// If the Swift calling convention is not in use, functions such as 
-// swift_allocBox and swift_makeBoxUnique that rely on their return value 
+// If the Swift calling convention is not in use, functions such as
+// swift_allocBox and swift_makeBoxUnique that rely on their return value
 // being passed in a register to be compatible with Swift may miscompile on
 // some platforms and silently fail.
 #if !__has_attribute(swiftcall)
@@ -186,11 +186,11 @@ swift::swift_verifyEndOfLifetime(HeapObject *object) {
   if (object->refCounts.getCount() != 0)
     swift::fatalError(/* flags = */ 0,
                       "Fatal error: Stack object escaped\n");
-  
+
   if (object->refCounts.getUnownedCount() != 1)
     swift::fatalError(/* flags = */ 0,
                       "Fatal error: Unowned reference to stack object\n");
-  
+
   if (object->refCounts.getWeakCount() != 0)
     swift::fatalError(/* flags = */ 0,
                       "Fatal error: Weak reference to stack object\n");
@@ -477,10 +477,10 @@ void swift::swift_unownedRelease(HeapObject *object) {
   // Only class objects can be unowned-retained and unowned-released.
   assert(object->metadata->isClassObject());
   assert(static_cast<const ClassMetadata*>(object->metadata)->isTypeMetadata());
-  
+
   if (object->refCounts.decrementUnownedShouldFree(1)) {
     auto classMetadata = static_cast<const ClassMetadata*>(object->metadata);
-    
+
     swift_slowDealloc(object, classMetadata->getInstanceSize(),
                       classMetadata->getInstanceAlignMask());
   }
@@ -537,7 +537,7 @@ void swift::swift_unownedRelease_n(HeapObject *object, int n) {
   // Only class objects can be unowned-retained and unowned-released.
   assert(object->metadata->isClassObject());
   assert(static_cast<const ClassMetadata*>(object->metadata)->isTypeMetadata());
-  
+
   if (object->refCounts.decrementUnownedShouldFree(n)) {
     auto classMetadata = static_cast<const ClassMetadata*>(object->metadata);
     swift_slowDealloc(object, classMetadata->getInstanceSize(),


### PR DESCRIPTION
This PR comes in 3 parts:

1. A refactor of the actor runtime. This involves creating an ActiveActorStatus to isolate the status manipulations to its own class. In addition, the API surface of the actor runtime has been been simplified to remove extra bookkeeping that is not needed.
2. Tracking the drainer identity in the ActiveActorStatus when the actor starts and stops running
3. Priority escalation of thread when contention is observed in the actor runtime.

Rdar: rdar://86100521