### PR TITLE
Add an opt-in flag to enforce (printable) ASCII only string literals

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -147,6 +147,9 @@ ERROR(lex_invalid_unicode_scalar,none,
       "invalid unicode scalar", ())
 ERROR(lex_unicode_escape_braces,none,
       "expected hexadecimal code in braces after unicode escape", ())
+ERROR(non_ascii_character_found,none,
+      "non-ASCII character found when compiling with -string-literals-must-be-ascii-only", ())
+
 ERROR(lex_illegal_multiline_string_start,none,
       "multi-line string literal content must begin on a new line", ())
 ERROR(lex_illegal_multiline_string_end,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -147,6 +147,9 @@ namespace swift {
     /// Enable experimental string processing
     bool EnableExperimentalStringProcessing = false;
 
+    /// Only ASCII string literals are allowed
+    bool StringLiteralsMustBeASCIIOnly = false;
+
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -529,6 +529,10 @@ def enable_experimental_string_processing :
   Flag<["-"], "enable-experimental-string-processing">,
   HelpText<"Enable experimental string processing">;
 
+def string_literals_must_be_ascii_only :
+  Flag<["-"], "string-literals-must-be-ascii-only">,
+  HelpText<"Enforce string literals to only allow ASCII characters">;
+
 def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -507,6 +507,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalBoundGenericExtensions |=
     Args.hasArg(OPT_enable_experimental_bound_generic_extensions);
 
+  Opts.StringLiteralsMustBeASCIIOnly |=
+      Args.hasArg(OPT_string_literals_must_be_ascii_only);
+
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
   Opts.CheckAPIAvailabilityOnly |=

--- a/test/Parse/ascii_only_literals.swift
+++ b/test/Parse/ascii_only_literals.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift -string-literals-must-be-ascii-only
+
+_ = "Normal string"
+// ok
+
+_ = "String with a café"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = "String with a 🍿"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = "String with a \u{24}"
+// ok - U+0024 is just an ASCII dollar sign
+
+_ = "String with some control characters \u{1} \u{2} \u{3} \u{4}"
+// ok
+
+_ = "String with a \u{2665}"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = "String with a non-breaking space"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = "String with another non-breaking space"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = """
+    multi
+    line
+    ascii
+    string
+    """
+// ok
+
+_ = """
+    multi
+    line
+    string
+    with 🍿
+    """
+// expected-error@-6{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}
+
+_ = "String with a null\u{0}byte"
+// ok - NUL is allowed
+
+_ = "String with a null\u{0}byte and a \u{2665}"
+// expected-error@-1{{non-ASCII character found when compiling with -string-literals-must-be-ascii-only}}


### PR DESCRIPTION
The primary motivation is that this flag, `-string-literals-must-be-ascii-only`, is to be used for the 'freestanding' stdlib which is compiling without Unicode data tables -- see <https://github.com/apple/swift/pull/40573> and <https://github.com/apple/swift/pull/41258> -- or for other use cases where full Unicode string support is not desired. In those cases, it's nice to have a compile time proof that there's no string literals used in the source code that would require these Unicode data tables and therefore would crash at runtime.