### PR TITLE
Many minor/obvious SIL API improvements that address lowering depends on

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -580,18 +580,19 @@ public:
     return getSubstCalleeConv().hasIndirectSILResults();
   }
 
-  /// If our apply site has a single direct result SILValue, return that
-  /// SILValue. Return SILValue() otherwise.
+  /// Get the SIL value that represents all of the given call's results. For a
+  /// single direct result, returns the result. For multiple results, returns a
+  /// fake tuple value. The tuple has no storage of its own. The real results
+  /// must be extracted from it.
   ///
-  /// This means that:
+  /// For ApplyInst, returns the single-value instruction itself.
   ///
-  /// 1. If we have an ApplyInst, we just visit the apply.
-  /// 2. If we have a TryApplyInst, we visit the first argument of the normal
-  ///    block.
-  /// 3. If we have a BeginApplyInst, we return SILValue() since the begin_apply
-  ///    yields values instead of returning them. A returned value should only
-  ///    be valid after a full apply site has completely finished executing.
-  SILValue getSingleDirectResult() const {
+  /// For TryApplyInst returns the continuation block argument.
+  ///
+  /// For BeginApplyInst, returns an invalid value. For coroutines, there is no
+  /// single value representing all results. Yielded values are generally
+  /// handled differently since they have the convention of incoming arguments.
+  SILValue getPseudoResult() const {
     switch (getKind()) {
     case FullApplySiteKind::ApplyInst:
       return SILValue(cast<ApplyInst>(getInstruction()));

--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -88,6 +88,19 @@ public:
   }
 };
 
+/// Compute a single block's dominance frontier.
+///
+/// Precondition: no critical edges (OSSA)
+///
+/// Postcondition: each block in \p frontier is dominated by \p root and either
+/// exits the function or has a single successor that is not dominated by \p
+/// root.
+///
+/// With no critical edges, the dominance frontier is identified simply by leaf
+/// blocks in the dominance subtree.
+void computeDominanceFrontier(SILBasicBlock *root, DominanceInfo *domTree,
+                              SmallVectorImpl<SILBasicBlock *> &frontier);
+
 /// Helper class for visiting basic blocks in dominance order, based on a
 /// worklist algorithm. Example usage:
 /// \code

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1689,7 +1689,7 @@ Result AccessUseDefChainVisitor<Impl, Result>::visit(SILValue sourceAddr) {
 
   case ValueKind::SILPhiArgument: {
     auto *phiArg = cast<SILPhiArgument>(sourceAddr);
-    if (phiArg->isPhiArgument()) {
+    if (phiArg->isPhi()) {
       return asImpl().visitPhi(phiArg);
     }
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -79,8 +79,7 @@ inline bool isForwardingConsume(SILValue value) {
 }
 
 /// Find leaf "use points" of \p guaranteedValue that determine its lifetime
-/// requirement. If \p usePoints is nullptr, then the simply returns true if no
-/// PointerEscape use was found.
+/// requirement. Return true if no PointerEscape use was found.
 ///
 /// Precondition: \p guaranteedValue is not a BorrowedValue.
 ///

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -581,7 +581,7 @@ struct PhiValue {
 
   PhiValue(SILValue value) {
     auto *blockArg = dyn_cast<SILPhiArgument>(value);
-    if (!blockArg || !blockArg->isPhiArgument())
+    if (!blockArg || !blockArg->isPhi())
       return;
 
     phiBlock = blockArg->getParent();
@@ -598,6 +598,11 @@ struct PhiValue {
 
   SILPhiArgument *getValue() const {
     return cast<SILPhiArgument>(phiBlock->getArgument(argIndex));
+  }
+
+  Operand *getOperand(SILBasicBlock *predecessor) {
+    auto *branch = cast<BranchInst>(predecessor->getTerminator());
+    return &branch->getAllOperands()[argIndex];
   }
 
   operator SILValue() const { return getValue(); }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2690,7 +2690,7 @@ private:
     // sync. We don't care if an instruction is used in global_addr.
     if (F)
       TheInst->verifyDebugInfo();
-    TheInst->verifyOperandOwnership();
+    TheInst->verifyOperandOwnership(&C.silConv);
 #endif
   }
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -896,19 +896,18 @@ public:
   ///   [trivial].
   ///
   /// * Otherwise, emit an actual store_borrow.
-  void emitStoreBorrowOperation(SILLocation loc, SILValue src,
-                                SILValue destAddr) {
+  SILInstruction *emitStoreBorrowOperation(SILLocation loc, SILValue src,
+                                           SILValue destAddr) {
     if (!hasOwnership()) {
-      return emitStoreValueOperation(loc, src, destAddr,
-                                     StoreOwnershipQualifier::Unqualified);
+      emitStoreValueOperation(loc, src, destAddr,
+                              StoreOwnershipQualifier::Unqualified);
+    } else if (src->getType().isTrivial(getFunction())) {
+      emitStoreValueOperation(loc, src, destAddr,
+                              StoreOwnershipQualifier::Trivial);
+    } else {
+      createStoreBorrow(loc, src, destAddr);
     }
-
-    if (src->getType().isTrivial(getFunction())) {
-      return emitStoreValueOperation(loc, src, destAddr,
-                                     StoreOwnershipQualifier::Trivial);
-    }
-
-    createStoreBorrow(loc, src, destAddr);
+    return &*std::prev(getInsertionPoint());
   }
 
   MarkUninitializedInst *

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -567,19 +567,30 @@ public:
   bool maySuspend() const;
 
 private:
-  /// Predicate used to filter OperandValueRange.
+  /// Functor for Operand::get()
   struct OperandToValue;
-  /// Predicate used to filter TransformedOperandValueRange.
+  /// Functor for Operand::get()
+  struct OperandRefToValue;
+  /// Predicate to filter NonTypeDependentOperandValueRange
+  struct NonTypeDependentOperandToValue;
+  /// Predicate to filter TransformedOperandValueRange.
   struct OperandToTransformedValue;
 
 public:
-  using OperandValueRange =
-      OptionalTransformRange<ArrayRef<Operand>, OperandToValue>;
+  using OperandValueRange = TransformRange<ArrayRef<Operand*>, OperandToValue>;
+  using OperandRefValueRange =
+    TransformRange<ArrayRef<Operand>, OperandRefToValue>;
+  using NonTypeDependentOperandValueRange =
+    OptionalTransformRange<ArrayRef<Operand>, NonTypeDependentOperandToValue>;
   using TransformedOperandValueRange =
-      OptionalTransformRange<ArrayRef<Operand>, OperandToTransformedValue>;
+    OptionalTransformRange<ArrayRef<Operand>, OperandToTransformedValue>;
 
-  OperandValueRange
-  getOperandValues(bool skipTypeDependentOperands = false) const;
+  static OperandValueRange getOperandValues(ArrayRef<Operand*> operands);
+
+  OperandRefValueRange getOperandValues() const;
+
+  NonTypeDependentOperandValueRange getNonTypeDependentOperandValues() const;
+
   TransformedOperandValueRange
   getOperandValues(std::function<SILValue(SILValue)> transformFn,
                    bool skipTypeDependentOperands) const;
@@ -879,14 +890,24 @@ inline const SILNode *SILNode::instAsNode(const SILInstruction *inst) {
 
 
 struct SILInstruction::OperandToValue {
-  const SILInstruction &i;
-  bool skipTypeDependentOps;
+  SILValue operator()(const Operand *use) const {
+    return use->get();
+  }
+};
 
-  OperandToValue(const SILInstruction &i, bool skipTypeDependentOps)
-      : i(i), skipTypeDependentOps(skipTypeDependentOps) {}
+struct SILInstruction::OperandRefToValue {
+  SILValue operator()(const Operand &use) const {
+    return use.get();
+  }
+};
+
+struct SILInstruction::NonTypeDependentOperandToValue {
+  const SILInstruction &i;
+
+  NonTypeDependentOperandToValue(const SILInstruction &i): i(i) {}
 
   Optional<SILValue> operator()(const Operand &use) const {
-    if (skipTypeDependentOps && i.isTypeDependentOperand(use))
+    if (i.isTypeDependentOperand(use))
       return None;
     return use.get();
   }
@@ -910,11 +931,21 @@ struct SILInstruction::OperandToTransformedValue {
   }
 };
 
+inline SILInstruction::OperandValueRange
+SILInstruction::getOperandValues(ArrayRef<Operand*> operands) {
+  return OperandValueRange(operands, OperandToValue());
+}
+
 inline auto
-SILInstruction::getOperandValues(bool skipTypeDependentOperands) const
-    -> OperandValueRange {
-  return OperandValueRange(getAllOperands(),
-                           OperandToValue(*this, skipTypeDependentOperands));
+SILInstruction::getOperandValues() const -> OperandRefValueRange {
+  return OperandRefValueRange(getAllOperands(), OperandRefToValue());
+}
+
+inline auto
+SILInstruction::getNonTypeDependentOperandValues() const
+  -> NonTypeDependentOperandValueRange {
+  return NonTypeDependentOperandValueRange(getAllOperands(),
+                                           NonTypeDependentOperandToValue(*this));
 }
 
 inline auto

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -773,7 +773,7 @@ public:
 
   /// Verify that all operands of this instruction have compatible ownership
   /// with this instruction.
-  void verifyOperandOwnership() const;
+  void verifyOperandOwnership(SILModuleConventions *silConv = nullptr) const;
 
   /// Verify that this instruction and its associated debug information follow
   /// all SIL debug info invariants.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1176,6 +1176,18 @@ public:
       return isa(i);
     return false;
   }
+
+  /// Return true if the forwarded value has the same representation. If true,
+  /// then the result can be mapped to the same storage without a move or copy.
+  ///
+  /// \p inst is an OwnershipForwardingMixin
+  static bool hasSameRepresentation(SILInstruction *inst);
+
+  /// Return true if the forwarded value is address-only either before or after
+  /// forwarding.
+  ///
+  /// \p inst is an OwnershipForwardingMixin
+  static bool isAddressOnly(SILInstruction *inst);
 };
 
 /// A single value inst that forwards a static ownership from its first operand.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -46,6 +46,7 @@ class ConsumingUseIterator;
 class NonConsumingUseIterator;
 class NonTypeDependentUseIterator;
 class SILValue;
+class SILModuleConventions;
 
 /// An enumeration which contains values for all the concrete ValueBase
 /// subclasses.
@@ -922,7 +923,8 @@ inline bool canAcceptUnownedValue(OperandOwnership operandOwnership) {
 }
 
 /// Return true if all OperandOwnership invariants hold.
-bool checkOperandOwnershipInvariants(const Operand *operand);
+bool checkOperandOwnershipInvariants(const Operand *operand,
+                                     SILModuleConventions *silConv = nullptr);
 
 /// Return the OperandOwnership for a forwarded operand when the forwarding
 /// operation has this "forwarding ownership" (as returned by
@@ -1039,22 +1041,25 @@ public:
   /// Return the use ownership of this operand.
   ///
   /// NOTE: This is implemented in OperandOwnership.cpp.
-  OperandOwnership getOperandOwnership() const;
+  OperandOwnership
+  getOperandOwnership(SILModuleConventions *silConv = nullptr) const;
 
   /// Return the ownership constraint that restricts what types of values this
   /// Operand can contain.
-  OwnershipConstraint getOwnershipConstraint() const {
-    return getOperandOwnership().getOwnershipConstraint();
+  OwnershipConstraint
+  getOwnershipConstraint(SILModuleConventions *silConv = nullptr) const {
+    return getOperandOwnership(silConv).getOwnershipConstraint();
   }
 
   /// Returns true if changing the operand to use a value with the given
   /// ownership kind, without rewriting the instruction, would not cause the
   /// operand to violate the operand's ownership constraints.
-  bool canAcceptKind(ValueOwnershipKind kind) const;
+  bool canAcceptKind(ValueOwnershipKind kind,
+                     SILModuleConventions *silConv = nullptr) const;
 
   /// Returns true if this operand and its value satisfy the operand's
   /// operand constraint.
-  bool satisfiesConstraints() const;
+  bool satisfiesConstraints(SILModuleConventions *silConv = nullptr) const;
 
   /// Returns true if this operand acts as a use that ends the lifetime its
   /// associated value, either by consuming the owned value or ending the

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -78,6 +78,16 @@ makeGuaranteedValueAvailable(SILValue value, SILInstruction *user,
                              DeadEndBlocks &deBlocks,
                              InstModCallbacks callbacks = InstModCallbacks());
 
+/// Compute the liveness boundary for a guaranteed value. Returns true if no
+/// uses are pointer escapes. If pointer escapes are present, the liveness
+/// boundary is still valid for all known uses.
+///
+/// Precondition: \p value has guaranteed ownership and no reborrows. It is
+/// either an "inner" guaranteed value or a simple borrow introducer whose
+/// end_borrows have not yet been inserted.
+bool computeGuaranteedBoundary(SILValue value,
+                               PrunedLivenessBoundary &boundary);
+
 //===----------------------------------------------------------------------===//
 //                        GuaranteedOwnershipExtension
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -82,7 +82,7 @@ SILParameterInfo SILFunctionArgument::getKnownParameterInfo() const {
 // expensive to call this helper instead of simply specifying phis with an
 // opcode. It results in repeated CFG traversals and repeated, unnecessary
 // switching over terminator opcodes.
-bool SILPhiArgument::isPhiArgument() const {
+bool SILPhiArgument::isPhi() const {
   // No predecessors indicates an unreachable block.
   if (getParent()->pred_empty())
     return false;
@@ -128,7 +128,7 @@ static SILValue getIncomingPhiValueForPred(const SILBasicBlock *parentBlock,
 }
 
 SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return SILValue();
 
   const auto *parentBlock = getParent();
@@ -145,7 +145,7 @@ SILValue SILPhiArgument::getIncomingPhiValue(SILBasicBlock *predBlock) const {
 
 bool SILPhiArgument::getIncomingPhiValues(
     SmallVectorImpl<SILValue> &returnedPhiValues) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return false;
 
   const auto *parentBlock = getParent();
@@ -162,14 +162,14 @@ bool SILPhiArgument::getIncomingPhiValues(
 }
 
 Operand *SILPhiArgument::getIncomingPhiOperand(SILBasicBlock *predBlock) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return nullptr;
   return getIncomingPhiOperandForPred(getParent(), predBlock, getIndex());
 }
 
 bool SILPhiArgument::getIncomingPhiOperands(
     SmallVectorImpl<Operand *> &returnedPhiOperands) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return false;
 
   const auto *parentBlock = getParent();
@@ -187,7 +187,7 @@ bool SILPhiArgument::getIncomingPhiOperands(
 
 bool SILPhiArgument::visitIncomingPhiOperands(
     function_ref<bool(Operand *)> visitor) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return false;
 
   const auto *parentBlock = getParent();
@@ -210,7 +210,7 @@ bool SILPhiArgument::visitIncomingPhiOperands(
 bool SILPhiArgument::getIncomingPhiValues(
     SmallVectorImpl<std::pair<SILBasicBlock *, SILValue>>
         &returnedPredBBAndPhiValuePairs) const {
-  if (!isPhiArgument())
+  if (!isPhi())
     return false;
 
   const auto *parentBlock = getParent();
@@ -318,8 +318,10 @@ TermInst *SILPhiArgument::getSingleTerminator() const {
 
 TermInst *SILPhiArgument::getTerminatorForResult() const {
   if (auto *termInst = getSingleTerminator()) {
-    if (!isa<BranchInst>(termInst) && !isa<CondBranchInst>(termInst))
+    if (!swift::isa<BranchInst>(termInst)
+        && !swift::isa<CondBranchInst>(termInst)) {
       return termInst;
+    }
   }
   return nullptr;
 }

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -401,7 +401,7 @@ bool SILBasicBlock::hasPhi() const {
   // It is sufficient to check whether the first argument is a phi.  A block
   // can't have both phis and terminator results.
   auto *argument = getArguments()[0];
-  return argument->isPhiArgument();
+  return argument->isPhi();
 }
 
 const SILDebugScope *SILBasicBlock::getScopeOfFirstNonMetaInstruction() {

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -318,8 +318,9 @@ SILFunction *Operand::getParentFunction() const {
   return self->getUser()->getFunction();
 }
 
-bool Operand::canAcceptKind(ValueOwnershipKind kind) const {
-  auto operandOwnership = getOperandOwnership();
+bool Operand::canAcceptKind(ValueOwnershipKind kind,
+                            SILModuleConventions *silConv) const {
+  auto operandOwnership = getOperandOwnership(silConv);
   auto constraint = operandOwnership.getOwnershipConstraint();
   if (constraint.satisfiesConstraint(kind)) {
     // Constraints aren't precise enough to enforce Unowned value uses.
@@ -332,8 +333,8 @@ bool Operand::canAcceptKind(ValueOwnershipKind kind) const {
   return false;
 }
 
-bool Operand::satisfiesConstraints() const {
-  return canAcceptKind(get().getOwnershipKind());
+bool Operand::satisfiesConstraints(SILModuleConventions *silConv) const {
+  return canAcceptKind(get().getOwnershipKind(), silConv);
 }
 
 bool Operand::isLifetimeEnding() const {

--- a/lib/SIL/Utils/Dominance.cpp
+++ b/lib/SIL/Utils/Dominance.cpp
@@ -141,3 +141,22 @@ void PostDominanceInfo::verify() const {
     abort();
   }
 }
+
+void
+swift::computeDominanceFrontier(SILBasicBlock *root,
+                                DominanceInfo *domTree,
+                                SmallVectorImpl<SILBasicBlock *> &frontier) {
+  auto *function = root->getParent();
+  assert(function->hasOwnership());
+  assert(frontier.empty());
+
+  DominanceOrder domOrder(root, domTree);
+  while (SILBasicBlock *block = domOrder.getNext()) {
+    DominanceInfoNode *domNode = domTree->getNode(block);
+    if (domNode->isLeaf()) {
+      frontier.push_back(block);
+      continue;
+    }
+    domOrder.pushChildren(block);
+  }
+}

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -789,7 +789,7 @@ protected:
       ref = svi->getOperand(0);
     };
     auto *phi = dyn_cast<SILPhiArgument>(ref);
-    if (!phi || !phi->isPhiArgument()) {
+    if (!phi || !phi->isPhi()) {
       return ref;
     }
     // Handle phis...
@@ -1533,7 +1533,7 @@ protected:
   void initializeDFS(SILValue root) {
     // If root is a phi, record it so that its uses aren't visited twice.
     if (auto *phi = dyn_cast<SILPhiArgument>(root)) {
-      if (phi->isPhiArgument())
+      if (phi->isPhi())
         visitedPhis.insert(phi);
     }
     pushUsers(root,

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -91,7 +91,9 @@ bool swift::canOpcodeForwardOwnedValues(Operand *use) {
 // points. Transitively find all nested scope-ending instructions by looking
 // through nested reborrows. Nested reborrows are not use points.
 bool swift::findInnerTransitiveGuaranteedUses(
-    SILValue guaranteedValue, SmallVectorImpl<Operand *> *usePoints) {
+  SILValue guaranteedValue, SmallVectorImpl<Operand *> *usePoints) {
+
+  bool foundPointerEscape = false;
 
   auto leafUse = [&](Operand *use) {
     if (usePoints && use->getOperandOwnership() != OperandOwnership::NonUse) {
@@ -127,7 +129,9 @@ bool swift::findInnerTransitiveGuaranteedUses(
 
     case OperandOwnership::ForwardingUnowned:
     case OperandOwnership::PointerEscape:
-      return false;
+      leafUse(use);
+      foundPointerEscape = true;
+      break;
 
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
@@ -143,17 +147,18 @@ bool swift::findInnerTransitiveGuaranteedUses(
       break;
 
     case OperandOwnership::InteriorPointer:
-      return false;
-
 #if 0 // FIXME!!! Enable in a following commit that fixes RAUW
-      // If our base guaranteed value does not have any consuming uses (consider
-      // function arguments), we need to be sure to include interior pointer
-      // operands since we may not get a use from a end_scope instruction.
+      // If our base guaranteed value does not have any consuming uses
+      // (consider function arguments), we need to be sure to include interior
+      // pointer operands since we may not get a use from a end_scope
+      // instruction.
       if (InteriorPointerOperand(use).findTransitiveUses(usePoints)
           != AddressUseKind::NonEscaping) {
-        return false;
+        foundPointerEscape = true;
       }
 #endif
+      leafUse(use);
+      foundPointerEscape = true;
       break;
 
     case OperandOwnership::ForwardingBorrow: {
@@ -192,7 +197,7 @@ bool swift::findInnerTransitiveGuaranteedUses(
       break;
     }
   }
-  return true;
+  return !foundPointerEscape;
 }
 
 /// Find all uses in the extended lifetime (i.e. including copies) of a simple

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1055,7 +1055,7 @@ bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
     // instruction
     if (isForwardingBorrow(value)) {
       if (auto *i = value->getDefiningInstruction()) {
-        llvm::copy(i->getOperandValues(true /*skip type dependent ops*/),
+        llvm::copy(i->getNonTypeDependentOperandValues(),
                    std::back_inserter(worklist));
         continue;
       }
@@ -1100,7 +1100,7 @@ BorrowedValue swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
     // instruction
     if (isForwardingBorrow(currentValue)) {
       if (auto *i = currentValue->getDefiningInstruction()) {
-        auto instOps = i->getOperandValues(true /*ignore type dependent ops*/);
+        auto instOps = i->getNonTypeDependentOperandValues();
         // If we have multiple incoming values, return .None. We can't handle
         // this.
         auto begin = instOps.begin();
@@ -1160,7 +1160,7 @@ bool swift::getAllOwnedValueIntroducers(
     // instruction
     if (isForwardingConsume(value)) {
       if (auto *i = value->getDefiningInstruction()) {
-        llvm::copy(i->getOperandValues(true /*skip type dependent ops*/),
+        llvm::copy(i->getNonTypeDependentOperandValues(),
                    std::back_inserter(worklist));
         continue;
       }
@@ -1201,7 +1201,7 @@ OwnedValueIntroducer swift::getSingleOwnedValueIntroducer(SILValue inputValue) {
     // instruction
     if (isForwardingConsume(currentValue)) {
       if (auto *i = currentValue->getDefiningInstruction()) {
-        auto instOps = i->getOperandValues(true /*ignore type dependent ops*/);
+        auto instOps = i->getNonTypeDependentOperandValues();
         // If we have multiple incoming values, return .None. We can't handle
         // this.
         auto begin = instOps.begin();

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -79,6 +79,11 @@ void PrunedLiveness::updateForUse(SILInstruction *user, bool lifetimeEnding) {
   auto useBlockLive = liveBlocks.updateForUse(user);
   // Record all uses of blocks on the liveness boundary. For blocks marked
   // LiveWithin, the boundary is considered to be the last use in the block.
+  //
+  // FIXME: Why is nonLifetimeEndingUsesInLiveOut inside PrunedLiveness, and
+  // what does it mean? Blocks may transition to LiveOut later. Or they may
+  // already be LiveOut from a previous use. After computing liveness, clients
+  // should check uses that are in PrunedLivenessBoundary.
   if (!lifetimeEnding && useBlockLive == PrunedLiveBlocks::LiveOut) {
     if (nonLifetimeEndingUsesInLiveOut)
       nonLifetimeEndingUsesInLiveOut->insert(user);

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -687,7 +687,8 @@ bool SILValueOwnershipChecker::checkUses() {
 //                           Top Level Entrypoints
 //===----------------------------------------------------------------------===//
 
-void SILInstruction::verifyOperandOwnership() const {
+void SILInstruction::verifyOperandOwnership(
+    SILModuleConventions *silConv) const {
   if (DisableOwnershipVerification)
     return;
 
@@ -736,7 +737,7 @@ void SILInstruction::verifyOperandOwnership() const {
     if (isTypeDependentOperand(op))
       continue;
 
-    if (!checkOperandOwnershipInvariants(&op)) {
+    if (!checkOperandOwnershipInvariants(&op, silConv)) {
       errorBuilder->handleMalformedSIL([&] {
         llvm::errs() << "Found an operand with invalid invariants.\n";
         llvm::errs() << "Value: " << op.get();
@@ -747,8 +748,8 @@ void SILInstruction::verifyOperandOwnership() const {
       });
     }
 
-    if (!op.satisfiesConstraints()) {
-      auto constraint = op.getOwnershipConstraint();
+    if (!op.satisfiesConstraints(silConv)) {
+      auto constraint = op.getOwnershipConstraint(silConv);
       SILValue opValue = op.get();
       auto valueOwnershipKind = opValue.getOwnershipKind();
       errorBuilder->handleMalformedSIL([&] {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1268,6 +1268,17 @@ public:
     if (auto *term = dyn_cast<OwnershipForwardingTermInst>(i)) {
       checkOwnershipForwardingTermInst(term);
     }
+
+    // Address-only values are potentially move-only, and unmovable if they are
+    // borrowed. Ensure that guaranteed address-only values are forwarded with
+    // the same representation. Non-destructive projection is
+    // allowed. Aggregation and destructive disaggregation is not allowed.
+    if (ownership == OwnershipKind::Guaranteed
+        && OwnershipForwardingMixin::isAddressOnly(i)) {
+      require(OwnershipForwardingMixin::hasSameRepresentation(i),
+              "Forwarding a guaranteed address-only value requires the same "
+              "representation since no move or copy is allowed.");
+    }
   }
 
   void checkDebugVariable(SILInstruction *inst) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1245,21 +1245,22 @@ public:
     }
   }
 
-  /// We are given an instruction \p fInst that forwards ownership from \p
-  /// operand to one of \p fInst's results, make sure that if we have a
-  /// forwarding instruction that can only accept owned or guaranteed ownership
-  /// that we are following that invariant.
+  /// For an instruction \p i that forwards ownership from an operand to one
+  /// of its results, check forwarding invariants.
   void checkOwnershipForwardingInst(SILInstruction *i) {
+    ValueOwnershipKind ownership =
+        OwnershipForwardingMixin::get(i)->getForwardingOwnershipKind();
+
     if (auto *o = dyn_cast<OwnedFirstArgForwardingSingleValueInst>(i)) {
       ValueOwnershipKind kind = OwnershipKind::Owned;
-      require(kind.isCompatibleWith(o->getForwardingOwnershipKind()),
+      require(kind.isCompatibleWith(ownership),
               "OwnedFirstArgForwardingSingleValueInst's ownership kind must be "
               "compatible with owned");
     }
 
     if (auto *o = dyn_cast<GuaranteedFirstArgForwardingSingleValueInst>(i)) {
       ValueOwnershipKind kind = OwnershipKind::Guaranteed;
-      require(kind.isCompatibleWith(o->getForwardingOwnershipKind()),
+      require(kind.isCompatibleWith(ownership),
               "GuaranteedFirstArgForwardingSingleValueInst's ownership kind "
               "must be compatible with guaranteed");
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1003,7 +1003,7 @@ public:
     // Verify that the `isPhiArgument` property is sound:
     // - Phi arguments come from branches.
     // - Non-phi arguments have a single predecessor.
-    assert(arg->isPhiArgument() && "precondition");
+    assert(arg->isPhi() && "precondition");
     for (SILBasicBlock *predBB : arg->getParent()->getPredecessorBlocks()) {
       auto *TI = predBB->getTerminator();
       if (F.hasOwnership()) {
@@ -1015,7 +1015,7 @@ public:
                 "All phi argument inputs must be from branches.");
       }
     }
-    if (arg->isPhiArgument() && prohibitAddressPhis()) {
+    if (arg->isPhi() && prohibitAddressPhis()) {
       // As a property of well-formed SIL, we disallow address-type
       // phis. Supporting them would prevent reliably reasoning about the
       // underlying storage of memory access. This reasoning is important for
@@ -1033,7 +1033,7 @@ public:
     checkLegalType(arg->getFunction(), arg, nullptr);
     checkValueBaseOwnership(arg);
     if (auto *phiArg = dyn_cast<SILPhiArgument>(arg)) {
-      if (phiArg->isPhiArgument())
+      if (phiArg->isPhi())
         visitSILPhiArgument(phiArg);
       else {
         // A non-phi BlockArgument must have a single predecessor unless it is

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -75,8 +75,7 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
     auto *ti = dyn_cast<TermInst>(user);
     if ((ti && !ti->isTransformationTerminator()) ||
         !canOpcodeForwardGuaranteedValues(op) ||
-        1 != count_if(user->getOperandValues(
-                          true /*ignore type dependent operands*/),
+        1 != count_if(user->getNonTypeDependentOperandValues(),
                       [&](SILValue v) {
                         return v.getOwnershipKind() == OwnershipKind::Owned;
                       })) {

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -575,8 +575,8 @@ bool DCE::removeDead() {
         continue;
       }
 
-      if (!arg->isPhiArgument()) {
-        // We cannot delete a non phi arg. If it was @owned, insert a
+      if (!arg->isPhi()) {
+        // We cannot delete a non phi. If it was @owned, insert a
         // destroy_value, because its consuming user has already been marked
         // dead and will be deleted.
         // We do not have to end lifetime of a @guaranteed non phi arg.

--- a/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
+++ b/lib/SILOptimizer/Transforms/PhiArgumentOptimizations.cpp
@@ -106,7 +106,7 @@ static bool hasOnlyNoneOwnershipIncomingValues(SILPhiArgument *phi) {
       if (incomingValue.getOwnershipKind() == OwnershipKind::None)
         continue;
       if (auto *incomingPhi = dyn_cast<SILPhiArgument>(incomingValue)) {
-        if (incomingPhi->isPhiArgument()) {
+        if (incomingPhi->isPhi()) {
           worklist.insert(incomingPhi);
           continue;
         }
@@ -153,7 +153,7 @@ bool RedundantPhiEliminationPass::optimizeArgs(SILBasicBlock *block) {
 
       SILArgument *arg1 = block->getArgument(arg1Idx);
       SILArgument *arg2 = block->getArgument(arg2Idx);
-      if (!arg1->isPhiArgument() || !arg2->isPhiArgument())
+      if (!arg1->isPhi() || !arg2->isPhi())
         continue;
 
       if (valuesAreEqual(arg1, arg2)) {
@@ -343,7 +343,7 @@ void PhiExpansionPass::run() {
   bool changed = false;
   for (SILBasicBlock &block : *getFunction()) {
     for (auto argAndIdx : enumerate(block.getArguments())) {
-      if (!argAndIdx.value()->isPhiArgument())
+      if (!argAndIdx.value()->isPhi())
         continue;
       
       unsigned idx = argAndIdx.index();

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1324,7 +1324,7 @@ TrampolineDest::TrampolineDest(SILBasicBlock *sourceBB,
   for (SILValue branchArg : targetBranch->getArgs()) {
     if (branchArg->getParentBlock() == targetBB) {
       auto *phi = dyn_cast<SILPhiArgument>(branchArg);
-      if (!phi || !phi->isPhiArgument()) {
+      if (!phi || !phi->isPhi()) {
         return;
       }
       branchArg = phi->getIncomingPhiValue(sourceBB);

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -133,7 +133,7 @@ TermInst *swift::deleteEdgeValue(TermInst *branch, SILBasicBlock *destBlock,
 }
 
 void swift::erasePhiArgument(SILBasicBlock *block, unsigned argIndex) {
-  assert(block->getArgument(argIndex)->isPhiArgument()
+  assert(block->getArgument(argIndex)->isPhi()
          && "Only should be used on phi arguments");
   block->eraseArgument(argIndex);
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2244,8 +2244,8 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
       Arguments.push_back(NewArg);
     }
     FullApplySite ApplySite = createReabstractionThunkApply(Builder);
-    SILValue ReturnValue = ApplySite.getSingleDirectResult();
-    assert(ReturnValue && "getSingleDirectResult out of sync with ApplySite?!");
+    SILValue ReturnValue = ApplySite.getPseudoResult();
+    assert(ReturnValue && "getPseudoResult out of sync with ApplySite?!");
     Builder.createReturn(Loc, ReturnValue);
 
     return Thunk;
@@ -2257,8 +2257,8 @@ SILFunction *ReabstractionThunkGenerator::createThunk() {
 
   FullApplySite ApplySite = createReabstractionThunkApply(Builder);
 
-  SILValue ReturnValue = ApplySite.getSingleDirectResult();
-  assert(ReturnValue && "getSingleDirectResult out of sync with ApplySite?!");
+  SILValue ReturnValue = ApplySite.getPseudoResult();
+  assert(ReturnValue && "getPseudoResult out of sync with ApplySite?!");
 
   if (ReturnValueAddr) {
     // Need to store the direct results to the original indirect address.

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -216,9 +216,11 @@ bool swift::hasOnlyEndOfScopeOrEndOfLifetimeUses(SILInstruction *inst) {
     for (Operand *use : result->getUses()) {
       SILInstruction *user = use->getUser();
       bool isDebugUser = user->isDebugInstruction();
-      if (!isa<DestroyValueInst>(user) && !isa<EndLifetimeInst>(user) &&
-          !isEndOfScopeMarker(user) && !isDebugUser)
+      if (!isa<DestroyValueInst>(user) && !isa<EndLifetimeInst>(user)
+          && !isa<DeallocStackInst>(user) && !isEndOfScopeMarker(user)
+          && !isDebugUser) {
         return false;
+      }
       // Include debug uses only in Onone mode.
       if (isDebugUser && inst->getFunction()->getEffectiveOptimizationMode() <=
                              OptimizationMode::NoOptimization)

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -22,3 +22,17 @@ func test<T>(_ t : T) {
   let a = S(a: t)
   a.foo()
 }
+
+func use<T>(_ t : T) {}
+
+// CHECK-SIL: sil hidden @$s16debug_value_addr11GenericSelfV1xACyxGx_tcfC : $@convention(method) <T> (@in T, @thin GenericSelf<T>.Type) -> GenericSelf<T> {
+// CHECK-SIL: bb0(%0 : $*T, %1 : $@thin GenericSelf<T>.Type):
+// CHECK-SIL-NEXT:  alloc_stack [lexical] $GenericSelf<T>, var, name "self", implicit, loc {{.*}}
+// CHECK-SIL-NEXT:  debug_value %0 : $*T, let, name "x", argno 1, expr op_deref, loc {{.*}}
+struct GenericSelf<T> {
+  init(x: T) {
+    // 'self' is a valid debug variable here even though there is
+    // nothing to initialize (the dead alloc_stack cannot be removed).
+    use(x)
+  }
+}


### PR DESCRIPTION
This large collection of very small and hopefully obvious changes to the SIL API and SIL verification was extracted from a rewrite of the address lowering pass. Merging this separately to simplify subsequent PRs for the opaque SIL values feature.