### PR TITLE
ABIChecker: teach ABI descriptor JSON to also keep track of constant values known at compile-time

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -66,6 +66,7 @@ namespace api {
 const uint8_t DIGESTER_JSON_VERSION = 7; // push SDKNodeRoot to lower-level
 const uint8_t DIGESTER_JSON_DEFAULT_VERSION = 0; // Use this version number for files before we have a version number in json.
 const StringRef ABIRootKey = "ABIRoot";
+const StringRef ConstValuesKey = "ConstValues";
 
 class SDKNode;
 typedef SDKNode* NodePtr;
@@ -737,6 +738,8 @@ struct TypeInitInfo {
   StringRef ValueOwnership;
 };
 
+struct PayLoad;
+
 class SwiftDeclCollector: public VisibleDeclConsumer {
   SDKContext &Ctx;
   SDKNode *RootNode;
@@ -757,7 +760,7 @@ public:
 
   // Serialize the content of all roots to a given file using JSON format.
   void serialize(StringRef Filename);
-  static void serialize(StringRef Filename, SDKNode *Root);
+  static void serialize(StringRef Filename, SDKNode *Root, PayLoad otherInfo);
 
   // After collecting decls, either from imported modules or from a previously
   // serialized JSON file, using this function to get the root of the SDK.
@@ -806,6 +809,7 @@ SDKNodeRoot *getSDKNodeRoot(SDKContext &SDKCtx,
 
 SDKNodeRoot *getEmptySDKNodeRoot(SDKContext &SDKCtx);
 
+void dumpSDKRoot(SDKNodeRoot *Root, PayLoad load, StringRef OutputFile);
 void dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile);
 
 int dumpSDKContent(const CompilerInvocation &InitInvok,

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -746,6 +746,9 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
     } else if (keyString == ABIRootKey) {
       Result = constructSDKNode(Ctx,
         cast<llvm::yaml::MappingNode>(Pair.getValue()));
+    } else if (keyString == ConstValuesKey) {
+      // We don't need to consume the const values from the compiler-side
+      Pair.skip();
     } else {
       Ctx.diagnose(Pair.getKey(), diag::sdk_node_unrecognized_key,
                               keyString);
@@ -2215,7 +2218,80 @@ static parseJsonEmit(SDKContext &Ctx, StringRef FileName) {
   }
   return {std::move(FileBufOrErr.get()), Result};
 }
+enum class ConstKind: uint8_t {
+  String = 0,
+  Int,
+};
+
+struct ConstExprInfo {
+  StringRef filePath;
+  ConstKind kind;
+  unsigned offset = 0;
+  unsigned length = 0;
+  StringRef value;
+  ConstExprInfo(StringRef filePath, ConstKind kind, unsigned offset,
+                unsigned length, StringRef value):
+    filePath(filePath), kind(kind), offset(offset), length(length), value(value) {}
+  ConstExprInfo() = default;
+};
+
+class ConstExtractor: public ASTWalker {
+  SDKContext &SCtx;
+  ASTContext &Ctx;
+  SourceManager &SM;
+  std::vector<ConstExprInfo> allConsts;
+
+  void record(Expr *E, ConstKind kind, StringRef Value) {
+    auto startLoc = E->getStartLoc();
+    // Asserts?
+    if (startLoc.isInvalid())
+      return;
+    auto endLoc = E->getEndLoc();
+    assert(endLoc.isValid());
+    endLoc = Lexer::getLocForEndOfToken(SM, endLoc);
+    auto bufferId = SM.findBufferContainingLoc(startLoc);
+    auto length = SM.getByteDistance(startLoc, endLoc);
+    auto file = SM.getIdentifierForBuffer(bufferId);
+    auto offset = SM.getLocOffsetInBuffer(startLoc, bufferId);
+    allConsts.emplace_back(file, kind, offset, length, Value);
+  }
+
+  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    if (E->isSemanticallyConstExpr()) {
+      if (auto *SL = dyn_cast<StringLiteralExpr>(E)) {
+        record(SL, ConstKind::String, SL->getValue());
+      }
+    }
+    return { true, E };
+  }
+public:
+  ConstExtractor(SDKContext &SCtx, ASTContext &Ctx): SCtx(SCtx), Ctx(Ctx),
+    SM(Ctx.SourceMgr) {}
+  void extract(ModuleDecl *MD) { MD->walk(*this); }
+  std::vector<ConstExprInfo> &getAllConstValues() { return allConsts; }
+};
 } // End of anonymous namespace
+
+template <> struct swift::json::ObjectTraits<ConstExprInfo> {
+  static void mapping(Output &out, ConstExprInfo &info) {
+    out.mapRequired("filePath", info.filePath);
+    StringRef kind;
+    switch(info.kind) {
+#define CASE(X) case ConstKind::X: kind = #X; break;
+    CASE(String)
+    CASE(Int)
+#undef CASE
+    }
+    out.mapRequired("kind", kind);
+    out.mapRequired("offset", info.offset);
+    out.mapRequired("length", info.length);
+    out.mapRequired("value", info.value);
+  }
+};
+
+struct swift::ide::api::PayLoad {
+  std::vector<ConstExprInfo> *allContsValues = nullptr;
+};
 
 // Construct all roots vector from a given file where a forest was
 // previously dumped.
@@ -2225,7 +2301,8 @@ void SwiftDeclCollector::deSerialize(StringRef Filename) {
 }
 
 // Serialize the content of all roots to a given file using JSON format.
-void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root) {
+void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root,
+                                   PayLoad OtherInfo) {
   std::error_code EC;
   llvm::raw_fd_ostream fs(Filename, EC, llvm::sys::fs::OF_None);
   json::Output yout(fs);
@@ -2233,12 +2310,15 @@ void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root) {
   SDKNodeRoot &root = *static_cast<SDKNodeRoot*>(Root);
   yout.beginObject();
   yout.mapRequired(ABIRootKey, root);
+  if (auto *constValues = OtherInfo.allContsValues) {
+    yout.mapRequired(ConstValuesKey, *constValues);
+  }
   yout.endObject();
 }
 
 // Serialize the content of all roots to a given file using JSON format.
 void SwiftDeclCollector::serialize(StringRef Filename) {
-  SwiftDeclCollector::serialize(Filename, RootNode);
+  SwiftDeclCollector::serialize(Filename, RootNode, PayLoad());
 }
 
 SDKNodeRoot *
@@ -2304,14 +2384,19 @@ swift::ide::api::getSDKNodeRoot(SDKContext &SDKCtx,
   return Collector.getSDKRoot();
 }
 
-void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile) {
+void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, PayLoad load,
+                                  StringRef OutputFile) {
   assert(Root);
   auto Opts = Root->getSDKContext().getOpts();
   if (Opts.Verbose)
     llvm::errs() << "Dumping SDK...\n";
-  SwiftDeclCollector::serialize(OutputFile, Root);
+  SwiftDeclCollector::serialize(OutputFile, Root, load);
   if (Opts.Verbose)
     llvm::errs() << "Dumped to "<< OutputFile << "\n";
+}
+
+void swift::ide::api::dumpSDKRoot(SDKNodeRoot *Root, StringRef OutputFile) {
+  dumpSDKRoot(Root, PayLoad(), OutputFile);
 }
 
 int swift::ide::api::dumpSDKContent(const CompilerInvocation &InitInvok,
@@ -2356,7 +2441,11 @@ void swift::ide::api::dumpModuleContent(ModuleDecl *MD, StringRef OutputFile,
   SDKContext ctx(opts);
   SwiftDeclCollector collector(ctx);
   collector.lookupVisibleDecls({MD});
-  dumpSDKRoot(collector.getSDKRoot(), OutputFile);
+  ConstExtractor extractor(ctx, MD->getASTContext());
+  extractor.extract(MD);
+  PayLoad payload;
+  payload.allContsValues = &extractor.getAllConstValues();
+  dumpSDKRoot(collector.getSDKRoot(), payload, OutputFile);
 }
 
 int swift::ide::api::findDeclUsr(StringRef dumpPath, CheckerOptions Opts) {

--- a/test/api-digester/const_values.swift
+++ b/test/api-digester/const_values.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: echo "public func foo() { let a = \"abc\" }" > %t/t1.swift
+// RUN: echo "public func bar() { let a = \"def\" }" > %t/t2.swift
+// RUN: %target-swift-frontend -emit-module %t/t1.swift %t/t2.swift -o %t/Foo.swiftmodule -emit-abi-descriptor-path %t/abi.json
+// RUN: %api-digester -deserialize-sdk -input-paths %t/abi.json -o %t.result
+
+// RUN: %FileCheck %s < %t/abi.json
+
+// CHECK: "kind": "String"
+// CHECK: "value": "abc"
+// CHECK: "kind": "String"
+// CHECK: "value": "def"


### PR DESCRIPTION
Emitted at the emit-module step, ABI descriptor is of an entensible JSON format. This patch sets
up a segment in the file to also keep track of all compile-time constant values for other tools
to consume. As the initial step, we only keep track of string literals in the source files.
