### PR TITLE
Disable implicit Sendable warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,26 +103,6 @@ Swift 5.6
   }
   ```
 
-* [SE-0302][]:
-
-  Swift will now produce warnings to indicate potential data races when
-  non-`Sendable` types are passed across actor or task boundaries. For
-  example:
-
-  ```swift
-  class MyCounter {
-    var value = 0
-  }
-
-  func f() -> MyCounter {
-    let counter = MyCounter()
-    Task {
-      counter.value += 1  // warning: capture of non-Sendable type 'MyCounter'
-    }
-    return counter
-  }
-  ```
-
 * [SE-0331][]:
 
   The conformance of the unsafe pointer types (e.g., `UnsafePointer`,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -749,6 +749,14 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
 
   auto defaultBehavior = defaultDiagnosticBehavior();
 
+  // If we're in Swift 5 without -warn-concurrency, suppress the diagnostic
+  // entirely. This is the partial rollback of SE-0302
+  ASTContext &ctx = fromDC->getASTContext();
+  if (!ctx.isSwiftVersionAtLeast(6) && !ctx.LangOpts.WarnConcurrency &&
+      (!conformanceCheck ||
+       *conformanceCheck == SendableCheck::ImpliedByStandardProtocol))
+    defaultBehavior = DiagnosticBehavior::Ignore;
+
   // If we are checking an implicit Sendable conformance, don't suppress
   // diagnostics for declarations in the same module. We want them so make
   // enclosing inferred types non-Sendable.
@@ -775,6 +783,15 @@ static bool diagnoseSingleNonSendableType(
     behavior = fromContext.diagnosticBehavior(nominal);
   } else {
     behavior = fromContext.defaultDiagnosticBehavior();
+
+    // If we're in Swift 5 without -warn-concurrency, suppress the diagnostic
+    // entirely. This is the partial rollback of SE-0302
+    ASTContext &ctx = fromContext.fromDC->getASTContext();
+    if (!ctx.isSwiftVersionAtLeast(6) && !ctx.LangOpts.WarnConcurrency &&
+        (!fromContext.conformanceCheck ||
+         *fromContext.conformanceCheck ==
+            SendableCheck::ImpliedByStandardProtocol))
+      behavior = DiagnosticBehavior::Ignore;
   }
 
   bool wasSuppressed = diagnose(type, behavior);

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -89,7 +89,6 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Sendability ------------------------------------------------------------
 class NotSendable { }
-// expected-note@-1{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
 @available(SwiftStdlib 5.1, *)
 func test_nonsendableContinuation() async throws {
@@ -99,7 +98,7 @@ func test_nonsendableContinuation() async throws {
 
   let _: NotSendable = try await withUnsafeThrowingContinuation { continuation in
     Task {
-      continuation.resume(returning: NotSendable()) // expected-warning{{capture of 'continuation' with non-sendable type 'UnsafeContinuation<NotSendable, Error>' in a `@Sendable` closure}}
+      continuation.resume(returning: NotSendable())
     }
   }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -11,7 +11,7 @@ extension NS1: Sendable { }
 // expected-note@-1 4{{conformance of 'NS1' to 'Sendable' has been explicitly marked unavailable here}}
 
 @available(SwiftStdlib 5.1, *)
-struct NS2 { // expected-note{{consider making struct 'NS2' conform to the 'Sendable' protocol}}
+struct NS2 {
   var ns1: NS1
 }
 
@@ -22,7 +22,7 @@ struct NS3 { }
 extension NS3: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
-class NS4 { } // expected-note{{class 'NS4' does not conform to the 'Sendable' protocol}}
+class NS4 { }
 
 @available(SwiftStdlib 5.1, *)
 func acceptCV<T: Sendable>(_: T) { }
@@ -53,12 +53,11 @@ func testCV(
 ) async {
   acceptCV(ns1) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
   acceptCV(ns1array) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
-  acceptCV(ns2) // expected-warning{{type 'NS2' does not conform to the 'Sendable' protocol}}
+  acceptCV(ns2)
   acceptCV(ns3) // expected-warning{{conformance of 'NS3' to 'Sendable' is only available in macOS 11.0 or newer}}
   // expected-note@-1{{add 'if #available' version check}}
-  acceptCV(ns4) // expected-warning{{type 'NS4' does not conform to the 'Sendable' protocol}}
-  acceptCV(fn) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
-  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptCV(ns4)
+  acceptCV(fn)
   acceptSendableFn(fn) // expected-error{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
 }
 

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -15,7 +15,6 @@ actor A {
 func testA(a: A) async {
   _ = await a.f() // CHECK: warning: cannot call function returning non-sendable type '[StrictStruct : NonStrictClass]' across actors}}
   // CHECK: note: struct 'StrictStruct' does not conform to the 'Sendable' protocol
-  // CHECK: note: class 'NonStrictClass' does not conform to the 'Sendable' protocol
 }
 
 extension NonStrictStruct: @unchecked Sendable { }

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -12,7 +12,7 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { } // expected-note {{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct MyType {
   var nsc: NonStrictClass
@@ -29,7 +29,7 @@ struct MyType3 {
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3) async {
   Task {
-    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(ns)
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2)
     print(mt3)

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -12,22 +12,22 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { }
 
 struct MyType {
   var nsc: NonStrictClass
 }
 
-struct MyType2 { // expected-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
+struct MyType2 {
   var nsc: NonStrictClass
   var ns: NS
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2) async {
   Task {
-    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(ns)
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
-    print(mt2) // expected-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
+    print(mt2)
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -12,7 +12,7 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct MyType {
   var nsc: NonStrictClass
@@ -25,7 +25,7 @@ struct MyType2: Sendable {
 
 func testA(ns: NS, mt: MyType, mt2: MyType2) async {
   Task {
-    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(ns)
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2)
   }


### PR DESCRIPTION
On-by-default Sendable warnings are still a bit too noisy, so eliminate
them except when we have explicit Sendable conformances. They can be
requested explicitly with `-warn-concurrency`.

Fixes rdar://88606724.
