### PR TITLE
Update what seems like an outdated comment

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the ASTNode, which is a union of Stmt, Expr, Decl,
-// Pattern, TypeRepr, StmtCondition, and CaseLabelItem
+// Pattern, TypeRepr, StmtCondition, and CaseLabelItem.
 //
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the ASTNode, which is a union of Stmt, Expr, and Decl.
+// This file defines the ASTNode, which is a union of Stmt, Expr, Decl,
+// Pattern, TypeRepr, StmtCondition, and CaseLabelItem
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Totally minor, but I was taking a look at the source for educational purposes and noticed that it seems ASTNode evolved to be a union of a few additional types without the file comment being updated.   Updated to reflect the code, if I understand it correctly.