### PR TITLE
Use Swift.def to define enums and switch cases for swift5 reflection sections

### DIFF
--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -14,15 +14,9 @@ namespace swift {
 
 /// Represents the nine reflection sections used by Swift
 enum ReflectionSectionKind : uint8_t {
-  fieldmd,
-  assocty,
-  builtin,
-  capture,
-  typeref,
-  reflstr,
-  conform,
-  protocs,
-  acfuncs,
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF) KIND,
+#include "llvm/BinaryFormat/Swift.def"
+#undef HANDLE_SWIFT_SECTION
 };
 
 /// Abstract base class responsible for providing the correct reflection section
@@ -43,24 +37,11 @@ class SwiftObjectFileFormatMachO : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
-    case fieldmd:
-      return "__swift5_fieldmd";
-    case assocty:
-      return "__swift5_assocty";
-    case builtin:
-      return "__swift5_builtin";
-    case capture:
-      return "__swift5_capture";
-    case typeref:
-      return "__swift5_typeref";
-    case reflstr:
-      return "__swift5_reflstr";
-    case conform:
-      return "__swift5_proto";
-    case protocs:
-      return "__swift5_protos";
-    case acfuncs:
-      return "__swift5_acfuncs";
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
+  case KIND:                                                                   \
+    return MACHO;
+#include "llvm/BinaryFormat/Swift.def"
+#undef HANDLE_SWIFT_SECTION
     }
     llvm_unreachable("Section type not found.");
   }
@@ -78,24 +59,11 @@ class SwiftObjectFileFormatELF : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
-    case fieldmd:
-      return "swift5_fieldmd";
-    case assocty:
-      return "swift5_assocty";
-    case builtin:
-      return "swift5_builtin";
-    case capture:
-      return "swift5_capture";
-    case typeref:
-      return "swift5_typeref";
-    case reflstr:
-      return "swift5_reflstr";
-    case conform:
-      return "swift5_protocol_conformances";
-    case protocs:
-      return "swift5_protocols";
-    case acfuncs:
-      return "swift5_accessible_functions";
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
+  case KIND:                                                                   \
+    return ELF;
+#include "llvm/BinaryFormat/Swift.def"
+#undef HANDLE_SWIFT_SECTION
     }
     llvm_unreachable("Section type not found.");
   }
@@ -110,24 +78,11 @@ class SwiftObjectFileFormatCOFF : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
-    case fieldmd:
-      return ".sw5flmd";
-    case assocty:
-      return ".sw5asty";
-    case builtin:
-      return ".sw5bltn";
-    case capture:
-      return ".sw5cptr";
-    case typeref:
-      return ".sw5tyrf";
-    case reflstr:
-      return ".sw5rfst";
-    case conform:
-      return ".sw5prtc$B";
-    case protocs:
-      return ".sw5prt$B";
-    case acfuncs:
-      return ".sw5acfn$B";
+#define HANDLE_SWIFT_SECTION(KIND, MACHO, ELF, COFF)                           \
+  case KIND:                                                                   \
+    return COFF;
+#include "llvm/BinaryFormat/Swift.def"
+#undef HANDLE_SWIFT_SECTION
     }
     llvm_unreachable("Section  not found.");
   }


### PR DESCRIPTION
With 698e04780b5560bbe25dd87ecec77fc381afd770 a Swift.def file has been defined in llvm-project to make defining the different swift5 reflection sections easier.

This change just updates ObjectFile.h to use that .def file