### PR TITLE
[ModuleCache] Disable flaky module-cache-diagnostics test on Windows

### DIFF
--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/modulecache)
-//
+
+// UNSUPPORTED: OS=windows-msvc
+// This test is flaky on Windows. rdar://88830153 SR-15869
+
 // Setup builds a module TestModule that depends on OtherModule and LeafModule (built from other.swift and leaf.swift).
 // During setup, input and intermediate mtimes are all set to a constant 'old' time (long in the past).
 //


### PR DESCRIPTION
This test is flaky on Windows, it appears to raise the expected error in a swiftinterface file instead of the local swift test file.