### PR TITLE
[NFC] Split up the "special convention" for runtime async functions

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -159,8 +159,7 @@ namespace irgen {
     }
   };
 
-  /// A function pointer value.
-  class FunctionPointer {
+  class FunctionPointerKind {
   public:
     enum class BasicKind {
       Function,
@@ -179,85 +178,124 @@ namespace irgen {
       DistributedExecuteTarget,
     };
 
-    class Kind {
-      static constexpr unsigned SpecialOffset = 2;
-      unsigned value;
-    public:
-      static constexpr BasicKind Function =
-        BasicKind::Function;
-      static constexpr BasicKind AsyncFunctionPointer =
-        BasicKind::AsyncFunctionPointer;
+  private:
+    static constexpr unsigned SpecialOffset = 2;
+    unsigned value;
+  public:
+    static constexpr BasicKind Function =
+      BasicKind::Function;
+    static constexpr BasicKind AsyncFunctionPointer =
+      BasicKind::AsyncFunctionPointer;
 
-      Kind(BasicKind kind) : value(unsigned(kind)) {}
-      Kind(SpecialKind kind) : value(unsigned(kind) + SpecialOffset) {}
-      Kind(CanSILFunctionType fnType)
-        : Kind(fnType->isAsync() ? BasicKind::AsyncFunctionPointer
-                                 : BasicKind::Function) {}
+    FunctionPointerKind(BasicKind kind)
+      : value(unsigned(kind)) {}
+    FunctionPointerKind(SpecialKind kind)
+      : value(unsigned(kind) + SpecialOffset) {}
+    FunctionPointerKind(CanSILFunctionType fnType)
+      : FunctionPointerKind(fnType->isAsync()
+                              ? BasicKind::AsyncFunctionPointer
+                              : BasicKind::Function) {}
 
-      BasicKind getBasicKind() const {
-        return value < SpecialOffset ? BasicKind(value) : BasicKind::Function;
-      }
-      bool isAsyncFunctionPointer() const {
-        return value == unsigned(BasicKind::AsyncFunctionPointer);
-      }
+    static FunctionPointerKind defaultSync() {
+      return BasicKind::Function;
+    }
+    static FunctionPointerKind defaultAsync() {
+      return BasicKind::AsyncFunctionPointer;
+    }
 
-      bool isSpecial() const {
-        return value >= SpecialOffset;
-      }
-      SpecialKind getSpecialKind() const {
-        assert(isSpecial());
-        return SpecialKind(value - SpecialOffset);
-      }
-      
-      bool isSpecialAsyncLet() const {
-        if (!isSpecial()) return false;
-        switch (getSpecialKind()) {
-        case SpecialKind::AsyncLetGet:
-        case SpecialKind::AsyncLetGetThrowing:
-        case SpecialKind::AsyncLetFinish:
-          return true;
+    BasicKind getBasicKind() const {
+      return value < SpecialOffset ? BasicKind(value) : BasicKind::Function;
+    }
+    bool isAsyncFunctionPointer() const {
+      return value == unsigned(BasicKind::AsyncFunctionPointer);
+    }
 
-        case SpecialKind::TaskFutureWaitThrowing:
-        case SpecialKind::TaskFutureWait:
-        case SpecialKind::AsyncLetWait:
-        case SpecialKind::AsyncLetWaitThrowing:
-        case SpecialKind::TaskGroupWaitNext:
-        case SpecialKind::DistributedExecuteTarget:
-          return false;
-        }
-        
-        return false;
-      }
+    bool isSpecial() const {
+      return value >= SpecialOffset;
+    }
+    SpecialKind getSpecialKind() const {
+      assert(isSpecial());
+      return SpecialKind(value - SpecialOffset);
+    }
 
-      /// Should we suppress the generic signature from the given function?
-      ///
-      /// This is a micro-optimization we apply to certain special functions
-      /// that we know don't need generics.
-      bool useSpecialConvention() const {
-        if (!isSpecial()) return false;
 
-        switch (getSpecialKind()) {
-        case SpecialKind::TaskFutureWaitThrowing:
-        case SpecialKind::TaskFutureWait:
-        case SpecialKind::AsyncLetWait:
-        case SpecialKind::AsyncLetWaitThrowing:
-        case SpecialKind::AsyncLetGet:
-        case SpecialKind::AsyncLetGetThrowing:
-        case SpecialKind::AsyncLetFinish:
-        case SpecialKind::TaskGroupWaitNext:
-        case SpecialKind::DistributedExecuteTarget:
-          return true;
-        }
-        llvm_unreachable("covered switch");
-      }
+    /// Given that this is an async function, does it have a
+    /// statically-specified size for its async context?
+    ///
+    /// Returning a non-None value is necessary for special functions
+    /// defined in the runtime.  Without this, we'll attempt to load
+    /// the context size from an async FP symbol which the runtime
+    /// doesn't actually emit.
+    Optional<Size> getStaticAsyncContextSize(IRGenModule &IGM) const;
 
-      friend bool operator==(Kind lhs, Kind rhs) {
-        return lhs.value == rhs.value;
+    /// Given that this is an async function, should we pass the
+    /// continuation function pointer and context directly to it
+    /// rather than building a frame?
+    ///
+    /// This is a micro-optimization that is reasonable for functions
+    /// that are expected to return immediately in a common fast path.
+    /// Other functions should not do this.
+    bool shouldPassContinuationDirectly() const {
+      if (!isSpecial()) return false;
+
+      switch (getSpecialKind()) {
+      case SpecialKind::TaskFutureWaitThrowing:
+      case SpecialKind::TaskFutureWait:
+      case SpecialKind::AsyncLetWait:
+      case SpecialKind::AsyncLetWaitThrowing:
+      case SpecialKind::AsyncLetGet:
+      case SpecialKind::AsyncLetGetThrowing:
+      case SpecialKind::AsyncLetFinish:
+      case SpecialKind::TaskGroupWaitNext:
+      case SpecialKind::DistributedExecuteTarget:
+        return true;
       }
-      friend bool operator!=(Kind lhs, Kind rhs) {
-        return !(lhs == rhs);
+      llvm_unreachable("covered switch");
+    }
+
+    /// Should we suppress passing arguments associated with the generic
+    /// signature from the given function?
+    ///
+    /// This is a micro-optimization for certain runtime functions that
+    /// are known to not need the generic arguments, probably because
+    /// they've already been stored elsewhere.
+    ///
+    /// This may only work for async function types right now.  If so,
+    /// that's a totally unnecessary restriction which should be easy
+    /// to lift, if you have a sync runtime function that would benefit
+    /// from this.
+    bool shouldSuppressPolymorphicArguments() const {
+      if (!isSpecial()) return false;
+
+      switch (getSpecialKind()) {
+      case SpecialKind::TaskFutureWaitThrowing:
+      case SpecialKind::TaskFutureWait:
+      case SpecialKind::AsyncLetWait:
+      case SpecialKind::AsyncLetWaitThrowing:
+      case SpecialKind::AsyncLetGet:
+      case SpecialKind::AsyncLetGetThrowing:
+      case SpecialKind::AsyncLetFinish:
+      case SpecialKind::TaskGroupWaitNext:
+      case SpecialKind::DistributedExecuteTarget:
+        return true;
       }
-    };
+      llvm_unreachable("covered switch");
+    }
+
+    friend bool operator==(FunctionPointerKind lhs, FunctionPointerKind rhs) {
+      return lhs.value == rhs.value;
+    }
+    friend bool operator!=(FunctionPointerKind lhs, FunctionPointerKind rhs) {
+      return !(lhs == rhs);
+    }
+  };
+
+  /// A function pointer value.
+  class FunctionPointer {
+  public:
+    using Kind = FunctionPointerKind;
+    using BasicKind = Kind::BasicKind;
+    using SpecialKind = Kind::SpecialKind;
 
   private:
     Kind kind;
@@ -388,11 +426,15 @@ namespace irgen {
     /// Form a FunctionPointer whose Kind is ::Function.
     FunctionPointer getAsFunction(IRGenFunction &IGF) const;
 
-    bool useStaticContextSize() const {
-      return !kind.isAsyncFunctionPointer();
+    Optional<Size> getStaticAsyncContextSize(IRGenModule &IGM) const {
+      return kind.getStaticAsyncContextSize(IGM);
     }
-
-    bool useSpecialConvention() const { return kind.useSpecialConvention(); }
+    bool shouldPassContinuationDirectly() const {
+      return kind.shouldPassContinuationDirectly();
+    }
+    bool shouldSuppressPolymorphicArguments() const {
+      return kind.shouldSuppressPolymorphicArguments();
+    }
   };
 
   class Callee {
@@ -456,7 +498,15 @@ namespace irgen {
       return Fn.getSignature();
     }
 
-    bool useSpecialConvention() const { return Fn.useSpecialConvention(); }
+    Optional<Size> getStaticAsyncContextSize(IRGenModule &IGM) const {
+      return Fn.getStaticAsyncContextSize(IGM);
+    }
+    bool shouldPassContinuationDirectly() const {
+      return Fn.shouldPassContinuationDirectly();
+    }
+    bool shouldSuppressPolymorphicArguments() const {
+      return Fn.shouldSuppressPolymorphicArguments();
+    }
 
     /// If this callee has a value for the Swift context slot, return
     /// it; otherwise return non-null.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -88,30 +88,24 @@ AsyncContextLayout irgen::getAsyncContextLayout(IRGenModule &IGM,
       IGM.getSILModule(), forwardingSubstitutionMap,
       IGM.getMaximalTypeExpansionContext());
   auto layout = getAsyncContextLayout(
-      IGM, originalType, substitutedType, forwardingSubstitutionMap,
-      /*useSpecialConvention*/ false,
-      FunctionPointer::Kind(FunctionPointer::BasicKind::AsyncFunctionPointer));
+      IGM, originalType, substitutedType, forwardingSubstitutionMap);
   return layout;
+}
+
+static Size getAsyncContextHeaderSize(IRGenModule &IGM) {
+  return 2 * IGM.getPointerSize() + Size(4);
 }
 
 AsyncContextLayout irgen::getAsyncContextLayout(
     IRGenModule &IGM, CanSILFunctionType originalType,
-    CanSILFunctionType substitutedType, SubstitutionMap substitutionMap,
-    bool useSpecialConvention, FunctionPointer::Kind kind) {
+    CanSILFunctionType substitutedType, SubstitutionMap substitutionMap) {
+  // FIXME: everything about this type is way more complicated than it
+  // needs to be now that we no longer pass and return things in memory
+  // in the async context and therefore the layout is totally static.
+
   SmallVector<const TypeInfo *, 4> typeInfos;
   SmallVector<SILType, 4> valTypes;
-  SmallVector<AsyncContextLayout::ArgumentInfo, 4> paramInfos;
-  SmallVector<SILResultInfo, 4> indirectReturnInfos;
-  SmallVector<SILResultInfo, 4> directReturnInfos;
 
-  SILFunctionConventions fnConv(substitutedType, IGM.getSILModule());
-
-  auto addTaskContinuationFunction = [&]() {
-    auto ty = SILType();
-    auto &ti = IGM.getTaskContinuationFunctionPtrTypeInfo();
-    valTypes.push_back(ty);
-    typeInfos.push_back(&ti);
-  };
   // AsyncContext * __ptrauth_swift_async_context_parent Parent;
   {
     auto ty = SILType();
@@ -122,9 +116,17 @@ AsyncContextLayout irgen::getAsyncContextLayout(
 
   // TaskContinuationFunction * __ptrauth_swift_async_context_resume
   //     ResumeParent;
-  addTaskContinuationFunction();
+  {
+    auto ty = SILType();
+    auto &ti = IGM.getTaskContinuationFunctionPtrTypeInfo();
+    valTypes.push_back(ty);
+    typeInfos.push_back(&ti);
+  }
 
   // AsyncContextFlags Flags;
+  // FIXME: this appears to be dead; we should adjust the layout of
+  // the special async contexts that assume its existence and then
+  // remove it.
   {
     auto ty = SILType::getPrimitiveObjectType(
         BuiltinIntegerType::get(32, IGM.IRGen.SIL.getASTContext())
@@ -134,20 +136,6 @@ AsyncContextLayout irgen::getAsyncContextLayout(
     typeInfos.push_back(&ti);
   }
 
-  // Add storage for data used by runtime entry points.
-  // See TaskFutureWaitAsyncContext.
-  if (kind.isSpecial()) {
-      // This needs to match the layout of TaskFutureWaitAsyncContext.
-      // Add storage for the waiting future's result pointer (OpaqueValue *).
-      auto ty = SILType();
-      auto &ti = IGM.getSwiftContextPtrTypeInfo();
-      // SwiftError *
-      valTypes.push_back(ty);
-      typeInfos.push_back(&ti);
-      // OpaqueValue *successResultPointer
-      valTypes.push_back(ty);
-      typeInfos.push_back(&ti);
-  }
   return AsyncContextLayout(IGM, LayoutStrategy::Optimal, valTypes, typeInfos,
                             originalType, substitutedType, substitutionMap);
 }
@@ -160,15 +148,46 @@ AsyncContextLayout::AsyncContextLayout(
                    fieldTypeInfos, /*typeToFill*/ nullptr),
       originalType(originalType), substitutedType(substitutedType),
       substitutionMap(substitutionMap)  {
-#ifndef NDEBUG
   assert(fieldTypeInfos.size() == fieldTypes.size() &&
          "type infos don't match types");
   assert(this->isFixedLayout());
-#endif
+  assert(this->getSize() == getAsyncContextHeaderSize(IGM));
 }
 
 Alignment IRGenModule::getAsyncContextAlignment() const {
   return Alignment(MaximumAlignment);
+}
+
+Optional<Size>
+FunctionPointerKind::getStaticAsyncContextSize(IRGenModule &IGM) const {
+  if (!isSpecial()) return None;
+
+  auto headerSize = getAsyncContextHeaderSize(IGM);
+  headerSize = headerSize.roundUpToAlignment(IGM.getPointerAlignment());
+
+  switch (getSpecialKind()) {
+  case SpecialKind::TaskFutureWaitThrowing:
+  case SpecialKind::TaskFutureWait:
+  case SpecialKind::AsyncLetWait:
+  case SpecialKind::AsyncLetWaitThrowing:
+  case SpecialKind::AsyncLetGet:
+  case SpecialKind::AsyncLetGetThrowing:
+  case SpecialKind::AsyncLetFinish:
+  case SpecialKind::TaskGroupWaitNext:
+  case SpecialKind::DistributedExecuteTarget:
+    // The current guarantee for all of these functions is the same.
+    // See TaskFutureWaitAsyncContext.
+    //
+    // If you add a new special runtime function, it is highly recommended
+    // that you make calls to it allocate a little more memory than this!
+    // These frames being this small is very arguably a mistake.
+    //
+    // FIXME: if we remove Flags in AsyncContextLayout (and thus from
+    // headerSize), account for it here so that we continue to pass the
+    // right amount of memory.
+    return headerSize + 2 * IGM.getPointerSize();
+  }
+  llvm_unreachable("covered switch");
 }
 
 void IRGenFunction::setupAsync(unsigned asyncContextIndex) {
@@ -386,13 +405,13 @@ namespace {
     bool CanUseSRet = true;
     bool CanUseError = true;
     bool CanUseSelf = true;
-    bool useSpecialConvention;
     unsigned AsyncContextIdx;
     unsigned AsyncResumeFunctionSwiftSelfIdx = 0;
+    FunctionPointerKind FnKind;
 
     SignatureExpansion(IRGenModule &IGM, CanSILFunctionType fnType,
-                       bool useSpecialConvention)
-        : IGM(IGM), FnType(fnType), useSpecialConvention(useSpecialConvention) {
+                       FunctionPointerKind fnKind)
+        : IGM(IGM), FnType(fnType), FnKind(fnKind) {
     }
 
     /// Expand the components of the primary entrypoint of the function type.
@@ -1605,12 +1624,12 @@ void SignatureExpansion::expandParameters() {
   }
 
   // Next, the generic signature.
-  if (hasPolymorphicParameters(FnType) && !useSpecialConvention)
+  if (hasPolymorphicParameters(FnType) &&
+      !FnKind.shouldSuppressPolymorphicArguments())
     expandPolymorphicSignature(IGM, FnType, ParamIRTypes);
-  if (useSpecialConvention) {
-    // Async waiting functions add the resume function pointer, and the context
-    // for the call.
-    // (But skip passing the metadata.)
+
+  // Certain special functions are passed the continuation directly.
+  if (FnKind.shouldPassContinuationDirectly()) {
     ParamIRTypes.push_back(IGM.Int8PtrTy);
     ParamIRTypes.push_back(IGM.SwiftContextPtrTy);
   }
@@ -1772,9 +1791,10 @@ void SignatureExpansion::expandAsyncEntryType() {
   }
 
   // Next, the generic signature.
-  if (hasPolymorphicParameters(FnType) && !useSpecialConvention)
+  if (hasPolymorphicParameters(FnType) &&
+      !FnKind.shouldSuppressPolymorphicArguments())
     expandPolymorphicSignature(IGM, FnType, ParamIRTypes);
-  if (useSpecialConvention) {
+  if (FnKind.shouldPassContinuationDirectly()) {
     // Async waiting functions add the resume function pointer.
     // (But skip passing the metadata.)
     ParamIRTypes.push_back(IGM.Int8PtrTy);
@@ -1908,9 +1928,9 @@ Signature SignatureExpansion::getSignature() {
 
 Signature Signature::getUncached(IRGenModule &IGM,
                                  CanSILFunctionType formalType,
-                                 bool useSpecialConvention) {
+                                 FunctionPointerKind fpKind) {
   GenericContextScope scope(IGM, formalType->getInvocationGenericSignature());
-  SignatureExpansion expansion(IGM, formalType, useSpecialConvention);
+  SignatureExpansion expansion(IGM, formalType, fpKind);
   expansion.expandFunctionType();
   return expansion.getSignature();
 }
@@ -1918,7 +1938,7 @@ Signature Signature::getUncached(IRGenModule &IGM,
 Signature Signature::forCoroutineContinuation(IRGenModule &IGM,
                                               CanSILFunctionType fnType) {
   assert(fnType->isCoroutine());
-  SignatureExpansion expansion(IGM, fnType, /*suppress generics*/false);
+  SignatureExpansion expansion(IGM, fnType, FunctionPointerKind(fnType));
   expansion.expandCoroutineContinuationType();
   return expansion.getSignature();
 }
@@ -1927,28 +1947,25 @@ Signature Signature::forAsyncReturn(IRGenModule &IGM,
                                     CanSILFunctionType fnType) {
   assert(fnType->isAsync());
   GenericContextScope scope(IGM, fnType->getInvocationGenericSignature());
-  SignatureExpansion expansion(IGM, fnType,
-                               /*suppress generics*/ false);
+  SignatureExpansion expansion(IGM, fnType, FunctionPointerKind(fnType));
   expansion.expandAsyncReturnType();
   return expansion.getSignature();
 }
 
 Signature Signature::forAsyncAwait(IRGenModule &IGM, CanSILFunctionType fnType,
-                                   bool useSpecialConvention) {
+                                   FunctionPointerKind fnKind) {
   assert(fnType->isAsync());
   GenericContextScope scope(IGM, fnType->getInvocationGenericSignature());
-  SignatureExpansion expansion(IGM, fnType,
-                               /*suppress generics*/ useSpecialConvention);
+  SignatureExpansion expansion(IGM, fnType, fnKind);
   expansion.expandAsyncAwaitType();
   return expansion.getSignature();
 }
 
 Signature Signature::forAsyncEntry(IRGenModule &IGM, CanSILFunctionType fnType,
-                                   bool useSpecialConvention) {
+                                   FunctionPointerKind fnKind) {
   assert(fnType->isAsync());
   GenericContextScope scope(IGM, fnType->getInvocationGenericSignature());
-  SignatureExpansion expansion(IGM, fnType,
-                               /*suppress generics*/ useSpecialConvention);
+  SignatureExpansion expansion(IGM, fnType, fnKind);
   expansion.expandAsyncEntryType();
   return expansion.getSignature();
 }
@@ -2024,11 +2041,14 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
 std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
     IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
     FunctionPointer functionPointer, llvm::Value *thickContext,
-    std::pair<bool, bool> values, Size initialContextSize) {
+    std::pair<bool, bool> values) {
   assert(values.first || values.second);
   assert(functionPointer.getKind() != FunctionPointer::Kind::Function);
+
   bool emitFunction = values.first;
   bool emitSize = values.second;
+  assert(emitFunction || emitSize);
+
   // Ensure that the AsyncFunctionPointer is not auth'd if it is not used and
   // that it is not auth'd more than once if it is needed.
   //
@@ -2050,12 +2070,22 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
     }
     return *afpPtrValue;
   };
+
   llvm::Value *fn = nullptr;
   if (emitFunction) {
-    if (functionPointer.useStaticContextSize()) {
+    // If the FP is not an async FP, then we just have the direct
+    // address of the async function.  This only happens for special
+    // async functions right now.
+    if (!functionPointer.getKind().isAsyncFunctionPointer()) {
+      assert(functionPointer.getStaticAsyncContextSize(IGF.IGM));
       fn = functionPointer.getRawPointer();
+
+    // If we've opportunistically also emitted the direct address of the
+    // function, always prefer that.
     } else if (auto *function = functionPointer.getRawAsyncFunction()) {
       fn = function;
+
+    // Otherwise, extract the function pointer from the async FP structure.
     } else {
       llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(
           getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
@@ -2064,18 +2094,18 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
           Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
           /*expectedType*/ functionPointer.getFunctionType()->getPointerTo());
     }
+
     if (auto authInfo =
             functionPointer.getAuthInfo().getCorrespondingCodeAuthInfo()) {
       fn = emitPointerAuthSign(IGF, fn, authInfo);
     }
   }
+
   llvm::Value *size = nullptr;
   if (emitSize) {
-    if (functionPointer.useStaticContextSize()) {
-      size = llvm::ConstantInt::get(IGF.IGM.Int32Ty,
-                                    initialContextSize.getValue());
+    if (auto staticSize = functionPointer.getStaticAsyncContextSize(IGF.IGM)) {
+      size = llvm::ConstantInt::get(IGF.IGM.Int32Ty, staticSize->getValue());
     } else {
-      assert(!functionPointer.useStaticContextSize());
       auto *sizePtr = IGF.Builder.CreateStructGEP(
           getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
           getAFPPtr(), 1);
@@ -2330,23 +2360,23 @@ class AsyncCallEmission final : public CallEmission {
   llvm::Value *calleeFunction = nullptr;
   llvm::Value *currentResumeFn = nullptr;
   llvm::Value *thickContext = nullptr;
-  Size initialContextSize = Size(0);
+  Size staticContextSize = Size(0);
   Optional<AsyncContextLayout> asyncContextLayout;
 
   AsyncContextLayout getAsyncContextLayout() {
     if (!asyncContextLayout) {
       asyncContextLayout.emplace(::getAsyncContextLayout(
           IGF.IGM, getCallee().getOrigFunctionType(),
-          getCallee().getSubstFunctionType(), getCallee().getSubstitutions(),
-          getCallee().useSpecialConvention(),
-          getCallee().getFunctionPointer().getKind()));
+          getCallee().getSubstFunctionType(), getCallee().getSubstitutions()));
     }
     return *asyncContextLayout;
   }
 
-  void saveValue(ElementLayout layout, Explosion &explosion, bool isOutlined) {
+  void saveValue(ElementLayout layout, llvm::Value *value, bool isOutlined) {
     Address addr = layout.project(IGF, context, /*offsets*/ llvm::None);
     auto &ti = cast<LoadableTypeInfo>(layout.getType());
+    Explosion explosion;
+    explosion.add(value);
     ti.initialize(IGF, explosion, addr, isOutlined);
   }
   void loadValue(ElementLayout layout, Explosion &explosion) {
@@ -2368,30 +2398,30 @@ public:
     auto layout = getAsyncContextLayout();
     // Allocate space for the async context.
 
-    initialContextSize = Size(0);
-    // Only c++ runtime functions should use the initial context size.
-    if (CurCallee.getFunctionPointer().getKind().isSpecial()) {
-      initialContextSize = layout.getSize();
-    }
     llvm::Value *dynamicContextSize32;
     std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
         IGF, CurCallee.getOrigFunctionType()->getRepresentation(),
-        CurCallee.getFunctionPointer(), thickContext,
-        std::make_pair(true, true), initialContextSize);
+        CurCallee.getFunctionPointer(), thickContext);
     auto *dynamicContextSize =
         IGF.Builder.CreateZExt(dynamicContextSize32, IGF.IGM.SizeTy);
-    contextBuffer = getCallee().useSpecialConvention()
-                        ? emitStaticAllocAsyncContext(IGF, initialContextSize)
-                        : emitAllocAsyncContext(IGF, dynamicContextSize);
+    if (auto staticSize = dyn_cast<llvm::ConstantInt>(dynamicContextSize)) {
+      staticContextSize = Size(staticSize->getZExtValue());
+      assert(!staticContextSize.isZero());
+      contextBuffer = emitStaticAllocAsyncContext(IGF, staticContextSize);
+    } else {
+      contextBuffer = emitAllocAsyncContext(IGF, dynamicContextSize);
+    }
     context = layout.emitCastTo(IGF, contextBuffer.getAddress());
   }
   void end() override {
     assert(contextBuffer.isValid());
     assert(context.isValid());
-    if (getCallee().useSpecialConvention())
-      emitStaticDeallocAsyncContext(IGF, contextBuffer, initialContextSize);
-    else
+    if (getCallee().getStaticAsyncContextSize(IGF.IGM)) {
+      assert(!staticContextSize.isZero());
+      emitStaticDeallocAsyncContext(IGF, contextBuffer, staticContextSize);
+    } else {
       emitDeallocAsyncContext(IGF, contextBuffer);
+    }
     super::end();
   }
   void setFromCallee() override {
@@ -2408,7 +2438,6 @@ public:
         Args[--LastArgWritten] = nullptr;
       }
     }
-    // We store the error pointer in the async context.
 
     llvm::Value *contextPtr = CurCallee.getSwiftContext();
     // Add the data pointer if we have one.
@@ -2427,7 +2456,7 @@ public:
     return FunctionPointer(
         FunctionPointer::Kind::Function, calleeFunction, codeAuthInfo,
         Signature::forAsyncAwait(IGF.IGM, getCallee().getOrigFunctionType(),
-                                 getCallee().useSpecialConvention()));
+                                 getCallee().getFunctionPointer().getKind()));
   }
 
   SILType getParameterType(unsigned index) override {
@@ -2448,9 +2477,10 @@ public:
     // Pass along the indirect result pointers.
     original.transferInto(asyncExplosion, fnConv.getNumIndirectSILResults());
 
-    // Pass the async context.
-    if (getCallee().useSpecialConvention()) {
-      // Pass the caller context.
+    // Pass the async context.  For special direct-continuation functions,
+    // we pass our own async context; otherwise we pass the context
+    // we created.
+    if (getCallee().shouldPassContinuationDirectly()) {
       asyncExplosion.add(IGF.getAsyncContext());
     } else
       asyncExplosion.add(contextBuffer.getAddress());
@@ -2511,40 +2541,42 @@ public:
     super::setArgs(asyncExplosion, false, witnessMetadata);
 
     auto layout = getAsyncContextLayout();
-    // Set caller info into the context.
-    if (!getCallee().useSpecialConvention()) { // caller context
+
+    // Innitialize the async context for returning if we're not using
+    // the special convention which suppresses that.
+    if (!getCallee().shouldPassContinuationDirectly()) {
+      // Set the caller context to the current context.
       Explosion explosion;
-      auto fieldLayout = layout.getParentLayout();
+      auto parentContextField = layout.getParentLayout();
       auto *context = IGF.getAsyncContext();
       if (auto schema = IGF.IGM.getOptions().PointerAuth.AsyncContextParent) {
         Address fieldAddr =
-            fieldLayout.project(IGF, this->context, /*offsets*/ llvm::None);
+            parentContextField.project(IGF, this->context,
+                                       /*offsets*/ llvm::None);
         auto authInfo = PointerAuthInfo::emit(
             IGF, schema, fieldAddr.getAddress(), PointerAuthEntity());
         context = emitPointerAuthSign(IGF, context, authInfo);
       }
-      explosion.add(context);
-      saveValue(fieldLayout, explosion, isOutlined);
-    }
-    if (!getCallee().useSpecialConvention()) { // Return to caller function.
+      saveValue(parentContextField, context, isOutlined);
+
+      // Set the caller resumption function to the resumption function
+      // for this suspension.
       assert(currentResumeFn == nullptr);
-      auto fieldLayout = layout.getResumeParentLayout();
+      auto resumeParentField = layout.getResumeParentLayout();
       currentResumeFn = IGF.Builder.CreateIntrinsicCall(
           llvm::Intrinsic::coro_async_resume, {});
       auto fnVal = currentResumeFn;
       // Sign the pointer.
       if (auto schema = IGF.IGM.getOptions().PointerAuth.AsyncContextResume) {
         Address fieldAddr =
-            fieldLayout.project(IGF, this->context, /*offsets*/ llvm::None);
+            resumeParentField.project(IGF, this->context, /*offsets*/ llvm::None);
         auto authInfo = PointerAuthInfo::emit(
             IGF, schema, fieldAddr.getAddress(), PointerAuthEntity());
         fnVal = emitPointerAuthSign(IGF, fnVal, authInfo);
       }
       fnVal = IGF.Builder.CreateBitCast(fnVal,
                                         IGF.IGM.TaskContinuationFunctionPtrTy);
-      Explosion explosion;
-      explosion.add(fnVal);
-      saveValue(fieldLayout, explosion, isOutlined);
+      saveValue(resumeParentField, fnVal, isOutlined);
     }
   }
   void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
@@ -2655,7 +2687,10 @@ public:
     arguments.push_back(
         IGM.getInt32(paramAttributeFlags));
     arguments.push_back(currentResumeFn);
-    auto resumeProjFn = getCallee().useSpecialConvention()
+    // The special direct-continuation convention will pass our context
+    // when it resumes.  The standard convention passes the callee's
+    // context, so we'll need to pop that off to get ours.
+    auto resumeProjFn = getCallee().shouldPassContinuationDirectly()
                             ? IGF.getOrCreateResumeFromSuspensionFn()
                             : IGF.getOrCreateResumePrjFn();
     arguments.push_back(
@@ -2676,7 +2711,7 @@ public:
     return IGF.emitSuspendAsyncCall(asyncContextIndex, resultTy, arguments);
   }
   llvm::Value *getResumeFunctionPointer() override {
-    assert(getCallee().useSpecialConvention());
+    assert(getCallee().shouldPassContinuationDirectly());
     assert(currentResumeFn == nullptr);
     currentResumeFn =
         IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_async_resume, {});

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -119,9 +119,7 @@ namespace irgen {
   AsyncContextLayout getAsyncContextLayout(IRGenModule &IGM,
                                            CanSILFunctionType originalType,
                                            CanSILFunctionType substitutedType,
-                                           SubstitutionMap substitutionMap,
-                                           bool useSpecialConvention,
-                                           FunctionPointer::Kind kind);
+                                           SubstitutionMap substitutionMap);
 
   /// Given an async function, get the pointer to the function to be called and
   /// the size of the context to be allocated.
@@ -135,8 +133,7 @@ namespace irgen {
   std::pair<llvm::Value *, llvm::Value *> getAsyncFunctionAndSize(
       IRGenFunction &IGF, SILFunctionTypeRepresentation representation,
       FunctionPointer functionPointer, llvm::Value *thickContext,
-      std::pair<bool, bool> values = {true, true},
-      Size initialContextSize = Size(0));
+      std::pair<bool, bool> values = {true, true});
   llvm::CallingConv::ID expandCallingConv(IRGenModule &IGM,
                                      SILFunctionTypeRepresentation convention,
                                      bool isAsync);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -570,7 +570,7 @@ Signature FuncSignatureInfo::getSignature(IRGenModule &IGM) const {
 
   // Update the cache and return.
   TheSignature = Signature::getUncached(IGM, FormalType,
-                                        /*suppress generics*/ false);
+                                        FunctionPointerKind(FormalType));
   assert(TheSignature.isValid());
   return TheSignature;
 }
@@ -595,11 +595,15 @@ getFuncSignatureInfoForLowered(IRGenModule &IGM, CanSILFunctionType type) {
   llvm_unreachable("bad function type representation");
 }
 
+Signature IRGenModule::getSignature(CanSILFunctionType type) {
+  return getSignature(type, FunctionPointerKind(type));
+}
+
 Signature IRGenModule::getSignature(CanSILFunctionType type,
-                                    bool useSpecialConvention) {
-  // Don't bother caching if we've been asked to suppress generics.
-  if (useSpecialConvention)
-    return Signature::getUncached(*this, type, useSpecialConvention);
+                                    FunctionPointerKind kind) {
+  // Don't bother caching if we're working with a special kind.
+  if (kind.isSpecial())
+    return Signature::getUncached(*this, type, kind);
 
   auto &sigInfo = getFuncSignatureInfoForLowered(*this, type);
   return sigInfo.getSignature(*this);
@@ -1071,10 +1075,7 @@ public:
             IGM, subIGF, fwd, staticFnPtr, calleeHasContext, origSig, origType,
             substType, outType, subs, layout, conventions),
         layout(getAsyncContextLayout(
-            subIGF.IGM, origType, substType, subs,
-            staticFnPtr ? staticFnPtr->useSpecialConvention() : false,
-            FunctionPointer::Kind(
-                FunctionPointer::BasicKind::AsyncFunctionPointer))),
+            subIGF.IGM, origType, substType, subs)),
         currentArgumentIndex(outType->getNumParameters()) {}
 
   void begin() override { super::begin(); }
@@ -1087,10 +1088,9 @@ public:
   }
   void mapAsyncParameters(FunctionPointer fnPtr) override {
     llvm::Value *dynamicContextSize32;
-    auto initialContextSize = Size(0);
     std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
         subIGF, origType->getRepresentation(), fnPtr, nullptr,
-        std::make_pair(true, true), initialContextSize);
+        std::make_pair(true, true));
     auto *dynamicContextSize =
         subIGF.Builder.CreateZExt(dynamicContextSize32, subIGF.IGM.SizeTy);
     calleeContextBuffer =
@@ -1162,7 +1162,7 @@ public:
     auto newFnPtr = FunctionPointer(
         FunctionPointer::Kind::Function, fnPtr.getPointer(subIGF), newAuthInfo,
         Signature::forAsyncAwait(subIGF.IGM, origType,
-                                 /*useSpecialConvention*/ false));
+                                 FunctionPointerKind::defaultAsync()));
     auto &Builder = subIGF.Builder;
 
     auto argValues = args.claimAll();
@@ -1269,13 +1269,12 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
 
   IRGenFunction subIGF(IGM, fwd);
   if (origType->isAsync()) {
+    auto fpKind = FunctionPointerKind::defaultAsync();
     auto asyncContextIdx =
-        Signature::forAsyncEntry(IGM, outType, /*useSpecialConvention*/ false)
+        Signature::forAsyncEntry(IGM, outType, fpKind)
             .getAsyncContextIndex();
     asyncLayout.emplace(irgen::getAsyncContextLayout(
-        IGM, origType, substType, subs, /*suppress generics*/ false,
-        FunctionPointer::Kind(
-            FunctionPointer::BasicKind::AsyncFunctionPointer)));
+        IGM, origType, substType, subs));
 
     //auto *calleeAFP = staticFnPtr->getDirectPointer();
     LinkEntity entity = LinkEntity::forPartialApplyForwarder(fwd);
@@ -1375,7 +1374,7 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
   // partially applied argument.
   bool hasPolymorphicParams =
       hasPolymorphicParameters(origType) &&
-      (!staticFnPtr || !staticFnPtr->useSpecialConvention());
+      (!staticFnPtr || !staticFnPtr->shouldSuppressPolymorphicArguments());
   if (!layout && hasPolymorphicParams) {
     assert(conventions.size() == 1);
     // We could have either partially applied an argument from the function

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -118,9 +118,7 @@ IRGenThunk::IRGenThunk(IRGenFunction &IGF, SILDeclRef declRef)
 
   if (isAsync) {
     asyncLayout.emplace(irgen::getAsyncContextLayout(
-        IGF.IGM, origTy, substTy, subMap, /*suppress generics*/ false,
-        FunctionPointer::Kind(
-            FunctionPointer::BasicKind::AsyncFunctionPointer)));
+        IGF.IGM, origTy, substTy, subMap));
   }
 }
 
@@ -251,7 +249,8 @@ void IRGenThunk::emit() {
 
   if (isAsync) {
     auto asyncContextIdx = Signature::forAsyncEntry(
-                               IGF.IGM, origTy, /*useSpecialConvention*/ false)
+                               IGF.IGM, origTy,
+                               FunctionPointerKind::defaultAsync())
                                .getAsyncContextIndex();
 
     auto entity = LinkEntity::forDispatchThunk(declRef);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -135,6 +135,7 @@ namespace irgen {
   class ForeignClassMetadataLayout;
   class ForeignFunctionInfo;
   class FormalType;
+  class FunctionPointerKind;
   class HeapLayout;
   class StructLayout;
   class IRGenDebugInfo;
@@ -1421,8 +1422,9 @@ public:
   void finalizeClangCodeGen();
   void finishEmitAfterTopLevel();
 
+  Signature getSignature(CanSILFunctionType fnType);
   Signature getSignature(CanSILFunctionType fnType,
-                         bool useSpecialConvention = false);
+                         FunctionPointerKind kind);
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -40,6 +40,7 @@ namespace swift {
 
 namespace irgen {
 
+class FunctionPointerKind;
 class IRGenModule;
 
 /// An encapsulation of different foreign calling-convention lowering
@@ -125,7 +126,7 @@ public:
   /// IRGenModule::getSignature(CanSILFunctionType), which is what
   /// clients should generally be using.
   static Signature getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
-                               bool useSpecialConvention);
+                               FunctionPointerKind kind);
 
   /// Compute the signature of a coroutine's continuation function.
   static Signature forCoroutineContinuation(IRGenModule &IGM,
@@ -134,9 +135,9 @@ public:
   static Signature forAsyncReturn(IRGenModule &IGM,
                                   CanSILFunctionType asyncType);
   static Signature forAsyncAwait(IRGenModule &IGM, CanSILFunctionType asyncType,
-                                 bool useSpecialConvention);
+                                 FunctionPointerKind kind);
   static Signature forAsyncEntry(IRGenModule &IGM, CanSILFunctionType asyncType,
-                                 bool useSpecialConvention);
+                                 FunctionPointerKind kind);
 
   llvm::FunctionType *getType() const {
     assert(isValid());


### PR DESCRIPTION
The special convention currently means three things:

1. There is no async FP symbol for the function.  Calls should go directly to the function symbol, and an async context of fixed static size should be allocated.  This is mandatory for calling runtime-provided async functions.

2. The callee context should be allocated but not initialized.  The main context pointer passed should be the caller's context, and the continuation function pointer and callee context should be passed as separate arguments.  The function will resume the continuation function pointer with the caller's context.  This is a micro-optimization appropriate for functions that are expected to frequently return immediately; other functions shouldn't bother.

3. Generic arguments should be suppressed.  This is a microoptimization for certain specific runtime functions where we happen to know that the runtime already stores the appropriate information internally.  Other functions probably don't want this.

Obviously, these different treatments should be split into different predicates so that functions can opt in to different subsets of them.

I've also set the code up so that runtime functions can more easily request a specific static async context size.  Previously, it was a confusingly embedded assumption that the static context size was always exactly two pointers more than the header.