### PR TITLE
Hoist destroys of owned lexical values.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -155,6 +155,10 @@ MoveValueInst *foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,
                                                  DominanceInfo &dominanceTree,
                                                  InstructionDeleter &deleter);
 
+bool hoistDestroysOfOwnedLexicalValue(SILValue const value,
+                                      SILFunction &function,
+                                      InstructionDeleter &deleter);
+
 } // namespace swift
 
 #endif // SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEBORROWSCOPES_H

--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -151,9 +151,9 @@ bool shrinkBorrowScope(
     BeginBorrowInst const &bbi, InstructionDeleter &deleter,
     SmallVectorImpl<CopyValueInst *> &modifiedCopyValueInsts);
 
-bool foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,
-                                       DominanceInfo &dominanceTree,
-                                       InstructionDeleter &deleter);
+MoveValueInst *foldDestroysOfCopiedLexicalBorrow(BeginBorrowInst *bbi,
+                                                 DominanceInfo &dominanceTree,
+                                                 InstructionDeleter &deleter);
 
 } // namespace swift
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -313,7 +313,7 @@ bool swift::findUsesOfSimpleValue(SILValue value,
             if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
               return false;
             }
-            usePoints->push_back(use);
+            usePoints->push_back(end);
             return true;
           })) {
         return false;

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -471,9 +471,15 @@ void CopyPropagation::run() {
       auto folded = foldDestroysOfCopiedLexicalBorrow(bbi, *domTree, deleter);
       if (!folded)
         break;
-      // We don't add the produced move_value instruction to the worklist
-      // because it can't handle propagation.
+      auto hoisted = hoistDestroysOfOwnedLexicalValue(folded, *f, deleter);
+      // Keep running even if the new move's destroys can't be hoisted.
+      (void)hoisted;
       firstRun = false;
+    }
+  }
+  for (auto *argument : f->getArguments()) {
+    if (argument->getOwnershipKind() == OwnershipKind::Owned) {
+      hoistDestroysOfOwnedLexicalValue(argument, *f, deleter);
     }
   }
   deleter.cleanupDeadInstructions();

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(swiftSILOptimizer PRIVATE
   InstOptUtils.cpp
   KeyPathProjector.cpp
   LexicalDestroyFolding.cpp
+  LexicalDestroyHoisting.cpp
   LoadStoreOptUtils.cpp
   LoopUtils.cpp
   OptimizerStatsUtils.cpp

--- a/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
@@ -1,0 +1,363 @@
+//=-- LexicalDestroyHoisting.cpp - Hoist destroy_values to deinit barriers. -=//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+/// Hoist destroys of owned lexical values (owned arguments and the results of
+/// move_value [lexical] instructions) up to deinit barriers.
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Builtins.h"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Analysis/Reachability.h"
+#include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "llvm/ADT/STLExtras.h"
+
+#define DEBUG_TYPE "copy-propagation"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                       MARK: LexicalDestroyHoisting
+//===----------------------------------------------------------------------===//
+
+namespace LexicalDestroyHoisting {
+
+/// The environment within which to hoist.
+struct Context final {
+  /// The owned lexical value whose destroys are to be hoisted.
+  SILValue const &value;
+
+  /// value->getDefiningInstruction()
+  SILInstruction *const definition;
+
+  SILFunction &function;
+
+  InstructionDeleter &deleter;
+
+  Context(SILValue const &value, SILFunction &function,
+          InstructionDeleter &deleter)
+      : value(value), definition(value->getDefiningInstruction()),
+        function(function), deleter(deleter) {
+    assert(value->isLexical());
+    assert(value->getOwnershipKind() == OwnershipKind::Owned);
+  }
+  Context(Context const &) = delete;
+  Context &operator=(Context const &) = delete;
+};
+
+/// How %value gets used.
+struct Usage final {
+  /// Instructions which are users of the simple (i.e. not reborrowed) value.
+  SmallPtrSet<SILInstruction *, 16> users;
+  // The instructions from which the hoisting starts, the destroy_values.
+  llvm::SmallSetVector<SILInstruction *, 4> ends;
+
+  Usage(){};
+  Usage(Usage const &) = delete;
+  Usage &operator=(Usage const &) = delete;
+};
+
+/// Identify users and destroy_values of %value.
+///
+/// returns true if all uses were found
+///         false otherwise
+bool findUsage(Context const &context, Usage &usage) {
+  SmallVector<Operand *, 16> uses;
+  if (!findUsesOfSimpleValue(context.value, &uses)) {
+    // If the value escapes, don't hoist.
+    return false;
+  }
+  for (auto *use : uses) {
+    // Add the destroy_values to the collection of ends so we can seed the data
+    // flow and determine whether any were reused.  They aren't uses over which
+    // we can't hoist though.
+    if (isa<DestroyValueInst>(use->getUser())) {
+      usage.ends.insert(use->getUser());
+    } else {
+      usage.users.insert(use->getUser());
+    }
+  }
+  return true;
+}
+
+/// How destroy_value hoisting is obstructed.
+struct DeinitBarriers final {
+  /// Blocks up to "before the beginning" of which hoisting was able to proceed.
+  BasicBlockSetVector hoistingReachesBeginBlocks;
+
+  /// Blocks to "after the end" of which hoisting was able to proceed.
+  BasicBlockSet hoistingReachesEndBlocks;
+
+  /// Instructions above which destroy_values cannot be hoisted.
+  SmallVector<SILInstruction *, 4> barriers;
+
+  /// Blocks one of whose phis is a barrier and consequently out of which
+  /// destroy_values cannot be hoisted.
+  SmallVector<SILBasicBlock *, 4> phiBarriers;
+
+  DeinitBarriers(Context &context)
+      : hoistingReachesBeginBlocks(&context.function),
+        hoistingReachesEndBlocks(&context.function) {}
+  DeinitBarriers(DeinitBarriers const &) = delete;
+  DeinitBarriers &operator=(DeinitBarriers const &) = delete;
+};
+
+/// Works backwards from the current location of destroy_values to the earliest
+/// place they can be hoisted to.
+///
+/// Implements BackwardReachability::BlockReachability.
+class DataFlow final {
+  Context const &context;
+  Usage const &uses;
+  DeinitBarriers &result;
+
+  enum class Classification { Barrier, Other };
+
+  BackwardReachability<DataFlow> reachability;
+
+public:
+  DataFlow(Context const &context, Usage const &uses, DeinitBarriers &result)
+      : context(context), uses(uses), result(result),
+        reachability(&context.function, *this) {
+    // Seed reachability with the scope ending uses from which the backwards
+    // data flow will begin.
+    for (auto *end : uses.ends) {
+      reachability.initLastUse(end);
+    }
+  }
+  DataFlow(DataFlow const &) = delete;
+  DataFlow &operator=(DataFlow const &) = delete;
+
+  void run() { reachability.solveBackward(); }
+
+private:
+  friend class BackwardReachability<DataFlow>;
+
+  bool hasReachableBegin(SILBasicBlock *block) {
+    return result.hoistingReachesBeginBlocks.contains(block);
+  }
+
+  void markReachableBegin(SILBasicBlock *block) {
+    result.hoistingReachesBeginBlocks.insert(block);
+  }
+
+  void markReachableEnd(SILBasicBlock *block) {
+    result.hoistingReachesEndBlocks.insert(block);
+  }
+
+  Classification classifyInstruction(SILInstruction *);
+
+  bool classificationIsBarrier(Classification);
+
+  void visitedInstruction(SILInstruction *, Classification);
+
+  bool checkReachableBarrier(SILInstruction *);
+
+  bool checkReachablePhiBarrier(SILBasicBlock *);
+};
+
+DataFlow::Classification
+DataFlow::classifyInstruction(SILInstruction *instruction) {
+  if (instruction == context.definition) {
+    return Classification::Barrier;
+  }
+  if (uses.users.contains(instruction)) {
+    return Classification::Barrier;
+  }
+  if (isDeinitBarrier(instruction)) {
+    return Classification::Barrier;
+  }
+  return Classification::Other;
+}
+
+bool DataFlow::classificationIsBarrier(Classification classification) {
+  switch (classification) {
+  case Classification::Barrier:
+    return true;
+  case Classification::Other:
+    return false;
+  }
+  llvm_unreachable("exhaustive switch not exhaustive?!");
+}
+
+void DataFlow::visitedInstruction(SILInstruction *instruction,
+                                  Classification classification) {
+  assert(classifyInstruction(instruction) == classification);
+  switch (classification) {
+  case Classification::Barrier:
+    result.barriers.push_back(instruction);
+    return;
+  case Classification::Other:
+    return;
+  }
+  llvm_unreachable("exhaustive switch not exhaustive?!");
+}
+
+bool DataFlow::checkReachableBarrier(SILInstruction *instruction) {
+  auto classification = classifyInstruction(instruction);
+  visitedInstruction(instruction, classification);
+  return classificationIsBarrier(classification);
+}
+
+bool DataFlow::checkReachablePhiBarrier(SILBasicBlock *block) {
+  assert(llvm::all_of(block->getArguments(),
+                      [&](auto argument) { return PhiValue(argument); }));
+
+  bool isBarrier =
+      llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
+        return classificationIsBarrier(
+            classifyInstruction(predecessor->getTerminator()));
+      });
+  if (isBarrier) {
+    result.phiBarriers.push_back(block);
+  }
+  return isBarrier;
+}
+
+/// Hoist the destroy_values of %value.
+class Rewriter final {
+  Context &context;
+  Usage const &uses;
+  DeinitBarriers const &barriers;
+
+  /// The destroy_value instructions for this owned lexical value that existed
+  /// before LexicalDestroyHoisting ran and which were not modified.
+  llvm::SmallPtrSet<SILInstruction *, 8> reusedDestroyValueInsts;
+
+public:
+  Rewriter(Context &context, Usage const &uses, DeinitBarriers const &barriers)
+      : context(context), uses(uses), barriers(barriers) {}
+  Rewriter(Rewriter const &) = delete;
+  Rewriter &operator=(Rewriter const &) = delete;
+
+  bool run();
+
+private:
+  bool createDestroyValue(SILInstruction *insertionPoint);
+};
+
+bool Rewriter::run() {
+  bool madeChange = false;
+
+  // Add destroy_values for phi barrier boundaries.
+  //
+  // A block is a phi barrier iff any of its predecessors' terminators get
+  // classified as barriers.
+  for (auto *block : barriers.phiBarriers) {
+    madeChange |= createDestroyValue(&block->front());
+  }
+
+  // Add destroy_values for barrier boundaries.
+  //
+  // Insert destroy_values after every non-terminator barrier.
+  //
+  // For terminator barriers, add destroy_values at the beginning of the
+  // successor blocks.  In order to reach a terminator and classify it as a
+  // barrier, all of a block P's successors B had reachable beginnings.  If any
+  // of them didn't, then BackwardReachability::meetOverSuccessors would never
+  // have returned true for P, so none of its instructions would ever have been
+  // classified (except for via checkReachablePhiBarrier, which doesn't record
+  // terminator barriers).
+  for (auto instruction : barriers.barriers) {
+    if (auto *terminator = dyn_cast<TermInst>(instruction)) {
+      auto successors = terminator->getParentBlock()->getSuccessorBlocks();
+      // In order for the instruction to have been classified as a barrier,
+      // reachability would have had to reach the block containing it.
+      assert(barriers.hoistingReachesEndBlocks.contains(
+                terminator->getParentBlock()));
+      for (auto *successor : successors) {
+        madeChange |= createDestroyValue(&successor->front());
+      }
+    } else {
+      auto *next = instruction->getNextInstruction();
+      assert(next);
+      madeChange |= createDestroyValue(next);
+    }
+  }
+
+  // Add destroy_values for control-flow boundaries.
+  //
+  // Insert destroy_values at the beginning of blocks which were preceded by a
+  // control flow branch (and which, thanks to the lack of critical edges,
+  // don't have multiple predecessors) whose end was not reachable (because
+  // reachability was not able to make it to the top of some other successor).
+  //
+  // In other words, a control flow boundary is the target edge from a block B
+  // to its single predecessor P not all of whose successors S in succ(P) had
+  // reachable beginnings.  We witness that fact about P's successors by way of
+  // P not having a reachable end--see BackwardReachability::meetOverSuccessors.
+  //
+  // control-flow-boundary(B) := beginning-reachable(B) && !end-reachable(P)
+  for (auto *block : barriers.hoistingReachesBeginBlocks) {
+    if (auto *predecessor = block->getSinglePredecessorBlock()) {
+      if (!barriers.hoistingReachesEndBlocks.contains(predecessor)) {
+        madeChange |= createDestroyValue(&block->front());
+      }
+    }
+  }
+
+  if (madeChange) {
+    // Remove all the original destroy_values instructions.
+    for (auto *end : uses.ends) {
+      if (reusedDestroyValueInsts.contains(end)) {
+        continue;
+      }
+      context.deleter.forceDelete(end);
+    }
+  }
+
+  return madeChange;
+}
+
+bool Rewriter::createDestroyValue(SILInstruction *insertionPoint) {
+  if (auto *ebi = dyn_cast<DestroyValueInst>(insertionPoint)) {
+    if (uses.ends.contains(insertionPoint)) {
+      reusedDestroyValueInsts.insert(insertionPoint);
+      return false;
+    }
+  }
+  auto builder = SILBuilderWithScope(insertionPoint);
+  builder.createDestroyValue(
+      RegularLocation::getAutoGeneratedLocation(insertionPoint->getLoc()),
+      context.value);
+  return true;
+}
+
+bool run(Context &context) {
+  Usage usage;
+  if (!findUsage(context, usage))
+    return false;
+
+  DeinitBarriers barriers(context);
+  DataFlow flow(context, usage, barriers);
+  flow.run();
+
+  Rewriter rewriter(context, usage, barriers);
+
+  return rewriter.run();
+}
+} // end namespace LexicalDestroyHoisting
+
+bool swift::hoistDestroysOfOwnedLexicalValue(SILValue const value,
+                                             SILFunction &function,
+                                             InstructionDeleter &deleter) {
+  if (!value->isLexical())
+    return false;
+  if (value->getOwnershipKind() != OwnershipKind::Owned)
+    return false;
+  LexicalDestroyHoisting::Context context(value, function, deleter);
+  return LexicalDestroyHoisting::run(context);
+}

--- a/test/Distributed/SIL/distributed_actor_default_init_sil_5.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil_5.swift
@@ -64,7 +64,6 @@ distributed actor MyDistActor {
 // CHECK: [[CONTINUE]]:
 // CHECK:        hop_to_executor [[SELF]] : $MyDistActor
 // CHECK-NEXT:   retain_value [[SYSTEM]] : $FakeActorSystem
-// CHECK-NEXT:   retain_value [[SYSTEM]] : $FakeActorSystem
 // CHECK-NEXT:   // function_ref FakeActorSystem.actorReady<A>(_:)
 // CHECK-NEXT:   [[READY_FN:%[0-9]+]] = function_ref @$s27FakeDistributedActorSystems0aC6SystemV10actorReadyyyx01_B00bC0RzAA0C7AddressV2IDRtzlF : $@convention(method) <τ_0_0 where τ_0_0 : DistributedActor, τ_0_0.ID == ActorAddress> (@guaranteed τ_0_0, @guaranteed FakeActorSystem) -> ()
 // CHECK-NEXT:   = apply [[READY_FN]]

--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -31,10 +31,10 @@ class Klass {}
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: debug_value [moved] undef
 // CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyAA5KlassCADnF'
 func useMove(_ k: __owned Klass) -> Klass {
@@ -65,10 +65,10 @@ func useMove(_ k: __owned Klass) -> Klass {
 // CHECK-SIL-NEXT: debug_value
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
+// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: debug_value [moved] undef
 // CHECK-SIL-NEXT: tuple
 // CHECK-SIL-NEXT: tuple
-// CHECK-SIL-NEXT: strong_release
 // CHECK-SIL-NEXT: return
 // CHECK-SIL: } // end sil function '$s8moveonly7useMoveyxxnRlzClF'
 func useMove<T : AnyObject>(_ k: __owned T) -> T {

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -233,12 +233,13 @@ bb3:
 // CHECK:      bb1:
 // CHECK-NEXT:   [[COPY:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:   apply %{{.*}}([[COPY]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb2:
+// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
 // CHECK-NEXT:   destroy_value [[OUTERCOPY]] : $C
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-LABEL: } // end sil function 'testLocalBorrowPostDomDestroy'
 sil [ossa] @testLocalBorrowPostDomDestroy : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
@@ -274,13 +275,14 @@ bb3:
 // CHECK:      bb1:
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb2:
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   destroy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-LABEL: } // end sil function 'testLocalBorrowNoPostDomDestroy'
 sil [ossa] @testLocalBorrowNoPostDomDestroy : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
@@ -316,17 +318,18 @@ bb3:
 // CHECK-NEXT:  apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:  [[ARGCOPY:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:  apply %2([[OUTERCOPY]], [[ARGCOPY:%.*]]) : $@convention(thin) (@owned C, @owned C) -> ()
+// CHECK-NEXT:  destroy_value %0 : $C
 // CHECK-NEXT:  br bb3
 // CHECK:     bb2:
 // CHECK-NEXT:  apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 //
 // This copy would be eliminated if the outer lifetime were also canonicalized (no unchecked_ownership_conversion)
+// CHECK-NEXT:  destroy_value %0 : $C
 // CHECK-NEXT:  [[COPY2:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:  destroy_value [[COPY2]] : $C
 // CHECK-NEXT:  destroy_value %4 : $C
 // CHECK-NEXT:  br bb3
 // CHECK: bb3:
-// CHECK-NEXT:  destroy_value %0 : $C
 // CHECK-LABEL: } // end sil function 'testLocalBorrowDoubleConsume'
 sil [ossa] @testLocalBorrowDoubleConsume : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -440,7 +440,9 @@ bb0:
 //
 // CHECK-LABEL: sil [ossa] @testCopyBorrow : $@convention(thin) <T> (@in T) -> () {
 // CHECK:       bb0(%0 : @owned $T):
+// CHECK:       [[COPY:%[^,]+]] = copy_value %0
 // CHECK:       destroy_value %0 : $T
+// CHECK:       destroy_value [[COPY]]
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return
 // CHECK-LABEL: } // end sil function 'testCopyBorrow'

--- a/test/SILOptimizer/lexical_destroy_hoisting.sil
+++ b/test/SILOptimizer/lexical_destroy_hoisting.sil
@@ -1,0 +1,463 @@
+// RUN: %target-sil-opt -copy-propagation -enable-sil-verify-all %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+// =============================================================================
+// = DECLARATIONS                                                             {{
+// =============================================================================
+
+class C {
+    weak var d: D?
+}
+class D {}
+struct S {}
+class DBox {
+  var d: D
+}
+
+struct CDCase {
+    var c: C
+    var d: D
+}
+
+class PointedTo {
+}
+class PointerWrapper {
+    var pointer: Builtin.RawPointer
+}
+
+enum OneOfThree { case one, two, three }
+
+sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @get_owned_c : $@convention(thin) () -> (@owned C)
+sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
+sil [ossa] @callee_optional_d_guaranteed: $@convention(thin) (@guaranteed Optional<D>) -> ()
+sil [ossa] @synchronization_point : $@convention(thin) () -> ()
+sil [ossa] @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
+sil [ossa] @barrier : $@convention(thin) () -> ()
+
+
+// =============================================================================
+// = DECLARATIONS                                                             }}
+// =============================================================================
+
+// =============================================================================
+// branching tests                                                            {{
+// =============================================================================
+
+// Hoist over br.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_1'
+sil [ossa] @hoist_over_branch_1 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br bl1
+bl1:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Hoist over cond_br.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         cond_br
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_2'
+sil [ossa] @hoist_over_branch_2 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, bl1, bl2
+bl1:
+    br exit
+bl2:
+    br exit
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Hoist over two brs.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_3 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         cond_br undef
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_3'
+sil [ossa] @hoist_over_branch_3 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, bl1, bl2
+bl1:
+    br exit
+bl2:
+    br exit
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't hoist over 1 / 2 brs.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[BL1:bb[0-9]+]], [[BL2:bb[0-9]+]]
+// CHECK:       [[BL1]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[BL2]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_4'
+sil [ossa] @hoist_over_branch_4 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    cond_br undef, bl1, bl2
+bl1:
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br exit
+bl2:
+    br exit
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Hoist over switch_enum.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_branch_5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C, [[CASE:%[^,]+]] : $OneOfThree):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         switch_enum [[CASE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_branch_5'
+sil [ossa] @hoist_over_branch_5 : $(@owned C, OneOfThree) -> () {
+entry(%instance: @owned $C, %case : $OneOfThree):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    switch_enum %case : $OneOfThree, case #OneOfThree.one!enumelt: one_dest, case #OneOfThree.two!enumelt: two_dest, case #OneOfThree.three!enumelt: three_dest
+one_dest:
+    br exit
+two_dest:
+    br exit
+three_dest:
+    br exit
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't hoist when there are reborrows.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_terminator_4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         br [[WORK:bb[0-9]+]]([[LIFETIME]] : $C)
+// CHECK:       [[WORK]]([[LIFETIME_2:%[^,]+]] : @guaranteed $C):
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         tuple ()
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br
+// CHECK-LABEL: } // end sil function 'hoist_over_terminator_4'
+sil [ossa] @hoist_over_terminator_4 : $@convention(thin) (@owned C) -> () {
+entry(%instance_c : @owned $C):
+    %lifetime_c_0 = begin_borrow %instance_c : $C
+    br work(%lifetime_c_0 : $C)
+
+work(%lifetime_c : @guaranteed $C):
+    end_borrow %lifetime_c : $C
+    %foo = tuple ()
+    destroy_value %instance_c : $C
+    br exit
+
+exit:
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't hoist over phi-use of value.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_some_barred_blocks : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]](undef : $C)
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[EXIT]]([[INSTANCE]] : $C)
+// CHECK:       [[EXIT]]([[THING:%[^,]+]] :
+// CHECK:         destroy_value [[THING]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_some_barred_blocks'
+sil [ossa] @dont_hoist_over_some_barred_blocks : $(@owned C) -> () {
+entry(%instance : @owned $C):
+    cond_br undef, left, right
+
+left:
+    destroy_value %instance : $C
+    br exit(undef : $C)
+
+right:
+    br exit(%instance : $C)
+
+exit(%thing : @owned $C):
+    destroy_value %thing : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// =============================================================================
+// branching tests                                                            }}
+// =============================================================================
+
+// =============================================================================
+// loop tests                                                                 {{
+// =============================================================================
+
+// Don't hoist over loop without uses.
+//
+// TODO: Eventually, we should hoist over such loops.
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_1 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         br [[LOOP_HEADER:bb[0-9]+]]
+// CHECK:       [[LOOP_HEADER]]:
+// CHECK:         br [[LOOP_BODY:bb[0-9]+]]
+// CHECK:       [[LOOP_BODY]]:
+// CHECK:         br [[LOOP_LATCH:bb[0-9]+]]
+// CHECK:       [[LOOP_LATCH]]:
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[LOOP_BACKEDGE:bb[0-9]+]]
+// CHECK:       [[LOOP_BACKEDGE]]:
+// CHECK:         br [[LOOP_HEADER]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_1'
+sil [ossa] @hoist_over_loop_1 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br loop_header
+loop_header:
+    br loop_body
+loop_body:
+    br loop_latch
+loop_latch:
+    cond_br undef, exit, loop_backedge
+loop_backedge:
+    br loop_header
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't hoist over loop with uses.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         br [[LOOP_HEADER:bb[0-9]+]]
+// CHECK:       [[LOOP_HEADER]]:
+// CHECK:         br [[LOOP_BODY:bb[0-9]+]]
+// CHECK:       [[LOOP_BODY]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[INSTANCE]])
+// CHECK:         br [[LOOP_LATCH:bb[0-9]+]]
+// CHECK:       [[LOOP_LATCH]]:
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[LOOP_BACKEDGE:bb[0-9]+]]
+// CHECK:       [[LOOP_BACKEDGE]]:
+// CHECK:         br [[LOOP_HEADER]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_2'
+sil [ossa] @hoist_over_loop_2 : $@convention(thin) (@owned C) -> () {
+entry(%instance: @owned $C):
+    br loop_header
+loop_header:
+    br loop_body
+loop_body:
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br loop_latch
+loop_latch:
+    cond_br undef, exit, loop_backedge
+loop_backedge:
+    br loop_header
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// =============================================================================
+// loop tests                                                                 }}
+// =============================================================================
+
+// =============================================================================
+// instruction tests                                                          {{
+// =============================================================================
+
+// Don't hoist over an apply that uses a copy of the value.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_apply_at_copy : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REGISTER_0:%[^,]+]] :
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         apply
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_apply_at_copy'
+sil [ossa] @dont_hoist_over_apply_at_copy : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %instance : $C
+  apply %callee_guaranteed(%copy) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %instance : $C
+  destroy_value %copy : $C
+
+  %result = tuple ()
+  return %result : $()
+}
+
+// Don't hoist over an apply that uses the value.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_apply_at_value : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_over_apply_at_value'
+sil [ossa] @hoist_over_apply_at_value : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %instance : $C
+  %result = tuple ()
+  return %result : $()
+}
+
+// Don't hoist over a try apply that uses the value.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_try_apply_at_value : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         try_apply undef([[INSTANCE]]) : {{.*}}, normal [[GOOD:bb[0-9]+]], error [[BAD:bb[0-9]+]] 
+// CHECK:       [[GOOD]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:       [[BAD]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_try_apply_at_value'
+sil [ossa] @dont_hoist_over_try_apply_at_value : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+  try_apply undef(%instance) : $@convention(thin) (@guaranteed C) -> @error Error, normal good, error bad
+
+good(%8 : $()):
+  destroy_value %instance : $C
+  %13 = tuple ()
+  return %13 : $()
+
+bad(%15 : @owned $Error):
+  destroy_value %instance : $C
+  throw %15 : $Error
+}
+
+// Don't hoist over barrier try_apply.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_try_apply_barrier : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         try_apply undef() : {{.*}}, normal [[GOOD:bb[0-9]+]], error [[BAD:bb[0-9]+]]
+// CHECK:       [[GOOD]]({{%[^,]+}} : $()):
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:       [[BAD]]([[ERROR:%[^,]+]] : @owned $Error):
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         throw [[ERROR]]
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_try_apply_barrier'
+sil [ossa] @dont_hoist_over_try_apply_barrier : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+  apply undef(%instance) : $@convention(thin) (@guaranteed C) -> ()
+  try_apply undef() : $@convention(thin) () -> @error Error, normal good, error bad
+
+good(%8 : $()):
+  destroy_value %instance : $C
+  %13 = tuple ()
+  return %13 : $()
+
+bad(%15 : @owned $Error):
+  destroy_value %instance : $C
+  throw %15 : $Error
+}
+
+// Hoist up to two parallel barrier applies from a block with two predecessors.
+//
+// CHECK-LABEL: sil [ossa] @hoist_up_to_two_barrier_applies : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply undef()
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply undef()
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'hoist_up_to_two_barrier_applies'
+sil [ossa] @hoist_up_to_two_barrier_applies : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  cond_br undef, left, right
+
+left:
+  %result_left = apply undef() : $@convention(thin) () -> ()
+  br exit
+
+right:
+  %result_right = apply undef() : $@convention(thin) () -> ()
+  br exit
+
+exit:
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Don't hoist over end_apply.  These are lowered to calls to continuations
+// which can have the same sorts of side-effects as function calls.
+
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_end_apply : {{.*}} {
+// CHECK:         end_apply
+// CHECK:         destroy_value
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_end_apply'
+sil [ossa] @dont_hoist_over_end_apply : $@convention(thin) (@owned C, S) -> () {
+entry(%instance : @owned $C, %input : $S):
+    %modify_s = function_ref @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
+    (%addr, %continuation) = begin_apply %modify_s() : $@yield_once @convention(thin) () -> @yields @inout S
+    store %input to [trivial] %addr : $*S
+    end_apply %continuation
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+
+// =============================================================================
+// instruction tests                                                          }}
+// =============================================================================
+

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -856,13 +856,14 @@ bad(%15 : @owned $Error):
 // CHECK:       [[LEFT]]:
 // CHECK:         apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
 // CHECK:         apply undef()
 // CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK-LABEL: } // end sil function 'hoist_up_to_two_barrier_applies'
 sil [ossa] @hoist_up_to_two_barrier_applies : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -425,10 +425,10 @@ right:
     br trampoline(%copy : $C)
 
 trampoline(%copy_1 : @owned $C):
-    end_borrow %lifetime : $C
     br exit
 
 exit:
+    end_borrow %lifetime : $C
     %retval = tuple ()
     destroy_value %copy_1 : $C
     destroy_value %instance : $C

--- a/test/SILOptimizer/shrink_borrow_scope.swift
+++ b/test/SILOptimizer/shrink_borrow_scope.swift
@@ -31,8 +31,8 @@ public func eliminate_copy_of_returned_then_consumed_owned_value(arg: __owned An
   // CHECK:       end_borrow [[ARG_LIFETIME]]
   // release result
   // release arg
-  // CHECK:       destroy_value [[RESULT]]
   // CHECK:       destroy_value [[ARG]]
+  // CHECK:       destroy_value [[RESULT]]
   // CHECK-LABEL: } // end sil function 'eliminate_copy_of_returned_then_consumed_owned_value'
 }
 


### PR DESCRIPTION
The new utility LexicalDestroyHoisting, which runs during copy propagation, hoists destroy_values of owned lexical values up to deinit barriers.  It is heavily based on the rewritten ShrinkBorrowScope.
