### PR TITLE
Darwin: introduce a global override for debug prefix map entries

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -235,6 +235,11 @@ protected:
   /// set to match the behavior of Clang.
   virtual bool shouldStoreInvocationInDebugInfo() const { return false; }
 
+  /// Specific toolchains should override this to provide additional
+  /// -debug-prefix-map entries. For example, Darwin has an RC_DEBUG_PREFIX_MAP
+  /// environment variable that is also understood by Clang.
+  virtual std::string getGlobalDebugPathRemapping() const { return {}; }
+  
   /// Gets the response file path and command line argument for an invocation
   /// if the tool supports response files and if the command line length would
   /// exceed system limits.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -859,6 +859,14 @@ bool toolchains::Darwin::shouldStoreInvocationInDebugInfo() const {
   return false;
 }
 
+std::string toolchains::Darwin::getGlobalDebugPathRemapping() const {
+  // This matches the behavior in Clang (see
+  // clang/lib/driver/ToolChains/Darwin.cpp).
+  if (const char *S = ::getenv("RC_DEBUG_PREFIX_MAP"))
+    return S;
+  return {};
+}
+
 static void validateLinkObjcRuntimeARCLiteLib(const toolchains::Darwin &TC,
                                               DiagnosticEngine &diags,
                                               const llvm::opt::ArgList &args) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -306,6 +306,12 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_debug_prefix_map);
   inputArgs.AddAllArgs(arguments, options::OPT_coverage_prefix_map);
 
+  std::string globalRemapping = getGlobalDebugPathRemapping();
+  if (!globalRemapping.empty()) {
+    arguments.push_back("-debug-prefix-map");
+    arguments.push_back(inputArgs.MakeArgString(globalRemapping));
+  }
+
   // Pass through the values passed to -Xfrontend.
   inputArgs.AddAllArgValues(arguments, options::OPT_Xfrontend);
 

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -73,7 +73,8 @@ protected:
   std::string findProgramRelativeToSwiftImpl(StringRef name) const override;
 
   bool shouldStoreInvocationInDebugInfo() const override;
-
+  std::string getGlobalDebugPathRemapping() const override;
+  
   /// Retrieve the target SDK version for the given target triple.
   Optional<llvm::VersionTuple>
   getTargetSDKVersion(const llvm::Triple &triple) const ;

--- a/test/Driver/debug-prefix-map.swift
+++ b/test/Driver/debug-prefix-map.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swiftc_driver -### -debug-prefix-map old=new %s 2>&1 | %FileCheck %s -check-prefix CHECK-SIMPLE
 // RUN: %target-swiftc_driver -### -debug-prefix-map old=n=ew %s 2>&1 | %FileCheck %s -check-prefix CHECK-COMPLEX
 // RUN: %target-swiftc_driver -### -debug-prefix-map old= %s 2>&1 | %FileCheck %s -check-prefix CHECK-EMPTY
+// RUN: env RC_DEBUG_PREFIX_MAP=old=new %target-swiftc_driver -target arm64-apple-macos12 -### %s 2>&1 | %FileCheck %s -check-prefix CHECK-SIMPLE
 
 // CHECK-INVALID: error: values for '-debug-prefix-map' must be in the format 'original=remapped', but 'old' was provided
 // CHECK-SIMPLE: debug-prefix-map old=new


### PR DESCRIPTION
This patch adds a new Darwin Swift driver environment variable in the spirit of
RC_DEBUG_OPTIONS, called RC_DEBUG_PREFIX_MAP, which allows a meta build tool to
add one additional -fdebug-prefix-map entry without the knowledge of the build
system.

See also https://reviews.llvm.org/D119850

rdar://85224717
