### PR TITLE
[Distributed] Treat `swift_distributed_execute_target` like a regular…

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -247,8 +247,9 @@ namespace irgen {
       case SpecialKind::AsyncLetGetThrowing:
       case SpecialKind::AsyncLetFinish:
       case SpecialKind::TaskGroupWaitNext:
-      case SpecialKind::DistributedExecuteTarget:
         return true;
+      case SpecialKind::DistributedExecuteTarget:
+        return false;
       }
       llvm_unreachable("covered switch");
     }
@@ -276,8 +277,9 @@ namespace irgen {
       case SpecialKind::AsyncLetGetThrowing:
       case SpecialKind::AsyncLetFinish:
       case SpecialKind::TaskGroupWaitNext:
-      case SpecialKind::DistributedExecuteTarget:
         return true;
+      case SpecialKind::DistributedExecuteTarget:
+        return false;
       }
       llvm_unreachable("covered switch");
     }


### PR DESCRIPTION
… async function

This means that:

- It's allowed to be generic;
- It doesn't need special context + resume handling micro-optimization.

This is made possible by https://github.com/apple/swift/pull/41382

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
