### PR TITLE
[IRGen] Validate that compiler crashes while building PythonKit

### DIFF
--- a/test/IRGen/compiler_crashers/lit.local.cfg
+++ b/test/IRGen/compiler_crashers/lit.local.cfg
@@ -1,0 +1,23 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+config.substitutions.insert(0, ('%build-irgen-test-overlays',
+                                '%target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -emit-module -enable-library-evolution -o %t -sdk %S/Inputs %S/Inputs/ObjectiveC.swift && '
+                                '%target-swift-frontend -enable-objc-interop -emit-module -enable-library-evolution -o %t -sdk %S/Inputs %S/Inputs/Foundation.swift -I %t'))
+
+config.substitutions.insert(0, ('%build-irgen-test-overlays\(mock-sdk-directory: ([^)]+)\)',
+                             SubstituteCaptures(r'%target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -emit-module -enable-library-evolution -o %t -sdk \1 \1/ObjectiveC.swift && '
+                                r'%target-swift-frontend -enable-objc-interop -emit-module -enable-library-evolution -o %t -sdk \1 \1/Foundation.swift -I %t')))
+
+def get_target_os():
+    import re
+    (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
+    return run_os
+
+if get_target_os() in ['windows-msvc']:
+    config.substitutions.insert(0, ('%target-abi', 'WIN'))
+    config.substitutions.insert(0, ('%target-import-type', 'INDIRECT'))
+else:
+    # FIXME(compnerd) do all the targets we currently support use SysV ABI?
+    config.substitutions.insert(0, ('%target-abi', 'SYSV'))
+    config.substitutions.insert(0, ('%target-import-type', 'DIRECT'))

--- a/test/IRGen/compiler_crashers/sr15871-crash-while-compiling-pythonkit-in-release-mode.swift
+++ b/test/IRGen/compiler_crashers/sr15871-crash-while-compiling-pythonkit-in-release-mode.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: not --crash %target-build-swift -emit-module -module-name sr15871 -emit-module-path %t/sr15871.swiftmodule -swift-version 5 -c %S/sr15871-crash-while-compiling-pythonkit-in-release-mode.swift
+// XFAIL: *
+
+// sr15871: crash while compiling PythonKit in release mode
+
+public func pythonObject() {
+  _ = PyCapsule_New({ _ in })
+}
+
+let PyCapsule_New: (@convention(c) (UnsafeMutableRawPointer?) -> Void) -> Void =
+  loadSymbol(name: "PyCapsule_New")
+
+func loadSymbol<T>(name: String, type: T.Type = T.self) -> T {
+  fatalError()
+}


### PR DESCRIPTION
Reports SR-15871. This crash is affecting the build process for compiling [philipturner/swift-for-tensorflow](https://github.com/philipturner/swift-for-tensorflow) in release mode, although I can work around it by removing PythonKit.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
