### PR TITLE
[5.6] [stdlib] Fix backwards count of Indic graphemes

### DIFF
--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -390,7 +390,8 @@ extension _StringGuts {
       // If we're currently in an indic sequence (or if our lhs is a linking
       // consonant), then this check and everything underneath ensures that
       // we continue being in one and may check if this extend is a Virama.
-      if state.isInIndicSequence || scalar1._isLinkingConsonant {
+      if state.isInIndicSequence ||
+         (!isBackwards && scalar1._isLinkingConsonant) {
         if y == .extend {
           let extendNormData = Unicode._NormData(scalar2, fastUpperbound: 0x300)
 
@@ -440,7 +441,8 @@ extension _StringGuts {
     // GB999
     default:
       // GB9c
-      if state.isInIndicSequence, state.hasSeenVirama, scalar2._isLinkingConsonant {
+      if !isBackwards, state.isInIndicSequence, state.hasSeenVirama,
+         scalar2._isLinkingConsonant {
         state.hasSeenVirama = false
         return false
       }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2332,6 +2332,17 @@ StringTests.test("GraphemeBreaking.Indic Sequences") {
   let test10 = "\u{003F}\u{094D}\u{0924}" // 2
   expectEqual(2, test10.count)
   expectBidirectionalCount(2, test10)
+
+#if _runtime(_ObjC)
+  let test11Foreign = NSString(string: "\u{930}\u{93e}\u{91c}\u{94d}") // 2
+  let test11 = test11Foreign as String
+  expectEqual(2, test11.count)
+  expectBidirectionalCount(2, test11)
+#endif
+
+  let test12 = "a\u{0915}\u{093C}\u{200D}\u{094D}\u{0924}a" // 3
+  expectEqual(3, test12.count)
+  expectBidirectionalCount(3, test12)
 }
 
 runAllTests()


### PR DESCRIPTION
When determining the grapheme boundaries of Indic sequences while walking backwards, there were some cases that were incorrectly being labeled as an Indic sequences.

For example, राज् is composed of:
`[.linkingConsonant, .spacingMark, .linkingConsonant, .virama]`

The rule defined by the CLDR here: https://github.com/unicode-org/cldr/tree/main/common/properties/segments
`9.3) LinkingConsonant ExtCccZwj* Virama ExtCccZwj* × LinkingConsonant`
was being incorrectly applied to the last two scalars when walking backwards, and as a result, the whole string was being counted as a singular grapheme instead of 2 (`\u{930}\u{93e}` and` \u{91c}\u{94d}`)

We have to at least be in an Indic sequence already when we see `(.linkingConsonant, .virama)` while walking backwards to be able to resolve any sort of state.

Resolves: rdar://88893489 & rdar://88866287