### PR TITLE
[RequirementMachine] Diagnose invalid requirements detected before rule construction.

### DIFF
--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -132,6 +132,7 @@ struct StructuralRequirement {
 struct RequirementError {
   enum class Kind {
     InvalidConformance,
+    ConcreteTypeMismatch,
   } kind;
 
   union {
@@ -139,6 +140,11 @@ struct RequirementError {
       Type subjectType;
       Type constraint;
     } invalidConformance;
+
+    struct {
+      Type type1;
+      Type type2;
+    } concreteTypeMismatch;
   };
 
   SourceLoc loc;
@@ -154,6 +160,15 @@ public:
     RequirementError error(Kind::InvalidConformance, loc);
     error.invalidConformance.subjectType = subjectType;
     error.invalidConformance.constraint = constraint;
+    return error;
+  }
+
+  static RequirementError forConcreteTypeMismatch(Type type1,
+                                                  Type type2,
+                                                  SourceLoc loc) {
+    RequirementError error(Kind::ConcreteTypeMismatch, loc);
+    error.concreteTypeMismatch.type1 = type1;
+    error.concreteTypeMismatch.type2 = type2;
     return error;
   }
 };

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -133,6 +133,7 @@ struct RequirementError {
   enum class Kind {
     InvalidConformance,
     ConcreteTypeMismatch,
+    NonTypeParameter,
   } kind;
 
   union {
@@ -145,6 +146,8 @@ struct RequirementError {
       Type type1;
       Type type2;
     } concreteTypeMismatch;
+
+    Type nonTypeParameter;
   };
 
   SourceLoc loc;
@@ -169,6 +172,13 @@ public:
     RequirementError error(Kind::ConcreteTypeMismatch, loc);
     error.concreteTypeMismatch.type1 = type1;
     error.concreteTypeMismatch.type2 = type2;
+    return error;
+  }
+
+  static RequirementError forNonTypeParameter(Type subject,
+                                              SourceLoc loc) {
+    RequirementError error(Kind::NonTypeParameter, loc);
+    error.nonTypeParameter = subject;
     return error;
   }
 };

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -134,6 +134,7 @@ struct RequirementError {
     InvalidConformance,
     ConcreteTypeMismatch,
     NonTypeParameter,
+    RedundantRequirement,
   } kind;
 
   union {
@@ -148,6 +149,8 @@ struct RequirementError {
     } concreteTypeMismatch;
 
     Type nonTypeParameter;
+
+    Requirement redundantRequirement;
   };
 
   SourceLoc loc;
@@ -179,6 +182,13 @@ public:
                                               SourceLoc loc) {
     RequirementError error(Kind::NonTypeParameter, loc);
     error.nonTypeParameter = subject;
+    return error;
+  }
+
+  static RequirementError forRedundantRequirement(Requirement req,
+                                                  SourceLoc loc) {
+    RequirementError error(Kind::RedundantRequirement, loc);
+    error.redundantRequirement = req;
     return error;
   }
 };

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -124,55 +124,6 @@ struct StructuralRequirement {
   bool inferred = false;
 };
 
-/// Represents an invalid requirement, such as `T: Int`.
-///
-/// Invalid requirements are recorded while computing the
-/// generic signature of a declaration, and diagnosed via
-/// \c diagnoseRequirementErrors .
-struct RequirementError {
-  /// The kind of requirement error.
-  enum class Kind {
-    InvalidConformance,
-    ConcreteTypeMismatch,
-    NonTypeParameter,
-    RedundantRequirement,
-  } kind;
-
-  /// The invalid requirement.
-  Requirement requirement;
-
-  SourceLoc loc;
-
-private:
-  RequirementError(Kind kind, Requirement requirement, SourceLoc loc)
-    : kind(kind), requirement(requirement), loc(loc) {}
-
-public:
-  static RequirementError forInvalidConformance(Type subjectType,
-                                                Type constraint,
-                                                SourceLoc loc) {
-    Requirement requirement(RequirementKind::Conformance, subjectType, constraint);
-    return {Kind::InvalidConformance, requirement, loc};
-  }
-
-  static RequirementError forConcreteTypeMismatch(Type type1,
-                                                  Type type2,
-                                                  SourceLoc loc) {
-    Requirement requirement(RequirementKind::SameType, type1, type2);
-    return {Kind::ConcreteTypeMismatch, requirement, loc};
-  }
-
-  static RequirementError forNonTypeParameter(Requirement req,
-                                              SourceLoc loc) {
-    return {Kind::NonTypeParameter, req, loc};
-  }
-
-  static RequirementError forRedundantRequirement(Requirement req,
-                                                  SourceLoc loc) {
-    return {Kind::RedundantRequirement, req, loc};
-  }
-};
-
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -124,6 +124,40 @@ struct StructuralRequirement {
   bool inferred = false;
 };
 
+/// Represents an invalid requirement, such as `T: Int`.
+///
+/// Invalid requirements are recorded while computing the
+/// generic signature of a declaration, and diagnosed via
+/// \c diagnoseRequirementErrors .
+struct RequirementError {
+  enum class Kind {
+    InvalidConformance,
+  } kind;
+
+  union {
+    struct {
+      Type subjectType;
+      Type constraint;
+    } invalidConformance;
+  };
+
+  SourceLoc loc;
+
+private:
+  RequirementError(Kind kind, SourceLoc loc)
+  : kind(kind), loc(loc) {}
+
+public:
+  static RequirementError forInvalidConformance(Type subjectType,
+                                                Type constraint,
+                                                SourceLoc loc) {
+    RequirementError error(Kind::InvalidConformance, loc);
+    error.invalidConformance.subjectType = subjectType;
+    error.invalidConformance.constraint = constraint;
+    return error;
+  }
+};
+
 } // end namespace swift
 
 #endif

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -527,6 +527,9 @@ void PropertyMap::inferConditionalRequirements(
     return;
 
   SmallVector<Requirement, 2> desugaredRequirements;
+  // FIXME: Store errors in the rewrite system to be diagnosed
+  // from the top-level generic signature requests.
+  SmallVector<RequirementError, 2> errors;
 
   // First, desugar all conditional requirements.
   for (auto req : conditionalRequirements) {
@@ -536,7 +539,7 @@ void PropertyMap::inferConditionalRequirements(
       llvm::dbgs() << "\n";
     }
 
-    desugarRequirement(req, desugaredRequirements);
+    desugarRequirement(req, desugaredRequirements, errors);
   }
 
   // Now, convert desugared conditional requirements to rules.

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -1,0 +1,80 @@
+//===--- Diagnostics.h - Requirement machine diagnostics --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REQUIREMENT_DIAGNOSTICS_H
+#define SWIFT_REQUIREMENT_DIAGNOSTICS_H
+
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Type.h"
+
+namespace swift {
+
+namespace rewriting {
+
+/// Represents an invalid requirement, such as `T: Int`.
+///
+/// Invalid requirements are recorded while computing the
+/// generic signature of a declaration, and diagnosed via
+/// \c diagnoseRequirementErrors .
+struct RequirementError {
+  /// The kind of requirement error.
+  enum class Kind {
+    /// A constraint to a non-protocol, non-class type, e.g. T: Int.
+    InvalidTypeRequirement,
+    /// A type mismatch, e.g. Int == String.
+    ConcreteTypeMismatch,
+    /// A requirement proven to be false, e.g. Bool: Collection
+    ConflictingRequirement,
+    /// A redundant requirement, e.g. T == T.
+    RedundantRequirement,
+  } kind;
+
+  /// The invalid requirement.
+  Requirement requirement;
+
+  SourceLoc loc;
+
+private:
+  RequirementError(Kind kind, Requirement requirement, SourceLoc loc)
+    : kind(kind), requirement(requirement), loc(loc) {}
+
+public:
+  static RequirementError forInvalidTypeRequirement(Type subjectType,
+                                                    Type constraint,
+                                                    SourceLoc loc) {
+    Requirement requirement(RequirementKind::Conformance, subjectType, constraint);
+    return {Kind::InvalidTypeRequirement, requirement, loc};
+  }
+
+  static RequirementError forConcreteTypeMismatch(Type type1,
+                                                  Type type2,
+                                                  SourceLoc loc) {
+    Requirement requirement(RequirementKind::SameType, type1, type2);
+    return {Kind::ConcreteTypeMismatch, requirement, loc};
+  }
+
+  static RequirementError forConflictingRequirement(Requirement req,
+                                                    SourceLoc loc) {
+    return {Kind::ConflictingRequirement, req, loc};
+  }
+
+  static RequirementError forRedundantRequirement(Requirement req,
+                                                  SourceLoc loc) {
+    return {Kind::RedundantRequirement, req, loc};
+  }
+};
+
+} // end namespace rewriting
+
+} // end namespace swift
+
+#endif

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -720,6 +720,8 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
+  diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
+
   return ctx.AllocateCopy(result);
 }
 
@@ -973,6 +975,8 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
       recordInheritedTypeRequirement(firstDecl, otherDecl);
     }
   }
+
+  diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
 
   return ctx.AllocateCopy(result);
 }

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -152,7 +152,7 @@ static void desugarLayoutRequirement(Type subjectType,
   if (!subjectType->isTypeParameter()) {
     Requirement requirement(RequirementKind::Layout,
                             subjectType, layout);
-    if (subjectType->isAnyClassReferenceType()) {
+    if (layout->isClass() && subjectType->isAnyClassReferenceType()) {
       errors.push_back(
           RequirementError::forRedundantRequirement(requirement, loc));
     } else {

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -561,6 +561,9 @@ bool swift::rewriting::diagnoseRequirementErrors(
       Type subjectType = error.requirement.getFirstType();
       Type constraint = error.requirement.getSecondType();
 
+      if (subjectType->hasError() || constraint->hasError())
+        break;
+
       // FIXME: The constraint string is printed directly here because
       // the current default is to not print `any` for existential
       // types, but this error message is super confusing without `any`
@@ -608,8 +611,12 @@ bool swift::rewriting::diagnoseRequirementErrors(
     }
 
     case RequirementError::Kind::ConflictingRequirement: {
+      auto subjectType = error.requirement.getFirstType();
+      if (subjectType->hasError())
+        break;
+
       ctx.Diags.diagnose(loc, diag::requires_not_suitable_archetype,
-                         error.requirement.getFirstType());
+                         subjectType);
       diagnosedError = true;
       break;
     }

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -532,9 +532,7 @@ void swift::rewriting::realizeInheritedRequirements(
 
 /// Emit diagnostics for the given \c RequirementErrors.
 ///
-/// \param ctx The AST context, which is used to determine whether
-/// requirement machine protocol signatures are enabled. If not,
-/// diagnostics will not be emitted.
+/// \param ctx The AST context in which to emit diagnostics.
 /// \param errors The set of requirement diagnostics to be emitted.
 /// \param allowConcreteGenericParams Whether concrete type parameters
 /// are permitted in the generic signature. If true, diagnostics will
@@ -547,9 +545,6 @@ bool swift::rewriting::diagnoseRequirementErrors(
     ASTContext &ctx, SmallVectorImpl<RequirementError> &errors,
     bool allowConcreteGenericParams) {
   bool diagnosedError = false;
-  if (ctx.LangOpts.RequirementMachineProtocolSignatures !=
-      RequirementMachineMode::Enabled)
-    return diagnosedError;
 
   for (auto error : errors) {
     SourceLoc loc = error.loc;
@@ -740,7 +735,10 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
+  if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
+      RequirementMachineMode::Enabled) {
+    diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
+  }
 
   return ctx.AllocateCopy(result);
 }
@@ -996,7 +994,10 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
+  if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
+      RequirementMachineMode::Enabled) {
+    diagnoseRequirementErrors(ctx, errors, /*allowConcreteGenericParams=*/false);
+  }
 
   return ctx.AllocateCopy(result);
 }

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -530,6 +530,19 @@ void swift::rewriting::realizeInheritedRequirements(
   }
 }
 
+/// Emit diagnostics for the given \c RequirementErrors.
+///
+/// \param ctx The AST context, which is used to determine whether
+/// requirement machine protocol signatures are enabled. If not,
+/// diagnostics will not be emitted.
+/// \param errors The set of requirement diagnostics to be emitted.
+/// \param allowConcreteGenericParams Whether concrete type parameters
+/// are permitted in the generic signature. If true, diagnostics will
+/// offer fix-its to turn invalid type requirements, e.g. T: Int, into
+/// same-type requirements.
+///
+/// \returns true if any errors were emitted, and false otherwise (including
+/// when only warnings were emitted).
 bool swift::rewriting::diagnoseRequirementErrors(
     ASTContext &ctx, SmallVectorImpl<RequirementError> &errors,
     bool allowConcreteGenericParams) {

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -40,7 +40,9 @@ namespace rewriting {
 // documentation
 // comments.
 
-void desugarRequirement(Requirement req, SmallVectorImpl<Requirement> &result);
+void desugarRequirement(Requirement req,
+                        SmallVectorImpl<Requirement> &result,
+                        SmallVectorImpl<RequirementError> &errors);
 
 void inferRequirements(Type type, SourceLoc loc, ModuleDecl *module,
                        SmallVectorImpl<StructuralRequirement> &result);

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
+#include "Diagnostics.h"
 #include "RewriteContext.h"
 #include "Symbol.h"
 #include "Term.h"

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -47,11 +47,17 @@ void inferRequirements(Type type, SourceLoc loc, ModuleDecl *module,
 
 void realizeRequirement(Requirement req, RequirementRepr *reqRepr,
                         ModuleDecl *moduleForInference,
-                        SmallVectorImpl<StructuralRequirement> &result);
+                        SmallVectorImpl<StructuralRequirement> &result,
+                        SmallVectorImpl<RequirementError> &errors);
 
 void realizeInheritedRequirements(TypeDecl *decl, Type type,
                                   ModuleDecl *moduleForInference,
-                                  SmallVectorImpl<StructuralRequirement> &result);
+                                  SmallVectorImpl<StructuralRequirement> &result,
+                                  SmallVectorImpl<RequirementError> &errors);
+
+void diagnoseRequirementErrors(ASTContext &ctx,
+                               SmallVectorImpl<RequirementError> &errors,
+                               bool allowConcreteGenericParams);
 
 std::pair<MutableTerm, MutableTerm>
 getRuleForRequirement(const Requirement &req,

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -57,7 +57,7 @@ void realizeInheritedRequirements(TypeDecl *decl, Type type,
                                   SmallVectorImpl<StructuralRequirement> &result,
                                   SmallVectorImpl<RequirementError> &errors);
 
-void diagnoseRequirementErrors(ASTContext &ctx,
+bool diagnoseRequirementErrors(ASTContext &ctx,
                                SmallVectorImpl<RequirementError> &errors,
                                bool allowConcreteGenericParams);
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -477,6 +477,11 @@ AbstractGenericSignatureRequestRQM::evaluate(
       baseSignature.getRequirements().begin(),
       baseSignature.getRequirements().end());
 
+  // We need to create this errors vector to pass to
+  // desugarRequirement, but this request should never
+  // diagnose errors.
+  SmallVector<RequirementError, 4> errors;
+
   // The requirements passed to this request may have been substituted,
   // meaning the subject type might be a concrete type and not a type
   // parameter.
@@ -488,7 +493,7 @@ AbstractGenericSignatureRequestRQM::evaluate(
   // requirements where the subject type is always a type parameter,
   // which is what the RuleBuilder expects.
   for (auto req : addedRequirements)
-    desugarRequirement(req, requirements);
+    desugarRequirement(req, requirements, errors);
 
   // Heap-allocate the requirement machine to save stack space.
   std::unique_ptr<RequirementMachine> machine(new RequirementMachine(

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -631,9 +631,9 @@ InferredGenericSignatureRequestRQM::evaluate(
     machine->computeMinimalGenericSignatureRequirements();
 
   auto result = GenericSignature::get(genericParams, minimalRequirements);
-  bool hadError = machine->hadError() || !errors.empty();
+  bool hadError = machine->hadError();
 
-  diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
+  hadError |= diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
 
   // FIXME: Handle allowConcreteGenericParams
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -633,7 +633,10 @@ InferredGenericSignatureRequestRQM::evaluate(
   auto result = GenericSignature::get(genericParams, minimalRequirements);
   bool hadError = machine->hadError();
 
-  hadError |= diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
+  if (ctx.LangOpts.RequirementMachineInferredSignatures ==
+      RequirementMachineMode::Enabled) {
+    hadError |= diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
+  }
 
   // FIXME: Handle allowConcreteGenericParams
 

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -40,3 +40,25 @@ func badTypeConformance4<T>(_: T) where @escaping (inout T) throws -> () : Equal
 func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
 // expected-error@-1 2 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
 // expected-error@-2{{type 'Sequence' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance6<T>(_: T) where [T] : Collection { }
+// expected-warning@-1{{redundant conformance constraint '[T]' : 'Collection'}}
+
+func concreteSameTypeRedundancy<T>(_: T) where Int == Int {}
+// expected-warning@-1{{redundant same-type constraint 'Int' == 'Int'}}
+
+func concreteSameTypeRedundancy<T>(_: T) where Array<Int> == Array<T> {}
+// expected-warning@-1{{redundant same-type constraint 'Array<Int>' == 'Array<T>'}}
+
+protocol P {}
+struct S: P {}
+func concreteConformanceRedundancy<T>(_: T) where S : P {}
+// expected-warning@-1{{redundant conformance constraint 'S' : 'P'}}
+
+class C {}
+func concreteLayoutRedundancy<T>(_: T) where C : AnyObject {}
+// expected-warning@-1{{redundant constraint 'C' : 'AnyObject'}}
+
+class C2: C {}
+func concreteSubclassRedundancy<T>(_: T) where C2 : C {}
+// expected-warning@-1{{redundant superclass constraint 'C2' : 'C'}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+
+func testInvalidConformance() {
+  // expected-error@+1 {{type 'T' constrained to non-protocol, non-class type 'Int'}}
+  func invalidIntConformance<T>(_: T) where T: Int {}
+
+  // expected-error@+1 {{type 'T' constrained to non-protocol, non-class type 'Int'}}
+  struct InvalidIntConformance<T: Int> {}
+
+  struct S<T> {
+    // expected-error@+2 {{type 'T' constrained to non-protocol, non-class type 'Int'}}
+    // expected-note@+1 {{use 'T == Int' to require 'T' to be 'Int'}}
+    func method() where T: Int {}
+  }
+}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -62,3 +62,12 @@ func concreteLayoutRedundancy<T>(_: T) where C : AnyObject {}
 class C2: C {}
 func concreteSubclassRedundancy<T>(_: T) where C2 : C {}
 // expected-warning@-1{{redundant superclass constraint 'C2' : 'C'}}
+
+protocol UselessProtocolWhereClause where Int == Int {}
+// expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}
+
+protocol InvalidProtocolWhereClause where Self: Int {}
+// expected-error@-1 {{type 'Self' constrained to non-protocol, non-class type 'Int'}}
+
+typealias Alias<T> = T where Int == Int
+// expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -78,3 +78,9 @@ protocol InvalidProtocolWhereClause where Self: Int {}
 
 typealias Alias<T> = T where Int == Int
 // expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}
+
+func cascadingConflictingRequirement<T>(_: T) where DoesNotExist : EqualComparable { }
+// expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
+
+func cascadingInvalidConformance<T>(_: T) where T : DoesNotExist { }
+// expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -21,3 +21,22 @@ protocol X {}
 
 // expected-error@+1{{generic signature requires types 'Double' and 'Int' to be the same}}
 extension X where NotAnInt == Int {}
+
+protocol EqualComparable {
+  func isEqual(_ other: Self) -> Bool
+}
+
+func badTypeConformance1<T>(_: T) where Int : EqualComparable {} // expected-error{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance2<T>(_: T) where T.Blarg : EqualComparable { } // expected-error{{'Blarg' is not a member type of type 'T'}}
+
+func badTypeConformance3<T>(_: T) where (T) -> () : EqualComparable { }
+// expected-error@-1{{type '(T) -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
+
+func badTypeConformance4<T>(_: T) where @escaping (inout T) throws -> () : EqualComparable { }
+// expected-error@-1{{type '(inout T) throws -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
+// expected-error@-2 2 {{@escaping attribute may only be used in function parameter position}}
+
+func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
+// expected-error@-1 2 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
+// expected-error@-2{{type 'Sequence' in conformance requirement does not refer to a generic parameter or associated type}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -13,3 +13,11 @@ func testInvalidConformance() {
     func method() where T: Int {}
   }
 }
+
+// Check directly-concrete same-type constraints
+typealias NotAnInt = Double
+
+protocol X {}
+
+// expected-error@+1{{generic signature requires types 'Double' and 'Int' to be the same}}
+extension X where NotAnInt == Int {}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -33,13 +33,11 @@ func badTypeConformance2<T>(_: T) where T.Blarg : EqualComparable { } // expecte
 func badTypeConformance3<T>(_: T) where (T) -> () : EqualComparable { }
 // expected-error@-1{{type '(T) -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
 
-func badTypeConformance4<T>(_: T) where @escaping (inout T) throws -> () : EqualComparable { }
+func badTypeConformance4<T>(_: T) where (inout T) throws -> () : EqualComparable { }
 // expected-error@-1{{type '(inout T) throws -> ()' in conformance requirement does not refer to a generic parameter or associated type}}
-// expected-error@-2 2 {{@escaping attribute may only be used in function parameter position}}
 
 func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
-// expected-error@-1 2 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
-// expected-error@-2{{type 'Sequence' in conformance requirement does not refer to a generic parameter or associated type}}
+// expected-error@-1 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
 
 func badTypeConformance6<T>(_: T) where [T] : Collection { }
 // expected-warning@-1{{redundant conformance constraint '[T]' : 'Collection'}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -59,9 +59,16 @@ class C {}
 func concreteLayoutRedundancy<T>(_: T) where C : AnyObject {}
 // expected-warning@-1{{redundant constraint 'C' : 'AnyObject'}}
 
+func concreteLayoutConflict<T>(_: T) where Int : AnyObject {}
+// expected-error@-1{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}}
+
 class C2: C {}
 func concreteSubclassRedundancy<T>(_: T) where C2 : C {}
 // expected-warning@-1{{redundant superclass constraint 'C2' : 'C'}}
+
+class D {}
+func concreteSubclassConflict<T>(_: T) where D : C {}
+// expected-error@-1{{type 'D' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol UselessProtocolWhereClause where Int == Int {}
 // expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}


### PR DESCRIPTION
This change diagnoses the following invalid requirements that are detected (and dropped) before rule construction:
* A conformance requirement to a non-protocol, non-class type, e.g. `T: Int`.
* Concrete same-type mismatches, e.g. `String == Int`. This is diagnosed as a conflict.
* Conformance/superclass/layout constraints on concrete types, e.g. `Int: P` and `[T]: Collection`. This is diagnosed either as a redundancy or as `type 'X' in requirement does not refer to a generic parameter or associated type`.
* Redundant same-type requirements, e.g. `Int == Int` or `Array<T> == Array<Int>`.

Requirement errors are represented with the `RequirementError` struct, which stores an error kind, a requirement, and a source location. Errors are recorded while computing a generic signature, and diagnosed in `diagnoseRequirementErrors`.

Currently, errors recorded with an invalid source location are simply skipped. Once source locations are plumbed through the rewrite system, a valid source location should become an assertion.

Resolves: rdar://88135553