### PR TITLE
Fix and generalize the printing of suppressible features

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -385,10 +385,14 @@ void getInheritedForPrinting(
 
 StringRef getAccessorKindString(AccessorKind value);
 
-bool printCompatibilityFeatureChecksPre(ASTPrinter &printer, Decl *decl);
-void printCompatibilityFeatureChecksPost(
-    ASTPrinter &printer,
-    llvm::function_ref<void()> printElse = []() -> void {});
+/// Call the given function nested appropriately within #if checks
+/// for the compiler features that it uses.  Note that printBody
+/// may be called multiple times if the declaration uses suppressible
+/// features.
+bool printWithCompatibilityFeatureChecks(ASTPrinter &printer,
+                                         PrintOptions &options,
+                                         Decl *decl,
+                                         llvm::function_ref<void()> printBody);
 
 } // namespace swift
 

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -26,8 +26,30 @@ enum class Feature {
   #include "swift/Basic/Features.def"
 };
 
+constexpr unsigned numFeatures() {
+  enum Features {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+    FeatureName,
+#include "swift/Basic/Features.def"
+    NumFeatures
+  };
+  return NumFeatures;
+}
+
+/// Determine whether the given feature is suppressible.
+bool isSuppressibleFeature(Feature feature);
+
 /// Determine the in-source name of the given feature.
 llvm::StringRef getFeatureName(Feature feature);
+
+/// Determine whether the first feature is more recent (and thus implies
+/// the existence of) the second feature.  Only meaningful for suppressible
+/// features.
+inline bool featureImpliesFeature(Feature feature, Feature implied) {
+  // Suppressible features are expected to be listed in order of
+  // addition in Features.def.
+  return (unsigned) feature < (unsigned) implied;
+}
 
 }
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -28,10 +28,24 @@
 //     Option: either a reference to a language option in the form
 //       "langOpts.<option name>" or "true" to indicate that it's always
 //       enabled.
+//
+// Suppressible language features can be suppressed when printing
+// an interface without having to suppress the entire declaration they're
+// contained within.  The declaration will be emitted multiple times,
+// each with a subset of the suppressible features.  To avoid combinatoric
+// re-emission, we assume a linear history: later features in this file
+// imply the existence of earlier features.  (This only needs to apply to
+// suppressible features.)
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef LANGUAGE_FEATURE
 #  error define LANGUAGE_FEATURE before including Features.def
+#endif
+
+#ifndef SUPPRESSIBLE_LANGUAGE_FEATURE
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+  LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
 #endif
 
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
@@ -57,8 +71,9 @@ LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "MainActor executor building 
 LANGUAGE_FEATURE(BuiltinMove, 0, "Builtin.move()", true)
 LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()", true)
 LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
-LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
 LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
-LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
 
+#undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/include/swift/Basic/FixedBitSet.h
+++ b/include/swift/Basic/FixedBitSet.h
@@ -1,0 +1,257 @@
+//===- llvm/ADT/FixedBitSet.h - Fixed-length bitset -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FixedBitSet template, which is basically
+// just std::bitset (a fixed-size inline-allocated bit vector) but with:
+//
+// - a cleaner interface for using the type to implement a set,
+//   especially a set of an enum type
+//
+// - a more useful set of operations, such as the ability to iterate
+//   over the set instead of scanning over all possible elements
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_ADT_FIXEDBITSET_H
+#define LLVM_ADT_FIXEDBITSET_H
+
+#include <assert.h>
+#include <inttypes.h>
+#include <initializer_list>
+#include "llvm/Support/MathExtras.h"
+
+namespace swift {
+
+namespace detail {
+// In principle, long sets would be happier if we chunked
+// at the pointer size instead of capping at 32, but we expect this
+// to be used with relatively short Sets where larger chunks
+// would introduce more padding.
+template <size_t numElements,
+          bool fitsInUInt8 = (numElements <= 8),
+          bool fitsInUInt16 = (numElements <= 16)>
+struct FixedBitSetStorageType;
+
+template <size_t numElements>
+struct FixedBitSetStorageType<numElements, true, true> {
+  using type = uint8_t;
+};
+
+template <size_t numElements>
+struct FixedBitSetStorageType<numElements, false, true> {
+  using type = uint16_t;
+};
+
+template <size_t numElements>
+struct FixedBitSetStorageType<numElements, false, false> {
+  using type = uint32_t;
+};
+
+} // end namespace detail
+
+/// A set of integral elements, all of which must be less than
+/// numElements.  Iteration produces elements in a sorted
+/// (numerically increasing) order.
+template <size_t numElements, class ValueType = size_t>
+class FixedBitSet {
+  static_assert(std::is_integral<ValueType>::value ||
+                std::is_enum<ValueType>::value,
+                "value type is not an integer or enum type");
+
+  using ChunkType = typename detail::FixedBitSetStorageType<numElements>::type;
+
+  static constexpr size_t chunkSize = CHAR_BIT * sizeof(ChunkType);
+  static constexpr size_t numChunks =
+    (numElements + chunkSize - 1) / chunkSize;
+
+  /// We represent the elements as an inline array of chunks, with
+  /// earlier chunks representing lower indices.  Any padding bits
+  /// in the last chunk (if the number of elements isn't an even
+  /// multiple of the chunk size) are always clear.
+  ChunkType chunks[numChunks] = {};
+
+  static size_t chunkIndex(ValueType i) {
+    return size_t(i) / chunkSize;
+  }
+  static size_t chunkMask(ValueType i) {
+    return ChunkType(1) << (size_t(i) % chunkSize);
+  }
+
+public:
+  /// Build an empty set.
+  FixedBitSet() {}
+
+  /// Build a set containing the given elements.
+  FixedBitSet(std::initializer_list<ValueType> elements) {
+    for (const auto &elt : elements)
+      insert(elt);
+  }
+
+  /// Return true if the set is empty.
+  bool empty() const {
+    for (auto chunk : chunks)
+      if (chunk != 0) return false;
+    return true;
+  }
+
+  /// Return whether the given element is present in the set.
+  bool contains(ValueType i) const {
+    assert(size_t(i) < numElements);
+    return chunks[chunkIndex(i)] & chunkMask(i);
+  }
+
+  /// Either insert or remove the given element.
+  void insertOrRemove(ValueType i, bool shouldInsert) {
+    if (shouldInsert)
+      insert(i);
+    else
+      remove(i);
+  }
+
+  /// Insert the given element.
+  void insert(ValueType i) {
+    assert(size_t(i) < numElements);
+    chunks[chunkIndex(i)] |= chunkMask(i);
+  }
+
+  /// Remove the given element from the set.
+  void remove(ValueType i) {
+    assert(size_t(i) < numElements);
+    chunks[chunkIndex(i)] &= ~chunkMask(i);
+  }
+
+  /// Add every element in the range to this set.
+  void insertAll() {
+    // Our invariant is that any padding bits are clear, so
+    // we need to set bits in the most significant chunk only
+    // for the bits that are set.
+    constexpr size_t partialBits = (numElements % chunkSize);
+    constexpr size_t firstIncompleteChunk =
+      partialBits == 0 ? numChunks : numChunks - 1;
+
+    for (size_t i = 0; i != firstIncompleteChunk; ++i)
+      chunks[i] = ~ChunkType(0);
+
+    if (partialBits != 0)
+      chunks[numChunks - 1] = (ChunkType(1) << partialBits) - 1;
+  }
+
+  /// Remove all of the elements in this set.
+  void removeAll() {
+    for (size_t i = 0; i != numChunks; ++i)
+      chunks[i] = 0;
+  }
+
+  /// Add all of the elements in the given set.
+  void insertAll(const FixedBitSet &other) {
+    for (size_t i = 0; i != numChunks; ++i) {
+      chunks[i] |= other.chunks[i];
+    }
+  }
+
+  /// Remove all of the elements that aren't in the given set.
+  void removeAllExcept(const FixedBitSet &other) {
+    for (size_t i = 0; i != numChunks; ++i) {
+      chunks[i] &= other.chunks[i];
+    }
+  }
+
+  /// Remove all of the elements that are also in the given set.
+  void removeAll(const FixedBitSet &other) {
+    for (size_t i = 0; i != numChunks; ++i) {
+      chunks[i] &= ~other.chunks[i];
+    }
+  }
+
+  class iterator {
+    const ChunkType *chunks;
+    size_t chunkIndex;
+
+    /// Our possibly-edited copy of the current chunk.  As we iterate
+    /// past elements, we clear the corresponding bit here and then find
+    /// the next chunk that has a bit set.  The invariant is that either
+    /// this is non-zero or chunkIndex == numChunks.
+    size_t remainingChunk;
+
+    friend class FixedBitSet;
+
+    // Constructor for begin().
+    iterator(const ChunkType *chunks, size_t chunkIndex,
+             size_t remainingChunk)
+      : chunks(chunks), chunkIndex(chunkIndex),
+        remainingChunk(remainingChunk) {
+      advance();
+    }
+
+    /// Constructor for end().
+    iterator(const ChunkType *chunks)
+      : chunks(chunks), chunkIndex(numChunks), remainingChunk(0) {}
+
+    /// Find the next element, if any, or else set chunkIndex to numChunks.
+    void advance() {
+      while (!remainingChunk) {
+        assert(chunkIndex < numChunks);
+        if (++chunkIndex == numChunks) break;
+        remainingChunk = chunks[chunkIndex];
+      }
+    }
+
+  public:
+    iterator &operator++() {
+      assert(remainingChunk && "incrementing a completed iterator");
+      //  rc     = aaaaaaaa100
+      //  rc - 1 = aaaaaaaa011
+      remainingChunk &= (remainingChunk - 1);
+      advance();
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    ValueType operator*() const {
+      assert(remainingChunk && "dereferencing a completed iterator");
+      return ValueType(chunkIndex * chunkSize
+                         + llvm::findFirstSet(remainingChunk,
+                                              llvm::ZB_Undefined));
+    }
+
+    bool operator==(const iterator &other) const {
+      assert(chunks == other.chunks &&
+             "comparing iterators from different bit Sets");
+      return chunkIndex == other.chunkIndex
+          && remainingChunk == other.remainingChunk;
+    }
+    bool operator!=(const iterator &other) const {
+      return !(*this == other);
+    }
+  };
+
+  iterator begin() const {
+    return iterator(chunks, 0, chunks[0]);
+  }
+  iterator end() const {
+    return iterator(chunks);
+  }
+
+  bool operator==(const FixedBitSet &other) const {
+    for (size_t i = 0; i != numChunks; ++i)
+      if (chunks[i] != other.chunks[i])
+        return false;
+    return true;
+  }
+  bool operator!=(const FixedBitSet &other) const {
+    return !(*this == other);
+  }
+};
+
+}  // end namespace swift
+
+#endif

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -394,6 +394,17 @@ llvm::StringRef swift::getFeatureName(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
+bool swift::isSuppressibleFeature(Feature feature) {
+  switch (feature) {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+  case Feature::FeatureName: return false;
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+  case Feature::FeatureName: return true;
+#include "swift/Basic/Features.def"
+  }
+  llvm_unreachable("covered switch");
+}
+
 DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {
   switch (AccessNoteBehavior) {
   case AccessNoteDiagnosticBehavior::Ignore:

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -152,4 +152,29 @@ public func stage(with actor: MyActor) { }
 // CHECK-NEXT: #endif
 public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
 
+// CHECK:      #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NEXT: #if $UnsafeInheritExecutor
+// CHECK-NEXT: @_unsafeInheritExecutor public func unsafeInheritExecutor() async
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func unsafeInheritExecutor() async
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #endif
+@_unsafeInheritExecutor
+public func unsafeInheritExecutor() async {}
+
+// CHECK:      #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NEXT: #if $UnsafeInheritExecutor
+// CHECK-NEXT: @_specialize{{.*}}
+// CHECK-NEXT: @_unsafeInheritExecutor public func multipleSuppressible<T>(value: T) async
+// CHECK-NEXT: #elsif $SpecializeAttributeWithAvailability
+// CHECK-NEXT: @_specialize{{.*}}
+// CHECK-NEXT: public func multipleSuppressible<T>(value: T) async
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func multipleSuppressible<T>(value: T) async
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #endif
+@_unsafeInheritExecutor
+@_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
+public func multipleSuppressible<T>(value: T) async {}
+
 // CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_unittest(SwiftBasicTests
   EncodedSequenceTest.cpp
   ExponentialGrowthAppendingBinaryByteStreamTests.cpp
   FileSystemTest.cpp
+  FixedBitSetTest.cpp
   FrozenMultiMapTest.cpp
   ImmutablePointerSetTest.cpp
   JSONSerialization.cpp

--- a/unittests/Basic/FixedBitSetTest.cpp
+++ b/unittests/Basic/FixedBitSetTest.cpp
@@ -1,0 +1,289 @@
+//===--- FixedBitSetTest.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/FixedBitSet.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+enum class Enum {
+  A, B, C, D
+};
+
+template <size_t numElements, class ElementType>
+static void expectIteration(const FixedBitSet<numElements, ElementType> &bitSet,
+                            std::initializer_list<ElementType> expected) {
+  auto ei = expected.begin(), ee = expected.end();
+  for (ElementType value : bitSet) {
+    EXPECT_FALSE(ei == ee);
+    EXPECT_EQ(*ei, value);
+    ++ei;
+  }
+  EXPECT_TRUE(ei == ee);
+}
+
+template <size_t numElements, class ElementType>
+static void expectIterationAll(const FixedBitSet<numElements, ElementType> &bitSet) {
+  ElementType expected = ElementType(0);
+  for (ElementType value : bitSet) {
+    EXPECT_EQ(expected, value);
+    expected = ElementType(size_t(expected) + 1);
+  }
+  EXPECT_EQ(ElementType(numElements), expected);
+}
+
+template <class T>
+static void simpleScript(T &bitSet) {
+  EXPECT_FALSE(bitSet.contains(Enum::C));
+  EXPECT_FALSE(bitSet.contains(Enum::D));
+  EXPECT_TRUE(bitSet.empty());
+  expectIteration(bitSet, {});
+
+  bitSet.insert(Enum::D);
+
+  EXPECT_FALSE(bitSet.contains(Enum::C));
+  EXPECT_TRUE(bitSet.contains(Enum::D));
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {Enum::D});
+
+  bitSet.insert(Enum::C);
+
+  EXPECT_TRUE(bitSet.contains(Enum::C));
+  EXPECT_TRUE(bitSet.contains(Enum::D));
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {Enum::C, Enum::D});
+
+  bitSet.insert(Enum::C);
+
+  EXPECT_TRUE(bitSet.contains(Enum::C));
+  EXPECT_TRUE(bitSet.contains(Enum::D));
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {Enum::C, Enum::D});
+
+  bitSet.remove(Enum::D);
+
+  EXPECT_TRUE(bitSet.contains(Enum::C));
+  EXPECT_FALSE(bitSet.contains(Enum::D));
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {Enum::C});
+
+  bitSet.remove(Enum::D);
+
+  EXPECT_TRUE(bitSet.contains(Enum::C));
+  EXPECT_FALSE(bitSet.contains(Enum::D));
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {Enum::C});
+
+  bitSet.remove(Enum::C);
+
+  EXPECT_FALSE(bitSet.contains(Enum::C));
+  EXPECT_FALSE(bitSet.contains(Enum::D));
+  EXPECT_TRUE(bitSet.empty());
+  expectIteration(bitSet, {});
+}
+
+TEST(FixedBitSet, simple_5bits) {
+  FixedBitSet<5, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_8bits) {
+  FixedBitSet<8, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_14bits) {
+  FixedBitSet<14, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_16bits) {
+  FixedBitSet<16, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_21bits) {
+  FixedBitSet<21, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_32bits) {
+  FixedBitSet<32, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_57bits) {
+  FixedBitSet<57, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, simple_141bits) {
+  FixedBitSet<141, Enum> bitSet;
+  simpleScript(bitSet);
+}
+
+TEST(FixedBitSet, initListConstructor) {
+  FixedBitSet<211, int> bitSet = { 51, 51, 89, 14, 175, 89 };
+  EXPECT_FALSE(bitSet.empty());
+  EXPECT_TRUE(bitSet.contains(14));
+  EXPECT_TRUE(bitSet.contains(51));
+  EXPECT_TRUE(bitSet.contains(89));
+  EXPECT_TRUE(bitSet.contains(175));
+  EXPECT_FALSE(bitSet.contains(200));
+  EXPECT_FALSE(bitSet.contains(0));
+  expectIteration(bitSet, {14, 51, 89, 175});
+}
+
+TEST(FixedBitSet, insertOrRemove) {
+  FixedBitSet<211, int> bitSet;
+  EXPECT_TRUE(bitSet.empty());
+  EXPECT_FALSE(bitSet.contains(143));
+  EXPECT_FALSE(bitSet.contains(200));
+  expectIteration(bitSet, {});
+
+  bitSet.insertOrRemove(143, true);
+  EXPECT_FALSE(bitSet.empty());
+  EXPECT_TRUE(bitSet.contains(143));
+  EXPECT_FALSE(bitSet.contains(200));
+  expectIteration(bitSet, {143});
+
+  bitSet.insertOrRemove(200, true);
+  EXPECT_FALSE(bitSet.empty());
+  EXPECT_TRUE(bitSet.contains(143));
+  EXPECT_TRUE(bitSet.contains(200));
+  expectIteration(bitSet, {143, 200});
+
+  bitSet.insertOrRemove(143, false);
+  EXPECT_FALSE(bitSet.empty());
+  EXPECT_FALSE(bitSet.contains(143));
+  EXPECT_TRUE(bitSet.contains(200));
+  expectIteration(bitSet, {200});
+}
+
+// nullary insertAll needs special attention in testing because of its
+// logic to avoid setting padding bits.
+
+TEST(FixedBitSet, insertAll_nullary_4_enum) {
+  FixedBitSet<4, Enum> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+  expectIteration(bitSet, {Enum::A, Enum::B, Enum::C, Enum::D});
+}
+
+TEST(FixedBitSet, insertAll_nullary_4) {
+  FixedBitSet<4, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_nullary_8) {
+  FixedBitSet<8, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_nullary_14) {
+  FixedBitSet<14, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_nullary_17) {
+  FixedBitSet<17, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_nullary_51) {
+  FixedBitSet<51, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_nullary_211) {
+  FixedBitSet<211, size_t> bitSet;
+  bitSet.insertAll();
+  EXPECT_FALSE(bitSet.empty());
+  expectIterationAll(bitSet);
+}
+
+TEST(FixedBitSet, insertAll_set) {
+  FixedBitSet<51, int> bitSet = { 34, 12, 0, 8 };
+  expectIteration(bitSet, {0, 8, 12, 34});
+
+  FixedBitSet<51, int> other = { 23, 12, 1, 2 };
+  bitSet.insertAll(other);
+  expectIteration(bitSet, {0, 1, 2, 8, 12, 23, 34});
+}
+
+TEST(FixedBitSet, removeAll_nullary) {
+  FixedBitSet<7, int> bitSet = { 6, 1, 4 };
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {1, 4, 6});
+
+  bitSet.removeAll();
+  EXPECT_TRUE(bitSet.empty());
+  expectIteration(bitSet, {});
+}
+
+TEST(FixedBitSet, removeAll_set) {
+  FixedBitSet<7, int> bitSet = { 6, 1, 4 };
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {1, 4, 6});
+
+  FixedBitSet<7, int> other = { 6, 3, 4 };
+  bitSet.removeAll(other);
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {1});
+
+  FixedBitSet<7, int> other2 = { 1, 0 };
+  bitSet.removeAll(other2);
+  EXPECT_TRUE(bitSet.empty());
+  expectIteration(bitSet, {});
+}
+
+TEST(FixedBitSet, removeAllExcept_set) {
+  FixedBitSet<7, int> bitSet = { 6, 1, 4 };
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {1, 4, 6});
+
+  FixedBitSet<7, int> other = { 6, 3, 4 };
+  bitSet.removeAllExcept(other);
+  EXPECT_FALSE(bitSet.empty());
+  expectIteration(bitSet, {4, 6});
+
+  FixedBitSet<7, int> other2 = { 1, 0 };
+  bitSet.removeAllExcept(other2);
+  EXPECT_TRUE(bitSet.empty());
+  expectIteration(bitSet, {});
+}
+
+TEST(FixedBitSet, equality) {
+  FixedBitSet<141, int> lhs = {};
+  FixedBitSet<141, int> rhs = {1};
+  EXPECT_NE(lhs, rhs);
+
+  lhs.insert(1);  
+  EXPECT_EQ(lhs, rhs);
+
+  rhs.insert(107);
+  EXPECT_NE(lhs, rhs);
+
+  lhs.insert(107);
+  EXPECT_EQ(lhs, rhs);
+}


### PR DESCRIPTION
Fix and generalize the printing of suppressible features, and make `@_unsafeInheritExecutor` a suppressible feature.
    
Some language features are required in order to parse a declaration correctly, but some can safely be ignored. For the latter, we'd like the module interface to simply contain the declaration twice, once with the feature and once without.  Some basic support for that was already added for the `SpecializeAttributeWithAvailability` feature, but it didn't interact correctly with required features that might be checked in the same `#if` clause (it simply introduced an `#else`), and it wasn't really set up to allow multiple features to be handled this way.  There were also a few other places that weren't updated to handle this, presumably because they never coincided with a `@_specialize` attribute.
    
Introduce the concept of a suppressible feature, which is anything that the `ASTPrinter` can modify the current `PrintOptions` in order to suppress.  Restructure the printing of compatibility checks so that we can print the body multiple times with different settings.  Print required feature checks in an outer `#if...#endif`, then perform a separate `#if...#else...#endif` within if we have suppressible features.  If there are multiple suppressible features, check for the most recent first, on the assumption that it will imply the rest; then perform subsequent checks with an `#elsif` clause.
    
This should be a far more solid foundation on which to build compatibility checks in the future.
    
`@_unsafeInheritExecutor` needs to be suppressible because it's been added to some rather important existing APIs.  Simply suppressing the entire decl will effectively block old tools from using a new SDK to build many existing projects (if they've adopted `async`).  Dropping the attribute changes the semantics of these functions, but only if the compiler features the SE-0338 scheduling change; this is a very narrow window of main-branch development builds of the tools, none of which were officially released.