### PR TITLE
[CodeCompletion] Precompute "filter name" 

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -52,12 +52,16 @@ namespace swift {
   /// Determine the part of speech for the given word.
   PartOfSpeech getPartOfSpeech(StringRef word);
 
+  /// Copy \p string to \p Allocator and return it as a null terminated C
+  /// string.
+  const char *copyCString(StringRef string, llvm::BumpPtrAllocator &Allocator);
+
   /// Scratch space used for returning a set of StringRefs.
   class StringScratchSpace {
     llvm::BumpPtrAllocator Allocator;
 
   public:
-    StringRef copyString(StringRef string);
+    StringRef copyString(StringRef string) { return string.copy(Allocator); }
 
     llvm::BumpPtrAllocator &getAllocator() { return Allocator; }
   };

--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -469,6 +469,52 @@ bool omitNeedlessWords(StringRef &baseName,
 /// If the name has a completion-handler suffix, strip off that suffix.
 Optional<StringRef> stripWithCompletionHandlerSuffix(StringRef name);
 
+/// Represents a string that can be efficiently retrieved either as a StringRef
+/// or as a null-terminated C string.
+class NullTerminatedStringRef {
+  StringRef Ref;
+
+public:
+  /// Create a \c NullTerminatedStringRef from a null-terminated C string with
+  /// size \p Size (excluding the null character).
+  NullTerminatedStringRef(const char *Data, size_t Size) : Ref(Data, Size) {
+    assert(Data != nullptr && Data[Size] == '\0' &&
+           "Data should be null-terminated");
+  }
+
+  /// Create an empty null-terminated string. \c data() is not a \c nullptr.
+  constexpr NullTerminatedStringRef() : Ref("") {}
+
+  /// Create an null terminated string with a C string.
+  constexpr NullTerminatedStringRef(const char *Data) : Ref(Data) {}
+
+  /// Create a null-terminated string, copying \p Str into \p A .
+  template <typename Allocator>
+  NullTerminatedStringRef(StringRef Str, Allocator &A) : Ref("") {
+    if (Str.empty())
+      return;
+
+    size_t size = Str.size();
+    char *memory = A.template Allocate<char>(size + 1);
+    memcpy(memory, Str.data(), size);
+    memory[size] = '\0';
+    Ref = {memory, size};
+  }
+
+  /// Returns the string as a `StringRef`. The `StringRef` does not include the
+  /// null character.
+  operator StringRef() const { return Ref; }
+
+  /// Returns the string as a null-terminated C string.
+  const char *data() const { return Ref.data(); }
+
+  /// The size of the string, excluding the null character.
+  size_t size() const { return Ref.size(); }
+
+  bool empty() const { return Ref.empty(); }
+  int compare(NullTerminatedStringRef RHS) const { return Ref.compare(RHS); }
+};
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_STRINGEXTRAS_H

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -735,6 +735,7 @@ class ContextFreeCodeCompletionResult {
   static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
 
   StringRef DiagnosticMessage;
+  StringRef FilterName;
 
 public:
   /// Memberwise initializer. \p AssociatedKInd is opaque and will be
@@ -753,13 +754,13 @@ public:
       CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
-      StringRef DiagnosticMessage)
+      StringRef DiagnosticMessage, StringRef FilterName)
       : Kind(Kind), KnownOperatorKind(KnownOperatorKind), IsSystem(IsSystem),
         CompletionString(CompletionString), ModuleName(ModuleName),
         BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
         ResultType(ResultType), NotRecommended(NotRecommended),
         DiagnosticSeverity(DiagnosticSeverity),
-        DiagnosticMessage(DiagnosticMessage) {
+        DiagnosticMessage(DiagnosticMessage), FilterName(FilterName) {
     this->AssociatedKind.Opaque = AssociatedKind;
     assert((NotRecommended == ContextFreeNotRecommendedReason::None) ==
                (DiagnosticSeverity == CodeCompletionDiagnosticSeverity::None) &&
@@ -869,7 +870,9 @@ public:
   CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
     return DiagnosticSeverity;
   }
-  StringRef getDiagnosticMessage() const { return DiagnosticMessage; };
+  StringRef getDiagnosticMessage() const { return DiagnosticMessage; }
+
+  StringRef getFilterName() const { return FilterName; }
 
   bool isOperator() const {
     if (getKind() == CodeCompletionResultKind::Declaration) {
@@ -1108,6 +1111,10 @@ public:
     } else {
       return getContextFreeResult().getDiagnosticMessage();
     }
+  }
+
+  StringRef getFilterName() const {
+    return getContextFreeResult().getFilterName();
   }
 
   /// Print a debug representation of the code completion result to \p OS.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -777,78 +777,54 @@ public:
                "isOperator implies operator kind != None");
   }
 
-  /// Constructs a \c Pattern, \c Keyword or \c BuiltinOperator result.
+  /// Constructs a \c Pattern or \c BuiltinOperator result.
   ///
   /// \note The caller must ensure that the \p CompletionString and \c
   /// StringRefs outlive this result, typically by storing them in the same
   /// \c CodeCompletionResultSink as the result itself.
-  ContextFreeCodeCompletionResult(
-      CodeCompletionResultKind Kind, CodeCompletionString *CompletionString,
+  static ContextFreeCodeCompletionResult *createPatternOrBuiltInOperatorResult(
+      llvm::BumpPtrAllocator &Allocator, CodeCompletionResultKind Kind,
+      CodeCompletionString *CompletionString,
       CodeCompletionOperatorKind KnownOperatorKind, StringRef BriefDocComment,
       CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
-      StringRef DiagnosticMessage)
-      : ContextFreeCodeCompletionResult(
-            Kind, /*AssociatedKind=*/0, KnownOperatorKind,
-            /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
-            BriefDocComment, /*AssociatedUSRs=*/{}, ResultType, NotRecommended,
-            DiagnosticSeverity, DiagnosticMessage) {}
+      StringRef DiagnosticMessage);
 
   /// Constructs a \c Keyword result.
   ///
   /// \note The caller must ensure that the \p CompletionString and
-  /// \p BriefDocComment outlive this result, typically by storing them in the
-  /// same \c CodeCompletionResultSink as the result itself.
-  ContextFreeCodeCompletionResult(CodeCompletionKeywordKind Kind,
-                                  CodeCompletionString *CompletionString,
-                                  StringRef BriefDocComment,
-                                  CodeCompletionResultType ResultType)
-      : ContextFreeCodeCompletionResult(
-            CodeCompletionResultKind::Keyword, static_cast<uint8_t>(Kind),
-            CodeCompletionOperatorKind::None, /*IsSystem=*/false,
-            CompletionString, /*ModuleName=*/"", BriefDocComment,
-            /*AssociatedUSRs=*/{}, ResultType,
-            ContextFreeNotRecommendedReason::None,
-            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
+  /// \p BriefDocComment outlive this result, typically by storing them in
+  /// the same \c CodeCompletionResultSink as the result itself.
+  static ContextFreeCodeCompletionResult *createKeywordResult(
+      llvm::BumpPtrAllocator &Allocator, CodeCompletionKeywordKind Kind,
+      CodeCompletionString *CompletionString, StringRef BriefDocComment,
+      CodeCompletionResultType ResultType);
 
   /// Constructs a \c Literal result.
   ///
   /// \note The caller must ensure that the \p CompletionString outlives this
   /// result, typically by storing them in the same \c CodeCompletionResultSink
   /// as the result itself.
-  ContextFreeCodeCompletionResult(CodeCompletionLiteralKind LiteralKind,
-                                  CodeCompletionString *CompletionString,
-                                  CodeCompletionResultType ResultType)
-      : ContextFreeCodeCompletionResult(
-            CodeCompletionResultKind::Literal,
-            static_cast<uint8_t>(LiteralKind), CodeCompletionOperatorKind::None,
-            /*IsSystem=*/false, CompletionString, /*ModuleName=*/"",
-            /*BriefDocComment=*/"",
-            /*AssociatedUSRs=*/{}, ResultType,
-            ContextFreeNotRecommendedReason::None,
-            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"") {}
+  static ContextFreeCodeCompletionResult *
+  createLiteralResult(llvm::BumpPtrAllocator &Allocator,
+                      CodeCompletionLiteralKind LiteralKind,
+                      CodeCompletionString *CompletionString,
+                      CodeCompletionResultType ResultType);
 
   /// Constructs a \c Declaration result.
   ///
   /// \note The caller must ensure that the \p CompletionString and all
   /// \c StringRefs outlive this result, typically by storing them in the same
   /// \c CodeCompletionResultSink as the result itself.
-  ContextFreeCodeCompletionResult(
-      CodeCompletionString *CompletionString, const Decl *AssociatedDecl,
-      StringRef ModuleName, StringRef BriefDocComment,
-      ArrayRef<StringRef> AssociatedUSRs, CodeCompletionResultType ResultType,
+  static ContextFreeCodeCompletionResult *createDeclResult(
+      llvm::BumpPtrAllocator &Allocator, CodeCompletionString *CompletionString,
+      const Decl *AssociatedDecl, StringRef ModuleName,
+      StringRef BriefDocComment, ArrayRef<StringRef> AssociatedUSRs,
+      CodeCompletionResultType ResultType,
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
-      StringRef DiagnosticMessage)
-      : ContextFreeCodeCompletionResult(
-            CodeCompletionResultKind::Declaration,
-            static_cast<uint8_t>(getCodeCompletionDeclKind(AssociatedDecl)),
-            CodeCompletionOperatorKind::None, getDeclIsSystem(AssociatedDecl),
-            CompletionString, ModuleName, BriefDocComment, AssociatedUSRs,
-            ResultType, NotRecommended, DiagnosticSeverity, DiagnosticMessage) {
-    assert(AssociatedDecl && "should have a decl");
-  }
+      StringRef DiagnosticMessage);
 
   CodeCompletionResultKind getKind() const { return Kind; }
 

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -64,12 +64,6 @@ std::string removeCodeCompletionTokens(StringRef Input,
                                        StringRef TokenName,
                                        unsigned *CompletionOffset);
 
-StringRef copyString(llvm::BumpPtrAllocator &Allocator,
-                     StringRef Str);
-
-const char *copyCString(llvm::BumpPtrAllocator &Allocator,
-                        StringRef Str);
-
 template <typename T>
 ArrayRef<T> copyArray(llvm::BumpPtrAllocator &Allocator,
                             ArrayRef<T> Arr) {

--- a/include/swift/IDE/CodeCompletionResultPrinter.h
+++ b/include/swift/IDE/CodeCompletionResultPrinter.h
@@ -13,12 +13,15 @@
 #ifndef SWIFT_IDE_CODECOMPLETIONRESULTPRINTER_H
 #define SWIFT_IDE_CODECOMPLETIONRESULTPRINTER_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Allocator.h"
 
 namespace swift {
 namespace ide {
 
 class CodeCompletionResult;
+class CodeCompletionString;
 
 void printCodeCompletionResultDescription(const CodeCompletionResult &Result,
                                           llvm::raw_ostream &OS,
@@ -37,8 +40,10 @@ void printCodeCompletionResultTypeNameAnnotated(
 void printCodeCompletionResultSourceText(
     const CodeCompletionResult &Result, llvm::raw_ostream &OS);
 
-void printCodeCompletionResultFilterName(
-    const CodeCompletionResult &Result, llvm::raw_ostream &OS);
+/// Print 'FilterName' from \p str into memory managed by \p Allocator and
+/// return it.
+llvm::StringRef getCodeCompletionResultFilterName(
+    const CodeCompletionString *Str, llvm::BumpPtrAllocator &Allocator);
 
 } // namespace ide
 } // namespace swift

--- a/include/swift/IDE/CodeCompletionResultPrinter.h
+++ b/include/swift/IDE/CodeCompletionResultPrinter.h
@@ -18,6 +18,9 @@
 #include "llvm/Support/Allocator.h"
 
 namespace swift {
+
+class NullTerminatedStringRef;
+
 namespace ide {
 
 class CodeCompletionResult;
@@ -41,9 +44,10 @@ void printCodeCompletionResultSourceText(
     const CodeCompletionResult &Result, llvm::raw_ostream &OS);
 
 /// Print 'FilterName' from \p str into memory managed by \p Allocator and
-/// return it.
-llvm::StringRef getCodeCompletionResultFilterName(
-    const CodeCompletionString *Str, llvm::BumpPtrAllocator &Allocator);
+/// return it as \c NullTerminatedStringRef .
+NullTerminatedStringRef
+getCodeCompletionResultFilterName(const CodeCompletionString *Str,
+                                  llvm::BumpPtrAllocator &Allocator);
 
 } // namespace ide
 } // namespace swift

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -457,10 +457,14 @@ StringRef swift::matchLeadingTypeName(StringRef name,
   return nameMismatch.getRestOfStr();
 }
 
-StringRef StringScratchSpace::copyString(StringRef string) {
-  void *memory = Allocator.Allocate(string.size(), alignof(char));
+const char *swift::copyCString(StringRef string,
+                               llvm::BumpPtrAllocator &Allocator) {
+  if (string.empty())
+    return "";
+  char *memory = Allocator.Allocate<char>(string.size() + 1);
   memcpy(memory, string.data(), string.size());
-  return StringRef(static_cast<char *>(memory), string.size());
+  memory[string.size()] = '\0';
+  return memory;
 }
 
 void InheritedNameSet::add(StringRef name) {

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/IDE/CodeCompletionCache.h"
 #include "swift/Basic/Cache.h"
+#include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
@@ -165,8 +166,11 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     }
 
     const char *p = strings + index;
-    auto size = read32le(p);
-    auto str = copyString(*V.Allocator, StringRef(p, size));
+    size_t size = read32le(p);
+    StringRef str = StringRef(p, size);
+    // Import the string to the allocator. Use null-terminated string to avoid
+    // potential copies in clients.
+    str = StringRef(copyCString(str, *V.Allocator), size);
     knownStrings[index] = str;
     return str;
   };

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -450,9 +450,8 @@ void swift::ide::printCodeCompletionResultSourceText(
   }
 }
 
-void swift::ide::printCodeCompletionResultFilterName(
-    const CodeCompletionResult &Result, llvm::raw_ostream &OS) {
-  auto str = Result.getCompletionString();
+static void printCodeCompletionResultFilterName(
+    const CodeCompletionString *str, llvm::raw_ostream &OS) {
   // FIXME: we need a more uniform way to handle operator completions.
   if (str->getChunks().size() == 1 && str->getChunks()[0].is(ChunkKind::Dot)) {
     OS << ".";
@@ -535,4 +534,16 @@ void swift::ide::printCodeCompletionResultFilterName(
       ++i;
     }
   }
+}
+
+StringRef swift::ide::getCodeCompletionResultFilterName(
+    const CodeCompletionString *Str, llvm::BumpPtrAllocator &Allocator) {
+  SmallString<32> buf;
+  llvm::raw_svector_ostream OS(buf);
+  printCodeCompletionResultFilterName(Str, OS);
+  size_t size = buf.size();
+  char *storage = Allocator.Allocate<char>(size + 1);
+  memcpy(storage, buf.data(), size);
+  storage[size] = '\0';
+  return {storage, size};
 }

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -537,12 +537,10 @@ static void printCodeCompletionResultFilterName(
   }
 }
 
-StringRef swift::ide::getCodeCompletionResultFilterName(
+NullTerminatedStringRef swift::ide::getCodeCompletionResultFilterName(
     const CodeCompletionString *Str, llvm::BumpPtrAllocator &Allocator) {
   SmallString<32> buf;
   llvm::raw_svector_ostream OS(buf);
   printCodeCompletionResultFilterName(Str, OS);
-  // Use 'copyCString' to get a null terminated StringRef just in case clients
-  // need it.
-  return {copyCString(buf, Allocator), buf.size()};
+  return NullTerminatedStringRef(buf, Allocator);
 }

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -13,6 +13,7 @@
 #include "swift/IDE/CodeCompletionResultPrinter.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/IDE/CodeCompletion.h"
 #include "swift/Markup/XMLUtils.h"
 #include "llvm/Support/raw_ostream.h"
@@ -541,9 +542,7 @@ StringRef swift::ide::getCodeCompletionResultFilterName(
   SmallString<32> buf;
   llvm::raw_svector_ostream OS(buf);
   printCodeCompletionResultFilterName(Str, OS);
-  size_t size = buf.size();
-  char *storage = Allocator.Allocate<char>(size + 1);
-  memcpy(storage, buf.data(), size);
-  storage[size] = '\0';
-  return {storage, size};
+  // Use 'copyCString' to get a null terminated StringRef just in case clients
+  // need it.
+  return {copyCString(buf, Allocator), buf.size()};
 }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -14,6 +14,7 @@
 #define LLVM_SOURCEKIT_LIB_SWIFTLANG_CODECOMPLETION_H
 
 #include "SourceKit/Core/LLVM.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/IDE/CodeCompletion.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
@@ -22,6 +23,7 @@
 namespace SourceKit {
 namespace CodeCompletion {
 
+using swift::NullTerminatedStringRef;
 using swift::ide::CodeCompletionDeclKind;
 using swift::ide::CodeCompletionFlair;
 using swift::ide::CodeCompletionKeywordKind;
@@ -161,7 +163,7 @@ public:
     return getSwiftResult().getBriefDocComment();
   }
 
-  ArrayRef<StringRef> getAssociatedUSRs() const {
+  ArrayRef<NullTerminatedStringRef> getAssociatedUSRs() const {
     return getSwiftResult().getAssociatedUSRs();
   }
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -95,14 +95,13 @@ public:
   /// should outlive the result, generally by being stored in the same
   /// \c CompletionSink or in a sink that was adopted by the sink that this
   /// \c Compleiton is being stored in.
-  Completion(const SwiftResult &base, StringRef name, StringRef description)
-      : base(base), name(name), description(description) {}
+  Completion(const SwiftResult &base, StringRef description)
+      : base(base), description(description) {}
 
   const SwiftResult &getSwiftResult() const { return base; }
 
   bool hasCustomKind() const { return opaqueCustomKind; }
   void *getCustomKind() const { return opaqueCustomKind; }
-  StringRef getName() const { return name; }
   StringRef getDescription() const { return description; }
   Optional<uint8_t> getModuleImportDepth() const { return moduleImportDepth; }
 
@@ -166,6 +165,10 @@ public:
     return getSwiftResult().getAssociatedUSRs();
   }
 
+  StringRef getFilterName() const {
+    return getSwiftResult().getFilterName();
+  }
+
   /// Allow "upcasting" the completion result to a SwiftResult.
   operator const SwiftResult &() const { return getSwiftResult(); }
 };
@@ -194,7 +197,6 @@ class CompletionBuilder {
   SemanticContextKind semanticContext;
   CodeCompletionFlair flair;
   CodeCompletionString *completionString;
-  llvm::SmallVector<char, 64> originalName;
   void *customKind = nullptr;
   Optional<uint8_t> moduleImportDepth;
   PopularityFactor popularityFactor;
@@ -223,7 +225,7 @@ public:
   void setPrefix(CodeCompletionString *prefix);
 
   StringRef getOriginalName() const {
-    return StringRef(originalName.begin(), originalName.size());
+    return base.getFilterName();
   }
 
   Completion *finish();

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -131,8 +131,8 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     auto *completionString =
         CodeCompletionString::create(sink.allocator, chunk);
     auto *contextFreeResult =
-        new (sink.allocator) ContextFreeCodeCompletionResult(
-            CodeCompletionResultKind::Pattern, completionString,
+        ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
+            sink.allocator, CodeCompletionResultKind::Pattern, completionString,
             CodeCompletionOperatorKind::None, /*BriefDocComment=*/"",
             CodeCompletionResultType::unknown(),
             ContextFreeNotRecommendedReason::None,

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -126,7 +126,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
 
   auto addCompletion = [&](CustomCompletionInfo customCompletion) {
     using Chunk = CodeCompletionString::Chunk;
-    auto nameCopy = copyString(sink.allocator, customCompletion.Name);
+    auto nameCopy = StringRef(customCompletion.Name).copy(sink.allocator);
     auto chunk = Chunk::createWithText(Chunk::ChunkKind::Text, 0, nameCopy);
     auto *completionString =
         CodeCompletionString::create(sink.allocator, chunk);
@@ -1187,7 +1187,7 @@ Completion *CompletionBuilder::finish() {
   }
 
   auto *result = new (sink.allocator)
-      Completion(*newBase, copyString(sink.allocator, description));
+      Completion(*newBase, description.str().copy(sink.allocator));
   result->moduleImportDepth = moduleImportDepth;
   result->popularityFactor = popularityFactor;
   result->opaqueCustomKind = customKind;

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -272,7 +272,7 @@ void CodeCompletionOrganizer::preSortCompletions(
                        [](Completion *const *a, Completion *const *b) {
 
      // Sort first by filter name (case-sensitive).
-     if (int primary = (*a)->getName().compare((*b)->getName()))
+     if (int primary = (*a)->getFilterName().compare((*b)->getFilterName()))
        return primary;
 
      // Next, sort by full description text.
@@ -313,7 +313,7 @@ static std::unique_ptr<Group> make_group(StringRef name) {
 
 static std::unique_ptr<Result> make_result(Completion *result) {
   auto r = std::make_unique<Result>(result);
-  r->name = result->getName().str();
+  r->name = result->getFilterName().str();
   r->description = result->getDescription().str();
   return r;
 }
@@ -377,7 +377,7 @@ bool FilterRules::hideFilterName(StringRef name) const {
 }
 
 bool FilterRules::hideCompletion(const Completion &completion) const {
-  return hideCompletion(completion.getSwiftResult(), completion.getName(),
+  return hideCompletion(completion.getSwiftResult(), completion.getFilterName(),
                         completion.getDescription(),
                         completion.getCustomKind());
 }
@@ -462,7 +462,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
                CodeCompletionResultTypeRelation::Invalid))
         continue;
 
-      NameStyle style(completion->getName());
+      NameStyle style(completion->getFilterName());
       bool hideUnderscore = options.hideUnderscores && style.leadingUnderscores;
       if (hideUnderscore && options.reallyHideAllUnderscores)
         continue;
@@ -530,23 +530,23 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
 
     bool match = false;
     if (options.fuzzyMatching && filterText.size() >= options.minFuzzyLength) {
-      match = pattern.matchesCandidate(completion->getName());
+      match = pattern.matchesCandidate(completion->getFilterName());
     } else {
-      match = completion->getName().startswith_insensitive(filterText);
+      match = completion->getFilterName().startswith_insensitive(filterText);
     }
 
     bool isExactMatch =
-        match && completion->getName().equals_insensitive(filterText);
+        match && completion->getFilterName().equals_insensitive(filterText);
 
     if (isExactMatch) {
       if (!exactMatch) { // first match
         exactMatch = completion;
-      } else if (completion->getName() != exactMatch->getName()) {
-        if (completion->getName() == filterText && // first case-sensitive match
-            exactMatch->getName() != filterText)
+      } else if (completion->getFilterName() != exactMatch->getFilterName()) {
+        if (completion->getFilterName() == filterText && // first case-sensitive match
+            exactMatch->getFilterName() != filterText)
           exactMatch = completion;
-        else if (pattern.scoreCandidate(completion->getName()) > // better match
-                 pattern.scoreCandidate(exactMatch->getName()))
+        else if (pattern.scoreCandidate(completion->getFilterName()) > // better match
+                 pattern.scoreCandidate(exactMatch->getFilterName()))
           exactMatch = completion;
       }
 
@@ -559,7 +559,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
     if (match) {
       auto wrapper = make_result(completion);
       if (options.fuzzyMatching) {
-        wrapper->matchScore = pattern.scoreCandidate(completion->getName());
+        wrapper->matchScore = pattern.scoreCandidate(completion->getFilterName());
       }
       wrapper->isExactMatch = isExactMatch;
 
@@ -1118,15 +1118,7 @@ CompletionBuilder::CompletionBuilder(CompletionSink &sink,
     : sink(sink), base(base) {
   semanticContext = base.getSemanticContext();
   flair = base.getFlair();
-  completionString =
-      const_cast<CodeCompletionString *>(base.getCompletionString());
-
-  // FIXME: this works around the fact we're producing invalid completion
-  // strings for our inner "." result.
-  if (base.getCompletionString()->getFirstTextChunkIndex().hasValue()) {
-    llvm::raw_svector_ostream OSS(originalName);
-    ide::printCodeCompletionResultFilterName(base, OSS);
-  }
+  completionString = nullptr;
 }
 
 void CompletionBuilder::setPrefix(CodeCompletionString *prefix) {
@@ -1153,7 +1145,6 @@ void CompletionBuilder::setPrefix(CodeCompletionString *prefix) {
 Completion *CompletionBuilder::finish() {
   const SwiftResult *newBase = &this->base;
   llvm::SmallString<64> nameStorage;
-  StringRef name = getOriginalName();
   if (modified) {
     // We've modified the original result, so build a new one.
     auto opKind = CodeCompletionOperatorKind::None;
@@ -1163,24 +1154,29 @@ Completion *CompletionBuilder::finish() {
     const ContextFreeCodeCompletionResult &contextFreeBase =
         base.getContextFreeResult();
 
+    auto *newCompletionString = contextFreeBase.getCompletionString();
+    auto newFilterName = contextFreeBase.getFilterName();
+    if (completionString) {
+      newCompletionString = completionString;
+      newFilterName =
+          getCodeCompletionResultFilterName(completionString, sink.allocator);
+    }
+
     ContextFreeCodeCompletionResult *contextFreeResult =
         new (sink.allocator) ContextFreeCodeCompletionResult(
             contextFreeBase.getKind(),
             contextFreeBase.getOpaqueAssociatedKind(), opKind,
-            contextFreeBase.isSystem(), completionString,
+            contextFreeBase.isSystem(), newCompletionString,
             contextFreeBase.getModuleName(),
             contextFreeBase.getBriefDocComment(),
             contextFreeBase.getAssociatedUSRs(),
             contextFreeBase.getResultType(),
             contextFreeBase.getNotRecommendedReason(),
             contextFreeBase.getDiagnosticSeverity(),
-            contextFreeBase.getDiagnosticMessage());
+            contextFreeBase.getDiagnosticMessage(),
+            newFilterName);
     newBase = base.withContextFreeResultSemanticContextAndFlair(
         *contextFreeResult, semanticContext, flair, sink.swiftSink);
-
-    llvm::raw_svector_ostream OSS(nameStorage);
-    ide::printCodeCompletionResultFilterName(*newBase, OSS);
-    name = OSS.str();
   }
 
   llvm::SmallString<64> description;
@@ -1191,8 +1187,7 @@ Completion *CompletionBuilder::finish() {
   }
 
   auto *result = new (sink.allocator)
-      Completion(*newBase, copyString(sink.allocator, name),
-                 copyString(sink.allocator, description));
+      Completion(*newBase, copyString(sink.allocator, description));
   result->moduleImportDepth = moduleImportDepth;
   result->popularityFactor = popularityFactor;
   result->opaqueCustomKind = customKind;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -68,8 +68,9 @@ struct SwiftToSourceKitCompletionAdapter {
                            bool legacyLiteralToKeyword,
                            bool annotatedDescription);
 
-  static void getResultAssociatedUSRs(ArrayRef<StringRef> AssocUSRs,
-                                      raw_ostream &OS);
+  static void
+  getResultAssociatedUSRs(ArrayRef<NullTerminatedStringRef> AssocUSRs,
+                          raw_ostream &OS);
 };
 
 } // anonymous namespace
@@ -594,7 +595,7 @@ getCodeCompletionKeywordKindForUID(UIdent uid) {
 }
 
 void SwiftToSourceKitCompletionAdapter::getResultAssociatedUSRs(
-    ArrayRef<StringRef> AssocUSRs, raw_ostream &OS) {
+    ArrayRef<NullTerminatedStringRef> AssocUSRs, raw_ostream &OS) {
   bool First = true;
   for (auto USR : AssocUSRs) {
     if (!First)

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -920,9 +920,9 @@ static void transformAndForwardResults(
     auto *completionString =
         CodeCompletionString::create(innerSink.allocator, chunks);
     ContextFreeCodeCompletionResult *contextFreeResult =
-        new (innerSink.allocator) ContextFreeCodeCompletionResult(
-            CodeCompletionResultKind::BuiltinOperator, completionString,
-            CodeCompletionOperatorKind::None,
+        ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
+            innerSink.allocator, CodeCompletionResultKind::BuiltinOperator,
+            completionString, CodeCompletionOperatorKind::None,
             /*BriefDocComment=*/"", CodeCompletionResultType::notApplicable(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -760,7 +760,7 @@ static StringRef getModuleName(const ValueDecl *VD,
       static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   if (auto ClangNode = VD->getClangNode()) {
     if (const auto *ClangMod = Importer->getClangOwningModule(ClangNode))
-      return copyString(Allocator, ClangMod->getFullModuleName());
+      return StringRef(ClangMod->getFullModuleName()).copy(Allocator);
     return "";
   }
 
@@ -824,7 +824,7 @@ struct DeclInfo {
 
 static StringRef copyAndClearString(llvm::BumpPtrAllocator &Allocator,
                                     SmallVectorImpl<char> &Str) {
-  auto Ref = copyString(Allocator, StringRef(Str.data(), Str.size()));
+  auto Ref = StringRef(Str.data(), Str.size()).copy(Allocator);
   Str.clear();
   return Ref;
 }
@@ -998,7 +998,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
     SmallVector<ParentInfo, 4> Parents;
     for (auto &Component : PathComponents) {
       SwiftLangSupport::printUSR(Component.VD, OS);
-      Parents.emplace_back(copyString(Allocator, Component.Title),
+      Parents.emplace_back(Component.Title.str().copy(Allocator),
                            Component.Kind,
                            copyAndClearString(Allocator, Buffer));
     };
@@ -1009,7 +1009,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
       SmallVector<ParentInfo, 4> FIParents;
       for (auto &Component: FI.ParentContexts) {
         SwiftLangSupport::printUSR(Component.VD, OS);
-        FIParents.emplace_back(copyString(Allocator, Component.Title),
+        FIParents.emplace_back(Component.Title.str().copy(Allocator),
                                Component.Kind,
                                copyAndClearString(Allocator, Buffer));
       }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1091,8 +1091,7 @@ printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
       Result->getCompletionString()->print(OS);
     }
 
-    OS << "; name=";
-    printCodeCompletionResultFilterName(*Result, OS);
+    OS << "; name=" << Result->getFilterName();
 
     if (IncludeSourceText) {
       OS << "; sourcetext=";


### PR DESCRIPTION
"Filter name" (aka "name") is computed from a `CodeCompletionString`, that is not a trivial operation.
Previously, filter names are computed when they are used. Since they are always used, there's not much benefit to compute them lazily. Also some operations used to compute them, used it, then threw it away. Especially, for cached completions, filter names for all global symbols from imported modules are computed for each completion session.

In this PR, precompute and cache "filter name" in `ContextFreeCodeCompletionResult`. Getting "filter name" is now a trivial operation. And it's guaranteed that each "filter name" is computed only once.

rdar://84036006 rdar://89058389