### PR TITLE
build-script: basic support for building with GCC

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -181,8 +181,11 @@ class Product(object):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.cmake_options = cmake.CMakeOptions()
-        self.common_c_flags = ['-Wno-unknown-warning-option',
-                               '-Werror=unguarded-availability-new']
+        if toolchain.cc.endswith('gcc'):
+            self.common_c_flags = []
+        else:
+            self.common_c_flags = ['-Wno-unknown-warning-option',
+                                   '-Werror=unguarded-availability-new']
 
     def is_release(self):
         """is_release() -> Bool


### PR DESCRIPTION
<!-- What's in this pull request? -->
This doesn't resolve all of the issues experienced when building the toolchain with GCC, but at least it allows the build script to start building LLVM. This is a prerequisite for building the whole toolchain on Alpine Linux with Musl.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-4632.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
