### PR TITLE
build-script: specify bootstrapping modes in --help

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -554,7 +554,10 @@ def create_argument_parser():
 
     option('--bootstrapping', store('bootstrapping_mode'),
            choices=['off', 'hosttools', 'bootstrapping', 'bootstrapping-with-hostlibs'],
-           help='The bootstrapping build mode for swift compiler modules')
+           help='The bootstrapping build mode for swift compiler modules. '
+                'Available modes: `off`, `hosttools`, `bootstrapping`, '
+                '`bootstrapping-with-hostlibs`, `crosscompile`, and '
+                '`crosscompile-with-hostlibs`')
 
     # -------------------------------------------------------------------------
     in_group('Host and cross-compilation targets')


### PR DESCRIPTION
This allows users of `build-script` to see all available bootstrapping modes without looking them up in source code.