### PR TITLE
[build] Remove vestiges of no-debugserver option

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -296,7 +296,6 @@ skip-test-watchos-host
 lldb
 
 # Use the system debugserver to run the lldb swift tests
-lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
 lldb-test-swift-only
@@ -304,7 +303,6 @@ lldb-assertions
 
 [preset: lldb-pull-request]
 lldb
-lldb-no-debugserver
 lldb-use-system-debugserver
 release-debuginfo
 test
@@ -1249,7 +1247,6 @@ compiler-vendor=apple
 # Cross compile for Apple Silicon
 cross-compile-hosts=macosx-arm64
 
-lldb-no-debugserver
 lldb-use-system-debugserver
 lldb-build-type=Release
 verbose-build

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -168,7 +168,6 @@ KNOWN_SETTINGS=(
     ## LLDB Options
     lldb-assertions                               "1"               "build lldb with assertions enabled"
     lldb-extra-cmake-args                         ""                "extra command line args to pass to lldb cmake"
-    lldb-no-debugserver                           ""                "delete debugserver after building it, and don't try to codesign it"
     lldb-test-cc                                  ""                "CC to use for building LLDB testsuite test inferiors.  Defaults to just-built, in-tree clang.  If set to 'host-toolchain', sets it to same as host-cc."
     lldb-test-swift-compatibility                 ""                "specify additional Swift compilers to test lldb with"
     lldb-test-swift-only                          "0"               "when running lldb tests, only include Swift-specific tests"


### PR DESCRIPTION
This option has been a no-op since https://github.com/apple/swift/pull/26272.