### PR TITLE
[stdlib] Build _CUnicode as part of _StringProcessing

### DIFF
--- a/stdlib/public/StringProcessing/CMakeLists.txt
+++ b/stdlib/public/StringProcessing/CMakeLists.txt
@@ -15,7 +15,9 @@ set(swift_string_processing_link_libraries
   swift_MatchingEngine)
 
 file(GLOB_RECURSE _STRING_PROCESSING_SOURCES
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_StringProcessing/*.swift")
+  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_StringProcessing/*.swift"
+  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_CUnicode/*.h"
+  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_CUnicode/*.c")
 set(STRING_PROCESSING_SOURCES)
 foreach(source ${_STRING_PROCESSING_SOURCES})
   file(TO_CMAKE_PATH "${source}" source)


### PR DESCRIPTION
This builds the _CUnicode target in the experimental string processing repo directly into _StringProcessing.