### PR TITLE
Explicit code-block fence around doc code snippet.

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -68,6 +68,7 @@ import Swift
 /// calls `stopMonitoring()` on the monitor.
 /// 4. Calls `startMonitoring` on the `QuakeMonitor`.
 ///
+/// ```
 ///     extension QuakeMonitor {
 ///
 ///         static var quakes: AsyncStream<Quake> {
@@ -83,6 +84,7 @@ import Swift
 ///             }
 ///         }
 ///     }
+/// ```
 ///
 /// Because the stream is an `AsyncSequence`, the call point can use the
 /// `for`-`await`-`in` syntax to process each `Quake` instance as the stream
@@ -265,7 +267,7 @@ public struct AsyncStream<Element> {
   /// The following example shows an `AsyncStream` created with this
   /// initializer that produces 100 random numbers on a one-second interval,
   /// calling `yield(_:)` to deliver each element to the awaiting call point.
-  /// When the `for` loop exits and the stream finishes by calling the
+  /// When the `for` loop exits, the stream finishes by calling the
   /// continuation's `finish()` method.
   ///
   ///     let stream = AsyncStream<Int>(Int.self,

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -69,21 +69,21 @@ import Swift
 /// 4. Calls `startMonitoring` on the `QuakeMonitor`.
 ///
 /// ```
-///     extension QuakeMonitor {
+/// extension QuakeMonitor {
 ///
-///         static var quakes: AsyncStream<Quake> {
-///             AsyncStream { continuation in
-///                 let monitor = QuakeMonitor()
-///                 monitor.quakeHandler = { quake in
-///                     continuation.yield(quake)
-///                 }
-///                 continuation.onTermination = { @Sendable _ in
-///                     monitor.stopMonitoring()
-///                 }
-///                 monitor.startMonitoring()
+///     static var quakes: AsyncStream<Quake> {
+///         AsyncStream { continuation in
+///             let monitor = QuakeMonitor()
+///             monitor.quakeHandler = { quake in
+///                 continuation.yield(quake)
 ///             }
+///             continuation.onTermination = { @Sendable _ in
+///                  monitor.stopMonitoring()
+///             }
+///             monitor.startMonitoring()
 ///         }
 ///     }
+/// }
 /// ```
 ///
 /// Because the stream is an `AsyncSequence`, the call point can use the

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -80,6 +80,7 @@ import Swift
 /// calls `stopMonitoring()` on the monitor.
 /// 5. Calls `startMonitoring` on the `QuakeMonitor`.
 ///
+/// ```
 ///     extension QuakeMonitor {
 ///
 ///         static var throwingQuakes: AsyncThrowingStream<Quake, Error> {
@@ -98,6 +99,7 @@ import Swift
 ///             }
 ///         }
 ///     }
+/// ```
 ///
 ///
 /// Because the stream is an `AsyncSequence`, the call point uses the
@@ -289,7 +291,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   /// The following example shows an `AsyncStream` created with this
   /// initializer that produces 100 random numbers on a one-second interval,
   /// calling `yield(_:)` to deliver each element to the awaiting call point.
-  /// When the `for` loop exits and the stream finishes by calling the
+  /// When the `for` loop exits, the stream finishes by calling the
   /// continuation's `finish()` method. If the random number is divisble by 5
   /// with no remainder, the stream throws a `MyRandomNumberError`.
   ///

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -81,24 +81,24 @@ import Swift
 /// 5. Calls `startMonitoring` on the `QuakeMonitor`.
 ///
 /// ```
-///     extension QuakeMonitor {
+/// extension QuakeMonitor {
 ///
-///         static var throwingQuakes: AsyncThrowingStream<Quake, Error> {
-///             AsyncThrowingStream { continuation in
-///                 let monitor = QuakeMonitor()
-///                 monitor.quakeHandler = { quake in
-///                     continuation.yield(quake)
-///                 }
-///                 monitor.errorHandler = { error in
-///                     continuation.finish(throwing: error)
-///                 }
-///                 continuation.onTermination = { @Sendable _ in
-///                     monitor.stopMonitoring()
-///                 }
-///                 monitor.startMonitoring()
+///     static var throwingQuakes: AsyncThrowingStream<Quake, Error> {
+///         AsyncThrowingStream { continuation in
+///             let monitor = QuakeMonitor()
+///             monitor.quakeHandler = { quake in
+///                  continuation.yield(quake)
 ///             }
+///             monitor.errorHandler = { error in
+///                 continuation.finish(throwing: error)
+///             }
+///             continuation.onTermination = { @Sendable _ in
+///                 monitor.stopMonitoring()
+///             }
+///             monitor.startMonitoring()
 ///         }
 ///     }
+/// }
 /// ```
 ///
 ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
Documentation: puts code-block fence syntax around a snippet in `AsyncStream` and `AsyncThrowingStream` whose formatting is ambiguous because it comes immediately after a numbered list.

Also fixes a grammatical error in the docs for `init(_:bufferingPolicy:_:)`.

This change only affects documentation comments.