### PR TITLE
[ClangImporter] Suffix ambiguous protocol names if C++ interop is enabled

### DIFF
--- a/test/Interop/Cxx/class/Inputs/class-protocol-name-clash.h
+++ b/test/Interop/Cxx/class/Inputs/class-protocol-name-clash.h
@@ -1,0 +1,5 @@
+@protocol TheClashingName
+@end
+
+@interface TheClashingName <TheClashingName>
+@end

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -87,3 +87,8 @@ module InvalidNestedStruct {
   header "invalid-nested-struct.h"
   requires cplusplus
 }
+
+module ClassProtocolNameClash {
+  header "class-protocol-name-clash.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/class-protocol-name-clash.swift
+++ b/test/Interop/Cxx/class/class-protocol-name-clash.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend %s -c -enable-cxx-interop -I %S/Inputs
+//
+// REQUIRES: objc_interop
+
+import ClassProtocolNameClash
+
+class Subclass : TheClashingName {}


### PR DESCRIPTION
The Clang Importer when C++ interop is not enabled, disambigate an Obj-C
class and protocol that are named the same by appending `Protocol` to
the protocol. This was not happening when C++ interop was enabled, but
should also apply to Obj-C++ modules.

The fix is providing an starting scope for the search, which the C++
name lookup need to actually find the similarly named counterpart.

Includes a test to avoid this problem creeping in again, and locally it
did not break any other tests.
