### PR TITLE
[cxx-interop] Start to import dependent types as `Any`

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -180,44 +180,108 @@ static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
   return newDecl;
 }
 
-// Derive a concrete function type for fdecl by substituting the generic args
-// and use that to derive the corresponding function type and parameter list.
-static std::pair<FunctionType *, ParameterList *>
-substituteFunctionTypeAndParamList(ASTContext &ctx, AbstractFunctionDecl *fdecl,
-                                   SubstitutionMap subst) {
-  FunctionType *newFnType = nullptr;
-  // Create a new ParameterList with the substituted type.
-  if (auto oldFnType = dyn_cast<GenericFunctionType>(
-          fdecl->getInterfaceType().getPointer())) {
-    newFnType = oldFnType->substGenericArgs(subst);
-  } else {
-    newFnType = cast<FunctionType>(fdecl->getInterfaceType().getPointer());
-  }
-  // The constructor type is a function type as follows:
-  //   (CType.Type) -> (Generic) -> CType
-  // And a method's function type is as follows:
-  //   (inout CType) -> (Generic) -> Void
-  // In either case, we only want the result of that function type because that
-  // is the function type with the generic params that need to be substituted:
-  //   (Generic) -> CType
-  if (isa<ConstructorDecl>(fdecl) || fdecl->isInstanceMember() ||
-      fdecl->isStatic())
-    newFnType = cast<FunctionType>(newFnType->getResult().getPointer());
-  SmallVector<ParamDecl *, 4> newParams;
-  unsigned i = 0;
+// Synthesize a thunk body for the function created in
+// "addThunkForDependentTypes". This will just cast all params and forward them
+// along to the specialized function. It will also cast the result before
+// returning it.
+static std::pair<BraceStmt *, bool>
+synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *context) {
+  ASTContext &ctx = afd->getASTContext();
 
-  for (auto paramTy : newFnType->getParams()) {
-    auto *oldParamDecl = fdecl->getParameters()->get(i);
-    auto *newParamDecl =
-        ParamDecl::cloneWithoutType(fdecl->getASTContext(), oldParamDecl);
-    newParamDecl->setInterfaceType(paramTy.getParameterType());
-    newParams.push_back(newParamDecl);
-    (void)++i;
-  }
-  auto *newParamList =
-      ParameterList::create(ctx, SourceLoc(), newParams, SourceLoc());
+  auto thunkDecl = cast<FuncDecl>(afd);
+  auto specializedFuncDecl = static_cast<FuncDecl *>(context);
 
-  return {newFnType, newParamList};
+  SmallVector<Argument, 8> forwardingParams;
+  unsigned paramIndex = 0;
+  for (auto param : *thunkDecl->getParameters()) {
+    if (isa<MetatypeType>(param->getType().getPointer())) {
+      paramIndex++;
+      continue;
+    }
+
+    auto paramRefExpr = new (ctx) DeclRefExpr(param, DeclNameLoc(),
+                                              /*Implicit=*/true);
+    paramRefExpr->setType(param->getType());
+
+    auto specParamTy = specializedFuncDecl->getParameters()->get(paramIndex)->getType();
+    auto cast = ForcedCheckedCastExpr::createImplicit(
+        ctx, paramRefExpr, specParamTy);
+
+    forwardingParams.push_back(Argument(SourceLoc(), Identifier(), cast));
+    paramIndex++;
+  }
+
+  auto *specializedFuncDeclRef = new (ctx) DeclRefExpr(ConcreteDeclRef(specializedFuncDecl),
+                                                       DeclNameLoc(), true);
+  specializedFuncDeclRef->setType(specializedFuncDecl->getInterfaceType());
+
+  auto argList = ArgumentList::createImplicit(ctx, forwardingParams);
+  auto *specializedFuncCallExpr = CallExpr::createImplicit(ctx, specializedFuncDeclRef, argList);
+  specializedFuncCallExpr->setType(specializedFuncDecl->getResultInterfaceType());
+  specializedFuncCallExpr->setThrows(false);
+
+  auto cast = ForcedCheckedCastExpr::createImplicit(
+      ctx, specializedFuncCallExpr, thunkDecl->getResultInterfaceType());
+
+  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), cast, /*implicit=*/true);
+  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
+                                /*implicit=*/true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+// Create a thunk to map functions with dependent types to their specialized
+// version. For example, create a thunk with type (Any) -> Any to wrap a
+// specialized function template with type (Dependent<T>) -> Dependent<T>.
+static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
+                                            FuncDecl *newDecl) {
+  bool updatedAnyParams = false;
+
+  SmallVector<ParamDecl *, 4> fixedParameters;
+  unsigned parameterIndex = 0;
+  for (auto *newFnParam : *newDecl->getParameters()) {
+    // If the un-specialized function had a parameter with type "Any" preserve
+    // that parameter. Otherwise, use the new function parameter.
+    auto oldParamType = oldDecl->getParameters()->get(parameterIndex)->getType();
+    if (oldParamType->isEqual(newDecl->getASTContext().TheAnyType)) {
+      updatedAnyParams = true;
+      auto newParam =
+          ParamDecl::cloneWithoutType(newDecl->getASTContext(), newFnParam);
+      newParam->setInterfaceType(oldParamType);
+      fixedParameters.push_back(newParam);
+    } else {
+      fixedParameters.push_back(newFnParam);
+    }
+    parameterIndex++;
+  }
+
+  // If we don't need this thunk, bail out.
+  if (!updatedAnyParams &&
+      !oldDecl->getResultInterfaceType()->isEqual(
+          oldDecl->getASTContext().TheAnyType))
+    return newDecl;
+
+  auto fixedParams =
+      ParameterList::create(newDecl->getASTContext(), fixedParameters);
+
+  Type fixedResultType;
+  if (oldDecl->getResultInterfaceType()->isEqual(
+          oldDecl->getASTContext().TheAnyType))
+      fixedResultType = oldDecl->getASTContext().TheAnyType;
+  else
+    fixedResultType = newDecl->getResultInterfaceType();
+
+  // We have to rebuild the whole function.
+  auto newFnDecl = FuncDecl::createImplicit(
+      newDecl->getASTContext(), newDecl->getStaticSpelling(),
+      newDecl->getName(), newDecl->getNameLoc(), newDecl->hasAsync(),
+      newDecl->hasThrows(), /*genericParams=*/nullptr, fixedParams,
+      fixedResultType, newDecl->getDeclContext());
+  newFnDecl->copyFormalAccessFrom(newDecl);
+  newFnDecl->setBodySynthesizer(synthesizeDependentTypeThunkParamForwarding, newDecl);
+  newFnDecl->setSelfAccessKind(newDecl->getSelfAccessKind());
+  newFnDecl->getAttrs().add(
+      new (newDecl->getASTContext()) TransparentAttr(/*IsImplicit=*/true));
+  return newFnDecl;
 }
 
 // Synthesizes the body of a thunk that takes extra metatype arguments and
@@ -268,16 +332,55 @@ static ValueDecl *generateThunkForExtraMetatypes(SubstitutionMap subst,
   // specialization, which are no longer now that we've specialized
   // this function. Create a thunk that only forwards the original
   // parameters along to the clang function.
-  auto thunkTypeAndParamList = substituteFunctionTypeAndParamList(oldDecl->getASTContext(),
-                                                                  oldDecl, subst);
+  SmallVector<ParamDecl *, 4> newParams;
+
+  for (auto param : *newDecl->getParameters()) {
+    auto *newParamDecl = ParamDecl::clone(newDecl->getASTContext(), param);
+    newParams.push_back(newParamDecl);
+  }
+
+  auto originalFnSubst = cast<AbstractFunctionDecl>(oldDecl)
+                             ->getInterfaceType()
+                             ->getAs<GenericFunctionType>()
+                             ->substGenericArgs(subst);
+  // The constructor type is a function type as follows:
+  //   (CType.Type) -> (Generic) -> CType
+  // And a method's function type is as follows:
+  //   (inout CType) -> (Generic) -> Void
+  // In either case, we only want the result of that function type because that
+  // is the function type with the generic params that need to be substituted:
+  //   (Generic) -> CType
+  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember() ||
+      oldDecl->isStatic())
+    originalFnSubst = cast<FunctionType>(originalFnSubst->getResult().getPointer());
+
+  for (auto paramTy : originalFnSubst->getParams()) {
+    if (!paramTy.getPlainType()->is<MetatypeType>())
+      continue;
+
+    auto dc = newDecl->getDeclContext();
+    auto paramVarDecl =
+        new (newDecl->getASTContext()) ParamDecl(
+            SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+            newDecl->getASTContext().getIdentifier("_"), dc);
+    paramVarDecl->setInterfaceType(paramTy.getPlainType());
+    paramVarDecl->setSpecifier(ParamSpecifier::Default);
+    newParams.push_back(paramVarDecl);
+  }
+
+  auto *newParamList =
+      ParameterList::create(newDecl->getASTContext(), SourceLoc(), newParams, SourceLoc());
+
   auto thunk = FuncDecl::createImplicit(
-      oldDecl->getASTContext(), oldDecl->getStaticSpelling(), oldDecl->getName(),
-      oldDecl->getNameLoc(), oldDecl->hasAsync(), oldDecl->hasThrows(),
-      /*genericParams=*/nullptr, thunkTypeAndParamList.second,
-      thunkTypeAndParamList.first->getResult(), oldDecl->getDeclContext());
-  thunk->copyFormalAccessFrom(oldDecl);
+      newDecl->getASTContext(), newDecl->getStaticSpelling(), oldDecl->getName(),
+      newDecl->getNameLoc(), newDecl->hasAsync(), newDecl->hasThrows(),
+      /*genericParams=*/nullptr, newParamList,
+      newDecl->getResultInterfaceType(), newDecl->getDeclContext());
+  thunk->copyFormalAccessFrom(newDecl);
   thunk->setBodySynthesizer(synthesizeForwardingThunkBody, newDecl);
-  thunk->setSelfAccessKind(oldDecl->getSelfAccessKind());
+  thunk->setSelfAccessKind(newDecl->getSelfAccessKind());
+  thunk->getAttrs().add(
+      new (newDecl->getASTContext()) TransparentAttr(/*IsImplicit=*/true));
 
   return thunk;
 }
@@ -325,6 +428,10 @@ static ConcreteDeclRef getCXXFunctionTemplateSpecialization(SubstitutionMap subs
     if (!subst.empty()) {
       newDecl = rewriteIntegerTypes(subst, decl, fn);
     }
+  }
+
+  if (auto fn = dyn_cast<FuncDecl>(decl)) {
+    newDecl = addThunkForDependentTypes(fn, cast<FuncDecl>(newDecl));
   }
 
   if (auto fn = dyn_cast<FuncDecl>(decl)) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -112,7 +112,7 @@ Solution::computeSubstitutions(GenericSignature sig,
 // On Windows and 32-bit platforms we need to force "Int" to actually be
 // re-imported as "Int." This is needed because otherwise, we cannot round-trip
 // "Int" and "UInt". For example, on Windows, "Int" will be imported into C++ as
-// "long long" and then back into Swift as "Int64" not "Int." 
+// "long long" and then back into Swift as "Int64" not "Int."
 static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
                                       AbstractFunctionDecl *newDecl) {
   auto originalFnSubst = cast<AbstractFunctionDecl>(oldDecl)
@@ -172,6 +172,7 @@ static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
         newFnDecl->setSelfAccessKind(func->getSelfAccessKind());
         newFnDecl->setSelfIndex(func->getSelfIndex());
       }
+
       return newFnDecl;
     }
   }

--- a/test/Interop/Cxx/templates/Inputs/dependent-types.h
+++ b/test/Interop/Cxx/templates/Inputs/dependent-types.h
@@ -1,0 +1,55 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_H
+
+template<class T>
+struct M {
+  T value;
+
+  using U = T;
+
+  T getValue() const { return value; }
+};
+
+template<class T, class U>
+M<U> differentDependentArgAndRet(M<T> a) { return {a.value}; }
+
+template<class T>
+M<T> dependantReturnTypeInffered(T a) { return {a}; }
+
+template<class T>
+M<T> dependantReturnTypeSameAsArg(M<T> a) { return {a.value}; }
+
+// TODO: still not supported yet (rdar://89034704)
+template<class T, class U>
+typename M<U>::U complexDifferentDependentArgAndRet(typename M<T>::U  a) { return a.value; }
+
+template<class T>
+typename M<T>::U complexDependantReturnTypeInffered(T a) { return a; }
+
+template<class T>
+typename M<T>::U complexDependantReturnTypeSameAsArg(typename M<T>::U  a) { return a.value; }
+
+template<class T>
+M<T> multipleArgs(M<T> a, T b, int c) { return {a.value + b}; }
+
+template<class T, class U>
+M<T> multipleDependentArgsInferred(M<T> a, M<U> b, T c, U d) { return {a.value}; }
+
+template<class T, class U>
+M<T> multipleDependentArgs(M<T> a, M<U> b) { return {a.value}; }
+
+template<class T>
+M<T> refToDependent(const T &a) { return {a}; }
+
+// TODO: We can't import this template rdar://89028943
+template<class T>
+T &dependentToRef(M<T> a) { return a.value; }
+
+// TODO: We can't convert inout types in a thunk: rdar://89034440
+template<class T>
+M<T> dependentRef(M<T> &a) { return {a.value}; }
+
+template<class T>
+M<T> dependentRefAndRefInferred(const M<T> &a, T &b) { return {a.value + b}; }
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEPENDENT_TYPES_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -132,3 +132,8 @@ module DefineReferencedInline {
   header "define-referenced-inline.h"
   requires cplusplus
 }
+
+module DependentTypes {
+  header "dependent-types.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/dependent-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/dependent-types-module-interface.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=DependentTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: func differentDependentArgAndRet<T, U>(_ a: Any, T: T.Type, U: U.Type) -> Any
+// CHECK: func dependantReturnTypeInffered<T>(_ a: T) -> Any
+// CHECK: func dependantReturnTypeSameAsArg<T>(_ a: Any, T: T.Type) -> Any
+// CHECK: func multipleArgs<T>(_ a: Any, _ b: T, _ c: Int32) -> Any
+// CHECK: func multipleDependentArgsInferred<T, U>(_ a: Any, _ b: Any, _ c: T, _ d: U) -> Any
+// CHECK: func multipleDependentArgs<T, U>(_ a: Any, _ b: Any, T: T.Type, U: U.Type) -> Any
+// CHECK: func refToDependent<T>(_ a: inout T) -> Any
+// CHECK: func dependentRef<T>(_ a: inout Any, T: T.Type) -> Any
+// CHECK: func dependentRefAndRefInferred<T>(_ a: inout Any, _ b: inout T) -> Any

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import DependentTypes
+
+// Check the test function:
+// CHECK-LABEL: sil [ossa] @$s4main4testSiyF : $@convention(thin) () -> Int
+// CHECK:   [[ANY_OUT:%.*]] = alloc_stack $Any
+
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @$sSC27dependantReturnTypeInfferedyypSiF : $@convention(thin) (Int) -> @out Any
+// CHECK:   apply [[THUNK_REF]]([[ANY_OUT]], %{{[0-9]+}}) : $@convention(thin) (Int) -> @out Any
+
+// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIlE
+// CHECK:   unconditional_checked_cast_addr Any in [[ANY_OUT]] : $*Any to __CxxTemplateInst1MIlE in [[SPEC_OUT]] : $*__CxxTemplateInst1MIlE
+// CHECK:   [[SPEC_VAL:%.*]] = load [trivial] [[SPEC_OUT]] : $*__CxxTemplateInst1MIlE
+
+// CHECK:   [[SPEC_TEMP:%.*]] = alloc_stack $__CxxTemplateInst1MIlE
+// CHECK:   store [[SPEC_VAL]] to [trivial] [[SPEC_TEMP]] : $*__CxxTemplateInst1MIlE
+
+// CHECK:   [[GET_VAL_FN:%.*]] = function_ref @_ZNK1MIlE8getValueEv : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIlE) -> Int
+// CHECK:   [[OUT_VAL:%.*]] = apply [[GET_VAL_FN]]([[SPEC_TEMP]]) : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIlE) -> Int
+
+// CHECK:   return [[OUT_VAL]] : $Int
+// CHECK-LABEL: end sil function '$s4main4testSiyF'
+
+
+// Check the synthesized thunk:
+// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$sSC27dependantReturnTypeInfferedyypSiF : $@convention(thin) (Int) -> @out Any
+// CHECK: bb0(%0 : $*Any, %1 : $Int):
+// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIlE
+// CHECK:   [[TMP_INT:%.*]] = alloc_stack $Int
+// CHECK:   store %1 to [trivial] [[TMP_INT]] : $*Int
+// CHECK:   [[TMP_INT_CASTED:%.*]] = alloc_stack $Int
+// CHECK:   unconditional_checked_cast_addr Int in [[TMP_INT]] : $*Int to Int in [[TMP_INT_CASTED]] : $*Int
+
+// CHECK:  [[ARG:%.*]] = load [trivial] [[TMP_INT_CASTED]] : $*Int
+// CHECK:   [[FN:%.*]] = function_ref @_Z27dependantReturnTypeInfferedIlE1MIT_ES1_ : $@convention(c) (Int) -> __CxxTemplateInst1MIlE
+// CHECK:   [[OUT:%.*]] = apply [[FN]]([[ARG]]) : $@convention(c) (Int) -> __CxxTemplateInst1MIlE
+
+// CHECK:   store [[OUT]] to [trivial] [[SPEC_OUT]] : $*__CxxTemplateInst1MIlE
+// CHECK:   unconditional_checked_cast_addr __CxxTemplateInst1MIlE in [[SPEC_OUT]] : $*__CxxTemplateInst1MIlE to Any in %0 : $*Any
+// CHECK-LABEL: end sil function '$sSC27dependantReturnTypeInfferedyypSiF'
+
+public func test() -> Int {
+  let m = dependantReturnTypeInffered(42) as! M<Int>
+  return m.getValue()
+}
+
+// CHECK-LABEL: sil [clang __CxxTemplateInst1MIlE.getValue] @_ZNK1MIlE8getValueEv : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIlE) -> Int
+// CHECK-LABEL: sil [serializable] [clang dependantReturnTypeInffered] @_Z27dependantReturnTypeInfferedIlE1MIT_ES1_ : $@convention(c) (Int) -> __CxxTemplateInst1MIlE

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+//
+// REQUIRES: executable_test
+
+import DependentTypes
+import StdlibUnittest
+
+var DependentTypesTestSuite = TestSuite("DependentTypesTestSuite")
+
+DependentTypesTestSuite.test("Different dependent arg and return type.") {
+  let m1 = differentDependentArgAndRet(M<Int>(value: 42), T: Int.self, U: Int.self) as! M<Int>
+  expectEqual(m1.getValue(), 42)
+
+  let m2 = dependantReturnTypeSameAsArg(M<Int>(value: 42), T: Int.self) as! M<Int>
+  expectEqual(m2.getValue(), 42)
+}
+
+DependentTypesTestSuite.test("Different dependent inferred by arg.") {
+  let m = dependantReturnTypeInffered(42) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+DependentTypesTestSuite.test("Multiple arguments (inferred type).") {
+  let m = multipleArgs(M<Int>(value: 40), 2, 10) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+DependentTypesTestSuite.test("Multiple dependent arguments (inferred type).") {
+  let m = multipleDependentArgsInferred(M<Int>(value: 42), M<CInt>(value: 0), 1, CInt(2)) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+DependentTypesTestSuite.test("Multiple dependent arguments (not inferred).") {
+  let m = multipleDependentArgs(M<Int>(value: 42), M<CInt>(value: 0), T: Int.self, U: Int.self) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/templates/member-templates.swift
+++ b/test/Interop/Cxx/templates/member-templates.swift
@@ -19,11 +19,11 @@ TemplatesTestSuite.test("Templated Add") {
   expectEqual(h.addMixedTypeParams(2, 1), 3)
 }
 
-TemplatesTestSuite.test("Returns other specialization") {
-  let t = TemplateClassWithMemberTemplates<CInt>(42)
-  var _5 = 5
-  let o = t.toOtherSpec(&_5)
-  // TODO: why is "o" Void here? rdar://88443730
-}
+// TODO: support this rdar://88443730
+// TemplatesTestSuite.test("Returns other specialization") {
+//   let t = TemplateClassWithMemberTemplates<CInt>(42)
+//   var _5 = 5
+//   let o = t.toOtherSpec(&_5)
+// }
 
 runAllTests()


### PR DESCRIPTION
This adds very basic support for functions that have dependent types in their signature. Eventually, this will become more robust, so we also support methods and more complex dependent types (such as dependent types with references, etc).

Bridging these types as Any isn't a great design solution, but it's a good fallback if we can't figure out how to import the type. Once the fallback is implemented well, we can start to get smarter about dependent types and import them as the actual generic when possible. 