### PR TITLE
RequirementMachine: Preserve replacement paths for redundant rules

### DIFF
--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -59,6 +59,12 @@ enum class DebugFlags : unsigned {
 
   /// Print debug output from generic signature minimization.
   Minimization = (1<<12),
+
+  /// Print redundant rules and their replacement paths.
+  RedundantRules = (1<<13),
+
+  /// Print more detail about redundant rules.
+  RedundantRulesDetail = (1<<14)
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -269,14 +269,14 @@ void PropertyMap::addSuperclassProperty(
     recordRelation(key, ruleID, layoutSymbol, System, debug);
   }
 
-  if (debug) {
-    llvm::dbgs() << "% New superclass " << superclassDecl->getName()
-                 << " for " << key << " is ";
-  }
-
   // If this is the first superclass requirement we've seen for this term,
   // just record it and we're done.
   if (!props->SuperclassDecl) {
+    if (debug) {
+      llvm::dbgs() << "% New superclass " << superclassDecl->getName()
+                   << " for " << key << "\n";
+    }
+
     props->SuperclassDecl = superclassDecl;
 
     assert(props->Superclasses.empty());
@@ -288,6 +288,11 @@ void PropertyMap::addSuperclassProperty(
     req.SuperclassType = property;
     req.SuperclassRule = ruleID;
     return;
+  }
+
+  if (debug) {
+    llvm::dbgs() << "% New superclass " << superclassDecl->getName()
+                 << " for " << key << " is ";
   }
 
   // Otherwise, we compare it against the existing superclass requirement.

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -40,6 +40,8 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("minimal-conformances", DebugFlags::MinimalConformances)
       .Case("protocol-dependencies", DebugFlags::ProtocolDependencies)
       .Case("minimization", DebugFlags::Minimization)
+      .Case("redundant-rules", DebugFlags::RedundantRules)
+      .Case("redundant-rules-detail", DebugFlags::RedundantRulesDetail)
       .Default(None);
     if (!flag) {
       llvm::errs() << "Unknown debug flag in -debug-requirement-machine "

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -188,6 +188,20 @@ void RewritePath::dump(llvm::raw_ostream &out,
   }
 }
 
+void RewritePath::dumpLong(llvm::raw_ostream &out,
+                           MutableTerm term,
+                           const RewriteSystem &system) const {
+  RewritePathEvaluator evaluator(term);
+
+  for (const auto &step : Steps) {
+    evaluator.dump(out);
+    evaluator.apply(step, system);
+    out << "\n";
+  }
+
+  evaluator.dump(out);
+}
+
 void RewriteLoop::verify(const RewriteSystem &system) const {
 #ifndef NDEBUG
   RewritePathEvaluator evaluator(Basepoint);
@@ -220,13 +234,17 @@ void RewriteLoop::dump(llvm::raw_ostream &out,
 }
 
 void RewritePathEvaluator::dump(llvm::raw_ostream &out) const {
-  out << "Primary stack:\n";
-  for (const auto &term : Primary) {
-    out << term << "\n";
+  for (unsigned i = 0, e = Primary.size(); i < e; ++i) {
+    if (i == Primary.size() - 1)
+      out << "-> ";
+    else
+      out << "   ";
+
+    out << Primary[i] << "\n";
   }
-  out << "\nSecondary stack:\n";
-  for (const auto &term : Secondary) {
-    out << term << "\n";
+
+  for (unsigned i = 0, e = Secondary.size(); i < e; ++i) {
+    out << "   " << Secondary[Secondary.size() - i - 1] << "\n";
   }
 }
 

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -409,6 +409,10 @@ public:
   void dump(llvm::raw_ostream &out,
             MutableTerm term,
             const RewriteSystem &system) const;
+
+  void dumpLong(llvm::raw_ostream &out,
+                MutableTerm term,
+                const RewriteSystem &system) const;
 };
 
 /// Information about protocol conformance rules appearing in a rewrite loop.

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -453,6 +453,10 @@ private:
   /// algorithms.
   std::vector<RewriteLoop> Loops;
 
+  /// A list of pairs where the first element is a rule number and the second
+  /// element is an equivalent rewrite path in terms of non-redundant rules.
+  std::vector<std::pair<unsigned, RewritePath>> RedundantRules;
+
   void propagateExplicitBits();
 
   Optional<std::pair<unsigned, unsigned>>

--- a/test/Generics/generic_objc_superclass.swift
+++ b/test/Generics/generic_objc_superclass.swift
@@ -13,9 +13,9 @@ func foo<T : Generic<U>, U>(_: T, _: U) {
 
 // CHECK-LABEL: Requirement machine for <τ_0_0, τ_0_1 where τ_0_0 : Generic<τ_0_1>>
 // CHECK-NEXT: Rewrite system: {
-// CHECK-NEXT: - τ_0_0.[superclass: Generic<τ_0_0> with <τ_0_1>] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[superclass: Generic<τ_0_1>] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[layout: AnyObject] => τ_0_0
 // CHECK-NEXT: }
 // CHECK: Property map: {
-// CHECK-NEXT:   τ_0_0 => { layout: AnyObject superclass: [superclass: Generic<τ_0_0> with <τ_0_1>] }
+// CHECK-NEXT:   τ_0_0 => { layout: AnyObject superclass: [superclass: Generic<τ_0_1>] }
 // CHECK-NEXT: }

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -3,7 +3,7 @@
 class G<T> {}
 
 protocol P1 { // expected-error {{cannot build rewrite system for protocol; concrete nesting limit exceeded}}
-// expected-note@-1 {{failed rewrite rule is [P1:A].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> with <[P1:A]>] => [P1:A]}}
+// expected-note@-1 {{failed rewrite rule is [P1:A].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<[P1:A]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => [P1:A]}}
   associatedtype A where A == G<B>
   associatedtype B where B == G<A>
 }

--- a/test/Generics/non_confluent.swift
+++ b/test/Generics/non_confluent.swift
@@ -45,7 +45,7 @@ struct S<U : P1> : P1 {
 
 protocol P3 {
 // expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>> with <[P3:U]>] => [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
+// expected-note@-2 {{failed rewrite rule is [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<[P3:U]>>>>>>>>>>>>] => [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
 
   associatedtype T : P1 where T == S<U>
 // expected-error@-1 {{type 'Self.U' does not conform to protocol 'P1'}}

--- a/test/Generics/sr12531.swift
+++ b/test/Generics/sr12531.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
 
 protocol AnyPropertyProtocol {
     associatedtype Root = Any
@@ -8,15 +8,21 @@ protocol AnyPropertyProtocol {
     var value: Value { get }
 }
 
+// CHECK-LABEL: .PartialPropertyProtocol@
+// CHECK-NEXT: Requirement signature: <Self where Self : AnyPropertyProtocol, Self.[AnyPropertyProtocol]KP : PartialKeyPath<Self.[AnyPropertyProtocol]Root>
 protocol PartialPropertyProtocol: AnyPropertyProtocol
 where KP: PartialKeyPath<Root> {
 }
 
+// CHECK-LABEL: .PropertyProtocol@
+// CHECK-NEXT: Requirement signature: <Self where Self : PartialPropertyProtocol, Self.[AnyPropertyProtocol]KP : WritableKeyPath<Self.[AnyPropertyProtocol]Root, Self.[AnyPropertyProtocol]Value>
 protocol PropertyProtocol: PartialPropertyProtocol
 where KP: WritableKeyPath<Root, Value> {
 }
 
 extension Dictionary where Value: AnyPropertyProtocol {
+    // CHECK-LABEL: .subscript@
+    // CHECK-NEXT: Generic signature: <R, V, P where P : PropertyProtocol, P.[AnyPropertyProtocol]Root == R, P.[AnyPropertyProtocol]Value == V>
     subscript<R, V, P>(key: Key, path: WritableKeyPath<R, V>) -> P? where P: PropertyProtocol, P.Root == R, P.Value == V {
         return self[key] as? P
     }

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -25,7 +25,7 @@ struct MergeTest<G : P1 & P2> {
 // CHECK: - τ_0_0.[P2:Z2] => τ_0_0.[P1:Z1]
 // CHECK: }
 // CHECK-LABEL: Property map: {
-// CHECK:  [P1:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P1:Y1], [P1:Z1]>] }
-// CHECK:  [P2:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P2:Y2], [P2:Z2]>] }
+// CHECK:  [P1:X] => { concrete_type: [concrete: Foo<[P1:Y1], [P1:Z1]>] }
+// CHECK:  [P2:X] => { concrete_type: [concrete: Foo<[P2:Y2], [P2:Z2]>] }
 // CHECK:  τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK: }

--- a/test/Generics/unify_nested_types_2.swift
+++ b/test/Generics/unify_nested_types_2.swift
@@ -25,7 +25,7 @@ struct G<T : P1 & P2> {}
 // CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - [P1:T].T => [P1:T].[P1:T]
-// CHECK: - τ_0_0.[P1:T].[concrete: X<τ_0_0> with <τ_0_0.[P2:U]>] => τ_0_0.[P1:T]
+// CHECK: - τ_0_0.[P1:T].[concrete: X<τ_0_0.[P2:U]>] => τ_0_0.[P1:T]
 // CHECK: - τ_0_0.[P1:T].[P1:T] => τ_0_0.[P1:T]
 // CHECK: }
 // CHECK: }

--- a/test/Generics/unify_nested_types_3.swift
+++ b/test/Generics/unify_nested_types_3.swift
@@ -28,11 +28,11 @@ struct G<T : P2a & P3a> {}
 
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P2a, τ_0_0 : P3a>
 // CHECK-LABEL: Rewrite system: {
-// CHECK: - τ_0_0.[P2a:T].[concrete: X<τ_0_0> with <τ_0_0.[P3a:U]>] => τ_0_0.[P2a:T]
-// CHECK: - τ_0_0.[P2a:T].[P2:T].[concrete: X<τ_0_0> with <τ_0_0.[P3a:U].[P1:T]>] => τ_0_0.[P2a:T].[P2:T]
+// CHECK: - τ_0_0.[P2a:T].[concrete: X<τ_0_0.[P3a:U]>] => τ_0_0.[P2a:T]
+// CHECK: - τ_0_0.[P2a:T].[P2:T].[concrete: X<τ_0_0.[P3a:U].[P1:T]>] => τ_0_0.[P2a:T].[P2:T]
 // CHECK: }
 // CHECK-LABEL: Property map: {
-// CHECK: τ_0_0.[P2a:T] => { conforms_to: [P2] concrete_type: [concrete: X<τ_0_0> with <τ_0_0.[P3a:U]>] }
-// CHECK: τ_0_0.[P2a:T].[P2:T] => { concrete_type: [concrete: X<τ_0_0> with <τ_0_0.[P3a:U].[P1:T]>] }
+// CHECK: τ_0_0.[P2a:T] => { conforms_to: [P2] concrete_type: [concrete: X<τ_0_0.[P3a:U]>] }
+// CHECK: τ_0_0.[P2a:T].[P2:T] => { concrete_type: [concrete: X<τ_0_0.[P3a:U].[P1:T]>] }
 // CHECK: }
 // CHECK: }

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -31,8 +31,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-NEXT: Rewrite system: {
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P2:B2]>] => τ_0_0.[P1:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<τ_0_0.[P2:A2], String, τ_0_0.[P2:B2]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
 // CHECK:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
@@ -41,10 +41,10 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
 // CHECK-NEXT:   [P2] => { conforms_to: [P2] }
-// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
-// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, [P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<[P2:A2], String, [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
-// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, String, τ_0_0.[P1:B1]>] }
 // CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
 // CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -35,8 +35,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
 // CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0> with <τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
 // CHECK:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
 // CHECK:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
@@ -45,10 +45,10 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
 // CHECK-NEXT:   [P2] => { conforms_to: [P2] }
-// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
-// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<[P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<[P2:A2], String, [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
-// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
 // CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
 // CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -35,22 +35,22 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-NEXT: Rewrite system: {
-// CHECK:      - [P1:X].[superclass: Base<τ_0_0> with <[P1:A1]>] => [P1:X] [explicit]
-// CHECK:      - [P2:X].[superclass: Derived<τ_0_0> with <[P2:A2]>] => [P2:X] [explicit]
+// CHECK:      - [P1:X].[superclass: Base<[P1:A1]>] => [P1:X] [explicit]
+// CHECK:      - [P2:X].[superclass: Derived<[P2:A2]>] => [P2:X] [explicit]
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Derived<τ_0_0> with <τ_0_0.[P2:A2]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Derived<τ_0_0.[P2:A2]>] => τ_0_0.[P1:X]
 // CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
 // CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
-// CHECK:      - τ_0_0.[P1:X].[superclass: Base<τ_0_0> with <τ_0_0.[P2:A2].[Q:T]>] => τ_0_0.[P1:X]
+// CHECK:      - τ_0_0.[P1:X].[superclass: Base<τ_0_0.[P2:A2].[Q:T]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P2:A2].[Q:T] => τ_0_0.[P1:A1]
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
 // CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [Q] => { conforms_to: [Q] }
-// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<τ_0_0> with <[P1:A1]>] }
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<[P1:A1]>] }
 // CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
-// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0> with <[P2:A2]>] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<[P2:A2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
-// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0> with <τ_0_0.[P2:A2]>] }
+// CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0.[P2:A2]>] }
 // CHECK-NEXT: }


### PR DESCRIPTION
This will be used for diagnostics eventually. For now it's just for debugging. Also to help with debugging, make a change to printing of superclass and concrete type symbols.