### PR TITLE
[StdlibUnittest] expectEqual: Use less opinionated argument names

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -181,106 +181,133 @@ public func identityComp(_ element: MinimalComparableValue)
   return element
 }
 
-public func expectEqual<T : Equatable>(_ expected: T, _ actual: T,
+public func expectEqual<T : Equatable>(
+  _ first: T,
+  _ second: T,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  expectEqualTest(expected, actual, message(),
+  file: String = #file, line: UInt = #line
+) {
+  expectEqualTest(first, second, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
 }
 
 public func expectEqual<T : Equatable, U : Equatable>(
-  _ expected: (T, U), _ actual: (T, U),
+  _ first: (T, U),
+  _ second: (T, U),
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  expectEqualTest(expected.0, actual.0, message(),
+  file: String = #file, line: UInt = #line
+) {
+  expectEqualTest(first.0, second.0, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.1, actual.1, message(),
+  expectEqualTest(first.1, second.1, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
 }
 
 public func expectEqual<T : Equatable, U : Equatable, V : Equatable>(
-  _ expected: (T, U, V), _ actual: (T, U, V),
+  _ first: (T, U, V),
+  _ second: (T, U, V),
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  expectEqualTest(expected.0, actual.0, message(),
+  file: String = #file, line: UInt = #line
+) {
+  expectEqualTest(first.0, second.0, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.1, actual.1, message(),
+  expectEqualTest(first.1, second.1, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.2, actual.2, message(),
+  expectEqualTest(first.2, second.2, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
 }
 
 public func expectEqual<T : Equatable, U : Equatable, V : Equatable, W : Equatable>(
-  _ expected: (T, U, V, W), _ actual: (T, U, V, W),
+  _ first: (T, U, V, W),
+  _ second: (T, U, V, W),
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  expectEqualTest(expected.0, actual.0, message(),
+  file: String = #file, line: UInt = #line
+) {
+  expectEqualTest(first.0, second.0, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.1, actual.1, message(),
+  expectEqualTest(first.1, second.1, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.2, actual.2, message(),
+  expectEqualTest(first.2, second.2, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
-  expectEqualTest(expected.3, actual.3, message(),
+  expectEqualTest(first.3, second.3, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 == $1}
 }
 
-public func expectEqual(_ expected: String, _ actual: Substring,
+public func expectEqual(
+  _ first: String,
+  _ second: Substring,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  if !(expected == actual) {
+  file: String = #file, line: UInt = #line
+) {
+  if !(first == second) {
     expectationFailure(
-      "expected: \(String(reflecting: expected)) (of type \(String(reflecting: type(of: expected))))\n"
-      + "actual: \(String(reflecting: actual)) (of type \(String(reflecting: type(of: actual))))",
+      """
+      first:  \(String(reflecting: first)) (of type \(String(reflecting: type(of: first))))
+      second: \(String(reflecting: second)) (of type \(String(reflecting: type(of: second))))
+      """,
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
     )
   }
 }
-public func expectEqual(_ expected: Substring, _ actual: String,
+public func expectEqual(
+  _ first: Substring,
+  _ second: String,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  if !(expected == actual) {
+  file: String = #file, line: UInt = #line
+) {
+  if !(first == second) {
     expectationFailure(
-      "expected: \(String(reflecting: expected)) (of type \(String(reflecting: type(of: expected))))\n"
-      + "actual: \(String(reflecting: actual)) (of type \(String(reflecting: type(of: actual))))",
+      """
+      first:  \(String(reflecting: first)) (of type \(String(reflecting: type(of: first))))
+      second: \(String(reflecting: second)) (of type \(String(reflecting: type(of: second))))
+      """,
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
     )
   }
 }
-public func expectEqual(_ expected: String, _ actual: String,
+public func expectEqual(
+  _ first: String,
+  _ second: String,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  if !(expected == actual) {
+  file: String = #file, line: UInt = #line
+) {
+  if !(first == second) {
     expectationFailure(
-      "expected: \(String(reflecting: expected)) (of type \(String(reflecting: type(of: expected))))\n"
-      + "actual: \(String(reflecting: actual)) (of type \(String(reflecting: type(of: actual))))",
+      """
+      first:  \(String(reflecting: first)) (of type \(String(reflecting: type(of: first))))
+      second: \(String(reflecting: second)) (of type \(String(reflecting: type(of: second))))
+      """,
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
     )
   }
 }
 
-public func expectEqualReference(_ expected: AnyObject?, _ actual: AnyObject?,
+public func expectEqualReference(
+  _ first: AnyObject?,
+  _ second: AnyObject?,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  expectEqualTest(expected, actual, message(),
+  file: String = #file, line: UInt = #line
+) {
+  expectEqualTest(first, second, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) {$0 === $1}
 }
 
@@ -298,30 +325,37 @@ public func expectationFailure(
 // See <rdar://26058520> Generic type constraints incorrectly applied to
 // functions with the same name
 public func expectEqualTest<T>(
-  _ expected: T, _ actual: T,
+  _ first: T,
+  _ second: T,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line, sameValue equal: (T, T) -> Bool
+  file: String = #file, line: UInt = #line,
+  sameValue equal: (T, T) -> Bool
 ) {
-  if !equal(expected, actual) {
+  if !equal(first, second) {
     expectationFailure(
-      "expected: \(String(reflecting: expected)) (of type \(String(reflecting: type(of: expected))))\n"
-      + "actual: \(String(reflecting: actual)) (of type \(String(reflecting: type(of: actual))))",
+      """
+      first:  \(String(reflecting: first)) (of type \(String(reflecting: type(of: first))))
+      second: \(String(reflecting: second)) (of type \(String(reflecting: type(of: second))))
+      """,
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
     )
   }
 }
 
-public func expectNotEqual<T : Equatable>(_ expected: T, _ actual: T,
+public func expectNotEqual<T : Equatable>(
+  _ first: T,
+  _ second: T,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-  if expected == actual {
+  file: String = #file, line: UInt = #line
+) {
+  if first == second {
     expectationFailure(
-      "unexpected value: \"\(actual)\" (of type \(String(reflecting: type(of: actual))))",
+      "unexpected value: \"\(second)\" (of type \(String(reflecting: type(of: second))))",
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
     )
@@ -329,30 +363,36 @@ public func expectNotEqual<T : Equatable>(_ expected: T, _ actual: T,
 }
 
 public func expectOptionalEqual<T>(
-  _ expected: T, _ actual: T?,
+  _ first: T,
+  _ second: T?,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line, sameValue equal: (T, T) -> Bool
+  file: String = #file, line: UInt = #line,
+  sameValue equal: (T, T) -> Bool
 ) {
-  if (actual == nil) || !equal(expected, actual!) {
+  if (second == nil) || !equal(first, second!) {
     expectationFailure(
-      "expected: \"\(expected)\" (of type \(String(reflecting: type(of: expected))))\n"
-      + "actual: \"\(actual.debugDescription)\" (of type \(String(reflecting: type(of: actual))))",
+      """
+      first:  \"\(first)\" (of type \(String(reflecting: type(of: first))))
+      second: \"\(second.debugDescription)\" (of type \(String(reflecting: type(of: second))))
+      """,
       trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
   }
 }
 
 public func expectEqual(
-  _ expected: Any.Type, _ actual: Any.Type,
+  _ first: Any.Type, _ second: Any.Type,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) {
-  expectEqualTest(expected, actual, message(),
-      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false) { $0 == $1 }
+  expectEqualTest(
+    first, second, message(),
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false
+  ) { $0 == $1 }
 }
 
 public func expectLT<T : Comparable>(_ lhs: T, _ rhs: T,

--- a/validation-test/StdlibUnittest/Common.swift
+++ b/validation-test/StdlibUnittest/Common.swift
@@ -438,8 +438,8 @@ AssertionsTestSuite.test("expectFailure/Pass") {
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/Pass
 // CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 1 (of type Swift.Int)
-// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> first: 1 (of type Swift.Int)
+// CHECK: stdout>>> second: 2 (of type Swift.Int)
 // CHECK: [       OK ] Assertions.expectFailure/Pass
 
 AssertionsTestSuite.test("expectFailure/UXPass")
@@ -452,8 +452,8 @@ AssertionsTestSuite.test("expectFailure/UXPass")
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/UXPass ({{X}}FAIL: [Custom(reason: test)])
 // CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 1 (of type Swift.Int)
-// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> first: 1 (of type Swift.Int)
+// CHECK: stdout>>> second: 2 (of type Swift.Int)
 // CHECK: [   UXPASS ] Assertions.expectFailure/UXPass
 
 AssertionsTestSuite.test("expectFailure/Fail") {
@@ -489,11 +489,11 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/Fail") {
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/Fail
 // CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 1 (of type Swift.Int)
-// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> first: 1 (of type Swift.Int)
+// CHECK: stdout>>> second: 2 (of type Swift.Int)
 // CHECK: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 3 (of type Swift.Int)
-// CHECK: stdout>>> actual: 4 (of type Swift.Int)
+// CHECK: stdout>>> first: 3 (of type Swift.Int)
+// CHECK: stdout>>> second: 4 (of type Swift.Int)
 // CHECK: [     FAIL ] Assertions.expectFailure/AfterFailure/Fail
 
 AssertionsTestSuite.test("expectFailure/AfterFailure/XFail")
@@ -507,11 +507,11 @@ AssertionsTestSuite.test("expectFailure/AfterFailure/XFail")
 }
 // CHECK: [ RUN      ] Assertions.expectFailure/AfterFailure/XFail ({{X}}FAIL: [Custom(reason: test)])
 // CHECK-NEXT: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 1 (of type Swift.Int)
-// CHECK: stdout>>> actual: 2 (of type Swift.Int)
+// CHECK: stdout>>> first: 1 (of type Swift.Int)
+// CHECK: stdout>>> second: 2 (of type Swift.Int)
 // CHECK: stdout>>> check failed at {{.*}}{{[/\\]}}StdlibUnittest{{[/\\]}}Common.swift, line
-// CHECK: stdout>>> expected: 3 (of type Swift.Int)
-// CHECK: stdout>>> actual: 4 (of type Swift.Int)
+// CHECK: stdout>>> first: 3 (of type Swift.Int)
+// CHECK: stdout>>> second: 4 (of type Swift.Int)
 // CHECK: [    XFAIL ] Assertions.expectFailure/AfterFailure/XFail
 
 AssertionsTestSuite.test("expectUnreachable") {
@@ -605,8 +605,8 @@ TestSuiteLifetimeTracked.test("failsIfLifetimeTrackedAreLeaked") {
 }
 // CHECK: [ RUN      ] TestSuiteLifetimeTracked.failsIfLifetimeTrackedAreLeaked
 // CHECK-NEXT: stdout>>> check failed at {{.*}}.swift, line [[@LINE-4]]
-// CHECK: stdout>>> expected: 0 (of type Swift.Int)
-// CHECK: stdout>>> actual: 1 (of type Swift.Int)
+// CHECK: stdout>>> first: 0 (of type Swift.Int)
+// CHECK: stdout>>> second: 1 (of type Swift.Int)
 // CHECK: [     FAIL ] TestSuiteLifetimeTracked.failsIfLifetimeTrackedAreLeaked
 
 TestSuiteLifetimeTracked.test("passesIfLifetimeTrackedAreResetAfterFailure") {}


### PR DESCRIPTION
Based on their argument names and messages, `expectEqual` and friends assume that the expected value of the calculation being tested will be provided as their first argument, and the actual value as the second:

```swift
expectEqual(4, 2 + 2)
```

This does not always match actual use -- folks like myself find the opposite ordering far more natural:

```swift
expectEqual(2 + 2, 4)
```

`expectEqual` currently uses the `expected`/`actual` terminology in its failure messages, causing confusion and needless suffering.

Change `expectEqual`'s declaration and error messages to use a naming scheme that does not assume specific roles for the two arguments. (Namely, use `first`/`second` instead of `expected`/`actual`.)

Alternative ways to solve this would be to use argument labels, as in `expectEqual(expected: 4, actual: 2 + 2)`, or to introduce some sort of expression builder scheme such as `expect(2 + 2).toEqual(2)`. These seem needlessly fussy and overly clever, respectively.
