### PR TITLE
[AutoDiff] Change decorators on derivatives of `FloatingPoint` functions

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -54,14 +54,14 @@ extension ${Self}: Differentiable {
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
 extension ${Self} {
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -)
   static func _vjpNegate(x: ${Self})
     -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
     return (-x, { v in -v })
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -)
   static func _jvpNegate(x: ${Self})
   -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
@@ -73,7 +73,7 @@ extension ${Self} {
 ${Availability(bits)}
 extension ${Self} {
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: +)
   static func _vjpAdd(
     lhs: ${Self}, rhs: ${Self}
@@ -82,7 +82,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: +)
   static func _jvpAdd(
     lhs: ${Self}, rhs: ${Self}
@@ -91,7 +91,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: +=)
   static func _vjpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -101,8 +101,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable @inline(__always)
   @derivative(of: +=)
   static func _jvpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -112,7 +111,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -)
   static func _vjpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -130,7 +129,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -=)
   static func _vjpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -140,7 +139,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -=)
   static func _jvpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -150,7 +149,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: *)
   static func _vjpMultiply(
     lhs: ${Self}, rhs: ${Self}
@@ -168,7 +167,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: *=)
   static func _vjpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -182,7 +181,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: *=)
   static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -202,7 +201,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: /)
   static func _jvpDivide(
     lhs: ${Self}, rhs: ${Self}
@@ -211,7 +210,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: /=)
   static func _vjpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -225,7 +224,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: /=)
   static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -246,7 +245,7 @@ where
   Self: Differentiable,
   Self == Self.TangentVector
 {
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: addingProduct)
   func _vjpAddingProduct(
     _ lhs: Self, _ rhs: Self
@@ -254,14 +253,14 @@ where
     return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
     let y = squareRoot()
     return (y, { v in v / (2 * y) })
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: minimum)
   static func _vjpMinimum(_ x: Self, _ y: Self) -> (
     value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)
@@ -270,7 +269,7 @@ where
     return (y, { v in (.zero, v) })
   }
 
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: maximum)
   static func _vjpMaximum(_ x: Self, _ y: Self) -> (
     value: Self, pullback: (TangentVector) -> (TangentVector, TangentVector)

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -120,7 +120,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: -)
   static func _jvpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -158,7 +158,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: *)
   static func _jvpMultiply(
     lhs: ${Self}, rhs: ${Self}
@@ -192,7 +192,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable
+  @inlinable @inline(__always)
   @derivative(of: /)
   static func _vjpDivide(
     lhs: ${Self}, rhs: ${Self}

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -54,16 +54,14 @@ extension ${Self}: Differentiable {
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
 extension ${Self} {
-  @usableFromInline
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _vjpNegate(x: ${Self})
     -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
     return (-x, { v in -v })
   }
 
-  @usableFromInline
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _jvpNegate(x: ${Self})
   -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
@@ -75,8 +73,7 @@ extension ${Self} {
 ${Availability(bits)}
 extension ${Self} {
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +)
   static func _vjpAdd(
     lhs: ${Self}, rhs: ${Self}
@@ -85,8 +82,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +)
   static func _jvpAdd(
     lhs: ${Self}, rhs: ${Self}
@@ -95,8 +91,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: +=)
   static func _vjpAddAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -117,8 +112,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _vjpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -127,8 +121,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -)
   static func _jvpSubtract(
     lhs: ${Self}, rhs: ${Self}
@@ -137,8 +130,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -=)
   static func _vjpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -148,8 +140,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: -=)
   static func _jvpSubtractAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -159,8 +150,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *)
   static func _vjpMultiply(
     lhs: ${Self}, rhs: ${Self}
@@ -169,8 +159,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *)
   static func _jvpMultiply(
     lhs: ${Self}, rhs: ${Self}
@@ -179,8 +168,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *=)
   static func _vjpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -194,8 +182,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: *=)
   static func _jvpMultiplyAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -206,8 +193,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /)
   static func _vjpDivide(
     lhs: ${Self}, rhs: ${Self}
@@ -216,8 +202,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /)
   static func _jvpDivide(
     lhs: ${Self}, rhs: ${Self}
@@ -226,8 +211,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /=)
   static func _vjpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, pullback: (inout ${Self}) -> ${Self}
@@ -241,8 +225,7 @@ extension ${Self} {
   }
 
   ${Availability(bits)}
-  @inlinable // FIXME(sil-serialize-all)
-  @_transparent
+  @inlinable
   @derivative(of: /=)
   static func _jvpDivideAssign(_ lhs: inout ${Self}, _ rhs: ${Self}) -> (
     value: Void, differential: (inout ${Self}, ${Self}) -> Void
@@ -263,7 +246,7 @@ where
   Self: Differentiable,
   Self == Self.TangentVector
 {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @derivative(of: addingProduct)
   func _vjpAddingProduct(
     _ lhs: Self, _ rhs: Self
@@ -271,7 +254,7 @@ where
     return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable
   @derivative(of: squareRoot)
   func _vjpSquareRoot() -> (value: Self, pullback: (Self) -> Self) {
     let y = squareRoot()


### PR DESCRIPTION
The `@_transparent` modifier appears nowhere else in the `_Differentiation` module, even on functions that are generic or non-generic. Also, no other AutoDiff functions are force-inlined like `@_transparent` does. This PR makes FloatingPointDifferentiation.swift.gyb consistent with the rest of the stdlib.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
