### PR TITLE
[NFC] 32-bit-safe ImportDiagnosticTarget 

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -110,9 +110,12 @@ public:
   virtual void anchor();
 };
 
+// ⚠️ DANGER ⚠️
+// Putting more than four types in this `PointerUnion` will break the build for
+// 32-bit hosts. If we need five or more types in the future, we'll need to
+// design a proper larger-than-word-sized type.
 typedef llvm::PointerUnion<const clang::Decl *, const clang::MacroInfo *,
-                           const clang::ModuleMacro *, const clang::Type *,
-                           const clang::Token *>
+                           const clang::Type *, const clang::Token *>
     ImportDiagnosticTarget;
 
 /// Class that imports Clang modules into Swift, mapping directly

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4221,9 +4221,6 @@ void ClangImporter::Implementation::diagnoseTargetDirectly(
   } else if (const clang::MacroInfo *macro =
                  target.dyn_cast<const clang::MacroInfo *>()) {
     Walker.VisitMacro(macro);
-  } else if (const clang::ModuleMacro *macro =
-                 target.dyn_cast<const clang::ModuleMacro *>()) {
-    Walker.VisitMacro(macro->getMacroInfo());
   }
 }
 
@@ -4237,7 +4234,7 @@ ClangImporter::Implementation::importDiagnosticTargetFromLookupTableEntry(
     return macro;
   } else if (const clang::ModuleMacro *macro =
                  entry.dyn_cast<clang::ModuleMacro *>()) {
-    return macro;
+    return macro->getMacroInfo();
   }
   llvm_unreachable("SwiftLookupTable::Single entry must be a NamedDecl, "
                    "MacroInfo or ModuleMacro pointer");


### PR DESCRIPTION
Previously, `ImportDiagnosticTarget` was a `PointerUnion` of five types. This required more spare bits than were available on 32-bit platforms, so the compiler (and more importantly, lldb) could not be built for those.

~~This commit makes `ImportDiagnosticTarget` a class which is still backed by a `PointerUnion` on 64-bit platforms, but uses `TaggedUnion` on 32-bit platforms. The API is designed to be a drop-in replacement; we might want to evolve it into something a little more like `ClangNode` in the future.~~

**Update for new implementation:** Fortunately, it turns out that there’s no good reason for `clang::ModuleMacro` to be part of the pointer union—we always convert it to `clang::MacroInfo` before looking up diagnostics anyway. Removing it gets us back into territory which ought to be 32-bit-safe.

Fixes rdar://88922618.