### PR TITLE
Platform: add a new submodule to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -92,6 +92,14 @@ module WinSDK [system] {
       export *
     }
 
+    // api-ms-win-core-memory-l1-1-0.dll
+    module memory {
+      header "memoryapi.h"
+      export *
+
+      link "OneCore.Lib"
+    }
+
     // api-ms-win-core-namedpipe-l1-1-2-0.dll
     module namedpipe {
       header "namedpipeapi.h"


### PR DESCRIPTION
This adds the memoryapi submodule to WinSDK which isolates the memoryapi
contract.  This enables additional functions such as
`QueryVirtualMemoryRegion` to now be available.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
