### PR TITLE
[AutoDiff] Fix incorrect derivative

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -268,7 +268,7 @@ where
   func _vjpAddingProduct(
     _ lhs: Self, _ rhs: Self
   ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
-    return (addingProduct(lhs, rhs), { _ in (1, rhs, lhs) })
+    return (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
   }
 
   @inlinable // FIXME(sil-serialize-all)

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -81,6 +81,7 @@ FloatingPointDerivativeTests.test("${Self}.squareRoot") {
 
 FloatingPointDerivativeTests.test("${Self}.addingProduct") {
   expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, of: { $0.addingProduct($1, $2) }))
+  expectEqual((2, 4, 6), pullback(at: ${Self}(10), 3, 2, of: { $0.addingProduct($1, $2) })(2))
 }
 
 FloatingPointDerivativeTests.test("${Self}.minimum") {


### PR DESCRIPTION
<!-- What's in this pull request? -->
The VJP derivative of `FloatingPoint.addingProduct` ignores the value of the pullback, assuming it is 1. This slipped by tests, which call `gradient(at:of:)` - a function that always passes 1 into the pullback. If the value passed into the pullback is 2, the output gradient will be 1/2 of what it should be.

The test for `FloatingPoint.addingProduct` has been modified to have two function calls - one which passes 1 into the pullback, and one which passes 2. Due to the magnitude of the test file, I am putting a hold on overhauling the entire thing with this new validation technique. After further discussion, such a change may be added to the pull request.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
