### PR TITLE
[ShrinkBorrowScope] Don't hoist over begin_borrows.

### DIFF
--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -953,6 +953,30 @@ exit(%value : @owned $C):
     return %retval : $()
 }
 
+// Don't hoist over begin_borrows of copies.
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_begin_borrow_copy : {{.*}} {
+// CHECK:         begin_borrow
+// CHECK:         copy_value
+// CHECK:         begin_borrow
+// CHECK:         end_borrow
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_begin_borrow_copy'
+sil [ossa] @dont_hoist_over_begin_borrow_copy : $@convention(thin) (@owned C) -> (@owned C) {
+entry(%owned_in : @owned $C):
+  %borrow_1 = begin_borrow [lexical] %owned_in : $C
+  apply undef(%borrow_1) : $@convention(thin) (@guaranteed C) -> ()
+  %copy_1_1 = copy_value %borrow_1 : $C
+  %borrow_out = begin_borrow [lexical] %copy_1_1 : $C
+  %copy_2 = copy_value %borrow_out : $C
+  end_borrow %borrow_1 : $C
+  destroy_value %owned_in : $C
+  apply undef(%borrow_out) : $@convention(thin) (@guaranteed C) -> ()
+  br exit(%copy_1_1 : $C, %borrow_out : $C, %copy_2 : $C)
+exit(%copy_1_2 : @owned $C, %borrow_in : @guaranteed $C, %copy_2_2 : @owned $C):
+  end_borrow %borrow_in : $C
+  destroy_value %copy_1_2 : $C
+  return %copy_2_2 : $C
+}
+
 // =============================================================================
 // instruction tests                                                          }}
 // =============================================================================


### PR DESCRIPTION
While it is sometimes valid to hoist over begin_borrows of copies of the borrowee, it is not always valid, as the test case committed here illustrates.  As a future optimization, we can reenable this hoisting with the appropriate condition.
