### PR TITLE
DiagnosticVerifier: Support line offsets in fix-it verification ranges

### DIFF
--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -15,35 +15,128 @@ func testNoneMarkerCheck() {
 func test0Fixits() {
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 
+  // CHECK: [[@LINE+1]]:80: error: expected fix-it verification within braces; example: '1-2=text' or 'none'
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{}}
+
+  // CHECK: [[@LINE+1]]:81: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+}}
+
+  // CHECK: [[@LINE+1]]:81: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-}}
+
+  // CHECK: [[@LINE+1]]:81: error: expected '-' range separator in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected colon-separated column number after line offset in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected colon-separated column number after line offset in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected '-' range separator in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1}}
+
+  // CHECK: [[@LINE+1]]:84: error: expected '-' range separator in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1:1}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:-1}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected line or column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-}}
+
+  // CHECK: [[@LINE+1]]:84: error: expected line or column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-}}
+
+  // CHECK: [[@LINE+1]]:85: error: expected line or column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1:1-}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1--}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1}}
+
+  // CHECK: [[@LINE+1]]:85: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1}}
+
+  // CHECK: [[@LINE+1]]:86: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:1-1}}
+
+  // CHECK: [[@LINE+1]]:83: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1--:}}
+
+  // CHECK: [[@LINE+1]]:84: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1:}}
+
+  // CHECK: [[@LINE+1]]:86: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1:}}
+
+  // CHECK: [[@LINE+1]]:87: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:1-1:}}
+
+  // CHECK: [[@LINE+1]]:85: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1:1}}
+
+  // CHECK: [[@LINE+1]]:86: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-+1:1}}
+
+  // CHECK: [[@LINE+1]]:87: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1:1}}
+
+  // CHECK: [[@LINE+1]]:89: error: expected '=' after range in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:1--1:1}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=}}
+
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}}
 
-  // CHECK: [[@LINE+1]]:80: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:80: error: expected line or column number in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x-1=a}}
 
-  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:82: error: expected line or column number in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-x=a}}
 
-  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-1=a}}
 
-  // CHECK: [[@LINE+1]]:80: error: invalid line number in fix-it verification
+  // CHECK: [[@LINE+1]]:80: error: expected line or column number in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x:1-1=a}}
 
-  // CHECK: [[@LINE+1]]:84: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:81: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+x:1-1=a}}
+
+  // CHECK: [[@LINE+1]]:84: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1:x=a}}
 
-  // CHECK: [[@LINE+1]]:82: error: invalid line number in fix-it verification
+  // CHECK: [[@LINE+1]]:82: error: expected line or column number in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-x:1=a}}
 
-  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:83: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-+x:1=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-1:x=a}}
 
-  // CHECK: [[@LINE+1]]:80: error: invalid line number in fix-it verification
+  // CHECK: [[@LINE+1]]:80: error: expected line or column number in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x:1-1:x=a}}
 
-  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  // CHECK: [[@LINE+1]]:81: error: expected line offset after leading '+' or '-' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+x:1-1:x=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-x:1=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x--x:1=a}}
 
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1:1=a}}
@@ -53,6 +146,15 @@ func test0Fixits() {
 
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1:1-1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-+1:1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:1-+1:1=a}}
 
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}}
@@ -95,13 +197,32 @@ func test1Fixits() {
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
 
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{98:15-98:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{200:15-200:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{100:15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{202:15-18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-102:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-204:18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-0:15-+0:18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15--0:18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {+0:15-210:18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{+1:15-+1:18=bb}}
+              bbx: 1)
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{216:15-+1:18=bb}}
+              bbx: 1)
+
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-1:15-18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{+0:15--1:18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-+1:18=aa}}
 }
 
 func test2Fixits() {

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -2,6 +2,7 @@
 
 protocol P0 { }
 protocol P0b { }
+class Class {}
 
 struct X0 : P0 { }
 
@@ -12,6 +13,7 @@ protocol P1 {
   associatedtype A2 // expected-note {{'A2' declared here}}
   associatedtype A3 // expected-note {{'A3' declared here}}
   associatedtype A4 // expected-note {{'A4' declared here}}
+  associatedtype A5 // expected-note {{'A5' declared here}}
 }
 
 // A typealias in a subprotocol should be written as a same-type
@@ -23,14 +25,18 @@ protocol P2 : P1 {
 // A redeclaration of an associated type that adds type/layout requirements
 // should be written via a where clause.
 protocol P3a : P1 {
-  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{25:18-25:18= where A: P0, A: P0b}}{{26:3-26:29=}}
+  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18--1:18= where A: P0, A: P0b}}{{28:3-28:29=}}
   associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
   associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A3 : P0}}{{3-34=}}
 
-  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{25:18-25:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{31:3-33:51=}}
+  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{33:3-35:51=}}
   associatedtype A4: P0 where A4: Collection,
                               A4.Element == A4.Index,
                               A4.SubSequence == A4
+
+  // expected-warning@+1 {{redeclaration of associated type 'A5' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A5: P0b & Class, A5 : Collection, A5.Element : Collection}}{{+0:3-+1:62=}}
+  associatedtype A5: P0b & Class where A5: Collection,
+                                       A5.Element: Collection
 }
 
 // ... unless it has adds a default type witness


### PR DESCRIPTION
Follow-up to #39572

The range syntax is now `([+-]?N:)?N-([+-]?N:)?N` where `N` is `[0-9]+`.
