### PR TITLE
Make test run only on x86_64/macos to fix arm64 macos bots.

### DIFF
--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -13,7 +13,7 @@
 // We only run this on macOS right now since we would need to pattern match
 // slightly differently on other platforms.
 // REQUIRES: OS=macosx
-
+// REQUIRES: CPU=x86_64
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
The reason why the test fails in this case is that it uses FileCheck on machine
specific LLVM-IR so the filechecking is not platform independent.
