### PR TITLE
[cxx-interop] Add support for operator! overloading

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1792,6 +1792,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_Caret:
     case clang::OverloadedOperatorKind::OO_Amp:
     case clang::OverloadedOperatorKind::OO_Pipe:
+    case clang::OverloadedOperatorKind::OO_Exclaim:
     case clang::OverloadedOperatorKind::OO_Less:
     case clang::OverloadedOperatorKind::OO_Greater:
     case clang::OverloadedOperatorKind::OO_LessLess:

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -21,6 +21,13 @@ struct LoadableIntWrapper {
   }
 };
 
+struct LoadableBoolWrapper {
+  bool value;
+  LoadableBoolWrapper operator!() {
+    return LoadableBoolWrapper{.value = !value};
+  }
+};
+
 struct AddressOnlyIntWrapper {
   int value;
 

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -7,6 +7,10 @@
 // CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK: }
 
+// CHECK: struct LoadableBoolWrapper {
+// CHECK:   static func ! (lhs: inout LoadableBoolWrapper) -> LoadableBoolWrapper
+// CHECK: }
+
 // CHECK: struct AddressOnlyIntWrapper {
 // CHECK:   mutating func callAsFunction() -> Int32
 // CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -13,6 +13,16 @@ public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> L
 
 // CHECK: sil [clang LoadableIntWrapper."-"] [[NAME]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
 
+public func exclaim(_ wrapper: inout LoadableBoolWrapper) -> LoadableBoolWrapper { !wrapper }
+
+// CHECK: bb0([[SELF:%.*]] : $*LoadableBoolWrapper):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*LoadableBoolWrapper
+// CHECK:   [[OP:%.*]] = function_ref [[NAME:@(_ZN19LoadableBoolWrapperntEv|\?\?7LoadableBoolWrapper@@QEAA\?AU0@XZ)]] : $@convention(c) (@inout LoadableBoolWrapper) -> LoadableBoolWrapper
+// CHECK:   apply [[OP]]([[SELFACCESS]]) : $@convention(c) (@inout LoadableBoolWrapper) -> LoadableBoolWrapper
+// CHECK:   end_access [[SELFACCESS]]
+
+// CHECK: sil [clang LoadableBoolWrapper."!"] [[NAME]] : $@convention(c) (@inout LoadableBoolWrapper) -> LoadableBoolWrapper
+
 public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
 
 // CHECK: bb0([[SELF:%.*]] : $*LoadableIntWrapper, [[RHS:%.*]] : $Int32):

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -10,6 +10,9 @@ let resultCall0 = lhs()
 let resultCall1 = lhs(1)
 let resultCall2 = lhs(1, 2)
 
+var boolWrapper = LoadableBoolWrapper(value: true)
+let notBoolResult = !boolWrapper
+
 var addressOnly = AddressOnlyIntWrapper(42)
 
 let addressOnlyResultCall0 = addressOnly()

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -31,6 +31,13 @@ OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
   expectEqual(57, resultTwoArgs)
 }
 
+OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
+  var wrapper = LoadableBoolWrapper(value: true)
+
+  let resultExclaim = !wrapper
+  expectEqual(false, resultExclaim.value)
+}
+
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   var wrapper = AddressOnlyIntWrapper(42)
 


### PR DESCRIPTION
This patch enables operator overloading for operator! when cxx interop is enabled. This is my first patch related to cxx interop, let me know if I should be doing something differently.

@plotfi @zoecarver @hyp 