### PR TITLE
[TypeChecker] Allow inference from default expressions in certain scenarios (under a flag)

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5504,6 +5504,7 @@ enum class ParamSpecifier : uint8_t {
 class ParamDecl : public VarDecl {
   friend class DefaultArgumentInitContextRequest;
   friend class DefaultArgumentExprRequest;
+  friend class DefaultArgumentTypeRequest;
 
   enum class ArgumentNameFlags : uint8_t {
     /// Whether or not this parameter is destructed.
@@ -5523,6 +5524,9 @@ class ParamDecl : public VarDecl {
 
   struct alignas(1 << StoredDefaultArgumentAlignInBits) StoredDefaultArgument {
     PointerUnion<Expr *, VarDecl *> DefaultArg;
+
+    /// The type of the default argument expression.
+    Type ExprType;
 
     /// Stores the context for the default argument as well as a bit to
     /// indicate whether the default expression has been type-checked.
@@ -5641,6 +5645,10 @@ public:
     return nullptr;
   }
 
+  /// Retrieve the type of the default expression (if any) associated with
+  /// this parameter declaration.
+  Type getTypeOfDefaultExpr() const;
+
   VarDecl *getStoredProperty() const {
     if (auto stored = DefaultValueAndFlags.getPointer())
       return stored->DefaultArg.dyn_cast<VarDecl *>();
@@ -5654,6 +5662,10 @@ public:
   /// \param isTypeChecked Whether this argument should be used as the
   /// parameter's fully type-checked default argument.
   void setDefaultExpr(Expr *E, bool isTypeChecked);
+
+  /// Sets a type of default expression associated with this parameter.
+  /// This should only be called by deserialization.
+  void setDefaultExprType(Type type);
 
   void setStoredProperty(VarDecl *var);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6254,7 +6254,12 @@ ERROR(cannot_default_generic_parameter_inferrable_from_another_parameter, none,
 
 ERROR(cannot_default_generic_parameter_inferrable_through_same_type, none,
       "cannot use default expression for inference of %0 because it "
-      "is inferrable through same-type requirement: %1",
+      "is inferrable through same-type requirement: '%1'",
+      (Type, StringRef))
+
+ERROR(cannot_default_generic_parameter_invalid_requirement, none,
+      "cannot use default expression for inference of %0 because "
+      "requirement '%1' refers to other generic parameters",
       (Type, StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6238,5 +6238,24 @@ ERROR(type_sequence_on_non_generic_param, none,
       "'@_typeSequence' must appear on a generic parameter",
       ())
 
+//------------------------------------------------------------------------------
+// MARK: Type inference from default expressions
+//------------------------------------------------------------------------------
+
+ERROR(cannot_default_generic_parameter_inferrable_from_result, none,
+      "cannot use default expression for inference of %0 because it "
+      "is inferrable from result type",
+      (Type))
+
+ERROR(cannot_default_generic_parameter_inferrable_from_another_parameter, none,
+      "cannot use default expression for inference of %0 because it "
+      "is inferrable from parameters %1",
+      (Type, StringRef))
+
+ERROR(cannot_default_generic_parameter_inferrable_through_same_type, none,
+      "cannot use default expression for inference of %0 because it "
+      "is inferrable through same-type requirement: %1",
+      (Type, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6244,11 +6244,6 @@ ERROR(type_sequence_on_non_generic_param, none,
 // MARK: Type inference from default expressions
 //------------------------------------------------------------------------------
 
-ERROR(cannot_default_generic_parameter_inferrable_from_result, none,
-      "cannot use default expression for inference of %0 because it "
-      "is inferrable from result type",
-      (Type))
-
 ERROR(cannot_default_generic_parameter_inferrable_from_another_parameter, none,
       "cannot use default expression for inference of %0 because it "
       "is inferrable from parameters %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -38,6 +38,8 @@ NOTE(extended_type_declared_here,none,
      "extended type declared here", ())
 NOTE(opaque_return_type_declared_here,none,
      "opaque return type declared here", ())
+NOTE(default_value_declared_here,none,
+     "default value declared here", ())
 
 //------------------------------------------------------------------------------
 // MARK: Constraint solver diagnostics
@@ -6261,6 +6263,10 @@ ERROR(cannot_default_generic_parameter_invalid_requirement, none,
       "cannot use default expression for inference of %0 because "
       "requirement '%1' refers to other generic parameters",
       (Type, StringRef))
+
+ERROR(cannot_convert_default_value_type_to_argument_type, none,
+      "cannot convert default value of type %0 to expected argument type %1 for parameter #%2",
+      (Type, Type, unsigned))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -41,6 +41,7 @@ class AccessorDecl;
 enum class AccessorKind;
 class ContextualPattern;
 class DefaultArgumentExpr;
+class DefaultArgumentType;
 class ClosureExpr;
 class GenericParamList;
 class PrecedenceGroupDecl;
@@ -2663,6 +2664,26 @@ public:
   bool isCached() const { return true; }
   Optional<Expr *> getCachedResult() const;
   void cacheResult(Expr *expr) const;
+};
+
+/// Computes the type of the default expression for a given parameter.
+class DefaultArgumentTypeRequest
+    : public SimpleRequest<DefaultArgumentTypeRequest, Type(ParamDecl *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  Type evaluate(Evaluator &evaluator, ParamDecl *param) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<Type> getCachedResult() const;
+  void cacheResult(Type type) const;
 };
 
 /// Computes the fully type-checked caller-side default argument within the

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -59,6 +59,8 @@ SWIFT_REQUEST(TypeChecker, CustomAttrTypeRequest,
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentExprRequest,
               Expr *(ParamDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DefaultArgumentTypeRequest,
+              Type(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultArgumentInitContextRequest,
               Initializer *(ParamDecl *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DefaultDefinitionTypeRequest,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -718,6 +718,10 @@ namespace swift {
     /// closures.
     bool EnableMultiStatementClosureInference = false;
 
+    /// Enable experimental support for generic parameter inference in
+    /// parameter positions from associated default expressions.
+    bool EnableTypeInferenceFromDefaultArguments = false;
+
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;
   };

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -857,6 +857,10 @@ def experimental_multi_statement_closures :
   Flag<["-"], "experimental-multi-statement-closures">,
   HelpText<"Enable experimental support for type inference in multi-statement closures">;
 
+def experimental_type_inference_from_defaults :
+  Flag<["-"], "enable-experimental-type-inference-from-defaults">,
+  HelpText<"Enable experimental support for generic parameter inference from default values">;
+
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
   HelpText<"Directory of prebuilt modules for loading module interfaces">;

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -382,6 +382,10 @@ enum class FixKind : uint8_t {
 
   /// Produce an error for not getting a compile-time constant
   NotCompileTimeConst,
+
+  /// Ignore a type mismatch while trying to infer generic parameter type
+  /// from default expression.
+  IgnoreDefaultExprTypeMismatch,
 };
 
 class ConstraintFix {
@@ -2894,6 +2898,29 @@ public:
 
   static AllowSwiftToCPointerConversion *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
+};
+
+class IgnoreDefaultExprTypeMismatch : public AllowArgumentMismatch {
+protected:
+  IgnoreDefaultExprTypeMismatch(ConstraintSystem &cs, Type argType,
+                                Type paramType, ConstraintLocator *locator)
+      : AllowArgumentMismatch(cs, FixKind::IgnoreDefaultExprTypeMismatch,
+                              argType, paramType, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow default expression conversion mismatch";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static IgnoreDefaultExprTypeMismatch *create(ConstraintSystem &cs,
+                                               Type argType, Type paramType,
+                                               ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreDefaultExprTypeMismatch;
+  }
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4176,6 +4176,14 @@ public:
                                ConstraintLocatorBuilder locator,
                                llvm::function_ref<Type(Type)> subst);
 
+  // Record the given requirement in the constraint system.
+  void openGenericRequirement(DeclContext *outerDC,
+                              unsigned index,
+                              const Requirement &requirement,
+                              bool skipProtocolSelfConstraint,
+                              ConstraintLocatorBuilder locator,
+                              llvm::function_ref<Type(Type)> subst);
+
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(
          ConstraintLocatorBuilder locator,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -80,6 +80,8 @@ Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
                     OptionSet<TypeCheckExprFlags> options);
 
+Type typeCheckParameterDefault(Expr *&, DeclContext *, Type, bool);
+
 } // end namespace TypeChecker
 
 } // end namespace swift
@@ -3044,6 +3046,10 @@ private:
   friend Optional<SolutionApplicationTarget>
   swift::TypeChecker::typeCheckExpression(
       SolutionApplicationTarget &target, OptionSet<TypeCheckExprFlags> options);
+
+  friend Type swift::TypeChecker::typeCheckParameterDefault(Expr *&,
+                                                            DeclContext *, Type,
+                                                            bool);
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4173,6 +4173,13 @@ public:
                              OpenedTypeMap &replacements,
                              ConstraintLocatorBuilder locator);
 
+  /// Open a generic parameter into a type variable and record
+  /// it in \c replacements.
+  TypeVariableType *openGenericParameter(DeclContext *outerDC,
+                                         GenericTypeParamType *parameter,
+                                         OpenedTypeMap &replacements,
+                                         ConstraintLocatorBuilder locator);
+
   /// Given generic signature open its generic requirements,
   /// using substitution function, and record them in the
   /// constraint system for further processing.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1207,6 +1207,27 @@ void DefaultArgumentExprRequest::cacheResult(Expr *expr) const {
 }
 
 //----------------------------------------------------------------------------//
+// DefaultArgumentTypeRequest computation.
+//----------------------------------------------------------------------------//
+
+Optional<Type> DefaultArgumentTypeRequest::getCachedResult() const {
+  auto *param = std::get<0>(getStorage());
+  auto *defaultInfo = param->DefaultValueAndFlags.getPointer();
+  if (!defaultInfo)
+    return None;
+
+  if (!defaultInfo->InitContextAndIsTypeChecked.getInt())
+    return None;
+
+  return defaultInfo->ExprType;
+}
+
+void DefaultArgumentTypeRequest::cacheResult(Type type) const {
+  auto *param = std::get<0>(getStorage());
+  param->setDefaultExprType(type);
+}
+
+//----------------------------------------------------------------------------//
 // CallerSideDefaultArgExprRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1051,6 +1051,9 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.EnableMultiStatementClosureInference |=
       Args.hasArg(OPT_experimental_multi_statement_closures);
 
+  Opts.EnableTypeInferenceFromDefaultArguments |=
+      Args.hasArg(OPT_experimental_type_inference_from_defaults);
+
   Opts.PrintFullConvention |=
       Args.hasArg(OPT_experimental_print_full_convention);
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2456,8 +2456,16 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
                                                      TypeConverter &TC,
                                                      SILDeclRef c) {
   auto *vd = c.getDecl();
-  auto resultTy = getParameterAt(vd,
-                                 c.defaultArgIndex)->getInterfaceType();
+  auto *pd = getParameterAt(vd, c.defaultArgIndex);
+
+  Type resultTy;
+
+  if (auto type = pd->getTypeOfDefaultExpr()) {
+    resultTy = type->mapTypeOutOfContext();
+  } else {
+    resultTy = pd->getInterfaceType();
+  }
+
   assert(resultTy && "Didn't find default argument?");
 
   // The result type might be written in terms of type parameters

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -257,6 +257,11 @@ ValueDecl *RequirementFailure::getDeclRef() const {
       return cast<ValueDecl>(getDC()->getAsDecl());
     }
 
+    if (contextualPurpose == CTP_DefaultParameter ||
+        contextualPurpose == CTP_AutoclosureDefaultParameter) {
+      return cast<ValueDecl>(getDC()->getParent()->getAsDecl());
+    }
+
     return getAffectedDeclFromType(contextualTy);
   }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2665,6 +2665,28 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where the type of default expression doesn't
+/// match expected type of the argument i.e. generic parameter type
+/// was inferred from result:
+///
+/// \code
+/// func test<T>(_: T = 42) -> T { ... }
+///
+/// let _: String = test() // conflict between `String` and `Int`.
+/// \endcode
+class DefaultExprTypeMismatch final : public ContextualFailure {
+public:
+  DefaultExprTypeMismatch(const Solution &solution, Type argType,
+                          Type paramType, ConstraintLocator *locator)
+      : ContextualFailure(solution, argType, paramType, locator) {}
+
+  SourceLoc getLoc() const override {
+    return constraints::getLoc(getLocator()->getAnchor());
+  }
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2076,3 +2076,18 @@ AllowSwiftToCPointerConversion::create(ConstraintSystem &cs,
                                        ConstraintLocator *locator) {
   return new (cs.getAllocator()) AllowSwiftToCPointerConversion(cs, locator);
 }
+
+bool IgnoreDefaultExprTypeMismatch::diagnose(const Solution &solution,
+                                             bool asNote) const {
+  DefaultExprTypeMismatch failure(solution, getFromType(), getToType(),
+                                  getLocator());
+  return failure.diagnose(asNote);
+}
+
+IgnoreDefaultExprTypeMismatch *
+IgnoreDefaultExprTypeMismatch::create(ConstraintSystem &cs, Type argType,
+                                      Type paramType,
+                                      ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreDefaultExprTypeMismatch(cs, argType, paramType, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1632,13 +1632,13 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     if (parameterBindings[paramIdx].empty()) {
       auto &ctx = cs.getASTContext();
 
-      if (paramTy->isTypeVariableOrMember() &&
+      if (paramTy->hasTypeVariable() &&
           ctx.TypeCheckerOpts.EnableTypeInferenceFromDefaultArguments) {
         auto *paramList = getParameterList(callee);
         auto defaultExprType = paramList->get(paramIdx)->getTypeOfDefaultExpr();
 
         // A caller side default.
-        if (!defaultExprType)
+        if (!defaultExprType || defaultExprType->hasError())
           continue;
 
         // If this is just a regular default type that works

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1615,38 +1615,46 @@ void ConstraintSystem::openGenericRequirements(
     llvm::function_ref<Type(Type)> substFn) {
   auto requirements = signature.getRequirements();
   for (unsigned pos = 0, n = requirements.size(); pos != n; ++pos) {
-    const auto &req = requirements[pos];
-
-    Optional<Requirement> openedReq;
-    auto openedFirst = substFn(req.getFirstType());
-
-    auto kind = req.getKind();
-    switch (kind) {
-    case RequirementKind::Conformance: {
-      auto protoDecl = req.getProtocolDecl();
-      // Determine whether this is the protocol 'Self' constraint we should
-      // skip.
-      if (skipProtocolSelfConstraint && protoDecl == outerDC &&
-          protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
-        continue;
-      openedReq = Requirement(kind, openedFirst, req.getSecondType());
-      break;
-    }
-    case RequirementKind::Superclass:
-    case RequirementKind::SameType:
-      openedReq = Requirement(kind, openedFirst, substFn(req.getSecondType()));
-      break;
-    case RequirementKind::Layout:
-      openedReq = Requirement(kind, openedFirst, req.getLayoutConstraint());
-      break;
-    }
-
     auto openedGenericLoc =
-        locator.withPathElement(LocatorPathElt::OpenedGeneric(signature));
-    addConstraint(*openedReq,
-                  openedGenericLoc.withPathElement(
-                      LocatorPathElt::TypeParameterRequirement(pos, kind)));
+      locator.withPathElement(LocatorPathElt::OpenedGeneric(signature));
+    openGenericRequirement(outerDC, pos, requirements[pos],
+                           skipProtocolSelfConstraint, openedGenericLoc,
+                           substFn);
   }
+}
+
+void ConstraintSystem::openGenericRequirement(
+    DeclContext *outerDC, unsigned index, const Requirement &req,
+    bool skipProtocolSelfConstraint, ConstraintLocatorBuilder locator,
+    llvm::function_ref<Type(Type)> substFn) {
+  Optional<Requirement> openedReq;
+  auto openedFirst = substFn(req.getFirstType());
+
+  auto kind = req.getKind();
+  switch (kind) {
+  case RequirementKind::Conformance: {
+    auto protoDecl = req.getProtocolDecl();
+    // Determine whether this is the protocol 'Self' constraint we should
+    // skip.
+    if (skipProtocolSelfConstraint && protoDecl == outerDC &&
+        protoDecl->getSelfInterfaceType()->isEqual(req.getFirstType()))
+      return;
+
+    openedReq = Requirement(kind, openedFirst, req.getSecondType());
+    break;
+  }
+  case RequirementKind::Superclass:
+  case RequirementKind::SameType:
+    openedReq = Requirement(kind, openedFirst, substFn(req.getSecondType()));
+    break;
+  case RequirementKind::Layout:
+    openedReq = Requirement(kind, openedFirst, req.getLayoutConstraint());
+    break;
+  }
+
+  addConstraint(*openedReq,
+                locator.withPathElement(
+                    LocatorPathElt::TypeParameterRequirement(index, kind)));
 }
 
 /// Add the constraint on the type used for the 'Self' type for a member

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1591,22 +1591,30 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
 
   // Create the type variables for the generic parameters.
   for (auto gp : sig.getGenericParams()) {
-    auto *paramLocator = getConstraintLocator(
-        locator.withPathElement(LocatorPathElt::GenericParameter(gp)));
-
-    auto typeVar = createTypeVariable(paramLocator, TVO_PrefersSubtypeBinding |
-                                                    TVO_CanBindToHole);
-    auto result = replacements.insert(std::make_pair(
-        cast<GenericTypeParamType>(gp->getCanonicalType()), typeVar));
-
-    assert(result.second);
-    (void)result;
+    (void)openGenericParameter(outerDC, gp, replacements, locator);
   }
 
   auto *baseLocator = getConstraintLocator(
       locator.withPathElement(LocatorPathElt::OpenedGeneric(sig)));
 
   bindArchetypesFromContext(*this, outerDC, baseLocator, replacements);
+}
+
+TypeVariableType *ConstraintSystem::openGenericParameter(
+    DeclContext *outerDC, GenericTypeParamType *parameter,
+    OpenedTypeMap &replacements, ConstraintLocatorBuilder locator) {
+  auto *paramLocator = getConstraintLocator(
+      locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
+
+  auto typeVar = createTypeVariable(paramLocator, TVO_PrefersSubtypeBinding |
+                                                      TVO_CanBindToHole);
+  auto result = replacements.insert(std::make_pair(
+      cast<GenericTypeParamType>(parameter->getCanonicalType()), typeVar));
+
+  assert(result.second);
+  (void)result;
+
+  return typeVar;
 }
 
 void ConstraintSystem::openGenericRequirements(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -535,15 +535,6 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
   {
     auto anchorTy = anchor->getInterfaceType()->castTo<GenericFunctionType>();
 
-    // Reject if generic parameters could be inferred from result type.
-    if (containsTypes(anchorTy->getResult(), genericParameters)) {
-      ctx.Diags.diagnose(
-          defaultValue->getLoc(),
-          diag::cannot_default_generic_parameter_inferrable_from_result,
-          paramInterfaceTy);
-      return Type();
-    }
-
     // Reject if generic parameters are used in multiple different positions
     // in the parameter list.
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1063,6 +1063,13 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
   return initExpr;
 }
 
+Type DefaultArgumentTypeRequest::evaluate(Evaluator &evaluator,
+                                          ParamDecl *param) const {
+  if (auto expr = param->getTypeCheckedDefaultExpr())
+    return expr->getType();
+  return Type();
+}
+
 Initializer *
 DefaultArgumentInitContextRequest::evaluate(Evaluator &eval,
                                             ParamDecl *param) const {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3197,13 +3197,15 @@ public:
     bool isIsolated;
     bool isCompileTimeConst;
     uint8_t rawDefaultArg;
+    TypeID defaultExprType;
 
     decls_block::ParamLayout::readRecord(scratch, argNameID, paramNameID,
                                          contextID, rawSpecifier,
                                          interfaceTypeID, isIUO, isVariadic,
                                          isAutoClosure, isIsolated,
                                          isCompileTimeConst,
-                                         rawDefaultArg);
+                                         rawDefaultArg,
+                                         defaultExprType);
 
     auto argName = MF.getIdentifier(argNameID);
     auto paramName = MF.getIdentifier(paramNameID);
@@ -3246,6 +3248,7 @@ public:
       param->setDefaultArgumentKind(*defaultArg);
       if (!blobData.empty())
         param->setDefaultValueStringRepresentation(blobData);
+      // TODO: Set default expression type.
     }
     return param;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3246,9 +3246,12 @@ public:
     // FIXME: Default argument expression, if available.
     if (auto defaultArg = getActualDefaultArgKind(rawDefaultArg)) {
       param->setDefaultArgumentKind(*defaultArg);
+
+      if (auto exprType = MF.getType(defaultExprType))
+        param->setDefaultExprType(exprType);
+
       if (!blobData.empty())
         param->setDefaultValueStringRepresentation(blobData);
-      // TODO: Set default expression type.
     }
     return param;
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 671; // ParameterizedProtocolType with multiple arguments
+const uint16_t SWIFTMODULE_VERSION_MINOR = 672; // default expression type
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1376,6 +1376,7 @@ namespace decls_block {
     BCFixed<1>,              // isIsolated?
     BCFixed<1>,              // isCompileTimeConst?
     DefaultArgumentField,    // default argument kind
+    TypeIDField,             // default argument type
     BCBlob                   // default argument text
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3779,10 +3779,8 @@ public:
       defaultArgumentText =
         param->getDefaultValueStringRepresentation(scratch);
 
-      if (argKind == swift::DefaultArgumentKind::Normal) {
-        if (auto *defaultExpr = param->getTypeCheckedDefaultExpr())
-          defaultExprType = defaultExpr->getType();
-      }
+      // Serialize the type of the default expression (if any).
+      defaultExprType = param->getTypeOfDefaultExpr();
     }
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[ParamLayout::Code];

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3770,11 +3770,20 @@ public:
     // any of the special ones.
     StringRef defaultArgumentText;
     SmallString<128> scratch;
+    // Type of the default expression.
+    Type defaultExprType;
+
     swift::DefaultArgumentKind argKind = param->getDefaultArgumentKind();
     if (argKind == swift::DefaultArgumentKind::Normal ||
-        argKind == swift::DefaultArgumentKind::StoredProperty)
+        argKind == swift::DefaultArgumentKind::StoredProperty) {
       defaultArgumentText =
         param->getDefaultValueStringRepresentation(scratch);
+
+      if (argKind == swift::DefaultArgumentKind::Normal) {
+        if (auto *defaultExpr = param->getTypeCheckedDefaultExpr())
+          defaultExprType = defaultExpr->getType();
+      }
+    }
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[ParamLayout::Code];
     ParamLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -3789,6 +3798,7 @@ public:
         param->isIsolated(),
         param->isCompileTimeConst(),
         getRawStableDefaultArgumentKind(argKind),
+        S.addTypeRef(defaultExprType),
         defaultArgumentText);
 
     if (interfaceType->hasError() && !S.allowCompilerErrors()) {

--- a/test/Constraints/Inputs/type_inference_via_defaults_other_module.swift
+++ b/test/Constraints/Inputs/type_inference_via_defaults_other_module.swift
@@ -1,0 +1,3 @@
+public func with_defaults<T>(_ v: T = 42.0) {
+  print("with_defaults: \(v); type = \(type(of: v))")
+}

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -enable-experimental-type-inference-from-defaults -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-swift-frontend -enable-experimental-type-inference-from-defaults -module-name main -typecheck -verify -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift
+
+func testInferFromResult<T>(_: T = 42) -> T { fatalError() }
+// expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable from result type}}
+
+func testInferFromOtherPos1<T>(_: T = 42, _: [T]) {}
+// expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1}}
+
+func testInferFromOtherPos2<T>(_: T = 42, _: T = 0.0) {}
+// expected-error@-1 2 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1}}
+
+protocol P {
+  associatedtype X
+}
+
+func testInferFromSameType<T, U: P>(_: T = 42, _: [U]) where T == U.X {}
+// expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable through same-type requirement: T == U.X}}
+
+func test1<T>(_: T = 42) {} // Ok
+
+struct S : P {
+  typealias X = Int
+}
+
+func test2<T: P>(_: T = S()) {} // Ok
+
+struct A : P {
+  typealias X = Double
+}
+
+class B : P {
+  typealias X = String
+
+  init() {}
+}
+
+func test2<T: P & AnyObject>(_: T = B()) {} // Ok
+
+func test2NonClassDefault<T: P & AnyObject>(_: T = S()) {}
+// expected-error@-1 {{global function 'test2NonClassDefault' requires that 'S' be a class type}}
+// expected-note@-2 {{where 'T' = 'S'}}
+
+func test2NonConformingDefault<T: P>(_: T = 42.0) {}
+// expected-error@-1 {{global function 'test2NonConformingDefault' requires that 'Double' conform to 'P'}}
+// expected-note@-2 {{where 'T' = 'Double'}}
+
+func testMultiple<T, U>(a: T = 42.0, b: U = "") {} // Ok
+
+// Subscripts
+
+extension S {
+  subscript<T: P>(a: T = S()) -> Int {
+    get { return 42 }
+  }
+
+  subscript<T: P, U: AnyObject>(a: T = S(), b: U = B()) -> Int {
+    get { return 42 }
+  }
+}
+
+
+func main() {
+  test1() // Ok
+
+  test2() // Ok
+  test2(A()) // Ok as well
+
+  testMultiple()                // Ok (T = Double, U = String)
+  testMultiple(a: 0)            // Ok (T = Int, U = String)
+  testMultiple(b: S())          // Ok (T = Double, U = S)
+  testMultiple(a: 0.0, b: "a")  // Ok
+
+  // From a different module
+  with_defaults() // Ok
+  with_defaults("") // Ok
+
+  _ = S()[] // Ok
+  _ = S()[B()] // Ok
+}

--- a/test/Constraints/type_inference_from_default_exprs_executable_test.swift
+++ b/test/Constraints/type_inference_from_default_exprs_executable_test.swift
@@ -99,6 +99,25 @@ struct OtherD : P {
   typealias X = OtherB
 }
 
+protocol Shape {
+}
+
+struct Circle : Shape {
+}
+
+struct Rectangle : Shape {
+}
+
+struct Figure<S: Shape> {
+  init(v: S = Circle()) {
+    print("Figure: \(v); type = \(type(of: v))")
+  }
+}
+
+enum TestE<T: Collection> {
+case a(_: T = [B()])
+}
+
 func run_tests() {
   test1()
   // CHECK: test1: 42; type = Int
@@ -159,6 +178,20 @@ func run_tests() {
 
   testReq1()
   // CHECK: testReq1: (main.E, main.B); type = (E, B)
+
+  _ = Figure.init()
+  // CHECK: Figure: Circle(); type = Circle
+  let _: Figure<Circle> = .init()
+  // CHECK: Figure: Circle(); type = Circle
+
+  func takesFigure<T>(_: Figure<T>) {}
+
+  takesFigure(.init())
+  // CHECK: Figure: Circle(); type = Circle
+
+  let e: TestE = .a()
+  print("ETEst: \(e); type = \(type(of: e))")
+  // CHECK: ETEst: a([main.B]); type = TestE<Array<B>>
 }
 
 @main struct Test {

--- a/test/Constraints/type_inference_from_default_exprs_executable_test.swift
+++ b/test/Constraints/type_inference_from_default_exprs_executable_test.swift
@@ -1,0 +1,168 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -enable-experimental-type-inference-from-defaults -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-type-inference-from-defaults -parse-as-library -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+protocol P {
+  associatedtype X
+}
+
+func test1<T>(_ v: T = 42) {
+  print("test1: \(v); type = \(type(of: v))")
+}
+
+struct S : P {
+  typealias X = Int
+}
+
+func test2<T: P>(_ v: T = S()) {
+  print("test2: \(v); type = \(type(of: v))")
+}
+
+struct A : P {
+  typealias X = Double
+}
+
+class B : P {
+  typealias X = String
+
+  init() {}
+}
+
+class C {
+  init() {}
+}
+
+func test2<T: P & AnyObject>(_ v: T = B()) {
+  print("test2(object): \(v); type = \(type(of: v))")
+}
+
+func testMultiple<T, U>(a: T = 42.0, b: U = "hello") {
+  print("testMultiple: a = \(a); type = \(type(of: a))")
+  print("testMultiple: b = \(b); type = \(type(of: b))")
+}
+
+// Subscripts
+
+extension S {
+  subscript<T: P>(a: T = S()) -> Int {
+    get {
+      print("subscript(a): a = \(a); type = \(type(of: a))")
+      return 42
+    }
+  }
+
+  subscript<T: P, U: AnyObject>(a a: T = S(), b: U = B()) -> Int {
+    get {
+      print("subscript(a, b): a = \(a); type = \(type(of: a))")
+      print("subscript(a, b): b = \(b); type = \(type(of: b))")
+      return 42
+    }
+  }
+}
+
+func testNested1<T>(_ v: [T] = [0, 1.0]) {
+  print("testNested1: \(v); type = \(type(of: v))")
+}
+func testNested2<T>(_ v: T? = 42.0) {
+  print("testNested2: \(v); type = \(type(of: v))")
+}
+
+struct D : P {
+  typealias X = B
+}
+
+func testNested3<T: P>(_ v: T = B()) where T.X == String {
+  print("testNested3: \(v); type = \(type(of: v))")
+}
+func testNested4<T: P>(_ v: [T]? = [D()]) where T.X: P, T.X: AnyObject {
+  print("testNested4: \(v); type = \(type(of: v))")
+}
+func testNested5<T: P, U>(_ v: (a: [T?], b: U) = (a: [D()], b: B())) where T.X == U, T.X: P, U: AnyObject {
+  print("testNested5: \(v); type = \(type(of: v))")
+}
+
+class GenClass<T> {}
+
+class E : GenClass<B> {
+}
+
+func testReq1<T, U>(_ v: (T, U) = (E(), B())) where T: GenClass<U>, U: AnyObject {
+  print("testReq1: \(v); type = \(type(of: v))")
+}
+
+class OtherB : P {
+  typealias X = String
+}
+
+struct OtherD : P {
+  typealias X = OtherB
+}
+
+func run_tests() {
+  test1()
+  // CHECK: test1: 42; type = Int
+  test1("hello")
+  // CHECK: test1: hello; type = String
+
+  test2(A())
+  // CHECK: test2: A(); type = A
+  test2()
+  // CHECK: test2(object): main.B; type = B
+
+  testMultiple()
+  // CHECK: testMultiple: a = 42.0; type = Double
+  // CHECK-NEXT: testMultiple: b = hello; type = String
+  testMultiple(a: 0)
+  // CHECK: testMultiple: a = 0; type = Int
+  // CHECK-NEXT: testMultiple: b = hello; type = String
+  testMultiple(b: S())
+  // CHECK: testMultiple: a = 42.0; type = Double
+  // CHECK-NEXT: testMultiple: b = S(); type = S
+  testMultiple(a: "a", b: 42.0 as Float)
+  // CHECK: testMultiple: a = a; type = String
+  // CHECK-NEXT: testMultiple: b = 42.0; type = Float
+
+  // From a different module
+  with_defaults()
+  // CHECK: with_defaults: 42.0; type = Double
+  with_defaults("str")
+  // CHECK: with_defaults: str; type = String
+
+  _ = S()[] // Ok
+  // CHECK: subscript(a): a = S(); type = S
+  _ = S()[B()] // Ok
+  // CHECK: subscript(a): a = main.B; type = B
+
+  _ = S()[a: B()] // Ok
+  // CHECK: subscript(a, b): a = main.B; type = B
+  // CHECK-NEXT: subscript(a, b): b = main.B; type = B
+
+  testNested1()
+  // CHECK: testNested1: [0.0, 1.0]; type = Array<Double>
+  testNested1(["a", "b"])
+  // CHECK: testNested1: ["a", "b"]; type = Array<String>
+  testNested2()
+  // CHECK: testNested2: Optional(42.0); type = Optional<Double>
+  testNested2(nil as Float?)
+  // CHECK: testNested2: nil; type = Optional<Float>
+  testNested3()
+  // CHECK: testNested3: main.B; type = B
+  testNested3(OtherB())
+  // CHECK: testNested3: main.OtherB; type = OtherB
+  testNested4()
+  // CHECK: testNested4: Optional([main.D()]); type = Optional<Array<D>>
+  testNested4([OtherD()])
+  // CHECK: testNested4: Optional([main.OtherD()]); type = Optional<Array<OtherD>>
+  testNested5()
+  // CHECK: testNested5: (a: [Optional(main.D())], b: main.B); type = (a: Array<Optional<D>>, b: B)
+
+  testReq1()
+  // CHECK: testReq1: (main.E, main.B); type = (E, B)
+}
+
+@main struct Test {
+  static func main() {
+    run_tests()
+  }
+}


### PR DESCRIPTION
In some circumstances generic argument(s) could only be inferred from a parameter that has a 
default expression associated with it, allow type-checker to infer types based on the default 
expression(s), for example:

```swift
func test(v: T = 42.0) { ... }
```

Callers of `test` are exempt from passing a value of `v` to resolve a type of `T`, generic argument
would get inferred as `Int` for empty argument list.

The same applies to generic parameters in nested positions i.e. `func test<T>(v: [T] = [...])`
or multiple generic parameters: `func test<K, V>(_: [K: V] = ....)`

The inference is not allowed when:

- Generic parameter is used in multiple locations in a parameter list (because it would be possible to
   resolve it unambiguously via supplying explicit argument), for example:
  - `test<T>(_: T, _: [T] = ...)`; 
  - Generic parameter could be inferred through its relationship to other parameters via same-type
  generic requirements, for example:
  - `func test<T: P, U>(_: T, _: U = ...) where U == T.X`

It's allowed to specify generic conformance requirements, layout and supertype constraints if
they do not involve other generic parameters.

The behavior is gated under `-enable-experimental-type-inference-from-defaults` frontend flag.

Resolves: rdar://86033180

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
