### PR TITLE
Enable SE-0341 "Opaque Parameter Declarations" by default. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 ## Swift 5.7
 
+* [SE-0341][]:
+
+  Opaque types can now be used in the parameters of functions and subscripts, wher they provide a shorthand syntax for the introduction of a generic parameter. For example, the following:
+
+  ```swift
+  func horizontal(_ v1: some View, _ v2: some View) -> some View {
+    HStack {
+      v1
+      v2
+    }
+  }
+  ```
+
+  is equivalent to
+
+  ```swift
+  func horizontal<V1: View, V2: View>(_ v1: V1, _ v2: V2) -> some View {
+    HStack {
+      v1
+      v2
+    }
+  }
+  ```
+
+  With this, `some` in a parameter type provides a generalization where the
+  caller chooses the parameter's type as well as its value, whereas `some` in
+  the result type provides a generalization where the callee chooses the
+  resulting type and value.
+
 * The compiler now correctly emits warnings for more kinds of expressions where a protocol conformance is used and may be unavailable at runtime. Previously, member reference expressions and type erasing expressions that used potentially unavailable conformances were not diagnosed, leading to potential crashes at runtime.
 
   ```swift
@@ -8962,6 +8991,7 @@ Swift 1.0
 [SE-0331]: <https://github.com/apple/swift-evolution/blob/main/proposals/0331-remove-sendable-from-unsafepointer.md>
 [SE-0337]: <https://github.com/apple/swift-evolution/blob/main/proposals/0337-support-incremental-migration-to-concurrency-checking.md>
 [SE-0335]: <https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md>
+[SE-0341]: <https://github.com/apple/swift-evolution/blob/main/proposals/0341-opaque-parameters.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4988,7 +4988,7 @@ ERROR(unable_to_parse_c_function_type,none,
 
 // Opaque types
 ERROR(unsupported_opaque_type,none,
-      "'some' types are only implemented for the declared type of properties and subscripts and the return type of functions", ())
+      "'some' types are only permitted in properties, subscripts, and functions", ())
 
 ERROR(opaque_type_unsupported_pattern,none,
       "'some' type can only be declared on a single property declaration", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4997,9 +4997,9 @@ ERROR(opaque_type_in_protocol_requirement,none,
       "'some' type cannot be the return type of a protocol requirement; did you mean to add an associated type?",
       ())
 ERROR(opaque_type_in_parameter,none,
-      "'some' cannot appear in parameter position in result "
-      "type %0",
-      (Type))
+      "'some' cannot appear in parameter position in %select{result|parameter}0"
+      " type %1",
+      (bool, Type))
 
 // Function differentiability
 ERROR(attr_only_on_parameters_of_differentiable,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -313,10 +313,6 @@ namespace swift {
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;
 
-    /// Enable experimental support for opaque parameter types, e.g.
-    /// `func f(collection: some Collection)`.
-    bool EnableExperimentalOpaqueParameters = false;
-
     /// Enable support for explicit existential types via the \c any
     /// keyword.
     bool EnableExplicitExistentialTypes = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -296,10 +296,6 @@ def enable_experimental_eager_clang_module_diagnostics :
   Flag<["-"], "enable-experimental-eager-clang-module-diagnostics">,
   HelpText<"Enable experimental eager diagnostics reporting on the importability of all referenced C, C++, and Objective-C libraries">;
 
-def enable_experimental_opaque_parameters :
-  Flag<["-"], "enable-experimental-opaque-parameters">,
-  HelpText<"Enable experimental support for opaque parameters">;
-
 def enable_experimental_pairwise_build_block :
   Flag<["-"], "enable-experimental-pairwise-build-block">,
   HelpText<"Enable experimental pairwise 'buildBlock' for result builders">;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2507,9 +2507,6 @@ static SmallVector<GenericTypeParamDecl *, 2>
 createOpaqueParameterGenericParams(
     GenericContext *genericContext, GenericParamList *parsedGenericParams) {
   ASTContext &ctx = genericContext->getASTContext();
-  if (!ctx.LangOpts.EnableExperimentalOpaqueParameters)
-    return { };
-
   auto value = dyn_cast_or_null<ValueDecl>(genericContext->getAsDecl());
   if (!value)
     return { };

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -445,9 +445,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 
-  Opts.EnableExperimentalOpaqueParameters |=
-      Args.hasArg(OPT_enable_experimental_opaque_parameters);
-
   Opts.EnableExplicitExistentialTypes |=
       Args.hasArg(OPT_enable_explicit_existential_types);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3251,6 +3251,44 @@ void TypeChecker::checkParameterList(ParameterList *params,
       }
     }
 
+    // Opaque types cannot occur in parameter position.
+    Type interfaceType = param->getInterfaceType();
+    if (interfaceType->hasTypeParameter()) {
+      interfaceType.findIf([&](Type type) {
+        if (auto fnType = type->getAs<FunctionType>()) {
+          for (auto innerParam : fnType->getParams()) {
+            auto paramType = innerParam.getPlainType();
+            if (!paramType->hasTypeParameter())
+              continue;
+
+            bool hadError = paramType.findIf([&](Type innerType) {
+              auto genericParam = innerType->getAs<GenericTypeParamType>();
+              if (!genericParam)
+                return false;
+
+              auto genericParamDecl = genericParam->getDecl();
+              if (!genericParamDecl)
+                return false;
+
+              if (!genericParamDecl->isOpaqueType())
+                return false;
+
+              param->diagnose(
+                 diag::opaque_type_in_parameter, true, interfaceType);
+              return true;
+            });
+
+            if (hadError)
+              return true;
+          }
+
+          return false;
+        }
+
+        return false;
+      });
+    }
+
     if (param->hasAttachedPropertyWrapper())
       (void) param->getPropertyWrapperInitializerInfo();
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -274,7 +274,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
 
         ctx.Diags.diagnose(repr->getLoc(),
                            diag::opaque_type_in_parameter,
-                           interfaceType);
+                           false, interfaceType);
         return true;
       }
     }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -73,7 +73,7 @@ struct Test {
   let inferredOpaqueStructural2 = (bar(), bas()) // expected-error{{inferred type}}
 }
 
-let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
+let zingle = {() -> some P in 1 } // expected-error{{'some' types are only permitted}}
 
 
 func twoOpaqueTypes() -> (some P, some P) { return (1, 2) }
@@ -81,15 +81,15 @@ func asArrayElem() -> [some P] { return [1] }
 
 // Invalid positions
 
-typealias Foo = some P // expected-error{{'some' types are only implemented}}
+typealias Foo = some P // expected-error{{'some' types are only permitted}}
 
-func blibble(blobble: some P) {} // expected-error{{'some' types are only implemented}}
+func blibble(blobble: some P) {}
 func blib() -> P & some Q { return 1 } // expected-error{{'some' should appear at the beginning}}
 func blab() -> some P? { return 1 } // expected-error{{must specify only}} expected-note{{did you mean to write an optional of an 'opaque' type?}}
-func blorb<T: some P>(_: T) { } // expected-error{{'some' types are only implemented}}
-func blub<T>() -> T where T == some P { return 1 } // expected-error{{'some' types are only implemented}} expected-error{{cannot convert}}
+func blorb<T: some P>(_: T) { } // expected-error{{'some' types are only permitted}}
+func blub<T>() -> T where T == some P { return 1 } // expected-error{{'some' types are only permitted}} expected-error{{cannot convert}}
 
-protocol OP: some P {} // expected-error{{'some' types are only implemented}}
+protocol OP: some P {} // expected-error{{'some' types are only permitted}}
 
 func foo() -> some P {
   let x = (some P).self // expected-error*{{}}

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -102,3 +102,10 @@ func testPrimaries(
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfInts)
   _ = takeMatchedPrimaryCollections(arrayOfInts, setOfStrings) // expected-error{{type of expression is ambiguous without more context}}
 }
+
+
+// Prohibit use of opaque parameters in consuming positions.
+typealias FnType<T> = (T) -> Void
+
+func consumingA(fn: (some P) -> Void) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}
+func consumingB(fn: FnType<some P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opaque-parameters -enable-parameterized-protocol-types -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-parameterized-protocol-types -disable-availability-checking
 
 protocol P { }
 


### PR DESCRIPTION
This proposal has been accepted. Implement the amendment that prohibits the use of opaque types in "consuming" positions of function types (which we also did for SE-0328), enable the feature by default, and update some diagnostics to stop implying that this feature cannot be used. 

Tracked by rdar://89107914