### PR TITLE
[move-function] Teach debug info how to handle reinits properly of vars.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -219,6 +219,7 @@ public:
   bool buildDebugInfoExpression(const SILDebugVariable &VarInfo,
                                 SmallVectorImpl<uint64_t> &Operands);
 
+  /// Emit a dbg.declare at the current insertion point in Builder.
   void emitVariableDeclaration(IRBuilder &Builder,
                                ArrayRef<llvm::Value *> Storage,
                                DebugTypeInfo Ty, const SILDebugScope *DS,
@@ -227,6 +228,7 @@ public:
                                IndirectionKind = DirectValue,
                                ArtificialKind = RealValue,
                                AddrDbgInstrKind = AddrDbgInstrKind::DbgDeclare);
+
   void emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
                         llvm::DILocalVariable *Var, llvm::DIExpression *Expr,
                         unsigned Line, unsigned Col, llvm::DILocalScope *Scope,
@@ -2646,7 +2648,6 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   auto *InlinedAt = createInlinedAt(DS);
   auto DL =
       llvm::DILocation::get(IGM.getLLVMContext(), Line, Col, Scope, InlinedAt);
-  auto *BB = Builder.GetInsertBlock();
 
   // An alloca may only be described by exactly one dbg.declare.
   if (isa<llvm::AllocaInst>(Storage) &&
@@ -2695,17 +2696,25 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
   };
   DbgInserter inserter{DBuilder, AddrDInstKind};
 
-  // If we have a single alloca, just insert the debug in
+  // If we have a single alloca...
   if (auto *Alloca = dyn_cast<llvm::AllocaInst>(Storage)) {
-    auto *ParentBB = Alloca->getParent();
-    auto InsertBefore = std::next(Alloca->getIterator());
-    if (InsertBefore != ParentBB->end())
+    auto *ParentBB = Builder.GetInsertBlock();
+    auto InsertBefore = Builder.GetInsertPoint();
+
+    if (AddrDInstKind == AddrDbgInstrKind::DbgDeclare) {
+      ParentBB = Alloca->getParent();
+      InsertBefore = std::next(Alloca->getIterator());
+    }
+
+    if (InsertBefore != ParentBB->end()) {
       inserter.insert(Alloca, Var, Expr, DL, &*InsertBefore);
-    else
+    } else {
       inserter.insert(Alloca, Var, Expr, DL, ParentBB);
+    }
     return;
   }
 
+  auto *BB = Builder.GetInsertBlock();
   if ((isa<llvm::IntrinsicInst>(Storage) &&
        cast<llvm::IntrinsicInst>(Storage)->getIntrinsicID() ==
            llvm::Intrinsic::coro_alloca_get)) {

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -g -emit-ir -o - %s | %FileCheck %s
-// RUN: %target-swift-frontend -parse-as-library -g -c %s -o %t/out.o
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-disable-pass=alloc-stack-hoisting -g -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -Xllvm -sil-disable-pass=alloc-stack-hoisting -g -c %s -o %t/out.o
 // RUN: %llvm-dwarfdump --show-children %t/out.o | %FileCheck -check-prefix=DWARF %s
 
 // This test checks that:
@@ -34,11 +34,11 @@ public protocol P {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo17copyableValueTestyyF"()
 //
-// We should have a llvm.dbg.addr for k since we moved it.
-// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_TEST:[0-9]*]],
-//
 // In contrast, we should have a dbg.declare for m since we aren't
 // CHECK: call void @llvm.dbg.declare(metadata {{.*}}** %m.debug, metadata ![[M_COPYABLE_VALUE_TEST:[0-9]*]],
+//
+// We should have a llvm.dbg.addr for k since we moved it.
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_TEST:[0-9]*]],
 //
 // Our undef should be an llvm.dbg.value. Counter-intuitively this works for
 // both llvm.dbg.addr /and/ llvm.dbg.value. Importantly though its metadata
@@ -79,7 +79,37 @@ public func copyableValueTest() {
     m.doSomething()
 }
 
-// TODO: Look at this.
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo15copyableVarTestyyF"()
+// CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_METADATA:[0-9]+]],
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_METADATA]],
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name	("$s3out15copyableVarTestyyF")
+// DWARF-NEXT: DW_AT_name	("copyableVarTest")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+// DWARF-NEXT: DW_AT_external	(
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location	(DW_OP_fbreg -24)
+// DWARF-NEXT: DW_AT_name	("m")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location	(0x{{[a-z0-9]+}}:
+// We check that we get two separate locations for the different lifetimes of
+// the values.
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name	("k")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
 public func copyableVarTest() {
     var k = Klass()
     k.doSomething()
@@ -89,6 +119,49 @@ public func copyableVarTest() {
     k.doSomething()
 }
 
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo20addressOnlyValueTestyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T, i8** %T.P)
+// CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
+// CHECK: @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
+// CHECK: @llvm.dbg.declare(metadata i8** %m.debug,
+// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDR_LET_METADATA:[0-9]+]],
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDR_LET_METADATA]],
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name   ("$s3out20addressOnlyValueTestyyxAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyValueTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("x")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
 public func addressOnlyValueTest<T : P>(_ x: T) {
     let k = x
     k.doSomething()
@@ -96,6 +169,50 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
     m.doSomething()
 }
 
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T, i8** %T.P)
+// CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
+// CHECK: @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
+// CHECK: @llvm.dbg.declare(metadata i8** %m.debug,
+// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA:[0-9]+]],
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDRONLY_VAR_METADATA]],
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name   ("$s3out18addressOnlyVarTestyyxAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyVarTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("x")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
 public func addressOnlyVarTest<T : P>(_ x: T) {
     var k = x
     k.doSomething()


### PR DESCRIPTION
[move-function] Teach debug info how to handle reinits properly of vars.

This fixes the issues I was in my earlier PR about seeing with vars not getting
appropriate debug info when moved. Now we get the right debug info and in the
dwarf can see the two live ranges of our moved value as we hoped for.

----

Some notes:

1. The main commit is the last move-function commit.
2. The rest are commits related to my fixing a bug in alloc_stack hoisting where we were merging/losing debug info at -Onone when debug info was enabled. I stopped us from doing this in such a case, so the debug info is restored. Otherwise, I lost a variable in my main commits debug info.