### PR TITLE
Temporary fix for OSSA RAUW utilities.

### DIFF
--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -609,10 +609,15 @@ struct RecurStruct {
 }
 
 // Test to make sure we do not crash on a use after free when the branch instructions in bb1 and bb2 are deleted
+//
+// FIXME: Fix OwnershipRAUW to handle guaranteed uses of the old CSE'd
+// value that are reborrows. The reborrowed uses are not dominated by
+// the old value, but they are still within the new values borrow scope.
+//
 // CHECK-LABEL: sil [ossa] @test_useafterfreeinrauw :
 // CHECK: bb0
 // CHECK: struct_extract
-// CHECK-NOT: struct_extract
+// FIXME-CHECK-NOT: struct_extract
 // CHECK: cond_br
 // CHECK-LABEL: } // end sil function 'test_useafterfreeinrauw'
 sil [ossa] @test_useafterfreeinrauw : $@convention(thin) (@guaranteed RecurStruct) -> @owned NonTrivialStruct {


### PR DESCRIPTION
This fix unblocks unrelated optimizer commits. A unit test will be
introduced with those commits.

The RAUW utility does not correctly handle reborrows. It is in the
middle of being rewritten. For now, simply bail out since this isn't
an important case to optimize.

Unblocks https://github.com/apple/swift/pull/41438
