### PR TITLE
[WIP] DistributedActors and distributed funcs in protocols must survive hop_to them

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -658,12 +658,11 @@ public:
 
   /// Retrieve the declaration of DistributedActorSystem.make().
   ///
-  /// \param actorOrSystem distributed actor or actor system to get the
-  /// remoteCall function for. Since the method we're looking for is an ad-hoc
-  /// requirement, a specific type MUST be passed here as it is not possible
-  /// to obtain the decl from just the `DistributedActorSystem` protocol type.
+  /// \param thunk the function from which we'll be invoking things on the obtained
+  /// actor system; This way we'll always get the right type, taking care of any
+  /// where clauses etc.
   FuncDecl *getMakeInvocationEncoderOnDistributedActorSystem(
-      NominalTypeDecl *actorOrSystem) const;
+      AbstractFunctionDecl *thunk) const;
 
   // Retrieve the declaration of
   // DistributedInvocationEncoder.recordGenericSubstitution(_:).

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4472,10 +4472,6 @@ public:
   /// semantics but has no corresponding witness table.
   bool isMarkerProtocol() const;
 
-  /// Is a protocol that can only be conformed by distributed actors.
-  /// Such protocols are allowed to contain distributed functions.
-  bool inheritsFromDistributedActor() const;
-
 private:
   void computeKnownProtocolKind() const;
 

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -31,6 +31,11 @@ class DeclContext;
 class FuncDecl;
 class NominalTypeDecl;
 
+/// Determine the concrete type of 'ActorSystem' as seen from the member.
+/// E.g. when in a protocol, and trying to determine what the actor system was
+/// constrained to.
+Type getConcreteReplacementForProtocolActorSystemType(ValueDecl *member);
+
 /// Determine the `ActorSystem` type for the given actor.
 Type getDistributedActorSystemType(NominalTypeDecl *actor);
 

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -37,7 +37,7 @@ class NominalTypeDecl;
 Type getConcreteReplacementForProtocolActorSystemType(ValueDecl *member);
 
 /// Determine the `ActorSystem` type for the given actor.
-Type getDistributedActorSystemType(NominalTypeDecl *actor);
+Type getDistributedActorSystemType(ClassDecl *actor);
 
 /// Determine the `ID` type for the given actor.
 Type getDistributedActorIDType(NominalTypeDecl *actor);

--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -45,6 +45,7 @@ KNOWN_SDK_TYPE_DECL(Concurrency, TaskLocal, ClassDecl, 1)
 
 // Distributed actors
 KNOWN_SDK_TYPE_DECL(Distributed, DistributedActor, ProtocolDecl, 0)
+KNOWN_SDK_TYPE_DECL(Distributed, DistributedActorSystem, ProtocolDecl, 0)
 KNOWN_SDK_TYPE_DECL(Distributed, RemoteCallTarget, StructDecl, 0)
 
 // String processing

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -771,6 +771,10 @@ public:
   /// Determines whether this type is an actor type.
   bool isActorType();
 
+  /// Determines whether this type conforms or inherits (if it's a protocol
+  /// type) from `DistributedActor`.
+  bool isDistributedActor();
+
   /// Determines the element type of a known
   /// [Autoreleasing]Unsafe[Mutable][Raw]Pointer variant, or returns null if the
   /// type is not a pointer.

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -105,6 +105,7 @@ struct SILDeclRef {
     /// entry point of a class ConstructorDecl or the constructor of a value
     /// ConstructorDecl.
     Allocator,
+
     /// Initializer - this constant references the initializing constructor
     /// entry point of the class ConstructorDecl in loc.
     Initializer,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -363,7 +363,7 @@ private:
   /// Action to be executed for serializing the SILModule.
   ActionCallback SerializeSILAction;
 
-#if NDEBUG
+#ifndef NDEBUG
   BasicBlockNameMapType basicBlockNames;
 #endif
 
@@ -456,20 +456,20 @@ public:
   bool isSerialized() const { return serialized; }
 
   void setBasicBlockName(const SILBasicBlock *block, StringRef name) {
-    #if NDEBUG
+#ifndef NDEBUG
     basicBlockNames[block] = name.str();
-    #endif
+#endif
   }
   Optional<StringRef> getBasicBlockName(const SILBasicBlock *block) {
-    #if NDEBUG
+#ifndef NDEBUG
     auto Known = basicBlockNames.find(block);
     if (Known == basicBlockNames.end())
       return None;
 
     return StringRef(Known->second);
-    #else
+#else
     return None;
-    #endif
+#endif
   }
 
   /// Serialize a SIL module using the configured SerializeSILAction.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1258,24 +1258,25 @@ FuncDecl *ASTContext::getEqualIntDecl() const {
   return getBinaryComparisonOperatorIntDecl(*this, "==", getImpl().EqualIntDecl);
 }
 
-AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
-    NominalTypeDecl *actorOrSystem, bool isVoidReturn) const {
-  assert(actorOrSystem && "distributed actor (or system) decl must be provided");
-  const NominalTypeDecl *system = actorOrSystem;
-  if (actorOrSystem->isDistributedActor()) {
-    auto var = actorOrSystem->getDistributedActorSystemProperty();
-    system = var->getInterfaceType()->getAnyNominal();
-  }
-
-  if (!system)
-    system = getProtocol(KnownProtocolKind::DistributedActorSystem);
-
-  auto mutableSystem = const_cast<NominalTypeDecl *>(system);
-  return evaluateOrDefault(
-      system->getASTContext().evaluator,
-      GetDistributedActorSystemRemoteCallFunctionRequest{mutableSystem, /*isVoidReturn=*/isVoidReturn},
-      nullptr);
-}
+//AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
+//    NominalTypeDecl *actorOrSystem, bool isVoidReturn) const {
+//  assert(actorOrSystem && "distributed actor (or system) decl must be provided");
+//  const NominalTypeDecl *system = actorOrSystem;
+//  if (actorOrSystem->isDistributedActor()) {
+//
+//    auto var = actorOrSystem->getDistributedActorSystemProperty();
+//    system = var->getInterfaceType()->getAnyNominal();
+//  }
+//
+//  if (!system)
+//    system = getProtocol(KnownProtocolKind::DistributedActorSystem);
+//
+//  auto mutableSystem = const_cast<NominalTypeDecl *>(system);
+//  return evaluateOrDefault(
+//      system->getASTContext().evaluator,
+//      GetDistributedActorSystemRemoteCallFunctionRequest{mutableSystem, /*isVoidReturn=*/isVoidReturn},
+//      nullptr);
+//}
 
 FuncDecl *ASTContext::getMakeInvocationEncoderOnDistributedActorSystem(
     AbstractFunctionDecl *thunk) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5294,11 +5294,6 @@ bool ProtocolDecl::isMarkerProtocol() const {
   return getAttrs().hasAttribute<MarkerAttr>();
 }
 
-bool ProtocolDecl::inheritsFromDistributedActor() const {
-  auto &C = getASTContext();
-  return inheritsFrom(C.getDistributedActorDecl());
-}
-
 ArrayRef<ProtocolDecl *> ProtocolDecl::getInheritedProtocols() const {
   auto *mutThis = const_cast<ProtocolDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  This file implements the Decl class and subclasses.
+//  This file handles lookups related to distributed actor decls.
 //
 //===----------------------------------------------------------------------===//
 
@@ -89,7 +89,7 @@ Type swift::getDistributedActorSystemActorIDRequirementType(NominalTypeDecl *sys
   assert(!system->isDistributedActor());
   auto &ctx = system->getASTContext();
 
-  auto protocol = ctx.getProtocol(KnownProtocolKind::DistributedActorSystem);
+  auto protocol = ctx.getDistributedActorSystemDecl();
   if (!protocol)
     return Type();
 
@@ -128,7 +128,7 @@ Type ASTContext::getAssociatedTypeOfDistributedSystemOfActor(
   if (!actorSystemDecl)
     return Type();
 
-  auto actorSystemProtocol = ctx.getProtocol(KnownProtocolKind::DistributedActorSystem);
+  auto actorSystemProtocol = ctx.getDistributedActorSystemDecl();
   if (!actorSystemProtocol)
     return Type();
 
@@ -252,7 +252,7 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
 
   // === Must be declared in a 'DistributedActorSystem' conforming type
   ProtocolDecl *systemProto =
-      C.getProtocol(KnownProtocolKind::DistributedActorSystem);
+      C.getDistributedActorSystemDecl();
 
   auto systemNominal = getDeclContext()->getSelfNominalTypeDecl();
   auto distSystemConformance = module->lookupConformance(
@@ -968,7 +968,7 @@ llvm::SmallPtrSet<ProtocolDecl *, 2>
 swift::extractDistributedSerializationRequirements(
     ASTContext &C, ArrayRef<Requirement> allRequirements) {
   llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
-  auto systemProto = C.getProtocol(KnownProtocolKind::DistributedActorSystem);
+  auto systemProto = C.getDistributedActorSystemDecl();
   auto serializationReqAssocType =
       systemProto->getAssociatedType(C.Id_SerializationRequirement);
   auto systemSerializationReqTy = serializationReqAssocType->getInterfaceType();

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -70,18 +70,13 @@ Type swift::getConcreteReplacementForProtocolActorSystemType(ValueDecl *member) 
   auto *DC = member->getDeclContext();
   auto DA = C.getDistributedActorDecl();
 
-  // === When declared inside a n actor, we can get the type directly
-  if (auto classDecl = dyn_cast<ClassDecl>(DC)) {
+  // === When declared inside an actor, we can get the type directly
+  if (auto classDecl = DC->getSelfClassDecl()) {
     return getDistributedActorSystemType(classDecl);
   }
 
   /// === Maybe the value is declared in a protocol?
-  ProtocolDecl *protocol = dyn_cast<ProtocolDecl>(member);
-  if (!protocol) {
-    protocol = DC->getSelfProtocolDecl();
-  }
-
-  if (protocol) {
+  if (auto protocol = DC->getSelfProtocolDecl()) {
     GenericSignature signature;
     if (auto *genericContext = member->getAsGenericContext()) {
       signature = genericContext->getGenericSignature();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -380,6 +380,20 @@ bool CanType::isTypeErasedGenericClassTypeImpl(CanType type) {
   return false;
 }
 
+static bool archetypeConformsTo(ArchetypeType *archetype, KnownProtocolKind protocol) {
+  auto &ctx = archetype->getASTContext();
+  auto expectedProto = ctx.getProtocol(protocol);
+  if (!expectedProto)
+    return false;
+
+  for (auto proto : archetype->getConformsTo()) {
+    if (proto == expectedProto || proto->inheritsFrom(expectedProto))
+      return true;
+  }
+
+  return false;
+}
+
 bool TypeBase::isActorType() {
   // Nominal types: check whether the declaration is an actor.
   if (auto nominal = getAnyNominal())
@@ -387,16 +401,7 @@ bool TypeBase::isActorType() {
 
   // Archetypes check for conformance to Actor.
   if (auto archetype = getAs<ArchetypeType>()) {
-    auto actorProto = getASTContext().getProtocol(KnownProtocolKind::Actor);
-    if (!actorProto)
-      return false;
-
-    for (auto proto : archetype->getConformsTo()) {
-      if (proto == actorProto || proto->inheritsFrom(actorProto))
-        return true;
-    }
-
-    return false;
+    return archetypeConformsTo(archetype, KnownProtocolKind::Actor);
   }
 
   // Existential types: check for Actor protocol.
@@ -417,6 +422,40 @@ bool TypeBase::isActorType() {
     }
 
     return false;
+  }
+
+  return false;
+}
+
+bool TypeBase::isDistributedActor() {
+  // Nominal types: check whether the declaration is an actor.
+  if (auto *nominal = getAnyNominal()) {
+    if (auto *classDecl = dyn_cast<ClassDecl>(nominal))
+      return classDecl->isDistributedActor();
+
+    if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal))
+      return false;
+  }
+
+  // Archetypes check for conformance to DistributedActor.
+  if (auto archetype = getAs<ArchetypeType>()) {
+    return archetypeConformsTo(archetype, KnownProtocolKind::DistributedActor);
+  }
+
+  // Existential types: check for DistributedActor protocol conformance.
+  if (isExistentialType()) {
+    auto actorProto = getASTContext().getDistributedActorDecl();
+    if (!actorProto)
+      return false;
+
+    // TODO(distributed): Inheritance is not yet supported.
+
+    auto layout = getExistentialLayout();
+    return llvm::any_of(layout.getProtocols(),
+                        [&actorProto](ProtocolType *protocol) {
+                          return protocol->getDecl() == actorProto ||
+                                 protocol->isDistributedActor();
+                        });
   }
 
   return false;

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -522,6 +522,7 @@ void SILGenFunction::emitFunction(FuncDecl *fd) {
              fd->getResultInterfaceType(), fd->hasThrows(), fd->getThrowsLoc());
 
   if (fd->isDistributedActorFactory()) {
+    // TODO(distributed): generalize as "emit body synthesized in SIL" marker
     // Synthesize the factory function body
     emitDistributedActorFactory(fd);
   } else {

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -145,32 +145,6 @@ static bool isDefaultActorType(CanType actorType, ModuleDecl *M,
   return false;
 }
 
-static bool isDefaultDistributedActorType(CanType actorType, SILFunction *F) {
-  auto *DC = F->getDeclContext();
-
-  if (auto classDecl = dyn_cast<ClassDecl>(DC)) {
-    return classDecl->isDistributedActor();
-  }
-
-  auto selfTy = F->getSelfArgument()->getDecl()->getInterfaceType();
-  if (auto archetype = dyn_cast<PrimaryArchetypeType>(actorType)) {
-    GenericSignature signature = DC->getGenericSignatureOfContext();
-    for (auto req : signature.getRequirements()) {
-      if (req.getFirstType()->isEqual(selfTy)) {
-        // It is a Self requirement on the actor where decl,
-        // check if it requires tha it is a distributed actor:
-        if (auto proto = req.getProtocolDecl()) {
-          if (proto->inheritsFromDistributedActor()) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return false;
-}
-
 static AccessorDecl *getUnownedExecutorGetter(ASTContext &ctx,
                                               ProtocolDecl *actorProtocol) {
   for (auto member: actorProtocol->getAllMembers()) {
@@ -204,9 +178,8 @@ SILValue LowerHopToActor::emitGetExecutor(SILLocation loc, SILValue actor,
   // If the actor type is a default actor, go ahead and devirtualize here.
   auto module = F->getModule().getSwiftModule();
   SILValue unmarkedExecutor;
-  fprintf(stderr, "[%s:%d] (%s) isDefaultDistributedActorType(actorType) = %d\n", __FILE__, __LINE__, __FUNCTION__, isDefaultDistributedActorType(actorType, F));
   if (isDefaultActorType(actorType, module, F->getResilienceExpansion()) ||
-      isDefaultDistributedActorType(actorType, F)) {
+      actorType->isDistributedActor()) {
     auto builtinName = ctx.getIdentifier(
       getBuiltinName(BuiltinValueKind::BuildDefaultActorExecutorRef));
     auto builtinDecl = cast<FuncDecl>(getBuiltinValueDecl(ctx, builtinName));

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -65,7 +65,7 @@ void emitDistributedActorSystemWitnessCall(
   auto &C = F.getASTContext();
 
   // Dig out the conformance to DistributedActorSystem.
-  ProtocolDecl *DAS = C.getDistributedActorDecl();
+  ProtocolDecl *DAS = C.getDistributedActorSystemDecl();
   assert(DAS);
   auto systemASTType = base->getType().getASTType();
   auto *module = M.getSwiftModule();
@@ -81,6 +81,8 @@ void emitDistributedActorSystemWitnessCall(
         OpenedExistentialAccess::Immutable);
   }
 
+  fprintf(stderr, "[%s:%d] (%s) systemASTType\n", __FILE__, __LINE__, __FUNCTION__);
+  systemASTType.dump();
   if (systemASTType->isTypeParameter() || systemASTType->is<ArchetypeType>()) {
     systemConfRef = ProtocolConformanceRef(DAS);
   } else {

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -65,8 +65,8 @@ void emitDistributedActorSystemWitnessCall(
   auto &C = F.getASTContext();
 
   // Dig out the conformance to DistributedActorSystem.
-  ProtocolDecl *systemProto = C.getProtocol(KnownProtocolKind::DistributedActorSystem);
-  assert(systemProto);
+  ProtocolDecl *DAS = C.getDistributedActorDecl();
+  assert(DAS);
   auto systemASTType = base->getType().getASTType();
   auto *module = M.getSwiftModule();
   ProtocolConformanceRef systemConfRef;
@@ -82,16 +82,16 @@ void emitDistributedActorSystemWitnessCall(
   }
 
   if (systemASTType->isTypeParameter() || systemASTType->is<ArchetypeType>()) {
-    systemConfRef = ProtocolConformanceRef(systemProto);
+    systemConfRef = ProtocolConformanceRef(DAS);
   } else {
-    systemConfRef = module->lookupConformance(systemASTType, systemProto);
+    systemConfRef = module->lookupConformance(systemASTType, DAS);
   }
 
   assert(!systemConfRef.isInvalid() &&
          "Missing conformance to `DistributedActorSystem`");
 
   // Dig out the method.
-  auto method = cast<FuncDecl>(systemProto->getSingleRequirement(methodName));
+  auto method = cast<FuncDecl>(DAS->getSingleRequirement(methodName));
   auto methodRef = SILDeclRef(method, SILDeclRef::Kind::Func);
   auto methodSILTy =
       M.Types.getConstantInfo(B.getTypeExpansionContext(), methodRef)
@@ -146,7 +146,6 @@ void emitDistributedActorSystemWitnessCall(
   auto params = methodSILFnTy->getParameters();
   for (size_t i = 0; i < args.size(); ++i) {
     auto arg = args[i];
-    // FIXME(distributed): handle multiple ones (!!!!)
     if (params[i].isFormalIndirect() &&
         !arg->getType().isAddress() &&
         !dyn_cast<AnyMetatypeType>(arg->getType().getASTType())) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -292,8 +292,8 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
       params.push_back(arg);
     }
   } else if (ICK == ImplicitConstructorKind::DefaultDistributedActor) {
-    assert(isa<ClassDecl>(decl));
-    assert(decl->isDistributedActor() &&
+    auto classDecl = dyn_cast<ClassDecl>(decl);
+    assert(classDecl && decl->isDistributedActor() &&
            "Only 'distributed actor' type can gain implicit distributed actor init");
 
     /// Add 'system' parameter to default init of distributed actors.
@@ -305,7 +305,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
       auto *arg = new (ctx) ParamDecl(SourceLoc(), Loc, ctx.Id_system, Loc,
                                       ctx.Id_system, decl);
       arg->setSpecifier(ParamSpecifier::Default);
-      arg->setInterfaceType(getDistributedActorSystemType(decl));
+      arg->setInterfaceType(getDistributedActorSystemType(classDecl));
       arg->setImplicit();
 
       params.push_back(arg);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -103,7 +103,6 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *actor) const {
   auto &C = actor->getASTContext();
   auto module = actor->getParentModule();
-//  auto module = C.getStdlibModule();
 
   auto sys = C.getProtocol(KnownProtocolKind::DistributedActorSystem);
   sys->dump();
@@ -114,10 +113,14 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
   if (!C.getLoadedModule(C.Id_Distributed))
     return nullptr;
 
+  auto classDecl = dyn_cast<ClassDecl>(actor);
+  if (!classDecl)
+    return nullptr;
+
   if (!actor->isDistributedActor())
     return nullptr;
 
-  auto expectedSystemType = getDistributedActorSystemType(actor);
+  auto expectedSystemType = getDistributedActorSystemType(classDecl);
   fprintf(stderr, "[%s:%d] (%s) expectedSystemType\n", __FILE__, __LINE__, __FUNCTION__);
   expectedSystemType.dump();
   auto DistSystemProtocol =

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -128,15 +128,18 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
 
 static ValueDecl *deriveDistributedActor_actorSystem(
     DerivedConformance &derived) {
-  assert(derived.Nominal->isDistributedActor());
   auto &C = derived.Context;
+
+  auto classDecl = dyn_cast<ClassDecl>(derived.Nominal);
+  assert(classDecl && derived.Nominal->isDistributedActor());
 
   // ```
   // nonisolated
   // let actorSystem: ActorSystem
   // ```
   // (no need for @actorIndependent because it is an immutable let)
-  auto propertyType = getDistributedActorSystemType(derived.Nominal);
+  fprintf(stderr, "[%s:%d] (%s) get type\n", __FILE__, __LINE__, __FUNCTION__);
+  auto propertyType = getDistributedActorSystemType(classDecl);
 
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5592,22 +5592,15 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
     }
 
     // distributed func must be declared inside an distributed actor
-    if (dc->getSelfClassDecl() &&
-        !dc->getSelfClassDecl()->isDistributedActor()) {
-      diagnoseAndRemoveAttr(
-          attr, diag::distributed_actor_func_not_in_distributed_actor);
-      return;
-    } else if (auto protoDecl = dc->getSelfProtocolDecl()){
-      if (!protoDecl->inheritsFromDistributedActor()) {
-        auto diag = diagnoseAndRemoveAttr(
-            attr, diag::distributed_actor_func_not_in_distributed_actor);
-        diagnoseDistributedFunctionInNonDistributedActorProtocol(
-            protoDecl, diag);
-        return;
+    auto selfTy = dc->getSelfTypeInContext();
+    if (!selfTy->isDistributedActor()) {
+      auto diagnostic = diagnoseAndRemoveAttr(
+        attr, diag::distributed_actor_func_not_in_distributed_actor);
+
+      if (auto *protoDecl = dc->getSelfProtocolDecl()) {
+        diagnoseDistributedFunctionInNonDistributedActorProtocol(protoDecl,
+                                                                 diagnostic);
       }
-    } else if (dc->getSelfStructDecl() || dc->getSelfEnumDecl()) {
-      diagnoseAndRemoveAttr(
-          attr, diag::distributed_actor_func_not_in_distributed_actor);
       return;
     }
   }

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -14,6 +14,7 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
+
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import _Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol LifecycleWatch: DistributedActor where ActorSystem == FakeRoundtripActorSystem {
+}
+
+extension LifecycleWatch {
+  func watch() async throws {
+    // nothing here
+  }
+
+  distributed func test() async throws {
+    try await self.watch()
+  }
+}
+
+distributed actor Worker: LifecycleWatch {
+
+}
+
+@main struct Main {
+  static func main() async {
+    let worker: any LifecycleWatch = Worker(system: DefaultDistributedActorSystem())
+    try! await worker.test()
+
+    print("OK") // CHECK: OK
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -26,21 +26,27 @@ protocol LifecycleWatch: DistributedActor where ActorSystem == FakeRoundtripActo
 extension LifecycleWatch {
   func watch() async throws {
     // nothing here
+    print("executed: \(#function)")
   }
 
   distributed func test() async throws {
+    print("executed: \(#function)")
     try await self.watch()
+    print("done executed: \(#function)")
   }
 }
 
 distributed actor Worker: LifecycleWatch {
-
 }
 
 @main struct Main {
   static func main() async {
     let worker: any LifecycleWatch = Worker(system: DefaultDistributedActorSystem())
     try! await worker.test()
+
+    // CHECK: executed: test()
+    // CHECK: executed: watch()
+    // CHECK: done executed: test()
 
     print("OK") // CHECK: OK
   }

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -40,6 +40,61 @@ struct MissingRemoteCall: DistributedActorSystem {
   }
 }
 
+struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
+  // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
+
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
+
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
+}
+
 struct Error_wrongReturn: DistributedActorSystem {
   // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
   // expected-note@-2{{protocol 'Error_wrongReturn' requires function 'remoteCall' with signature:}}


### PR DESCRIPTION
Resolves rdar://84054772

Declaring a protocol that is `protocol X: DistributedActor` and having a distributed func in an extension on it, causes crashes in two situations:

- attempting to get an executor off it, triggers assertions that a non Actor type tries to get an executor -- this is fine for a distributed actor though; for now we just always treat it as Default and get the global executor; we'll align the two later
- SIL synthesis of the distributed thunk needs to find the ActorSystem of the protocol's where clause, or some type alias along the way and use it during synthesis so we don't crash not being able to find the system field (and type).

The latter part I'm still struggling with, but getting through it.