### PR TITLE
accept serialized modules with superflous global-actor annotations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4794,8 +4794,8 @@ ERROR(global_actor_on_actor_class,none,
 ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
 ERROR(global_actor_on_storage_of_value_type,none,
-      "stored property %0 within %1 cannot have a global actor",
-      (DeclName, DescriptiveDeclKind))
+      "stored property %0 within struct cannot have a global actor",
+      (DeclName))
 ERROR(global_actor_non_unsafe_init,none,
       "global actor attribute %0 argument can only be '(unsafe)'", (Type))
 ERROR(global_actor_non_final_class,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -323,6 +323,11 @@ GlobalActorAttributeRequest::evaluate(
   // Check that a global actor attribute makes sense on this kind of
   // declaration.
   auto decl = subject.get<Decl *>();
+
+  // no further checking required if it's from a serialized module.
+  if (decl->getDeclContext()->getParentSourceFile() == nullptr)
+    return result;
+
   auto globalActorAttr = result->first;
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     // Nominal types are okay...
@@ -358,7 +363,7 @@ GlobalActorAttributeRequest::evaluate(
           if (isa<StructDecl>(nominal) && !isWrappedValueOfPropWrapper(var)) {
 
             var->diagnose(diag::global_actor_on_storage_of_value_type,
-                          var->getName(), nominal->getDescriptiveKind())
+                          var->getName())
               .highlight(globalActorAttr->getRangeWithAt())
               .warnUntilSwiftVersion(6);
 

--- a/test/Concurrency/Inputs/SerializedStruct.swift
+++ b/test/Concurrency/Inputs/SerializedStruct.swift
@@ -1,0 +1,6 @@
+
+public struct MySerializedStruct {
+  @MainActor public var counter = 0
+
+  public init() {}
+}

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedStruct.swiftmodule -module-name SerializedStruct %S/Inputs/SerializedStruct.swift
+// RUN: %target-swift-frontend %s -typecheck -disable-availability-checking -swift-version 6 -I %t
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test ensures that, when loading a Swift 5 serialized module with
+// a global-actor annotation that is an error in Swift 6, but only a warning
+// in Swift 5, then we do not reject the import as an error.
+
+import SerializedStruct
+
+// use it to force the right checks happen.
+func test() async -> Int {
+  let x = MySerializedStruct()
+  return await x.counter // Because the module is from Swift 5, an await is needed.
+}


### PR DESCRIPTION
When compiling with Swift 6 mode, but using a serialized module
that is using Swift 5 that contains a struct with global-actor
isolation on its stored property, we should not emit an error
for that stored property. Only a warning was emitted when compiling
that module, but the checks here were treating that module as being
type-checked again under a Swift 6 world.

resolves rdar://89159261