### PR TITLE
[sil-opt] Propagate to IRGenOptions whether we have debug info and or optimizations enabled.

### DIFF
--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -31,7 +31,7 @@ class IRGenModule;
 std::pair<IRGenerator *, IRGenModule *>
 createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
                   StringRef MainInputFilenameForDebugInfo,
-                  StringRef PrivateDiscriminator);
+                  StringRef PrivateDiscriminator, IRGenOptions &options);
 
 /// Delete the IRGenModule and IRGenerator obtained by the above call.
 void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -937,9 +937,8 @@ static void initLLVMModule(const IRGenModule &IGM, SILModule &SIL) {
 std::pair<IRGenerator *, IRGenModule *>
 swift::irgen::createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
                                 StringRef MainInputFilenameForDebugInfo,
-                                StringRef PrivateDiscriminator) {
-
-  IRGenOptions Opts;
+                                StringRef PrivateDiscriminator,
+                                IRGenOptions &Opts) {
   IRGenerator *irgen = new IRGenerator(Opts, *SILMod);
   auto targetMachine = irgen->createTargetMachine();
   if (!targetMachine)

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -296,6 +296,18 @@ static llvm::cl::opt<OptimizationMode> OptModeFlag(
                                 "ignore debug info, reduce runtime")),
     llvm::cl::init(OptimizationMode::NotSet));
 
+static llvm::cl::opt<IRGenDebugInfoLevel> IRGenDebugInfoLevelArg(
+    "irgen-debuginfo-level", llvm::cl::desc("IRGen debug info level"),
+    llvm::cl::values(clEnumValN(IRGenDebugInfoLevel::None, "none",
+                                "No debug info"),
+                     clEnumValN(IRGenDebugInfoLevel::LineTables, "line-tables",
+                                "Line tables only"),
+                     clEnumValN(IRGenDebugInfoLevel::ASTTypes, "ast-types",
+                                "Line tables + AST type references"),
+                     clEnumValN(IRGenDebugInfoLevel::DwarfTypes, "dwarf-types",
+                                "Line tables + AST type refs + Dwarf types")),
+    llvm::cl::init(IRGenDebugInfoLevel::ASTTypes));
+
 static llvm::cl::opt<OptGroup> OptimizationGroup(
     llvm::cl::desc("Predefined optimization groups:"),
     llvm::cl::values(
@@ -684,6 +696,7 @@ int main(int argc, char **argv) {
   } else {
     IRGenOpts.OptMode = OptModeFlag;
   }
+  IRGenOpts.DebugInfoLevel = IRGenDebugInfoLevelArg;
 
   // Note: SILOpts, LangOpts, and IRGenOpts must be set before the
   // CompilerInstance is initializer below based on Invocation.

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -675,8 +675,18 @@ int main(int argc, char **argv) {
     SILOpts.OptMode = OptModeFlag;
   }
 
-  // Note: SILOpts must be set before the CompilerInstance is initializer below
-  // based on Invocation.
+  auto &IRGenOpts = Invocation.getIRGenOptions();
+  if (OptModeFlag == OptimizationMode::NotSet) {
+    if (OptimizationGroup == OptGroup::Diagnostics)
+      IRGenOpts.OptMode = OptimizationMode::NoOptimization;
+    else
+      IRGenOpts.OptMode = OptimizationMode::ForSpeed;
+  } else {
+    IRGenOpts.OptMode = OptModeFlag;
+  }
+
+  // Note: SILOpts, LangOpts, and IRGenOpts must be set before the
+  // CompilerInstance is initializer below based on Invocation.
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -784,7 +784,8 @@ int main(int argc, char **argv) {
   case OptGroup::Unknown: {
     auto T = irgen::createIRGenModule(
         SILMod.get(), Invocation.getOutputFilenameForAtMostOnePrimary(),
-        Invocation.getMainInputFilenameForDebugInfoForAtMostOnePrimary(), "");
+        Invocation.getMainInputFilenameForDebugInfoForAtMostOnePrimary(), "",
+        IRGenOpts);
     runCommandLineSelectedPasses(SILMod.get(), T.second);
     irgen::deleteIRGenModule(T);
     break;


### PR DESCRIPTION
Was working on fixing a bug in alloc stack hoisting and I realized we did not have this setup correctly. Without this any IRGen SIL passes can not be tested with debug info enabled inclusive or optimizations disabled. We in those passes should be able to reason about this.