### PR TITLE
[nfc] XFAIL dependent-types.swift on i386 while I fix the issue.

### DIFF
--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
+//
+// For some reason this is failing on i386: rdar://89166707.
+// XFAIL: CPU=i386
 
 import DependentTypes
 import StdlibUnittest


### PR DESCRIPTION
Unblock the bots while I find a solution to the crash.
