### PR TITLE
[cxx-interop] Fix crash when inout parameter is used in some "template contexts".

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
+++ b/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
@@ -34,6 +34,9 @@ template <typename T>
 T templateTypeParamUsedInReferenceParam(T &t) { return t; }
 
 template <typename T, typename U>
+T templateTypeParamNotUsedInSignatureWithRef(T &t) { return t; }
+
+template <typename T, typename U>
 void templateTypeParamNotUsedInSignatureWithVarargs(...) {}
 
 template <typename T, typename U, typename V>

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -35,6 +35,13 @@ DependentTypesTestSuite.test("Multiple dependent arguments (not inferred).") {
   expectEqual(m.getValue(), 42)
 }
 
+DependentTypesTestSuite.test("Takes inout argument and returns dependent type.") {
+  var x = 42
+  let m = refToDependent(&x) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+
 // We still have some problems calling methods on Windows: SR-13129 and rdar://88391102
 #if !os(Windows)
 DependentTypesTestSuite.test("Function template methods") {

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
@@ -39,4 +39,10 @@ TemplateNotInSignatureTestSuite.test("Member function templates (static)") {
   Struct.templateTypeParamNotUsedInSignatureStatic(T: Int.self)
 }
 
+TemplateNotInSignatureTestSuite.test("Type not used in signature and takes an inout parameter.") {
+  var x = 42
+  let out = templateTypeParamNotUsedInSignatureWithRef(&x, U: Int.self)
+  expectEqual(out, 42)
+}
+
 runAllTests()


### PR DESCRIPTION
We used to incorrectly forward inout parameters in the thunk for both template parameters that aren't used in the signature and in the thunk for dependent types as Any.

Now this works in the simple case. We'll need to do something more complicated when we have an `inout Any` for dependent types because we will need to somehow cast without copying. This will probably require synthesizing the SIL of the thunk manually.