### PR TITLE
[SSADestroyHoisting] Aliasable addr args respect deinit barriers.

### DIFF
--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -634,9 +634,13 @@ bool HoistDestroys::foldBarrier(SILInstruction *barrier,
                                 const KnownStorageUses &knownUses,
                                 const DeinitBarriers &deinitBarriers) {
   if (auto *eai = dyn_cast<EndAccessInst>(barrier)) {
+    auto *bai = eai->getBeginAccess();
+    // Don't hoist a destroy into an unrelated access scope.
+    if (stripAccessMarkers(bai) != stripAccessMarkers(storageRoot))
+      return false;
     SILInstruction *instruction = eai;
     while ((instruction = instruction->getPreviousInstruction())) {
-      if (instruction == eai->getBeginAccess())
+      if (instruction == bai)
         return false;
       if (foldBarrier(instruction, storageRoot))
         return true;

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -821,11 +821,17 @@ void SSADestroyHoisting::run() {
   // Arguments enclose everything.
   for (auto *arg : getFunction()->getArguments()) {
     if (arg->getType().isAddress()) {
-      bool isInout = cast<SILFunctionArgument>(arg)
-                         ->getArgumentConvention()
-                         .isInoutConvention();
-      changed |= hoistDestroys(arg, /*ignoreDeinitBarriers=*/
-                               isInout, remainingDestroyAddrs, deleter);
+      auto convention = cast<SILFunctionArgument>(arg)->getArgumentConvention();
+      // This is equivalent to writing
+      //
+      //     convention == SILArgumentConvention::Indirect_Inout
+      //
+      // but communicates the rationale: in order to ignore deinit barriers, the
+      // address must be exclusively accessed and be a modification.
+      bool ignoreDeinitBarriers = convention.isInoutConvention() &&
+                                  convention.isExclusiveIndirectParameter();
+      changed |= hoistDestroys(arg, ignoreDeinitBarriers, remainingDestroyAddrs,
+                               deleter);
     }
   }
 

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -255,6 +255,21 @@ entry(%instance : @none $TrivialStruct):
     return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @nohoist_inout_aliasable : {{.*}} {
+// CHECK:         apply
+// CHECK:         destroy_addr
+// CHECK-LABEL: } // end sil function 'nohoist_inout_aliasable'
+sil [ossa] @nohoist_inout_aliasable : $@convention(thin) (@inout_aliasable X) -> () {
+entry(%addr : $*X):
+  %value = load [copy] %addr : $*X
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  destroy_addr %addr : $*X
+  store %value to [init] %addr : $*X
+  %tuple = tuple ()
+  return %tuple : $()
+}
+
 // Fold destroy_addr and a load [copy] into a load [take] even when that
 // load [take] is guarded by an access scope.
 //
@@ -426,4 +441,3 @@ entry(%instance : @owned $X):
   dealloc_stack %addr_outer : $*X
   return %value : $X
 }
-

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -398,3 +398,32 @@ entry(%instance : @owned $X):
 
   return %loaded : $X
 }
+
+// Don't fold a destroy_addr with a load [copy] that occurs within the scope of
+// an access to unrelated storage.
+//
+// CHECK-LABEL: sil [ossa] @nofold_into_unrelated_barrier_scope : {{.*}} {
+// CHECK:         load [copy]
+// CHECK-LABEL: } // end sil function 'nofold_into_unrelated_barrier_scope'
+sil [ossa] @nofold_into_unrelated_barrier_scope : $@convention(thin) (@owned X) -> (@owned X) {
+entry(%instance : @owned $X):
+  %copy = copy_value %instance : $X
+  %addr_outer = alloc_stack $X
+  %addr_inner = alloc_stack $X
+  store %copy to [init] %addr_outer : $*X
+  store %instance to [init] %addr_inner : $*X
+
+  %access = begin_access [modify] [static] %addr_outer : $*X
+  apply undef(%access) : $@convention(thin) (@inout X) -> ()
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  destroy_addr %access : $*X
+  apply %unknown() : $@convention(thin) () -> ()
+  %value = load [copy] %addr_inner : $*X
+  end_access %access : $*X
+  destroy_addr %addr_inner : $*X
+
+  dealloc_stack %addr_inner : $*X
+  dealloc_stack %addr_outer : $*X
+  return %value : $X
+}
+


### PR DESCRIPTION
Previously, all arguments using an inout convention were hoisted ignoring deinit barriers.  That was incorrect because @inout_aliasable addresses are modifications but aren't exclusive.  Here, that's fixed by only allowing arguments with the @inout convention to be hoisted.

Also, took this opportunity to check in a fix to folding:

If a load [copy] appears near the end of the scope protecting access to another address and a destroy_addr of the loaded address appears afterwards, don't fold the destroy into the scope.  The reason is that doing so could allow a deinit which previously executed outside the exclusivity scope to subsequently execute within it.

