### PR TITLE
Support parameterized protocols with multiple arguments

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4402,10 +4402,10 @@ public:
   /// a protocol having nested types (ObjC protocols).
   ArrayRef<AssociatedTypeDecl *> getAssociatedTypeMembers() const;
 
-  /// Returns the primary associated type, or nullptr if there isn't one. This is
-  /// the associated type that is parametrized with a same-type requirement in a
-  /// parametrized protocol type of the form SomeProtocol<SomeArgType>.
-  AssociatedTypeDecl *getPrimaryAssociatedType() const;
+  /// Returns the list of primary associated types. These are the associated
+  /// types that is parametrized with same-type requirements in a
+  /// parametrized protocol type of the form SomeProtocol<Arg1, Arg2...>.
+  ArrayRef<AssociatedTypeDecl *> getPrimaryAssociatedTypes() const;
 
   /// Returns a protocol requirement with the given name, or nullptr if the
   /// name has multiple overloads, or no overloads at all.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3734,11 +3734,13 @@ ERROR(not_a_generic_definition,none,
 ERROR(not_a_generic_type,none,
       "cannot specialize non-generic type %0", (Type))
 ERROR(parameterized_protocol_not_supported,none,
-      "protocol type with generic argument can only be used as a generic constraint", ())
+      "protocol type with generic arguments can only be used as a generic constraint", ())
 ERROR(protocol_does_not_have_primary_assoc_type,none,
       "cannot specialize protocol type %0", (Type))
-ERROR(protocol_cannot_have_multiple_generic_arguments,none,
-      "protocol type %0 can only be specialized with exactly one argument", (Type))
+ERROR(parameterized_protocol_too_many_type_arguments,none,
+      "protocol type %0 can specialized with too many type parameters "
+      "(got %1, but expected at most %2)",
+      (Type, unsigned, unsigned))
 ERROR(cannot_specialize_self,none,
       "cannot specialize 'Self'", ())
 NOTE(specialize_explicit_type_instead,none,

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -26,11 +26,6 @@ namespace swift {
   class ProtocolType;
   class ProtocolCompositionType;
 
-struct PrimaryAssociatedTypeRequirement {
-  AssociatedTypeDecl *AssocType;
-  Type Argument;
-};
-
 struct ExistentialLayout {
   enum Kind { Class, Error, Opaque };
 
@@ -117,7 +112,7 @@ private:
 
   /// Zero or more primary associated type requirements from a
   /// ParameterizedProtocolType
-  ArrayRef<PrimaryAssociatedTypeRequirement> sameTypeRequirements;
+  ArrayRef<Type> sameTypeRequirements;
 };
 
 }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -313,10 +313,10 @@ public:
   void cacheResult(bool value) const;
 };
 
-/// Find the primary associated type of the given protocol.
-class PrimaryAssociatedTypeRequest :
-    public SimpleRequest<PrimaryAssociatedTypeRequest,
-                         AssociatedTypeDecl *(ProtocolDecl *),
+/// Find the list of primary associated types of the given protocol.
+class PrimaryAssociatedTypesRequest :
+    public SimpleRequest<PrimaryAssociatedTypesRequest,
+                         ArrayRef<AssociatedTypeDecl *>(ProtocolDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -325,7 +325,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  AssociatedTypeDecl *
+  ArrayRef<AssociatedTypeDecl *>
   evaluate(Evaluator &evaluator, ProtocolDecl *decl) const;
 
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -262,8 +262,8 @@ SWIFT_REQUEST(TypeChecker, PropertyWrapperTypeInfoRequest,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest, bool(ProtocolDecl *),
               SeparatelyCached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, PrimaryAssociatedTypeRequest,
-              AssociatedTypeDecl *(ProtocolDecl *),
+SWIFT_REQUEST(TypeChecker, PrimaryAssociatedTypesRequest,
+              ArrayRef<AssociatedTypeDecl *>(ProtocolDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequirementRequest,
               Requirement(WhereClauseOwner, unsigned, TypeResolutionStage),

--- a/include/swift/AST/TypeDifferenceVisitor.h
+++ b/include/swift/AST/TypeDifferenceVisitor.h
@@ -344,8 +344,8 @@ public:
     if (asImpl().visit(type1.getBaseType(), type2.getBaseType()))
       return true;
 
-    return asImpl().visit(type1.getArgumentType(),
-                          type2.getArgumentType());
+    return visitComponentArray(type1, type2,
+                               type1->getArgs(), type2->getArgs());
   }
 
   bool visitExistentialType(CanExistentialType type1,

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -342,10 +342,19 @@ class TypeMatcher {
           return false;
         }
 
-        return this->visit(firstParametrizedProto.getArgumentType(),
-                           secondParametrizedProto->getArgumentType(),
-                           sugaredFirstType->castTo<ParameterizedProtocolType>()
-                               ->getArgumentType());
+        auto firstArgs = firstParametrizedProto->getArgs();
+        auto secondArgs = secondParametrizedProto->getArgs();
+
+        if (firstArgs.size() == secondArgs.size()) {
+          for (unsigned i : indices(firstArgs)) {
+            return this->visit(CanType(firstArgs[i]),
+                               secondArgs[i],
+                               sugaredFirstType->castTo<ParameterizedProtocolType>()
+                                   ->getArgs()[i]);
+          }
+
+          return true;
+        }
       }
 
       return mismatch(firstParametrizedProto.getPointer(), secondType,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5289,6 +5289,8 @@ public:
             Bits.ParameterizedProtocolType.ArgCount};
   }
 
+  void getRequirements(Type baseType, SmallVectorImpl<Requirement> &reqs) const;
+
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, Base, getArgs());
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -413,6 +413,11 @@ protected:
     Count : 32
   );
 
+  SWIFT_INLINE_BITFIELD_FULL(ParameterizedProtocolType, TypeBase, 32,
+    /// The number of type arguments.
+    ArgCount : 32
+  );
+
   SWIFT_INLINE_BITFIELD_FULL(TupleType, TypeBase, 1+32,
     /// Whether an element of the tuple is inout, __shared or __owned.
     /// Values cannot have such tuple types in the language.
@@ -5243,8 +5248,8 @@ private:
 BEGIN_CAN_TYPE_WRAPPER(ProtocolCompositionType, Type)
 END_CAN_TYPE_WRAPPER(ProtocolCompositionType, Type)
 
-/// ParameterizedProtocolType - A type that constrains the primary associated
-/// type of a protocol to an argument type.
+/// ParameterizedProtocolType - A type that constrains one or more primary
+/// associated type of a protocol to a list of argument types.
 ///
 /// Written like a bound generic type, eg Sequence<Int>.
 ///
@@ -5252,6 +5257,7 @@ END_CAN_TYPE_WRAPPER(ProtocolCompositionType, Type)
 /// - Inheritance clauses of protocols, generic parameters, associated types
 /// - Conformance requirements in where clauses
 /// - Extensions
+/// - Opaque result types
 ///
 /// Assuming that the primary associated type of Sequence is Element, the
 /// desugaring is that T : Sequence<Int> is equivalent to
@@ -5260,51 +5266,52 @@ END_CAN_TYPE_WRAPPER(ProtocolCompositionType, Type)
 /// T : Sequence where T.Element == Int.
 /// \endcode
 class ParameterizedProtocolType final : public TypeBase,
-    public llvm::FoldingSetNode {
+    public llvm::FoldingSetNode,
+    private llvm::TrailingObjects<ParameterizedProtocolType, Type> {
   friend struct ExistentialLayout;
+  friend TrailingObjects;
 
   ProtocolType *Base;
-  AssociatedTypeDecl *AssocType;
   Type Arg;
 
 public:
   /// Retrieve an instance of a protocol composition type with the
   /// given set of members.
   static Type get(const ASTContext &C, ProtocolType *base,
-                  Type arg);
+                  ArrayRef<Type> args);
 
   ProtocolType *getBaseType() const {
     return Base;
   }
 
-  AssociatedTypeDecl *getAssocType() const {
-    return AssocType;
-  }
-
-  Type getArgumentType() const {
-    return Arg;
+  ArrayRef<Type> getArgs() const {
+    return {getTrailingObjects<Type>(),
+            Bits.ParameterizedProtocolType.ArgCount};
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, Base, Arg);
+    Profile(ID, Base, getArgs());
   }
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ProtocolType *base,
-                      Type arg);
+                      ArrayRef<Type> args);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::ParameterizedProtocol;
   }
-  
+
 private:
   ParameterizedProtocolType(const ASTContext *ctx,
-                            ProtocolType *base, Type arg,
+                            ProtocolType *base,
+                            ArrayRef<Type> args,
                             RecursiveTypeProperties properties);
 };
 BEGIN_CAN_TYPE_WRAPPER(ParameterizedProtocolType, Type)
   PROXY_CAN_TYPE_SIMPLE_GETTER(getBaseType)
-  PROXY_CAN_TYPE_SIMPLE_GETTER(getArgumentType)
+  CanTypeArrayRef getArgs() const {
+    return CanTypeArrayRef(getPointer()->getArgs());
+  }
 END_CAN_TYPE_WRAPPER(ParameterizedProtocolType, Type)
 
 /// An existential type, spelled with \c any .

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3947,7 +3947,9 @@ namespace {
                                         StringRef label) {
       printCommon(label, "parameterized_protocol_type");
       printRec("base", T->getBaseType());
-      printRec("arg", T->getArgumentType());
+      for (auto arg : T->getArgs()) {
+        printRec(arg);
+      }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6105,7 +6105,8 @@ public:
   void visitParameterizedProtocolType(ParameterizedProtocolType *T) {
     visit(T->getBaseType());
     Printer << "<";
-    visit(T->getArgumentType());
+    interleave(T->getArgs(), [&](Type Ty) { visit(Ty); },
+               [&] { Printer << ", "; });
     Printer << ">";
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5398,9 +5398,10 @@ bool ProtocolDecl::existentialRequiresAny() const {
     ExistentialRequiresAnyRequest{const_cast<ProtocolDecl *>(this)}, true);
 }
 
-AssociatedTypeDecl *ProtocolDecl::getPrimaryAssociatedType() const {
+ArrayRef<AssociatedTypeDecl *>
+ProtocolDecl::getPrimaryAssociatedTypes() const {
   return evaluateOrDefault(getASTContext().evaluator,
-    PrimaryAssociatedTypeRequest{const_cast<ProtocolDecl *>(this)},
+    PrimaryAssociatedTypesRequest{const_cast<ProtocolDecl *>(this)},
     nullptr);
 }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4523,14 +4523,13 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
                                                 source)))
         anyErrors = true;
 
-    auto *assocType = protoDecl->getPrimaryAssociatedType();
-    auto depType = DependentMemberType::get(
-        resolvedSubject.getDependentType(*this), assocType);
-    if (isErrorResult(addSameTypeRequirement(Type(depType),
-                                             paramProtoType->getArgs()[0],
-                                             source,
-                                             UnresolvedHandlingKind::GenerateConstraints)))
-      anyErrors = true;
+    SmallVector<Requirement, 2> reqs;
+    auto baseType = resolvedSubject.getDependentType(*this);
+    paramProtoType->getRequirements(baseType, reqs);
+    for (auto req : reqs) {
+      if (isErrorResult(addRequirement(req, source, inferForModule)))
+        anyErrors = true;
+    }
 
     return anyErrors ? ConstraintResult::Conflicting
                      : ConstraintResult::Resolved;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4523,11 +4523,11 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
                                                 source)))
         anyErrors = true;
 
-    auto *assocType = paramProtoType->getAssocType();
+    auto *assocType = protoDecl->getPrimaryAssociatedType();
     auto depType = DependentMemberType::get(
         resolvedSubject.getDependentType(*this), assocType);
     if (isErrorResult(addSameTypeRequirement(Type(depType),
-                                             paramProtoType->getArgumentType(),
+                                             paramProtoType->getArgs()[0],
                                              source,
                                              UnresolvedHandlingKind::GenerateConstraints)))
       anyErrors = true;

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -217,16 +217,15 @@ static void desugarConformanceRequirement(Type subjectType, Type constraintType,
   }
 
   if (auto *paramType = constraintType->getAs<ParameterizedProtocolType>()) {
-    auto *protoDecl = paramType->getBaseType()->getDecl();
-
     desugarConformanceRequirement(subjectType, paramType->getBaseType(),
                                   loc, result, errors);
 
-    auto *assocType = protoDecl->getPrimaryAssociatedType();
+    SmallVector<Requirement, 2> reqs;
+    paramType->getRequirements(subjectType, reqs);
 
-    auto memberType = lookupMemberType(subjectType, protoDecl, assocType);
-    desugarSameTypeRequirement(memberType, paramType->getArgs()[0],
-                               loc, result, errors);
+    for (const auto &req : reqs)
+      desugarRequirement(req, result, errors);
+
     return;
   }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -225,7 +225,7 @@ static void desugarConformanceRequirement(Type subjectType, Type constraintType,
     auto *assocType = protoDecl->getPrimaryAssociatedType();
 
     auto memberType = lookupMemberType(subjectType, protoDecl, assocType);
-    desugarSameTypeRequirement(memberType, paramType->getArgumentType(),
+    desugarSameTypeRequirement(memberType, paramType->getArgs()[0],
                                loc, result, errors);
     return;
   }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -299,10 +299,7 @@ ExistentialLayout::ExistentialLayout(ParameterizedProtocolType *type) {
   assert(type->isCanonical());
 
   *this = ExistentialLayout(type->getBaseType());
-  sameTypeRequirements = {
-      reinterpret_cast<PrimaryAssociatedTypeRequirement *>(&type->AssocType),
-      1
-  };
+  sameTypeRequirements = type->getArgs();
 }
 
 ExistentialLayout TypeBase::getExistentialLayout() {
@@ -1555,9 +1552,11 @@ CanType TypeBase::computeCanonicalType() {
   case TypeKind::ParameterizedProtocol: {
     auto *PPT = cast<ParameterizedProtocolType>(this);
     auto Base = cast<ProtocolType>(PPT->getBaseType()->getCanonicalType());
-    auto Arg = PPT->getArgumentType()->getCanonicalType();
+    SmallVector<Type, 1> CanArgs;
+    for (Type t : PPT->getArgs())
+      CanArgs.push_back(t->getCanonicalType());
     auto &C = Base->getASTContext();
-    Result = ParameterizedProtocolType::get(C, Base, Arg).getPointer();
+    Result = ParameterizedProtocolType::get(C, Base, CanArgs).getPointer();
     break;
   }
   case TypeKind::Existential: {
@@ -3877,20 +3876,22 @@ void ProtocolCompositionType::Profile(llvm::FoldingSetNodeID &ID,
 
 ParameterizedProtocolType::ParameterizedProtocolType(
     const ASTContext *ctx,
-    ProtocolType *base, Type arg,
+    ProtocolType *base, ArrayRef<Type> args,
     RecursiveTypeProperties properties)
   : TypeBase(TypeKind::ParameterizedProtocol, /*Context=*/ctx, properties),
-    Base(base), AssocType(base->getDecl()->getPrimaryAssociatedType()),
-    Arg(arg) {
-  assert(AssocType != nullptr &&
-         "Protocol doesn't have a primary associated type");
+    Base(base) {
+  assert(args.size() > 0);
+  Bits.ParameterizedProtocolType.ArgCount = args.size();
+  for (unsigned i : indices(args))
+    getTrailingObjects<Type>()[i] = args[i];
 }
 
 void ParameterizedProtocolType::Profile(llvm::FoldingSetNodeID &ID,
                                         ProtocolType *baseTy,
-                                        Type argTy) {
+                                        ArrayRef<Type> args) {
   ID.AddPointer(baseTy);
-  ID.AddPointer(argTy.getPointer());
+  for (auto arg : args)
+    ID.AddPointer(arg.getPointer());
 }
 
 bool ProtocolType::requiresClass() {
@@ -5649,25 +5650,15 @@ case TypeKind::Id:
     SmallVector<Type, 4> substMembers;
     auto members = pc->getMembers();
     bool anyChanged = false;
-    unsigned index = 0;
     for (auto member : members) {
       auto substMember = member.transformWithPosition(pos, fn);
       if (!substMember)
         return Type();
-      
-      if (anyChanged) {
-        substMembers.push_back(substMember);
-        ++index;
-        continue;
-      }
-      
-      if (substMember.getPointer() != member.getPointer()) {
+
+      substMembers.push_back(substMember);
+
+      if (substMember.getPointer() != member.getPointer())
         anyChanged = true;
-        substMembers.append(members.begin(), members.begin() + index);
-        substMembers.push_back(substMember);
-      }
-      
-      ++index;
     }
     
     if (!anyChanged)
@@ -5681,7 +5672,6 @@ case TypeKind::Id:
   case TypeKind::ParameterizedProtocol: {
     auto *ppt = cast<ParameterizedProtocolType>(base);
     Type base = ppt->getBaseType();
-    Type arg = ppt->getArgumentType();
 
     bool anyChanged = false;
 
@@ -5692,12 +5682,17 @@ case TypeKind::Id:
     if (substBase.getPointer() != base.getPointer())
       anyChanged = true;
 
-    auto substArg = arg.transformWithPosition(TypePosition::Invariant, fn);
-    if (!substArg)
-      return Type();
+    SmallVector<Type, 2> substArgs;
+    for (auto arg : ppt->getArgs()) {
+      auto substArg = arg.transformWithPosition(TypePosition::Invariant, fn);
+      if (!substArg)
+        return Type();
 
-    if (substArg.getPointer() != arg.getPointer())
-      anyChanged = true;
+      substArgs.push_back(substArg);
+
+      if (substArg.getPointer() != arg.getPointer())
+        anyChanged = true;
+    }
 
     if (!anyChanged)
       return *this;
@@ -5705,7 +5700,7 @@ case TypeKind::Id:
     return ParameterizedProtocolType::get(
         Ptr->getASTContext(),
         substBase->castTo<ProtocolType>(),
-        substArg);
+        substArgs);
   }
   }
   

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -178,7 +178,11 @@ class Traversal : public TypeVisitor<Traversal, bool>
     if (doIt(ty->getBaseType()))
       return true;
 
-    return doIt(ty->getArgumentType());
+    for (auto arg : ty->getArgs())
+      if (doIt(arg))
+        return true;
+
+    return false;
   }
 
   bool visitExistentialType(ExistentialType *ty) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -698,15 +698,17 @@ ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
   return false;
 }
 
-AssociatedTypeDecl *
-PrimaryAssociatedTypeRequest::evaluate(Evaluator &evaluator,
-                                       ProtocolDecl *decl) const {
+ArrayRef<AssociatedTypeDecl *>
+PrimaryAssociatedTypesRequest::evaluate(Evaluator &evaluator,
+                                        ProtocolDecl *decl) const {
+  SmallVector<AssociatedTypeDecl *, 2> assocTypes;
+
   for (auto *assocType : decl->getAssociatedTypeMembers()) {
     if (assocType->getAttrs().hasAttribute<PrimaryAssociatedTypeAttr>())
-      return assocType;
+      assocTypes.push_back(assocType);
   }
 
-  return nullptr;
+  return decl->getASTContext().AllocateCopy(assocTypes);
 }
 
 bool

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -533,12 +533,9 @@ static Type formExtensionInterfaceType(
     auto *protoTy = paramProtoTy->getBaseType();
     type = protoTy;
 
-    auto *depMemTy = DependentMemberType::get(
+    paramProtoTy->getRequirements(
         protoTy->getDecl()->getSelfInterfaceType(),
-        protoTy->getDecl()->getPrimaryAssociatedType());
-    sameTypeReqs.emplace_back(
-      RequirementKind::SameType, depMemTy,
-      paramProtoTy->getArgs()[0]);
+        sameTypeReqs);
   }
 
   Type parentType = type->getNominalParent();

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -535,10 +535,10 @@ static Type formExtensionInterfaceType(
 
     auto *depMemTy = DependentMemberType::get(
         protoTy->getDecl()->getSelfInterfaceType(),
-        paramProtoTy->getAssocType());
+        protoTy->getDecl()->getPrimaryAssociatedType());
     sameTypeReqs.emplace_back(
       RequirementKind::SameType, depMemTy,
-      paramProtoTy->getArgumentType());
+      paramProtoTy->getArgs()[0]);
   }
 
   Type parentType = type->getNominalParent();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 670; // alloc-stack was-moved
+const uint16_t SWIFTMODULE_VERSION_MINOR = 671; // ParameterizedProtocolType with multiple arguments
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1108,7 +1108,7 @@ namespace decls_block {
   using ParameterizedProtocolTypeLayout = BCRecordLayout<
     PARAMETERIZED_PROTOCOL_TYPE,
     TypeIDField,         // base
-    TypeIDWithBitField   // argument
+    BCArray<TypeIDField> // arguments
   >;
 
   using BoundGenericTypeLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4761,12 +4761,16 @@ public:
   visitParameterizedProtocolType(const ParameterizedProtocolType *type) {
     using namespace decls_block;
 
+    SmallVector<TypeID, 4> args;
+    for (auto arg : type->getArgs())
+      args.push_back(S.addTypeRef(arg));
+
     unsigned abbrCode =
         S.DeclTypeAbbrCodes[ParameterizedProtocolTypeLayout::Code];
     ParameterizedProtocolTypeLayout::emitRecord(
         S.Out, S.ScratchRecord, abbrCode,
         S.addTypeRef(type->getBaseType()),
-        S.addTypeRef(type->getArgumentType()));
+        args);
   }
 
   void

--- a/test/type/parameterized_protocol.swift
+++ b/test/type/parameterized_protocol.swift
@@ -85,6 +85,21 @@ protocol SequenceWrapperProtocol2 {
 }
 
 
+/// Multiple primary associated types
+protocol Collection {
+  @_primaryAssociatedType associatedtype Element
+  @_primaryAssociatedType associatedtype Index
+}
+
+// CHECK-LABEL: .testCollection1@
+// CHECK-NEXT: Generic signature: <T where T : Collection, T.[Collection]Element == String>
+func testCollection1<T : Collection<String>>(_: T) {}
+
+// CHECK-LABEL: .testCollection2@
+// CHECK-NEXT: Generic signature: <T where T : Collection, T.[Collection]Element == String, T.[Collection]Index == Int>
+func testCollection2<T : Collection<String, Int>>(_: T) {}
+
+
 /// Parametrized protocol in opaque result type
 
 struct OpaqueTypes<E> {
@@ -126,20 +141,20 @@ extension Sequence<Int> {
 /// Cannot use parameterized protocol as the type of a value
 
 func takesSequenceOfInt1(_: Sequence<Int>) {}
-// expected-error@-1 {{protocol type with generic argument can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
 
 func returnsSequenceOfInt1() -> Sequence<Int> {}
-// expected-error@-1 {{protocol type with generic argument can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
 
 func takesSequenceOfInt2(_: any Sequence<Int>) {}
-// expected-error@-1 {{protocol type with generic argument can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
 
 func returnsSequenceOfInt2() -> any Sequence<Int> {}
-// expected-error@-1 {{protocol type with generic argument can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
 
 func typeExpr() {
   _ = Sequence<Int>.self
-  // expected-error@-1 {{protocol type with generic argument can only be used as a generic constraint}}
+  // expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
 }
 
 /// Not supported as a protocol composition term for now


### PR DESCRIPTION
This is the first of two PRs updating the implementation to match the pitch. Parser support for declaring primary associated types is coming up.