### PR TITLE
[move-function] Make the dbginfo test optimized_stdlib only.

### DIFF
--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -14,6 +14,7 @@
 // slightly differently on other platforms.
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
+// REQUIRES: optimized_stdlib
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
This relies on the move function which only works appropriately with an
optimized stdlib.
