### PR TITLE
[Diagnostics] Fix missing `any` warnings for type aliases.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4705,8 +4705,8 @@ ERROR(any_not_existential,none,
        "'any' has no effect on %select{concrete type|type parameter}0 %1",
        (bool, Type))
 ERROR(existential_requires_any,none,
-      "protocol %0 as a type must be explicitly marked as 'any'",
-      (Identifier))
+      "%select{protocol |}1%0 as a type must be explicitly marked as 'any'",
+      (Type, bool))
 
 ERROR(nonisolated_let,none,
       "'nonisolated' is meaningless on 'let' declarations because "

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4148,29 +4148,29 @@ public:
       if (proto->existentialRequiresAny()) {
         Ctx.Diags.diagnose(comp->getNameLoc(),
                            diag::existential_requires_any,
-                           proto->getName())
+                           proto->getDeclaredInterfaceType(),
+                           /*isAlias=*/false)
             .limitBehavior(DiagnosticBehavior::Warning);
       }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
       auto type = Type(alias->getDeclaredInterfaceType()->getDesugaredType());
-      type.findIf([&](Type type) -> bool {
-        if (T->isInvalid())
-          return false;
-        if (type->isExistentialType()) {
-          auto layout = type->getExistentialLayout();
-          for (auto *proto : layout.getProtocols()) {
-            auto *protoDecl = proto->getDecl();
-            if (!protoDecl->existentialRequiresAny())
-              continue;
+      // If this is a type alias to a constraint type, the type
+      // alias name must be prefixed with 'any' to be used as an
+      // existential type.
+      if (type->isConstraintType()) {
+        auto layout = type->getExistentialLayout();
+        for (auto *proto : layout.getProtocols()) {
+          auto *protoDecl = proto->getDecl();
+          if (!protoDecl->existentialRequiresAny())
+            continue;
 
-            Ctx.Diags.diagnose(comp->getNameLoc(),
-                               diag::existential_requires_any,
-                               protoDecl->getName())
-                .limitBehavior(DiagnosticBehavior::Warning);
-          }
+          Ctx.Diags.diagnose(comp->getNameLoc(),
+                             diag::existential_requires_any,
+                             alias->getDeclaredInterfaceType(),
+                             /*isAlias=*/true)
+              .limitBehavior(DiagnosticBehavior::Warning);
         }
-        return false;
-      });
+      }
     }
   }
 
@@ -4198,6 +4198,9 @@ void TypeChecker::checkExistentialTypes(Decl *decl) {
   } else if (auto *genericDecl = dyn_cast<GenericTypeDecl>(decl)) {
     checkExistentialTypes(ctx, genericDecl->getGenericParams());
     checkExistentialTypes(ctx, genericDecl->getTrailingWhereClause());
+    if (auto *typeAlias = dyn_cast<TypeAliasDecl>(decl)) {
+      checkExistentialTypes(ctx, typeAlias);
+    }
   } else if (auto *assocType = dyn_cast<AssociatedTypeDecl>(decl)) {
     checkExistentialTypes(ctx, assocType->getTrailingWhereClause());
   } else if (auto *extDecl = dyn_cast<ExtensionDecl>(decl)) {
@@ -4225,6 +4228,19 @@ void TypeChecker::checkExistentialTypes(ASTContext &ctx, Stmt *stmt) {
 
   ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/true);
   stmt->walk(visitor);
+}
+
+void TypeChecker::checkExistentialTypes(ASTContext &ctx,
+                                        TypeAliasDecl *typeAlias) {
+  if (!typeAlias || !typeAlias->getUnderlyingTypeRepr())
+    return;
+
+  // A type alias to a plain constraint type is allowed.
+  if (typeAlias->getUnderlyingType()->isConstraintType())
+    return;
+
+  ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/true);
+  typeAlias->getUnderlyingTypeRepr()->walk(visitor);
 }
 
 void TypeChecker::checkExistentialTypes(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -251,6 +251,10 @@ void checkExistentialTypes(Decl *decl);
 /// Check for invalid existential types in the given statement.
 void checkExistentialTypes(ASTContext &ctx, Stmt *stmt);
 
+/// Check for invalid existential types in the underlying type of
+/// the given type alias.
+void checkExistentialTypes(ASTContext &ctx, TypeAliasDecl *typeAlias);
+
 /// Check for invalid existential types in the given generic requirement
 /// list.
 void checkExistentialTypes(ASTContext &ctx,

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -236,3 +236,24 @@ func testAnyTypeExpr() {
 
 func hasInvalidExistential(_: any DoesNotExistIHope) {}
 // expected-error@-1 {{cannot find type 'DoesNotExistIHope' in scope}}
+
+protocol Input {
+  associatedtype A
+}
+protocol Output {
+  associatedtype A
+}
+
+// expected-warning@+2{{protocol 'Input' as a type must be explicitly marked as 'any'}}
+// expected-warning@+1{{protocol 'Output' as a type must be explicitly marked as 'any'}}
+typealias InvalidFunction = (Input) -> Output
+func testInvalidFunctionAlias(fn: InvalidFunction) {}
+
+typealias ExistentialFunction = (any Input) -> any Output
+func testFunctionAlias(fn: ExistentialFunction) {}
+
+typealias Constraint = Input
+func testConstraintAlias(x: Constraint) {} // expected-warning{{'Constraint' (aka 'Input') as a type must be explicitly marked as 'any'}}
+
+typealias Existential = any Input
+func testExistentialAlias(x: Existential, y: any Constraint) {}


### PR DESCRIPTION
Only warn when using a type alias if the underlying type is directly a constraint type, e.g.

```swift
protocol P {
  associatedtype A
}

typealias Constraint = P

let x: Constraint // warning for missing 'any' on 'Constraint'
```

Also check the underlying type at the declaration of a type alias for missing 'any' if the underlying type is not directly a constraint type, e.g.

```swift
protocol P {
  associatedtype A
}

typealias Function = (P) -> Void // warning for missing 'any' on 'P'
```

Resolves: rdar://88980470