### PR TITLE
[DiagnosticVerifier] Define LineColumnRange::NoValue

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -35,6 +35,8 @@ struct ExpectedFixIt {
 };
 } // end namespace swift
 
+constexpr unsigned LineColumnRange::NoValue;
+
 const LineColumnRange &
 CapturedFixItInfo::getLineColumnRange(const SourceManager &SM,
                                       unsigned BufferID,


### PR DESCRIPTION
This is to fix a link failure in debug builds.
cc: @AnthonyLatsis 