### PR TITLE
DiagnosticVerifier: Allow specifying locations vs. ranges in fix-it verifications

### DIFF
--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -317,11 +317,14 @@ DiagnosticVerifier::renderFixits(ArrayRef<CapturedFixItInfo> ActualFixIts,
           OS << ActualRange.StartLine << ':';
         OS << ActualRange.StartCol;
 
-        OS << '-';
+        const bool isMultiline = ActualRange.StartLine != ActualRange.EndLine;
+        if (isMultiline || ActualRange.StartCol != ActualRange.EndCol) {
+          OS << '-';
 
-        if (ActualRange.EndLine != ActualRange.StartLine)
-          OS << ActualRange.EndLine << ':';
-        OS << ActualRange.EndCol;
+          if (isMultiline)
+            OS << ActualRange.EndLine << ':';
+          OS << ActualRange.EndCol;
+        }
 
         OS << '=';
 

--- a/test/FixCode/verify-fixits.swift.result
+++ b/test/FixCode/verify-fixits.swift.result
@@ -5,7 +5,7 @@
 func f1() {
   guard true { return } // expected-error {{expected 'else' after 'guard' condition}}
 
-  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{14-14=else }} {{none}}
+  guard true { return } // expected-error {{expected 'else' after 'guard' condition}} {{14=else }} {{none}}
 }
 
 func labeledFunc(aa: Int, bb: Int) {}

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -24,7 +24,7 @@ func test0Fixits() {
   // CHECK: [[@LINE+1]]:81: error: expected line offset after leading '+' or '-' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-}}
 
-  // CHECK: [[@LINE+1]]:81: error: expected '-' range separator in fix-it verification
+  // CHECK: [[@LINE+1]]:81: error: expected '-' range separator or '=' after location in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1}}
 
   // CHECK: [[@LINE+1]]:82: error: expected colon-separated column number after line offset in fix-it verification
@@ -33,16 +33,19 @@ func test0Fixits() {
   // CHECK: [[@LINE+1]]:82: error: expected colon-separated column number after line offset in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1}}
 
+  // CHECK: [[@LINE+1]]:82: error: expected colon-separated column number after line offset in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1=}}
+
   // CHECK: [[@LINE+1]]:82: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:}}
 
   // CHECK: [[@LINE+1]]:83: error: expected column number after ':' in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:}}
 
-  // CHECK: [[@LINE+1]]:83: error: expected '-' range separator in fix-it verification
+  // CHECK: [[@LINE+1]]:83: error: expected '-' range separator or '=' after location in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1}}
 
-  // CHECK: [[@LINE+1]]:84: error: expected '-' range separator in fix-it verification
+  // CHECK: [[@LINE+1]]:84: error: expected '-' range separator or '=' after location in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1:1}}
 
   // CHECK: [[@LINE+1]]:83: error: expected column number after ':' in fix-it verification
@@ -92,6 +95,15 @@ func test0Fixits() {
 
   // CHECK: [[@LINE+1]]:89: error: expected '=' after range in fix-it verification
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{+1:1--1:1}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{-1:1=a}}
 
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=}}
@@ -197,22 +209,22 @@ func test1Fixits() {
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
 
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{200:15-200:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{212:15-212:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{202:15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{214:15-18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-204:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-216:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{-0:15-+0:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15--0:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {+0:15-210:18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{+0:15-222:18=aa}}
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{+1:15-+1:18=bb}}
               bbx: 1)
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
-  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{216:15-+1:18=bb}}
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{228:15-+1:18=bb}}
               bbx: 1)
 
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
@@ -248,4 +260,20 @@ func test2Fixits() {
 
   // CHECK: [[@LINE+1]]:137: error: expected fix-it not seen; actual fix-its seen: {{{{}}15-18=aa}} {{{{}}23-26=bb}}
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}} {{15-18=aa}} {{23-26=xx}} {{none}}
+}
+
+protocol P {
+  associatedtype A
+}
+func testFixitWithLocation(_: inout Bool) {
+  var bool = true
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{25=&}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{+0:25=&}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{25-25=&}}
+
+  // CHECK: [[@LINE+1]]:126: error: expected fix-it not seen; actual fix-it seen: {{{{}}25-25=&}}
+  testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{24-24=&}}
 }

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -274,6 +274,6 @@ func testFixitWithLocation(_: inout Bool) {
   // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
   testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{25-25=&}}
 
-  // CHECK: [[@LINE+1]]:126: error: expected fix-it not seen; actual fix-it seen: {{{{}}25-25=&}}
+  // CHECK: [[@LINE+1]]:126: error: expected fix-it not seen; actual fix-it seen: {{{{}}25=&}}
   testFixitWithLocation(bool) // expected-error {{passing value of type 'Bool' to an inout parameter requires explicit '&'}} {{24-24=&}}
 }

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -25,16 +25,16 @@ protocol P2 : P1 {
 // A redeclaration of an associated type that adds type/layout requirements
 // should be written via a where clause.
 protocol P3a : P1 {
-  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18--1:18= where A: P0, A: P0b}}{{28:3-28:29=}}
-  associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
-  associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A3 : P0}}{{3-34=}}
+  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18= where A: P0, A: P0b}}{{28:3-28:29=}}
+  associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
+  associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18= where A3 : P0}}{{3-34=}}
 
-  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{33:3-35:51=}}
+  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{33:3-35:51=}}
   associatedtype A4: P0 where A4: Collection,
                               A4.Element == A4.Index,
                               A4.SubSequence == A4
 
-  // expected-warning@+1 {{redeclaration of associated type 'A5' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A5: P0b & Class, A5 : Collection, A5.Element : Collection}}{{+0:3-+1:62=}}
+  // expected-warning@+1 {{redeclaration of associated type 'A5' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18= where A5: P0b & Class, A5 : Collection, A5.Element : Collection}}{{+0:3-+1:62=}}
   associatedtype A5: P0b & Class where A5: Collection,
                                        A5.Element: Collection
 }

--- a/test/diagnostics/verifier.swift
+++ b/test/diagnostics/verifier.swift
@@ -16,12 +16,12 @@ let y: Int = "hello, world!" // expected-error@:49 {{cannot convert value of typ
 // Wrong fix-it
 let z: Int = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{3-3=foobarbaz}}
-// CHECK: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36-36= as! Int{{[}][}]}}
+// CHECK: expected fix-it not seen; actual fix-it seen: {{[{][{]}}36= as! Int{{[}][}]}}
 
 // Expected no fix-it
 let a: Bool = "hello, world!" as Any
 // expected-error@-1 {{cannot convert value of type}} {{none}}
-// CHECK: expected no fix-its; actual fix-it seen: {{[{][{]}}37-37= as! Bool{{[}][}]}}
+// CHECK: expected no fix-its; actual fix-it seen: {{[{][{]}}37= as! Bool{{[}][}]}}
 
 // Unexpected error
 _ = foo()


### PR DESCRIPTION
This spares us from needless repetition in the bounds of insertion fix-its.
