### PR TITLE
[benchmark] Adopt the new Clock APIs from SE-0329

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -29,8 +29,9 @@ struct MeasurementMetadata {
   let yields: Int /// Yield Count
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct BenchResults {
-  typealias T = Int
+  typealias T = Duration
   private let samples: [T]
   let meta: MeasurementMetadata?
   let stats: Stats
@@ -51,12 +52,13 @@ struct BenchResults {
     return samples[index]
   }
 
-  var sampleCount: T { return samples.count }
-  var min: T { return samples.first! }
-  var max: T { return samples.last! }
-  var mean: T { return Int(stats.mean.rounded()) }
-  var sd: T { return Int(stats.standardDeviation.rounded()) }
-  var median: T { return self[0.5] }
+  var sampleCount: Int { samples.count }
+  // These are all in microseconds
+  var min: Int { samples.first!.microseconds }
+  var max: Int { samples.last!.microseconds }
+  var mean: Int { Int(stats.mean.rounded()) }
+  var sd: Int { Int(stats.standardDeviation.rounded()) }
+  var median: Int { self[0.5].microseconds }
 }
 
 public var registeredBenchmarks: [BenchmarkInfo] = []
@@ -75,17 +77,18 @@ enum TestAction {
   case listTests
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct TestConfig {
   /// The delimiter to use when printing output.
   let delim: String
 
-  /// Duration of the test measurement in seconds.
+  /// Duration of the test measurement.
   ///
   /// Used to compute the number of iterations, if no fixed amount is specified.
   /// This is useful when one wishes for a test to run for a
   /// longer amount of time to perform performance analysis on the test in
   /// instruments.
-  let sampleTime: Double
+  let sampleTime: Duration
 
   /// Number of iterations averaged in the sample.
   /// When not specified, we'll compute the number of iterations to be averaged
@@ -118,7 +121,7 @@ struct TestConfig {
 
   /// After we run the tests, should the harness sleep to allow for utilities
   /// like leaks that require a PID to run on the test harness.
-  let afterRunSleep: UInt32?
+  let afterRunSleep: Duration?
 
   /// The list of tests to run.
   let tests: [(index: String, info: BenchmarkInfo)]
@@ -135,8 +138,8 @@ struct TestConfig {
       var numIters: UInt?
       var quantile: UInt?
       var delta: Bool?
-      var afterRunSleep: UInt32?
-      var sampleTime: Double?
+      var afterRunSleep: Duration?
+      var sampleTime: Duration?
       var verbose: Bool?
       var logMemory: Bool?
       var logMeta: Bool?
@@ -154,8 +157,8 @@ struct TestConfig {
         try tags.split(separator: ",").map(String.init).map {
           try checked({ BenchmarkCategory(rawValue: $0) }, $0) })
     }
-    func finiteDouble(value: String) -> Double? {
-      return Double(value).flatMap { $0.isFinite ? $0 : nil }
+    func parseDuration(_ value: String) -> Duration? {
+      return Double(value).flatMap { $0.isFinite ? Duration.seconds($0) : nil }
     }
 
     // Configure the command line argument parser
@@ -181,7 +184,7 @@ struct TestConfig {
                   help: "report quantiles with delta encoding")
     p.addArgument("--sample-time", \.sampleTime,
                   help: "duration of test measurement in seconds\ndefault: 1",
-                  parser: finiteDouble)
+                  parser: parseDuration)
     p.addArgument("--verbose", \.verbose, defaultValue: true,
                   help: "increase output verbosity")
     p.addArgument("--memory", \.logMemory, defaultValue: true,
@@ -200,7 +203,7 @@ struct TestConfig {
                   parser: tags)
     p.addArgument("--sleep", \.afterRunSleep,
                   help: "number of seconds to sleep after benchmarking",
-                  parser: { UInt32($0) })
+                  parser: parseDuration)
     p.addArgument("--list", \.action, defaultValue: .listTests,
                   help: "don't run the tests, just log the list of test \n" +
                         "numbers, names and tags (respects specified filters)")
@@ -214,7 +217,7 @@ struct TestConfig {
 
     // Configure from the command line arguments, filling in the defaults.
     delim = c.delim ?? ","
-    sampleTime = c.sampleTime ?? 1.0
+    sampleTime = c.sampleTime ?? Duration.seconds(1)
     numIters = c.numIters.map { Int($0) }
     numSamples = c.numSamples.map { Int($0) }
     minSamples = c.minSamples.map { Int($0) }
@@ -320,28 +323,29 @@ extension String {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct Stats {
-    var n: Int = 0
-    var s: Double = 0.0
-    var mean: Double = 0.0
-    var variance: Double { return n < 2 ? 0.0 : s / Double(n - 1) }
-    var standardDeviation: Double { return variance.squareRoot() }
+  var n: Int = 0
+  var s: Double = 0.0
+  var mean: Double = 0.0
+  var variance: Double { return n < 2 ? 0.0 : s / Double(n - 1) }
+  var standardDeviation: Double { return variance.squareRoot() }
 
-    static func collect(_ s: inout Stats, _ x: Int){
-        Stats.runningMeanVariance(&s, Double(x))
-    }
+  static func collect(_ s: inout Stats, _ x: Duration) {
+    Stats.runningMeanVariance(&s, x.seconds)
+  }
 
-    /// Compute running mean and variance using B. P. Welford's method.
-    ///
-    /// See Knuth TAOCP vol 2, 3rd edition, page 232, or
-    /// https://www.johndcook.com/blog/standard_deviation/
-    static func runningMeanVariance(_ stats: inout Stats, _ x: Double){
-        let n = stats.n + 1
-        let (k, m_, s_) = (Double(n), stats.mean, stats.s)
-        let m = m_ + (x - m_) / k
-        let s = s_ + (x - m_) * (x - m)
-        (stats.n, stats.mean, stats.s) = (n, m, s)
-    }
+  /// Compute running mean and variance using B. P. Welford's method.
+  ///
+  /// See Knuth TAOCP vol 2, 3rd edition, page 232, or
+  /// https://www.johndcook.com/blog/standard_deviation/
+  static func runningMeanVariance(_ stats: inout Stats, _ x: Double) {
+    let n = stats.n + 1
+    let (k, m_, s_) = (Double(n), stats.mean, stats.s)
+    let m = m_ + (x - m_) / k
+    let s = s_ + (x - m_) * (x - m)
+    (stats.n, stats.mean, stats.s) = (n, m, s)
+  }
 }
 
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
@@ -353,71 +357,51 @@ func stopTrackingObjects(_: UnsafePointer<CChar>) -> Int
 
 #endif
 
-final class Timer {
-#if os(Linux)
-  typealias TimeT = timespec
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+typealias BenchmarkClock = SuspendingClock
 
-  func getTime() -> TimeT {
-    var ts = timespec(tv_sec: 0, tv_nsec: 0)
-    clock_gettime(CLOCK_REALTIME, &ts)
-    return ts
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension Duration {
+  var seconds: Double {
+    let (seconds, attoseconds) = components
+    return Double(seconds) + Double(attoseconds) * 1e-18
+  }
+  var nanoseconds: Int64 {
+    let (seconds, attoseconds) = components
+    return seconds * 1_000_000_000 + attoseconds / 1_000_000_000
   }
 
-  func diffTimeInNanoSeconds(from start: TimeT, to end: TimeT) -> UInt64 {
-    let oneSecond = 1_000_000_000 // ns
-    var elapsed = timespec(tv_sec: 0, tv_nsec: 0)
-    if end.tv_nsec - start.tv_nsec < 0 {
-      elapsed.tv_sec = end.tv_sec - start.tv_sec - 1
-      elapsed.tv_nsec = end.tv_nsec - start.tv_nsec + oneSecond
-    } else {
-      elapsed.tv_sec = end.tv_sec - start.tv_sec
-      elapsed.tv_nsec = end.tv_nsec - start.tv_nsec
-    }
-    return UInt64(elapsed.tv_sec) * UInt64(oneSecond) + UInt64(elapsed.tv_nsec)
-  }
-#else
-  typealias TimeT = UInt64
-  var info = mach_timebase_info_data_t(numer: 0, denom: 0)
-
-  init() {
-    mach_timebase_info(&info)
+  var microseconds: Int {
+    let (seconds, attoseconds) = components
+    return Int(seconds * 1_000_000 + attoseconds / 1_000_000_000_000)
   }
 
-  func getTime() -> TimeT {
-    return mach_absolute_time()
+  var milliseconds: Int64 {
+    let (seconds, attoseconds) = components
+    return seconds * 1_000 + attoseconds / 1_000_000_000_000_000
   }
-
-  func diffTimeInNanoSeconds(from start: TimeT, to end: TimeT) -> UInt64 {
-    let elapsed = end - start
-    return elapsed * UInt64(info.numer) / UInt64(info.denom)
-  }
-#endif
-}
-
-extension UInt64 {
-  var microseconds: Int { return Int(self / 1000) }
 }
 
 /// Performance test runner that measures benchmarks and reports the results.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 final class TestRunner {
   let c: TestConfig
-  let timer = Timer()
-  var start, end, lastYield: Timer.TimeT
+  var start, end, lastYield: BenchmarkClock.Instant
   let baseline = TestRunner.getResourceUtilization()
-  let schedulerQuantum = UInt64(10_000_000) // nanoseconds (== 10ms, macos)
+  let schedulerQuantum = Duration.milliseconds(10) // assuming macOS
   var yieldCount = 0
 
   init(_ config: TestConfig) {
     self.c = config
-    let now = timer.getTime()
+    let now = BenchmarkClock.now
     (start, end, lastYield) = (now, now, now)
   }
 
   /// Offer to yield CPU to other processes and return current time on resume.
-  func yield() -> Timer.TimeT {
+  func yield() -> BenchmarkClock.Instant {
     sched_yield()
     yieldCount += 1
-    return timer.getTime()
+    return BenchmarkClock.now
   }
 
 #if os(Linux)
@@ -428,17 +412,13 @@ final class TestRunner {
   }
 #else
   private static func getExecutedInstructions() -> UInt64 {
-    if #available(OSX 10.9, iOS 7.0, *) {
-      var u = rusage_info_v4()
-      withUnsafeMutablePointer(to: &u) { p in
-        p.withMemoryRebound(to: Optional<rusage_info_t>.self, capacity: 1) { up in
-          let _ = proc_pid_rusage(getpid(), RUSAGE_INFO_V4, up)
-        }
+    var u = rusage_info_v4()
+    withUnsafeMutablePointer(to: &u) { p in
+      p.withMemoryRebound(to: Optional<rusage_info_t>.self, capacity: 1) { up in
+        let _ = proc_pid_rusage(getpid(), RUSAGE_INFO_V4, up)
       }
-      return u.ri_instructions
-    } else {
-      return 0
     }
+    return u.ri_instructions
   }
 #endif
 
@@ -501,11 +481,11 @@ final class TestRunner {
   }
 
   private func startMeasurement() {
-    let spent = timer.diffTimeInNanoSeconds(from: lastYield, to: end)
-    let nextSampleEstimate = UInt64(Double(lastSampleTime) * 1.5)
+    let spent = end - lastYield
+    let nextSampleEstimate = lastSampleTime * 1.5
 
     if (spent + nextSampleEstimate < schedulerQuantum) {
-        start = timer.getTime()
+        start = BenchmarkClock.now
     } else {
         logVerbose("    Yielding after ~\(spent.microseconds) μs")
         let now = yield()
@@ -514,7 +494,7 @@ final class TestRunner {
   }
 
   private func stopMeasurement() {
-    end = timer.getTime()
+    end = BenchmarkClock.now
   }
 
   private func resetMeasurements() {
@@ -523,13 +503,13 @@ final class TestRunner {
     yieldCount = 0
   }
 
-  /// Time in nanoseconds spent running the last function
-  var lastSampleTime: UInt64 {
-    return timer.diffTimeInNanoSeconds(from: start, to: end)
+  /// Time spent running the last function
+  var lastSampleTime: Duration {
+    end - start
   }
 
-  /// Measure the `fn` and return the average sample time per iteration (μs).
-  func measure(_ name: String, fn: (Int) -> Void, numIters: Int) -> Int {
+  /// Measure the `fn` and return the average sample time per iteration.
+  func measure(_ name: String, fn: (Int) -> Void, numIters: Int) -> Duration {
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
     name.withCString { p in startTrackingObjects(p) }
 #endif
@@ -542,7 +522,7 @@ final class TestRunner {
     name.withCString { p in stopTrackingObjects(p) }
 #endif
 
-    return lastSampleTime.microseconds / numIters
+    return lastSampleTime / numIters
   }
 
   func logVerbose(_ msg: @autoclosure () -> String) {
@@ -560,11 +540,11 @@ final class TestRunner {
     }
     logVerbose("Running \(test.name)")
 
-    var samples: [Int] = []
+    var samples: [Duration] = []
 
-    func addSample(_ time: Int) {
-      logVerbose("    Sample \(samples.count),\(time)")
-      samples.append(time)
+    func addSample(_ duration: Duration) {
+      logVerbose("    Sample \(samples.count),\(duration)")
+      samples.append(duration)
     }
 
     resetMeasurements()
@@ -576,11 +556,10 @@ final class TestRunner {
     }
 
     // Determine number of iterations for testFn to run for desired time.
-    func iterationsPerSampleTime() -> (numIters: Int, oneIter: Int) {
+    func iterationsPerSampleTime() -> (numIters: Int, oneIter: Duration) {
       let oneIter = measure(test.name, fn: testFn, numIters: 1)
-      if oneIter > 0 {
-        let timePerSample = Int(c.sampleTime * 1_000_000.0) // microseconds (μs)
-        return (max(timePerSample / oneIter, 1), oneIter)
+      if oneIter > .zero {
+        return (max(Int(c.sampleTime / oneIter), 1), oneIter)
       } else {
         return (1, oneIter)
       }
@@ -653,10 +632,12 @@ final class TestRunner {
       func values(r: BenchResults) -> [String] {
         func quantiles(q: Int) -> [Int] {
           let qs = (0...q).map { i in r[Double(i) / Double(q)] }
-          return c.delta ?
-            qs.reduce(into: (encoded: [], last: 0)) {
-              $0.encoded.append($1 - $0.last); $0.last = $1
-            }.encoded : qs
+          return (c.delta
+            ? qs.reduce(into: (encoded: [], last: Duration.zero)) {
+                $0.encoded.append(($1 - $0.last).microseconds)
+                $0.last = $1
+              }.encoded
+            : qs.map { $0.microseconds })
         }
         let values: [Int] = [r.sampleCount] +
           (c.quantile.map(quantiles)
@@ -701,6 +682,9 @@ extension Hasher {
 }
 
 public func main() {
+  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
+    fatalError("Sorry, this version of benchmarks requires a dev stdlib")
+  }
   let config = TestConfig(registeredBenchmarks)
   switch (config.action) {
   case .listTests:
@@ -725,7 +709,8 @@ public func main() {
     }
     TestRunner(config).runBenchmarks()
     if let x = config.afterRunSleep {
-      sleep(x)
+      var ts = timespec(x)
+      nanosleep(&ts, nil)
     }
   }
 }

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -89,6 +89,8 @@ void swift_get_time(
 #endif
       break;
     }
+    default:
+      abort();
   }
 }
 
@@ -136,5 +138,7 @@ switch (clock_id) {
 #endif
       break;
     }
+   default:
+     abort();
   }
 }

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -74,8 +74,6 @@ extension Clock {
   }
 }
 
-@available(SwiftStdlib 5.7, *)
-@usableFromInline
 enum _ClockID: Int32 {
   case continuous = 1
   case suspending = 2
@@ -83,16 +81,14 @@ enum _ClockID: Int32 {
 
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_get_time")
-@usableFromInline
 internal func _getTime(
   seconds: UnsafeMutablePointer<Int64>,
   nanoseconds: UnsafeMutablePointer<Int64>,
-  clock: _ClockID)
+  clock: CInt)
 
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_get_clock_res")
-@usableFromInline
 internal func _getClockRes(
   seconds: UnsafeMutablePointer<Int64>,
   nanoseconds: UnsafeMutablePointer<Int64>,
-  clock: _ClockID)
+  clock: CInt)

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -59,7 +59,7 @@ extension ContinuousClock: Clock {
     _getClockRes(
       seconds: &seconds,
       nanoseconds: &nanoseconds,
-      clock: .continuous)
+      clock: _ClockID.continuous.rawValue)
     return .seconds(seconds) + .nanoseconds(nanoseconds)
   }
 
@@ -70,7 +70,7 @@ extension ContinuousClock: Clock {
     _getTime(
       seconds: &seconds,
       nanoseconds: &nanoseconds,
-      clock: .continuous)
+      clock: _ClockID.continuous.rawValue)
     return ContinuousClock.Instant(_value:
       .seconds(seconds) + .nanoseconds(nanoseconds))
   }

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -60,7 +60,7 @@ extension SuspendingClock: Clock {
     _getTime(
       seconds: &seconds,
       nanoseconds: &nanoseconds,
-      clock: .suspending)
+      clock: _ClockID.suspending.rawValue)
     return SuspendingClock.Instant(_value:
       .seconds(seconds) + .nanoseconds(nanoseconds))
   }
@@ -73,7 +73,7 @@ extension SuspendingClock: Clock {
     _getClockRes(
       seconds: &seconds,
       nanoseconds: &nanoseconds,
-      clock: .suspending)
+      clock: _ClockID.suspending.rawValue)
     return .seconds(seconds) + .nanoseconds(nanoseconds)
   }
 

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -42,9 +42,14 @@ public struct Duration: Sendable {
   @usableFromInline
   internal var _high: Int64
 
+  @inlinable
+  internal init(_low: UInt64, high: Int64) {
+    self._low = _low
+    self._high = high
+  }
+
   internal init(_attoseconds: _Int128) {
-    self._low = _attoseconds.low
-    self._high = _attoseconds.high
+    self.init(_low: _attoseconds.low, high: _attoseconds.high)
   }
 
   /// Construct a `Duration` by adding attoseconds to a seconds value.

--- a/stdlib/public/core/Int128.swift.gyb
+++ b/stdlib/public/core/Int128.swift.gyb
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 % for signed in [False, True]:
-%   U = 'U' if signed else ''
+%   U = '' if signed else 'U'
+%   Self = '_Int128' if signed else '_UInt128'
+%   Other = '_UInt128' if signed else '_Int128'
 /// A 128-bit ${'signed' if signed else 'unsigned'} integer type.
 internal struct _${U}Int128 {
   internal typealias High = ${U}Int64
@@ -40,6 +42,13 @@ internal struct _${U}Int128 {
   internal init() {
     self.init(high: 0, low: 0)
   }
+
+  internal init(bitPattern v: ${Other}) {
+    self.init(high: High(bitPattern: v.high), low: v.low)
+  }
+
+  internal static var zero: Self { Self(high: 0, low: 0) }
+  internal static var one: Self { Self(high: 0, low: 1) }
 }
 
 extension _${U}Int128: CustomStringConvertible {
@@ -82,9 +91,9 @@ extension _${U}Int128 {
 
 extension _${U}Int128: AdditiveArithmetic {
   internal static func - (_ lhs: Self, _ rhs: Self) -> Self {
-    var lhs = lhs
-    lhs -= rhs
-    return lhs
+    let (result, overflow) = lhs.subtractingReportingOverflow(rhs)
+    _precondition(!overflow, "Overflow in -")
+    return result
   }
 
   internal static func -= (_ lhs: inout Self, _ rhs: Self) {
@@ -94,9 +103,9 @@ extension _${U}Int128: AdditiveArithmetic {
   }
 
   internal static func + (_ lhs: Self, _ rhs: Self) -> Self {
-    var lhs = lhs
-    lhs += rhs
-    return lhs
+    let (result, overflow) = lhs.addingReportingOverflow(rhs)
+    _precondition(!overflow, "Overflow in +")
+    return result
   }
 
   internal static func += (_ lhs: inout Self, _ rhs: Self) {
@@ -110,7 +119,15 @@ extension _${U}Int128: Numeric {
   internal typealias Magnitude = _UInt128
 
   internal var magnitude: Magnitude {
-    Magnitude(_wideMagnitude22(self.components))
+    % if signed:
+    var result = _UInt128(bitPattern: self)
+    guard high._isNegative else { return result }
+    result.high = ~result.high
+    result.low = ~result.low
+    return result.addingReportingOverflow(.one).partialValue
+    % else:
+    return self
+    % end
   }
 
   internal init(_ magnitude: Magnitude) {
@@ -148,9 +165,9 @@ extension _${U}Int128: Numeric {
   }
 
   internal static func * (_ lhs: Self, _ rhs: Self) -> Self {
-    var lhs = lhs
-    lhs *= rhs
-    return lhs
+    let (result, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+    _precondition(!overflow, "Overflow in *")
+    return result
   }
 
   internal static func *= (_ lhs: inout Self, _ rhs: Self) {
@@ -160,57 +177,49 @@ extension _${U}Int128: Numeric {
   }
 }
 
-
-% if signed:
-extension _Int128 {
-  internal typealias Words = _UInt128.Words
-}
-% else:
-extension _UInt128 {
+extension _${U}Int128 {
   internal struct Words {
-    internal var high: High.Words
-    internal var low: Low.Words
+    internal var _value: _${U}Int128
 
-    internal init(_ value: _UInt128) {
-      self.init(high: value.high.words, low: value.low.words)
-    }
-
-    internal init(_ value: _Int128) {
-      self.init(_UInt128(truncatingIfNeeded: value))
-    }
-
-    internal init(high: High.Words, low: Low.Words) {
-      self.high = high
-      self.low = low
+    internal init(_ value: _${U}Int128) {
+      self._value = value
     }
   }
 }
 
-extension _UInt128.Words: RandomAccessCollection {
+extension _${U}Int128.Words: RandomAccessCollection {
+  internal typealias Element = UInt
   internal typealias Index = Int
+  internal typealias Indices = Range<Int>
+  internal typealias SubSequence = Slice<Self>
 
-  internal var startIndex: Index {
-    0
-  }
+  internal var count: Int { 128 / UInt.bitWidth }
+  internal var startIndex: Int { 0 }
+  internal var endIndex: Int { count }
+  internal var indices: Indices { startIndex ..< endIndex }
+  internal func index(after i: Int) -> Int { i + 1 }
+  internal func index(before i: Int) -> Int { i - 1 }
 
-  internal var endIndex: Index {
-    count
-  }
+  internal subscript(position: Int) -> UInt {
+    get {
+      _precondition(position >= 0 && position < endIndex,
+        "Word index out of range")
+      let shift = position &* UInt.bitWidth
+      _internalInvariant(shift < _${U}Int128.bitWidth)
 
-  internal var count: Int {
-    low.count + high.count
-  }
-
-  internal subscript(_ i: Index) -> UInt {
-    if i < low.count {
-      return low[i + low.startIndex]
+      let r = _wideMaskedShiftRight(
+        _value.components, UInt64(truncatingIfNeeded: shift))
+      return r.low._lowWord
     }
-    return high[i - low.count + high.startIndex]
   }
 }
-% end
 
 extension _${U}Int128: FixedWidthInteger {
+  @_transparent
+  internal var _lowWord: UInt {
+    low._lowWord
+  }
+
   internal var words: Words {
     Words(self)
   }
@@ -227,9 +236,7 @@ extension _${U}Int128: FixedWidthInteger {
     self.init(high: High.min, low: Low.min)
   }
 
-  internal static var bitWidth: Int {
-    High.bitWidth + Low.bitWidth
-  }
+  internal static var bitWidth: Int { 128 }
 
   internal func addingReportingOverflow(
     _ rhs: Self
@@ -249,15 +256,23 @@ extension _${U}Int128: FixedWidthInteger {
   internal func multipliedReportingOverflow(
     by rhs: Self
   ) -> (partialValue: Self, overflow: Bool) {
-    let (carry, product) = multipliedFullWidth(by: rhs)
-    let result = Self(truncatingIfNeeded: product)
-
-    let isNegative = Self.isSigned && (self._isNegative != rhs._isNegative)
-    let didCarry = isNegative ? carry != ~Self.zero : carry != Self.zero
-    let hadPositiveOverflow = Self.isSigned &&
-                              !isNegative && product.leadingZeroBitCount == 0
-
-    return (result, didCarry || hadPositiveOverflow)
+    % if signed:
+    let isNegative = (self._isNegative != rhs._isNegative)
+    let (p, overflow) = self.magnitude.multipliedReportingOverflow(
+      by: rhs.magnitude)
+    let r = _Int128(bitPattern: isNegative ? ~(p &- .one) : p)
+    return (r, overflow || (isNegative != r._isNegative))
+    % else:
+    let h1 = self.high.multipliedReportingOverflow(by: rhs.low)
+    let h2 = self.low.multipliedReportingOverflow(by: rhs.high)
+    let h3 = h1.partialValue.addingReportingOverflow(h2.partialValue)
+    let (h, l) = self.low.multipliedFullWidth(by: rhs.low)
+    let high = h3.partialValue.addingReportingOverflow(h)
+    let overflow = (
+      (self.high != 0 && rhs.high != 0)
+      || h1.overflow || h2.overflow || h3.overflow || high.overflow)
+    return (Self(high: high.partialValue, low: l), overflow)
+    % end
   }
 
   internal func quotientAndRemainder(
@@ -333,7 +348,7 @@ extension _${U}Int128: FixedWidthInteger {
       low: mid1.high + mid2.low)
 
     if isNegative {
-      let (lowComplement, overflow) = (~low).addingReportingOverflow(1)
+      let (lowComplement, overflow) = (~low).addingReportingOverflow(.one)
       return (~high + (overflow ? 1 : 0), lowComplement)
     } else {
       return (high, low)
@@ -343,15 +358,10 @@ extension _${U}Int128: FixedWidthInteger {
   internal func dividingFullWidth(
     _ dividend: (high: Self, low: Self.Magnitude)
   ) -> (quotient: Self, remainder: Self) {
+    % if signed:
     let m = _wideMagnitude22(dividend)
-    let (q, r) = _wideDivide42(
-      (m.high.components, m.low.components),
-      by: self.magnitude.components)
-    let quotient = Self.Magnitude(q)
-    let remainder = Self.Magnitude(r)
-    guard Self.isSigned else {
-      return (Self(quotient), Self(remainder))
-    }
+    let (quotient, remainder) = self.magnitude.dividingFullWidth(m)
+
     let isNegative = (self.high._isNegative != dividend.high.high._isNegative)
     let quotient_ = (isNegative
       ? (quotient == Self.min.magnitude ? Self.min : 0 - Self(quotient))
@@ -360,13 +370,17 @@ extension _${U}Int128: FixedWidthInteger {
       ? 0 - Self(remainder)
       : Self(remainder))
     return (quotient_, remainder_)
+    % else:
+    let (q, r) = _wideDivide42(
+      (dividend.high.components, dividend.low.components),
+      by: self.components)
+    return (Self(q), Self(r))
+    % end
   }
 
-/* disabled since it causes a compile failure in LLDB
   internal static prefix func ~(x: Self) -> Self {
     Self(high: ~x.high, low: ~x.low)
   }
-*/
 
   internal static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs.low &= rhs.low
@@ -413,11 +427,19 @@ extension _${U}Int128: FixedWidthInteger {
     lhs &>>= rhs
   }
 
-  internal static func &<<= (_ lhs: inout Self, _ rhs: Self) {
+  internal static func &<< (lhs: Self, rhs: Self) -> Self {
+    Self(_wideMaskedShiftLeft(lhs.components, rhs.low))
+  }
+
+  internal static func &>> (lhs: Self, rhs: Self) -> Self {
+    Self(_wideMaskedShiftRight(lhs.components, rhs.low))
+  }
+
+  internal static func &<<= (lhs: inout Self, rhs: Self) {
     _wideMaskedShiftLeft(&lhs.components, rhs.low)
   }
 
-  internal static func &>>= (_ lhs: inout Self, _ rhs: Self) {
+  internal static func &>>= (lhs: inout Self, rhs: Self) {
     _wideMaskedShiftRight(&lhs.components, rhs.low)
   }
 
@@ -590,7 +612,7 @@ private func _wideMaskedShiftLeft<F: FixedWidthInteger>(
   var high = lhs.high &<< F(rhs)
   let rollover = F.Magnitude(F.bitWidth) &- rhs
   high |= F(truncatingIfNeeded: lhs.low &>> rollover)
-  var low = lhs.low &<< rhs
+  let low = lhs.low &<< rhs
   return (high, low)
 }
 


### PR DESCRIPTION
This experimental PR builds on #41485 and adopts the Clock APIs from [SE-0329] in the Swift Benchmark Suite.

[SE-0329]: https://github.com/apple/swift-evolution/blob/main/proposals/0329-clock-instant-duration.md

