### PR TITLE
Concurrency: fix inconsistent _asyncLet_get signatures

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -44,12 +44,12 @@ public func _asyncLetEnd(
 /// Wait if necessary and then project the result value of an async let
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_get")
-public func _asyncLet_get(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async -> Builtin.RawPointer
+public func _asyncLet_get(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async
 
 /// Wait if necessary and then project the result value of an async let that throws
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("swift_asyncLet_get_throwing")
-public func _asyncLet_get_throwing(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async throws -> Builtin.RawPointer
+public func _asyncLet_get_throwing(_ asyncLet: Builtin.RawPointer, _ resultBuffer: Builtin.RawPointer) async throws
 
 /// Wait if necessary and then tear down the async let task
 @available(SwiftStdlib 5.1, *)

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -59,6 +59,10 @@ Func AsyncSequence.prefix(while:) is now with @preconcurrency
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
 Func _runAsyncMain(_:) is now with @preconcurrency
+Func _asyncLet_get(_:_:) has mangled name changing from '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> Builtin.RawPointer' to '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> ()'
+Func _asyncLet_get(_:_:) has return type change from Builtin.RawPointer to ()
+Func _asyncLet_get_throwing(_:_:) has mangled name changing from '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> Builtin.RawPointer' to '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> ()'
+Func _asyncLet_get_throwing(_:_:) has return type change from Builtin.RawPointer to ()
 Protocol Actor has added inherited protocol AnyActor
 Protocol Actor has generic signature change from <Self : AnyObject, Self : Swift.Sendable> to <Self : _Concurrency.AnyActor>
 Struct CheckedContinuation has removed conformance to UnsafeSendable


### PR DESCRIPTION
The implementation of `swift_asyncLet_get` asynchronously returns only async context, and the result is written in the given buffer. But its Swift level declaration in Concurrency module has `async ->  Builtin.RawPointer` result.
This extra result type affects the number of parameters of a resumption function that is passed as a continuation function of `swift_asyncLet_get`, and it results in having an extra parameter in a resumption function.
But the implementation only passes only async context to the resumption function, so callee and caller signatures are mismatched. It causes crash in WebAssembly target.

This patch fixes the signature inconsistency between the caller and callee assumptions.

https://github.com/apple/swift/blob/b0043966cd868e06fdebbfe1ae16b20d954d8089/stdlib/public/Concurrency/AsyncLet.cpp#L228-L247

Link: https://github.com/swiftwasm/swift/pull/4288