### PR TITLE
[NFC] Fixing some stdlib unused warnings

### DIFF
--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -154,7 +154,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     guard buffer.count > 0 else { return (makeIterator(), 0) }
     let start = buffer.baseAddress!
     let c = Swift.min(self.count, buffer.count)
-    let end = _copyContents(subRange: 0 ..< c, initializing: start)
+    _ = _copyContents(subRange: 0 ..< c, initializing: start)
     return (IndexingIterator(_elements: self, _position: c), c)
   }
 }

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -822,8 +822,8 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
         // class type to use _ContiguousArrayStorage<AnyObject> when we bridge
         // to objective-c we need to set the correct Element type so that when
         // we bridge back we can use O(1) bridging i.e we can adopt the storage.
-        _swift_setClassMetadata(_ContiguousArrayStorage<Element>.self,
-                                onObject: _storage)
+        _ = _swift_setClassMetadata(_ContiguousArrayStorage<Element>.self,
+                                    onObject: _storage)
       }
       return _storage
     }

--- a/stdlib/public/core/Int128.swift.gyb
+++ b/stdlib/public/core/Int128.swift.gyb
@@ -590,7 +590,7 @@ private func _wideMaskedShiftLeft<F: FixedWidthInteger>(
   var high = lhs.high &<< F(rhs)
   let rollover = F.Magnitude(F.bitWidth) &- rhs
   high |= F(truncatingIfNeeded: lhs.low &>> rollover)
-  var low = lhs.low &<< rhs
+  let low = lhs.low &<< rhs
   return (high, low)
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Simply addressing warnings on stdlib build 
```
${SRC_PATH}//stdlib/public/core/CocoaArray.swift:157:9: warning: initialization of immutable value 'end' was never used; consider replacing with assignment to '_' or removing it
    let end = _copyContents(subRange: 0 ..< c, initializing: start)
    ~~~~^~~
    _
${SRC_PATH}/stdlib/public/core/ContiguousArrayBuffer.swift:825:9: warning: result of call to '_swift_setClassMetadata(_:onObject:)' is unused
        _swift_setClassMetadata(_ContiguousArrayStorage<Element>.self,
        ^                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
${SRC_PATH}/stdlib/public/core/Int128.swift.gyb:593:7: warning: variable 'low' was never mutated; consider changing to 'let' constant
  var low = lhs.low &<< rhs
  ~~~ ^
  let
```

