### PR TITLE
[move-function] Be more pedantic about ensuring that undef dbg value have same scope/loc as the original dbg value.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -1777,7 +1777,9 @@ bool DataflowState::process(
       if (auto debug = DebugVarCarryingInst::getFromValue(address)) {
         debug.markAsMoved();
         if (auto varInfo = debug.getVarInfo()) {
-          builder.createDebugValue(
+          SILBuilderWithScope undefBuilder(builder);
+          undefBuilder.setCurrentDebugScope(debug.inst->getDebugScope());
+          undefBuilder.createDebugValue(
               debug.inst->getLoc(),
               SILUndef::get(address->getType(), builder.getModule()), *varInfo,
               false /*poison*/, true /*was moved*/);
@@ -1923,7 +1925,9 @@ static bool performSingleBasicBlockAnalysis(DataflowState &dataflowState,
     // Also, mark the alloc_stack as being moved at some point.
     if (auto debug = DebugVarCarryingInst::getFromValue(address)) {
       if (auto varInfo = debug.getVarInfo()) {
-        builder.createDebugValue(
+        SILBuilderWithScope undefBuilder(builder);
+        undefBuilder.setCurrentDebugScope(debug.inst->getDebugScope());
+        undefBuilder.createDebugValue(
             debug.inst->getLoc(),
             SILUndef::get(address->getType(), builder.getModule()), *varInfo,
             false,
@@ -2031,11 +2035,15 @@ static bool performSingleBasicBlockAnalysis(DataflowState &dataflowState,
                            IsInitialization);
     if (auto debug = DebugVarCarryingInst::getFromValue(address)) {
       if (auto varInfo = debug.getVarInfo()) {
-        builder.createDebugValue(
-            debug.inst->getLoc(),
-            SILUndef::get(address->getType(), builder.getModule()), *varInfo,
-            false,
+        {
+          SILBuilderWithScope undefBuilder(builder);
+          undefBuilder.setCurrentDebugScope(debug.inst->getDebugScope());
+          undefBuilder.createDebugValue(
+              debug.inst->getLoc(),
+              SILUndef::get(address->getType(), builder.getModule()), *varInfo,
+              false,
             /*was moved*/ true);
+        }
         {
           // Make sure at the reinit point to create a new debug value after the
           // reinit instruction so we reshow the variable.
@@ -2078,7 +2086,9 @@ static bool performSingleBasicBlockAnalysis(DataflowState &dataflowState,
                dumpBitVector(llvm::dbgs(), bitVector); llvm::dbgs() << '\n');
     if (auto debug = DebugVarCarryingInst::getFromValue(address)) {
       if (auto varInfo = debug.getVarInfo()) {
-        builder.createDebugValue(
+        SILBuilderWithScope undefBuilder(builder);
+        undefBuilder.setCurrentDebugScope(debug.inst->getDebugScope());
+        undefBuilder.createDebugValue(
             debug.inst->getLoc(),
             SILUndef::get(address->getType(), builder.getModule()), *varInfo,
             false,

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -38,13 +38,13 @@ public protocol P {
 // CHECK: call void @llvm.dbg.declare(metadata {{.*}}** %m.debug, metadata ![[M_COPYABLE_VALUE_TEST:[0-9]*]],
 //
 // We should have a llvm.dbg.addr for k since we moved it.
-// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_TEST:[0-9]*]],
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_TEST:[0-9]*]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
 //
 // Our undef should be an llvm.dbg.value. Counter-intuitively this works for
 // both llvm.dbg.addr /and/ llvm.dbg.value. Importantly though its metadata
 // should be for k since that is the variable that we are telling the debugger
 // is no longer defined.
-// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_VALUE_TEST]],
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_VALUE_TEST]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 //
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -81,8 +81,10 @@ public func copyableValueTest() {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo15copyableVarTestyyF"()
 // CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
-// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_METADATA:[0-9]+]],
-// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_METADATA]],
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+// TODO: Should this be a deref like the original?
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -123,8 +125,8 @@ public func copyableVarTest() {
 // CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
 // CHECK: @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
 // CHECK: @llvm.dbg.declare(metadata i8** %m.debug,
-// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDR_LET_METADATA:[0-9]+]],
-// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDR_LET_METADATA]],
+// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDR_LET_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDR_LET_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //
@@ -173,8 +175,9 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
 // CHECK: @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
 // CHECK: @llvm.dbg.declare(metadata i8** %m.debug,
-// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA:[0-9]+]],
-// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDRONLY_VAR_METADATA]],
+// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDRONLY_VAR_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+// CHECK: @llvm.dbg.addr(metadata i8** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 // CHECK: ret void
 // CHECK-NEXT: }
 //

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -38,13 +38,13 @@ public protocol P {
 // CHECK: call void @llvm.dbg.declare(metadata {{.*}}** %m.debug, metadata ![[M_COPYABLE_VALUE_TEST:[0-9]*]],
 //
 // We should have a llvm.dbg.addr for k since we moved it.
-// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_TEST:[0-9]*]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_METADATA:[0-9]*]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
 //
 // Our undef should be an llvm.dbg.value. Counter-intuitively this works for
 // both llvm.dbg.addr /and/ llvm.dbg.value. Importantly though its metadata
 // should be for k since that is the variable that we are telling the debugger
 // is no longer defined.
-// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_VALUE_TEST]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_VALUE_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 //
 // CHECK: ret void
 // CHECK-NEXT: }
@@ -224,3 +224,12 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
     k = x
     k.doSomething()
 }
+
+//////////////////////////
+// Late Metadata Checks //
+//////////////////////////
+
+// CHECK-DAG: ![[K_COPYABLE_VALUE_METADATA]] = !DILocalVariable(name: "k",
+// CHECK-DAG: ![[K_COPYABLE_VAR_METADATA]] = !DILocalVariable(name: "k",
+// CHECK-DAG: ![[K_ADDR_LET_METADATA]] = !DILocalVariable(name: "k",
+// CHECK-DAG: ![[K_ADDRONLY_VAR_METADATA]] = !DILocalVariable(name: "k",


### PR DESCRIPTION
Otherwise, LLVM doesn't consider them to be the same. I also added some tests to validate this behavior.