### PR TITLE
swift-inspect: fix all the typos/correctness issues

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
@@ -28,10 +28,10 @@ internal func backtrace(_ stack: [swift_reflection_ptr_t], style: BacktraceStyle
   // shallowest, so `main` will be somewhere near the end.
   switch style {
   case .oneline:
-    return self.reversed().map { entry($0) }.joined(separator: " | ")
+    return stack.reversed().map { entry($0) }.joined(separator: " | ")
   case .long:
-    return self.reversed().enumerated().map {
-      " \(String(repeating: " ", count: $0 + 1)\(entry($1))"
-    }.joined(separtor: "\n")
+    return stack.reversed().enumerated().map {
+      " \(String(repeating: " ", count: $0 + 1))\(entry($1))"
+    }.joined(separator: "\n")
   }
 }

--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -24,7 +24,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   public var process: ProcessHandle { task }
   public private(set) var context: SwiftReflectionContextRef!
 
-  private var swiftCore: ??? = ???
+  private var swiftCore: CSTypeRef
 
   static var QueryDataLayout: QueryDataLayoutFunction {
     return { (context, type, _, output) in
@@ -43,7 +43,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
 
       case DLQ_GetObjCReservedLowBits:
         var size: UInt8 = 0
-#if os(macoS)
+#if os(macOS)
         // Only 64-bit macOS reserves pointer bit-packing.
         if MemoryLayout<UnsafeRawPointer>.stride == 8 { size = 1 }
 #endif
@@ -102,7 +102,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     var task: task_t = task_t()
     let result = task_for_pid(mach_task_self_, processId, &task)
     guard result == KERN_SUCCESS else {
-      print("unable to get task for pid \(processId): \(String(cString: mach_error_string(result)) (0x\(String(result, radix: 16)))")
+      print("unable to get task for pid \(processId): \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
       return nil
     }
     self.task = task
@@ -154,7 +154,7 @@ extension DarwinRemoteProcess {
           ranges.forEach {
             body(swift_addr_t($0.address), UInt64($0.size))
           }
-        }
+        })
       }
     }
   }
@@ -165,7 +165,7 @@ extension DarwinRemoteProcess {
 
     let result = task_threads(self.task, &threadList, &threadCount)
     guard result == KERN_SUCCESS else {
-      print("unable to gather threads for process: \(String(cString: mach_error_string(result)) (0x\(String(result, radix: 16)))")
+      print("unable to gather threads for process: \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
       return []
     }
 
@@ -195,7 +195,7 @@ extension DarwinRemoteProcess {
               thread_info(threadList![i], thread_flavor_t(THREAD_IDENTIFIER_INFO),
                           $0, &infoCount)
           guard result == ERROR_SUCCESS else {
-            print("unable to get info for thread \(i): \(String(cString: mach_error_string(result)) (0x\(String(result, radix: 16)))")
+            print("unable to get info for thread \(i): \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
             return
           }
 

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConformanceCache.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConformanceCache.swift
@@ -20,7 +20,7 @@ internal struct DumpConformanceCache: ParsableCommand {
   var options: UniversalOptions
 
   func run() throws {
-    try inspec(process: options.nameOrPid) { process in
+    try inspect(process: options.nameOrPid) { process in
       try process.context.iterateConformanceCache { type, proto in
         let type: String = process.context.name(type: type) ?? "<unknown>"
         let conformance: String = process.context.name(protocol: proto) ?? "<unknown>"

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
@@ -18,7 +18,7 @@ private struct Metadata {
   var allocation: swift_metadata_allocation_t?
 
   let name: String
-  let isArayOfClass: Bool
+  let isArrayOfClass: Bool
 
   var offset: Int? { allocation.map { Int(self.ptr - $0.ptr) } }
 }
@@ -28,7 +28,7 @@ internal struct DumpGenericMetadata: ParsableCommand {
     abstract: "Print the target's generic metadata allocations.")
 
   @OptionGroup()
-  var universalOptions: UniversalOptions
+  var options: UniversalOptions
 
   @OptionGroup()
   var backtraceOptions: BacktraceOptions
@@ -50,7 +50,9 @@ internal struct DumpGenericMetadata: ParsableCommand {
       }
 
       let stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]]? =
-          backtrace.style == nil ? nil : try process.context.allocationStacks
+          backtraceOptions.style == nil
+              ? nil
+              : try process.context.allocationStacks
 
       print("Address", "Allocation", "Size", "Offset", "isArrayOfClass", "Name", separator: "\t")
       generics.forEach {
@@ -62,7 +64,7 @@ internal struct DumpGenericMetadata: ParsableCommand {
         }
         print($0.isArrayOfClass, terminator: "\t")
         print($0.name)
-        if let style = backtrace.style, let allocation = $0.allocation {
+        if let style = backtraceOptions.style, let allocation = $0.allocation {
           if let stack = stacks?[allocation.ptr] {
             print(backtrace(stack, style: style, process.symbolicate))
           } else {

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
@@ -18,7 +18,7 @@ internal struct DumpRawMetadata: ParsableCommand {
     abstract: "Print the target's metadata allocations.")
 
   @OptionGroup()
-  var universalOptions: UniversalOptions
+  var options: UniversalOptions
 
   @OptionGroup()
   var backtraceOptions: BacktraceOptions
@@ -26,12 +26,14 @@ internal struct DumpRawMetadata: ParsableCommand {
   func run() throws {
     try inspect(process: options.nameOrPid) { process in
       let stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]]? =
-          backtrace.style == nil ? nl : try process.context.allocationStacks
+          backtraceOptions.style == nil
+              ? nil
+              : try process.context.allocationStacks
 
       try process.context.allocations.forEach { allocation in
         let name: String = process.context.name(allocation: allocation.tag) ??  "<unknown>"
-        print("Metadata allocation at: \(hex: allocation.ptr) size: \(allocation.size) tag: \(allocation.tag) (\(name))"
-        if let style = backtrace.style {
+        print("Metadata allocation at: \(hex: allocation.ptr) size: \(allocation.size) tag: \(allocation.tag) (\(name))")
+        if let style = backtraceOptions.style {
           if let stack = stacks?[allocation.ptr] {
             print(backtrace(stack, style: style, process.symbolicate))
           } else {

--- a/tools/swift-inspect/Sources/swift-inspect/Process.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Process.swift
@@ -12,12 +12,10 @@
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
-#endif
 
-internal typealias ProcessIdentifier = pid_t
+internal typealias ProcessIdentifier = DarwinRemoteProcess.ProcessIdentifier
 
 internal func process(matching: String) -> ProcessIdentifier? {
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   return pidFromHint(matching)
-#endif
 }
+#endif

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteMirror+Extensions.swift
@@ -23,7 +23,7 @@ extension swift_metadata_allocation_t: Comparable {
     lhs.ptr == rhs.ptr
   }
 
-  public static func < (lhs: self, rhs: Self) -> Bool {
+  public static func < (lhs: Self, rhs: Self) -> Bool {
     lhs.ptr < rhs.ptr
   }
 }
@@ -46,7 +46,7 @@ extension SwiftReflectionContextRef {
   internal var allocations: [swift_metadata_allocation_t] {
     get throws {
       var allocations: [swift_metadata_allocation_t] = []
-      try iterateMetdataAllocations {
+      try iterateMetadataAllocations {
         allocations.append($0)
       }
       return allocations
@@ -56,18 +56,19 @@ extension SwiftReflectionContextRef {
   internal var allocationStacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]] {
     get throws {
       var stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]] = [:]
-      try iterateMetadataAllocationBacktraces { allocation, count, stack, in
-        stacks[allocation] = Aray(UnsafeBufferPointer(start: stack, count: count))
+      try iterateMetadataAllocationBacktraces { allocation, count, stack in
+        stacks[allocation] =
+            Array(UnsafeBufferPointer(start: stack, count: count))
       }
       return stacks
     }
   }
 
   internal func name(type: swift_reflection_ptr_t) -> String? {
-    let typeref: UInt64 = swift_reflection_typeRefForMetadata(self, UInt(type)
+    let typeref: UInt64 = swift_reflection_typeRefForMetadata(self, UInt(type))
     if typeref == 0 { return nil }
 
-    guard let name = swift_reflection_copyDemangled_NameForTypeRef(self, typeref) else {
+    guard let name = swift_reflection_copyDemangledNameForTypeRef(self, typeref) else {
       return nil
     }
     defer { free(name) }

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -16,7 +16,7 @@ internal protocol RemoteProcess: AnyObject {
   associatedtype ProcessIdentifier
   associatedtype ProcessHandle
 
-  var process: ProcesHandle { get }
+  var process: ProcessHandle { get }
   var context: SwiftReflectionContextRef! { get }
 
   init?(processId: ProcessIdentifier)


### PR DESCRIPTION
Fix the many typos and missing `)` instances.  Replace the inline array
removal with explicit duplication due to the behaviour of `#if`.  This
allows the tool to build after the changes for the refactoring.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
