### PR TITLE
[SwiftCompiler] Add DiagnosticEngine bridging

### DIFF
--- a/SwiftCompilerSources/Sources/AST/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/AST/CMakeLists.txt
@@ -6,6 +6,9 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_swift_compiler_module(Basic
-  SourceLoc.swift
-  Utils.swift)
+add_swift_compiler_module(AST
+  DEPENDS
+    Basic
+  SOURCES
+    DiagnosticEngine.swift)
+

--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -1,0 +1,123 @@
+//===--- DiagnosticEngine.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import ASTBridging
+
+import Basic
+
+public typealias DiagID = BridgedDiagID
+
+extension BridgedDiagnosticArgument {
+  init(stringRef val: BridgedStringRef) {
+    self.init(kind: .stringRef, value: .init(stringRefValue: val))
+  }
+  init(int val: Int) {
+    self.init(kind: .int, value: .init(intValue: val))
+  }
+}
+
+public protocol DiagnosticArgument {
+  func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void)
+}
+extension String: DiagnosticArgument {
+  public func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void) {
+    withBridgedStringRef { fn(BridgedDiagnosticArgument(stringRef: $0)) }
+  }
+}
+extension Int: DiagnosticArgument {
+  public func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void) {
+    fn(BridgedDiagnosticArgument(int: self))
+  }
+}
+
+public struct DiagnosticFixIt {
+  public let start: SourceLoc
+  public let byteLength: Int
+  public let text: String
+
+  public init(start: SourceLoc, byteLength: Int, replacement text: String) {
+    self.start = start
+    self.byteLength = byteLength
+    self.text = text
+  }
+
+  func withBridgedDiagnosticFixIt(_ fn: (BridgedDiagnosticFixIt) -> Void) {
+    text.withBridgedStringRef { bridgedTextRef in
+      let bridgedDiagnosticFixIt = BridgedDiagnosticFixIt(
+        start: start.bridged,
+        byteLength: byteLength,
+        text: bridgedTextRef)
+      fn(bridgedDiagnosticFixIt)
+    }
+  }
+}
+
+public struct DiagnosticEngine {
+  private let bridged: BridgedDiagnosticEngine
+
+  public init(bridged: BridgedDiagnosticEngine) {
+    self.bridged = bridged
+  }
+
+  public func diagnose(_ position: SourceLoc?,
+                       _ id: DiagID,
+                       _ args: [DiagnosticArgument],
+                       highlight: CharSourceRange? = nil,
+                       fixIts: [DiagnosticFixIt] = []) {
+
+    let bridgedSourceLoc: BridgedSourceLoc = position.bridged
+    let bridgedHighlightRange: BridgedCharSourceRange = highlight.bridged
+    var bridgedArgs: [BridgedDiagnosticArgument] = []
+    var bridgedFixIts: [BridgedDiagnosticFixIt] = []
+
+    // Build a higher-order function to wrap every 'withBridgedXXX { ... }'
+    // calls, so we don't escape anything from the closure. 'bridgedArgs' and
+    // 'bridgedFixIts' are temporary storage to store bridged values. So they
+    // should not be used after the closue is executed.
+ 
+    var closure: () -> Void = {
+      bridgedArgs.withBridgedArrayRef { bridgedArgsRef in
+        bridgedFixIts.withBridgedArrayRef { bridgedFixItsRef in
+          DiagnosticEngine_diagnose(bridged, bridgedSourceLoc,
+                                    id, bridgedArgsRef,
+                                    bridgedHighlightRange, bridgedFixItsRef)
+        }
+      }
+    }
+    for arg in args {
+      closure = { [closure, arg] in
+        arg._withBridgedDiagnosticArgument { bridgedArg in
+          bridgedArgs.append(bridgedArg)
+          closure()
+        }
+      }
+    }
+    for fixIt in fixIts {
+      closure = { [closure, fixIt] in
+        fixIt.withBridgedDiagnosticFixIt { bridgedFixIt in
+          bridgedFixIts.append(bridgedFixIt)
+          closure()
+        }
+      }
+    }
+
+    closure()
+  }
+
+  public func diagnose(_ position: SourceLoc?,
+                       _ id: DiagID,
+                       _ args: DiagnosticArgument...,
+                       highlight: CharSourceRange? = nil,
+                       fixIts: DiagnosticFixIt...) {
+    diagnose(position, id, args, highlight: highlight, fixIts: fixIts)
+  }
+}

--- a/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
+++ b/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
@@ -1,0 +1,67 @@
+//===--- SourceLoc.swift - SourceLoc bridiging utilities ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public struct SourceLoc {
+  /// Points into a source file.
+  let locationInFile: UnsafePointer<UInt8>
+
+  public init?(locationInFile: UnsafePointer<UInt8>?) {
+    guard let locationInFile = locationInFile else {
+      return nil
+    }
+    self.locationInFile = locationInFile
+  }
+
+  public init?(bridged: BridgedSourceLoc) {
+    guard let locationInFile = bridged.pointer else {
+      return nil
+    }
+    self.init(locationInFile: locationInFile)
+  }
+
+  public var bridged: BridgedSourceLoc {
+    .init(pointer: locationInFile)
+  }
+}
+
+extension Optional where Wrapped == SourceLoc {
+  public var bridged: BridgedSourceLoc {
+    self?.bridged ?? .init(pointer: nil)
+  }
+}
+
+public struct CharSourceRange {
+  private let start: SourceLoc
+  private let byteLength: Int
+
+  public init(start: SourceLoc, byteLength: Int) {
+    self.start = start
+    self.byteLength = byteLength
+  }
+
+  public init?(bridged: BridgedCharSourceRange) {
+    guard let start = SourceLoc(bridged: bridged.start) else {
+      return nil
+    }
+    self.init(start: start, byteLength: bridged.byteLength)
+  }
+
+  public var bridged: BridgedCharSourceRange {
+    .init(start: start.bridged, byteLength: byteLength)
+  }
+}
+
+extension Optional where Wrapped == CharSourceRange {
+  public var bridged: BridgedCharSourceRange {
+    self?.bridged ?? .init(start: .init(pointer: nil), byteLength: 0)
+  }
+}

--- a/SwiftCompilerSources/Sources/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/CMakeLists.txt
@@ -9,6 +9,7 @@
 # NOTE: Subdirectories must be added in dependency order.
 
 add_subdirectory(Basic)
+add_subdirectory(AST)
 if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
   add_subdirectory(ExperimentalRegex)
 endif()

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1,0 +1,82 @@
+//===--- ASTBridging.h - header for the swift SILBridging module ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_ASTBRIDGING_H
+#define SWIFT_AST_ASTBRIDGING_H
+
+#include "swift/Basic/BasicBridging.h"
+#include "swift/Basic/Compiler.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
+//===----------------------------------------------------------------------===//
+// Diagnostic Engine
+//===----------------------------------------------------------------------===//
+
+// TODO: Move this to somewhere common header.
+#if __has_attribute(enum_extensibility)
+#define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
+#else
+#define ENUM_EXTENSIBILITY_ATTR(arg)
+#endif
+
+// NOTE: This must be the same underlying value as C++ 'swift::DiagID' defined
+// in 'DiagnosticList.cpp'.
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
+#define DIAG(KIND, ID, Options, Text, Signature) BridgedDiagID_##ID,
+#include "swift/AST/DiagnosticsAll.def"
+} BridgedDiagID;
+
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticArgumentKind {
+  BridgedDiagnosticArgumentKind_StringRef,
+  BridgedDiagnosticArgumentKind_Int,
+} BridgedDiagnosticArgumentKind;
+
+typedef struct {
+  BridgedDiagnosticArgumentKind kind;
+  union {
+    BridgedStringRef stringRefValue;
+    SwiftInt intValue;
+  } value;
+} BridgedDiagnosticArgument;
+
+typedef struct {
+  BridgedSourceLoc start;
+  SwiftInt byteLength;
+  BridgedStringRef text;
+} BridgedDiagnosticFixIt;
+
+typedef struct {
+  void * _Nonnull object;
+} BridgedDiagnosticEngine;
+
+// FIXME: Can we bridge InFlightDiagnostic?
+void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, BridgedSourceLoc loc,
+                               BridgedDiagID diagID, BridgedArrayRef arguments,
+                               BridgedCharSourceRange highlight,
+                               BridgedArrayRef fixIts);
+
+bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SWIFT_AST_ASTBRIDGING_H

--- a/include/swift/AST/BridgingUtils.h
+++ b/include/swift/AST/BridgingUtils.h
@@ -1,0 +1,28 @@
+//===--- BridgingUtils.h - utilities for swift bridging -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_BRIDGINGUTILS_H
+#define SWIFT_AST_BRIDGINGUTILS_H
+
+#include "swift/AST/ASTBridging.h"
+#include "swift/AST/DiagnosticEngine.h"
+
+namespace swift {
+
+inline BridgedDiagnosticEngine getBridgedDiagnosticEngine(DiagnosticEngine *D) {
+  return {(void *)D};
+}
+
+} // namespace swift
+
+#endif
+

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -43,6 +43,19 @@ void OStream_write(BridgedOStream os, BridgedStringRef str);
 
 void freeBridgedStringRef(BridgedStringRef str);
 
+//===----------------------------------------------------------------------===//
+// Source location
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  const unsigned char * _Nullable pointer;
+} BridgedSourceLoc;
+
+typedef struct {
+  BridgedSourceLoc start;
+  SwiftInt byteLength;
+} BridgedCharSourceRange;
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #ifdef __cplusplus

--- a/include/swift/Basic/BridgingUtils.h
+++ b/include/swift/Basic/BridgingUtils.h
@@ -36,6 +36,27 @@ inline llvm::ArrayRef<T> getArrayRef(BridgedArrayRef bridged) {
   return {static_cast<const T *>(bridged.data), bridged.numElements};
 }
 
+inline SourceLoc getSourceLoc(const BridgedSourceLoc &bridged) {
+  return SourceLoc(
+      llvm::SMLoc::getFromPointer((const char *)bridged.pointer));
+}
+
+inline BridgedSourceLoc getBridgedSourceLoc(const SourceLoc &loc) {
+  return {static_cast<const unsigned char *>(loc.getOpaquePointerValue())};
+}
+
+inline CharSourceRange
+getCharSourceRange(const BridgedCharSourceRange &bridged) {
+  auto start = getSourceLoc(bridged.start);
+  return CharSourceRange(start, bridged.byteLength);
+}
+
+inline BridgedCharSourceRange
+getBridgedCharSourceRange(const CharSourceRange &range) {
+  auto start = getBridgedSourceLoc(range.getStart());
+  return {start, range.getByteLength()};
+}
+
 /// Copies the string in an malloc'ed memory and the caller is responsible for
 /// freeing it. 'freeBridgedStringRef()' is available in 'BasicBridging.h'
 inline BridgedStringRef

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -4,6 +4,11 @@ module BasicBridging {
   export *
 }
 
+module ASTBridging {
+  header "AST/ASTBridging.h"
+  export *
+}
+
 module SILBridging {
   header "SIL/SILBridging.h"
   export *

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -1,0 +1,75 @@
+//===--- ASTBridging.cpp - AST bridging functions -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTBridging.h"
+
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/Basic/BridgingUtils.h"
+
+using namespace swift;
+
+namespace {
+/// BridgedDiagnosticEngine -> DiagnosticEngine *.
+DiagnosticEngine *getDiagnosticEngine(const BridgedDiagnosticEngine &bridged) {
+  return static_cast<DiagnosticEngine *>(bridged.object);
+}
+
+/// BridgedDiagnosticArgument -> DiagnosticArgument
+DiagnosticArgument
+getDiagnosticArugment(const BridgedDiagnosticArgument &bridged) {
+  switch (bridged.kind) {
+  case BridgedDiagnosticArgumentKind_StringRef:
+    return {getStringRef(bridged.value.stringRefValue)};
+  case BridgedDiagnosticArgumentKind_Int:
+    return {(int)bridged.value.intValue};
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+} // namespace
+
+void DiagnosticEngine_diagnose(
+    BridgedDiagnosticEngine bridgedEngine, BridgedSourceLoc bridgedLoc,
+    BridgedDiagID bridgedDiagID,
+    BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
+    BridgedCharSourceRange bridgedHighlight,
+    BridgedArrayRef /*BridgedDiagnosticFixIt*/ bridgedFixIts) {
+  auto *D = getDiagnosticEngine(bridgedEngine);
+
+  auto loc = getSourceLoc(bridgedLoc);
+  auto diagID = static_cast<DiagID>(bridgedDiagID);
+  SmallVector<DiagnosticArgument, 2> arguments;
+  for (auto bridgedArg :
+       getArrayRef<BridgedDiagnosticArgument>(bridgedArguments)) {
+    arguments.push_back(getDiagnosticArugment(bridgedArg));
+  }
+  auto inflight = D->diagnose(loc, diagID, arguments);
+
+  // Add highlight.
+  auto highlight = getCharSourceRange(bridgedHighlight);
+  if (highlight.isValid()) {
+    inflight.highlightChars(highlight.getStart(), highlight.getEnd());
+  }
+
+  // Add fix-its.
+  for (auto bridgedFixIt : getArrayRef<BridgedDiagnosticFixIt>(bridgedFixIts)) {
+    auto range = CharSourceRange(getSourceLoc(bridgedFixIt.start),
+                                 bridgedFixIt.byteLength);
+    auto text = getStringRef(bridgedFixIt.text);
+    inflight.fixItReplaceChars(range.getStart(), range.getEnd(), text);
+  }
+}
+
+bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine bridgedEngine) {
+  auto *D = getDiagnosticEngine(bridgedEngine);
+  return D->hadAnyError();
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_host_library(swiftAST STATIC
   AccessNotes.cpp
   AccessRequests.cpp
   ArgumentList.cpp
+  ASTBridging.cpp
   ASTContext.cpp
   ASTDemangler.cpp
   ASTDumper.cpp


### PR DESCRIPTION
* `SourceLoc` and `CharSourceRange` bridging in `Basic`
* New `AST` bridging. `DiagID`, `DiagnosticArgument`, `DiagnosticFixIt`, and `DiagnosticEngine`

Preparation for Regex literal parsing diagnostics. #41492 