### PR TITLE
[test] return early when test cannot succeed

### DIFF
--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -429,6 +429,10 @@ UnsafeMutableBufferPointerTestSuite.test("Slice.withContiguousStorageIfAvailable
 }
 
 UnsafeMutableRawBufferPointerTestSuite.test("Slice.withContiguousStorageIfAvailable") {
+  guard #available(SwiftStdlib 5.7, *) else {
+    return
+  }
+
   for test in subscriptRangeTests {
     let c = test.collection.map({ UInt8($0.value/1000) })
     let buffer = UnsafeMutableRawBufferPointer.allocate(


### PR DESCRIPTION
- This test requires Swift 5.7

Resolves rdar://89052037
