### PR TITLE
[CSDiagnostics] Look through l-value conversions when mismatch is in …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4563,6 +4563,14 @@ bool ConstraintSystem::repairFailures(
         break;
       }
 
+      // If this is a problem with result type of a subscript setter,
+      // let's re-attempt to repair without l-value conversion in the
+      // locator to fix underlying type mismatch.
+      if (path.back().is<LocatorPathElt::FunctionResult>()) {
+        return repairFailures(lhs, rhs, matchKind, conversionsOrFixes,
+                              getConstraintLocator(anchor, path));
+      }
+
       // If this is a function type param type mismatch in any position,
       // the mismatch we want to report is for the whole structural type.
       auto last = std::find_if(

--- a/validation-test/Sema/SwiftUI/rdar84580119.swift
+++ b/validation-test/Sema/SwiftUI/rdar84580119.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+extension HorizontalAlignment {
+  private enum MyHorizontalAlignment: AlignmentID {
+    static func defaultValue(in d: ViewDimensions) -> CGFloat { d.width }
+  }
+}
+
+extension EnvironmentValues {
+  var myHorizontalAlignment: AlignmentID? {
+    get { fatalError() }
+    set { self[\.MyHorizontalAlignmentEnvironmentKey.self] = newValue }
+    // expected-error@-1 {{generic parameter 'K' could not be inferred}}
+    // expected-error@-2 {{cannot infer key path type from context; consider explicitly specifying a root type}}
+  }
+}
+
+struct MyHorizontalAlignmentEnvironmentKey: EnvironmentKey {
+  static var defaultValue: AlignmentID?
+}


### PR DESCRIPTION
…subscript setter

`repairFailures` needs a special case when l-value conversion is
associated with a result type of subscript setter because otherwise
it falls through and treats result type as if it's an argument type,
which leads to crashes.

Resolves: rdar://84580119

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
