### PR TITLE
[cxx-interop] Synthesize read accessors to represent C++ [] operators

### DIFF
--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -362,11 +362,24 @@ public:
     return { ReadImplKind::Get };
   }
 
+  /// Equivalent to immutableComputed storage info, but with a read
+  /// accessor instead of a get accessor.
+  static StorageImplInfo getBorrowedImmutableComputed() {
+    return {ReadImplKind::Read};
+  }
+
   /// Describe the implementation of a mutable property implemented with
   /// getter and setter.
   static StorageImplInfo getMutableComputed() {
     return { ReadImplKind::Get, WriteImplKind::Set,
              ReadWriteImplKind::MaterializeToTemporary };
+  }
+
+  /// Equivalent to mutableComputed storage info, but with a read accessor
+  /// instead of a get accessor.
+  static StorageImplInfo getMutableComputedWithBorrowedRead() {
+    return {ReadImplKind::Read, WriteImplKind::Set,
+            ReadWriteImplKind::MaterializeToTemporary};
   }
 
   /// Does this implementation description require storage?

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -253,10 +253,25 @@ static void makeComputed(AbstractStorageDecl *storage,
                          AccessorDecl *getter, AccessorDecl *setter) {
   assert(getter);
   if (setter) {
-    storage->setImplInfo(StorageImplInfo::getMutableComputed());
+    if (getter->getAccessorKind() == AccessorKind::Read) {
+      storage->setImplInfo(
+          StorageImplInfo::getMutableComputedWithBorrowedRead());
+    } else if (getter->getAccessorKind() == AccessorKind::Get) {
+      storage->setImplInfo(StorageImplInfo::getMutableComputed());
+    } else {
+      llvm_unreachable("Only get and read accessors are currently supported "
+                       "for syntherized accessors");
+    }
     storage->setAccessors(SourceLoc(), {getter, setter}, SourceLoc());
   } else {
-    storage->setImplInfo(StorageImplInfo::getImmutableComputed());
+    if (getter->getAccessorKind() == AccessorKind::Read) {
+      storage->setImplInfo(StorageImplInfo::getBorrowedImmutableComputed());
+    } else if (getter->getAccessorKind() == AccessorKind::Get) {
+      storage->setImplInfo(StorageImplInfo::getImmutableComputed());
+    } else {
+      llvm_unreachable("Only get and read accessors are currently supported "
+                       "for syntherized accessors");
+    }
     storage->setAccessors(SourceLoc(), {getter}, SourceLoc());
   }
 }
@@ -7780,7 +7795,23 @@ SwiftDeclConverter::importAccessor(const clang::ObjCMethodDecl *clangAccessor,
   return accessor;
 }
 
-/// Synthesizer callback for a subscript getter.
+/// Determines if an accessor returning the given type should
+/// use a read accessor or a get accessor.
+static bool accessorResultTypeWorthYielding(const swift::Type &type) {
+  // For the time being, this optimization is focused C++ operator[]
+  // that return non trivial types by reference.
+  const auto pointerElementType = type->getAnyPointerElementType();
+  if (!pointerElementType)
+    return false;
+
+  const auto structDecl = pointerElementType->getStructOrBoundGenericStruct();
+  if (!structDecl)
+    return false;
+
+  return structDecl->isCxxNonTrivial();
+}
+
+/// Synthesizer callback for a subscript getter or reader.
 static std::pair<BraceStmt *, bool>
 synthesizeSubscriptGetterBody(AbstractFunctionDecl *afd, void *context) {
   auto getterDecl = cast<AccessorDecl>(afd);
@@ -7791,7 +7822,13 @@ synthesizeSubscriptGetterBody(AbstractFunctionDecl *afd, void *context) {
   Expr *selfExpr = createSelfExpr(getterDecl);
   DeclRefExpr *keyRefExpr = createParamRefExpr(getterDecl, 0);
 
-  Type elementTy = getterDecl->getResultInterfaceType();
+  const bool shouldUseReadAccessor =
+      accessorResultTypeWorthYielding(getterImpl->getResultInterfaceType());
+
+  const Type rawElementTy = getterImpl->getResultInterfaceType();
+  Type elementTy = rawElementTy->getAnyPointerElementType()
+                       ? rawElementTy->getAnyPointerElementType()
+                       : rawElementTy;
 
   auto *getterImplCallExpr =
       createAccessorImplCallExpr(getterImpl, selfExpr, keyRefExpr);
@@ -7823,12 +7860,18 @@ synthesizeSubscriptGetterBody(AbstractFunctionDecl *afd, void *context) {
     propertyExpr = pointeePropertyRefExpr;
   }
 
-  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(),
-                                         propertyExpr,
-                                         /*implicit=*/ true);
+  // If generating a read accesor, synthesize a yield statement, and a return
+  // statement otherwise
+  const ASTNode braceStmtContents =
+      shouldUseReadAccessor
+          ? static_cast<ASTNode>(
+                YieldStmt::create(ctx, SourceLoc(), SourceLoc(), {propertyExpr},
+                                  SourceLoc(), /*implicit=*/true))
+          : new (ctx) ReturnStmt(SourceLoc(), propertyExpr, /*implicit=*/true);
 
-  auto body = BraceStmt::create(ctx, SourceLoc(), { returnStmt }, SourceLoc(),
-                                /*implicit=*/ true);
+  auto body =
+      BraceStmt::create(ctx, SourceLoc(), {braceStmtContents}, SourceLoc(),
+                        /*implicit=*/true);
   return { body, /*isTypeChecked=*/true };
 }
 
@@ -7978,19 +8021,17 @@ SwiftDeclConverter::makeSubscript(FuncDecl *getter, FuncDecl *setter) {
                                                            getterImpl->getClangNode());
   subscript->setAccess(AccessLevel::Public);
 
-  AccessorDecl *getterDecl = AccessorDecl::create(ctx,
-                                                  getterImpl->getLoc(),
-                                                  getterImpl->getLoc(),
-                                                  AccessorKind::Get,
-                                                  subscript,
-                                                  SourceLoc(),
-                                                  subscript->getStaticSpelling(),
-                                                  /*async*/ false, SourceLoc(),
-                                                  /*throws*/ false, SourceLoc(),
-                                                  nullptr,
-                                                  bodyParams,
-                                                  elementTy,
-                                                  dc);
+  const bool shouldUseReadAccessor =
+      accessorResultTypeWorthYielding(getterImpl->getResultInterfaceType());
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      ctx, getterImpl->getLoc(), getterImpl->getLoc(),
+      shouldUseReadAccessor ? AccessorKind::Read : AccessorKind::Get, subscript,
+      SourceLoc(), subscript->getStaticSpelling(),
+      /*async*/ false, SourceLoc(),
+      /*throws*/ false, SourceLoc(), nullptr, bodyParams,
+      // Read accessors are special coroutines and return an empty tuple.
+      shouldUseReadAccessor ? TupleType::getEmpty(ctx) : elementTy, dc);
+
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2663,8 +2663,8 @@ namespace {
     }
 
     void emitUsingAccessor(AccessorKind accessorKind, bool isDirect) {
-      auto accessor =
-        SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
+      auto accessor = SGF.SGM.getAccessorDeclRef(
+          Storage->getSynthesizedAccessor(accessorKind));
 
       switch (accessorKind) {
       case AccessorKind::Get:
@@ -3148,7 +3148,7 @@ static SGFAccessKind getBaseAccessKind(SILGenModule &SGM,
 
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor: {
-    auto accessor = member->getOpaqueAccessor(strategy.getAccessor());
+    auto accessor = member->getSynthesizedAccessor(strategy.getAccessor());
     return getBaseAccessKindForAccessor(SGM, accessor, baseFormalType);
   }
     

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -209,6 +209,12 @@ private:
   NonTrivial S;
 };
 
+struct NonTrivialArrayByRef {
+  NonTrivial &operator[](int x) { return S; }
+private:
+  NonTrivial S;
+};
+
 struct PtrByVal {
   int *operator[](int x) { return &a; }
 private:

--- a/test/Interop/Cxx/operators/read-accessor.swift
+++ b/test/Interop/Cxx/operators/read-accessor.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import MemberInline
+
+var arr = NonTrivialArrayByRef()
+let _ = arr[0].f + 1;
+
+// Verify that a read accessor is generated, and that the yielded non trivial type is not copied.
+
+// CHECK:     // main
+// CHECK:     sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+// CHECK-NOT: alloc_stack $NonTrivial
+// CHECK:     [[OP_REF:%[0-9]+]] = function_ref {{@.*NonTrivialArrayByRef.*}} : $@convention(cxx_method) (Int32, @inout NonTrivialArrayByRef) -> UnsafeMutablePointer<NonTrivial>
+// CHECK:     [[RESULT_POINTER:%[0-9]+]] = apply [[OP_REF]]({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(cxx_method) (Int32, @inout NonTrivialArrayByRef) -> UnsafeMutablePointer<NonTrivial>
+// CHECK:     [[RESULT_ADDRESS:%[0-9]+]] = struct_extract [[RESULT_POINTER]] : $UnsafeMutablePointer<NonTrivial>, #UnsafeMutablePointer._rawValue
+// CHECK:     [[PTR_TO_ADDR:%[0-9]+]] = pointer_to_address [[RESULT_ADDRESS]] : $Builtin.RawPointer to [strict] $*NonTrivial
+// CHECK:     [[ACCESS:%[0-9]+]] = begin_access [read] [unsafe] [[PTR_TO_ADDR]] : $*NonTrivial
+// CHECK:     [[F_ADDR:%[0-9]+]] = struct_element_addr [[ACCESS]] : $*NonTrivial, #NonTrivial.f
+// CHECK:     {{%[0-9]+}} = load [[F_ADDR]] : $*Int32
+// CHECK:     // end sil function 'main'
+
+// CHECK: // NonTrivialArrayByRef.subscript.read
+// CHECK: sil shared [transparent] @${{.*NonTrivialArrayByRef.*}} : $@yield_once @convention(method) (Int32, @inout NonTrivialArrayByRef) -> @yields @in_guaranteed NonTrivial
+// CHECK-NOT: copy_addr {{%[0-9]+}} to [initialization] {{%[0-9]+}} : $*NonTrivial


### PR DESCRIPTION
Previously, C++ [] operators were imported into Swift
by synthesizing a subscript containing a getter and a
setter. Both these produce unnecessary copies. A read
accessor instead yields a borrowed reference, rather
than performing a copy. This change attempts to, when appropriate,
synthesize a read accessor instead of a getter.