### PR TITLE
Keep the assocty section when emitting reflection metadata for debugging

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1374,7 +1374,7 @@ emitAssociatedTypeMetadataRecord(const RootProtocolConformance *conformance) {
   if (!normalConf)
     return;
 
-  if (IRGen.Opts.ReflectionMetadata != ReflectionMetadataMode::Runtime)
+  if (IRGen.Opts.ReflectionMetadata != ReflectionMetadataMode::DebuggerOnly)
     return;
 
   SmallVector<std::pair<StringRef, CanType>, 2> AssociatedTypes;


### PR DESCRIPTION
<!-- What's in this pull request? -->
LLDB needs the Associated Type section to work. For example, it's needed to simply break in the indicated line in the code below:
```
protocol Foo {
  associatedtype T
}

extension Foo {
  func foo(_ things: [T]) {
    // Break here
    for thing in things { print(thing) }
  }
}

struct Test: Foo {
  typealias T = Int
}

func main() {
  Test().foo([0,1,2,3])
}

main()
```
