### PR TITLE
[alloc-stack-hoisting] Handle alloc_stack [move] correctly.

### DIFF
--- a/lib/IRGen/AllocStackHoisting.cpp
+++ b/lib/IRGen/AllocStackHoisting.cpp
@@ -12,16 +12,21 @@
 
 #define DEBUG_TYPE "alloc-stack-hoisting"
 
-#include "swift/IRGen/IRGenSILPasses.h"
 #include "swift/AST/Availability.h"
-#include "swift/SILOptimizer/Analysis/Analysis.h"
-#include "swift/SILOptimizer/PassManager/Passes.h"
-#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/AST/IRGenOptions.h"
+#include "swift/AST/SemanticAttrs.h"
+#include "swift/IRGen/IRGenSILPasses.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/Dominance.h"
+#include "swift/SIL/LoopInfo.h"
+#include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/SILArgument.h"
-#include "swift/AST/SemanticAttrs.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 
 #include "IRGenModule.h"
 #include "NonFixedTypeInfo.h"
@@ -95,7 +100,22 @@ public:
   ///
   /// This assumes that the live ranges of the alloc_stack instructions are
   /// non-overlapping.
-  void assignStackLocation(SmallVectorImpl<SILInstruction *> &FunctionExits);
+  void assignStackLocation(
+      SmallVectorImpl<SILInstruction *> &FunctionExits,
+      SmallVectorImpl<DebugValueInst *> &DebugValueToBreakBlocksAt);
+
+  /// Returns true if any of the alloc_stack that we are merging were
+  /// moved. Causes us to insert extra debug addr.
+  ///
+  /// TODO: In the future we want to do this for /all/ alloc_stack but that
+  /// would require us moving /most of/ swift's IRGen emission to use
+  /// llvm.dbg.addr instead of llvm.dbg.declare and that would require us to do
+  /// statistics to make sure that we haven't hurt debuggability by making the
+  /// change.
+  bool hasMovedElt() const {
+    return llvm::any_of(Elts,
+                        [](AllocStackInst *asi) { return asi->getWasMoved(); });
+  }
 };
 } // end anonymous namespace
 
@@ -125,21 +145,40 @@ insertDeallocStackAtEndOf(SmallVectorImpl<SILInstruction *> &FunctionExits,
 
 /// Hack to workaround a clang LTO bug.
 LLVM_ATTRIBUTE_NOINLINE
-void moveAllocStackToBeginningOfBlock(AllocStackInst* AS, SILBasicBlock *BB) {
+void moveAllocStackToBeginningOfBlock(
+    AllocStackInst *AS, SILBasicBlock *BB, bool haveMovedElt,
+    SmallVectorImpl<DebugValueInst *> &DebugValueToBreakBlocksAt) {
+  // If we have var info, create the debug_value at the alloc_stack position and
+  // invalidate the alloc_stack's var info. This transfers the debug info state
+  // of the debug_value to the original position.
+  if (haveMovedElt) {
+    if (auto varInfo = AS->getVarInfo()) {
+      SILBuilderWithScope Builder(AS);
+      auto *DVI = Builder.createDebugValue(AS->getLoc(), AS, *varInfo);
+      DVI->markAsMoved();
+      DebugValueToBreakBlocksAt.push_back(DVI);
+      AS->invalidateVarInfo();
+      AS->markAsMoved();
+    }
+  }
   AS->moveFront(BB);
 }
 
 /// Assign a single alloc_stack instruction to all the alloc_stacks in the
 /// partition.
 void Partition::assignStackLocation(
-    SmallVectorImpl<SILInstruction *> &FunctionExits) {
+    SmallVectorImpl<SILInstruction *> &FunctionExits,
+    SmallVectorImpl<DebugValueInst *> &DebugValueToBreakBlocksAt) {
   assert(!Elts.empty() && "Must have a least one location");
+  bool hasAtLeastOneMovedElt = hasMovedElt();
+
   // The assigned location is the first alloc_stack in our partition.
   auto *AssignedLoc = Elts[0];
 
   // Move this assigned location to the beginning of the entry block.
   auto *EntryBB = AssignedLoc->getFunction()->getEntryBlock();
-  moveAllocStackToBeginningOfBlock(AssignedLoc, EntryBB);
+  moveAllocStackToBeginningOfBlock(AssignedLoc, EntryBB, hasAtLeastOneMovedElt,
+                                   DebugValueToBreakBlocksAt);
 
   // Erase the dealloc_stacks.
   eraseDeallocStacks(AssignedLoc);
@@ -153,6 +192,15 @@ void Partition::assignStackLocation(
     if (AssignedLoc == AllocStack) continue;
     eraseDeallocStacks(AllocStack);
     AllocStack->replaceAllUsesWith(AssignedLoc);
+    if (hasAtLeastOneMovedElt) {
+      if (auto VarInfo = AllocStack->getVarInfo()) {
+        SILBuilderWithScope Builder(AllocStack);
+        auto *DVI = Builder.createDebugValue(AllocStack->getLoc(), AssignedLoc,
+                                             *VarInfo);
+        DVI->markAsMoved();
+        DebugValueToBreakBlocksAt.push_back(DVI);
+      }
+    }
     AllocStack->eraseFromParent();
   }
 }
@@ -234,6 +282,13 @@ class MergeStackSlots {
   SmallVector<Partition, 2> PartitionByType;
   /// The function exits.
   SmallVectorImpl<SILInstruction *> &FunctionExits;
+  /// If we are merging any alloc_stack that were moved, to work around a bug in
+  /// SelectionDAG that sinks to llvm.dbg.addr, we need to break blocks right
+  /// after each llvm.dbg.addr.
+  ///
+  /// TODO: Once we have /any/ FastISel/better SelectionDAG support, this can be
+  /// removed.
+  SmallVector<DebugValueInst *, 4> DebugValueToBreakBlocksAt;
 
 public:
   MergeStackSlots(SmallVectorImpl<AllocStackInst *> &AllocStacks,
@@ -241,7 +296,7 @@ public:
 
   /// Merge alloc_stack instructions if possible and hoist them to the entry
   /// block.
-  void mergeSlots();
+  SILAnalysis::InvalidationKind mergeSlots(DominanceInfo *domToUpdate);
 };
 } // end anonymous namespace
 
@@ -264,7 +319,10 @@ MergeStackSlots::MergeStackSlots(SmallVectorImpl<AllocStackInst *> &AllocStacks,
 
 /// Merge alloc_stack instructions if possible and hoist them to the entry
 /// block.
-void MergeStackSlots::mergeSlots() {
+SILAnalysis::InvalidationKind
+MergeStackSlots::mergeSlots(DominanceInfo *DomToUpdate) {
+  auto Result = SILAnalysis::InvalidationKind::Instructions;
+
   for (auto &PartitionOfOneType : PartitionByType) {
     Liveness Live(PartitionOfOneType);
 
@@ -312,11 +370,26 @@ void MergeStackSlots::mergeSlots() {
     // Assign stack locations to disjoint partition hoisting alloc_stacks to the
     // entry block at the same time.
     for (auto &Par : DisjointPartitions) {
-      Par.assignStackLocation(FunctionExits);
+      Par.assignStackLocation(FunctionExits, DebugValueToBreakBlocksAt);
     }
   }
-}
 
+  // Now that we have finished merging slots/hoisting, break any blocks that we
+  // need to.
+  if (!DebugValueToBreakBlocksAt.empty()) {
+    auto &Mod = DebugValueToBreakBlocksAt.front()->getModule();
+    SILBuilderContext Context(Mod);
+    do {
+      auto *Next = DebugValueToBreakBlocksAt.pop_back_val();
+      splitBasicBlockAndBranch(Context, Next->getNextInstruction(), DomToUpdate,
+                               nullptr);
+    } while (!DebugValueToBreakBlocksAt.empty());
+
+    Result = SILAnalysis::InvalidationKind::BranchesAndInstructions;
+  }
+
+  return Result;
+}
 
 namespace {
 /// Hoist alloc_stack instructions to the entry block and merge them.
@@ -329,13 +402,20 @@ class HoistAllocStack {
   SmallVector<AllocStackInst *, 16> AllocStackToHoist;
   SmallVector<SILInstruction *, 8> FunctionExits;
 
+  Optional<SILAnalysis::InvalidationKind> InvalidationKind = None;
+
+  DominanceInfo *DomInfoToUpdate = nullptr;
+
 public:
   HoistAllocStack(SILFunction *F, irgen::IRGenModule &Mod)
       : F(F), IRGenMod(Mod) {}
 
-  /// Try to hoist generic alloc_stack instructions to the entry block.
-  /// Returns true if the function was changed.
-  bool run();
+  /// Try to hoist generic alloc_stack instructions to the entry block.  Returns
+  /// none if the function was not changed. Otherwise, returns the analysis
+  /// invalidation kind to use if the function was changed.
+  Optional<SILAnalysis::InvalidationKind> run();
+
+  void setDominanceToUpdate(DominanceInfo *DI) { DomInfoToUpdate = DI; }
 
 private:
   /// Collect generic alloc_stack instructions that can be moved to the entry
@@ -395,37 +475,38 @@ void HoistAllocStack::collectHoistableInstructions() {
 /// Hoist the alloc_stack instructions to the entry block and sink the
 /// dealloc_stack instructions to the function exists.
 void HoistAllocStack::hoist() {
-
   if (SILUseStackSlotMerging) {
     MergeStackSlots Merger(AllocStackToHoist, FunctionExits);
-    Merger.mergeSlots();
-  } else {
-    // Hoist alloc_stacks to the entry block and delete dealloc_stacks.
-    auto *EntryBB = F->getEntryBlock();
-    for (auto *AllocStack : AllocStackToHoist) {
-      // Insert at the beginning of the entry block.
-      AllocStack->moveFront(EntryBB);
-      // Delete dealloc_stacks.
-      eraseDeallocStacks(AllocStack);
-    }
-    // Insert dealloc_stack in the exit blocks.
-    for (auto *AllocStack : AllocStackToHoist) {
-      insertDeallocStackAtEndOf(FunctionExits, AllocStack);
-    }
+    InvalidationKind = Merger.mergeSlots(DomInfoToUpdate);
+    return;
+  }
+
+  // Hoist alloc_stacks to the entry block and delete dealloc_stacks.
+  auto *EntryBB = F->getEntryBlock();
+  for (auto *AllocStack : AllocStackToHoist) {
+    // Insert at the beginning of the entry block.
+    AllocStack->moveFront(EntryBB);
+    // Delete dealloc_stacks.
+    eraseDeallocStacks(AllocStack);
+    InvalidationKind = SILAnalysis::InvalidationKind::Instructions;
+  }
+  // Insert dealloc_stack in the exit blocks.
+  for (auto *AllocStack : AllocStackToHoist) {
+    insertDeallocStackAtEndOf(FunctionExits, AllocStack);
   }
 }
 
 /// Try to hoist generic alloc_stack instructions to the entry block.
 /// Returns true if the function was changed.
-bool HoistAllocStack::run() {
+Optional<SILAnalysis::InvalidationKind> HoistAllocStack::run() {
   collectHoistableInstructions();
 
   // Nothing to hoist?
   if (AllocStackToHoist.empty())
-    return false;
+    return {};
 
   hoist();
-  return true;
+  return InvalidationKind;
 }
 
 namespace {
@@ -434,9 +515,20 @@ class AllocStackHoisting : public SILFunctionTransform {
     auto *F = getFunction();
     auto *Mod = getIRGenModule();
     assert(Mod && "This pass must be run as part of an IRGen pipeline");
-    bool Changed = HoistAllocStack(F, *Mod).run();
-    if (Changed) {
-      PM->invalidateAnalysis(F, SILAnalysis::InvalidationKind::Instructions);
+
+    HoistAllocStack Hoist(F, *Mod);
+
+    // Update DomInfo when breaking. We don't use loop info right now this late,
+    // so we don't need to do that.
+    auto *DA = getAnalysis<DominanceAnalysis>();
+    if (DA->hasFunctionInfo(F))
+      Hoist.setDominanceToUpdate(DA->get(F));
+
+    auto InvalidationKind = Hoist.run();
+
+    if (InvalidationKind) {
+      AnalysisPreserver preserveDominance(DA);
+      PM->invalidateAnalysis(F, *InvalidationKind);
     }
   }
 };

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1484,6 +1484,9 @@ public:
 
     verifyOpenedArchetype(AI, AI->getElementType().getASTType());
 
+    require(!AI->isVarInfoInvalidated() || !bool(AI->getVarInfo()),
+            "AllocStack Var Info should be None if invalidated");
+
     // There used to be a check if all uses of ASI are inside the alloc-dealloc
     // range. But apparently it can be the case that ASI has uses after the
     // dealloc_stack. This can come up if the source contains a

--- a/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
+++ b/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
@@ -1,0 +1,257 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -alloc-stack-hoisting -opt-mode=none | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+// Make sure that we hoist the debug info and split its debug info into a
+// separate debug_value.
+//
+// CHECK-LABEL: sil @hoist_generic_1 :
+// CHECK: bb0({{.*}}):
+// Make sure the debug info isn't on the alloc_stack any more.
+// CHECK:   [[STACK:%.*]] = alloc_stack [moved] $T{{[ ]*}} // users:
+// CHECK: bb1:
+// CHECK:   debug_value [moved] [[STACK]] : $*T, let, name "x"
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: bb2:
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: dealloc_stack
+// CHECK: bb3:
+// CHECK: dealloc_stack
+// CHECK:   return
+sil @hoist_generic_1 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  cond_br %1, bb1, bb2
+
+bb1:
+  %2 = alloc_stack [moved] $T, let, name "x"
+  copy_addr [take] %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  br bb3
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+bb3:
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil @hoist_generic_2 :
+// CHECK: bb0([[ARG:%.*]] : $*T,
+// CHECK-NEXT:   [[STACK:%.*]] = alloc_stack [moved] $T{{[ ]*}} // users:
+// CHECK-NEXT:   cond_br {{%.*}}, bb1, bb4
+//
+// CHECK: bb1:
+// CHECK-NEXT:   debug_value [moved] [[STACK]] : $*T, let, name "x"
+// CHECK-NEXT:   br bb2
+//
+// CHECK: bb2:
+// CHECK:        debug_value [moved] [[STACK]] : $*T, let, name "y"
+// CHECK-NEXT:   br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   destroy_addr [[STACK]]
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb4:
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb5:
+// CHECK-NEXT: br bb6
+//
+// CHECK: bb6:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: dealloc_stack [[STACK]]
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'hoist_generic_2'
+sil @hoist_generic_2 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  cond_br %1, bb1, bb2
+
+bb1:
+  %2 = alloc_stack [moved] $T, let, name "x"
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %3 = alloc_stack [moved] $T, let, name "y"
+  copy_addr %0 to [initialization] %3 : $*T
+  destroy_addr %3 : $*T
+  dealloc_stack %3 : $*T
+  destroy_addr %0 : $*T
+  br bb3
+
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// This case we are not moving anything so we are leaving in the default
+// behavior which is not breaking blocks and not inserting debug_info.
+//
+// CHECK-LABEL: sil @hoist_generic_3 :
+// CHECK: bb0([[ARG:%.*]] : $*T,
+// CHECK-NEXT:   [[STACK:%.*]] = alloc_stack $T{{[ ]*}}, let, name "x"
+// CHECK-NOT:    debug_value
+// CHECK: } // end sil function 'hoist_generic_3'
+sil @hoist_generic_3 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  cond_br %1, bb1, bb2
+
+bb1:
+  %2 = alloc_stack $T, let, name "x"
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %3 = alloc_stack $T, let, name "y"
+  copy_addr %0 to [initialization] %3 : $*T
+  destroy_addr %3 : $*T
+  dealloc_stack %3 : $*T
+  destroy_addr %0 : $*T
+  br bb3
+
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+////////////////////////////////////////////////
+// Mix and Match Moved and Non Moved -> Moved //
+////////////////////////////////////////////////
+
+// CHECK-LABEL: sil @mix_and_match_1 :
+// CHECK: bb0([[ARG:%.*]] : $*T,
+// CHECK-NEXT:   [[STACK:%.*]] = alloc_stack [moved] $T{{[ ]*}} // users:
+// CHECK-NEXT:   cond_br {{%.*}}, bb1, bb4
+//
+// CHECK: bb1:
+// CHECK-NEXT:   debug_value [moved] [[STACK]] : $*T, let, name "x"
+// CHECK-NEXT:   br bb2
+//
+// CHECK: bb2:
+// CHECK:        debug_value [moved] [[STACK]] : $*T, let, name "y"
+// CHECK-NEXT:   br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   destroy_addr [[STACK]]
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb4:
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb5:
+// CHECK-NEXT: br bb6
+//
+// CHECK: bb6:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: dealloc_stack [[STACK]]
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'mix_and_match_1'
+sil @mix_and_match_1 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  cond_br %1, bb1, bb2
+
+bb1:
+  %2 = alloc_stack $T, let, name "x"
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %3 = alloc_stack [moved] $T, let, name "y"
+  copy_addr %0 to [initialization] %3 : $*T
+  destroy_addr %3 : $*T
+  dealloc_stack %3 : $*T
+  destroy_addr %0 : $*T
+  br bb3
+
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @mix_and_match_2 :
+// CHECK: bb0([[ARG:%.*]] : $*T,
+// CHECK-NEXT:   [[STACK:%.*]] = alloc_stack [moved] $T{{[ ]*}} // users:
+// CHECK-NEXT:   cond_br {{%.*}}, bb1, bb4
+//
+// CHECK: bb1:
+// CHECK-NEXT:   debug_value [moved] [[STACK]] : $*T, let, name "x"
+// CHECK-NEXT:   br bb2
+//
+// CHECK: bb2:
+// CHECK:        debug_value [moved] [[STACK]] : $*T, let, name "y"
+// CHECK-NEXT:   br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   destroy_addr [[STACK]]
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb4:
+// CHECK-NEXT:   destroy_addr [[ARG]]
+// CHECK-NEXT:   br bb5
+//
+// CHECK: bb5:
+// CHECK-NEXT: br bb6
+//
+// CHECK: bb6:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: dealloc_stack [[STACK]]
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'mix_and_match_2'
+sil @mix_and_match_2 : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  cond_br %1, bb1, bb2
+
+bb1:
+  %2 = alloc_stack [moved] $T, let, name "x"
+  copy_addr %0 to [initialization] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  %3 = alloc_stack $T, let, name "y"
+  copy_addr %0 to [initialization] %3 : $*T
+  destroy_addr %3 : $*T
+  dealloc_stack %3 : $*T
+  destroy_addr %0 : $*T
+  br bb3
+
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
This is just a quick fix to stop us from dropping live values such as m in the
following example:

```
public func addressOnlyVarTest<T : P>(_ x: T) {
    var k = x
    k.doSomething()
    let m = _move(k)
    m.doSomething()
    k = x
    k.doSomething()
}
```

Before this change, we would just drop m and one wouldn't even see it in the
debugger.

I am only doing this currently for cases where when we merge at least one
alloc_stack was moved. The reason why is that to implement this correctly, I
need to use llvm.dbg.addr and changing the debug info from using
llvm.dbg.declare -> llvm.dbg.addr requires statistics and needs to be done a
little later in the swift development process. If one of these alloc_stack had
the [moved] marker attached to it, we know the user /did/ use move so they have
in a sense opted into having a move function effect its program so we are only
changing how new code appears in the debugger.
