### PR TITLE
Mark stdlib/Assert-debugPrecondition-off.swift as REQUIRES: executable_test.

### DIFF
--- a/validation-test/stdlib/Assert-debugPrecondition-off.swift
+++ b/validation-test/stdlib/Assert-debugPrecondition-off.swift
@@ -10,6 +10,7 @@
 // RUN: %target-run %t/Assert_Unchecked | %FileCheck --check-prefixes=UNCHECKED %s
 
 // UNSUPPORTED: swift_stdlib_debug_preconditions_in_release
+// REQUIRES: executable_test
 
 // DEBUG: _isStdlibDebugChecksEnabled: true
 // RELEASE: _isStdlibDebugChecksEnabled: false


### PR DESCRIPTION
Failing in non_executable CI here: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-device-non_executable//35/console