### PR TITLE
[5.6] Fix invalid warning for enum cases named self

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4723,19 +4723,20 @@ static void diagUnqualifiedAccessToMethodNamedSelf(const Expr *E,
           if (auto typeContext = DC->getInnermostTypeContext()) {
             // self() is not easily confusable
             if (!isa<CallExpr>(Parent.getAsExpr())) {
-
               auto baseType = typeContext->getDeclaredInterfaceType();
-              auto baseTypeString = baseType.getString();
+              if (!baseType->getEnumOrBoundGenericEnum()) {
+                auto baseTypeString = baseType.getString();
 
-              Ctx.Diags.diagnose(E->getLoc(), diag::self_refers_to_method,
-                                 baseTypeString);
+                Ctx.Diags.diagnose(E->getLoc(), diag::self_refers_to_method,
+                    baseTypeString);
 
-              Ctx.Diags
+                Ctx.Diags
                   .diagnose(E->getLoc(),
-                            diag::fix_unqualified_access_member_named_self,
-                            baseTypeString)
+                      diag::fix_unqualified_access_member_named_self,
+                      baseTypeString)
                   .fixItInsert(E->getLoc(), diag::insert_type_qualification,
-                               baseType);
+                      baseType);
+              }
             }
           }
         }

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -116,3 +116,13 @@ struct TypeWithSelfProperty {
     
     let `self`: () = ()
 }
+
+enum EnumCaseNamedSelf {
+    case `self`
+
+    init() {
+        self = .self // OK
+        self = .`self` // OK
+        self = EnumCaseNamedSelf.`self` // OK
+    }
+}


### PR DESCRIPTION
https://github.com/apple/swift/pull/37992/ introduced a warning when you
were likely to confuse `self` with `TypeName.self`, this also applied to
enum cases that were named `self`, these cases should not be easily
confused at call sites since their use requires prefixing them with a
`.`. There was also no way to avoid this warning since other syntax such
as `TypeName.self`, which produces the enum type instead, or
`` TypeName.`self` `` which produced the same warning again.

Fixes #57970

(cherry picked from commit f6b2e2e40c17ead39b01cf7fc63e15f55483db38) / https://github.com/apple/swift/pull/41520