### PR TITLE
Disable a debugging assertion in the remote mirror MPE evaluation code

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -2032,18 +2032,19 @@ public:
 
             if (!spareBitsMask.isZero()) {
 
-#if !defined(NDEBUG)
-              // DEBUG ASSERTION: compare the locally-computed spare bit mask to the
-              // one we got from the compiler.  If they're different, then
-              // either the compiler is emitting the wrong thing or the
-              // local runtime computation isn't quite right.
+#if 0  // TODO: This should be !defined(NDEBUG)
+              // DEBUG verification that compiler mask and locally-computed
+              // mask are the same (whenever both are available).
               BitMask locallyComputedSpareBitsMask(PayloadSize);
               auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
               auto locallyComputedSpareBitsMaskIsValid
                 = populateSpareBitsMask(Cases, locallyComputedSpareBitsMask, mpePointerSpareBits);
-              // assert(locallyComputedSpareBitsMaskIsValid); // Until we expect local computation to always succeed
+              // If the local computation were always correct, we could:
+              // assert(locallyComputedSpareBitsMaskIsValid);
               if (locallyComputedSpareBitsMaskIsValid) {
-                // If we can compute a mask locally, it should match the compiler one
+                // Whenever the compiler and local computation both produce
+                // data, they should agree.
+                // TODO: Make this true, then change `#if 0` above
                 assert(locallyComputedSpareBitsMask == spareBitsMask);
               }
 #endif
@@ -2071,6 +2072,9 @@ public:
         BitMask spareBitsMask(PayloadSize);
         auto mpePointerSpareBits = TC.getBuilder().getMultiPayloadEnumPointerMask();
         auto validSpareBitsMask = populateSpareBitsMask(Cases, spareBitsMask, mpePointerSpareBits);
+        // For DEBUGGING, disable fallback to local computation to
+        // make missing compiler data more obvious:
+        // validSpareBitsMask = false;
         if (!validSpareBitsMask) {
           // If we couldn't correctly determine the spare bits mask,
           // return a TI that will always fail when asked for XIs or value.


### PR DESCRIPTION
Background:  There are two sources of truth for the MPE spare bit mask in this code:

* The MPE reflection record which has a bit mask computed by the compiler.
  This should always be correct.

* A local computation within the RemoteMirror library.
  This is known to be incomplete, but is _supposed_ to fail cleanly
  when it hits a case it can't handle.

We need both of the above:  The first should always be accurate
so we obviously prefer it.  But old binaries don't have that data,
so we need the fallback computation.

When both of the above are available, they should agree, but apparently
the local computation still doesn't understand what it doesn't understand.

Resolves rdar://89360996

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
