### PR TITLE
[cxx interop] Fix issue where const overloaded disambiguated methods were not in the lookup table

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3651,16 +3651,6 @@ namespace {
         }
       }
 
-      //
-//      for (auto &cxxMethod : Impl.cxxMethods) {
-//        for (auto &mutFuncPtr : cxxMethod.getSecond().second) {
-//          Decl *member =
-//              Impl.importDecl(mutFuncPtr->getUnderlyingDecl(),
-//                              getActiveSwiftVersion());
-//            if(member)
-//              result->addMemberToLookupTable(member);
-//        }
-//      }
       result->setMemberLoader(&Impl, 0);
       return result;
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3334,7 +3334,7 @@ namespace {
       // Track whether this record contains fields we can't reference in Swift
       // as stored properties.
       bool hasUnreferenceableStorage = false;
-      
+
       // Track whether this record contains fields that can't be zero-
       // initialized.
       bool hasZeroInitializableStorage = true;
@@ -3444,11 +3444,12 @@ namespace {
       // that differ this way so we can disambiguate later
       for (auto m : decl->decls()) {
         if (auto method = dyn_cast<clang::CXXMethodDecl>(m)) {
-          if(method->getDeclName().isIdentifier()) {
-            if(Impl.cxxMethods.find(method->getName()) == Impl.cxxMethods.end()) {
+          if (method->getDeclName().isIdentifier()) {
+            if (Impl.cxxMethods.find(method->getName()) ==
+                Impl.cxxMethods.end()) {
               Impl.cxxMethods[method->getName()] = {};
             }
-            if(method->isConst()) {
+            if (method->isConst()) {
               // Add to const set
               Impl.cxxMethods[method->getName()].first.insert(method);
             } else {
@@ -3478,8 +3479,8 @@ namespace {
 
         if (auto field = dyn_cast<clang::FieldDecl>(nd)) {
           // Non-nullable pointers can't be zero-initialized.
-          if (auto nullability = field->getType()
-                ->getNullability(Impl.getClangASTContext())) {
+          if (auto nullability =
+                  field->getType()->getNullability(Impl.getClangASTContext())) {
             if (*nullability == clang::NullabilityKind::NonNull)
               hasZeroInitializableStorage = false;
           }
@@ -3522,6 +3523,18 @@ namespace {
         }
 
         if (auto MD = dyn_cast<FuncDecl>(member)) {
+
+          // When 2 CXXMethods diff by "constness" alone we differentiate them
+          // by changing the name of one. That changed method needs to be added
+          // to the lookup table since it cannot be found lazily.
+          if (auto cxxMethod = dyn_cast<clang::CXXMethodDecl>(m)) {
+            if (cxxMethod->getDeclName().isIdentifier()) {
+              auto &mutableFuncPtrs = Impl.cxxMethods[cxxMethod->getName()].second;
+              if(mutableFuncPtrs.contains(cxxMethod)) {
+                result->addMemberToLookupTable(member);
+              }
+            }
+          }
           methods.push_back(MD);
           continue;
         }
@@ -3596,10 +3609,10 @@ namespace {
         //
         // If we can completely represent the struct in SIL, leave the body
         // implicit, otherwise synthesize one to call property setters.
-        auto valueCtor = createValueConstructor(
-            Impl, result, members,
-            /*want param names*/true,
-            /*want body*/hasUnreferenceableStorage);
+        auto valueCtor =
+            createValueConstructor(Impl, result, members,
+                                   /*want param names*/ true,
+                                   /*want body*/ hasUnreferenceableStorage);
         if (!hasUnreferenceableStorage)
           valueCtor->setIsMemberwiseInitializer();
 
@@ -3630,14 +3643,24 @@ namespace {
             continue;
 
           auto getterAndSetter = subscriptInfo.second;
-          auto subscript = makeSubscript(getterAndSetter.first,
-                                         getterAndSetter.second);
+          auto subscript =
+              makeSubscript(getterAndSetter.first, getterAndSetter.second);
           // Also add subscripts directly because they won't be found from the
           // clang decl.
           result->addMember(subscript);
         }
       }
 
+      //
+//      for (auto &cxxMethod : Impl.cxxMethods) {
+//        for (auto &mutFuncPtr : cxxMethod.getSecond().second) {
+//          Decl *member =
+//              Impl.importDecl(mutFuncPtr->getUnderlyingDecl(),
+//                              getActiveSwiftVersion());
+//            if(member)
+//              result->addMemberToLookupTable(member);
+//        }
+//      }
       result->setMemberLoader(&Impl, 0);
       return result;
     }

--- a/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
@@ -3,10 +3,6 @@
 
 struct HasAmbiguousMethods {
 
-  // No input
-  void ping() { ++mutableMethodsCalledCount; }
-  void ping() const {}
-
   // One input (const first)
   int increment(int a) const {
     return a + 1;

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=AmbiguousMethods -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// CHECK: mutating func pingMutating()
-// CHECK: func ping()
-
 // CHECK: func increment(_ a: Int32) -> Int32
 // CHECK: mutating func incrementMutating(_ a: Int32) -> Int32
 

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -8,20 +8,37 @@ import AmbiguousMethods
 
 var CxxAmbiguousMethodTestSuite = TestSuite("CxxAmbiguousMethods")
 
+// It's important to check that both calling the const version first
+// and the mutable version first pass. This helps confirm that the lookup
+// table is being properly seeded.
+CxxAmbiguousMethodTestSuite.test("ping const first") {
+  var instance = HasAmbiguousMethods()
+
+  instance.ping()
+  instance.pingMutable()
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
+CxxAmbiguousMethodTestSuite.test("ping mutable first") {
+  var instance = HasAmbiguousMethods()
+
+  instance.pingMutable()
+  instance.ping()
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+}
+
 CxxAmbiguousMethodTestSuite.test("numberOfMutableMethodsCalled: () -> Int") {
   var instance = HasAmbiguousMethods()
 
   // Sanity check. Make sure we start at 0
+  // and that calling numberOfMutableMethodsCalled doesn't change
+  // the count
   expectEqual(0, instance.numberOfMutableMethodsCalled())
-
-  // Make sure calling numberOfMutableMethodsCalled above didn't
-  // change the count
   expectEqual(0, instance.numberOfMutableMethodsCalled())
 
   // Check that mutable version _does_ change the mutable call count
+  expectEqual(0, instance.numberOfMutableMethodsCalled())
   expectEqual(1, instance.numberOfMutableMethodsCalledMutating())
-
-  expectEqual(1, instance.numberOfMutableMethodsCalled())
 }
 
 CxxAmbiguousMethodTestSuite.test("Basic Increment: (Int) -> Int") {

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -11,23 +11,7 @@ var CxxAmbiguousMethodTestSuite = TestSuite("CxxAmbiguousMethods")
 // It's important to check that both calling the const version first
 // and the mutable version first pass. This helps confirm that the lookup
 // table is being properly seeded.
-CxxAmbiguousMethodTestSuite.test("ping const first") {
-  var instance = HasAmbiguousMethods()
-
-  instance.ping()
-  instance.pingMutable()
-  expectEqual(1, instance.numberOfMutableMethodsCalled())
-}
-
-CxxAmbiguousMethodTestSuite.test("ping mutable first") {
-  var instance = HasAmbiguousMethods()
-
-  instance.pingMutable()
-  instance.ping()
-  expectEqual(1, instance.numberOfMutableMethodsCalled())
-}
-
-CxxAmbiguousMethodTestSuite.test("numberOfMutableMethodsCalled: () -> Int") {
+CxxAmbiguousMethodTestSuite.test("[Const First] numberOfMutableMethodsCalled: () -> Int") {
   var instance = HasAmbiguousMethods()
 
   // Sanity check. Make sure we start at 0
@@ -39,6 +23,15 @@ CxxAmbiguousMethodTestSuite.test("numberOfMutableMethodsCalled: () -> Int") {
   // Check that mutable version _does_ change the mutable call count
   expectEqual(0, instance.numberOfMutableMethodsCalled())
   expectEqual(1, instance.numberOfMutableMethodsCalledMutating())
+}
+
+CxxAmbiguousMethodTestSuite.test("[Mutable First] numberOfMutableMethodsCalled: () -> Int") {
+  var instance = HasAmbiguousMethods()
+
+  // Call mutable first
+  expectEqual(1, instance.numberOfMutableMethodsCalledMutating())
+  expectEqual(1, instance.numberOfMutableMethodsCalled())
+
 }
 
 CxxAmbiguousMethodTestSuite.test("Basic Increment: (Int) -> Int") {


### PR DESCRIPTION
When disambiguating Cxx const and mutable overloaded methods the mutable version would fail since it was missing for the lookup table. To fix this, post import, find those decls that are cxxMethods and explicitly add them to the lookup table if they are the mutable versions.

Note: This PR may end up not being needed depending on how we settle on disambiguating const overloaded methods.