### PR TITLE
Sema: Reject 'any P' in inheritance clause

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2784,9 +2784,11 @@ WARNING(anyobject_class_inheritance_deprecated,Deprecation,
 ERROR(multiple_inheritance,none,
   "multiple inheritance from classes %0 and %1", (Type, Type))
 ERROR(inheritance_from_non_protocol_or_class,none,
-  "inheritance from non-protocol, non-class type %0", (Type))
+  "inheritance from non-protocol, non-class type '%0'", (StringRef))
 ERROR(inheritance_from_non_protocol,none,
-  "inheritance from non-protocol type %0", (Type))
+  "inheritance from non-protocol type '%0'", (StringRef))
+ERROR(inheritance_from_anyobject,none,
+  "only protocols can inherit from 'AnyObject'", ())
 ERROR(inheritance_from_parameterized_protocol,none,
   "cannot inherit from protocol type with generic argument %0", (Type))
 ERROR(superclass_not_first,none,

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -142,8 +142,8 @@ Type EnumRawTypeRequest::evaluate(Evaluator &evaluator,
     auto &inheritedType = *inheritedTypeResult;
     if (!inheritedType) continue;
 
-    // Skip existential types.
-    if (inheritedType->isExistentialType()) continue;
+    // Skip protocol conformances.
+    if (inheritedType->isConstraintType()) continue;
 
     // We found a raw type; return it.
     return inheritedType;

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -105,20 +105,20 @@ extension ExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'Exp
 // ---------------------------------------------------------------------------
 // Suppression of synthesized conformances
 // ---------------------------------------------------------------------------
-class SynthesizedClass1 : AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedClass1 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 class SynthesizedClass2 { }
-extension SynthesizedClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension SynthesizedClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 class SynthesizedClass3 : AnyObjectRefinement { }
 
 class SynthesizedClass4 { }
 extension SynthesizedClass4 : AnyObjectRefinement { }
 
-class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 class SynthesizedSubClass2 : SynthesizedClass2 { }
-extension SynthesizedSubClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension SynthesizedSubClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 class SynthesizedSubClass3 : SynthesizedClass1, AnyObjectRefinement { }
 
@@ -169,12 +169,12 @@ extension MFExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'M
 // ---------------------------------------------------------------------------
 class MFSynthesizedClass1 { }
 
-extension MFSynthesizedClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MFSynthesizedClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 class MFSynthesizedClass4 { }
 extension MFSynthesizedClass4 : AnyObjectRefinement { }
 
-extension MFSynthesizedSubClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MFSynthesizedSubClass2 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 extension MFSynthesizedSubClass3 : AnyObjectRefinement { }
 
@@ -198,7 +198,7 @@ extension MMSuper1 : MMP1 { } // expected-warning{{conformance of 'MMSuper1' to 
 extension MMSuper1 : MMP2a { } // expected-warning{{conformance of 'MMSuper1' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSuper1 : MMP3b { } // okay
 
-extension MMSub1 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MMSub1 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 extension MMSub2 : MMP1 { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
 extension MMSub2 : MMP2a { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
@@ -209,7 +209,7 @@ extension MMSub2 : MMAnyObjectRefinement { } // okay
 extension MMSub3 : MMP1 { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
 extension MMSub3 : MMP2a { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSub3 : MMP3b { } // okay
-extension MMSub3 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MMSub3 : AnyObject { } // expected-error{{only protocols can inherit from 'AnyObject'}}
 
 extension MMSub4 : MMP1 { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP1' was already stated in the type's module 'placement_module_B'}}
 extension MMSub4 : MMP2a { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP2a' was already stated in the type's module 'placement_module_B'}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -257,3 +257,24 @@ func testConstraintAlias(x: Constraint) {} // expected-warning{{'Constraint' (ak
 
 typealias Existential = any Input
 func testExistentialAlias(x: Existential, y: any Constraint) {}
+
+// Reject explicit existential types in inheritance clauses
+protocol Empty {}
+
+struct S : any Empty {} // expected-error {{inheritance from non-protocol type 'any Empty'}}
+class C : any Empty {} // expected-error {{inheritance from non-protocol, non-class type 'any Empty'}}
+
+// FIXME: Diagnostics are not great in the enum case because we confuse this with a raw type
+
+enum E : any Empty { // expected-error {{raw type 'Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'E' declares raw type 'Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'Empty' is not Equatable}}
+  case hack
+}
+
+enum EE : Equatable, any Empty { // expected-error {{raw type 'Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'EE' declares raw type 'Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'Empty' is not Equatable}}
+// expected-error@-3 {{raw type 'Empty' must appear first in the enum inheritance clause}}
+  case hack
+}


### PR DESCRIPTION
This uncovers another issue, where `@unchecked Sendable` resolves as `any Sendable` rather than `Sendable`, so fix that by using the correct TypeResolverContext.


Resolves #56304.