### PR TITLE
Fix a use-after-free with task tracing

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1540,7 +1540,7 @@ static void swift_job_runImpl(Job *job, ExecutorRef executor) {
   SWIFT_TASK_DEBUG_LOG("%s(%p)", __func__, job);
   runJobInEstablishedExecutorContext(job);
 
-  concurrency::trace::job_run_end(job, &executor, traceHandle);
+  concurrency::trace::job_run_end(&executor, traceHandle);
   trackingInfo.leave();
 
   // Give up the current executor if this is a switching context

--- a/stdlib/public/Concurrency/Tracing.h
+++ b/stdlib/public/Concurrency/Tracing.h
@@ -75,11 +75,22 @@ void job_enqueue_global_with_delay(unsigned long long delay, Job *job);
 
 void job_enqueue_main_executor(Job *job);
 
-// This returns a handle that must be passed to the corresponding call to
-// task_run_end.
-uint64_t job_run_begin(Job *job, ExecutorRef *executor);
+struct job_run_info {
+  /// The ID of the task that started running.
+  uint64_t taskId;
 
-void job_run_end(Job *job, ExecutorRef *executor, uint64_t beginHandle);
+  /// The signpost ID for this task execution, or OS_SIGNPOST_ID_INVALID
+  /// if the job was not a task.
+  uint64_t handle;
+};
+
+// This returns information that must be passed to the corresponding
+// call to task_run_end.  Any information we want to log must be
+// extracted from the job when we start to run it because execution
+// will invalidate the job.
+job_run_info job_run_begin(Job *job, ExecutorRef *executor);
+
+void job_run_end(ExecutorRef *executor, job_run_info info);
 
 } // namespace trace
 } // namespace concurrency

--- a/stdlib/public/Concurrency/TracingStubs.h
+++ b/stdlib/public/Concurrency/TracingStubs.h
@@ -60,9 +60,9 @@ inline void job_enqueue_global_with_delay(unsigned long long delay, Job *job) {}
 
 inline void job_enqueue_main_executor(Job *job) {}
 
-inline uint64_t job_run_begin(Job *job, ExecutorRef *executor) { return 0; }
+inline job_run_info job_run_begin(Job *job, ExecutorRef *executor) { return {}; }
 
-inline void job_run_end(Job *job, ExecutorRef *executor, uint64_t beginHandle) {
+inline void job_run_end(ExecutorRef *executor, job_run_info info) {
 }
 
 } // namespace trace


### PR DESCRIPTION
   
We cannot access the executed job after it has finished executing:
    
- If it's a non-task job, it is always invalidated; such jobs are self-owning, and they are expected to destroy themselves after execution.
    
- If it's a task, and it completes during execution, it will invalidate itself synchronously, e.g. by releasing itself.  At this point, it must be assumed that the task memory has been releaed.
    
- If it's a task, and it hasn't completed during execution, we are now racing with whatever event *does* complete the task.
    
Any information we want to log about the job must be recorded when it starts to run.
    
Fixes rdar://88817560
