### PR TITLE
swift-inspect: add some documentation

### DIFF
--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -1,3 +1,43 @@
 # swift-inspect
 
-A description of this package.
+swift-inspect is a debugging tool which allows you to inspect a live Swift process to gain insight into the runtime interactions of the application.
+
+swift-inspect uses the reflection APIs to introspect the live process.  It relies on the swift remote mirror library to remotely reconstruct data types.
+
+### Building
+
+swift-inspect can be built using [swift-package-manager](https://github.com/apple/swift-package-manager).
+
+##### Windows
+
+In order to build on Windows, some additional parameters must be passed to the build tool to locate the necessary libraries.
+
+~~~
+swift build -Xcc -I%DEVELOPER_DIR%\Toolchains\unknown-Asserts-development.xctoolchain\usr\include\swift\SwiftRemoteMirror -Xlinker %DEVELOPER_DIR%\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib
+~~~
+
+### Using
+
+The following inspection operations are available currently.
+
+##### All Platforms
+
+dump-cache-nodes &lt;name-or-pid&gt;
+: Print the metadata cache nodes.
+
+dump-conformance-cache &lt;name-or-pid&gt;
+: Print the content of the protocol conformance cache.
+
+dump-generic-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
+: Print generic metadata allocations.
+
+dump-raw-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
+: Print metadata allocations.
+
+##### Darwin Only
+
+dump-arrays &lt;name-or-pid&gt;
+: Print information about array objects in the target
+
+dump-concurrency &lt;name-or-pid&gt;
+: Print information about tasks, actors, and threads under Concurrency.


### PR DESCRIPTION
This adds some documentation about swift-inspect and how to build it on
Windows, which requires additional flags to locate the SwiftRemoteMirror
library from the toolchain.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
