### PR TITLE
[MemAccessUtils] Corrected inverted condition.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -405,13 +405,13 @@ static bool isBarrierApply(FullApplySite) {
 static bool mayAccessPointer(SILInstruction *instruction) {
   if (!instruction->mayReadOrWriteMemory())
     return false;
-  bool fail = false;
-  visitAccessedAddress(instruction, [&fail](Operand *operand) {
+  bool isUnidentified = false;
+  visitAccessedAddress(instruction, [&isUnidentified](Operand *operand) {
     auto accessStorage = AccessStorage::compute(operand->get());
-    if (accessStorage.getKind() != AccessRepresentation::Kind::Unidentified)
-      fail = true;
+    if (accessStorage.getKind() == AccessRepresentation::Kind::Unidentified)
+      isUnidentified = true;
   });
-  return fail;
+  return isUnidentified;
 }
 
 static bool mayLoadWeakOrUnowned(SILInstruction *instruction) {

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -327,6 +327,25 @@ exit:
   return %321 : $()
 }
 
+// Hoist a destroy_addr of an @in argument over a load from an alloc_stack.
+//
+// CHECK-LABEL: sil [ossa] @test_hoist_over_load_from_stack : {{.*}} {
+// CHECK:         apply
+// CHECK:         destroy_addr
+// CHECK:         load [take]
+// CHECK-LABEL: } // end sil function 'test_hoist_over_load_from_stack'
+sil [ossa] @test_hoist_over_load_from_stack : $@convention(thin) (@in X) -> @owned X {
+entry(%in_addr : $*X):
+  %stack_addr = alloc_stack $X
+  copy_addr %in_addr to [initialization] %stack_addr : $*X
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  %retval = load [take] %stack_addr : $*X
+  destroy_addr %in_addr : $*X
+  dealloc_stack %stack_addr : $*X
+  return %retval : $X
+}
+
 // Fold destroy_addr and a load [copy] into a load [take] even when that
 // load [take] is guarded by an access scope.
 //
@@ -442,9 +461,10 @@ entry(%instance : @owned $S):
 }
 
 // Don't fold with an unrelated load [copy].
+//
 // CHECK-LABEL: sil [ossa] @nofold_unrelated_scoped_load_copy : {{.*}} {
-// CHECK:         load [copy] 
 // CHECK:         destroy_addr
+// CHECK:         load [copy] 
 // CHECK:         destroy_addr
 // CHECK-LABEL: // end sil function 'nofold_unrelated_scoped_load_copy'
 sil [ossa] @nofold_unrelated_scoped_load_copy : $@convention(thin) (@owned X) -> (@owned X) {

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -581,18 +581,21 @@ entry(%instance_c: @owned $C, %instance_d: @owned $D):
     return %instance_c : $C
 }
 
-// Don't hoist over store to an address which itself is (earlier) stored into a
-// field of the object being borrowed.
-// TODO: Eventually, we should be able to hoist over such a store.
-// CHECK-LABEL: sil [ossa] @hoist_over_load : $@convention(thin) () -> () {
-// CHECK:        [[D:%[^,]+]] = alloc_ref $PointerWrapper                  
-// CHECK:        [[LIFETIME:%[^,]+]] = begin_borrow [[D]] : $PointerWrapper          
-// CHECK:        [[ADDR:%[^,]+]] = alloc_stack $PointedTo                     
-// CHECK:        [[C:%[^,]+]] = alloc_ref $PointedTo                       
-// CHECK:        store [[C]] to [init] [[ADDR]] : $*PointedTo             
-// CHECK-NEXT:    end_borrow [[LIFETIME]] : $PointerWrapper                 
-// CHECK-LABEL: } // end sil function 'hoist_over_load'
-sil [ossa] @hoist_over_load : $@convention(thin) () -> () {
+// Hoist over store to unrelated stack address.  Do not hoist over store to
+// field of lifetime.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_store : $@convention(thin) () -> () {
+// CHECK:        [[D:%[^,]+]] = alloc_ref $PointerWrapper
+// CHECK:        [[LIFETIME:%[^,]+]] = begin_borrow [[D]] : $PointerWrapper
+// CHECK:        [[ADDR:%[^,]+]] = alloc_stack $PointedTo
+// CHECK:        [[PTR:%[^,]+]] = address_to_pointer [[ADDR]]
+// CHECK:        [[FIELD:%[^,]+]] = ref_element_addr [[LIFETIME]]
+// CHECK:        store [[PTR]] to [trivial] [[FIELD]]
+// CHECK:        end_borrow [[LIFETIME]] : $PointerWrapper
+// CHECK:        [[C:%[^,]+]] = alloc_ref $PointedTo
+// CHECK:        store [[C]] to [init] [[ADDR]] : $*PointedTo
+// CHECK-LABEL: } // end sil function 'hoist_over_store'
+sil [ossa] @hoist_over_store : $@convention(thin) () -> () {
 bb0:
   %d = alloc_ref $PointerWrapper
   %lifetime = begin_borrow %d : $PointerWrapper


### PR DESCRIPTION
The function mayAccessPointer is attempting to determine whether the specified instruction accesses a raw/unsafe pointer of unknown provenance.  To do that, it visits all the address operands and checks whether any of them have an ::Unidentified access representation kind.

Previously, the condition was inverted: all address uses _except_ those whose kinds were unidentified were judged to be potential accessors to raw/unsafe pointers.  Here that's fixed by inverting the condition.  To help clarify things, the variable name is changed too.
