### PR TITLE
swift-inspect: more typo/correctness fixes

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -151,8 +151,10 @@ extension DarwinRemoteProcess {
                                      UnsafeMutableRawPointer(mutating: $0),
                                      CUnsignedInt(MALLOC_PTR_IN_USE_RANGE_TYPE),
                                      { (task, context, type, ranges, count) in
+          let callback: (swift_addr_t, UInt64) -> Void =
+              context!.assumingMemoryBound(to: ((swift_addr_t, UInt64) -> Void).self).pointee
           ranges.forEach {
-            body(swift_addr_t($0.address), UInt64($0.size))
+            callback(swift_addr_t($0.address), UInt64($0.size))
           }
         })
       }

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import ArgumentParser
+import SwiftRemoteMirror
 
 internal struct DumpArrays: ParsableCommand {
   static let configuration = CommandConfiguration(
@@ -23,14 +25,20 @@ internal struct DumpArrays: ParsableCommand {
     try inspect(process: options.nameOrPid) { process in
       print("Address", "Size", "Count", "Is Class", separator: "\t")
       process.iterateHeap { (allocation, size) in
-        let metadata: swift_reflectioN_ptr_t =
+        let metadata: UInt =
             swift_reflection_metadataForObject(process.context, UInt(allocation))
         if metadata == 0 { return }
-        guard process.context.isContiguousArray(metadata: metadata) else { return }
+        guard process.context.isContiguousArray(swift_reflection_ptr_t(metadata)) else {
+          return
+        }
 
-        let isClass = process.context.isArrayOfClass(metdata)
+        let ReadBytes: RemoteProcess.ReadBytesFunction =
+            type(of: process).ReadBytes
+        let this = process.toOpaqueRef()
+
+        let isClass = process.context.isArrayOfClass(swift_reflection_ptr_t(metadata))
         let count = process.context.arrayCount(swift_reflection_ptr_t(allocation),
-                                               process.ReadBytes)
+                                               { ReadBytes(this, $0, UInt64($1), nil) })
         print("\(hex: swift_reflection_ptr_t(allocation))\t\(size)\t\(count.map(String.init) ?? "<unknown>")\t\(isClass)")
       }
     }


### PR DESCRIPTION
This cleans up the DumpArray operation and fixes an unintentional,
undesirable change to the heap iteration on Darwin.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
