### PR TITLE
Sema: Warn about non-final classes conforming to protocols with a same-type requirement on 'Self'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1942,6 +1942,11 @@ ERROR(type_does_not_conform,none,
 WARNING(type_does_not_conform_swiftui_warning,none,
         "type %0 does not conform to protocol %1", (Type, Type))
 
+ERROR(non_final_class_cannot_conform_to_self_same_type,none,
+      "non-final class %0 cannot safely conform to protocol %1, "
+      "which requires that 'Self' is exactly equal to %2",
+      (Type, Type, Type))
+
 ERROR(cannot_use_nil_with_this_type,none,
       "'nil' cannot be used in context expecting type %0", (Type))
 

--- a/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
+++ b/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
@@ -9,7 +9,11 @@ public protocol Q {
   associatedtype B
 }
 
+// This is rejected, because 'A.B == Self' means that 'Self' must
+// exactly equal C; since C is not final, this means the conformance
+// is not covariant.
 public class C : P {
+// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self' is exactly equal to 'Self.A.B'; this is an error in Swift 6}}
   public typealias A = D
 }
 

--- a/test/Generics/rdar80503090.swift
+++ b/test/Generics/rdar80503090.swift
@@ -19,6 +19,7 @@ extension P where T : Q {
 }
 
 class C : P {}
+// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self' is exactly equal to 'Self.T'; this is an error in Swift 6}}
 
 extension P where T : C {
   // CHECK-LABEL: Generic signature: <Self where Self == C>

--- a/validation-test/compiler_crashers_2_fixed/0189-sr10033.swift
+++ b/validation-test/compiler_crashers_2_fixed/0189-sr10033.swift
@@ -14,7 +14,9 @@ extension P2 {
 }
 
 class C1 : P1 {
+// expected-warning@-1 {{non-final class 'C1' cannot safely conform to protocol 'P1', which requires that 'Self' is exactly equal to 'Self.A2.A1'; this is an error in Swift 6}}
   class A2 : P2 {
+  // expected-warning@-1 {{non-final class 'C1.A2' cannot safely conform to protocol 'P2', which requires that 'Self' is exactly equal to 'Self.A1.A2'; this is an error in Swift 6}}
     typealias A1 = C1
   }
 }


### PR DESCRIPTION
This is unsound because it breaks covariance of protocol conformances
on classes. See the test case and changelog entry for details.