### PR TITLE
[Importer] Wrap the VFS passed to Clang with an overlay FS instead

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1099,8 +1099,7 @@ ClangImporter::create(ASTContext &ctx,
 
   // Wrap Swift's FS to allow Clang to override the working directory
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-      llvm::vfs::RedirectingFileSystem::create({}, true,
-                                               *ctx.SourceMgr.getFileSystem());
+    new llvm::vfs::OverlayFileSystem(ctx.SourceMgr.getFileSystem());
 
   // Create a new Clang compiler invocation.
   {

--- a/test/SourceKit/CursorInfo/cursor_overlay.swift
+++ b/test/SourceKit/CursorInfo/cursor_overlay.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// RUN: sed -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/A@g" -e "s@NAME_DIR@%{/t:regex_replacement}/B@g" %t/base.yaml > %t/overlay.yaml
+
+//--- use.swift
+import MyMod
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+3):13 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-A %s
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+2):22 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-B %s
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):31 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-C %s
+func f(arg: A, arg2: B, arg3: C) {}
+
+//--- A/A.h
+// CHECK-A: source.lang.swift.ref.struct ({{.*}}{{/|\\}}A{{/|\\}}A.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct A {
+  int a;
+};
+
+//--- A/B.h
+
+//--- A/C.h
+// CHECK-C: source.lang.swift.ref.struct ({{.*}}{{/|\\}}A{{/|\\}}C.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct C {
+  int c;
+};
+
+//--- B/B.h
+#include "C.h"
+
+// CHECK-B: source.lang.swift.ref.struct ({{.*}}{{/|\\}}B{{/|\\}}B.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct B {
+  int b;
+};
+
+//--- B/module.modulemap
+module MyMod {
+  header "A.h"
+  header "B.h"
+}
+
+//--- base.yaml
+{
+  version: 0,
+  redirecting-with: "fallback",
+  use-external-names: true,
+  roots: [
+    {
+      type: "directory-remap",
+      name: "NAME_DIR",
+      external-contents: "EXTERNAL_DIR"
+    }
+  ]
+}
+


### PR DESCRIPTION
`OverlayFileSystem` is very simple - it just passes along each request
to each VFS it contains until one is successful (or none are). Use it
when wrapping the VFS to pass down into the Clang invocation creation,
instead of the much more complicated `RedirectingFileSystem`.

This has the side effect of also fixing a case where due to a bug in
`RedirectingFileSystem`, the originally passed in path will be returned
regardless of `use-external-name`. While that should also be fixed,
there is no reason to use this VFS here anyway.

Added a small cursor info test case that should catch issues like this
in the future.