### PR TITLE
[CMake] Merge Clang's features file with Swift's

### DIFF
--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -6,16 +6,20 @@ add_dependencies(swiftOption
 target_link_libraries(swiftOption PRIVATE
   swiftBasic)
 
-set(features_file_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
+set(features_merger "${SWIFT_SOURCE_DIR}/utils/merge-features.py")
+set(features_file_swift_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
+set(features_file_clang_src "${LLVM_MAIN_SRC_DIR}/../clang/tools/driver/features.json")
 set(features_file_dest "${CMAKE_BINARY_DIR}/share/swift/features.json")
 
 add_custom_command(
   OUTPUT
     ${features_file_dest}
   COMMAND
-    ${CMAKE_COMMAND} -E copy ${features_file_src} ${features_file_dest}
+    ${features_merger} -f ${features_file_swift_src} -p \"\" -f ${features_file_clang_src} -p clang- ${features_file_dest}
   DEPENDS
-    ${features_file_src}
+    ${features_merger}
+    ${features_file_swift_src}
+    ${features_file_clang_src}
 )
 
 add_custom_target(swift-features-file DEPENDS ${features_file_dest})

--- a/utils/merge-features.py
+++ b/utils/merge-features.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+
+
+def error(message):
+    sys.stderr.write(message)
+    sys.stderr.write("\n")
+    sys.exit(1)
+
+
+def invalid_file(features_file, message):
+    error(f"Invalid features file '{features_file}': {message}")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
+        Merges the given feature files together into DEST (or stdout if DEST
+        is not given). Each file FILE must be given a corresponding PREFIX to
+        prefix the name of each entry in its features list, though these could
+        be empty if no prefix is required.
+
+        Note that the files and prefixes are treated as an ordered list, ie.
+        the first FILE corresponds to the first PREFIX.
+        """)
+
+    parser.add_argument(
+        "--file", "-f", action="append", dest="files",
+        help="path of a file to merge"
+    )
+    parser.add_argument(
+        "--prefix", "-p", action="append", dest="prefixes",
+        help="prefix to prepend to the name of each feature"
+    )
+    parser.add_argument(
+        "dest", nargs="?",
+        help="path to store the merged file"
+    )
+
+    return parser.parse_known_args()
+
+
+def read_features(from_file, add_prefix):
+    with open(from_file, "r") as f:
+        features_dict = json.load(f)
+
+    if "features" not in features_dict:
+        invalid_file(from_file, "missing 'features' key")
+
+    features = []
+    for feature in features_dict["features"]:
+        if "name" not in feature:
+            invalid_file(from_file, "missing name in features list")
+
+        features.append({"name": add_prefix + feature["name"]})
+    return features
+
+
+def main():
+    (args, _) = parse_args()
+
+    if not args.files:
+        error("No files to merge were provided")
+
+    if len(args.files) != len(args.prefixes):
+        error("Must supply the same number of files and prefixes")
+
+    features = []
+    for i, (f, prefix) in enumerate(zip(args.files, args.prefixes)):
+        features.extend(read_features(f, prefix))
+
+    data = {
+        "features": features
+    }
+
+    if args.dest:
+        with open(args.dest, "w") as f:
+            json.dump(data, f, indent=2)
+    else:
+        sys.stdout.write(json.dumps(data, indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Clang has a new `redirecting-with` property in the VFS overlay files.
While this could be added to Swift's features as well, it is generally
the case that features provided by Clang can also be useful to know for
clients of Swift. Merge the features from Clang into Swift's features
file with the "clang-" prefix to differentiate them.