### PR TITLE
Pre-fix some build failures that we'll see with newer llvm

### DIFF
--- a/include/swift/ABI/TypeIdentity.h
+++ b/include/swift/ABI/TypeIdentity.h
@@ -19,6 +19,7 @@
 #define SWIFT_ABI_TYPEIDENTITY_H
 
 #include "swift/Basic/LLVM.h"
+#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/StringRef.h>
 
 namespace swift {

--- a/include/swift/Basic/DiverseStack.h
+++ b/include/swift/Basic/DiverseStack.h
@@ -395,8 +395,7 @@ class DiverseValueBuffer {
 public:
   DiverseValueBuffer(const T &value) {
     size_t size = value.allocated_size();
-    data.reserve(size);
-    data.set_size(size);
+    data.resize_for_overwrite(size);
     memcpy(data.data(), reinterpret_cast<const void *>(&value), size);
   }
 

--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/StableHasher.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SMLoc.h"
 #include <functional>

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_STATISTIC_H
 #define SWIFT_BASIC_STATISTIC_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Timer.h"

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_DEMANGLING_MANGLINGUTILS_H
 #define SWIFT_DEMANGLING_MANGLINGUTILS_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "swift/Demangling/NamespaceMacros.h"
 #include "swift/Demangling/Punycode.h"

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -20,6 +20,7 @@
 
 #include "swift/Remote/RemoteAddress.h"
 #include "swift/SwiftRemoteMirror/MemoryReaderInterface.h"
+#include "llvm/ADT/Optional.h"
 
 #include <cstring>
 #include <functional>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -277,12 +277,12 @@ SILInstructionResultArray::end() const {
 
 inline SILInstructionResultArray::reverse_iterator
 SILInstructionResultArray::rbegin() const {
-  return llvm::make_reverse_iterator(end());
+  return std::make_reverse_iterator(end());
 }
 
 inline SILInstructionResultArray::reverse_iterator
 SILInstructionResultArray::rend() const {
-  return llvm::make_reverse_iterator(begin());
+  return std::make_reverse_iterator(begin());
 }
 
 inline SILInstructionResultArray::range

--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -397,11 +397,11 @@ public:
 
   bool hasValue() const { return !Storage.isNull(); }
 
-  AbsoluteRawSyntax &getValue() LLVM_LVALUE_FUNCTION {
+  AbsoluteRawSyntax &getValue() & {
     assert(hasValue());
     return Storage;
   }
-  AbsoluteRawSyntax const &getValue() const LLVM_LVALUE_FUNCTION {
+  AbsoluteRawSyntax const &getValue() const & {
     assert(hasValue());
     return Storage;
   }

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -416,11 +416,11 @@ public:
 
   bool hasValue() const { return !Storage.getAbsoluteRaw().isNull(); }
 
-  SyntaxDataRef &getValue() LLVM_LVALUE_FUNCTION {
+  SyntaxDataRef &getValue() & {
     assert(hasValue());
     return Storage;
   }
-  SyntaxDataRef const &getValue() const LLVM_LVALUE_FUNCTION {
+  SyntaxDataRef const &getValue() const & {
     assert(hasValue());
     return Storage;
   }

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -675,8 +675,8 @@ static Words::iterator matchTypeNameFromBackWithSpecialCases(
 
       if (shortenedNameWord != newShortenedNameWord) {
         unsigned targetSize = newShortenedNameWord.size();
-        auto newIter = llvm::make_reverse_iterator(WordIterator(name,
-                                                                targetSize));
+        auto newIter = std::make_reverse_iterator(WordIterator(name,
+                                                               targetSize));
 #ifndef NDEBUG
         while (nameWordRevIter.base().getPosition() > targetSize)
           ++nameWordRevIter;

--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -45,8 +45,7 @@ public:
   Explosion &operator=(const Explosion &) = delete;
   Explosion(Explosion &&other) : NextValue(0) {
     // Do an uninitialized copy of the non-consumed elements.
-    Values.reserve(other.size());
-    Values.set_size(other.size());
+    Values.resize_for_overwrite(other.size());
     std::uninitialized_copy(other.begin(), other.end(), Values.begin());
 
     // Remove everything from the other explosion.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -3257,8 +3257,7 @@ void CallEmission::setFromCallee() {
 
   // Set up the args array.
   assert(Args.empty());
-  Args.reserve(numArgs);
-  Args.set_size(numArgs);
+  Args.resize_for_overwrite(numArgs);
   LastArgWritten = numArgs;
 }
 

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -200,7 +200,7 @@ void MemoryLocations::analyzeLocation(SILValue loc) {
   SubLocationMap subLocationMap;
   if (!analyzeLocationUsesRecursively(loc, currentLocIdx, collectedVals,
                                       subLocationMap)) {
-    locations.set_size(currentLocIdx);
+    locations.truncate(currentLocIdx);
     for (SILValue V : collectedVals) {
       addr2LocIdx.erase(V);
     }

--- a/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
+++ b/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
@@ -91,7 +91,7 @@ using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
   size_t reserve = out.size() + utf8.size();
-  out.reserve(reserve);
+  out.resize_for_overwrite(reserve);
   const char *utf8_begin = utf8.begin();
   wchar_t *wide_begin = out.end();
   auto res = Convert::ConvertFromUTF8(&utf8_begin, utf8.end(),
@@ -99,13 +99,13 @@ static void convertFromUTF8(llvm::StringRef utf8,
                                       lenientConversion);
   assert(res == conversionOK && "utf8-to-wide conversion failed!");
   (void)res;
-  out.set_size(wide_begin - out.begin());
+  out.truncate(wide_begin - out.begin());
 }
 
 static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
                           llvm::SmallVectorImpl<char> &out) {
   size_t reserve = out.size() + wide.size()*4;
-  out.reserve(reserve);
+  out.resize_for_overwrite(reserve);
   const wchar_t *wide_begin = wide.begin();
   char *utf8_begin = out.end();
   auto res = Convert::ConvertToUTF8(&wide_begin, wide.end(),
@@ -113,7 +113,7 @@ static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
                                     lenientConversion);
   assert(res == conversionOK && "wide-to-utf8 conversion failed!");
   (void)res;
-  out.set_size(utf8_begin - out.begin());
+  out.truncate(utf8_begin - out.begin());
 }
 } // end anonymous namespace
 


### PR DESCRIPTION
Fixes some build failures on the "next" branch that also seem like generally good changes to take in "main".  
* Include Optional.h and Hashing.h in more places
* Use std::make_reverse_iterator
* Remove use of `LLVM_LVALUE_FUNCTION`
* Migrate from `SmallVector::set_size` to `resize_for_overwrite` (and `truncate`)