### PR TITLE
[SIL] abort_apply insts maySynchronize.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1378,7 +1378,8 @@ bool SILInstruction::mayTrap() const {
 bool SILInstruction::maySynchronize() const {
   // TODO: We need side-effect analysis and library annotation for this to be
   //       a reasonable API.  For now, this is just a placeholder.
-  return isa<FullApplySite>(this) || isa<EndApplyInst>(this);
+  return isa<FullApplySite>(this) || isa<EndApplyInst>(this) ||
+         isa<AbortApplyInst>(this);
 }
 
 bool SILInstruction::isMetaInstruction() const {

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -36,6 +36,7 @@ sil [ossa] @callee_optional_d_guaranteed: $@convention(thin) (@guaranteed Option
 sil [ossa] @synchronization_point : $@convention(thin) () -> ()
 sil [ossa] @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
 sil [ossa] @barrier : $@convention(thin) () -> ()
+sil [ossa] @failable : $@convention(thin) () -> @error Error
 
 
 // =============================================================================
@@ -888,7 +889,7 @@ exit:
 
 // Don't hoist over end_apply.  These are lowered to calls to continuations
 // which can have the same sorts of side-effects as function calls.
-
+//
 // CHECK-LABEL: sil [ossa] @dont_hoist_over_end_apply : {{.*}} {
 // CHECK:       end_apply
 // CHECK:       end_borrow
@@ -904,6 +905,40 @@ entry(%instance : @owned $C, %input : $S):
     destroy_value %instance : $C
     %retval = tuple ()
     return %retval : $()
+}
+
+// Don't hoist over abort_apply.  These are lowered to calls to continuations
+// which can have the same sorts of side-effects as function calls.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_abort_apply : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REGISTER_1:%[^,]+]] : $Error):
+// CHECK:         abort_apply
+// CHECK:         end_borrow
+// CHECK:         destroy_value
+// CHECK:         tuple
+// CHECK:         throw
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_abort_apply'
+sil [ossa] @dont_hoist_over_abort_apply : $@convention(thin) (@owned C, S) -> @error Error {
+entry(%instance : @owned $C, %input : $S):
+    %lifetime = begin_borrow [lexical] %instance : $C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+    %modify_s = function_ref @modify_s : $@yield_once @convention(thin) () -> @yields @inout S
+    (%addr, %continuation) = begin_apply %modify_s() : $@yield_once @convention(thin) () -> @yields @inout S
+    %failable = function_ref @failable : $@convention(thin) () -> @error Error
+    try_apply %failable() : $@convention(thin) () -> @error Error, normal success, error failure
+success(%retval : $()):
+    store %input to [trivial] %addr : $*S
+    end_apply %continuation
+    end_borrow %lifetime : $C
+    destroy_value %instance : $C
+    return %retval : $()
+failure(%error : $Error):
+    abort_apply %continuation
+    %blah = tuple ()
+    end_borrow %lifetime : $C
+    destroy_value %instance : $C
+    throw %error : $Error
 }
 
 // Don't hoist out of a block when one of its predecessors has a terminator that


### PR DESCRIPTION
Just as a full apply may have side-effects including synchronization, so may an abort_apply, which is lowered to the apply of a continuation.
