### PR TITLE
ModuleInterface: add a frontend flag to skip printing import statement corresponding to a module name.

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -55,6 +55,9 @@ struct ModuleInterfaceOptions {
 
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
+
+  /// A list of modules we shouldn't import in the public interfaces.
+  std::vector<std::string> ModulesToSkipInPublicInterface;
 };
 
 extern version::Version InterfaceFormatVersion;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1012,4 +1012,9 @@ def new_driver_path
   : Separate<["-"], "new-driver-path">, MetaVarName<"<path>">,
   HelpText<"Path of the new driver to be used">;
 
+def skip_import_in_public_interface:
+  Separate<["-"], "skip-import-in-public-interface">,
+  HelpText<"Skip the import statement corresponding to a module name "
+           "when printing the public interface.">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -360,6 +360,9 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
       Opts.PrintSPIs = true;
     }
   }
+  for (auto val: Args.getAllArgValues(OPT_skip_import_in_public_interface)) {
+    Opts.ModulesToSkipInPublicInterface.push_back(val);
+  }
 }
 
 /// Save a copy of any flags marked as ModuleInterfaceOption, if running

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -225,6 +225,11 @@ static void printImports(raw_ostream &out,
       continue;
     }
 
+    if (llvm::count(Opts.ModulesToSkipInPublicInterface,
+                    importedModule->getName().str())) {
+      continue;
+    }
+
     llvm::SmallSetVector<Identifier, 4> spis;
     M->lookupImportedSPIGroups(importedModule, spis);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -866,6 +866,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
     // Copy the settings from the module interface to add SPI printing.
     ModuleInterfaceOptions privOpts = Invocation.getModuleInterfaceOptions();
     privOpts.PrintSPIs = true;
+    privOpts.ModulesToSkipInPublicInterface.clear();
 
     hadAnyError |= printModuleInterfaceIfNeeded(
         Invocation.getPrivateModuleInterfaceOutputPathForWholeModule(),

--- a/test/ModuleInterface/skip-import-in-public-interface.swift
+++ b/test/ModuleInterface/skip-import-in-public-interface.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/I)
+
+// RUN: %target-swift-frontend -emit-module -module-name Foo %s -DFoo -emit-module-path %t/I/Foo.swiftmodule
+// RUN: %target-swift-frontend -typecheck -module-name Bar %s -I %t/I -emit-module-interface-path %t/Bar.swiftinterface -emit-private-module-interface-path %t/Bar.private.swiftinterface -skip-import-in-public-interface Foo
+
+// RUN: %FileCheck %s --check-prefix=PUBLIC-INTERFACE < %t/Bar.swiftinterface
+// RUN: %FileCheck %s --check-prefix=PRIVATE-INTERFACE < %t/Bar.private.swiftinterface
+
+#if Foo
+
+public func fooFunc() {}
+
+#else
+
+import Foo
+
+public func barFunc() {}
+
+#endif
+
+// PUBLIC-INTERFACE-NOT: import Foo
+// PRIVATE-INTERFACE: import Foo


### PR DESCRIPTION

Related: rdar://63465931
