### PR TITLE
[stdlib] relax stride check in UnsafePointer.withMemoryRebound

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -315,9 +315,10 @@ public struct UnsafePointer<Pointee>: _Pointer {
   ) rethrows -> Result {
     _debugPrecondition(
       Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
-      MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
-      ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
-      : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
+      ( count == 1 ||
+        MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
+        ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
+        : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0 )
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
@@ -1001,9 +1002,10 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   ) rethrows -> Result {
     _debugPrecondition(
       Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
-      MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
-      ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
-      : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
+      ( count == 1 ||
+        MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
+        ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
+        : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0 )
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -498,6 +498,20 @@ ${SelfName}TestSuite.test("withMemoryReboundSE0333") {
   }
 }
 
+${SelfName}TestSuite.test("withMemoryReboundSE0333.capacity1") {
+  let mutablePtr = UnsafeMutablePointer<(Int,Bool,UInt8)>.allocate(capacity: 1)
+  defer { mutablePtr.deallocate() }
+  let ptr = ${SelfName}<(Int, Bool, UInt8)>(mutablePtr)
+  // test rebinding to a shorter type with the same alignment
+  ptr.withMemoryRebound(to: (Int, Bool).self, capacity: 1) {
+    // Make sure the closure argument is a ${SelfName}
+    let ptrT: ${SelfName}<(Int, Bool)> = $0
+    // and that the element is (Int, Bool).
+    let mutablePtrT = UnsafeMutablePointer(mutating: ptrT)
+    expectType((Int, Bool).self, &mutablePtrT.pointee)
+  }
+}
+
 % end
 
 runAllTests()


### PR DESCRIPTION
- The new stride check in `UnsafePointer.withMemoryRebound` makes less sense when rebinding memory for a single element.
- This skips the stride-matching portion of the `_debugPrecondition` in `withMemoryRebound` when `count == 1`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-15912](https://bugs.swift.org/browse/SR-15912).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
