### PR TITLE
RequirementMachine: Introduce 'concrete contraction' pre-processing pass before building rewrite system

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -530,6 +530,11 @@ namespace swift {
     RequirementMachineMode RequirementMachineInferredSignatures =
         RequirementMachineMode::Disabled;
 
+    /// Disable preprocessing pass to eliminate conformance requirements
+    /// on generic parameters which are made concrete. Usually you want this
+    /// enabled. It can be disabled for debugging and testing.
+    bool EnableRequirementMachineConcreteContraction = true;
+
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -355,6 +355,10 @@ def requirement_machine_max_concrete_nesting : Joined<["-"], "requirement-machin
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the maximum concrete type nesting depth before giving up">;
 
+def disable_requirement_machine_concrete_contraction : Flag<["-"], "disable-requirement-machine-concrete-contraction">,
+  HelpText<"Disable preprocessing pass to eliminate conformance requirements "
+           "on generic parameters which are made concrete">;
+
 def dump_type_witness_systems : Flag<["-"], "dump-type-witness-systems">,
   HelpText<"Enables dumping type witness systems from associated type inference">;
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -75,6 +75,7 @@ add_swift_host_library(swiftAST STATIC
   ProtocolConformance.cpp
   RawComment.cpp
   RequirementEnvironment.cpp
+  RequirementMachine/ConcreteContraction.cpp
   RequirementMachine/ConcreteTypeWitness.cpp
   RequirementMachine/GenericSignatureQueries.cpp
   RequirementMachine/HomotopyReduction.cpp

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -1,0 +1,569 @@
+//===--- ConcreteContraction.cpp - Preprocessing concrete conformances ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// The concrete contraction pass runs after requirement desugaring and before
+// rewrite rules are built from desugared requirements when constructing a
+// rewrite system for a user-written generic signature.
+//
+// This is an imperfect hack to deal with two issues:
+//
+// a) When a generic parameter is subject to both a conformance requirement and
+//    a concrete type requirement (or a superclass requirement where the
+//    superclass also conforms to the protocol), the conformance requirement
+//    becomes redundant during property map construction.
+//
+//    However, unlike other kinds of requirements, dropping a conformance
+//    requirement can change canonical types in the rewrite system, and in
+//    particular, it can change the canonical types of other minimal
+//    requirements, if the protocol in the conformance requirement has
+//    associated types.
+//
+//    Consider this example:
+//
+//        protocol P {
+//          associatedtype T
+//        }
+//
+//        protocol Q {}
+//
+//        struct S<T> : P {}
+//
+//        struct Holder<A : P, B : P> where A.T : Q {}
+//
+//        extension Holder where A == S<B.T> {}
+//
+//    The signature of the extension is built from these requirements:
+//
+//    - A : P
+//    - B : P
+//    - A.T : Q
+//    - A == S<B.T>
+//
+//    In this rewrite system, the canonical type of 'B.T' is 'A.T', so the
+//    requirements canonicalize as follows:
+//
+//    - A : P
+//    - B : P
+//    - A.T : Q
+//    - A == S<A.T>
+//
+//    Also, the first requirement 'A : P' is redundant in this rewrite system,
+//    because 'A == S<B.T>' and S conforms to P.
+//
+//    However, simply dropping 'A : P' is not enough. If the user instead
+//    directly wrote a signature with the original requirements omitting
+//    'A : P', we would have:
+//
+//    - B : P
+//    - A == S<B.T>
+//    - B.T : Q
+//
+//    Indeed, computing canonical types from the first rewrite system produces
+//    different results, because 'B.T' canonicalizes to 'A.T' and not 'B.T'.
+//
+// b) The GenericSignatureBuilder permitted references to "fully concrete"
+//    member types of a dependent type that were not associated types from
+//    conformance requirements.
+//
+//    That is, the following was permitted:
+//
+//    class C {
+//      typealias A = Int
+//    }
+//
+//    <T, U where T : C, U == T.A>
+//
+//    The requirement 'U == T.A' was resolved to 'U == Int', despite 'T' not
+//    declaring any protocol conformance requirements with an associated type
+//    named 'A' (or any conformance requirements at all).
+//
+// The GenericSignatureBuilder dealt with a) using a "rebuilding" pass that
+// build a new generic signature after dropping redundant conformance
+// requirements, feeding the original requirements back in. The behavior b)
+// was a consequence of how requirement resolution was implemented, by calling
+// into name lookup.
+//
+// The Requirement Machine's approach to both a) and b) doesn't handle as many
+// cases, but is much simpler and hopefully more robust. Before building the
+// rewrite system, we pre-process the requirements and identify generic
+// parameters subject to a superclass or concrete type requirement. Then, we
+// substitute this generic parameter for the superclass or concrete type,
+// respectively, in all other requirements.
+//
+// In the above example, it produces the following list of requirements:
+//
+//    - S<B.T> : P
+//    - B : P
+//    - S<B.T>.T : Q
+//    - A == S<B.T>
+//
+// The requirements are fed back into desugarRequirements(), and we get:
+//
+//    - B : P
+//    - B.T : Q
+//    - A == S<B.T>
+//
+// This also handles b), where the original requirements are:
+//
+//    - T : C
+//    - U == T.A
+//
+// and after concrete contraction, we get
+//
+//    - T : C
+//    - U == Int
+//
+// Since this is all a heuristic that is applied before the rewrite system is
+// built, it doesn't handle cases where a nested type of a generic parameter is
+// subject to both a concrete type and conformance requirement, nor does it
+// handle more complex cases where the redundant conformance is only discovered
+// via an intermediate same-type requirement, such as the following:
+//
+//    <T, U, V where T == S<V>, T == U, U : P>
+//
+// If concrete contraction fails, the minimized generic signature will fail
+// verification if it still contains incorrectly-canonicalized types.
+//
+// We might need a more general solution eventually, but for now this is good
+// enough to handle the cases where this arises in practice.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/GenericParamKey.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "RequirementLowering.h"
+
+using namespace swift;
+using namespace rewriting;
+
+namespace {
+
+/// Utility class to store some shared state.
+class ConcreteContraction {
+  bool Debug;
+
+  llvm::SmallDenseMap<GenericParamKey, Type> ConcreteTypes;
+  llvm::SmallDenseMap<GenericParamKey, Type> Superclasses;
+
+  Optional<Type> substTypeParameter(GenericTypeParamType *rootParam,
+                                    DependentMemberType *memberType,
+                                    Type concreteType) const;
+  Type substTypeParameter(Type type,
+                          bool subjectTypeOfConformance=false) const;
+  Type substType(Type type) const;
+  Requirement substRequirement(const Requirement &req) const;
+
+public:
+  ConcreteContraction(bool debug) : Debug(debug) {}
+
+  bool performConcreteContraction(
+      ArrayRef<StructuralRequirement> requirements,
+      SmallVectorImpl<StructuralRequirement> &result);
+};
+
+}  // end namespace
+
+/// Find the most canonical member type of \p decl named \p name, using the
+/// canonical type order.
+static TypeDecl *lookupConcreteNestedType(ModuleDecl *module,
+                                          NominalTypeDecl *decl,
+                                          Identifier name) {
+  SmallVector<ValueDecl *, 2> foundMembers;
+  module->lookupQualified(
+      decl, DeclNameRef(name),
+      NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
+      foundMembers);
+
+  SmallVector<TypeDecl *, 2> concreteDecls;
+  for (auto member : foundMembers)
+    concreteDecls.push_back(cast<TypeDecl>(member));
+
+  if (concreteDecls.empty())
+    return nullptr;
+
+  return *std::min_element(concreteDecls.begin(), concreteDecls.end(),
+                           [](TypeDecl *type1, TypeDecl *type2) {
+                             return TypeDecl::compare(type1, type2) < 0;
+                           });
+}
+
+/// A re-implementation of Type::subst() that also handles unresolved
+/// DependentMemberTypes by performing name lookup into the base type.
+///
+/// When substituting a superclass requirement, we have to handle the
+/// case where the superclass might not conform to the protocol in
+/// question. For example, you can have a generic signature like this
+///
+///     <T where T : Sequence, T : SomeClass, T.Element == Int>
+///
+/// If SomeClass does not conform to Sequence, the type T is understood
+/// to be some subclass of SomeClass which does conform to Sequence;
+/// this is perfectly valid, and we cannot substitute the 'T.Element'
+/// requirement. In this case, this method returns None.
+Optional<Type> ConcreteContraction::substTypeParameter(
+    GenericTypeParamType *rootParam,
+    DependentMemberType *memberType,
+    Type concreteType) const {
+  if (memberType == nullptr)
+    return concreteType;
+
+  auto baseType = memberType->getBase()->getAs<DependentMemberType>();
+  auto substBaseType = substTypeParameter(rootParam, baseType, concreteType);
+  if (!substBaseType)
+    return None;
+
+  auto *decl = (*substBaseType)->getAnyNominal();
+  if (decl == nullptr) {
+    llvm::dbgs() << "@@@ Not a nominal type: " << *substBaseType << "\n";
+    return None;
+  }
+
+  auto *module = decl->getParentModule();
+
+  // A resolved DependentMemberType stores an associated type declaration.
+  //
+  // Handle this by looking up the corresponding type witness in the base
+  // type's conformance to the associated type's protocol.
+  if (auto *assocType = memberType->getAssocType()) {
+    auto conformance = module->lookupConformance(
+        *substBaseType, assocType->getProtocol());
+
+    // The base type doesn't conform, in which case the requirement remains
+    // unsubstituted.
+    if (!conformance)
+      return None;
+
+    return assocType->getDeclaredInterfaceType()
+                    ->castTo<DependentMemberType>()
+                    ->substBaseType(module, *substBaseType);
+  }
+
+  // An unresolved DependentMemberType stores an identifier. Handle this
+  // by performing a name lookup into the base type.
+  auto *typeDecl = lookupConcreteNestedType(module, decl,
+                                            memberType->getName());
+  if (typeDecl == nullptr) {
+    // The base type doesn't contain a member type with this name, in which
+    // case the requirement remains unsubstituted.
+    if (Debug) {
+      llvm::dbgs() << "@@@ Lookup of " << memberType->getName() << " failed on "
+                   << *substBaseType << "\n";
+    }
+    return None;
+  }
+
+  // Substitute the base type into the member type.
+  auto subMap = (*substBaseType)->getContextSubstitutionMap(
+      module, typeDecl->getDeclContext());
+  return typeDecl->getDeclaredInterfaceType().subst(subMap);
+}
+
+/// Replace the generic parameter at the root of \p type, which must be a
+/// type parameter, with the superclass or concrete type requirement that
+/// the generic parameter is subject to.
+///
+/// Note that if the generic parameter has a superclass conformance, we
+/// only substitute if it's the root of a member type; the generic parameter
+/// itself does not become concrete when it's superclass-constrained, unless
+/// it is the subject of a conformance requirement.
+Type ConcreteContraction::substTypeParameter(
+    Type type, bool subjectTypeOfConformance) const {
+  assert(type->isTypeParameter());
+
+  auto rootParam = type->getRootGenericParam();
+  auto key = GenericParamKey(rootParam);
+
+  Type concreteType;
+  {
+    auto found = ConcreteTypes.find(key);
+    if (found != ConcreteTypes.end())
+      concreteType = found->second;
+  }
+
+  Type superclass;
+  {
+    auto found = Superclasses.find(key);
+    if (found != Superclasses.end())
+      superclass = found->second;
+  }
+
+  if (!concreteType && !superclass)
+    return type;
+
+  if (!concreteType) {
+    assert(superclass);
+
+    // For a superclass requirement, don't substitute the generic parameter
+    // itself, only nested types thereof -- unless it's the subject type of
+    // a conformance requirement.
+    if (type->is<GenericTypeParamType>() &&
+        !subjectTypeOfConformance)
+      return type;
+
+    concreteType = superclass;
+  }
+
+  auto result = substTypeParameter(
+      rootParam, type->getAs<DependentMemberType>(),
+      concreteType);
+
+  if (!result)
+    return type;
+
+  return *result;
+}
+
+/// Substitute all type parameters occurring in structural positions of \p type.
+Type ConcreteContraction::substType(Type type) const {
+  return type.transformRec(
+      [&](Type type) -> Optional<Type> {
+        if (!type->isTypeParameter())
+          return None;
+
+        return substTypeParameter(type);
+      });
+}
+
+/// Substitute all type parameters occurring in the given requirement.
+Requirement
+ConcreteContraction::substRequirement(const Requirement &req) const {
+  auto firstType = req.getFirstType();
+
+  switch (req.getKind()) {
+  case RequirementKind::Superclass:
+  case RequirementKind::SameType: {
+    auto substFirstType = firstType;
+
+    // If the requirement is of the form 'T == C' or 'T : C', don't
+    // substitute T, since then we end up with 'C == C' or 'C : C',
+    // losing the requirement.
+    if (!firstType->is<GenericTypeParamType>()) {
+      substFirstType = substTypeParameter(firstType);
+    }
+
+    auto secondType = req.getSecondType();
+    auto substSecondType = substType(secondType);
+
+    return Requirement(req.getKind(),
+                       substFirstType,
+                       substSecondType);
+  }
+
+  case RequirementKind::Conformance: {
+    auto substFirstType = substTypeParameter(
+        firstType, /*subjectTypeOfConformance=*/true);
+
+    auto *proto = req.getProtocolDecl();
+    auto *module = proto->getParentModule();
+    if (!substFirstType->isTypeParameter() &&
+        !module->lookupConformance(substFirstType, proto)) {
+      // Handle the case of <T where T : P, T : C> where C is a class and
+      // C does not conform to P by leaving the conformance requirement
+      // unsubstituted.
+      return req;
+    }
+
+    // Otherwise, replace the generic parameter in the conformance
+    // requirement with the concrete type. It will desugar to nothing
+    // (if the conformance is conditional) or to zero or more
+    // conditional requirements needed to satisfy the conformance.
+    return Requirement(req.getKind(),
+                       substFirstType,
+                       req.getSecondType());
+  }
+
+  case RequirementKind::Layout: {
+    auto substFirstType = substTypeParameter(firstType);
+
+    return Requirement(req.getKind(),
+                       substFirstType,
+                       req.getLayoutConstraint());
+  }
+  }
+}
+
+/// Substitute all occurrences of generic parameters subject to superclass
+/// or concrete type requirements with their corresponding superclass or
+/// concrete type.
+///
+/// If this returns false, \p result should be ignored and the requirements
+/// remain unchanged. If this returns true, \p result should replace the
+/// original \p requirements.
+bool ConcreteContraction::performConcreteContraction(
+    ArrayRef<StructuralRequirement> requirements,
+    SmallVectorImpl<StructuralRequirement> &result) {
+
+  // Phase 1 - collect concrete type and superclass requirements where the
+  // subject type is a generic parameter.
+  for (auto req : requirements) {
+    auto subjectType = req.req.getFirstType();
+    assert(subjectType->isTypeParameter() &&
+           "You forgot to call desugarRequirement()");
+
+    auto genericParam = subjectType->getAs<GenericTypeParamType>();
+    if (!genericParam)
+      continue;
+
+    auto kind = req.req.getKind();
+    switch (kind) {
+    case RequirementKind::SameType: {
+      auto constraintType = req.req.getSecondType();
+
+      // Same-type requirements between type parameters are not interesting
+      // to this pass.
+      if (constraintType->isTypeParameter())
+        break;
+
+      auto entry = std::make_pair(GenericParamKey(genericParam),
+                                  constraintType);
+      bool inserted = ConcreteTypes.insert(entry).second;
+      if (!inserted) {
+        if (Debug) {
+          llvm::dbgs() << "@ Concrete contraction cannot proceed: "
+                       << "duplicate concrete type requirements\n";
+          return false;
+        }
+      }
+
+      break;
+    }
+    case RequirementKind::Superclass: {
+      auto constraintType = req.req.getSecondType();
+      assert(!constraintType->isTypeParameter() &&
+             "You forgot to call desugarRequirement()");
+
+      auto entry = std::make_pair(GenericParamKey(genericParam),
+                                  constraintType);
+      bool inserted = Superclasses.insert(entry).second;
+      if (!inserted) {
+        if (Debug) {
+          llvm::dbgs() << "@ Concrete contraction cannot proceed: "
+                       << "duplicate superclass requirements\n";
+          return false;
+        }
+      }
+
+      break;
+    }
+    case RequirementKind::Conformance:
+    case RequirementKind::Layout:
+      break;
+    }
+  }
+
+  // If there's nothing to do just return.
+  if (ConcreteTypes.empty() && Superclasses.empty())
+    return false;
+
+  // If a generic parameter is subject to both a concrete type and superclass
+  // requirement, bail out because we're not smart enough to figure out what's
+  // going on.
+  for (auto pair : ConcreteTypes) {
+    auto subjectType = pair.first;
+
+    if (Superclasses.find(subjectType) != Superclasses.end()) {
+      if (Debug) {
+        llvm::dbgs() << "@ Concrete contraction cannot proceed; "
+                     << "τ_" << subjectType.Depth << "_" << subjectType.Index
+                     << " has both a concrete type and superclass requirement";
+      }
+      return false;
+    }
+  }
+
+  if (Debug) {
+    llvm::dbgs() << "@ Concrete types: @\n";
+    for (auto pair : ConcreteTypes) {
+      llvm::dbgs() << "- τ_" << pair.first.Depth
+                   << "_" << pair.first.Index << " == "
+                   << pair.second << "\n";
+    }
+
+    llvm::dbgs() << "@ Superclasses: @\n";
+    for (auto pair : Superclasses) {
+      llvm::dbgs() << "- τ_" << pair.first.Depth
+                   << "_" << pair.first.Index << " : "
+                   << pair.second << "\n";
+    }
+  }
+
+  // Phase 2: Replace each concretely-conforming generic parameter with its
+  // concrete type.
+  for (auto req : requirements) {
+    // Substitute the requirement.
+    Optional<Requirement> substReq = substRequirement(req.req);
+
+    // If substitution failed, we have a conflict; bail out here so that we can
+    // diagnose the conflict later.
+    if (!substReq) {
+      if (Debug) {
+        llvm::dbgs() << "@ Concrete contraction cannot proceed; requirement ";
+        llvm::dbgs() << "substitution failed:\n";
+        req.req.dump(llvm::dbgs());
+        llvm::dbgs() << "\n";
+      }
+
+      return false;
+    }
+
+    if (Debug) {
+      llvm::dbgs() << "@ Substituted requirement: ";
+      substReq->dump(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
+
+    // Otherwise, desugar the requirement again, since we might now have a
+    // requirement where the left hand side is not a type parameter.
+    //
+    // FIXME: Do we need to check for errors? Right now they're just ignored.
+    SmallVector<Requirement, 4> reqs;
+    SmallVector<RequirementError> errors;
+    desugarRequirement(*substReq, reqs, errors);
+    for (auto desugaredReq : reqs) {
+      if (Debug) {
+        llvm::dbgs() << "@@ Desugared requirement: ";
+        desugaredReq.dump(llvm::dbgs());
+        llvm::dbgs() << "\n";
+      }
+      result.push_back({desugaredReq, req.loc, req.inferred});
+    }
+  }
+
+  if (Debug) {
+    llvm::dbgs() << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n";
+    llvm::dbgs() << "@ Concrete contraction succeeded @\n";
+    llvm::dbgs() << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n";
+  }
+
+  return true;
+}
+
+/// Substitute all occurrences of generic parameters subject to superclass
+/// or concrete type requirements with their corresponding superclass or
+/// concrete type.
+///
+/// If this returns false, \p result should be ignored and the requirements
+/// remain unchanged. If this returns true, \p result should replace the
+/// original \p requirements.
+bool swift::rewriting::performConcreteContraction(
+    ArrayRef<StructuralRequirement> requirements,
+    SmallVectorImpl<StructuralRequirement> &result,
+    bool debug) {
+  ConcreteContraction concreteContraction(debug);
+  return concreteContraction.performConcreteContraction(requirements, result);
+}

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -159,7 +159,8 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
           concreteRule.markConflicting();
 
         auto &conformanceRule = System.getRule(conformanceRuleID);
-        if (conformanceRule.getRHS().size() == key.size())
+        if (!conformanceRule.isIdentityConformanceRule() &&
+            conformanceRule.getRHS().size() == key.size())
           conformanceRule.markConflicting();
       }
 

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -61,7 +61,10 @@ enum class DebugFlags : unsigned {
   RedundantRules = (1<<12),
 
   /// Print more detail about redundant rules.
-  RedundantRulesDetail = (1<<13)
+  RedundantRulesDetail = (1<<13),
+
+  /// Print debug output from the concrete contraction pre-processing pass.
+  ConcreteContraction = (1<<14)
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -131,6 +131,12 @@ struct RuleBuilder {
   void collectRulesFromReferencedProtocols();
 };
 
+// Defined in ConcreteContraction.cpp.
+bool performConcreteContraction(
+    ArrayRef<StructuralRequirement> requirements,
+    SmallVectorImpl<StructuralRequirement> &result,
+    bool debug);
+
 } // end namespace rewriting
 
 } // end namespace swift

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -499,6 +499,17 @@ AbstractGenericSignatureRequestRQM::evaluate(
       requirements.push_back({req, SourceLoc(), /*wasInferred=*/false});
   }
 
+  // Preprocess requirements to eliminate conformances on generic parameters
+  // which are made concrete.
+  if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
+    SmallVector<StructuralRequirement, 4> contractedRequirements;
+    if (performConcreteContraction(requirements, contractedRequirements,
+                                   ctx.getRewriteContext().getDebugOptions()
+                                      .contains(DebugFlags::ConcreteContraction))) {
+      std::swap(contractedRequirements, requirements);
+    }
+  }
+
   // Heap-allocate the requirement machine to save stack space.
   std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
       ctx.getRewriteContext()));
@@ -612,6 +623,17 @@ InferredGenericSignatureRequestRQM::evaluate(
   // an extension whose extended type is a generic typealias.
   for (const auto &req : addedRequirements)
     requirements.push_back({req, SourceLoc(), /*wasInferred=*/true});
+
+  // Preprocess requirements to eliminate conformances on generic parameters
+  // which are made concrete.
+  if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
+    SmallVector<StructuralRequirement, 4> contractedRequirements;
+    if (performConcreteContraction(requirements, contractedRequirements,
+                                   ctx.getRewriteContext().getDebugOptions()
+                                      .contains(DebugFlags::ConcreteContraction))) {
+      std::swap(contractedRequirements, requirements);
+    }
+  }
 
   // Heap-allocate the requirement machine to save stack space.
   std::unique_ptr<RequirementMachine> machine(new RequirementMachine(

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -41,6 +41,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("minimization", DebugFlags::Minimization)
       .Case("redundant-rules", DebugFlags::RedundantRules)
       .Case("redundant-rules-detail", DebugFlags::RedundantRulesDetail)
+      .Case("concrete-contraction", DebugFlags::ConcreteContraction)
       .Default(None);
     if (!flag) {
       llvm::errs() << "Unknown debug flag in -debug-requirement-machine "

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -121,17 +121,12 @@ public:
     Layout,
 
     /// When appearing at the end of a term, denotes that the term
-    /// is exactly equal to the concrete type.
-    ConcreteType,
+    /// is a subclass of the superclass constraint.
+    Superclass,
 
     /// When appearing at the end of a term, denotes that the term
-    /// is a subclass of the superclass constraint.
-    ///
-    /// Note that this orders after ConcreteType, to ensure compatibility
-    /// with the GenericSignatureBuilder on pathological generic signatures
-    /// where a type is subject to both a superclass and concrete type
-    /// requirement that imply each other.
-    Superclass,
+    /// is exactly equal to the concrete type.
+    ConcreteType,
   };
 
   static const unsigned NumKinds = 8;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -964,6 +964,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (Args.hasArg(OPT_disable_requirement_machine_concrete_contraction))
+    Opts.EnableRequirementMachineConcreteContraction = false;
+
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
   return HadError || UnsupportedOS || UnsupportedArch;

--- a/test/Generics/abstract_type_witnesses_in_protocols.swift
+++ b/test/Generics/abstract_type_witnesses_in_protocols.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype T

--- a/test/Generics/abstract_type_witnesses_in_protocols_2.swift
+++ b/test/Generics/abstract_type_witnesses_in_protocols_2.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype X

--- a/test/Generics/concrete_conformance_minimization.swift
+++ b/test/Generics/concrete_conformance_minimization.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 struct MyOptionSet : OptionSet {
   let rawValue: UInt

--- a/test/Generics/concrete_conformance_rule_simplified.swift
+++ b/test/Generics/concrete_conformance_rule_simplified.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P1 {}
 

--- a/test/Generics/concrete_nesting_elimination_order.swift
+++ b/test/Generics/concrete_nesting_elimination_order.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T

--- a/test/Generics/concrete_nesting_elimination_order_2.swift
+++ b/test/Generics/concrete_nesting_elimination_order_2.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T

--- a/test/Generics/conditional_requirement_inference.swift
+++ b/test/Generics/conditional_requirement_inference.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol Equatable {}
 

--- a/test/Generics/conditional_requirement_inference_2.swift
+++ b/test/Generics/conditional_requirement_inference_2.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 // A more complicated example.
 protocol Equatable {}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 protocol P {}
 class C {}

--- a/test/Generics/indirectly_concrete_generic_param.swift
+++ b/test/Generics/indirectly_concrete_generic_param.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 class S<T, U> where T : P, U == T.T {}
 
@@ -13,5 +13,5 @@ class C : P {
   typealias T = Int
 }
 
-// CHECK-LABEL: Generic signature: <X, T, U where X : S<T, C.T>, T : C, U == C.T>
+// CHECK-LABEL: Generic signature: <X, T, U where X : S<T, Int>, T : C, U == Int>
 extension G where X : S<T, U>, T : C {}

--- a/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
+++ b/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=on %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction %s 2>&1 | %FileCheck %s
 
 public protocol P {
   associatedtype A : Q where A.B == Self

--- a/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
+++ b/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=on %s 2>&1 | %FileCheck %s
 
 public protocol P {
   associatedtype A : Q where A.B == Self
@@ -21,20 +21,26 @@ public class D : Q {
   public typealias B = C
 }
 
-// Both <T : P & C> and <T : C & P> minimize to <T where T == C>:
+// This is fine, because FinalC is final.
+public final class FinalC : P {
+  public typealias A = FinalD
+}
+
+public class FinalD : Q {
+  public typealias B = FinalC
+}
+
+// With the GSB, both <T : P & C> and <T : C & P> minimized to <T where T == C>:
 // - T : P and T : C imply that T.A == C.A == D;
 // - T : P also implies that T.A.B == T, via A.B == Self in P;
 // - Since T.A == D, T.A.B == D.B, therefore Self == D.B.
 // - D.B is a typealias for C, so really Self == C.
+//
+// The Requirement Machine leaves it as <T : C>. Technically this is an ABI break,
+// but the entire construction is unsound unless C is final.
 
-// CHECK-LABEL: Generic signature: <T where T == C>
-public func takesBoth1<T : P & C>(_: T) {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
-// expected-note@-2 {{conformance constraint 'T' : 'P' implied here}}
-// expected-error@-3 {{same-type requirement makes generic parameter 'T' non-generic}}
+// CHECK-LABEL: Generic signature: <T where T : C>
+public func takesBoth1<T>(_: T) where T : P, T : C {}
 
-// CHECK-LABEL: Generic signature: <U where U == C>
-public func takesBoth2<U : C & P>(_: U) {}
-// expected-warning@-1 {{redundant conformance constraint 'U' : 'P'}}
-// expected-note@-2 {{conformance constraint 'U' : 'P' implied here}}
-// expected-error@-3 {{same-type requirement makes generic parameter 'U' non-generic}}
+// CHECK-LABEL: Generic signature: <U where U : C>
+public func takesBoth2<U>(_: U) where U : C, U : P {}

--- a/test/Generics/protocol_self_concrete_error.swift
+++ b/test/Generics/protocol_self_concrete_error.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+
+// This triggered a Requirement Machine assertion because the permanent
+// 'identity conformance' rule ([P].[P] => [P]) was the source of the
+// conflict.
+
+struct S {}
+
+protocol P where Self == S {}

--- a/test/Generics/protocol_self_concrete_error.swift
+++ b/test/Generics/protocol_self_concrete_error.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -disable-requirement-machine-concrete-contraction
 
 // This triggered a Requirement Machine assertion because the permanent
 // 'identity conformance' rule ([P].[P] => [P]) was the source of the

--- a/test/Generics/rdar65263302.swift
+++ b/test/Generics/rdar65263302.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -verify -emit-ir %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -verify -emit-ir -requirement-machine-inferred-signatures=verify %s
 
 public protocol P {
     associatedtype Element

--- a/test/Generics/rdar77462797.swift
+++ b/test/Generics/rdar77462797.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 protocol P {}
 

--- a/test/Generics/rdar79570734.swift
+++ b/test/Generics/rdar79570734.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 public protocol P1 {
   associatedtype A
@@ -16,5 +16,5 @@ public struct S2: P2 {}
 // CHECK-LABEL: Generic signature: <X, Y where X : P1, Y : P2, Y == X.[P1]A>
 public struct G<X: P1, Y: P2> where Y == X.A {}
 
-// CHECK-LABEL: Generic signature: <X, Y where X == S1, Y == S1.A>
+// CHECK-LABEL: Generic signature: <X, Y where X == S1, Y == S2>
 public extension G where X == S1 {}

--- a/test/Generics/rdar80503090.swift
+++ b/test/Generics/rdar80503090.swift
@@ -22,7 +22,7 @@ class C : P {}
 // expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self' is exactly equal to 'Self.T'; this is an error in Swift 6}}
 
 extension P where T : C {
-  // CHECK-LABEL: Generic signature: <Self where Self == C>
+  // CHECK-LABEL: Generic signature: <Self where Self : C>
   func test() {
     missing()
   }

--- a/test/Generics/rdar80503090.swift
+++ b/test/Generics/rdar80503090.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype T where T == Self

--- a/test/Generics/sr8945.swift
+++ b/test/Generics/sr8945.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sr8945-other.swift -emit-module-path %t/other.swiftmodule -module-name other
-// RUN: %target-swift-frontend -emit-silgen %s -I%t
+// RUN: %target-swift-frontend -emit-silgen %s -I%t -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 import other
 
@@ -10,6 +10,8 @@ public class C : P {
 
 public func takesInt(_: Int) {}
 
+// CHECK-LABEL: .foo@
+// CHECK-NEXT: Generic signature: <T, S where T : C, S : Sequence, S.[Sequence]Element == Int>
 public func foo<T : C, S : Sequence>(_: T, _ xs: S) where S.Element == T.T {
   for x in xs {
     takesInt(x)

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
 
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 class A {
@@ -66,16 +66,16 @@ class S : P2 {
   typealias T = C
 }
 
-// CHECK: superclassConformance1
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
+// CHECK-LABEL: .superclassConformance1(t:)@
+// CHECK-NEXT: Generic signature: <T where T : C>
 func superclassConformance1<T>(t: T)
   where T : C, // expected-note{{conformance constraint 'T' : 'P3' implied here}}
         T : P3 {} // expected-warning{{redundant conformance constraint 'T' : 'P3'}}
 
 
 
-// CHECK: superclassConformance2
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
+// CHECK-LABEL: .superclassConformance2(t:)@
+// CHECK-NEXT: Generic signature: <T where T : C>
 func superclassConformance2<T>(t: T)
   where T : C, // expected-note{{conformance constraint 'T' : 'P3' implied here}}
    T : P3 {} // expected-warning{{redundant conformance constraint 'T' : 'P3'}}
@@ -84,8 +84,8 @@ protocol P4 { }
 
 class C2 : C, P4 { }
 
-// CHECK: superclassConformance3
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
+// CHECK-LABEL: .superclassConformance3(t:)@
+// CHECK-NEXT: Generic signature: <T where T : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
 // expected-note@-2{{superclass constraint 'T' : 'C' implied here}}
@@ -109,8 +109,8 @@ protocol P7 {
 	// expected-error@-2{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 }
 
-// CHECK: superclassConformance4
-// CHECK: Generic signature: <T, U where T : P3, U : P3, T.[P3]T : C, T.[P3]T == U.[P3]T>
+// CHECK-LABEL: .superclassConformance4@
+// CHECK-NEXT: Generic signature: <T, U where T : P3, U : P3, T.[P3]T : C, T.[P3]T == U.[P3]T>
 func superclassConformance4<T: P3, U: P3>(_: T, _: U)
   where T.T: C, // expected-note{{superclass constraint 'U.T' : 'C' implied here}}
         U.T: C, // expected-warning{{redundant superclass constraint 'U.T' : 'C'}}
@@ -130,6 +130,8 @@ class Classical : Elementary {
   }
 }
 
+// CHECK-LABEL: .genericFunc@
+// CHECK-NEXT: Generic signature: <T, U where T : Elementary, U : Classical, T.[Elementary]Element == Int>
 func genericFunc<T : Elementary, U : Classical>(_: T, _: U) where T.Element == U.Element {}
 
 // Lookup within superclass constraints.
@@ -141,10 +143,16 @@ class C8 {
   struct A { }
 }
 
+// CHECK-LABEL: .superclassLookup1@
+// CHECK-NEXT: Generic signature: <T where T : C8, T : P8, T.[P8]B == C8.A>
 func superclassLookup1<T: C8 & P8>(_: T) where T.A == T.B { }
 
+// CHECK-LABEL: .superclassLookup2@
+// CHECK-NEXT: Generic signature: <T where T : C8, T : P8, T.[P8]B == C8.A>
 func superclassLookup2<T: P8>(_: T) where T.A == T.B, T: C8 { }
 
+// CHECK-LABEL: .superclassLookup3@
+// CHECK-NEXT: Generic signature: <T where T : C8, T : P8, T.[P8]B == C8.A>
 func superclassLookup3<T>(_: T) where T.A == T.B, T: C8, T: P8 { }
 
 // SR-5165
@@ -158,9 +166,8 @@ protocol P10 {
   associatedtype A: C9
 }
 
-// CHECK: superclass_constraint.(file).testP10
-// CHECK: Generic signature: <T where T : P10, T.[P10]A : C10>
-// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0.[P10]A : C10>
+// CHECK-LABEL: .testP10@
+// CHECK-NEXT: Generic signature: <T where T : P10, T.[P10]A : C10>
 func testP10<T>(_: T) where T: P10, T.A: C10 { }
 
 // Nested types of generic class-constrained type parameters.
@@ -183,7 +190,7 @@ protocol X {
 	associatedtype Y : A
 }
 
-// CHECK-DAG: .noRedundancyWarning@
+// CHECK-LABEL: .noRedundancyWarning@
 // CHECK: Generic signature: <C where C : X, C.[X]Y == B>
 func noRedundancyWarning<C : X>(_ wrapper: C) where C.Y == B {}
 
@@ -222,7 +229,7 @@ public class Teddy: Pony {}
 public struct Paddock<P: Pony> {}
 
 public struct Barn<T: Teddy> {
-  // CHECK-DAG: Barn.foo@
+  // CHECK-LABEL: Barn.foo@
   // CHECK: Generic signature: <T, S where T : Teddy>
   public func foo<S>(_: S, _: Barn<T>, _: Paddock<T>) {}
 }

--- a/test/Generics/superclass_constraint_nested_type.swift
+++ b/test/Generics/superclass_constraint_nested_type.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 // rdar://problem/39481178 - Introducing a superclass constraint does not add
 // same-type constraints on nested types
@@ -15,9 +16,13 @@ class C : P {
 // same-type constraint 'T == C.Q (aka Int)' having been inferred:
 
 extension P {
+  // CHECK-LABEL: .f1@
+  // CHECK-NEXT: <Self, T where Self : C, T == Int>
   func f1<T>(_: T) where T == Q, Self : C {}
   // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
 
+  // CHECK-LABEL: .f2@
+  // CHECK-NEXT: <Self, T where Self : C, T == Int>
   func f2<T>(_: T) where Self : C, T == Q {}
   // expected-error@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
 }

--- a/test/Generics/superclass_constraint_self_derived.swift
+++ b/test/Generics/superclass_constraint_self_derived.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype T : Q
@@ -17,6 +17,8 @@ func takesR<T : R>(_: T) {}
 class C<T : Q> : P {}
 
 struct Outer<T : P> {
+  // CHECK-LABEL: .Inner@
+  // CHECK-NEXT: Generic signature: <T, U where T : C<U>, U : Q>
   struct Inner<U> where T : C<U> {
     func doStuff(_ u: U) {
       takesR(u.t)

--- a/test/multifile/protocol-conformance-rdar39805133.swift
+++ b/test/multifile/protocol-conformance-rdar39805133.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -verify -emit-ir -o - -primary-file %s %S/Inputs/protocol-conformance-rdar39805133-other.swift -module-name foo -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -emit-ir -o - -primary-file %s %S/Inputs/protocol-conformance-rdar39805133-other.swift -module-name foo -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 // RUN: %target-swift-frontend -emit-ir -o - %s -primary-file %S/Inputs/protocol-conformance-rdar39805133-other.swift -module-name foo -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 protocol _Int : DefaultInit {
@@ -27,5 +27,3 @@ protocol AtLeast0 : _Int {}
 extension _0_ : AtLeast0 {}
 protocol AtLeast1 : AtLeast0 {}
 extension Inc : AtLeast1, AtLeast0 where T == _0_ {}
-// expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is τ_0_0.[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[concrete: Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<Inc<_0_>>>>>>>>>>>] => τ_0_0.[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1].[_Int:Plus1]}}

--- a/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -requirement-machine-inferred-signatures=verify
 
 protocol C {
   associatedtype I
@@ -19,5 +20,7 @@ struct PEN<_S : PST> : SL {
 
 struct PE<N : SL> {
   let n: N
+  // CHECK-LABEL: .c@
+  // CHECK-NEXT: Generic signature: <N, S where N == PEN<S>, S : PST>
   static func c<S>(_: PE<N>) where N == PEN<S> {}
 }

--- a/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 struct Box<Representation, T> {
     let value: Representation
@@ -7,6 +9,9 @@ enum Repr {}
 extension Repr {
     typealias RawEnum = ()
 }
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Box
+// CHECK-NEXT: Generic signature: <Representation, T where Representation == Repr, T == ()>
 extension Box where Representation == Repr, T == Representation.RawEnum {
     init(rawEnumValue: Representation.RawEnum) {
         let _: ().Type = T.self

--- a/validation-test/compiler_crashers_2_fixed/rdar69073431.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar69073431.swift
@@ -1,11 +1,13 @@
-// RUN: %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
 
 import Combine
 
 @available(macOS 10.15, *)
 extension Publishers.Share {
-    func foo<A: Publisher, B: Publisher>() where Upstream == Publishers.FlatMap<A, B>, B.Output == UInt8 {
+    // CHECK-LABEL: .foo()@
+    // CHECK-NEXT: Generic signature: <Upstream, A, B where Upstream == Publishers.FlatMap<A, B>, A : Publisher, B : Publisher, A.[Publisher]Failure == B.[Publisher]Failure, B.[Publisher]Output == UInt8>
+    func foo<A: Publisher, B: Publisher>() where Upstream == Publishers.FlatMap<A, B>, A : Publisher, B : Publisher, B.Output == UInt8 {
         
     }
 }


### PR DESCRIPTION
See the comment at the top of ConcreteContraction.cpp for a detailed explanation.

Fixes rdar://problem/88135912.