### PR TITLE
Factor out NameImporter parts that don't depend on ASTContext (NFC)

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2115,10 +2115,8 @@ static bool isObjCMethodResultAudited(const clang::Decl *decl) {
 
 DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
     clang::QualType type, OptionalTypeKind clangOptionality,
-    DeclBaseName baseName, StringRef argumentLabel, bool isFirstParameter,
-    bool isLastParameter, NameImporter &nameImporter) {
-  auto baseNameStr = baseName.userFacingName();
-
+    StringRef baseNameStr, StringRef argumentLabel, bool isFirstParameter,
+    bool isLastParameter, NameImporterBase &nameImporter) {
   // Don't introduce a default argument for the first parameter of setters.
   if (isFirstParameter && camel_case::getFirstWord(baseNameStr) == "set")
     return DefaultArgumentKind::None;
@@ -2647,8 +2645,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
       auto defaultArg = inferDefaultArgument(
           param->getType(), optionalityOfParam,
-          importedName.getDeclName().getBaseName(), name.str(), paramIndex == 0,
-          isLastParameter, getNameImporter());
+          importedName.getDeclName().getBaseName().userFacingName(), name.str(),
+          paramIndex == 0, isLastParameter, getNameImporter());
       if (defaultArg != DefaultArgumentKind::None)
         paramInfo->setDefaultArgumentKind(defaultArg);
     }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -829,10 +829,9 @@ public:
   /// so it should not be used when referencing Clang symbols.
   ///
   /// \param D The Clang declaration whose name should be imported.
-  importer::ImportedName importFullName(const clang::NamedDecl *D,
-                                        Version version,
-                                        clang::DeclarationName givenName =
-                                          clang::DeclarationName()) {
+  importer::ImportedName
+  importFullName(const clang::NamedDecl *D, Version version,
+                 clang::DeclarationName givenName = clang::DeclarationName()) {
     return getNameImporter().importName(D, version, givenName);
   }
 
@@ -1344,9 +1343,9 @@ public:
   /// given Clang \c type, \c baseName, and optionality.
   static DefaultArgumentKind
   inferDefaultArgument(clang::QualType type, OptionalTypeKind clangOptionality,
-                       DeclBaseName baseName, StringRef argumentLabel,
+                       StringRef baseName, StringRef argumentLabel,
                        bool isFirstParameter, bool isLastParameter,
-                       importer::NameImporter &nameImporter);
+                       importer::NameImporterBase &nameImporter);
 
   /// Import the parameter and return types of an Objective-C method.
   ///

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1899,7 +1899,7 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   auto failed = nameImporter.forEachDistinctImportName(
       named, currentVersion,
       [&](ImportedName importedName, ImportNameVersion version) {
-        table.addEntry(importedName.getDeclName(), named,
+        table.addEntry(importedName.getDeclNameOrNull(), named,
                        importedName.getEffectiveContext());
 
         // Also add the subscript entry, if needed.


### PR DESCRIPTION
Factor out NameImporter parts that don't depend on ASTContext (NFC)
into a base class NameImporterBase. Inheriting this class wouuld allow LLDB to
instantiate a NameImporter without a swift::ASTContext and use it to resolve
Clang-imported type names in TypeSystemSwiftTypeRef without having to sping up a
Swift compiler instance.
    
The lookup result ImportedName has been split into a base class and two
implementations, one using ParsedDeclName and one using DeclName as storage. The
importNameImpl method returns the dual ImportNameResult. This is design is to
avoid templatetizing NameImporter to reduce code size impact.