### PR TITLE
swift-inspect: enable `dump-arrays` on Windows

### DIFF
--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -22,6 +22,9 @@ The following inspection operations are available currently.
 
 ##### All Platforms
 
+dump-arrays &lt;name-or-pid&gt;
+: Print information about array objects in the target
+
 dump-cache-nodes &lt;name-or-pid&gt;
 : Print the metadata cache nodes.
 
@@ -35,9 +38,6 @@ dump-raw-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
 : Print metadata allocations.
 
 ##### Darwin Only
-
-dump-arrays &lt;name-or-pid&gt;
-: Print information about array objects in the target
 
 dump-concurrency &lt;name-or-pid&gt;
 : Print information about tasks, actors, and threads under Concurrency.

--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -141,9 +141,7 @@ internal final class DarwinRemoteProcess: RemoteProcess {
     let module = CSSymbolGetSymbolOwner(symbol)
     return (CSSymbolOwnerGetName(module), CSSymbolGetName(symbol))
   }
-}
 
-extension DarwinRemoteProcess {
   internal func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {
     withoutActuallyEscaping(body) {
       withUnsafePointer(to: $0) {
@@ -160,7 +158,9 @@ extension DarwinRemoteProcess {
       }
     }
   }
+}
 
+extension DarwinRemoteProcess {
   internal var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
     var threadList: UnsafeMutablePointer<thread_t>?
     var threadCount: mach_msg_type_number_t = 0

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import ArgumentParser
 import SwiftRemoteMirror
 
@@ -28,6 +27,7 @@ internal struct DumpArrays: ParsableCommand {
         let metadata: UInt =
             swift_reflection_metadataForObject(process.context, UInt(allocation))
         if metadata == 0 { return }
+
         guard process.context.isContiguousArray(swift_reflection_ptr_t(metadata)) else {
           return
         }
@@ -44,5 +44,3 @@ internal struct DumpArrays: ParsableCommand {
     }
   }
 }
-
-#endif

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -42,6 +42,7 @@ internal protocol RemoteProcess: AnyObject {
   static var GetSymbolAddress: GetSymbolAddressFunction { get }
 
   func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?)
+  func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void)
 }
 
 extension RemoteProcess {

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -77,6 +77,7 @@ internal struct SwiftInspect: ParsableCommand {
     DumpRawMetadata.self,
     DumpGenericMetadata.self,
     DumpCacheNodes.self,
+    DumpArrays.self,
   ]
 #endif
 


### PR DESCRIPTION
Adjust the implementation of `DumpArrays` to enumerate the allocations
first before processing them as the heap may alter in between.  This
significantly impacts performance on Windows.

Hoist `iterateHeaps` into the `RemoteProcess` protocol, requiring an
implementation on all platforms.  If the platform is unable to implement
heap traversal, it would be possible to simply leave the callback
uncalled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
