### PR TITLE
Revert async-main lookup resolution

### DIFF
--- a/test/Concurrency/async_main_resolution.swift
+++ b/test/Concurrency/async_main_resolution.swift
@@ -6,6 +6,8 @@
 // sync main is nested deeper in protocols than async, use async
 // async and sync are same level, use async
 
+// REQUIRES: rdar89500797
+
 // REQUIRES: concurrency
 // UNSUPPORTED: VENDOR=apple
 

--- a/test/Concurrency/async_main_resolution_macos.swift
+++ b/test/Concurrency/async_main_resolution_macos.swift
@@ -2,6 +2,8 @@
 // sync main is nested deeper in protocols than async, use async if supported
 // async and sync are same level, use async if supported
 
+// REQUIRES: rdar89500797
+
 // async main is nested in the protocol chain from `MyMain`
 // Always choose Sync overload
 // RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -DASYNC_NESTED -DINHERIT_SYNC -typecheck -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC

--- a/test/Concurrency/where_clause_main_resolution.swift
+++ b/test/Concurrency/where_clause_main_resolution.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG1 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-CONFIG1
+// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG2 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-CONFIG2
+// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG3 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-CONFIG3
+
+// REQUIRES: concurrency
+
+protocol AppConfiguration { }
+
+struct Config1: AppConfiguration {}
+struct Config2: AppConfiguration {}
+struct Config3: AppConfiguration {}
+
+protocol App {
+    associatedtype Configuration: AppConfiguration
+}
+
+extension App where Configuration == Config1 {
+// CHECK-CONFIG1: (func_decl implicit "$main()" interface type='(MainType.Type) -> () -> ()'
+// CHECK-CONFIG1: where_clause_main_resolution.swift:[[# @LINE+1 ]]
+    static func main() { }
+}
+
+extension App where Configuration == Config2 {
+// CHECK-CONFIG2: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
+// CHECK-CONFIG2: where_clause_main_resolution.swift:[[# @LINE+1 ]]
+    static func main() async { }
+}
+
+extension App {
+// CHECK-CONFIG3: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
+// CHECK-CONFIG3: where_clause_main_resolution.swift:[[# @LINE+1 ]]
+    static func main() async { }
+}
+
+@main
+struct MainType : App {
+
+#if CONFIG1
+    typealias Configuration = Config1
+#elseif CONFIG2
+    typealias Configuration = Config2
+#elseif CONFIG3
+    typealias Configuration = Config3
+#endif
+}


### PR DESCRIPTION
The resolution that I was using ignored `where` clauses, so it would select irrelevant `main` functions while looking for an `async` main function. This gives async main functions too much power. I'm trying to tune the constraint solver to not penalize async main functions without over-powering them so that it's still possible to have synchronous main functions. I'm putting back the old resolution until I get that figured out.

Reverting: https://github.com/apple/swift/pull/40577
rdar://89273310