### PR TITLE
RequirementMachine: Add fourth 'check' option to 'on'/'off'/'verify' flags

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -88,7 +88,10 @@ namespace swift {
     Enabled = 1,
 
     /// Use both and assert if the results do not match.
-    Verify = 2
+    Verify = 2,
+
+    /// Use both, print a message only but do not assert on mismatch.
+    Check = 3,
   };
 
   /// A collection of options that affect the language dialect and

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -626,15 +626,15 @@ def no_emit_module_separately:
 
 def requirement_machine_protocol_signatures_EQ : Joined<["-"], "requirement-machine-protocol-signatures=">,
   Flags<[FrontendOption]>,
-  HelpText<"Control usage of experimental protocol requirement signature minimization: 'on', 'off', or 'verify'">;
+  HelpText<"Control usage of experimental protocol requirement signature minimization: 'on', 'off', 'verify' or 'check'">;
 
 def requirement_machine_abstract_signatures_EQ : Joined<["-"], "requirement-machine-abstract-signatures=">,
   Flags<[FrontendOption]>,
-  HelpText<"Control usage of experimental generic signature minimization: 'on', 'off', or 'verify'">;
+  HelpText<"Control usage of experimental generic signature minimization: 'on', 'off', 'verify' or 'check'">;
 
 def requirement_machine_inferred_signatures_EQ : Joined<["-"], "requirement-machine-inferred-signatures=">,
   Flags<[FrontendOption]>,
-  HelpText<"Control usage of experimental generic signature minimization: 'on', 'off', or 'verify'">;
+  HelpText<"Control usage of experimental generic signature minimization: 'on', 'off', 'verify' or 'check'">;
 
 def experimental_hermetic_seal_at_link:
   Flag<["-"], "experimental-hermetic-seal-at-link">,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8382,7 +8382,8 @@ AbstractGenericSignatureRequest::evaluate(
   case RequirementMachineMode::Enabled:
     return buildViaRQM();
 
-  case RequirementMachineMode::Verify: {
+  case RequirementMachineMode::Verify:
+  case RequirementMachineMode::Check: {
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
@@ -8401,7 +8402,9 @@ AbstractGenericSignatureRequest::evaluate(
       gsbResult.getPointer()->print(llvm::errs(), opts);
       llvm::errs() << "\n";
 
-      abort();
+      if (ctx.LangOpts.RequirementMachineAbstractSignatures
+          == RequirementMachineMode::Verify)
+        abort();
     }
 
     return rqmResult;
@@ -8559,7 +8562,8 @@ InferredGenericSignatureRequest::evaluate(
   case RequirementMachineMode::Enabled:
     return buildViaRQM();
 
-  case RequirementMachineMode::Verify: {
+  case RequirementMachineMode::Verify:
+  case RequirementMachineMode::Check: {
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
@@ -8578,7 +8582,9 @@ InferredGenericSignatureRequest::evaluate(
       gsbResult.getPointer()->print(llvm::errs(), opts);
       llvm::errs() << "\n";
 
-      abort();
+      if (ctx.LangOpts.RequirementMachineInferredSignatures
+          == RequirementMachineMode::Verify)
+        abort();
     }
 
     return rqmResult;
@@ -8672,7 +8678,8 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
   case RequirementMachineMode::Enabled:
     return buildViaRQM();
 
-  case RequirementMachineMode::Verify: {
+  case RequirementMachineMode::Verify:
+  case RequirementMachineMode::Check: {
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
@@ -8697,7 +8704,9 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
       gsbSig.print(llvm::errs(), opts);
       llvm::errs() << "\n";
 
-      abort();
+      if (ctx.LangOpts.RequirementMachineProtocolSignatures
+          == RequirementMachineMode::Verify)
+        abort();
     }
 
     return rqmResult;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -886,6 +886,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         .Case("off", RequirementMachineMode::Disabled)
         .Case("on", RequirementMachineMode::Enabled)
         .Case("verify", RequirementMachineMode::Verify)
+        .Case("check", RequirementMachineMode::Check)
         .Default(None);
 
     if (value)
@@ -900,6 +901,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         .Case("off", RequirementMachineMode::Disabled)
         .Case("on", RequirementMachineMode::Enabled)
         .Case("verify", RequirementMachineMode::Verify)
+        .Case("check", RequirementMachineMode::Check)
         .Default(None);
 
     if (value)
@@ -914,6 +916,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         .Case("off", RequirementMachineMode::Disabled)
         .Case("on", RequirementMachineMode::Enabled)
         .Case("verify", RequirementMachineMode::Verify)
+        .Case("check", RequirementMachineMode::Check)
         .Default(None);
 
     if (value)

--- a/test/SILGen/type_lowering_subst_function_type_caseiterable.swift
+++ b/test/SILGen/type_lowering_subst_function_type_caseiterable.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-silgen %s -requirement-machine-abstract-signatures=on | %FileCheck %s
+
+// This is a GenericSignatureBuilder bug fixed with the Requirement Machine, from
+// https://bugs.swift.org/browse/SR-15917.
+
+public struct Foo<Unused: CaseIterable> {
+  public struct Nested {}
+
+  public let closure: () -> Nested
+}
+
+// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s029type_lowering_subst_function_A13_caseiterable3FooV7closureAC6NestedVyx_Gycvg : $@convention(method) <Unused where Unused : CaseIterable> (@guaranteed Foo<Unused>) -> @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : CaseIterable, τ_0_0 == τ_0_1> () -> Foo<τ_0_0>.Nested for <Unused, Unused>


### PR DESCRIPTION
This compares the results like 'verify' and prints output if there is a mismatch, but does not assert.