### PR TITLE
[CodeCompletion] Multiple code cleanups after split up of CodeCompletion.cpp

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -61,9 +61,9 @@ ArrayRef<T> copyArray(llvm::BumpPtrAllocator &Allocator,
 
 bool isDynamicLookup(Type T);
 
-void postProcessResults(MutableArrayRef<CodeCompletionResult *> results,
-                        CompletionKind Kind, DeclContext *DC,
-                        CodeCompletionResultSink *Sink);
+void postProcessCompletionResults(
+    MutableArrayRef<CodeCompletionResult *> results, CompletionKind Kind,
+    DeclContext *DC, CodeCompletionResultSink *Sink);
 
 void deliverCompletionResults(CodeCompletionContext &CompletionContext,
                               CompletionLookup &Lookup, DeclContext *DC,

--- a/include/swift/IDE/CodeCompletionContext.h
+++ b/include/swift/IDE/CodeCompletionContext.h
@@ -90,7 +90,9 @@ public:
   }
 
   /// Allocate a string owned by the code completion context.
-  StringRef copyString(StringRef Str);
+  StringRef copyString(StringRef Str) {
+    return Str.copy(*CurrentResults.Allocator);
+  }
 
   /// Sort code completion results in an implementation-defined order
   /// in place.

--- a/include/swift/IDE/DotExprCompletion.h
+++ b/include/swift/IDE/DotExprCompletion.h
@@ -24,7 +24,6 @@ namespace ide {
 /// (\c CompletionKind::DotExpr ) from the solutions formed during expression
 /// type-checking.
 class DotExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
-public:
   struct Result {
     Type BaseTy;
     ValueDecl *BaseDecl;
@@ -34,7 +33,6 @@ public:
     bool IsImplicitSingleExpressionReturn;
   };
 
-private:
   DeclContext *DC;
   CodeCompletionExpr *CompletionExpr;
   SmallVector<Result, 4> Results;
@@ -46,10 +44,6 @@ public:
                                      CodeCompletionExpr *CompletionExpr)
       : DC(DC), CompletionExpr(CompletionExpr) {}
 
-  /// Get the results collected from any sawSolutions() callbacks recevied so
-  /// far.
-  ArrayRef<Result> getResults() const { return Results; }
-
   /// True if at least one solution was passed via the \c sawSolution
   /// callback.
   bool gotCallback() const { return GotCallback; }
@@ -59,12 +53,11 @@ public:
   void fallbackTypeCheck();
 
   void sawSolution(const constraints::Solution &solution) override;
-};
 
-void deliverDotExprResults(
-    ArrayRef<DotExprTypeCheckCompletionCallback::Result> Results,
-    Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc, bool IsInSelector,
-    CodeCompletionContext &CompletionCtx, CodeCompletionConsumer &Consumer);
+  void deliverResults(Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc,
+                      bool IsInSelector, CodeCompletionContext &CompletionCtx,
+                      CodeCompletionConsumer &Consumer);
+};
 
 } // end namespace ide
 } // end namespace swift

--- a/include/swift/IDE/KeyPathCompletion.h
+++ b/include/swift/IDE/KeyPathCompletion.h
@@ -21,7 +21,6 @@ namespace swift {
 namespace ide {
 
 class KeyPathTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
-public:
   struct Result {
     /// The type on which completion should occur, i.e. a result type of the
     /// previous component.
@@ -30,23 +29,18 @@ public:
     bool OnRoot;
   };
 
-private:
   KeyPathExpr *KeyPath;
   SmallVector<Result, 4> Results;
 
 public:
   KeyPathTypeCheckCompletionCallback(KeyPathExpr *KeyPath) : KeyPath(KeyPath) {}
 
-  ArrayRef<Result> getResults() const { return Results; }
-
   void sawSolution(const constraints::Solution &solution) override;
-};
 
-void deliverKeyPathResults(
-    ArrayRef<KeyPathTypeCheckCompletionCallback::Result> Results,
-    DeclContext *DC, SourceLoc DotLoc,
-    ide::CodeCompletionContext &CompletionCtx,
-    CodeCompletionConsumer &Consumer);
+  void deliverResults(DeclContext *DC, SourceLoc DotLoc,
+                      ide::CodeCompletionContext &CompletionCtx,
+                      CodeCompletionConsumer &Consumer);
+};
 
 } // end namespace ide
 } // end namespace swift

--- a/include/swift/IDE/UnresolvedMemberCompletion.h
+++ b/include/swift/IDE/UnresolvedMemberCompletion.h
@@ -25,13 +25,11 @@ namespace ide {
 /// formed during expression type-checking.
 class UnresolvedMemberTypeCheckCompletionCallback
     : public TypeCheckCompletionCallback {
-public:
   struct ExprResult {
     Type ExpectedTy;
     bool IsImplicitSingleExpressionReturn;
   };
 
-private:
   CodeCompletionExpr *CompletionExpr;
   SmallVector<ExprResult, 4> ExprResults;
   SmallVector<Type, 1> EnumPatternTypes;
@@ -42,12 +40,6 @@ public:
       CodeCompletionExpr *CompletionExpr)
       : CompletionExpr(CompletionExpr) {}
 
-  ArrayRef<ExprResult> getExprResults() const { return ExprResults; }
-
-  /// If we are completing in a pattern matching position, the types of all
-  /// enums for whose cases are valid as an \c EnumElementPattern.
-  ArrayRef<Type> getEnumPatternTypes() const { return EnumPatternTypes; }
-
   /// True if at least one solution was passed via the \c sawSolution
   /// callback.
   bool gotCallback() const { return GotCallback; }
@@ -57,13 +49,11 @@ public:
   void fallbackTypeCheck(DeclContext *DC);
 
   void sawSolution(const constraints::Solution &solution) override;
-};
 
-void deliverUnresolvedMemberResults(
-    ArrayRef<UnresolvedMemberTypeCheckCompletionCallback::ExprResult> Results,
-    ArrayRef<Type> EnumPatternTypes, DeclContext *DC, SourceLoc DotLoc,
-    ide::CodeCompletionContext &CompletionCtx,
-    CodeCompletionConsumer &Consumer);
+  void deliverResults(DeclContext *DC, SourceLoc DotLoc,
+                      ide::CodeCompletionContext &CompletionCtx,
+                      CodeCompletionConsumer &Consumer);
+};
 
 } // end namespace ide
 } // end namespace swift

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1160,7 +1160,7 @@ static void addConditionalCompilationFlags(ASTContext &Ctx,
 /// If \p Sink is passed, the pointer of the each result may be replaced with a
 /// pointer to the new item allocated in \p Sink.
 /// If \p Sink is nullptr, the pointee of each result may be modified in place.
-void swift::ide::postProcessResults(
+void swift::ide::postProcessCompletionResults(
     MutableArrayRef<CodeCompletionResult *> results, CompletionKind Kind,
     DeclContext *DC, CodeCompletionResultSink *Sink) {
   for (CodeCompletionResult *&result : results) {
@@ -1314,9 +1314,9 @@ void swift::ide::deliverCompletionResults(
   Lookup.RequestedCachedResults.clear();
   CompletionContext.typeContextKind = Lookup.typeContextKind();
 
-  postProcessResults(CompletionContext.getResultSink().Results,
-                     CompletionContext.CodeCompletionKind, DC,
-                     /*Sink=*/nullptr);
+  postProcessCompletionResults(CompletionContext.getResultSink().Results,
+                               CompletionContext.CodeCompletionKind, DC,
+                               /*Sink=*/nullptr);
 
   Consumer.handleResultsAndModules(CompletionContext, RequestedModules, DC);
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1350,9 +1350,8 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
 
     Expr *CheckedBase = CodeCompleteTokenExpr->getBase();
-    deliverDotExprResults(Lookup.getResults(), CheckedBase, CurDeclContext,
-                          DotLoc, isInsideObjCSelector(), CompletionContext,
-                          Consumer);
+    Lookup.deliverResults(CheckedBase, CurDeclContext, DotLoc,
+                          isInsideObjCSelector(), CompletionContext, Consumer);
     return true;
   }
   case CompletionKind::UnresolvedMember: {
@@ -1368,9 +1367,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
       Lookup.fallbackTypeCheck(CurDeclContext);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
-    deliverUnresolvedMemberResults(Lookup.getExprResults(),
-                                   Lookup.getEnumPatternTypes(), CurDeclContext,
-                                   DotLoc, CompletionContext, Consumer);
+    Lookup.deliverResults(CurDeclContext, DotLoc, CompletionContext, Consumer);
     return true;
   }
   case CompletionKind::KeyPathExprSwift: {
@@ -1384,8 +1381,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
         Context.CompletionCallback, &Lookup);
     typeCheckContextAt(CurDeclContext, CompletionLoc);
 
-    deliverKeyPathResults(Lookup.getResults(), CurDeclContext, DotLoc,
-                          CompletionContext, Consumer);
+    Lookup.deliverResults(CurDeclContext, DotLoc, CompletionContext, Consumer);
     return true;
   }
   default:

--- a/lib/IDE/CodeCompletionConsumer.cpp
+++ b/lib/IDE/CodeCompletionConsumer.cpp
@@ -134,8 +134,8 @@ void SimpleCachingCodeCompletionConsumer::handleResultsAndModules(
     assert(V.hasValue());
     auto newItems = copyCodeCompletionResults(
         context.getResultSink(), **V, R.OnlyTypes, R.OnlyPrecedenceGroups);
-    postProcessResults(newItems, context.CodeCompletionKind, DC,
-                       &context.getResultSink());
+    postProcessCompletionResults(newItems, context.CodeCompletionKind, DC,
+                                 &context.getResultSink());
   }
 
   handleResults(context);

--- a/lib/IDE/CodeCompletionContext.cpp
+++ b/lib/IDE/CodeCompletionContext.cpp
@@ -15,10 +15,6 @@
 using namespace swift;
 using namespace swift::ide;
 
-StringRef CodeCompletionContext::copyString(StringRef Str) {
-  return Str.copy(*CurrentResults.Allocator);
-}
-
 std::vector<CodeCompletionResult *>
 CodeCompletionContext::sortCompletionResults(
     ArrayRef<CodeCompletionResult *> Results) {

--- a/lib/IDE/DotExprCompletion.cpp
+++ b/lib/IDE/DotExprCompletion.cpp
@@ -91,8 +91,7 @@ void DotExprTypeCheckCompletionCallback::sawSolution(
   }
 }
 
-void swift::ide::deliverDotExprResults(
-    ArrayRef<DotExprTypeCheckCompletionCallback::Result> Results,
+void DotExprTypeCheckCompletionCallback::deliverResults(
     Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc, bool IsInSelector,
     CodeCompletionContext &CompletionCtx, CodeCompletionConsumer &Consumer) {
   ASTContext &Ctx = DC->getASTContext();

--- a/lib/IDE/KeyPathCompletion.cpp
+++ b/lib/IDE/KeyPathCompletion.cpp
@@ -73,8 +73,7 @@ void KeyPathTypeCheckCompletionCallback::sawSolution(
   Results.push_back({BaseType, /*OnRoot=*/(ComponentIndex == 0)});
 }
 
-void swift::ide::deliverKeyPathResults(
-    ArrayRef<KeyPathTypeCheckCompletionCallback::Result> Results,
+void KeyPathTypeCheckCompletionCallback::deliverResults(
     DeclContext *DC, SourceLoc DotLoc,
     ide::CodeCompletionContext &CompletionCtx,
     CodeCompletionConsumer &Consumer) {

--- a/lib/IDE/UnresolvedMemberCompletion.cpp
+++ b/lib/IDE/UnresolvedMemberCompletion.cpp
@@ -138,9 +138,8 @@ void UnresolvedMemberTypeCheckCompletionCallback::fallbackTypeCheck(
                              [&](const Solution &S) { sawSolution(S); });
 }
 
-void swift::ide::deliverUnresolvedMemberResults(
-    ArrayRef<UnresolvedMemberTypeCheckCompletionCallback::ExprResult> Results,
-    ArrayRef<Type> EnumPatternTypes, DeclContext *DC, SourceLoc DotLoc,
+void UnresolvedMemberTypeCheckCompletionCallback::deliverResults(
+    DeclContext *DC, SourceLoc DotLoc,
     ide::CodeCompletionContext &CompletionCtx,
     CodeCompletionConsumer &Consumer) {
   ASTContext &Ctx = DC->getASTContext();
@@ -149,14 +148,15 @@ void swift::ide::deliverUnresolvedMemberResults(
 
   assert(DotLoc.isValid());
   Lookup.setHaveDot(DotLoc);
-  Lookup.shouldCheckForDuplicates(Results.size() + EnumPatternTypes.size() > 1);
+  Lookup.shouldCheckForDuplicates(ExprResults.size() + EnumPatternTypes.size() >
+                                  1);
 
   // Get the canonical versions of the top-level types
   SmallPtrSet<CanType, 4> originalTypes;
-  for (auto &Result : Results)
+  for (auto &Result : ExprResults)
     originalTypes.insert(Result.ExpectedTy->getCanonicalType());
 
-  for (auto &Result : Results) {
+  for (auto &Result : ExprResults) {
     Lookup.setExpectedTypes({Result.ExpectedTy},
                             Result.IsImplicitSingleExpressionReturn,
                             /*expectsNonVoid*/ true);


### PR DESCRIPTION
- Make `deliver*Result` functions members on their `TypeCheckCompletionCallback`
- Move implementation of `CodeCompletionContext::copyString` to header
- Rename `postProcessResults` to `postProcessCompletionResults`