### PR TITLE
[cxx-interop][IRGen] Walk initializer decls when walking constructor decls

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -53,6 +53,15 @@ public:
     return true;
   }
 
+  bool VisitCXXConstructorDecl(clang::CXXConstructorDecl *CXXCD) {
+    callback(CXXCD);
+    for (clang::CXXCtorInitializer *CXXCI : CXXCD->inits()) {
+      if (clang::FieldDecl *FD = CXXCI->getMember())
+        callback(FD);
+    }
+    return true;
+  }
+
   bool VisitCXXConstructExpr(clang::CXXConstructExpr *CXXCE) {
     callback(CXXCE->getConstructor());
     return true;

--- a/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function-from-nested-calls.h
+++ b/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function-from-nested-calls.h
@@ -1,0 +1,13 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_CODEGEN_INPUTS_CONSTRUCTOR_CALLS_FUNCTION_FROM_NESTED_CALLS_H
+#define TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_CODEGEN_INPUTS_CONSTRUCTOR_CALLS_FUNCTION_FROM_NESTED_CALLS_H
+
+inline int get42Level4() { return 42; }
+inline int get42Level3() { return get42Level4(); }
+inline int get42Level2() { return get42Level3(); }
+inline int get42Level1() { return get42Level2(); }
+
+struct Hold42WithLongInitCallGraph {
+  int m = get42Level1();
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_THROUGH_MEMBER_INPUTS_CONSTRUCTOR_CALLS_FUNCTION_FROM_NESTED_STRUCT_H

--- a/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function-from-nested-struct.h
+++ b/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function-from-nested-struct.h
@@ -14,4 +14,18 @@ inline int callConstructor(int value) {
   return IncrementUser::Incrementor(value).value;
 }
 
+inline int get42() { return 42; }
+
+struct HoldMemberThatHolds42 {
+  struct Hold42 {
+    int m = get42();
+  };
+
+  Hold42 holder;
+};
+
+struct HoldMemberThatHoldsMemberThatHolds42 {
+  HoldMemberThatHolds42 holder;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_THROUGH_MEMBER_INPUTS_CONSTRUCTOR_CALLS_FUNCTION_FROM_NESTED_STRUCT_H

--- a/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function.h
+++ b/test/Interop/Cxx/class/inline-function-codegen/Inputs/constructor-calls-function.h
@@ -10,4 +10,19 @@ struct Incrementor {
 
 inline int callConstructor(int value) { return Incrementor(value).incrementee; }
 
+inline int get42() { return 42; }
+
+template <typename T>
+T passThroughArgT(T t) {
+  return t;
+}
+
+struct Hold42 {
+  int m = get42();
+};
+
+struct Hold23 {
+  int m = passThroughArgT<int>(23);
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_THROUGH_MEMBER_INPUTS_CONSTRUCTOR_CALLS_FUNCTION_H

--- a/test/Interop/Cxx/class/inline-function-codegen/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inline-function-codegen/Inputs/module.modulemap
@@ -8,6 +8,11 @@ module ConstructorCallsFunctionFromNestedStruct {
   requires cplusplus
 }
 
+module ConstructorCallsFunctionFromNestedCalls {
+  header "constructor-calls-function-from-nested-calls.h"
+  requires cplusplus
+}
+
 module ConstructorCallsMethod {
   header "constructor-calls-method.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-execution.swift
@@ -7,8 +7,18 @@ import StdlibUnittest
 
 var MembersTestSuite = TestSuite("MembersTestSuite")
 
-MembersTestSuite.test("constructor calls function") {
+MembersTestSuite.test("constructor calls function (explicit)") {
   expectEqual(42, callConstructor(41))
+}
+
+MembersTestSuite.test("constructor calls function (implicit)") {
+  let holder = Hold42()
+  expectEqual(42, holder.m)
+}
+
+MembersTestSuite.test("constructor calls template function (implicit)") {
+  let holder = Hold23()
+  expectEqual(23, holder.m)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-execution.swift
@@ -1,0 +1,15 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import ConstructorCallsFunctionFromNestedCalls
+import StdlibUnittest
+
+var MembersTestSuite = TestSuite("MembersTestSuite")
+
+MembersTestSuite.test("constructor calls function from nested calls") {
+  let holder = Hold42WithLongInitCallGraph()
+  expectEqual(42, holder.m)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import ConstructorCallsFunctionFromNestedCalls
+
+let a = Hold42WithLongInitCallGraph()
+
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level1v|"\?get42Level1@@YAHXZ"}}
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level2v|"\?get42Level2@@YAHXZ"}}
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level3v|"\?get42Level3@@YAHXZ"}}
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level4v|"\?get42Level4@@YAHXZ"}}

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-execution.swift
@@ -7,8 +7,13 @@ import StdlibUnittest
 
 var MembersTestSuite = TestSuite("MembersTestSuite")
 
-MembersTestSuite.test("constructor calls function from nested struct") {
+MembersTestSuite.test("constructor calls function from nested struct (explicit)") {
   expectEqual(42, callConstructor(41))
+}
+
+MembersTestSuite.test("constructor calls function from nested struct (implicit)") {
+  let holder = HoldMemberThatHolds42()
+  expectEqual(42, holder.holder.m)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
@@ -6,4 +6,10 @@ public func getIncrementorValue() -> CInt {
   return callConstructor(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+let a = HoldMemberThatHolds42()
+let b = HoldMemberThatHoldsMemberThatHolds42()
+
+let sum = a.holder.m + b.holder.holder.m
+
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
@@ -6,4 +6,11 @@ public func getIncrementorValue() -> CInt {
   return callConstructor(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+let a = Hold42()
+let b = Hold23()
+
+let sum = a.m + b.m
+
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}
+// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z15passThroughArgTIiET_S0_|"\?\?\$passThroughArgT@H@@YAHH@Z"}}


### PR DESCRIPTION
This addresses SR-15272.

When you have a function (e.g. 'foo') which is used in a constructor
initializer (e.g. constructor of some class 'Bar'), and you use the
constructor from swift code without directly using the function (e.g.
Bar's ctor is used from swift but foo isn't, foo is used from Bar's ctor),
you will get a link error. My fix is as follows:

When walking the clangAST to be imported, make sure you look at each
CXXCtorInitializer for each CXXConstructorDecl you see.