### PR TITLE
Improve description of the pi constant

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -328,7 +328,9 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// `infinity` is greater than this value.
   static var greatestFiniteMagnitude: Self { get }
 
-  /// The mathematical constant pi.
+  /// The ratio of a circle's circumference to its diameter.
+  ///
+  /// Also equivalent to half a revolution in radians.
   ///
   /// This value should be rounded toward zero to keep user computations with
   /// angles from inadvertently ending up in the wrong quadrant. A type that

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -331,7 +331,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   /// 
   /// This constant is equivalent to 180°, or half a revolution of a circle,
-  /// when used in angle measurement.
+  /// when used as an angle measurement in radians.
   ///
   /// This value is rounded toward zero to keep user computations with angles
   /// from inadvertently ending up in the wrong quadrant. A type that conforms

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -330,8 +330,8 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
 
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   /// 
-  /// The π constant is equivalent to 180°, or half a revolution of a circle,
-  /// when used as an angle measurement in radians.
+  /// π is equivalent to 180°, or a half turn, when measuring an angle in
+  /// radians.
   ///
   /// This value is rounded toward zero to keep user computations with angles
   /// from inadvertently ending up in the wrong quadrant. A type that conforms

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -328,9 +328,14 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// `infinity` is greater than this value.
   static var greatestFiniteMagnitude: Self { get }
 
-  /// The ratio of a circle's circumference to its diameter.
+  /// The mathematical constant π, approximately equal to 3.14159.
   ///
-  /// Also equivalent to half a revolution in radians.
+  /// This constant is most often defined as the numerical value of the ratio
+  /// of a circle's circumference to its diameter, which is the same for all
+  /// circles.
+  ///
+  /// A common application of this constant in geometry is to measure a half
+  /// revolution in radians. Used like this, it is equivalent to 180 degrees.
   ///
   /// This value should be rounded toward zero to keep user computations with
   /// angles from inadvertently ending up in the wrong quadrant. A type that

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -337,10 +337,10 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// A common application of this constant in geometry is to measure a half
   /// revolution in radians. Used like this, it is equivalent to 180 degrees.
   ///
-  /// This value should be rounded toward zero to keep user computations with
-  /// angles from inadvertently ending up in the wrong quadrant. A type that
-  /// conforms to the `FloatingPoint` protocol provides the value for `pi` at
-  /// its best possible precision.
+  /// This value is rounded toward zero to keep user computations with angles
+  /// from inadvertently ending up in the wrong quadrant. A type that conforms
+  /// to the `FloatingPoint` protocol provides the value for `pi` at its best
+  /// possible precision.
   ///
   ///     print(Double.pi)
   ///     // Prints "3.14159265358979"

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -330,7 +330,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
 
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   /// 
-  /// This constant is equivalent to 180°, or half a revolution of a circle,
+  /// The π constant is equivalent to 180°, or half a revolution of a circle,
   /// when used as an angle measurement in radians.
   ///
   /// This value is rounded toward zero to keep user computations with angles

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -329,9 +329,9 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   static var greatestFiniteMagnitude: Self { get }
 
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
-  ///
-  /// A common application of this constant in geometry is to measure a half
-  /// revolution in radians. Used like this, it is equivalent to 180 degrees.
+  /// 
+  /// This constant is equivalent to 180°, or half a revolution of a circle,
+  /// when used in angle measurement.
   ///
   /// This value is rounded toward zero to keep user computations with angles
   /// from inadvertently ending up in the wrong quadrant. A type that conforms

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -344,6 +344,10 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///
   ///     print(Double.pi)
   ///     // Prints "3.14159265358979"
+  ///
+  /// See [this Wikipedia article][wiki] for more information.
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Pi
   static var pi: Self { get }
 
   // NOTE: Rationale for "ulp" instead of "epsilon":

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -328,7 +328,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   /// `infinity` is greater than this value.
   static var greatestFiniteMagnitude: Self { get }
 
-  /// The mathematical constant π, approximately equal to 3.14159.
+  /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   ///
   /// This constant is most often defined as the numerical value of the ratio
   /// of a circle's circumference to its diameter, which is the same for all
@@ -344,8 +344,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
   ///
   ///     print(Double.pi)
   ///     // Prints "3.14159265358979"
-  ///
-  /// See [this Wikipedia article][wiki] for more information.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Pi
   static var pi: Self { get }

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -330,8 +330,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
 
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   /// 
-  /// π is equivalent to 180°, or a half turn, when measuring an angle in
-  /// radians.
+  /// When measuring an angle in radians, π is equivalent to a half-turn.
   ///
   /// This value is rounded toward zero to keep user computations with angles
   /// from inadvertently ending up in the wrong quadrant. A type that conforms

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -330,10 +330,6 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
 
   /// The [mathematical constant π][wiki], approximately equal to 3.14159.
   ///
-  /// This constant is most often defined as the numerical value of the ratio
-  /// of a circle's circumference to its diameter, which is the same for all
-  /// circles.
-  ///
   /// A common application of this constant in geometry is to measure a half
   /// revolution in radians. Used like this, it is equivalent to 180 degrees.
   ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR proposes a small tweak to the documentation associated with the pi constant in the FloatingPoint module.

Suggested here: https://github.com/apple/swift-numerics/issues/89#issuecomment-1054425264

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
