### PR TITLE
[update-checkout] Switch string processing to swift/main

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -123,7 +123,7 @@
                 "swift-cmark-gfm": "gfm",
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
-                "swift-experimental-string-processing": "dev/8"
+                "swift-experimental-string-processing": "swift/main"
             }
         },
         "rebranch": {
@@ -157,7 +157,7 @@
                 "sourcekit-lsp": "main",
                 "swift-format": "main",
                 "swift-installer-scripts": "main",
-                "swift-experimental-string-processing": "dev/8"
+                "swift-experimental-string-processing": "swift/main"
             }
         },
         "release/5.6": {
@@ -308,7 +308,7 @@
                 "sourcekit-lsp": "main",
                 "swift-format": "main",
                 "swift-installer-scripts": "main",
-                "swift-experimental-string-processing": "dev/8"
+                "swift-experimental-string-processing": "swift/main"
             }
         },
         "release/5.4": {


### PR DESCRIPTION
Switch to using swift/main as the integration branch for apple/swift-experimental-string-processing.

Integration process documentation: apple/swift-experimental-string-processing#170