### PR TITLE
[stdlib] String.UnicodeScalarView: Fix some index validation issues

### DIFF
--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -169,5 +169,67 @@ StringTraps.test("UTF8ViewIndex/offsetCrash")
   _ = s8.utf8[i]
 }
 
+StringTraps.test("UnicodeScalarView index(before:) trap on startIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let s = "abc"
+  var i = s.unicodeScalars.endIndex
+  i = s.unicodeScalars.index(before: i)
+  i = s.unicodeScalars.index(before: i)
+  i = s.unicodeScalars.index(before: i)
+  expectCrashLater()
+  i = s.unicodeScalars.index(before: i)
+}
+
+StringTraps.test("UnicodeScalarView index(before:) trap on startIndex after scalar alignment")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let s = "🥦 Floret of broccoli"
+  var i = s.utf8.index(after: s.utf8.startIndex)
+  expectCrashLater()
+  // `i` is equivalent to `s.startIndex` as far as `String.UnicodeScalarView` is
+  // concerned
+  i = s.unicodeScalars.index(before: i)
+}
+
+StringTraps.test("UnicodeScalarView index(after:) trap on endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let s = "abc"
+  var i = s.unicodeScalars.startIndex
+  i = s.unicodeScalars.index(after: i)
+  i = s.unicodeScalars.index(after: i)
+  i = s.unicodeScalars.index(after: i)
+  expectCrashLater()
+  i = s.unicodeScalars.index(after: i)
+}
+
+StringTraps.test("UnicodeScalarView index(after:) trap on i > endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let long = "abcd"
+  var i = long.unicodeScalars.endIndex
+
+  let s = "abc"
+  expectCrashLater()
+  i = s.unicodeScalars.index(after: i)
+}
+
 runAllTests()
 


### PR DESCRIPTION
`String.UnicodeScalarView` currently lacks proper index validation in its `index(after:)` and `index(before:)` methods, leading to out-of-bounds memory accesses when index navigation methods in this view are given invalid indices.

(Also see https://github.com/apple/swift/pull/41598 and https://github.com/apple/swift/pull/41417)

rdar://89498541