### PR TITLE
[CodeCompletion] Some more code cleanup

### DIFF
--- a/include/swift/IDE/DotExprCompletion.h
+++ b/include/swift/IDE/DotExprCompletion.h
@@ -33,24 +33,17 @@ class DotExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
     bool IsImplicitSingleExpressionReturn;
   };
 
-  DeclContext *DC;
   CodeCompletionExpr *CompletionExpr;
   SmallVector<Result, 4> Results;
   llvm::DenseMap<std::pair<Type, Decl *>, size_t> BaseToSolutionIdx;
-  bool GotCallback = false;
 
 public:
-  DotExprTypeCheckCompletionCallback(DeclContext *DC,
-                                     CodeCompletionExpr *CompletionExpr)
-      : DC(DC), CompletionExpr(CompletionExpr) {}
-
-  /// True if at least one solution was passed via the \c sawSolution
-  /// callback.
-  bool gotCallback() const { return GotCallback; }
+  DotExprTypeCheckCompletionCallback(CodeCompletionExpr *CompletionExpr)
+      : CompletionExpr(CompletionExpr) {}
 
   /// Typecheck the code completion expression in isolation, calling
   /// \c sawSolution for each solution formed.
-  void fallbackTypeCheck();
+  void fallbackTypeCheck(DeclContext *DC) override;
 
   void sawSolution(const constraints::Solution &solution) override;
 

--- a/include/swift/IDE/UnresolvedMemberCompletion.h
+++ b/include/swift/IDE/UnresolvedMemberCompletion.h
@@ -33,20 +33,11 @@ class UnresolvedMemberTypeCheckCompletionCallback
   CodeCompletionExpr *CompletionExpr;
   SmallVector<ExprResult, 4> ExprResults;
   SmallVector<Type, 1> EnumPatternTypes;
-  bool GotCallback = false;
 
 public:
   UnresolvedMemberTypeCheckCompletionCallback(
       CodeCompletionExpr *CompletionExpr)
       : CompletionExpr(CompletionExpr) {}
-
-  /// True if at least one solution was passed via the \c sawSolution
-  /// callback.
-  bool gotCallback() const { return GotCallback; }
-
-  /// Typecheck the code completion expression in its outermost expression
-  /// context, calling \c sawSolution for each solution formed.
-  void fallbackTypeCheck(DeclContext *DC);
 
   void sawSolution(const constraints::Solution &solution) override;
 

--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -36,11 +36,24 @@ namespace swift {
   }
 
   class TypeCheckCompletionCallback {
+    bool GotCallback = false;
+
   public:
+    virtual ~TypeCheckCompletionCallback() {}
+
     /// Called for each solution produced while  type-checking an expression
     /// that the code completion expression participates in.
-    virtual void sawSolution(const constraints::Solution &solution) = 0;
-    virtual ~TypeCheckCompletionCallback() {}
+    virtual void sawSolution(const constraints::Solution &solution) {
+      GotCallback = true;
+    };
+
+    /// True if at least one solution was passed via the \c sawSolution
+    /// callback.
+    bool gotCallback() const { return GotCallback; }
+
+    /// Typecheck the code completion expression in its outermost expression
+    /// context, calling \c sawSolution for each solution formed.
+    virtual void fallbackTypeCheck(DeclContext *DC);
   };
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1333,8 +1333,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     assert(CodeCompleteTokenExpr);
     assert(CurDeclContext);
 
-    DotExprTypeCheckCompletionCallback Lookup(CurDeclContext,
-                                              CodeCompleteTokenExpr);
+    DotExprTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr);
     llvm::SaveAndRestore<TypeCheckCompletionCallback*>
       CompletionCollector(Context.CompletionCallback, &Lookup);
     typeCheckContextAt(CurDeclContext, CompletionLoc);
@@ -1345,7 +1344,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     // typechecking still resolve even these cases would be beneficial for
     // tooling in general though.
     if (!Lookup.gotCallback())
-      Lookup.fallbackTypeCheck();
+      Lookup.fallbackTypeCheck(CurDeclContext);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
 

--- a/lib/IDE/DotExprCompletion.cpp
+++ b/lib/IDE/DotExprCompletion.cpp
@@ -21,7 +21,7 @@ using namespace swift;
 using namespace swift::constraints;
 using namespace swift::ide;
 
-void DotExprTypeCheckCompletionCallback::fallbackTypeCheck() {
+void DotExprTypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
   assert(!gotCallback());
 
   // Default to checking the completion expression in isolation.
@@ -46,7 +46,7 @@ void DotExprTypeCheckCompletionCallback::fallbackTypeCheck() {
 
 void DotExprTypeCheckCompletionCallback::sawSolution(
     const constraints::Solution &S) {
-  GotCallback = true;
+  TypeCheckCompletionCallback::sawSolution(S);
   auto &CS = S.getConstraintSystem();
   auto *ParsedExpr = CompletionExpr->getBase();
   auto *SemanticExpr = ParsedExpr->getSemanticsProvidingExpr();

--- a/lib/IDE/KeyPathCompletion.cpp
+++ b/lib/IDE/KeyPathCompletion.cpp
@@ -21,6 +21,8 @@ using namespace swift::ide;
 
 void KeyPathTypeCheckCompletionCallback::sawSolution(
     const constraints::Solution &S) {
+  TypeCheckCompletionCallback::sawSolution(S);
+
   // Determine the code completion.
   size_t ComponentIndex = 0;
   for (auto &Component : KeyPath->getComponents()) {

--- a/lib/IDE/UnresolvedMemberCompletion.cpp
+++ b/lib/IDE/UnresolvedMemberCompletion.cpp
@@ -82,7 +82,7 @@ static VarDecl *getMatchVarIfInPatternMatch(CodeCompletionExpr *CompletionExpr,
 
 void UnresolvedMemberTypeCheckCompletionCallback::sawSolution(
     const constraints::Solution &S) {
-  GotCallback = true;
+  TypeCheckCompletionCallback::sawSolution(S);
 
   auto &CS = S.getConstraintSystem();
   Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
@@ -117,25 +117,6 @@ void UnresolvedMemberTypeCheckCompletionCallback::sawSolution(
       }
     }
   }
-}
-
-void UnresolvedMemberTypeCheckCompletionCallback::fallbackTypeCheck(
-    DeclContext *DC) {
-  assert(!gotCallback());
-
-  CompletionContextFinder finder(DC);
-  if (!finder.hasCompletionExpr())
-    return;
-
-  auto fallback = finder.getFallbackCompletionExpr();
-  if (!fallback)
-    return;
-
-  SolutionApplicationTarget completionTarget(fallback->E, fallback->DC,
-                                             CTP_Unused, Type(),
-                                             /*isDiscared=*/true);
-  typeCheckForCodeCompletion(completionTarget, /*needsPrecheck*/ true,
-                             [&](const Solution &S) { sawSolution(S); });
 }
 
 void UnresolvedMemberTypeCheckCompletionCallback::deliverResults(

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -848,3 +848,22 @@ bool swift::isImplicitSingleExpressionReturn(ConstraintSystem &CS,
   }
   return false;
 }
+
+void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
+  assert(!GotCallback);
+
+  CompletionContextFinder finder(DC);
+  if (!finder.hasCompletionExpr())
+    return;
+
+  auto fallback = finder.getFallbackCompletionExpr();
+  if (!fallback)
+    return;
+
+  SolutionApplicationTarget completionTarget(fallback->E, fallback->DC,
+                                             CTP_Unused, Type(),
+                                             /*isDiscared=*/true);
+  TypeChecker::typeCheckForCodeCompletion(
+      completionTarget, /*needsPrecheck*/ true,
+      [&](const Solution &S) { sawSolution(S); });
+}


### PR DESCRIPTION
- Extract common implementation of `sawSolution` and `fallbackTypeCheck` to `TypeCheckCompletionCallback`
- Make `CodeCompletionCallbacksImpl::addSuperKeywords` a static method (This matches the other `add*Keywords` methods)