### PR TITLE
[Parse] Better recover from regex error

### DIFF
--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -51,12 +51,11 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
   regexLiteralParsingFn(regexText.str().c_str(), &errorStr, &version,
                         /*captureStructureOut*/ capturesBuf.data(),
                         /*captureStructureSize*/ capturesBuf.size());
-  if (errorStr) {
-    diagnose(Tok, diag::regex_literal_parsing_error, errorStr);
-    return makeParserError();
-  }
-
   auto loc = consumeToken();
+  if (errorStr) {
+    diagnose(loc, diag::regex_literal_parsing_error, errorStr);
+    return makeParserResult(new (Context) ErrorExpr(loc));
+  }
   return makeParserResult(RegexLiteralExpr::createParsed(
       Context, loc, regexText, version, capturesBuf));
 }

--- a/test/StringProcessing/Parse/regex_parse_error.swift
+++ b/test/StringProcessing/Parse/regex_parse_error.swift
@@ -1,6 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
 // REQUIRES: swift_in_compiler
 
+_ = re'(' // expected-error {{expected ')'}}
+
+// FIXME: Should be 'group openings'
+_ = re')' // expected-error {{closing ')' does not balance any groups openings}}
+
 let s = #/\\/''/ // expected-error {{unterminated regex literal}}
 _ = #|\| // expected-error {{unterminated regex literal}}
 _ = #// // expected-error {{unterminated regex literal}}


### PR DESCRIPTION
Instead of returning a parser error, which results in generic parser recovery that skips until the next decl, return an `ErrorExpr` so we can continue parsing.
