### PR TITLE
[ASTPrinter] Fix printing inconsistent implementation-only imports

### DIFF
--- a/test/SPI/Inputs/experimental_spi_imports_inconsistent.swift
+++ b/test/SPI/Inputs/experimental_spi_imports_inconsistent.swift
@@ -1,0 +1,1 @@
+@_implementationOnly import InconsistentlyImported

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -7,15 +7,21 @@
 // RUN: %target-swift-frontend -emit-module %S/Inputs/ioi_helper.swift -module-name ExperimentalImported -emit-module-path %t/ExperimentalImported.swiftmodule -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name IOIImported -emit-module-path %t/IOIImported.swiftmodule -swift-version 5 -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name SPIImported -emit-module-path %t/SPIImported.swiftmodule -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/empty.swift -module-name InconsistentlyImported -emit-module-path %t/InconsistentlyImported.swiftmodule -swift-version 5 -enable-library-evolution
 
 /// Test the generated swiftinterface.
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -emit-private-module-interface-path %t/main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t -experimental-spi-imports
+// RUN: %target-swift-frontend -typecheck %s %S/Inputs/experimental_spi_imports_inconsistent.swift -emit-module-interface-path %t/main.swiftinterface -emit-private-module-interface-path %t/main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t -experimental-spi-imports
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/main.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/main.private.swiftinterface
 
 @_spi(dummy) @_implementationOnly import ExperimentalImported
 // CHECK-PUBLIC-NOT: import ExperimentalImported
 // CHECK-PRIVATE: @_implementationOnly @_spi{{.*}} import ExperimentalImported
+
+// This is also imported as implementation-only via another source file.
+import InconsistentlyImported
+// CHECK-PUBLIC: {{^}}import InconsistentlyImported
+// CHECK-PRIVATE: {{^}}import InconsistentlyImported
 
 @_implementationOnly import IOIImported
 // CHECK-PUBLIC-NOT: IOIImported


### PR DESCRIPTION
Make sure we print imports that are sometimes normal and sometimes
implementation-only in the experimental SPI imports mode.

rdar://89620638