### PR TITLE
[SourceKit] Print custom attributes in interface-gen requests

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -494,7 +494,7 @@ SIMPLE_DECL_ATTR(_implementationOnly, ImplementationOnly,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   84)
 DECL_ATTR(_custom, Custom,
-  OnAnyDecl | UserInaccessible |
+  OnAnyDecl | RejectByParser |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   85)
 SIMPLE_DECL_ATTR(propertyWrapper, PropertyWrapper,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -845,6 +845,18 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
   case DAK_Custom: {
+
+    auto attr = cast<CustomAttr>(this);
+    if (auto type = attr->getType()) {
+      // Print custom attributes only if the attribute decl is accessible.
+      // FIXME: rdar://85477478 They should be rejected.
+      if (auto attrDecl = type->getNominalOrBoundGenericNominal()) {
+        if (attrDecl->getFormalAccess() < Options.AccessFilter) {
+          return false;
+        }
+      }
+    }
+
     if (!Options.IsForSwiftInterface)
       break;
     // For Swift interface, we should print result builder attributes

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -685,17 +685,11 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   AttributeVector attributes;
   AttributeVector modifiers;
 
-  CustomAttr *FuncBuilderAttr = nullptr;
-  if (auto *VD = dyn_cast_or_null<ValueDecl>(D)) {
-    FuncBuilderAttr = VD->getAttachedResultBuilder();
-  }
   for (auto DA : llvm::reverse(FlattenedAttrs)) {
     // Always print result builder attribute.
-    bool isResultBuilderAttr = DA == FuncBuilderAttr;
     if (!Options.PrintImplicitAttrs && DA->isImplicit())
       continue;
     if (!Options.PrintUserInaccessibleAttrs &&
-        !isResultBuilderAttr &&
         DeclAttribute::isUserInaccessible(DA->getKind()))
       continue;
     if (Options.excludeAttrKind(DA->getKind()))

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -32,11 +32,11 @@
 // CHECK-NEXT:  var fromNullableHandler: String { get async }
 
 // CHECK:       @available(*, renamed: "getter:mainDogProp()")
-// CHECK-NEXT:  func getMainDog(_ completion: @escaping @Sendable (String) -> Void)
+// CHECK-NEXT:  func getMainDog(_ completion: @escaping @MainActor (String) -> Void)
 // CHECK-NEXT:  var mainDogProp: String { get async }
 
 // CHECK:       @available(*, renamed: "regularMainDog()")
-// CHECK-NEXT:  func regularMainDog(_ completion: @escaping @Sendable (String) -> Void)
+// CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor (String) -> Void)
 // CHECK-NEXT:  @discardableResult
 // CHECK-NEXT:  func regularMainDog() async -> String
 // CHECK: }

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -28,7 +28,7 @@ public func returnsAlias() -> Alias<Int> {
 }
 
 @resultBuilder
-struct BridgeBuilder {
+public struct BridgeBuilder {
     static func buildBlock(_: Any...) {}
 }
 

--- a/test/SourceKit/Inputs/concurrency/gen_concurrency.swift
+++ b/test/SourceKit/Inputs/concurrency/gen_concurrency.swift
@@ -2,4 +2,7 @@ class ClassWithAsyncAndHandler {
   @available(*, renamed: "foo(_:)")
   func foo(_ operation: String, completionHandler handler: @escaping (Int) -> Void) {}
   func foo(_ operation: String) async -> Int { 0 }
+
+  @MainActor
+  func mainActorMethod() {}
 }

--- a/test/SourceKit/Inputs/concurrency/header_concurrency.h
+++ b/test/SourceKit/Inputs/concurrency/header_concurrency.h
@@ -2,4 +2,6 @@
 
 @interface ClassWithHandlerMethod
 -(void)methodWithHandler:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
+
+-(void)mainActorMethod __attribute__((__swift_attr__("@UIActor")));
 @end

--- a/test/SourceKit/InterfaceGen/gen_custom_attributes.swift
+++ b/test/SourceKit/InterfaceGen/gen_custom_attributes.swift
@@ -8,11 +8,26 @@
 // RUN: %sourcekitd-test -req=interface-gen -module MyModule -- -target %target-triple -I %t | %FileCheck %s --check-prefix=SWIFTMODULE
 // RUN: %sourcekitd-test -req=doc-info -module MyModule -- -target %target-triple -I %t | %FileCheck %s --check-prefix=DOCINFO
 
+@available(SwiftStdlib 5.1, *)
+@globalActor
+public struct PublicActor {
+  public actor MyActor { }
+  public static let shared = MyActor()
+}
+
+@available(SwiftStdlib 5.1, *)
+@globalActor
+struct InternalActor {
+  actor MyActor { }
+  static let shared = MyActor()
+}
+
 @propertyWrapper
-public struct OrLess {
+public struct PublicOrLess {
   private var threshold: Int
   private var number: Int = 0
-  init(wrappedValue: Int, threshold: Int) {
+
+  public init(wrappedValue: Int, threshold: Int) {
     self.threshold = threshold
     self.wrappedValue = wrappedValue
   }
@@ -22,38 +37,78 @@ public struct OrLess {
   }
 }
 
+@propertyWrapper
+struct InternalOrLess {
+  private var threshold: Int
+  private var number: Int = 0
+
+  init(wrappedValue: Int, threshold: Int) {
+    self.threshold = threshold
+    self.wrappedValue = wrappedValue
+  }
+  var wrappedValue: Int {
+    get { return number }
+    set { number = min(newValue, 12) }
+  }
+}
+
 @resultBuilder
-public struct IntBuilder {
+public struct PublicBuilder {
     public static func buildBlock(_ val: Int) -> Int { val }
 }
+
+@resultBuilder
+struct InternalBuilder {
+  static func buildBlock(_ val: Int) -> Int { val }
+}
+
 
 public struct TestStruct {
 
   @MainActor public func mainActorMethod() {}
   @MainActor(unsafe) public func mainActorUnsafeMethod() {}
 
-  @OrLess(threshold: 12) public var twelveOrLess = 13
+  @available(SwiftStdlib 5.1, *)
+  @PublicActor public func publicActorMethod() {}
+  @available(SwiftStdlib 5.1, *)
+  @InternalActor public func internalActorMethod() {}
 
-  @IntBuilder public var intValue: Int { 1 }
+  @PublicOrLess(threshold: 12) public var publicOrLess = 13
+  @InternalOrLess(threshold: 42) public var internalOrLess = 56
+
+  @PublicBuilder public var publicBuilderVal: Int { 1 }
+  @InternalBuilder public var internalBuilderVal: Int { 1 }
 }
 
 // SWIFTSOURCE: public struct TestStruct {
 // SWIFTSOURCE:     @MainActor public func mainActorMethod()
 // SWIFTSOURCE:     @MainActor public func mainActorUnsafeMethod()
-// SWIFTSOURCE:     @MyModule.OrLess public var twelveOrLess: Int { get set }
-// SWIFTSOURCE:     @MyModule.IntBuilder public var intValue: Int { get }
+// SWIFTSOURCE:     @MyModule.PublicActor public func publicActorMethod()
+// SWIFTSOURCE:     @MyModule.InternalActor public func internalActorMethod()
+// SWIFTSOURCE:     @MyModule.PublicOrLess public var publicOrLess: Int { get set }
+// SWIFTSOURCE:     @MyModule.InternalOrLess public var internalOrLess: Int { get set }
+// SWIFTSOURCE:     @MyModule.PublicBuilder public var publicBuilderVal: Int { get }
+// SWIFTSOURCE:     @MyModule.InternalBuilder public var internalBuilderVal: Int { get }
 // SWIFTSOURCE: }
 
 // SWIFTMODULE: public struct TestStruct {
 // SWIFTMODULE:     @MainActor public func mainActorMethod()
 // SWIFTMODULE:     @MainActor public func mainActorUnsafeMethod()
-// SWIFTMODULE:     @MyModule.OrLess public var twelveOrLess: Int
-// SWIFTMODULE:     @MyModule.IntBuilder public var intValue: Int { get }
+// SWIFTMODULE:     @MyModule.PublicActor public func publicActorMethod()
+// SWIFTMODULE:     public func internalActorMethod()
+// SWIFTMODULE:     @MyModule.PublicOrLess public var publicOrLess: Int
+// SWIFTMODULE:     public var internalOrLess: Int
+// SWIFTMODULE:     @MyModule.PublicBuilder public var publicBuilderVal: Int { get }
+// SWIFTMODULE:     public var internalBuilderVal: Int { get }
 // SWIFTMODULE: }
 
 // DOCINFO: struct TestStruct {
 // DOCINFO:     @MainActor func mainActorMethod()
 // DOCINFO:     @MainActor func mainActorUnsafeMethod()
-// DOCINFO:     @MyModule.OrLess var twelveOrLess: Int
-// DOCINFO:     @MyModule.IntBuilder var intValue: Int { get }
+// DOCINFO:     @MyModule.PublicActor func publicActorMethod()
+// DOCINFO:     func internalActorMethod()
+// DOCINFO:     @MyModule.PublicOrLess var publicOrLess: Int
+// DOCINFO:     var internalOrLess: Int
+// DOCINFO:     @MyModule.PublicBuilder var publicBuilderVal: Int { get }
+// DOCINFO:     var internalBuilderVal: Int { get }
 // DOCINFO: }

--- a/test/SourceKit/InterfaceGen/gen_custom_attributes.swift
+++ b/test/SourceKit/InterfaceGen/gen_custom_attributes.swift
@@ -1,0 +1,59 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+// RUN: %sourcekitd-test -req=interface-gen %s -- %s -target %target-triple -module-name MyModule | %FileCheck %s --check-prefix=SWIFTSOURCE
+
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/MyModule.swiftmodule %s
+// RUN: %sourcekitd-test -req=interface-gen -module MyModule -- -target %target-triple -I %t | %FileCheck %s --check-prefix=SWIFTMODULE
+// RUN: %sourcekitd-test -req=doc-info -module MyModule -- -target %target-triple -I %t | %FileCheck %s --check-prefix=DOCINFO
+
+@propertyWrapper
+public struct OrLess {
+  private var threshold: Int
+  private var number: Int = 0
+  init(wrappedValue: Int, threshold: Int) {
+    self.threshold = threshold
+    self.wrappedValue = wrappedValue
+  }
+  public var wrappedValue: Int {
+    get { return number }
+    set { number = min(newValue, 12) }
+  }
+}
+
+@resultBuilder
+public struct IntBuilder {
+    public static func buildBlock(_ val: Int) -> Int { val }
+}
+
+public struct TestStruct {
+
+  @MainActor public func mainActorMethod() {}
+  @MainActor(unsafe) public func mainActorUnsafeMethod() {}
+
+  @OrLess(threshold: 12) public var twelveOrLess = 13
+
+  @IntBuilder public var intValue: Int { 1 }
+}
+
+// SWIFTSOURCE: public struct TestStruct {
+// SWIFTSOURCE:     @MainActor public func mainActorMethod()
+// SWIFTSOURCE:     @MainActor public func mainActorUnsafeMethod()
+// SWIFTSOURCE:     @MyModule.OrLess public var twelveOrLess: Int { get set }
+// SWIFTSOURCE:     @MyModule.IntBuilder public var intValue: Int { get }
+// SWIFTSOURCE: }
+
+// SWIFTMODULE: public struct TestStruct {
+// SWIFTMODULE:     @MainActor public func mainActorMethod()
+// SWIFTMODULE:     @MainActor public func mainActorUnsafeMethod()
+// SWIFTMODULE:     @MyModule.OrLess public var twelveOrLess: Int
+// SWIFTMODULE:     @MyModule.IntBuilder public var intValue: Int { get }
+// SWIFTMODULE: }
+
+// DOCINFO: struct TestStruct {
+// DOCINFO:     @MainActor func mainActorMethod()
+// DOCINFO:     @MainActor func mainActorUnsafeMethod()
+// DOCINFO:     @MyModule.OrLess var twelveOrLess: Int
+// DOCINFO:     @MyModule.IntBuilder var intValue: Int { get }
+// DOCINFO: }

--- a/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
+++ b/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
@@ -11,6 +11,9 @@
 // SWIFT-GEN-INTERFACE-NEXT:    internal func foo(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // SWIFT-GEN-INTERFACE:         internal func foo(_ operation: String) async -> Int
 
+// SWIFT-GEN-INTERFACE:         @MainActor internal func mainActorMethod()
+
+
 // RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/../Inputs/concurrency/header_concurrency.h -- %s -Xfrontend -enable-objc-interop -import-objc-header %S/../Inputs/concurrency/header_concurrency.h -sdk %clang-importer-sdk | %FileCheck %s --check-prefix=OBJC-GEN-INTERFACE
 
 // But don't print @available if it was implicitly added to an imported Clang decl (rdar://76685011).
@@ -18,3 +21,5 @@
 // OBJC-GEN-INTERFACE-NOT:     @available
 // OBJC-GEN-INTERFACE:         func method(withHandler operation: String!, completionHandler handler: (@Sendable (Int) -> Void)!)
 // OBJC-GEN-INTERFACE:         func method(withHandler operation: String!) async -> Int
+
+// OBJC-GEN-INTERFACE:         @MainActor open func mainActorMethod()

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -342,3 +342,5 @@ enum E1 {
 
   func foo() -> @_nonEphemeral UnsafeMutableRawPointer? { return nil } // expected-error {{attribute can only be applied to declarations, not types}}
 }
+
+@_custom func testCustomAttribute() {} // expected-error {{unknown attribute '_custom'}}

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1086,6 +1086,12 @@ static bool reportModuleDocInfo(CompilerInvocation Invocation,
   ASTContext &Ctx = CI.getASTContext();
   registerIDERequestFunctions(Ctx.evaluator);
 
+  // Load implict imports so that Clang importer can use it.
+  for (auto unloadedImport :
+       CI.getMainModule()->getImplicitImportInfo().AdditionalUnloadedImports) {
+    (void)Ctx.getModule(unloadedImport.module.getModulePath());
+  }
+
   SourceTextInfo IFaceInfo;
   if (getModuleInterfaceInfo(Ctx, ModuleName, IFaceInfo))
     return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -381,11 +381,10 @@ SwiftInterfaceGenContext::create(StringRef DocumentName,
   ASTContext &Ctx = CI.getASTContext();
   CloseClangModuleFiles scopedCloseFiles(*Ctx.getClangModuleLoader());
 
-  // Load standard library so that Clang importer can use it.
-  auto *Stdlib = Ctx.getModuleByIdentifier(Ctx.StdlibModuleName);
-  if (!Stdlib) {
-    ErrMsg = "Could not load the stdlib module";
-    return nullptr;
+  // Load implict imports so that Clang importer can use them.
+  for (auto unloadedImport :
+       CI.getMainModule()->getImplicitImportInfo().AdditionalUnloadedImports) {
+    (void)Ctx.getModule(unloadedImport.module.getModulePath());
   }
 
   if (IsModule) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2960,11 +2960,10 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
-  // Load standard library so that Clang importer can use it.
-  auto *Stdlib = getModuleByFullName(Context, Context.StdlibModuleName);
-  if (!Stdlib) {
-    llvm::errs() << "Failed loading stdlib\n";
-    return 1;
+  // Load implict imports so that Clang importer can use it.
+  for (auto unloadedImport :
+       CI.getMainModule()->getImplicitImportInfo().AdditionalUnloadedImports) {
+    (void)Context.getModule(unloadedImport.module.getModulePath());
   }
 
   // If needed, load _Concurrency library so that the Clang importer can use it.
@@ -3028,11 +3027,10 @@ static int doPrintHeaders(const CompilerInvocation &InitInvok,
   registerIDERequestFunctions(CI.getASTContext().evaluator);
   auto &Context = CI.getASTContext();
 
-  // Load standard library so that Clang importer can use it.
-  auto *Stdlib = getModuleByFullName(Context, Context.StdlibModuleName);
-  if (!Stdlib) {
-    llvm::errs() << "Failed loading stdlib\n";
-    return 1;
+  // Load implict imports so that Clang importer can use it.
+  for (auto unloadedImport :
+       CI.getMainModule()->getImplicitImportInfo().AdditionalUnloadedImports) {
+    (void)Context.getModule(unloadedImport.module.getModulePath());
   }
 
   auto &FEOpts = Invocation.getFrontendOptions();


### PR DESCRIPTION
Custom attributes were not printed because they are marked `UserInaccesible`.

* Make CustomAttr `RejectByParser` instead of `UserInaccessible`
* Remove special treatment for Result Builder attributes
* Load implicit modules in module/header interface gen requests

rdar://79927502
