### PR TITLE
[SIL] Fix incorrect verifier check when generic functions have been made non-polymorphic

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5832,7 +5832,9 @@ public:
 
     // Make sure that our SILFunction only has context generic params if our
     // SILFunctionType is non-polymorphic.
-    if (F->getGenericEnvironment()) {
+    if (F->getGenericEnvironment() &&
+        !F->getGenericEnvironment()->getGenericSignature()
+            ->areAllParamsConcrete()) {
       require(FTy->isPolymorphic(),
               "non-generic function definitions cannot have a "
               "generic environment");

--- a/test/SILGen/objc_generic_class.swift
+++ b/test/SILGen/objc_generic_class.swift
@@ -41,3 +41,13 @@ class Generic<T>: NSObject {
 class SubGeneric1<U, V>: Generic<Int> {
 }
 
+
+// Ensure that the verifier doesn't reject @objc functions where all of the
+// generic parameters have been same-typed to concrete types.
+public struct GenericStruct<T> { }
+
+public extension GenericStruct where T == String {
+  public class Y {
+    @objc public func f() -> String { "hello" }
+  }
+}


### PR DESCRIPTION
The verifier wasn't accounting for the case where all generic parameters have been same-typed constrained to concrete types.