### PR TITLE
[test] stdlib/StringTraps: Add some coverage for foreign traps in UTF-8/16 views

### DIFF
--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -10,6 +10,9 @@
 // UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
+#if _runtime(_ObjC)
+import Foundation // For NSString
+#endif
 
 let testSuiteSuffix = _isDebugAssertConfiguration() ? "_debug" : "_release"
 
@@ -131,7 +134,7 @@ StringTraps.test("UTF16ViewSubscript/endIndex")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
-  var s = "abc"
+  let s = "abc"
   var i = s.utf16.startIndex
   i = s.utf16.index(after: i)
   i = s.utf16.index(after: i)
@@ -259,6 +262,96 @@ StringTraps.test("UnicodeScalarView index(after:) trap on i > endIndex")
   expectCrashLater()
   i = s.unicodeScalars.index(after: i)
 }
+
+StringTraps.test("UnicodeScalarView index(before:) trap on i > endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let long = "abcd"
+  var i = long.unicodeScalars.endIndex
+
+  let s = "abc"
+  expectCrashLater()
+  i = s.unicodeScalars.index(before: i)
+}
+
+#if _runtime(_ObjC)
+StringTraps.test("UTF8View foreign index(after:) trap on i > endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let long = "🐘 This is a quite large string, with lots of data"
+  let short = ("🐭 I'm much smaller" as NSString) as String
+
+  var i = long.utf8.endIndex
+  expectCrashLater()
+  // Note: we expect that `short` will be UTF-16 encoded here -- this trap only
+  // happens on the foreign path. For native/shared strings, the UTF-8 view's
+  // `index(after:)` is essentially doing a simple `i + 1`, like Array does.
+  i = short.utf8.index(after: i)
+}
+#endif
+
+#if _runtime(_ObjC)
+StringTraps.test("UTF8View foreign index(before:) trap on i > endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let long = "🐘 This is a quite large string, with lots of data"
+  let short = ("🐭 I'm much smaller" as NSString) as String
+
+  var i = long.utf8.endIndex
+  expectCrashLater()
+  // Note: we expect that `short` will be UTF-16 encoded here -- this trap only
+  // happens on the foreign path. For native/shared strings, the UTF-8 view's
+  // `index(before:)` is essentially doing a simple `i - 1`, like Array does.
+  // (Following the unconditional i != startIndex check.)
+  i = short.utf8.index(before: i)
+}
+#endif
+
+#if _runtime(_ObjC)
+StringTraps.test("UTF8View foreign index(after:) trap on i == endIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let s = ("🦧 The Librarian" as NSString) as String
+
+  var i = s.utf8.endIndex
+  expectCrashLater()
+  // Note: we expect that `short` will be UTF-16 encoded here -- this trap only
+  // happens on the foreign path. For native/shared strings, the UTF-8 view's
+  // `index(after:)` is essentially doing a simple `i + 1`, like Array does.
+  i = s.utf8.index(after: i)
+}
+#endif
+
+#if _runtime(_ObjC)
+StringTraps.test("UTF8View foreign index(before:) trap on i == startIndex")
+.skip(
+  .custom({ _isFastAssertConfiguration() },
+  reason: "trap is not guaranteed to happen in -Ounchecked"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let s = ("🦧 The Librarian" as NSString) as String
+  var i = s.utf8.startIndex
+  expectCrashLater()
+  i = s.utf8.index(before: i)
+}
+#endif
 
 runAllTests()
 


### PR DESCRIPTION
These trigger Objective-C exceptions in Foundation, but the fact these operations reliably trap when applied to foreign strings is part of the String contract in the stdlib, and we should have regression tests for them.
