### PR TITLE
RequirementMachine: Reduce replacement paths for redundant rules to left-canonical normal form

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -545,6 +545,10 @@ namespace swift {
     /// enabled. It can be disabled for debugging and testing.
     bool EnableRequirementMachineConcreteContraction = true;
 
+    /// Enable the stronger minimization algorithm. This is just for debugging;
+    /// if you have a testcase which requires this, please submit a bug report.
+    bool EnableRequirementMachineLoopNormalization = false;
+
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -359,6 +359,9 @@ def disable_requirement_machine_concrete_contraction : Flag<["-"], "disable-requ
   HelpText<"Disable preprocessing pass to eliminate conformance requirements "
            "on generic parameters which are made concrete">;
 
+def enable_requirement_machine_loop_normalization : Flag<["-"], "enable-requirement-machine-loop-normalization">,
+  HelpText<"Enable stronger minimization algorithm, for debugging only">;
+
 def dump_type_witness_systems : Flag<["-"], "dump-type-witness-systems">,
   HelpText<"Enables dumping type witness systems from associated type inference">;
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -83,6 +83,7 @@ add_swift_host_library(swiftAST STATIC
   RequirementMachine/InterfaceType.cpp
   RequirementMachine/KnuthBendix.cpp
   RequirementMachine/MinimalConformances.cpp
+  RequirementMachine/NormalizeRewritePath.cpp
   RequirementMachine/PropertyMap.cpp
   RequirementMachine/PropertyRelations.cpp
   RequirementMachine/PropertyUnification.cpp

--- a/lib/AST/RequirementMachine/NormalizeRewritePath.cpp
+++ b/lib/AST/RequirementMachine/NormalizeRewritePath.cpp
@@ -1,0 +1,241 @@
+//===--- LeftCanonicalForm.cpp - Left canonical form of a rewrite path ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Algorithm for reducing a rewrite path to left-canonical form:
+//
+// - Adjacent steps that are inverses of each other cancel out. for example
+//   these two steps will be eliminated:
+//
+//     (A => B) ⊗ (B => A)
+//
+// - Interchange law moves rewrites "to the left", for example
+//
+//     X.(U => V) ⊗ (X => Y).V
+//
+//   becomes
+//
+//     (X => Y).U ⊗ Y.(U => V)
+//
+// These two transformations are iterated until fixed point to produce a
+// equivalent rewrite path that is simpler.
+//
+// From "Homotopy reduction systems for monoid presentations",
+// https://www.sciencedirect.com/science/article/pii/S0022404997000959
+//
+//===----------------------------------------------------------------------===//
+
+#include "RewriteLoop.h"
+#include "RewriteSystem.h"
+#include "llvm/ADT/SmallVector.h"
+#include <utility>
+
+using namespace swift;
+using namespace rewriting;
+
+/// Returns true if this rewrite step is an inverse of \p other
+/// (and vice versa).
+bool RewriteStep::isInverseOf(const RewriteStep &other) const {
+  if (Kind != other.Kind)
+    return false;
+
+  if (StartOffset != other.StartOffset)
+    return false;
+
+  if (Inverse != !other.Inverse)
+    return false;
+
+  switch (Kind) {
+  case RewriteStep::Rule:
+    return Arg == other.Arg;
+
+  default:
+    return false;
+  }
+
+  assert(EndOffset == other.EndOffset && "Bad whiskering?");
+  return true;
+}
+
+bool RewriteStep::maybeSwapRewriteSteps(RewriteStep &other,
+                                        const RewriteSystem &system) {
+  if (Kind != RewriteStep::Rule ||
+      other.Kind != RewriteStep::Rule)
+    return false;
+
+  // Two rewrite steps are _orthogonal_ if they rewrite disjoint subterms
+  // in context. Orthogonal rewrite steps commute, so we can canonicalize
+  // a path by placing the left-most step first.
+  //
+  // Eg, A.U.B.(X => Y).C ⊗ A.(U => V).B.Y == A.(U => V).B.X ⊗ A.V.B.(X => Y).
+  //
+  // Or, in diagram form. We want to turn this:
+  //
+  //   ----- time ----->
+  // +---------+---------+
+  // |    A    |    A    |
+  // +---------+---------+
+  // |    U    | U ==> V |
+  // +---------+---------+
+  // |    B    |    B    |
+  // +---------+---------+
+  // | X ==> Y |    Y    |
+  // +---------+---------+
+  // |    C    |    C    |
+  // +---------+---------+
+  //
+  // Into this:
+  //
+  // +---------+---------+
+  // |    A    |    A    |
+  // +---------+---------+
+  // | U ==> V |    V    |
+  // +---------+---------+
+  // |    B    |    B    |
+  // +---------+---------+
+  // |    X    | X ==> Y |
+  // +---------+---------+
+  // |    C    |    C    |
+  // +---------+---------+
+  //
+  // Note that
+  //
+  // StartOffset == |A|+|U|+|B|
+  // EndOffset = |C|
+  //
+  // other.StartOffset = |A|
+  // other.EndOffset = |B|+|Y|+|C|
+  //
+  // After interchange, we adjust:
+  //
+  // StartOffset = |A|
+  // EndOffset = |B|+|X|+|C|
+  //
+  // other.StartOffset = |A|+|V|+|B|
+  // other.EndOffset = |C|
+
+  const auto &rule = system.getRule(Arg);
+  auto lhs = (Inverse ? rule.getRHS() : rule.getLHS());
+  auto rhs = (Inverse ? rule.getLHS() : rule.getRHS());
+
+  const auto &otherRule = system.getRule(other.Arg);
+  auto otherLHS = (other.Inverse ? otherRule.getRHS() : otherRule.getLHS());
+  auto otherRHS = (other.Inverse ? otherRule.getLHS() : otherRule.getRHS());
+
+  if (StartOffset < other.StartOffset + otherLHS.size())
+    return false;
+
+  std::swap(*this, other);
+  EndOffset += (lhs.size() - rhs.size());
+  other.StartOffset += (otherRHS.size() - otherLHS.size());
+
+  return true;
+}
+
+/// Cancels out adjacent rewrite steps that are inverses of each other.
+/// This does not change either endpoint of the path, and the path does
+/// not necessarily need to be a loop.
+bool RewritePath::computeFreelyReducedForm() {
+  SmallVector<RewriteStep, 4> newSteps;
+  bool changed = false;
+
+  for (const auto &step : Steps) {
+    if (!newSteps.empty() &&
+        newSteps.back().isInverseOf(step)) {
+      changed = true;
+      newSteps.pop_back();
+      continue;
+    }
+
+    newSteps.push_back(step);
+  }
+
+  if (!changed)
+    return false;
+  std::swap(newSteps, Steps);
+  return changed;
+}
+
+/// Apply the interchange rule until fixed point (see maybeSwapRewriteSteps()).
+bool RewritePath::computeLeftCanonicalForm(const RewriteSystem &system) {
+  bool changed = false;
+
+  for (unsigned i = 1, e = Steps.size(); i < e; ++i) {
+    auto &prevStep = Steps[i - 1];
+    auto &step = Steps[i];
+
+    if (prevStep.maybeSwapRewriteSteps(step, system))
+      changed = true;
+  }
+
+  return changed;
+}
+
+/// Compute freely-reduced left-canonical normal form of a path.
+void RewritePath::computeNormalForm(const RewriteSystem &system) {
+  // FIXME: This can be more efficient.
+  bool changed;
+  do {
+    changed = false;
+    changed |= computeFreelyReducedForm();
+    changed |= computeLeftCanonicalForm(system);
+  } while (changed);
+}
+
+/// Given a path that is a loop around the given basepoint, cancels out
+/// pairs of terms from the ends that are inverses of each other, applying
+/// the corresponding translation to the basepoint.
+///
+/// For example, consider this loop with basepoint 'X':
+///
+///   (X => Y.A) * (Y.A => Y.B) * Y.(B => A) * (Y.A => X)
+///
+/// The first step is the inverse of the last step, so the cyclic
+/// reduction is the loop (Y.A => Y.B) * Y.(B => A), with a new
+/// basepoint 'Y.A'.
+bool RewritePath::computeCyclicallyReducedForm(MutableTerm &basepoint,
+                                               const RewriteSystem &system) {
+  RewritePathEvaluator evaluator(basepoint);
+  unsigned count = 0;
+
+  while (2 * count + 1 < size()) {
+    auto left = Steps[count];
+    auto right = Steps[Steps.size() - count - 1];
+    if (!left.isInverseOf(right))
+      break;
+
+    // Update the basepoint by applying the first step in the path.
+    evaluator.apply(left, system);
+
+    ++count;
+  }
+
+  std::rotate(Steps.begin(), Steps.begin() + count, Steps.end() - count);
+  Steps.erase(Steps.end() - 2 * count, Steps.end());
+
+  basepoint = evaluator.getCurrentTerm();
+  return count > 0;
+}
+
+/// Compute cyclically-reduced left-canonical normal form of a loop.
+void RewriteLoop::computeNormalForm(const RewriteSystem &system) {
+  // FIXME: This can be more efficient.
+  bool changed;
+  do {
+    changed = false;
+    changed |= Path.computeFreelyReducedForm();
+    changed |= Path.computeCyclicallyReducedForm(Basepoint, system);
+    changed |= Path.computeLeftCanonicalForm(system);
+
+    if (changed)
+      markDirty();
+  } while (changed);
+}

--- a/lib/AST/RequirementMachine/PropertyRelations.cpp
+++ b/lib/AST/RequirementMachine/PropertyRelations.cpp
@@ -65,9 +65,9 @@ unsigned RewriteSystem::recordRelation(Symbol lhsProperty,
       Term::get(rhsTerm, Context));
 }
 
-/// Record a relation ([concrete: C].[P] => [concrete: C : P])
-/// or ([superclass: C].[P] => [concrete: C : P]) which combines a
-/// concrete type symbol (or a superclass symbol) with a protocol
+/// Record a relation ([concrete: C].[P] => [concrete: C].[concrete: C : P])
+/// or ([superclass: C].[P] => [superclass: C].[concrete: C : P]) which combines
+/// a concrete type symbol (or a superclass symbol) with a protocol
 /// symbol to form a single a concrete conformance symbol.
 unsigned RewriteSystem::recordConcreteConformanceRelation(
     Symbol concreteSymbol, Symbol protocolSymbol,
@@ -83,6 +83,7 @@ unsigned RewriteSystem::recordConcreteConformanceRelation(
   lhsTerm.add(protocolSymbol);
 
   MutableTerm rhsTerm;
+  rhsTerm.add(concreteSymbol);
   rhsTerm.add(concreteConformanceSymbol);
 
   return recordRelation(

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -355,6 +355,11 @@ struct RewriteStep {
             RewritePathEvaluator &evaluator,
             const RewriteSystem &system) const;
 
+  bool isInverseOf(const RewriteStep &other) const;
+
+  bool maybeSwapRewriteSteps(RewriteStep &other,
+                             const RewriteSystem &system);
+
 private:
   static unsigned getConcreteProjectionArg(unsigned differenceID,
                                            unsigned substitutionIndex) {
@@ -405,6 +410,15 @@ public:
   bool replaceRuleWithPath(unsigned ruleID, const RewritePath &path);
 
   void invert();
+
+  bool computeFreelyReducedForm();
+
+  bool computeCyclicallyReducedForm(MutableTerm &basepoint,
+                                    const RewriteSystem &system);
+
+  bool computeLeftCanonicalForm(const RewriteSystem &system);
+
+  void computeNormalForm(const RewriteSystem &system);
 
   void dump(llvm::raw_ostream &out,
             MutableTerm term,
@@ -490,6 +504,8 @@ public:
       llvm::SmallDenseMap<const ProtocolDecl *,
                           ProtocolConformanceRules, 2> &result,
       const RewriteSystem &system) const;
+
+  void computeNormalForm(const RewriteSystem &system);
 
   void verify(const RewriteSystem &system) const;
 

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -454,12 +454,18 @@ private:
   /// Cached value for getDecomposeCount().
   unsigned DecomposeCount : 15;
 
-  /// Loops are deleted once they no longer contain rules in empty context,
-  /// since at that point they don't participate in minimization and do not
-  /// need to be considered.
+  /// A useful loop contains at least one rule in empty context, even if that
+  /// rule appears multiple times or also in non-empty context. The only loops
+  /// that are elimination candidates contain a rule in empty context *exactly
+  /// once*. A useful loop can become an elimination candidate after
+  /// normalization.
+  unsigned Useful : 1;
+
+  /// Loops are deleted once they are no longer useful, as defined above.
   unsigned Deleted : 1;
 
-  /// If true, RulesInEmptyContext should be recomputed.
+  /// If true, Useful, RulesInEmptyContext, ProjectionCount, and DecomposeCount
+  /// should be recomputed.
   unsigned Dirty : 1;
 
   void recompute(const RewriteSystem &system);
@@ -469,11 +475,11 @@ public:
     : Basepoint(basepoint), Path(path) {
     ProjectionCount = 0;
     DecomposeCount = 0;
-
+    Useful = 0;
     Deleted = 0;
 
-    // Initially, RulesInEmptyContext and ProjectionCount are not valid because
-    // they have not been computed yet.
+    // Initially, cached values are not valid because they have not been
+    // computed yet.
     Dirty = 1;
   }
 
@@ -491,7 +497,7 @@ public:
     Dirty = 1;
   }
 
-  bool isInContext(const RewriteSystem &system) const;
+  bool isUseful(const RewriteSystem &system) const;
 
   ArrayRef<unsigned>
   findRulesAppearingOnceInEmptyContext(const RewriteSystem &system) const;

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -627,7 +627,7 @@ void RewriteSystem::recordRewriteLoop(MutableTerm basepoint,
   if (!RecordLoops)
     return;
 
-  // Ignore the rewrite rule if it is not part of our minimization domain.
+  // Ignore the rewrite loop if it is not part of our minimization domain.
   if (!isInMinimizationDomain(basepoint.getRootProtocol()))
     return;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -486,6 +486,8 @@ private:
   void computeMinimalConformances(
       llvm::DenseSet<unsigned> &redundantConformances);
 
+  void normalizeRedundantRules();
+
 public:
   void recordRewriteLoop(MutableTerm basepoint,
                          RewritePath path);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1005,6 +1005,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_requirement_machine_concrete_contraction))
     Opts.EnableRequirementMachineConcreteContraction = false;
 
+  if (Args.hasArg(OPT_enable_requirement_machine_loop_normalization))
+    Opts.EnableRequirementMachineLoopNormalization = true;
+
   Opts.DumpTypeWitnessSystems = Args.hasArg(OPT_dump_type_witness_systems);
 
   return HadError || UnsupportedOS || UnsupportedArch;

--- a/test/Generics/concrete_conformance_minimization.swift
+++ b/test/Generics/concrete_conformance_minimization.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction -enable-requirement-machine-loop-normalization 2>&1 | %FileCheck %s
 
 struct MyOptionSet : OptionSet {
   let rawValue: UInt

--- a/test/Generics/concrete_conformance_rule_simplified.swift
+++ b/test/Generics/concrete_conformance_rule_simplified.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction -enable-requirement-machine-loop-normalization 2>&1 | %FileCheck %s
 
 protocol P1 {}
 

--- a/test/Generics/loop_normalization_1.swift
+++ b/test/Generics/loop_normalization_1.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -enable-requirement-machine-loop-normalization 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype T
+}
+
+struct C {}
+
+// CHECK-LABEL: .f1@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f1<T: P, U: P>(_: T, _: U) where T.T == C, T.T == U.T { }
+
+// CHECK-LABEL: .f2@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f2<T: P, U: P>(_: T, _: U) where U.T == C, T.T == U.T { }
+
+// CHECK-LABEL: .f3@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f3<T: P, U: P>(_: T, _: U) where T.T == C, U.T == C, T.T == U.T { }
+
+// CHECK-LABEL: .f4@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f4<T: P, U: P>(_: T, _: U) where T.T == C, T.T == U.T, U.T == C { }
+
+// CHECK-LABEL: .f5@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f5<T: P, U: P>(_: T, _: U) where T.T == U.T, T.T == C, U.T == C { }
+
+// CHECK-LABEL: .f6@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f6<T: P, U: P>(_: T, _: U) where U.T == C, T.T == C, T.T == U.T { }
+
+// CHECK-LABEL: .f7@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f7<T: P, U: P>(_: T, _: U) where T.T == C, U.T == C, T.T == U.T { }
+
+// CHECK-LABEL: .f8@
+// CHECK-NEXT: Generic signature: <T, U where T : P, U : P, T.[P]T == C, U.[P]T == C>
+func f8<T: P, U: P>(_: T, _: U) where T.T == U.T, U.T == C, T.T == C { }

--- a/test/Generics/loop_normalization_2.swift
+++ b/test/Generics/loop_normalization_2.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -enable-requirement-machine-loop-normalization 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype A
+}
+
+protocol P2 : P1 where A == S0 {
+  associatedtype B : P2 = S2
+    where B.A == A, B.B == B
+}
+
+struct S0 {}
+
+struct S1 : P2 {}
+
+struct S2 : P2 {}
+
+// CHECK-LABEL: .Q1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Q1]T == S1>
+protocol Q1 {
+  associatedtype T where T : P2, T == S1
+}
+
+// CHECK-LABEL: .Q2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[Q2]T == S2>
+protocol Q2 {
+  associatedtype T where T : P2, T == S2
+}

--- a/test/Generics/redundant_parent_path_in_protocol.swift
+++ b/test/Generics/redundant_parent_path_in_protocol.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -enable-requirement-machine-loop-normalization 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: redundant_parent_path_in_protocol.(file).P1@
 // CHECK-NEXT: Requirement signature: <Self>


### PR DESCRIPTION
This brings back the code I deleted in 1bf6102f1e8db552e4fe401b7e4ecfcad5908116 but repurposes it to only simplify the replacement paths recorded for redundant rewrite rules by default.

The `-enable-requirement-machine-loop-normalization` flag enables this for all rewrite loops. Running the validation tests with that flag uncovered a latent bug. I updated a few tests to explicitly pass this flag in an additional RUN: line to exercise this code path.

I have yet to see an example that requires loop normalization to be enabled in order to minimize correctly. However, I strongly suspect such cases exist.

Finally, add some more assertions to GenericSignature::verify().