### PR TITLE
RequirementMachine: Fix minimization when protocol is constrained to a class that conforms to the protocol

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -106,6 +106,8 @@ public:
 
   bool isProtocolRefinementRule() const;
 
+  bool isCircularConformanceRule() const;
+
   /// See above for an explanation of these predicates.
   bool isPermanent() const {
     return Permanent;

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=off
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+// FIXME: Both RUN lines should pass 'on' once diagnostics are implemented.
 
 protocol P {}
 class C {}
@@ -38,7 +40,11 @@ func derivedViaConcreteY1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
 // expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
 
-// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+// CHECK: Generic signature: <A, B where A : Y<B>>
+//
+// FIXME: Should be <A, B where A : Y<B>, B : C>, but redundant
+// superclass requirements currently block concrete contraction.
+
 func derivedViaConcreteY2<A, B>(_: A, _: B)
   where A : V, B : C, A : Y<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}

--- a/test/Generics/protocol_superclass_cycle.swift
+++ b/test/Generics/protocol_superclass_cycle.swift
@@ -1,8 +1,54 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P : C {}
-final class C : P {}
+class C : P {}
 
-// CHECK: Generic signature: <T where T : P>
-func foo<T : P>(_: T) {}
+// CHECK-LABEL: .SubP@
+// CHECK-NEXT: Requirement signature: <Self where Self : P>
+protocol SubP : P {}
+
+protocol Q {
+  associatedtype T
+}
+
+// CHECK-LABEL: .foo1@
+// CHECK-NEXT: Generic signature: <T where T : P>
+func foo1<T : P>(_: T) {}
+
+// CHECK-LABEL: .foo1a@
+// CHECK-NEXT: Generic signature: <T where T : P>
+func foo1a<T>(_: T) where T : P, T : C {}
+
+// CHECK-LABEL: .foo1b@
+// CHECK-NEXT: Generic signature: <T where T : P>
+func foo1b<T>(_: T) where T : C, T : P {}
+
+// CHECK-LABEL: .foo2@
+// CHECK-NEXT: Generic signature: <T where T : Q, T.[Q]T : P>
+func foo2<T : Q>(_: T) where T.T : P {}
+
+// CHECK-LABEL: .foo3@
+// CHECK-NEXT: Generic signature: <T where T : SubP>
+func foo3<T : SubP>(_: T) {}
+
+// CHECK-LABEL: .foo4@
+// CHECK-NEXT: Generic signature: <T where T : Q, T.[Q]T : SubP>
+func foo4<T : Q>(_: T) where T.T : SubP {}
+
+protocol SuperP {}
+
+// CHECK-LABEL: .SubSuperP@
+// CHECK-NEXT: Requirement signature: <Self where Self : SuperC>
+protocol SubSuperP : SuperP, SuperC {}
+
+class SuperC : SubSuperP {}
+
+// CHECK-LABEL: .foo5@
+// CHECK-NEXT: Generic signature: <T where T : SubSuperP>
+func foo5<T : SubSuperP>(_: T) {}
+
+// CHECK-LABEL: .foo6@
+// CHECK-NEXT: Generic signature: <T where T : Q, T.[Q]T : SubSuperP>
+func foo6<T : Q>(_: T) where T.T : SubSuperP {}
+

--- a/test/SILGen/protocol_superclass_cycle.swift
+++ b/test/SILGen/protocol_superclass_cycle.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s
+// RUN: %target-swift-frontend -emit-silgen -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on %s
 
 // When a protocol has a superclass requirement on 'Self' and the class
 // itself conforms concretely, the forwarding substitution map will have


### PR DESCRIPTION
Consider this example:

    protocol P : C {}
    class C : P {}

    <T where T : P>

The GenericSignatureBuilder thinks the minimized signature is `<T where T : P>`. The RequirementMachine would minimize it down to `<T where T : C>`. The latter is more correct, since the conformance here is concrete and no witness table needs to be passed in at runtime, however for strict binary compatibility we need to produce the same signature as the GenericSignatureBuilder.

Accomplish this by changing the minimal conformances algorithm to detect "circular concrete conformance rules", which take the form

    [P].[concrete: C : Q]

Where Q : P. These rules are given special handling. Ordinarily a protocol conformance rule is eliminated before a concrete conformance rule; however concrete conformances derived from circular conformances are considered to be redundant from the get-go, preventing protocol conformances that can be written in terms of such concrete conformances from themselves becoming redundant.

Fixes rdar://problem/89633532.