### PR TITLE
Add exported symbol on non-Apple platforms to enumerate MetadataSection structures at runtime.

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -520,10 +520,14 @@ public:
     // These are marked as ref-qualified (the &) to make sure they can't be
     // called on temporaries, since the temporary would be destroyed before the
     // return value can be used, making it invalid.
-    const ElemTy *begin() & { return Start; }
-    const ElemTy *end() & { return Start + Count; }
+    const ElemTy *begin() const& { return Start; }
+    const ElemTy *end() const& { return Start + Count; }
+    const ElemTy& operator [](size_t index) const& {
+      assert(index < count() && "out-of-bounds access to snapshot element");
+      return Start[index];
+    }
 
-    size_t count() { return Count; }
+    size_t count() const { return Count; }
   };
 
   // This type cannot be safely copied or moved.

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -71,6 +71,22 @@ struct SectionInfo {
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(struct swift::MetadataSections *sections);
 
+/// Enumerate all metadata sections in the current process that are known to the
+/// Swift runtime.
+///
+/// \param body A function to invoke once per metadata sections structure.
+///   If this function returns \c false, enumeration is stopped.
+/// \param context An additional context pointer to pass to \a body.
+///
+/// On Mach-O-based platforms (i.e. Apple platforms), this function is
+/// unavailable. On those plaforms, use dyld API to enumerate loaded images and
+/// their corresponding metadata sections.
+SWIFT_RUNTIME_EXPORT SWIFT_WEAK_IMPORT
+void swift_enumerateAllMetadataSections(
+  bool (* body)(const swift::MetadataSections *sections, void *context),
+  void *context
+);
+
 #ifndef NDEBUG
 
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -14,6 +14,7 @@
 #include "../SwiftShims/MetadataSections.h"
 
 #include <cstdint>
+#include <new>
 
 extern "C" const char __ImageBase[];
 
@@ -64,9 +65,9 @@ static void swift_image_constructor() {
   { reinterpret_cast<uintptr_t>(&__start_##name) + sizeof(__start_##name),     \
     reinterpret_cast<uintptr_t>(&__stop_##name) - reinterpret_cast<uintptr_t>(&__start_##name) - sizeof(__start_##name) }
 
-  sections = {
+  new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,
-      __ImageBase,
+      { __ImageBase },
 
       nullptr,
       nullptr,

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -14,6 +14,7 @@
 #include "../SwiftShims/MetadataSections.h"
 
 #include <cstddef>
+#include <new>
 
 extern "C" const char __dso_handle[];
 
@@ -55,9 +56,9 @@ static void swift_image_constructor() {
   { reinterpret_cast<uintptr_t>(&__start_##name),                              \
     static_cast<uintptr_t>(&__stop_##name - &__start_##name) }
 
-  sections = {
+  new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,
-      __dso_handle,
+      { __dso_handle },
 
       nullptr,
       nullptr,

--- a/test/Runtime/enumerate_metadata_sections.swift
+++ b/test/Runtime/enumerate_metadata_sections.swift
@@ -1,0 +1,49 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+#if os(Linux) || os(Windows)
+import Swift
+import SwiftShims
+import StdlibUnittest
+
+let EnumerateMetadataSections = TestSuite("EnumerateMetadataSections")
+
+@_silgen_name("swift_enumerateAllMetadataSections")
+func swift_enumerateAllMetadataSections(
+  _ body: @convention(c) (
+    _ sections: UnsafePointer<MetadataSections>,
+    _ context: UnsafeMutableRawPointer
+  ) -> Bool,
+  _ context: UnsafeMutableRawPointer
+)
+
+public protocol P { }
+public struct S: P { }
+
+EnumerateMetadataSections.test("swift_enumerateAllMetadataSections works") {
+  var sectionsEnumerated = 0
+  swift_enumerateAllMetadataSections({ sections, context in
+    let sectionsEnumerated = context.bindMemory(to: Int.self, capacity: 1)
+
+    // Confirm that the base address of the metadata sections was loaded.
+    let baseAddress = sections.pointee.baseAddress
+    expectNotNil(baseAddress)
+
+    // Confirm that P and S above have been emitted.
+    if baseAddress == #dsohandle {
+      expectNotNil(sections.pointee.swift5_protocols)
+      expectNotNil(sections.pointee.swift5_protocol_conformances)
+      expectNotNil(sections.pointee.swift5_type_metadata)
+    }
+
+    sectionsEnumerated.pointee += 1
+    return true
+  }, &sectionsEnumerated)
+
+  // Confirm that at least one section was enumerated.
+  expectGT(sectionsEnumerated, 0)
+}
+
+runAllTests()
+
+#endif


### PR DESCRIPTION
Add exported symbol on non-Apple platforms to enumerate MetadataSection structures at runtime.

<!-- What's in this pull request? -->
On Apple platforms, it is possible to enumerate the loaded metadata section structures of a process using dyld API. This is useful when, for example, looking up types that conform to a specific protocol (as might be done by e.g. swift-argument-parser.)

On non-Apple platforms, it is not possible to look up these structures because their addresses are not exported. The structures are instead statically declared and, when an image is loaded, are ingested by `swift_addNewDSOImage()` (by way of static constructors emitted during compilation.)

The end result is that there is no way, even when leveraging deep knowledge of the Swift ABI, to examine loaded Swift metadata on non-Apple platforms. This PR adds an exported function to the runtime named `swift_copyAllMetadataSections()`. This function returns a C array of `swift::MetadataSections` structures. Client code can then call this function and inspect the resulting structures as needed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
