### PR TITLE
Fix generics invariant violations in protocol requirement override checking

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -101,14 +101,14 @@ using AssociativityCacheType =
 struct OverrideSignatureKey {
   GenericSignature baseMethodSig;
   GenericSignature derivedMethodSig;
-  Decl *subclassDecl;
+  NominalTypeDecl *derivedNominal;
 
   OverrideSignatureKey(GenericSignature baseMethodSignature,
                        GenericSignature derivedMethodSignature,
-                       Decl *subclassDecl)
+                       NominalTypeDecl *derivedNominal)
     : baseMethodSig(baseMethodSignature),
       derivedMethodSig(derivedMethodSignature),
-      subclassDecl(subclassDecl) {}
+      derivedNominal(derivedNominal) {}
 };
 
 namespace llvm {
@@ -120,27 +120,27 @@ template <> struct DenseMapInfo<OverrideSignatureKey> {
                       const OverrideSignatureKey rhs) {
     return lhs.baseMethodSig.getPointer() == rhs.baseMethodSig.getPointer() &&
            lhs.derivedMethodSig.getPointer() == rhs.derivedMethodSig.getPointer() &&
-           lhs.subclassDecl == rhs.subclassDecl;
+           lhs.derivedNominal == rhs.derivedNominal;
   }
 
   static inline OverrideSignatureKey getEmptyKey() {
     return OverrideSignatureKey(DenseMapInfo<GenericSignature>::getEmptyKey(),
                                 DenseMapInfo<GenericSignature>::getEmptyKey(),
-                                DenseMapInfo<Decl *>::getEmptyKey());
+                                DenseMapInfo<NominalTypeDecl *>::getEmptyKey());
   }
 
   static inline OverrideSignatureKey getTombstoneKey() {
     return OverrideSignatureKey(
         DenseMapInfo<GenericSignature>::getTombstoneKey(),
         DenseMapInfo<GenericSignature>::getTombstoneKey(),
-        DenseMapInfo<Decl *>::getTombstoneKey());
+        DenseMapInfo<NominalTypeDecl *>::getTombstoneKey());
   }
 
   static unsigned getHashValue(const OverrideSignatureKey &Val) {
     return hash_combine(
         DenseMapInfo<GenericSignature>::getHashValue(Val.baseMethodSig),
         DenseMapInfo<GenericSignature>::getHashValue(Val.derivedMethodSig),
-        DenseMapInfo<Decl *>::getHashValue(Val.subclassDecl));
+        DenseMapInfo<NominalTypeDecl *>::getHashValue(Val.derivedNominal));
   }
 };
 } // namespace llvm
@@ -5214,11 +5214,11 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   assert(isa<AbstractFunctionDecl>(base) || isa<SubscriptDecl>(base));
   assert(isa<AbstractFunctionDecl>(derived) || isa<SubscriptDecl>(derived));
 
-  const auto baseClass = base->getDeclContext()->getSelfClassDecl();
-  const auto derivedClass = derived->getDeclContext()->getSelfClassDecl();
+  const auto baseNominal = base->getDeclContext()->getSelfNominalTypeDecl();
+  const auto derivedNominal = derived->getDeclContext()->getSelfNominalTypeDecl();
 
-  assert(baseClass != nullptr);
-  assert(derivedClass != nullptr);
+  assert(baseNominal != nullptr);
+  assert(derivedNominal != nullptr);
 
   const auto baseGenericSig =
       base->getAsGenericContext()->getGenericSignature();
@@ -5228,10 +5228,6 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
   if (base == derived)
     return derivedGenericSig;
 
-  const auto derivedSuperclass = derivedClass->getSuperclass();
-  if (derivedSuperclass.isNull())
-    return nullptr;
-
   if (derivedGenericSig.isNull())
     return nullptr;
 
@@ -5240,21 +5236,14 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
 
   auto key = OverrideSignatureKey(baseGenericSig,
                                   derivedGenericSig,
-                                  derivedClass);
+                                  derivedNominal);
 
   if (getImpl().overrideSigCache.find(key) !=
       getImpl().overrideSigCache.end()) {
     return getImpl().overrideSigCache.lookup(key);
   }
 
-  const auto derivedClassSig = derivedClass->getGenericSignature();
-
-  unsigned derivedDepth = 0;
-  unsigned baseDepth = 0;
-  if (derivedClassSig)
-    derivedDepth = derivedClassSig.getGenericParams().back()->getDepth() + 1;
-  if (const auto baseClassSig = baseClass->getGenericSignature())
-    baseDepth = baseClassSig.getGenericParams().back()->getDepth() + 1;
+  const auto derivedNominalSig = derivedNominal->getGenericSignature();
 
   SmallVector<GenericTypeParamType *, 2> addedGenericParams;
   if (const auto *gpList = derived->getAsGenericContext()->getGenericParams()) {
@@ -5264,38 +5253,59 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
     }
   }
 
-  const auto subMap = derivedSuperclass->getContextSubstitutionMap(
-      derivedClass->getModuleContext(), baseClass);
-
-  auto substFn = [&](SubstitutableType *type) -> Type {
-    auto *gp = cast<GenericTypeParamType>(type);
-
-    if (gp->getDepth() < baseDepth) {
-      return Type(gp).subst(subMap);
-    }
-
-    return CanGenericTypeParamType::get(
-        gp->isTypeSequence(), gp->getDepth() - baseDepth + derivedDepth,
-        gp->getIndex(), *this);
-  };
-
-  auto lookupConformanceFn =
-      [&](CanType depTy, Type substTy,
-          ProtocolDecl *proto) -> ProtocolConformanceRef {
-    if (auto conf = subMap.lookupConformance(depTy, proto))
-      return conf;
-
-    return ProtocolConformanceRef(proto);
-  };
-
   SmallVector<Requirement, 2> addedRequirements;
-  for (auto reqt : baseGenericSig.getRequirements()) {
-    if (auto substReqt = reqt.subst(substFn, lookupConformanceFn)) {
-      addedRequirements.push_back(*substReqt);
+
+  if (isa<ProtocolDecl>(baseNominal)) {
+    assert(isa<ProtocolDecl>(derivedNominal));
+
+    for (auto reqt : baseGenericSig.getRequirements()) {
+      addedRequirements.push_back(reqt);
+    }
+  } else {
+    const auto derivedSuperclass = cast<ClassDecl>(derivedNominal)
+        ->getSuperclass();
+    if (derivedSuperclass.isNull())
+      return nullptr;
+
+    unsigned derivedDepth = 0;
+    unsigned baseDepth = 0;
+    if (derivedNominalSig)
+      derivedDepth = derivedNominalSig.getGenericParams().back()->getDepth() + 1;
+    if (const auto baseNominalSig = baseNominal->getGenericSignature())
+      baseDepth = baseNominalSig.getGenericParams().back()->getDepth() + 1;
+
+    const auto subMap = derivedSuperclass->getContextSubstitutionMap(
+        derivedNominal->getModuleContext(), baseNominal);
+
+    auto substFn = [&](SubstitutableType *type) -> Type {
+      auto *gp = cast<GenericTypeParamType>(type);
+
+      if (gp->getDepth() < baseDepth) {
+        return Type(gp).subst(subMap);
+      }
+
+      return CanGenericTypeParamType::get(
+          gp->isTypeSequence(), gp->getDepth() - baseDepth + derivedDepth,
+          gp->getIndex(), *this);
+    };
+
+    auto lookupConformanceFn =
+        [&](CanType depTy, Type substTy,
+            ProtocolDecl *proto) -> ProtocolConformanceRef {
+      if (auto conf = subMap.lookupConformance(depTy, proto))
+        return conf;
+
+      return ProtocolConformanceRef(proto);
+    };
+
+    for (auto reqt : baseGenericSig.getRequirements()) {
+      if (auto substReqt = reqt.subst(substFn, lookupConformanceFn)) {
+        addedRequirements.push_back(*substReqt);
+      }
     }
   }
 
-  auto genericSig = buildGenericSignature(*this, derivedClassSig,
+  auto genericSig = buildGenericSignature(*this, derivedNominalSig,
                                           std::move(addedGenericParams),
                                           std::move(addedRequirements));
   getImpl().overrideSigCache.insert(std::make_pair(key, genericSig));

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -511,15 +511,9 @@ SubstitutionMap::getOverrideSubstitutions(
                                       Optional<SubstitutionMap> derivedSubs) {
   // For overrides within a protocol hierarchy, substitute the Self type.
   if (auto baseProto = baseDecl->getDeclContext()->getSelfProtocolDecl()) {
-    if (auto derivedProtoSelf =
-          derivedDecl->getDeclContext()->getSelfInterfaceType()) {
-      return SubstitutionMap::getProtocolSubstitutions(
-                                             baseProto,
-                                             derivedProtoSelf,
-                                             ProtocolConformanceRef(baseProto));
-    }
-
-    return SubstitutionMap();
+    auto baseSig = baseDecl->getInnermostDeclContext()
+        ->getGenericSignatureOfContext();
+    return baseSig->getIdentitySubstitutionMap();
   }
 
   auto *baseClass = baseDecl->getDeclContext()->getSelfClassDecl();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -164,25 +164,23 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
   //
   // We can still succeed with a subtype match later in
   // OverrideMatcher::match().
-  if (decl->getDeclContext()->getSelfClassDecl()) {
-    if (auto declCtx = decl->getAsGenericContext()) {
-      auto *parentCtx = parentDecl->getAsGenericContext();
+  if (auto declCtx = decl->getAsGenericContext()) {
+    auto *parentCtx = parentDecl->getAsGenericContext();
 
-      if (declCtx->isGeneric() != parentCtx->isGeneric())
-        return false;
+    if (declCtx->isGeneric() != parentCtx->isGeneric())
+      return false;
 
-      if (declCtx->isGeneric() &&
-          (declCtx->getGenericParams()->size() !=
-           parentCtx->getGenericParams()->size()))
-        return false;
+    if (declCtx->isGeneric() &&
+        (declCtx->getGenericParams()->size() !=
+         parentCtx->getGenericParams()->size()))
+      return false;
 
-      auto &ctx = decl->getASTContext();
-      auto sig = ctx.getOverrideGenericSignature(parentDecl, decl);
-      if (sig &&
-          declCtx->getGenericSignature().getCanonicalSignature() !=
-              sig.getCanonicalSignature()) {
-        return false;
-      }
+    auto &ctx = decl->getASTContext();
+    auto sig = ctx.getOverrideGenericSignature(parentDecl, decl);
+    if (sig &&
+        declCtx->getGenericSignature().getCanonicalSignature() !=
+            sig.getCanonicalSignature()) {
+      return false;
     }
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -165,6 +165,15 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
   // We can still succeed with a subtype match later in
   // OverrideMatcher::match().
   if (auto declCtx = decl->getAsGenericContext()) {
+    // The below logic now works correctly for protocol requirements which are
+    // themselves generic, but that would be an ABI break, since we would now
+    // drop the protocol requirements from witness tables. Simulate the old
+    // behavior by not considering generic declarations in protocols as
+    // overrides at all.
+    if (decl->getDeclContext()->getSelfProtocolDecl() &&
+        declCtx->isGeneric())
+      return false;
+
     auto *parentCtx = parentDecl->getAsGenericContext();
 
     if (declCtx->isGeneric() != parentCtx->isGeneric())

--- a/test/decl/protocol/override_generic.swift
+++ b/test/decl/protocol/override_generic.swift
@@ -1,13 +1,15 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -emit-silgen %s -verify -warn-implicit-overrides | %FileCheck %s
 
 protocol Base {
-  func foo1<T : P>(_: T, _: T.T)
+  func foo1<T : P>(_: T)
   func foo2<T : P>(_: T, _: T.T)
+  func foo3<T : P>(_: T, _: T.T)
 }
 
 protocol Derived : Base {
-  func foo1<T : P>(_: T, _: T.T)
-  func foo2<T : Q>(_: T, _: T.T)
+  func foo1<T : P>(_: T)
+  func foo2<T : P>(_: T, _: T.T)
+  func foo3<T : Q>(_: T, _: T.T)
 }
 
 protocol P {
@@ -17,3 +19,28 @@ protocol P {
 protocol Q {
   associatedtype T
 }
+
+struct S : Derived {
+  func foo1<T : P>(_: T) {}
+  func foo2<T : P>(_: T, _: T.T) {}
+  func foo3<T : P>(_: T, _: T.T) {}
+  func foo3<T : Q>(_: T, _: T.T) {}
+}
+
+// Make sure that Derived.foo1 and Derived.foo2 are not counted as overrides of
+// Base.foo1 and Base.foo2 respectively. Even though their types match, bugs
+// in Swift 5.6 and earlier prevented them from being overrides. We can't fix
+// it now because it would be an ABI break.
+
+// CHECK-LABEL: sil_witness_table hidden S: Derived module override_generic {
+// CHECK-NEXT: base_protocol Base: S: Base module override_generic
+// CHECK-NEXT: method #Derived.foo1: <Self where Self : Derived><T where T : P> (Self) -> (T) -> () : @$s16override_generic1SVAA7DerivedA2aDP4foo1yyqd__AA1PRd__lFTW
+// CHECK-NEXT: method #Derived.foo2: <Self where Self : Derived><T where T : P> (Self) -> (T, T.T) -> () : @$s16override_generic1SVAA7DerivedA2aDP4foo2yyqd___1TQyd__tAA1PRd__lFTW
+// CHECK-NEXT: method #Derived.foo3: <Self where Self : Derived><T where T : Q> (Self) -> (T, T.T) -> () : @$s16override_generic1SVAA7DerivedA2aDP4foo3yyqd___1TQyd__tAA1QRd__lFTW
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden S: Base module override_generic {
+// CHECK-NEXT: method #Base.foo1: <Self where Self : Base><T where T : P> (Self) -> (T) -> () : @$s16override_generic1SVAA4BaseA2aDP4foo1yyqd__AA1PRd__lFTW
+// CHECK-NEXT: method #Base.foo2: <Self where Self : Base><T where T : P> (Self) -> (T, T.T) -> () : @$s16override_generic1SVAA4BaseA2aDP4foo2yyqd___1TQyd__tAA1PRd__lFTW
+// CHECK-NEXT: method #Base.foo3: <Self where Self : Base><T where T : P> (Self) -> (T, T.T) -> () : @$s16override_generic1SVAA4BaseA2aDP4foo3yyqd___1TQyd__tAA1PRd__lFTW
+// CHECK-NEXT: }

--- a/test/decl/protocol/override_generic.swift
+++ b/test/decl/protocol/override_generic.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Base {
+  func foo1<T : P>(_: T, _: T.T)
+  func foo2<T : P>(_: T, _: T.T)
+}
+
+protocol Derived : Base {
+  func foo1<T : P>(_: T, _: T.T)
+  func foo2<T : Q>(_: T, _: T.T)
+}
+
+protocol P {
+  associatedtype T
+}
+
+protocol Q {
+  associatedtype T
+}

--- a/validation-test/compiler_crashers_2_fixed/sr15826.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15826.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct Observable<T> {}
+
+public protocol BaseVariant: CaseIterable, Equatable {}
+
+public protocol FeatureGate {
+    associatedtype Variant: BaseVariant
+}
+
+public enum FeatureVariantState<T: BaseVariant>: Equatable {}
+
+public protocol BaseGatingProvider {
+    func exposeFeatureVariantState<G: FeatureGate>(for featureGate: G)
+        -> Observable<FeatureVariantState<G.Variant>>
+}
+
+public struct UserFeatureGate<Variant: BaseVariant>: FeatureGate {}
+
+public protocol UserGatingProvider: BaseGatingProvider {
+    func exposeFeatureVariantState<V>(for featureGate: UserFeatureGate<V>)
+    -> Observable<FeatureVariantState<V>>
+}


### PR DESCRIPTION
We have to be careful not to feed an invalid type parameter into the Requirement Machine since that triggers asserts instead of returning bogus results like the GenericSignatureBuilder.

Fixes https://bugs.swift.org/browse/SR-15826 / rdar://problem/89641535.