### PR TITLE
[Distributed] Make distributed actors show up as actors in code completion

### DIFF
--- a/lib/IDE/CodeCompletionResult.cpp
+++ b/lib/IDE/CodeCompletionResult.cpp
@@ -177,7 +177,7 @@ ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
   case DeclKind::Struct:
     return CodeCompletionDeclKind::Struct;
   case DeclKind::Class:
-    if (cast<ClassDecl>(D)->isActor()) {
+    if (cast<ClassDecl>(D)->isAnyActor()) {
       return CodeCompletionDeclKind::Actor;
     } else {
       return CodeCompletionDeclKind::Class;


### PR DESCRIPTION
Distributed actors should show up as actors in completion for now.

Later we'll do a separate distributed actor category for them

resolves rdar://89113097

```
bool NominalTypeDecl::isAnyActor() const {
  return isActor() || isDistributedActor();
}
```