### PR TITLE
[CodeCompletion] Migrate expression completions to solver-based

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -113,6 +113,12 @@ class CompletionLookup final : public swift::VisibleDeclConsumer {
   /// Expected types of the code completion expression.
   ExpectedTypeContext expectedTypeContext;
 
+  /// Variables whose type was determined while type checking the code
+  /// completion expression and that are thus not recorded in the AST.
+  /// This in particular applies to params of closures that contain the code
+  /// completion token.
+  llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+
   bool CanCurrDeclContextHandleAsync = false;
   bool HaveDot = false;
   bool IsUnwrappedOptional = false;
@@ -206,6 +212,11 @@ public:
                    const DeclContext *CurrDeclContext,
                    CodeCompletionContext *CompletionContext = nullptr);
 
+  void setSolutionSpecificVarTypes(
+      llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes) {
+    this->SolutionSpecificVarTypes = SolutionSpecificVarTypes;
+  }
+
   void setHaveDot(SourceLoc DotLoc) {
     HaveDot = true;
     this->DotLoc = DotLoc;
@@ -225,6 +236,10 @@ public:
   }
 
   void setIdealExpectedType(Type Ty) { expectedTypeContext.setIdealType(Ty); }
+
+  void setCanCurrDeclContextHandleAsync(bool CanCurrDeclContextHandleAsync) {
+    this->CanCurrDeclContextHandleAsync = CanCurrDeclContextHandleAsync;
+  }
 
   const ExpectedTypeContext *getExpectedTypeContext() const {
     return &expectedTypeContext;

--- a/include/swift/IDE/ExprCompletion.h
+++ b/include/swift/IDE/ExprCompletion.h
@@ -1,0 +1,66 @@
+//===--- ExprCompletion.h -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_EXPRCOMPLETION_H
+#define SWIFT_IDE_EXPRCOMPLETION_H
+
+#include "swift/IDE/CodeCompletionConsumer.h"
+#include "swift/IDE/CodeCompletionContext.h"
+#include "swift/Sema/CodeCompletionTypeChecking.h"
+
+namespace swift {
+namespace ide {
+
+class ExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
+public:
+  struct Result {
+    /// The contextual type that the code completion expression should produce.
+    Type ExpectedType;
+
+    /// If the code completion expression is an implicit return in a
+    /// single-expression closure.
+    bool IsImplicitSingleExpressionReturn;
+
+    /// Whether the surrounding context is async and thus calling async
+    /// functions is supported.
+    bool IsInAsyncContext;
+
+    /// Types of variables that were determined in the solution that produced
+    /// this result. This in particular includes parameters of closures that
+    /// were type-checked with the code completion expression.
+    llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+  };
+
+private:
+  CodeCompletionExpr *CompletionExpr;
+  DeclContext *DC;
+
+  SmallVector<Result, 4> Results;
+
+public:
+  /// \param DC The decl context in which the \p CompletionExpr occurs.
+  ExprTypeCheckCompletionCallback(CodeCompletionExpr *CompletionExpr,
+                                  DeclContext *DC)
+      : CompletionExpr(CompletionExpr), DC(DC) {}
+
+  void sawSolution(const constraints::Solution &solution) override;
+
+  /// \param CCLoc The location of the code completion token.
+  void deliverResults(SourceLoc CCLoc,
+                      ide::CodeCompletionContext &CompletionCtx,
+                      CodeCompletionConsumer &Consumer);
+};
+
+} // end namespace ide
+} // end namespace swift
+
+#endif // SWIFT_IDE_EXPRCOMPLETION_H

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -106,7 +106,9 @@ void ArgumentTypeCheckCompletionCallback::sawSolution(const Solution &S) {
   }
 
   if (!ParentCall || ParentCall == CompletionExpr) {
-    assert(false && "no containing call?");
+    // We might not have a call that contains the code completion expression if
+    // we type-checked the fallback code completion expression that only
+    // contains the code completion token, but not the surrounding call.
     return;
   }
 

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -20,6 +20,7 @@ add_swift_host_library(swiftIDE STATIC
   ConformingMethodList.cpp
   DependencyChecking.cpp
   DotExprCompletion.cpp
+  ExprCompletion.cpp
   ExprContextAnalysis.cpp
   Formatting.cpp
   FuzzyStringMatcher.cpp

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -804,8 +804,13 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
   assert(!Name.empty() && "name should not be empty");
 
   Type VarType;
-  if (VD->hasInterfaceType())
+  auto SolutionSpecificType = SolutionSpecificVarTypes.find(VD);
+  if (SolutionSpecificType != SolutionSpecificVarTypes.end()) {
+    assert(!VarType && "Type recorded in the AST and is also solution-specific?");
+    VarType = SolutionSpecificType->second;
+  } else if (VD->hasInterfaceType()) {
     VarType = getTypeOfMember(VD, dynamicLookupInfo);
+  }
 
   Optional<ContextualNotRecommendedReason> NotRecommended;
   // "not recommended" in its own getter.

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -1,0 +1,92 @@
+//===--- ExprCompletion.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDE/ExprCompletion.h"
+#include "swift/IDE/CodeCompletion.h"
+#include "swift/IDE/CompletionLookup.h"
+#include "swift/Sema/ConstraintSystem.h"
+
+using namespace swift;
+using namespace swift::ide;
+using namespace swift::constraints;
+
+void ExprTypeCheckCompletionCallback::sawSolution(
+    const constraints::Solution &S) {
+  TypeCheckCompletionCallback::sawSolution(S);
+
+  auto &CS = S.getConstraintSystem();
+
+  // Prefer to get the expected type as the completion expression's contextual
+  // type. If that fails (because there is no explicit contextual type spelled
+  // out in the source), the code completion expression will have been
+  // type-checked to its expected contextual type.
+  Type ExpectedTy =
+      CS.getContextualType(CompletionExpr, /*forConstraint=*/false);
+  if (!ExpectedTy) {
+    ExpectedTy = S.getResolvedType(CompletionExpr);
+  }
+  if (ExpectedTy->hasUnresolvedType()) {
+    ExpectedTy = Type();
+  }
+
+  bool ImplicitReturn = isImplicitSingleExpressionReturn(CS, CompletionExpr);
+
+  // We are in an async context if
+  //  - the decl context is async or
+  //  - the decl context is sync but it's used in a context that expectes an
+  //    async function. This happens if the code completion token is in a
+  //    closure that doesn't contain any async calles. Thus the closure is
+  //    type-checked as non-async, but it might get converted to an async
+  //    closure based on its contextual type.
+  bool isAsync = CS.isAsynchronousContext(DC);
+  if (!isAsync) {
+    auto target = S.solutionApplicationTargets.find(dyn_cast<ClosureExpr>(DC));
+    if (target != S.solutionApplicationTargets.end()) {
+      if (auto ContextTy = target->second.getClosureContextualType()) {
+        if (auto ContextFuncTy =
+                S.simplifyType(ContextTy)->getAs<AnyFunctionType>()) {
+          isAsync = ContextFuncTy->isAsync();
+        }
+      }
+    }
+  }
+
+  llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+  for (auto NT : S.nodeTypes) {
+    if (auto VD = dyn_cast_or_null<VarDecl>(NT.first.dyn_cast<Decl *>())) {
+      SolutionSpecificVarTypes[VD] = S.simplifyType(NT.second);
+    }
+  }
+
+  Results.push_back(
+      {ExpectedTy, ImplicitReturn, isAsync, SolutionSpecificVarTypes});
+}
+
+void ExprTypeCheckCompletionCallback::deliverResults(
+    SourceLoc CCLoc, ide::CodeCompletionContext &CompletionCtx,
+    CodeCompletionConsumer &Consumer) {
+  ASTContext &Ctx = DC->getASTContext();
+  CompletionLookup Lookup(CompletionCtx.getResultSink(), Ctx, DC,
+                          &CompletionCtx);
+
+  for (auto &Result : Results) {
+    Lookup.setExpectedTypes(Result.ExpectedType,
+                            Result.IsImplicitSingleExpressionReturn);
+    Lookup.setCanCurrDeclContextHandleAsync(Result.IsInAsyncContext);
+    Lookup.setSolutionSpecificVarTypes(Result.SolutionSpecificVarTypes);
+
+    Lookup.getValueCompletionsInDeclContext(CCLoc);
+    Lookup.getSelfTypeCompletionInDeclContext(CCLoc, /*isForDeclResult=*/false);
+  }
+
+  deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);
+}

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9017,6 +9017,9 @@ SolutionApplicationTarget SolutionApplicationTarget::walk(ASTWalker &walker) {
     return result;
   }
 
+  case Kind::closure:
+    return *this;
+
   case Kind::function:
     return SolutionApplicationTarget(
         *getAsFunction(),

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4102,6 +4102,7 @@ bool ConstraintSystem::generateConstraints(
   case SolutionApplicationTarget::Kind::expression:
     llvm_unreachable("Handled above");
 
+  case SolutionApplicationTarget::Kind::closure:
   case SolutionApplicationTarget::Kind::caseLabelItem:
   case SolutionApplicationTarget::Kind::function:
   case SolutionApplicationTarget::Kind::stmtCondition:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9917,6 +9917,9 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     }
   }
 
+  SolutionApplicationTarget target(closure, contextualType);
+  setSolutionApplicationTarget(closure, target);
+
   // Generate constraints from the body of this closure.
   return !generateConstraints(closure);
 }

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -125,7 +125,7 @@ Optional<Fallback> CompletionContextFinder::getFallbackCompletionExpr() const {
   if (fallback)
     return fallback;
 
-  if (getCompletionExpr()->getBase() && getCompletionExpr() != InitialExpr)
+  if (getCompletionExpr() != InitialExpr)
     return Fallback{getCompletionExpr(), fallbackDC, separatePrecheck};
   return None;
 }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -313,6 +313,7 @@ void constraints::performSyntacticDiagnosticsForTarget(
     target.getFunctionBody()->walk(walker);
     return;
   }
+  case SolutionApplicationTarget::Kind::closure:
   case SolutionApplicationTarget::Kind::stmtCondition:
   case SolutionApplicationTarget::Kind::caseLabelItem:
   case SolutionApplicationTarget::Kind::patternBinding:

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -104,7 +104,7 @@ struct NestedStructWithClosureMember1 {
 struct StructWithClosureMemberAndLocal {
   var c = {
     var x = 0
-    #^DELAYED_10?check=WITH_GLOBAL_DECLS_AND_LOCAL1^#
+    #^DELAYED_10?check=WITH_GLOBAL_DECLS_AND_LOCAL1;xfail=sr16012^#
   }
 }
 

--- a/validation-test/IDE/crashers_2_fixed/0031-fallback-typecheck-call-arg.swift
+++ b/validation-test/IDE/crashers_2_fixed/0031-fallback-typecheck-call-arg.swift
@@ -1,0 +1,9 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+func tryMap(_ x: (String) -> Void) {}
+
+func fetch() {
+    tryMap { data in
+        doesNotExist(data: data, #^COMPLETE^#)
+    }
+}

--- a/validation-test/IDE/crashers_2_fixed/0034-closure-solution-application-target-applied-twice.swift
+++ b/validation-test/IDE/crashers_2_fixed/0034-closure-solution-application-target-applied-twice.swift
@@ -1,0 +1,17 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+@resultBuilder public struct WiewBuilder {
+  static func buildBlock<T>(_ content: T) -> T { return content }
+}
+
+func pnAppear(perform action: () -> Void) {}
+
+public func asyncAfter(execute work: () -> Void) {}
+
+struct ProgressView {
+  @WiewBuilder var body: Void {
+    pnAppear(perform: {
+      #^COMPLETE^#asyncAfter() {}
+    })
+  }
+}

--- a/validation-test/IDE/crashers_2_fixed/0035-closure-solution-application-target-applied-twice-2.swift
+++ b/validation-test/IDE/crashers_2_fixed/0035-closure-solution-application-target-applied-twice-2.swift
@@ -1,0 +1,20 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+@resultBuilder public struct WiewBuilder {
+  static func buildBlock<T>(_ content: T) -> T { return content }
+}
+
+func pnAppear(_ action: () -> Void) {}
+
+struct BispatchQueue {
+  static func bsyncAfter(execute work: () -> Void) {}
+}
+
+
+public struct ProgressView {
+  @WiewBuilder var body: Void {
+    pnAppear({
+      BispatchQueue#^COMPLETE^#.bsyncAfter() {}
+    })
+  }
+}


### PR DESCRIPTION
Migrate `StmtOrExpr` completions to solver-based.