### PR TITLE
[ClangImporter] Accept external diagnostic client (NFC)

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -159,12 +159,16 @@ public:
   /// \param dwarfImporterDelegate A helper object that can synthesize
   /// Clang Decls from debug info. Used by LLDB.
   ///
+  /// \param diagClient An optional clang diagnostic consumer for surfacing
+  /// diagnostics to ClangImporter users. Used by LLDB.
+  ///
   /// \returns a new Clang module importer, or null (with a diagnostic) if
   /// an error occurred.
   static std::unique_ptr<ClangImporter>
-  create(ASTContext &ctx,
-         std::string swiftPCHHash = "", DependencyTracker *tracker = nullptr,
-         DWARFImporterDelegate *dwarfImporterDelegate = nullptr);
+  create(ASTContext &ctx, std::string swiftPCHHash = "",
+         DependencyTracker *tracker = nullptr,
+         DWARFImporterDelegate *dwarfImporterDelegate = nullptr,
+         std::unique_ptr<clang::DiagnosticConsumer> diagClient = {});
 
   static std::vector<std::string>
   getClangArguments(ASTContext &ctx);

--- a/lib/ClangImporter/ClangDiagnosticConsumer.h
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.h
@@ -59,10 +59,13 @@ private:
   SourceLoc DiagLoc;
   const bool DumpToStderr;
 
+  std::unique_ptr<clang::DiagnosticConsumer> ExternalDiagClient;
+
 public:
-  ClangDiagnosticConsumer(ClangImporter::Implementation &impl,
-                          clang::DiagnosticOptions &clangDiagOptions,
-                          bool dumpToStderr);
+  ClangDiagnosticConsumer(
+      ClangImporter::Implementation &impl,
+      clang::DiagnosticOptions &clangDiagOptions, bool dumpToStderr,
+      std::unique_ptr<clang::DiagnosticConsumer> externalDiagClient = {});
 
   LoadModuleRAII handleImport(const clang::IdentifierInfo *name,
                               SourceLoc diagLoc) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1068,9 +1068,10 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
 }
 
 std::unique_ptr<ClangImporter>
-ClangImporter::create(ASTContext &ctx,
-                      std::string swiftPCHHash, DependencyTracker *tracker,
-                      DWARFImporterDelegate *dwarfImporterDelegate) {
+ClangImporter::create(ASTContext &ctx, std::string swiftPCHHash,
+                      DependencyTracker *tracker,
+                      DWARFImporterDelegate *dwarfImporterDelegate,
+                      std::unique_ptr<clang::DiagnosticConsumer> diagClient) {
   std::unique_ptr<ClangImporter> importer{
       new ClangImporter(ctx, tracker, dwarfImporterDelegate)};
   auto &importerOpts = ctx.ClangImporterOpts;
@@ -1156,7 +1157,7 @@ ClangImporter::create(ASTContext &ctx,
     // options---as opposed to the temporary one we made above.
     auto actualDiagClient = std::make_unique<ClangDiagnosticConsumer>(
         importer->Impl, instance.getDiagnosticOpts(),
-        importerOpts.DumpClangDiagnostics);
+        importerOpts.DumpClangDiagnostics, std::move(diagClient));
     instance.createDiagnostics(actualDiagClient.release());
   }
 


### PR DESCRIPTION
Add an optional `clang::DiagnosticConsumer` parameter to `ClangImporter::create`. This is an NFC change and will be used by lldb to log errors encountered via ClangImporter.

This would ideally use `ChainedDiagnosticConsumer` to compose `ClangDiagnosticConsumer` together with the diagnostic consumer injected by the caller (this was the initial implementation), but currently `ClangImporter::Implementation` assumes that its `Instance->getDiagnosticClient()` returns a `ClangDiagnosticConsumer` and blindly downcasts. I would like to break this dependency in a follow up change.

Instead, `ClangDiagnosticConsumer` now acts as a chained consumer, by allowing the caller to inject another diagnostic consumer (via constructor), and proxying diagnostics events to this injected diagnostic consumer.