### PR TITLE
add coverage for <<error-type>> + Sendable diagnostic issue

### DIFF
--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -73,3 +73,13 @@ public actor MyActor: MyProto {
   public func foo<F>(aFoo: F) async where F: Sendable { }
   public func bar<B>(aBar: B) async where B: Sendable { }
 }
+
+// rdar://82452688 - make sure sendable checking doesn't fire for a capture
+// of a value of error-type
+@available(SwiftStdlib 5.1, *)
+func f() async {
+  let n = wobble() // expected-error{{cannot find 'wobble' in scope}}
+  @Sendable func nested() {
+    n.pointee += 1
+  }
+}


### PR DESCRIPTION
when a variable with type `<<error-type>>` was captured in a
sendable function's environment, we use to emit a diagnostic
about it not being sendable, but it's for a bogus type.

at some point this issue disappeared as the sendable implementation
evolved, but this commit adds regression coverage.

resolves rdar://82452688