### PR TITLE
[TypeChecker] NFC: Restrict executable test for type inference from d…

### DIFF
--- a/test/Constraints/type_inference_from_default_exprs_executable_test.swift
+++ b/test/Constraints/type_inference_from_default_exprs_executable_test.swift
@@ -3,6 +3,8 @@
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-type-inference-from-defaults -parse-as-library -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
+// REQUIRES: OS=macosx
+
 protocol P {
   associatedtype X
 }


### PR DESCRIPTION
…efaults to macOS

Resolves: rdar://89708883

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
