### PR TITLE
[CSClosure] Delay type-checking of local functions until body is rewr…

### DIFF
--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -208,3 +208,28 @@ func test_custom_tilde_equals_operator_matching() {
     }
   }
 }
+
+// Local functions can capture variables before they are declared.
+func test_local_function_capturing_vars() {
+  struct A {
+    var cond: Bool
+  }
+
+  func test<T>(fn: () -> T) -> T {
+    fn()
+  }
+
+  func outer(a: A) {
+    test {
+      func local() {
+        if !message.isEmpty { // Ok
+          print(message)
+        }
+
+        message = "World" // Ok
+      }
+
+      var message = a.cond ? "hello" : ""
+    }
+  }
+}


### PR DESCRIPTION
…itten

A local function can capture a variable that has been declared after it,
which means that type-checking such declaration in-order would trigger
sub-typecheck that would corrupt AST underness the solution application
walker.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
