### PR TITLE
New syntax for declaring primary associated types

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -661,10 +661,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   APIBreakingToAdd | APIBreakingToRemove,
   118)
 
-SIMPLE_DECL_ATTR(_primaryAssociatedType,
-  PrimaryAssociatedType, OnAssociatedType | UserInaccessible |
-  APIStableToAdd | ABIStableToAdd | APIBreakingToRemove | ABIStableToRemove,
-  119)
+// 119 is unused
 
 SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,
   OnFunc | UserInaccessible | NotSerialized | OnNominalType |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -505,6 +505,11 @@ protected:
     IsOpaqueType : 1
   );
 
+  SWIFT_INLINE_BITFIELD_FULL(AssociatedTypeDecl, AbstractTypeParamDecl, 1,
+    /// Whether this is a primary associated type.
+    IsPrimary : 1
+  );
+
   SWIFT_INLINE_BITFIELD_EMPTY(GenericTypeDecl, TypeDecl);
 
   SWIFT_INLINE_BITFIELD(TypeAliasDecl, GenericTypeDecl, 1+1,
@@ -3207,6 +3212,14 @@ public:
                      SourceLoc nameLoc, TrailingWhereClause *trailingWhere,
                      LazyMemberLoader *definitionResolver,
                      uint64_t resolverData);
+
+  bool isPrimary() const {
+    return Bits.AssociatedTypeDecl.IsPrimary;
+  }
+
+  void setPrimary() {
+    Bits.AssociatedTypeDecl.IsPrimary = true;
+  }
 
   /// Get the protocol in which this associated type is declared.
   ProtocolDecl *getProtocol() const {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1797,8 +1797,14 @@ ERROR(redundant_class_requirement,none,
 ERROR(late_class_requirement,none,
       "'class' must come first in the requirement list", ())
 ERROR(where_inside_brackets,none,
-        "'where' clause next to generic parameters is obsolete, "
-        "must be written following the declaration's type", ())
+      "'where' clause next to generic parameters is obsolete, "
+      "must be written following the declaration's type", ())
+
+
+ERROR(expected_rangle_primary_associated_type_list,PointsToFirstBadToken,
+      "expected '>' to complete primary associated type list", ())
+ERROR(expected_primary_associated_type_name,PointsToFirstBadToken,
+      "expected an identifier to name primary associated type", ())
 
 //------------------------------------------------------------------------------
 // MARK: Conditional compilation parsing diagnostics

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -511,6 +511,12 @@ struct PrintOptions {
   QualifyNestedDeclarations ShouldQualifyNestedDeclarations =
       QualifyNestedDeclarations::Never;
 
+  /// If true, we print a protocol's primary associated types using the
+  /// primary associated type syntax: protocol Foo<Type1, ...>.
+  ///
+  /// If false, we print them as ordinary associated types.
+  bool PrintPrimaryAssociatedTypes = true;
+
   /// If this is not \c nullptr then function bodies (including accessors
   /// and constructors) will be printed by this function.
   std::function<void(const ValueDecl *, ASTPrinter &)> FunctionBody;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -74,6 +74,6 @@ LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
 LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
-
+SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes, 0, "Primary associated types", true)
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1199,6 +1199,9 @@ public:
   void parseAbstractFunctionBody(AbstractFunctionDecl *AFD);
   BodyAndFingerprint
   parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
+
+  ParserStatus parsePrimaryAssociatedTypes(
+      SmallVectorImpl<AssociatedTypeDecl *> &AssocTypes);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4539,6 +4539,7 @@ AssociatedTypeDecl::AssociatedTypeDecl(DeclContext *dc, SourceLoc keywordLoc,
     : AbstractTypeParamDecl(DeclKind::AssociatedType, dc, name, nameLoc),
       KeywordLoc(keywordLoc), DefaultDefinition(defaultDefinition),
       TrailingWhere(trailingWhere) {
+  Bits.AssociatedTypeDecl.IsPrimary = 0;
 }
 
 AssociatedTypeDecl::AssociatedTypeDecl(DeclContext *dc, SourceLoc keywordLoc,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7963,6 +7963,107 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   return DCC.fixupParserResult(Status, CD);
 }
 
+ParserStatus Parser::parsePrimaryAssociatedTypes(
+    SmallVectorImpl<AssociatedTypeDecl *> &AssocTypes) {
+  SourceLoc LAngleLoc = consumeStartingLess();
+
+  ParserStatus Result;
+  SyntaxParsingContext PATContext(SyntaxContext,
+                                  SyntaxKind::PrimaryAssociatedTypeList);
+
+  bool HasNextParam = false;
+  do {
+    SyntaxParsingContext ATContext(SyntaxContext,
+                                   SyntaxKind::PrimaryAssociatedType);
+
+    // Note that we're parsing a declaration.
+    StructureMarkerRAII ParsingDecl(*this, Tok.getLoc(),
+                                    StructureMarkerKind::Declaration);
+
+    // Parse attributes.
+    DeclAttributes Attrs;
+    if (Tok.hasComment())
+      Attrs.add(new (Context) RawDocCommentAttr(Tok.getCommentRange()));
+    parseDeclAttributeList(Attrs);
+
+    // Parse the name of the parameter.
+    Identifier Name;
+    SourceLoc NameLoc;
+    if (parseIdentifier(Name, NameLoc, /*diagnoseDollarPrefix=*/true,
+                        diag::expected_primary_associated_type_name)) {
+      Result.setIsParseError();
+      break;
+    }
+
+    // Parse the ':' followed by a type.
+    SmallVector<InheritedEntry, 1> Inherited;
+    if (Tok.is(tok::colon)) {
+      (void)consumeToken();
+      ParserResult<TypeRepr> Ty;
+
+      if (Tok.isAny(tok::identifier, tok::code_complete, tok::kw_protocol,
+                    tok::kw_Any)) {
+        Ty = parseType();
+      } else if (Tok.is(tok::kw_class)) {
+        diagnose(Tok, diag::unexpected_class_constraint);
+        diagnose(Tok, diag::suggest_anyobject)
+        .fixItReplace(Tok.getLoc(), "AnyObject");
+        consumeToken();
+        Result.setIsParseError();
+      } else {
+        diagnose(Tok, diag::expected_generics_type_restriction, Name);
+        Result.setIsParseError();
+      }
+
+      if (Ty.hasCodeCompletion())
+        return makeParserCodeCompletionStatus();
+
+      if (Ty.isNonNull())
+        Inherited.push_back({Ty.get()});
+    }
+
+    ParserResult<TypeRepr> UnderlyingTy;
+    if (Tok.is(tok::equal)) {
+      SyntaxParsingContext InitContext(SyntaxContext,
+                                       SyntaxKind::TypeInitializerClause);
+      consumeToken(tok::equal);
+      UnderlyingTy = parseType(diag::expected_type_in_associatedtype);
+      Result |= UnderlyingTy;
+      if (UnderlyingTy.isNull())
+        return Result;
+    }
+
+    auto *AssocType = new (Context)
+        AssociatedTypeDecl(CurDeclContext, NameLoc, Name, NameLoc,
+                           UnderlyingTy.getPtrOrNull(),
+                           /*trailingWhere=*/nullptr);
+    AssocType->getAttrs() = Attrs;
+    if (!Inherited.empty())
+      AssocType->setInherited(Context.AllocateCopy(Inherited));
+    AssocType->getAttrs().add(new (Context) PrimaryAssociatedTypeAttr(
+        /*Implicit=*/true));
+
+    AssocTypes.push_back(AssocType);
+
+    // Parse the comma, if the list continues.
+    HasNextParam = consumeIf(tok::comma);
+  } while (HasNextParam);
+
+  // Parse the closing '>'.
+  SourceLoc RAngleLoc;
+  if (startsWithGreater(Tok)) {
+    RAngleLoc = consumeStartingGreater();
+  } else {
+    diagnose(Tok, diag::expected_rangle_primary_associated_type_list);
+    diagnose(LAngleLoc, diag::opening_angle);
+
+    // Skip until we hit the '>'.
+    RAngleLoc = skipUntilGreaterInTypeList();
+  }
+
+  return Result;
+}
+
 /// Parse a 'protocol' declaration, doing no token skipping on error.
 ///
 /// \verbatim
@@ -7970,7 +8071,17 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
 ///      protocol-head '{' protocol-member* '}'
 ///
 ///   protocol-head:
-///     'protocol' attribute-list identifier inheritance? 
+///     attribute-list 'protocol' identifier primary-associated-type-list?
+///     inheritance? 
+///
+///   primary-associated-type-list:
+///     '<' primary-associated-type+ '>'
+///
+///   primary-associated-type:
+///     identifier inheritance? default-associated-type
+///
+///   default-associated-type:
+///     '=' type
 ///
 ///   protocol-member:
 ///      decl-func
@@ -7991,12 +8102,20 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   if (Status.isErrorOrHasCompletion())
     return Status;
 
-  // Protocols don't support generic parameters, but people often want them and
-  // we want to have good error recovery if they try them out.  Parse them and
-  // produce a specific diagnostic if present.
-  if (startsWithLess(Tok)) {
-    diagnose(Tok, diag::generic_arguments_protocol);
-    maybeParseGenericParams();
+  SmallVector<AssociatedTypeDecl *, 2> PrimaryAssociatedTypes;
+
+  if (Context.LangOpts.EnableParameterizedProtocolTypes) {
+    if (startsWithLess(Tok)) {
+      Status |= parsePrimaryAssociatedTypes(PrimaryAssociatedTypes);
+    }
+  } else {
+    // Protocols don't support generic parameters, but people often want them and
+    // we want to have good error recovery if they try them out.  Parse them and
+    // produce a specific diagnostic if present.
+    if (startsWithLess(Tok)) {
+      diagnose(Tok, diag::generic_arguments_protocol);
+      maybeParseGenericParams();
+    }
   }
 
   DebuggerContextChange DCC (*this);
@@ -8034,6 +8153,12 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     CodeCompletion->setParsedDecl(Proto);
 
   ContextChange CC(*this, Proto);
+
+  // Re-parent the primary associated type declarations into the protocol.
+  for (auto *AssocType : PrimaryAssociatedTypes) {
+    AssocType->setDeclContext(Proto);
+    Proto->addMember(AssocType);
+  }
 
   // Parse the body.
   {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8040,8 +8040,7 @@ ParserStatus Parser::parsePrimaryAssociatedTypes(
     AssocType->getAttrs() = Attrs;
     if (!Inherited.empty())
       AssocType->setInherited(Context.AllocateCopy(Inherited));
-    AssocType->getAttrs().add(new (Context) PrimaryAssociatedTypeAttr(
-        /*Implicit=*/true));
+    AssocType->setPrimary();
 
     AssocTypes.push_back(AssocType);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -316,8 +316,6 @@ public:
 
   void visitUnsafeInheritExecutorAttr(UnsafeInheritExecutorAttr *attr);
 
-  void visitPrimaryAssociatedTypeAttr(PrimaryAssociatedTypeAttr *attr);
-
   void checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs);
 };
 
@@ -5892,10 +5890,6 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
   if (!fn->isAsyncContext()) {
     diagnose(attr->getLocation(), diag::inherits_executor_without_async);
   }
-}
-
-void AttributeChecker::visitPrimaryAssociatedTypeAttr(
-    PrimaryAssociatedTypeAttr *attr) {
 }
 
 namespace {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -704,7 +704,7 @@ PrimaryAssociatedTypesRequest::evaluate(Evaluator &evaluator,
   SmallVector<AssociatedTypeDecl *, 2> assocTypes;
 
   for (auto *assocType : decl->getAssociatedTypeMembers()) {
-    if (assocType->getAttrs().hasAttribute<PrimaryAssociatedTypeAttr>())
+    if (assocType->isPrimary())
       assocTypes.push_back(assocType);
   }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1572,8 +1572,6 @@ namespace  {
     UNINTERESTING_ATTR(TypeSequence)
     UNINTERESTING_ATTR(CompileTimeConst)
 
-    UNINTERESTING_ATTR(PrimaryAssociatedType)
-
     UNINTERESTING_ATTR(BackDeploy)
 
     UNINTERESTING_ATTR(UnsafeInheritExecutor)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2777,11 +2777,13 @@ public:
     TypeID defaultDefinitionID;
     bool isImplicit;
     ArrayRef<uint64_t> rawOverriddenIDs;
+    bool isPrimary;
 
     decls_block::AssociatedTypeDeclLayout::readRecord(scratch, nameID,
                                                       contextID,
                                                       defaultDefinitionID,
                                                       isImplicit,
+                                                      isPrimary,
                                                       rawOverriddenIDs);
 
     auto DC = MF.getDeclContext(contextID);
@@ -2815,6 +2817,9 @@ public:
       }
     }
     assocType->setOverriddenDecls(overriddenAssocTypes);
+
+    if (isPrimary)
+      assocType->setPrimary();
 
     return assocType;
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 674; // decl block renumbering
+const uint16_t SWIFTMODULE_VERSION_MINOR = 675; // primary associated types
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1233,6 +1233,7 @@ namespace decls_block {
     DeclContextIDField,  // context decl
     TypeIDField,         // default definition
     BCFixed<1>,          // implicit flag
+    BCFixed<1>,          // is primary
     BCArray<DeclIDField> // overridden associated types
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3465,6 +3465,7 @@ public:
       contextID.getOpaqueValue(),
       S.addTypeRef(assocType->getDefaultDefinitionType()),
       assocType->isImplicit(),
+      assocType->isPrimary(),
       overriddenAssocTypeIDs);
   }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -72,9 +72,7 @@ func testMagic(pt: any P.Type) {
 }
 
 // --- With primary associated types and opaque parameter types
-protocol CollectionOf: Collection {
-  @_primaryAssociatedType associatedtype Element
-}
+protocol CollectionOf<Element>: Collection { }
 
 extension Array: CollectionOf { }
 extension Set: CollectionOf { }

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -module-name ParameterizedProtocols -emit-module-interface-path %t/ParameterizedProtocols.swiftinterface -enable-parameterized-protocol-types %s
+// RUN: %FileCheck %s < %t/ParameterizedProtocols.swiftinterface
+
+public protocol HasPrimaryAssociatedTypes<T, U : Collection, V : Equatable = Int> where U.Element == Int {}
+
+// CHECK: #if compiler(>=5.3) && $PrimaryAssociatedTypes
+// CHECK-NEXT: public protocol HasPrimaryAssociatedTypes<T, U : Swift.Collection, V : Swift.Equatable = Swift.Int> where Self.U.Element == Swift.Int {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public protocol HasPrimaryAssociatedTypes {
+// CHECK-NEXT:   associatedtype T
+// CHECK-NEXT:   associatedtype U : Swift.Collection where Self.U.Element == Swift.Int
+// CHECK-NEXT:   associatedtype V : Swift.Equatable = Swift.Int
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -68,9 +68,7 @@ func testAnyDictionary(numberNames: [Int: String]) {
 }
 
 // Combine with parameterized protocol types
-protocol PrimaryCollection: Collection {
-  @_primaryAssociatedType associatedtype Element
-}
+protocol PrimaryCollection<Element>: Collection {}
 
 extension Array: PrimaryCollection { }
 extension Set: PrimaryCollection { }

--- a/test/type/parameterized_protocol.swift
+++ b/test/type/parameterized_protocol.swift
@@ -3,16 +3,30 @@
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -enable-parameterized-protocol-types -requirement-machine-inferred-signatures=verify -disable-availability-checking 2>&1 | %FileCheck %s
 
 
-protocol Sequence {
-  @_primaryAssociatedType associatedtype Element
+/// Test some invalid syntax first
+
+protocol Invalid1<> {}
+// expected-error@-1 {{expected an identifier to name primary associated type}}
+
+protocol Invalid2<A B> {}
+// expected-error@-1 {{expected '>' to complete primary associated type list}}
+// expected-note@-2 {{to match this opening '<'}}
+
+protocol Invalid3<Element, +> {}
+// expected-error@-1 {{expected an identifier to name primary associated type}}
+// expected-error@-2 {{expected '>' to complete primary associated type list}}
+// expected-note@-3 {{to match this opening '<'}}
+
+
+/// Test semantics
+
+protocol Sequence<Element> {
   // expected-note@-1 {{protocol requires nested type 'Element'; do you want to add it?}}
 }
 
 struct ConcreteSequence<Element> : Sequence {}
 
-protocol EquatableSequence {
-  @_primaryAssociatedType associatedtype Element : Equatable
-}
+protocol EquatableSequence<Element : Equatable> {}
 
 struct ConcreteEquatableSequence<Element : Equatable> : EquatableSequence {}
 
@@ -86,10 +100,7 @@ protocol SequenceWrapperProtocol2 {
 
 
 /// Multiple primary associated types
-protocol Collection {
-  @_primaryAssociatedType associatedtype Element
-  @_primaryAssociatedType associatedtype Index
-}
+protocol Collection<Element, Index> {}
 
 // CHECK-LABEL: .testCollection1@
 // CHECK-NEXT: Generic signature: <T where T : Collection, T.[Collection]Element == String>

--- a/utils/gyb_syntax_support/GenericNodes.py
+++ b/utils/gyb_syntax_support/GenericNodes.py
@@ -64,6 +64,27 @@ GENERIC_NODES = [
                    is_optional=True),
          ]),
 
+    Node('PrimaryAssociatedTypeList', kind='SyntaxCollection',
+         element='PrimaryAssociatedType'),
+
+    # primary-associated-type -> type-name
+    #                          | type-name (: type-identifier)? (= type)?
+    Node('PrimaryAssociatedType', kind='Syntax',
+         traits=['WithTrailingComma'],
+         children=[
+             Child('Attributes', kind='AttributeList',
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Name', kind='IdentifierToken'),
+             Child('Colon', kind='ColonToken',
+                   is_optional=True),
+             Child('InheritedType', kind='Type',
+                   is_optional=True),
+             Child('Initializer', kind='TypeInitializerClause',
+                   is_optional=True),
+             Child('TrailingComma', kind='CommaToken',
+                   is_optional=True),
+         ]),
+
     # generic-parameter-clause -> '<' generic-parameter-list '>'
     Node('GenericParameterClause', kind='Syntax',
          children=[

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -255,6 +255,8 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'UnavailabilityCondition': 251,
     'AvailabilityEntry' : 252,
     'RegexLiteralExpr': 253,
+    'PrimaryAssociatedTypeList' : 254,
+    'PrimaryAssociatedType' : 255,
 }
 
 


### PR DESCRIPTION
The new syntax looks like a generic parameter list, eg

```swift
protocol SetProtocol<Element : Equatable> {}
```

You can also specify the default associated type:

```swift
protocol DictionaryProtocol<Key : Hashable, Value = UIViewController> {}
```

Proposal is here: https://github.com/apple/swift-evolution/pull/1538