### PR TITLE
cross-module-optimization: be more conservative when emitting a TBD file.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -172,6 +172,8 @@ public:
   /// Emit a mapping of profile counters for use in coverage.
   bool EmitProfileCoverageMapping = false;
 
+  bool emitTBD = false;
+
   /// Should we use a pass pipeline passed in via a json file? Null by default.
   llvm::StringRef ExternalPassPipelineFilename;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1670,6 +1670,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       OPT_disable_previous_implementation_calls_in_dynamic_replacements);
   Opts.ParseStdlib = FEOpts.ParseStdlib;
 
+  Opts.emitTBD = FEOpts.InputsAndOutputs.hasTBDPath();
+
   if (const Arg *A = Args.getLastArg(OPT_save_optimization_record_EQ)) {
     llvm::Expected<llvm::remarks::Format> formatOrErr =
         llvm::remarks::parseFormat(A->getValue());

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -1,0 +1,10 @@
+
+import Submodule
+
+public func incrementByThree(_ x: Int) -> Int {
+  return incrementByOne(x) + 2
+}
+
+public func incrementByThreeWithCall(_ x: Int) -> Int {
+  return incrementByOneNoCMO(x) + 2
+}

--- a/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
@@ -1,0 +1,10 @@
+
+public func incrementByOne(_ x: Int) -> Int {
+  return x + 1
+}
+
+@_semantics("optimize.no.crossmodule")
+public func incrementByOneNoCMO(_ x: Int) -> Int {
+  return x + 1
+}
+

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -1,0 +1,43 @@
+
+// RUN: %empty-directory(%t) 
+
+// RUN: %target-build-swift -O -wmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
+// RUN: %target-build-swift -O -wmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
+// RUN: %target-build-swift -O -wmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o
+
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -emit-sil | %FileCheck %s
+
+
+import Module
+import ModuleTBD
+
+// CHECK-LABEL: sil @$s4Main11doIncrementyS2iF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main11doIncrementyS2iF'
+public func doIncrement(_ x: Int) -> Int {
+  return Module.incrementByThree(x)
+}
+
+// CHECK-LABEL: sil @$s4Main19doIncrementWithCallyS2iF
+// CHECK:         function_ref @$s9Submodule19incrementByOneNoCMOyS2iF
+// CHECK:       } // end sil function '$s4Main19doIncrementWithCallyS2iF'
+public func doIncrementWithCall(_ x: Int) -> Int {
+  return Module.incrementByThreeWithCall(x)
+}
+
+// CHECK-LABEL: sil @$s4Main14doIncrementTBDyS2iF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main14doIncrementTBDyS2iF'
+public func doIncrementTBD(_ x: Int) -> Int {
+  return ModuleTBD.incrementByThree(x)
+}
+
+// CHECK-LABEL: sil @$s4Main22doIncrementTBDWithCallyS2iF
+// CHECK:         function_ref @$s9ModuleTBD24incrementByThreeWithCallyS2iF
+// CHECK:       } // end sil function '$s4Main22doIncrementTBDWithCallyS2iF'
+public func doIncrementTBDWithCall(_ x: Int) -> Int {
+  return ModuleTBD.incrementByThreeWithCall(x)
+}
+


### PR DESCRIPTION
If we are emitting a TBD file, the TBD file only contains public symbols of this module.
But not public symbols of imported modules which are statically linked to the current binary.
This prevents referencing public symbols from other modules which could (potentially) linked statically.
Unfortunately there is no way to find out if another module is linked statically or dynamically, so we have to be conservative.

Fixes an unresolved-symbol linker error.
rdar://89364148
