### PR TITLE
SIL: don't add effects attributes for storage decls.

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -101,17 +101,19 @@ void SILFunctionBuilder::addFunctionAttributes(
   }
 
   llvm::SmallVector<const EffectsAttr *, 8> customEffects;
-  for (auto *attr : Attrs.getAttributes<EffectsAttr>()) {
-    auto *effectsAttr = cast<EffectsAttr>(attr);
-    if (effectsAttr->getKind() == EffectsKind::Custom) {
-      customEffects.push_back(effectsAttr);
-    } else {
-      if (F->getEffectsKind() != EffectsKind::Unspecified &&
-          F->getEffectsKind() != effectsAttr->getKind()) {
-        mod.getASTContext().Diags.diagnose(effectsAttr->getLocation(),
-            diag::warning_in_effects_attribute, "mismatching function effects");
+  if (constant) {
+    for (auto *attr : Attrs.getAttributes<EffectsAttr>()) {
+      auto *effectsAttr = cast<EffectsAttr>(attr);
+      if (effectsAttr->getKind() == EffectsKind::Custom) {
+        customEffects.push_back(effectsAttr);
       } else {
-        F->setEffectsKind(effectsAttr->getKind());
+        if (F->getEffectsKind() != EffectsKind::Unspecified &&
+            F->getEffectsKind() != effectsAttr->getKind()) {
+          mod.getASTContext().Diags.diagnose(effectsAttr->getLocation(),
+              diag::warning_in_effects_attribute, "mismatching function effects");
+        } else {
+          F->setEffectsKind(effectsAttr->getKind());
+        }
       }
     }
   }


### PR DESCRIPTION
Only for accessor functions.
This is important because the clang importer sets "readonly" attributes for a getter also on the storage decl, which would propagate to the setter. Unfortunately I don't have a test case.

This PR restores the old behavior which was changed by https://github.com/apple/swift/pull/40957.

rdar://88876417
