### PR TITLE
IRGen: Use the current function name for the swift_suspend_dispatch thunk

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2366,8 +2366,7 @@ IRGenFunction::createAsyncDispatchFn(const FunctionPointer &fnPtr,
   auto *dispatchFnTy =
       llvm::FunctionType::get(IGM.VoidTy, argTys, false /*vaargs*/);
   llvm::SmallString<40> name;
-  llvm::raw_svector_ostream(name)
-      << "__swift_suspend_dispatch_" << argTypes.size();
+  llvm::raw_svector_ostream(name) << CurFn->getName() << ".0";
   llvm::Function *dispatch =
       llvm::Function::Create(dispatchFnTy, llvm::Function::InternalLinkage,
                              llvm::StringRef(name), &IGM.Module);

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -72,7 +72,7 @@ bb0:
 // CHECK:      {{musttail call swifttailcc|tail call swiftcc}} void @swift_continuation_await(%swift.continuation_context* %0)
 // CHECK-NEXT: ret void
 
-// CHECK: define {{.*}} void @__swift_suspend_dispatch_1(i8* %0, %swift.context* %1)
+// CHECK: define {{.*}} void @async_continuation.0(i8* %0, %swift.context* %1)
 // CHECK-NOT: define
 // CHECK:  tail call swift{{(tail)?}}cc void %{{.*}}(%swift.context* swiftasync %1)
 // CHECK-NEXT:  ret void


### PR DESCRIPTION
This is an incremental improvement of the debug info at a suspend apply site.

Before this patch the debug info at the call site would use the
`__swift_suspend_dispatch` function name as the current function after
coro lowering has inlined the thunk.

The proper fix is to rewire the debug info such that the thunk name is
never mentioned rather the current function that suspend site sits in is
used.

Until I have figured out how to do that using the current function name
instead of `__swift_suspend_dispatch.5` for the thunk is an incremental
improvement in the debug information consumers can observe.

rdar://88579737
