### PR TITLE
Disable test/SILOptimizer/copy_propagation_borrow.sil on arm64e

### DIFF
--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -7,6 +7,12 @@
 
 // REQUIRES: asserts
 
+// arm64e checks that there is a sound Swift stdlib but the test compiles itself
+// as `-module Swift` and so that verification fails. (in some ptrauth
+// verification code)
+
+// UNSUPPORTED: CPU=arm64e
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
ptrauth verification checks in IRGen check for a sound Swift stdlib but the
test compiles itself with so that verification fails.

rdar://89743974