### PR TITLE
RequirementMachine: Fix some problems in concrete contraction and a couple of other issues

### DIFF
--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -231,7 +231,10 @@ Optional<Type> ConcreteContraction::substTypeParameter(
 
   auto *decl = (*substBaseType)->getAnyNominal();
   if (decl == nullptr) {
-    llvm::dbgs() << "@@@ Not a nominal type: " << *substBaseType << "\n";
+    if (Debug) {
+      llvm::dbgs() << "@@@ Not a nominal type: " << *substBaseType << "\n";
+    }
+
     return None;
   }
 

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -864,18 +864,15 @@ RewriteSystem::getMinimizedGenericSignatureRules() const {
 
 /// Verify that each loop begins and ends at its basepoint.
 void RewriteSystem::verifyRewriteLoops() const {
-#ifndef NDEBUG
   for (const auto &loop : Loops) {
     loop.verify(*this);
   }
-#endif
 }
 
 /// Assert if homotopy reduction failed to eliminate a redundant conformance,
 /// since this suggests a misunderstanding on my part.
 void RewriteSystem::verifyRedundantConformances(
     const llvm::DenseSet<unsigned> &redundantConformances) const {
-#ifndef NDEBUG
   for (unsigned ruleID : redundantConformances) {
     const auto &rule = getRule(ruleID);
     assert(!rule.isPermanent() &&
@@ -893,14 +890,12 @@ void RewriteSystem::verifyRedundantConformances(
       abort();
     }
   }
-#endif
 }
 
 // Assert if homotopy reduction failed to eliminate a rewrite rule it was
 // supposed to delete.
 void RewriteSystem::verifyMinimizedRules(
     const llvm::DenseSet<unsigned> &redundantConformances) const {
-#ifndef NDEBUG
   unsigned redundantRuleCount = 0;
 
   for (unsigned ruleID : indices(Rules)) {
@@ -982,5 +977,4 @@ void RewriteSystem::verifyMinimizedRules(
       abort();
     }
   }
-#endif
 }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -742,7 +742,6 @@ void MinimalConformances::dumpMinimalConformanceEquation(
 }
 
 void MinimalConformances::verifyMinimalConformanceEquations() const {
-#ifndef NDEBUG
   for (const auto &pair : ConformancePaths) {
     const auto &rule = System.getRule(pair.first);
     auto *proto = rule.getLHS().back().getProtocol();
@@ -804,7 +803,6 @@ void MinimalConformances::verifyMinimalConformanceEquations() const {
       }
     }
   }
-#endif
 }
 
 bool MinimalConformances::isDerivedViaCircularConformanceRule(
@@ -884,7 +882,6 @@ void MinimalConformances::computeMinimalConformances() {
 
 /// Check invariants.
 void MinimalConformances::verifyMinimalConformances() const {
-#ifndef NDEBUG
   for (const auto &pair : ConformancePaths) {
     unsigned ruleID = pair.first;
     const auto &rule = System.getRule(ruleID);
@@ -913,7 +910,6 @@ void MinimalConformances::verifyMinimalConformances() const {
       abort();
     }
   }
-#endif
 }
 
 void MinimalConformances::dumpMinimalConformances(

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -524,6 +524,9 @@ AbstractGenericSignatureRequestRQM::evaluate(
   auto result = GenericSignature::get(genericParams, minimalRequirements);
   bool hadError = machine->hadError();
 
+  if (!hadError)
+    result.verify();
+
   return GenericSignatureWithError(result, hadError);
 }
 
@@ -668,6 +671,10 @@ InferredGenericSignatureRequestRQM::evaluate(
   }
 
   // FIXME: Handle allowConcreteGenericParams
+
+  // Check invariants.
+  if (!hadError)
+    result.verify();
 
   return GenericSignatureWithError(result, hadError);
 }

--- a/lib/AST/RequirementMachine/RewriteLoop.cpp
+++ b/lib/AST/RequirementMachine/RewriteLoop.cpp
@@ -203,7 +203,6 @@ void RewritePath::dumpLong(llvm::raw_ostream &out,
 }
 
 void RewriteLoop::verify(const RewriteSystem &system) const {
-#ifndef NDEBUG
   RewritePathEvaluator evaluator(Basepoint);
 
   for (const auto &step : Path) {
@@ -222,7 +221,6 @@ void RewriteLoop::verify(const RewriteSystem &system) const {
     evaluator.dump(llvm::errs());
     abort();
   }
-#endif
 }
 
 void RewriteLoop::dump(llvm::raw_ostream &out,

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -631,14 +631,12 @@ void RewriteSystem::recordRewriteLoop(MutableTerm basepoint,
 }
 
 void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
-#ifndef NDEBUG
-
 #define ASSERT_RULE(expr) \
   if (!(expr)) { \
     llvm::errs() << "&&& Malformed rewrite rule: " << rule << "\n"; \
     llvm::errs() << "&&& " << #expr << "\n\n"; \
     dump(llvm::errs()); \
-    assert(expr); \
+    abort(); \
   }
 
   for (const auto &rule : Rules) {
@@ -705,7 +703,6 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
   }
 
 #undef ASSERT_RULE
-#endif
 }
 
 void RewriteSystem::dump(llvm::raw_ostream &out) const {

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -78,8 +78,6 @@ void TypeDifference::dump(llvm::raw_ostream &out) const {
 }
 
 void TypeDifference::verify(RewriteContext &ctx) const {
-#ifndef NDEBUG
-
 #define VERIFY(expr, str) \
   if (!(expr)) { \
     llvm::errs() << "TypeDifference::verify(): " << str << "\n"; \
@@ -113,7 +111,6 @@ void TypeDifference::verify(RewriteContext &ctx) const {
   }
 
 #undef VERIFY
-#endif
 }
 
 namespace {
@@ -213,8 +210,6 @@ namespace {
     }
 
     void verify() const {
-#ifndef NDEBUG
-
 #define VERIFY(expr, str) \
   if (!(expr)) { \
     llvm::errs() << "ConcreteTypeMatcher::verify(): " << str << "\n"; \
@@ -258,7 +253,6 @@ namespace {
       }
 
 #undef VERIFY
-#endif
     }
 
     void dump(llvm::raw_ostream &out) const {
@@ -460,7 +454,6 @@ RewriteSystem::computeTypeDifference(Term baseTerm, Symbol lhs, Symbol rhs,
 
   bool isConflict = (matcher.ConcreteConflicts.size() > 0);
 
-#ifndef NDEBUG
   if (!isConflict) {
     // The meet operation should be commutative.
     if (lhsMeetRhs.RHS != rhsMeetLhs.RHS) {
@@ -523,7 +516,6 @@ RewriteSystem::computeTypeDifference(Term baseTerm, Symbol lhs, Symbol rhs,
       }
     }
   }
-#endif
 
   if (lhs != lhsMeetRhs.RHS)
     lhsDifferenceID = recordTypeDifference(lhsMeetRhs);

--- a/test/Generics/concrete_contraction_substitute_non_nominal_base.swift
+++ b/test/Generics/concrete_contraction_substitute_non_nominal_base.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype T : Q
+}
+
+protocol Q {
+  associatedtype U
+}
+
+struct S<T : Q> : P {}
+
+// Make sure concrete contraction can transform X.T.U => S<Y>.T.U => Y.U
+struct G<X : P, Y : Q> where X.T.U == Int {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y where X == S<Y>, Y : Q, Y.[Q]U == Int>
+extension G where X == S<Y> {}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=off
-// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 // FIXME: Both RUN lines should pass 'on' once diagnostics are implemented.
 
@@ -22,42 +22,53 @@ protocol W {
   associatedtype T : AnyObject
 }
 
-// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+// CHECK-LABEL: .derivedViaConcreteX1@
+// CHECK-NEXT: Generic signature: <A, B where A : X<B>, B : P>
 func derivedViaConcreteX1<A, B>(_: A, _: B)
   where A : U, A : X<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
 // expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
 
-// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+// CHECK-LABEL: .derivedViaConcreteX2@
+// CHECK-NEXT: Generic signature: <A, B where A : X<B>, B : P>
 func derivedViaConcreteX2<A, B>(_: A, _: B)
   where A : U, B : P, A : X<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
 // expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
 
-// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+// CHECK-LABEL: .derivedViaConcreteY1@
+// CHECK-NEXT: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY1<A, B>(_: A, _: B)
   where A : V, A : Y<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
 // expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
 
-// CHECK: Generic signature: <A, B where A : Y<B>>
-//
-// FIXME: Should be <A, B where A : Y<B>, B : C>, but redundant
-// superclass requirements currently block concrete contraction.
-
+// CHECK-LABEL: .derivedViaConcreteY2@
+// CHECK-NEXT: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY2<A, B>(_: A, _: B)
   where A : V, B : C, A : Y<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
 // expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
 
-// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+// CHECK-LABEL: .derivedViaConcreteZ1@
+// CHECK-NEXT: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ1<A, B>(_: A, _: B)
   where A : W, A : Z<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
 
-// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+// CHECK-LABEL: .derivedViaConcreteZ2@
+// CHECK-NEXT: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ2<A, B>(_: A, _: B)
   where A : W, B : AnyObject, A : Z<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
+
+class Base {}
+class Derived<T : C> : Base, V {}
+
+struct G<X : Base, Y> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y where X == Derived<Y>, Y : C>
+extension G where X == Derived<Y> {}

--- a/test/Generics/minimal_conformances_compare_concrete.swift
+++ b/test/Generics/minimal_conformances_compare_concrete.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction -dump-requirement-machine 2>&1 | %FileCheck %s --check-prefix=RULE
+
+protocol P {}
+
+class Base : P {}
+
+class Derived : Base {}
+
+struct G<X> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X where X == Derived>
+extension G where X : Base, X : P, X == Derived {}
+
+// RULE: + superclass: τ_0_0 Base
+// RULE: + conforms_to: τ_0_0 P
+// RULE: + same_type: τ_0_0 Derived
+
+// RULE: Rewrite system: {
+// RULE-NEXT: - [P].[P] => [P] [permanent]
+// RULE-NEXT: - τ_0_0.[superclass: Base] => τ_0_0 [explicit]
+// RULE-NEXT: - τ_0_0.[P] => τ_0_0 [explicit]
+// RULE-NEXT: - τ_0_0.[concrete: Derived] => τ_0_0 [explicit]
+// RULE-NEXT: - τ_0_0.[layout: _NativeClass] => τ_0_0
+// RULE-NEXT: - τ_0_0.[superclass: Derived] => τ_0_0
+// RULE-NEXT: - τ_0_0.[concrete: Derived : P] => τ_0_0
+// RULE-NEXT: - τ_0_0.[concrete: Base : P] => τ_0_0
+// RULE-NEXT: }
+
+// Notes:
+//
+// - concrete contraction kills the 'X : P' requirement before building the
+//   rewrite system so this test passes trivially.
+//
+// - without concrete contraction, we used to hit a problem where the sort
+//   in the minimal conformances algorithm would hit the unordered concrete
+//   conformances [concrete: Derived : P] vs [concrete: Base : P].

--- a/test/Generics/sr15826.swift
+++ b/test/Generics/sr15826.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+protocol AProtocol {
+  associatedtype B: BProtocol where B.A == Self
+}
+
+protocol BProtocol {
+  associatedtype A: AProtocol
+}
+
+protocol CProtocol {
+  associatedtype A: AProtocol
+}
+
+protocol DProtocol {
+  associatedtype A: AProtocol
+
+  // CHECK-LABEL: .DProtocol.foo(c:)@
+  // CHECK-NEXT: <Self, C where Self : DProtocol, C : CProtocol, Self.[DProtocol]A == C.[CProtocol]A>
+  func foo<C: CProtocol>(c: C) where C.A == A
+}
+
+struct Foo<Value> {
+  // CHECK-LABEL: .Foo.bar(c:)@
+  // CHECK-NEXT: <Value, C where Value == C.[CProtocol]A, C : CProtocol>
+  func bar<C: CProtocol>(c: C) where C.A == Value {}
+}


### PR DESCRIPTION
This addresses an issue I found while building the Eureka project in the source compatibility suite with -requirement-machine-abstract-signatures=verify.