### PR TITLE
Build fix for CentOS 7: somehow the default template argument isn't visible

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1685,7 +1685,7 @@ Serializer::writeASTBlockEntity(ProtocolConformance *conformance) {
     auto protocolID = addDeclRef(builtin->getProtocol());
     auto genericSigID = addGenericSignatureRef(builtin->getGenericSignature());
 
-    SmallVector<uint64_t> requirementData;
+    SmallVector<uint64_t, 16> requirementData;
     serializeGenericRequirements(builtin->getConditionalRequirements(),
                                  requirementData);
 


### PR DESCRIPTION
I didn't mean to use the default argument anyway, so this is fine.

rdar://89744467