### PR TITLE
[NFC][CodeCompletion] Remove 'declTypeContext' field from the result builder

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -283,7 +283,7 @@ private:
 static void addSelectorModifierKeywords(CodeCompletionResultSink &sink) {
   auto addKeyword = [&](StringRef Name, CodeCompletionKeywordKind Kind) {
     CodeCompletionResultBuilder Builder(sink, CodeCompletionResultKind::Keyword,
-                                        SemanticContextKind::None, {});
+                                        SemanticContextKind::None);
     Builder.setKeywordKind(Kind);
     Builder.addTextChunk(Name);
     Builder.addCallParameterColon();
@@ -646,7 +646,7 @@ static void addKeyword(CodeCompletionResultSink &Sink, StringRef Name,
                        StringRef TypeAnnotation = "",
                        CodeCompletionFlair Flair = {}) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
   Builder.setKeywordKind(Kind);
   Builder.addKeyword(Name);
   Builder.addFlair(Flair);
@@ -868,7 +868,7 @@ static void addSuperKeyword(CodeCompletionResultSink &Sink, DeclContext *DC) {
     return;
 
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::CurrentNominal, {});
+                                      SemanticContextKind::CurrentNominal);
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
     if (AFD->getOverriddenDecl() != nullptr) {
       Builder.addFlair(CodeCompletionFlairBit::CommonKeywordAtCurrentPosition);
@@ -886,7 +886,7 @@ static void addOpaqueTypeKeyword(CodeCompletionResultSink &Sink) {
 
 static void addAnyTypeKeyword(CodeCompletionResultSink &Sink, Type T) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
   Builder.setKeywordKind(CodeCompletionKeywordKind::None);
   Builder.addKeyword("Any");
   Builder.addTypeAnnotation(T, PrintOptions());
@@ -1040,7 +1040,7 @@ static void addPoundDirectives(CodeCompletionResultSink &Sink) {
               nullptr) {
         CodeCompletionResultBuilder Builder(Sink,
                                             CodeCompletionResultKind::Keyword,
-                                            SemanticContextKind::None, {});
+                                            SemanticContextKind::None);
         Builder.addBaseName(name);
         Builder.setKeywordKind(K);
         if (consumer)
@@ -1100,7 +1100,7 @@ static void addPlatformConditions(CodeCompletionResultSink &Sink) {
             Sink, CodeCompletionResultKind::Pattern,
             // FIXME: SemanticContextKind::CurrentModule is not correct.
             // Use 'None' (and fix prioritization) or introduce a new context.
-            SemanticContextKind::CurrentModule, {});
+            SemanticContextKind::CurrentModule);
         Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
         Builder.addBaseName(Name);
         Builder.addLeftParen();
@@ -1150,7 +1150,7 @@ static void addConditionalCompilationFlags(ASTContext &Ctx,
         Sink, CodeCompletionResultKind::Keyword,
         // FIXME: SemanticContextKind::CurrentModule is not correct.
         // Use 'None' (and fix prioritization) or introduce a new context.
-        SemanticContextKind::CurrentModule, {});
+        SemanticContextKind::CurrentModule);
     Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
     Builder.addTextChunk(Flag);
   }

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -49,7 +49,6 @@ class CodeCompletionResultBuilder {
   SmallVector<CodeCompletionString::Chunk, 4> Chunks;
   llvm::PointerUnion<const ModuleDecl *, const clang::Module *>
       CurrentModule;
-  ExpectedTypeContext declTypeContext;
   bool Cancelled = false;
   ContextFreeNotRecommendedReason ContextFreeNotRecReason =
       ContextFreeNotRecommendedReason::None;
@@ -90,10 +89,8 @@ class CodeCompletionResultBuilder {
 public:
   CodeCompletionResultBuilder(CodeCompletionResultSink &Sink,
                               CodeCompletionResultKind Kind,
-                              SemanticContextKind SemanticContext,
-                              const ExpectedTypeContext &declTypeContext)
-      : Sink(Sink), Kind(Kind), SemanticContext(SemanticContext),
-        declTypeContext(declTypeContext) {}
+                              SemanticContextKind SemanticContext)
+      : Sink(Sink), Kind(Kind), SemanticContext(SemanticContext) {}
 
   ~CodeCompletionResultBuilder() {
     finishResult();

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -280,8 +280,7 @@ void CompletionLookup::addSubModuleNames(
     std::vector<std::pair<std::string, bool>> &SubModuleNameVisibilityPairs) {
   for (auto &Pair : SubModuleNameVisibilityPairs) {
     CodeCompletionResultBuilder Builder(
-        Sink, CodeCompletionResultKind::Declaration, SemanticContextKind::None,
-        expectedTypeContext);
+        Sink, CodeCompletionResultKind::Declaration, SemanticContextKind::None);
     auto MD = ModuleDecl::create(Ctx.getIdentifier(Pair.first), Ctx);
     Builder.setAssociatedDecl(MD);
     Builder.addBaseName(MD->getNameStr());
@@ -325,8 +324,7 @@ void CompletionLookup::addModuleName(
     return;
 
   CodeCompletionResultBuilder Builder(
-      Sink, CodeCompletionResultKind::Declaration, SemanticContextKind::None,
-      expectedTypeContext);
+      Sink, CodeCompletionResultKind::Declaration, SemanticContextKind::None);
   Builder.setAssociatedDecl(MD);
   auto moduleName = MD->getName();
 
@@ -827,7 +825,7 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
 
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(VD, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(VD, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(VD);
   addLeadingDot(Builder);
   addValueBaseName(Builder, Name);
@@ -991,7 +989,7 @@ void CompletionLookup::addPoundAvailable(Optional<StmtKind> ParentKind) {
       Sink, CodeCompletionResultKind::Keyword,
       // FIXME: SemanticContextKind::Local is not correct.
       // Use 'None' (and fix prioritization) or introduce a new context.
-      SemanticContextKind::Local, expectedTypeContext);
+      SemanticContextKind::Local);
   Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
   Builder.addBaseName("available");
   Builder.addLeftParen();
@@ -1007,7 +1005,7 @@ void CompletionLookup::addPoundSelector(bool needPound) {
     return;
 
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
   if (needPound)
     Builder.addTextChunk("#selector");
   else
@@ -1027,7 +1025,7 @@ void CompletionLookup::addPoundKeyPath(bool needPound) {
     return;
 
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
   if (needPound)
     Builder.addTextChunk("#keyPath");
   else
@@ -1076,8 +1074,7 @@ void CompletionLookup::addSubscriptCallPattern(
       Sink,
       SD ? CodeCompletionResultKind::Declaration
          : CodeCompletionResultKind::Pattern,
-      SemanticContext ? *SemanticContext : getSemanticContextKind(SD),
-      expectedTypeContext);
+      SemanticContext ? *SemanticContext : getSemanticContextKind(SD));
   if (SD)
     Builder.setAssociatedDecl(SD);
   if (!HaveLParen) {
@@ -1117,8 +1114,7 @@ void CompletionLookup::addFunctionCallPattern(
         Sink,
         AFD ? CodeCompletionResultKind::Declaration
             : CodeCompletionResultKind::Pattern,
-        SemanticContext ? *SemanticContext : getSemanticContextKind(AFD),
-        expectedTypeContext);
+        SemanticContext ? *SemanticContext : getSemanticContextKind(AFD));
     Builder.addFlair(CodeCompletionFlairBit::ArgumentLabels);
     if (AFD)
       Builder.setAssociatedDecl(AFD);
@@ -1274,7 +1270,7 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
                            bool trivialTrailingClosure = false) {
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResultKind::Declaration,
-        getSemanticContext(FD, Reason, dynamicLookupInfo), expectedTypeContext);
+        getSemanticContext(FD, Reason, dynamicLookupInfo));
     Builder.setAssociatedDecl(FD);
 
     if (IsSuperRefExpr && CurrentMethod &&
@@ -1414,7 +1410,7 @@ void CompletionLookup::addConstructorCall(const ConstructorDecl *CD,
   auto addConstructorImpl = [&](bool includeDefaultArgs = true) {
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResultKind::Declaration,
-        getSemanticContext(CD, Reason, dynamicLookupInfo), expectedTypeContext);
+        getSemanticContext(CD, Reason, dynamicLookupInfo));
     Builder.setAssociatedDecl(CD);
 
     if (IsSuperRefExpr && CurrentMethod &&
@@ -1524,7 +1520,7 @@ void CompletionLookup::addSubscriptCall(const SubscriptDecl *SD,
 
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(SD, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(SD, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(SD);
 
   if (NotRecommended)
@@ -1563,7 +1559,7 @@ void CompletionLookup::addNominalTypeRef(const NominalTypeDecl *NTD,
                                          DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(NTD, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(NTD, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(NTD);
   addLeadingDot(Builder);
   Builder.addBaseName(NTD->getName().str());
@@ -1587,7 +1583,7 @@ void CompletionLookup::addTypeAliasRef(const TypeAliasDecl *TAD,
                                        DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(TAD, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(TAD, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(TAD);
   addLeadingDot(Builder);
   Builder.addBaseName(TAD->getName().str());
@@ -1613,7 +1609,7 @@ void CompletionLookup::addGenericTypeParamRef(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(GP, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(GP, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(GP);
   addLeadingDot(Builder);
   Builder.addBaseName(GP->getName().str());
@@ -1625,7 +1621,7 @@ void CompletionLookup::addAssociatedTypeRef(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(AT, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(AT, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(AT);
   addLeadingDot(Builder);
   Builder.addBaseName(AT->getName().str());
@@ -1637,7 +1633,7 @@ void CompletionLookup::addPrecedenceGroupRef(PrecedenceGroupDecl *PGD) {
   auto semanticContext =
       getSemanticContext(PGD, DeclVisibilityKind::VisibleAtTopLevel, {});
   CodeCompletionResultBuilder builder(
-      Sink, CodeCompletionResultKind::Declaration, semanticContext, {});
+      Sink, CodeCompletionResultKind::Declaration, semanticContext);
 
   builder.addBaseName(PGD->getName().str());
   builder.setAssociatedDecl(PGD);
@@ -1653,7 +1649,7 @@ void CompletionLookup::addEnumElementRef(const EnumElementDecl *EED,
 
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(EED, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(EED, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(EED);
 
   addLeadingDot(Builder);
@@ -1687,7 +1683,7 @@ void CompletionLookup::addKeyword(StringRef Name, Type TypeAnnotation,
                                   CodeCompletionKeywordKind KeyKind,
                                   unsigned NumBytesToErase) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SK, expectedTypeContext);
+                                      SK);
   addLeadingDot(Builder);
   Builder.addKeyword(Name);
   Builder.setKeywordKind(KeyKind);
@@ -1701,8 +1697,7 @@ void CompletionLookup::addKeyword(StringRef Name, StringRef TypeAnnotation,
                                   CodeCompletionKeywordKind KeyKind,
                                   CodeCompletionFlair flair) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None,
-                                      expectedTypeContext);
+                                      SemanticContextKind::None);
   Builder.addFlair(flair);
   addLeadingDot(Builder);
   Builder.addKeyword(Name);
@@ -1715,16 +1710,14 @@ void CompletionLookup::addDeclAttrParamKeyword(StringRef Name,
                                                StringRef Annotation,
                                                bool NeedSpecify) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None,
-                                      expectedTypeContext);
+                                      SemanticContextKind::None);
   Builder.addDeclAttrParamKeyword(Name, Annotation, NeedSpecify);
 }
 
 void CompletionLookup::addDeclAttrKeyword(StringRef Name,
                                           StringRef Annotation) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::None,
-                                      expectedTypeContext);
+                                      SemanticContextKind::None);
   Builder.addDeclAttrKeyword(Name, Annotation);
 }
 
@@ -1758,7 +1751,7 @@ bool CompletionLookup::addCompoundFunctionNameIfDesiable(
 
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
-      getSemanticContext(AFD, Reason, dynamicLookupInfo), expectedTypeContext);
+      getSemanticContext(AFD, Reason, dynamicLookupInfo));
   Builder.setAssociatedDecl(AFD);
 
   // Base name
@@ -2018,8 +2011,7 @@ bool CompletionLookup::tryTupleExprCompletions(Type ExprType) {
   unsigned Index = 0;
   for (auto TupleElt : TT->getElements()) {
     CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Pattern,
-                                        SemanticContextKind::CurrentNominal,
-                                        expectedTypeContext);
+                                        SemanticContextKind::CurrentNominal);
     addLeadingDot(Builder);
     if (TupleElt.hasName()) {
       Builder.addBaseName(TupleElt.getName().str());
@@ -2211,7 +2203,7 @@ void CompletionLookup::collectOperators(
 void CompletionLookup::addPostfixBang(Type resultType) {
   CodeCompletionResultBuilder builder(Sink,
                                       CodeCompletionResultKind::BuiltinOperator,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
   // FIXME: we can't use the exclamation mark chunk kind, or it isn't
   // included in the completion name.
   builder.addTextChunk("!");
@@ -2226,7 +2218,7 @@ void CompletionLookup::addPostfixOperatorCompletion(OperatorDecl *op,
   auto semanticContext =
       getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel, {});
   CodeCompletionResultBuilder builder(
-      Sink, CodeCompletionResultKind::Declaration, semanticContext, {});
+      Sink, CodeCompletionResultKind::Declaration, semanticContext);
 
   // FIXME: handle variable amounts of space.
   if (HaveLeadingSpace)
@@ -2252,7 +2244,7 @@ void CompletionLookup::tryPostfixOperator(Expr *expr, PostfixOperatorDecl *op) {
 void CompletionLookup::addAssignmentOperator(Type RHSType, Type resultType) {
   CodeCompletionResultBuilder builder(Sink,
                                       CodeCompletionResultKind::BuiltinOperator,
-                                      SemanticContextKind::None, {});
+                                      SemanticContextKind::None);
 
   if (HaveLeadingSpace)
     builder.addAnnotatedWhitespace(" ");
@@ -2276,7 +2268,7 @@ void CompletionLookup::addInfixOperatorCompletion(OperatorDecl *op,
   auto semanticContext =
       getSemanticContext(op, DeclVisibilityKind::VisibleAtTopLevel, {});
   CodeCompletionResultBuilder builder(
-      Sink, CodeCompletionResultKind::Declaration, semanticContext, {});
+      Sink, CodeCompletionResultKind::Declaration, semanticContext);
   builder.setAssociatedDecl(op);
 
   if (HaveLeadingSpace)
@@ -2468,7 +2460,7 @@ void CompletionLookup::addPoundLiteralCompletions(bool needPound) {
     }
 
     CodeCompletionResultBuilder builder(Sink, CodeCompletionResultKind::Keyword,
-                                        SemanticContextKind::None, {});
+                                        SemanticContextKind::None);
     builder.addFlair(flair);
     builder.setLiteralKind(literalKind.getValue());
     builder.setKeywordKind(kwKind);
@@ -2500,7 +2492,7 @@ void CompletionLookup::addValueLiteralCompletions() {
           bool isKeyword = false) {
         CodeCompletionResultBuilder builder(Sink,
                                             CodeCompletionResultKind::Literal,
-                                            SemanticContextKind::None, {});
+                                            SemanticContextKind::None);
         builder.setLiteralKind(kind);
         builder.addFlair(flair);
 
@@ -2573,7 +2565,7 @@ void CompletionLookup::addValueLiteralCompletions() {
   // Add tuple completion (item, item).
   {
     CodeCompletionResultBuilder builder(Sink, CodeCompletionResultKind::Literal,
-                                        SemanticContextKind::None, {});
+                                        SemanticContextKind::None);
     builder.setLiteralKind(LK::Tuple);
     builder.addFlair(flair);
 
@@ -2773,7 +2765,7 @@ void CompletionLookup::addCallArgumentCompletionResults(
         Sink, CodeCompletionResultKind::Pattern,
         // FIXME: SemanticContextKind::Local is not correct.
         // Use 'None' (and fix prioritization) or introduce a new context.
-        SemanticContextKind::Local, {});
+        SemanticContextKind::Local);
     Builder.addCallArgument(Arg->getLabel(), Identifier(), Arg->getPlainType(),
                             ContextType, Arg->isVariadic(), Arg->isInOut(),
                             /*IsIUO=*/false, Arg->isAutoClosure(),
@@ -2924,8 +2916,7 @@ void CompletionLookup::getAttributeDeclParamCompletions(DeclAttrKind AttrKind,
 void CompletionLookup::getTypeAttributeKeywordCompletions() {
   auto addTypeAttr = [&](StringRef Name) {
     CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                        SemanticContextKind::None,
-                                        expectedTypeContext);
+                                        SemanticContextKind::None);
     Builder.addAttributeKeyword(Name, "Type Attribute");
   };
   addTypeAttr("autoclosure");
@@ -3036,8 +3027,7 @@ void CompletionLookup::getSelfTypeCompletionInDeclContext(
   }
 
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Keyword,
-                                      SemanticContextKind::CurrentNominal,
-                                      expectedTypeContext);
+                                      SemanticContextKind::CurrentNominal);
   Builder.addKeyword("Self");
   Builder.setKeywordKind(CodeCompletionKeywordKind::kw_Self);
   addTypeAnnotation(Builder, selfType);
@@ -3135,7 +3125,7 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
   const_cast<DeclContext *>(CurrDeclContext)->walkContext(Finder);
   for (auto name : Finder.Result) {
     CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Pattern,
-                                        SemanticContextKind::Local, {});
+                                        SemanticContextKind::Local);
     Builder.addTextChunk(name.str());
   }
 }

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -215,7 +215,7 @@ void CompletionOverrideLookup::addMethodOverride(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(Sink,
                                       CodeCompletionResultKind::Declaration,
-                                      SemanticContextKind::Super, {});
+                                      SemanticContextKind::Super);
   Builder.setResultTypeNotApplicable();
   Builder.setAssociatedDecl(FD);
   addValueOverride(FD, Reason, dynamicLookupInfo, Builder, hasFuncIntroducer);
@@ -234,7 +234,7 @@ void CompletionOverrideLookup::addVarOverride(
 
   CodeCompletionResultBuilder Builder(Sink,
                                       CodeCompletionResultKind::Declaration,
-                                      SemanticContextKind::Super, {});
+                                      SemanticContextKind::Super);
   Builder.setAssociatedDecl(VD);
   addValueOverride(VD, Reason, dynamicLookupInfo, Builder, hasVarIntroducer);
 }
@@ -244,7 +244,7 @@ void CompletionOverrideLookup::addSubscriptOverride(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(Sink,
                                       CodeCompletionResultKind::Declaration,
-                                      SemanticContextKind::Super, {});
+                                      SemanticContextKind::Super);
   Builder.setResultTypeNotApplicable();
   Builder.setAssociatedDecl(SD);
   addValueOverride(SD, Reason, dynamicLookupInfo, Builder, false);
@@ -256,7 +256,7 @@ void CompletionOverrideLookup::addTypeAlias(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(Sink,
                                       CodeCompletionResultKind::Declaration,
-                                      SemanticContextKind::Super, {});
+                                      SemanticContextKind::Super);
   Builder.setResultTypeNotApplicable();
   Builder.setAssociatedDecl(ATD);
   if (!hasTypealiasIntroducer && !hasAccessModifier)
@@ -273,7 +273,7 @@ void CompletionOverrideLookup::addConstructor(
     DynamicLookupInfo dynamicLookupInfo) {
   CodeCompletionResultBuilder Builder(Sink,
                                       CodeCompletionResultKind::Declaration,
-                                      SemanticContextKind::Super, {});
+                                      SemanticContextKind::Super);
   Builder.setResultTypeNotApplicable();
   Builder.setAssociatedDecl(CD);
 
@@ -469,7 +469,7 @@ void CompletionOverrideLookup::addResultBuilderBuildCompletion(
     NominalTypeDecl *builder, Type componentType,
     ResultBuilderBuildFunction function) {
   CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Pattern,
-                                      SemanticContextKind::CurrentNominal, {});
+                                      SemanticContextKind::CurrentNominal);
   Builder.setResultTypeNotApplicable();
 
   if (!hasFuncIntroducer) {


### PR DESCRIPTION
This field is not used anymore
(I forgot to remove it in https://github.com/apple/swift/commit/84f0c5723a4fec70c39c1559fb449d22e7432f92)