### PR TITLE
[Requirement Machine] Diagnose redundant requirements.

### DIFF
--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -578,8 +578,11 @@ void PropertyMap::inferConditionalRequirements(
         for (const auto &rule : builder.PermanentRules)
           System.addPermanentRule(rule.first, rule.second);
 
-        for (const auto &rule : builder.RequirementRules)
-          System.addExplicitRule(rule.first, rule.second);
+        for (const auto &rule : builder.RequirementRules) {
+          auto lhs = std::get<0>(rule);
+          auto rhs = std::get<1>(rule);
+          System.addExplicitRule(lhs, rhs, /*requirementID=*/None);
+        }
       }
     }
 

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -581,7 +581,7 @@ void PropertyMap::inferConditionalRequirements(
         for (const auto &rule : builder.RequirementRules) {
           auto lhs = std::get<0>(rule);
           auto rhs = std::get<1>(rule);
-          System.addExplicitRule(lhs, rhs, /*requirementID=*/None, errors);
+          System.addExplicitRule(lhs, rhs, /*requirementID=*/None);
         }
       }
     }

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -581,7 +581,7 @@ void PropertyMap::inferConditionalRequirements(
         for (const auto &rule : builder.RequirementRules) {
           auto lhs = std::get<0>(rule);
           auto rhs = std::get<1>(rule);
-          System.addExplicitRule(lhs, rhs, /*requirementID=*/None);
+          System.addExplicitRule(lhs, rhs, /*requirementID=*/None, errors);
         }
       }
     }

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -64,7 +64,11 @@ enum class DebugFlags : unsigned {
   RedundantRulesDetail = (1<<13),
 
   /// Print debug output from the concrete contraction pre-processing pass.
-  ConcreteContraction = (1<<14)
+  ConcreteContraction = (1<<14),
+
+  /// Print debug output from propagating explicit requirement
+  /// IDs from redundant rules.
+  PropagateRequirementIDs = (1<<15),
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -184,7 +184,7 @@ void RewriteSystem::propagateExplicitBits() {
       for (unsigned ruleID : rulesInEmptyContext) {
         auto &rule = getRule(ruleID);
         if (!rule.isPermanent() && !rule.isExplicit())
-          rule.markExplicit(None);
+          rule.markExplicit();
       }
     }
   }
@@ -220,7 +220,7 @@ void RewriteSystem::propagateRedundantRequirementIDs() {
           replacement.dump(llvm::dbgs());
         }
 
-        replacement.markExplicit(requirementID);
+        replacement.setRequirementID(requirementID);
       }
     }
   }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -195,17 +195,21 @@ void RewriteSystem::propagateExplicitBits() {
       loop.findRulesAppearingOnceInEmptyContext(*this);
 
     bool sawExplicitRule = false;
+    Optional<unsigned> requirementID = None;
 
     for (unsigned ruleID : rulesInEmptyContext) {
       const auto &rule = getRule(ruleID);
-      if (rule.isExplicit())
+      if (rule.isExplicit()) {
         sawExplicitRule = true;
+        requirementID = rule.getRequirementID();
+        break;
+      }
     }
     if (sawExplicitRule) {
       for (unsigned ruleID : rulesInEmptyContext) {
         auto &rule = getRule(ruleID);
         if (!rule.isPermanent() && !rule.isExplicit())
-          rule.markExplicit();
+          rule.markExplicit(requirementID);
       }
     }
   }

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -74,24 +74,14 @@ void RewriteLoop::recompute(const RewriteSystem &system) {
 
   ProjectionCount = 0;
   DecomposeCount = 0;
-
-  // Rules appearing in empty context (possibly more than once).
-  llvm::SmallDenseSet<unsigned, 2> rulesInEmptyContext;
-
-  // The number of times each rule appears (with or without context).
-  llvm::SmallDenseMap<unsigned, unsigned, 2> ruleMultiplicity;
+  Useful = false;
 
   RewritePathEvaluator evaluator(Basepoint);
-
   for (auto step : Path) {
     switch (step.Kind) {
-    case RewriteStep::Rule: {
-      if (!step.isInContext() && !evaluator.isInContext())
-        rulesInEmptyContext.insert(step.getRuleID());
-
-      ++ruleMultiplicity[step.getRuleID()];
+    case RewriteStep::Rule:
+      Useful |= (!step.isInContext() && !evaluator.isInContext());
       break;
-    }
 
     case RewriteStep::LeftConcreteProjection:
       ++ProjectionCount;
@@ -112,18 +102,7 @@ void RewriteLoop::recompute(const RewriteSystem &system) {
     evaluator.apply(step, system);
   }
 
-  Useful = !rulesInEmptyContext.empty();
-
-  RulesInEmptyContext.clear();
-
-  // Collect all rules that we saw exactly once in empty context.
-  for (auto rule : rulesInEmptyContext) {
-    auto found = ruleMultiplicity.find(rule);
-    assert(found != ruleMultiplicity.end());
-
-    if (found->second == 1)
-      RulesInEmptyContext.push_back(rule);
-  }
+  RulesInEmptyContext = Path.getRulesInEmptyContext(Basepoint, system);
 }
 
 /// A rewrite rule is redundant if it appears exactly once in a loop
@@ -227,48 +206,8 @@ void RewriteSystem::propagateRedundantRequirementIDs() {
     if (!requirementID.hasValue())
       continue;
 
-    // FIXME: This code is almost identical to `RewriteLoop::recompute`.
-
-    // Rules appearing in empty context (possibly more than once).
-    llvm::SmallDenseSet<unsigned, 2> rulesInEmptyContext;
-    // The number of times each rule appears (with or without context).
-    llvm::SmallDenseMap<unsigned, unsigned, 2> ruleFrequency;
-
-    RewritePathEvaluator evaluator(MutableTerm(rule.getLHS()));
-    for (auto step : rewritePath) {
-      switch (step.Kind) {
-      case RewriteStep::Rule: {
-        if (!step.isInContext() && !evaluator.isInContext())
-          rulesInEmptyContext.insert(step.getRuleID());
-
-        ++ruleFrequency[step.getRuleID()];
-        break;
-      }
-
-      case RewriteStep::LeftConcreteProjection:
-      case RewriteStep::Decompose:
-      case RewriteStep::PrefixSubstitutions:
-      case RewriteStep::Shift:
-      case RewriteStep::Relation:
-      case RewriteStep::DecomposeConcrete:
-      case RewriteStep::RightConcreteProjection:
-        break;
-      }
-
-      evaluator.apply(step, *this);
-    }
-
-    // Collect all rules that we saw exactly once in empty context.
-    SmallVector<unsigned, 1> rulesOnceInEmptyContext;
-    for (auto rule : rulesInEmptyContext) {
-      auto found = ruleFrequency.find(rule);
-      assert(found != ruleFrequency.end());
-
-      if (found->second == 1)
-        rulesOnceInEmptyContext.push_back(rule);
-    }
-
-    for (auto ruleID : rulesOnceInEmptyContext) {
+    MutableTerm lhs(rule.getLHS());
+    for (auto ruleID : rewritePath.getRulesInEmptyContext(lhs, *this)) {
       auto &replacement = Rules[ruleID];
       if (!replacement.isPermanent() &&
           !replacement.getRequirementID().hasValue()) {
@@ -487,6 +426,51 @@ bool RewritePath::replaceRuleWithPath(unsigned ruleID,
 
   std::swap(newSteps, Steps);
   return true;
+}
+
+SmallVector<unsigned, 1>
+RewritePath::getRulesInEmptyContext(const MutableTerm &term,
+                                    const RewriteSystem &system) {
+  // Rules appearing in empty context (possibly more than once).
+  llvm::SmallDenseSet<unsigned, 2> rulesInEmptyContext;
+  // The number of times each rule appears (with or without context).
+  llvm::SmallDenseMap<unsigned, unsigned, 2> ruleFrequency;
+
+  RewritePathEvaluator evaluator(term);
+  for (auto step : Steps) {
+    switch (step.Kind) {
+    case RewriteStep::Rule: {
+      if (!step.isInContext() && !evaluator.isInContext())
+        rulesInEmptyContext.insert(step.getRuleID());
+
+      ++ruleFrequency[step.getRuleID()];
+      break;
+    }
+
+    case RewriteStep::LeftConcreteProjection:
+    case RewriteStep::Decompose:
+    case RewriteStep::PrefixSubstitutions:
+    case RewriteStep::Shift:
+    case RewriteStep::Relation:
+    case RewriteStep::DecomposeConcrete:
+    case RewriteStep::RightConcreteProjection:
+      break;
+    }
+
+    evaluator.apply(step, system);
+  }
+
+  // Collect all rules that we saw exactly once in empty context.
+  SmallVector<unsigned, 1> rulesOnceInEmptyContext;
+  for (auto rule : rulesInEmptyContext) {
+    auto found = ruleFrequency.find(rule);
+    assert(found != ruleFrequency.end());
+
+    if (found->second == 1)
+      rulesOnceInEmptyContext.push_back(rule);
+  }
+
+  return rulesOnceInEmptyContext;
 }
 
 /// Find a rule to delete by looking through all loops for rewrite rules appearing

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -59,7 +59,7 @@ void realizeInheritedRequirements(TypeDecl *decl, Type type,
                                   SmallVectorImpl<RequirementError> &errors);
 
 bool diagnoseRequirementErrors(ASTContext &ctx,
-                               SmallVectorImpl<RequirementError> &errors,
+                               ArrayRef<RequirementError> errors,
                                bool allowConcreteGenericParams);
 
 std::pair<MutableTerm, MutableTerm>
@@ -104,7 +104,12 @@ struct RuleBuilder {
 
   /// New rules derived from requirements written by the user, which can be
   /// eliminated by homotopy reduction.
-  std::vector<std::pair<MutableTerm, MutableTerm>> RequirementRules;
+  std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>>
+      RequirementRules;
+
+  /// Requirements written in source code. The requirement ID in the above
+  /// \c RequirementRules vector is an index into this array.
+  std::vector<StructuralRequirement> WrittenRequirements;
 
   /// Enables debugging output. Controlled by the -dump-requirement-machine
   /// frontend flag.
@@ -123,7 +128,8 @@ struct RuleBuilder {
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
   void addRequirement(const Requirement &req,
-                      const ProtocolDecl *proto);
+                      const ProtocolDecl *proto,
+                      Optional<unsigned> requirementID);
   void addRequirement(const StructuralRequirement &req,
                       const ProtocolDecl *proto);
   void addTypeAlias(const ProtocolTypeAlias &alias,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -96,6 +96,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/false,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
+                    std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 
@@ -138,6 +139,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true, protos,
+                    std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 
@@ -185,6 +187,7 @@ RequirementMachine::initWithWrittenRequirements(
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
+                    std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -75,7 +75,8 @@ void RequirementMachine::checkCompletionResult(CompletionResult result) const {
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
+RequirementMachine::initWithGenericSignature(CanGenericSignature sig,
+                                             SmallVectorImpl<RequirementError> &errors) {
   Sig = sig;
   Params.append(sig.getGenericParams().begin(),
                 sig.getGenericParams().end());
@@ -98,7 +99,8 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules));
+                    std::move(builder.RequirementRules),
+                    errors);
 
   auto result = computeCompletion(RewriteSystem::DisallowInvalidRequirements);
 
@@ -123,7 +125,8 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
+RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
+                                      SmallVectorImpl<RequirementError> &errors) {
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 
   if (Dump) {
@@ -141,7 +144,8 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
   System.initialize(/*recordLoops=*/true, protos,
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules));
+                    std::move(builder.RequirementRules),
+                    errors);
 
   auto result = computeCompletion(RewriteSystem::AllowInvalidRequirements);
 
@@ -167,7 +171,8 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
 std::pair<CompletionResult, unsigned>
 RequirementMachine::initWithWrittenRequirements(
     ArrayRef<GenericTypeParamType *> genericParams,
-    ArrayRef<StructuralRequirement> requirements) {
+    ArrayRef<StructuralRequirement> requirements,
+    SmallVectorImpl<RequirementError> &errors) {
   Params.append(genericParams.begin(), genericParams.end());
 
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
@@ -189,7 +194,8 @@ RequirementMachine::initWithWrittenRequirements(
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules));
+                    std::move(builder.RequirementRules),
+                    errors);
 
   auto result = computeCompletion(RewriteSystem::AllowInvalidRequirements);
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -75,8 +75,7 @@ void RequirementMachine::checkCompletionResult(CompletionResult result) const {
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithGenericSignature(CanGenericSignature sig,
-                                             SmallVectorImpl<RequirementError> &errors) {
+RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
   Sig = sig;
   Params.append(sig.getGenericParams().begin(),
                 sig.getGenericParams().end());
@@ -99,8 +98,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules),
-                    errors);
+                    std::move(builder.RequirementRules));
 
   auto result = computeCompletion(RewriteSystem::DisallowInvalidRequirements);
 
@@ -125,8 +123,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig,
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
-                                      SmallVectorImpl<RequirementError> &errors) {
+RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 
   if (Dump) {
@@ -144,8 +141,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
   System.initialize(/*recordLoops=*/true, protos,
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules),
-                    errors);
+                    std::move(builder.RequirementRules));
 
   auto result = computeCompletion(RewriteSystem::AllowInvalidRequirements);
 
@@ -171,8 +167,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
 std::pair<CompletionResult, unsigned>
 RequirementMachine::initWithWrittenRequirements(
     ArrayRef<GenericTypeParamType *> genericParams,
-    ArrayRef<StructuralRequirement> requirements,
-    SmallVectorImpl<RequirementError> &errors) {
+    ArrayRef<StructuralRequirement> requirements) {
   Params.append(genericParams.begin(), genericParams.end());
 
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
@@ -194,8 +189,7 @@ RequirementMachine::initWithWrittenRequirements(
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
                     std::move(builder.PermanentRules),
-                    std::move(builder.RequirementRules),
-                    errors);
+                    std::move(builder.RequirementRules));
 
   auto result = computeCompletion(RewriteSystem::AllowInvalidRequirements);
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -91,18 +91,15 @@ class RequirementMachine final {
   void checkCompletionResult(CompletionResult result) const;
 
   std::pair<CompletionResult, unsigned>
-  initWithGenericSignature(CanGenericSignature sig,
-                           SmallVectorImpl<RequirementError> &errors);
+  initWithGenericSignature(CanGenericSignature sig);
 
   std::pair<CompletionResult, unsigned>
-  initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
-                    SmallVectorImpl<RequirementError> &errors);
+  initWithProtocols(ArrayRef<const ProtocolDecl *> protos);
 
   std::pair<CompletionResult, unsigned>
   initWithWrittenRequirements(
       ArrayRef<GenericTypeParamType *> genericParams,
-      ArrayRef<StructuralRequirement> requirements,
-      SmallVectorImpl<RequirementError> &errors);
+      ArrayRef<StructuralRequirement> requirements);
 
   bool isComplete() const;
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -91,15 +91,18 @@ class RequirementMachine final {
   void checkCompletionResult(CompletionResult result) const;
 
   std::pair<CompletionResult, unsigned>
-  initWithGenericSignature(CanGenericSignature sig);
+  initWithGenericSignature(CanGenericSignature sig,
+                           SmallVectorImpl<RequirementError> &errors);
 
   std::pair<CompletionResult, unsigned>
-  initWithProtocols(ArrayRef<const ProtocolDecl *> protos);
+  initWithProtocols(ArrayRef<const ProtocolDecl *> protos,
+                    SmallVectorImpl<RequirementError> &errors);
 
   std::pair<CompletionResult, unsigned>
   initWithWrittenRequirements(
       ArrayRef<GenericTypeParamType *> genericParams,
-      ArrayRef<StructuralRequirement> requirements);
+      ArrayRef<StructuralRequirement> requirements,
+      SmallVectorImpl<RequirementError> &errors);
 
   bool isComplete() const;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -419,6 +419,12 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
     }
   }
 
+  if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
+      RequirementMachineMode::Enabled) {
+    diagnoseRequirementErrors(ctx, machine->System.getErrors(),
+                              /*allowConcreteGenericParams=*/false);
+  }
+
   // Return the result for the specific protocol this request was kicked off on.
   return *result;
 }
@@ -668,6 +674,8 @@ InferredGenericSignatureRequestRQM::evaluate(
   if (ctx.LangOpts.RequirementMachineInferredSignatures ==
       RequirementMachineMode::Enabled) {
     hadError |= diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
+    hadError |= diagnoseRequirementErrors(ctx, machine->System.getErrors(),
+                                          allowConcreteGenericParams);
   }
 
   // FIXME: Handle allowConcreteGenericParams

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -354,7 +354,7 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
 
   SmallVector<RequirementError, 4> errors;
 
-  auto status = machine->initWithProtocols(component, errors);
+  auto status = machine->initWithProtocols(component);
   if (status.first != CompletionResult::Success) {
     // All we can do at this point is diagnose and give each protocol an empty
     // requirement signature.
@@ -524,7 +524,7 @@ AbstractGenericSignatureRequestRQM::evaluate(
       ctx.getRewriteContext()));
 
   auto status =
-      machine->initWithWrittenRequirements(genericParams, requirements, errors);
+      machine->initWithWrittenRequirements(genericParams, requirements);
   machine->checkCompletionResult(status.first);
 
   auto minimalRequirements =
@@ -652,7 +652,7 @@ InferredGenericSignatureRequestRQM::evaluate(
       ctx.getRewriteContext()));
 
   auto status =
-      machine->initWithWrittenRequirements(genericParams, requirements, errors);
+      machine->initWithWrittenRequirements(genericParams, requirements);
   if (status.first != CompletionResult::Success) {
     ctx.Diags.diagnose(loc,
                        diag::requirement_machine_completion_failed,

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -421,7 +421,15 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
 
   if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
       RequirementMachineMode::Enabled) {
+    // Diagnose trivially invalid requirements from the rewrite
+    // system.
     diagnoseRequirementErrors(ctx, machine->System.getErrors(),
+                              /*allowConcreteGenericParams=*/false);
+
+    // Diagnose redundant requirements found during signature
+    // minimization.
+    auto redundancies = machine->System.getRedundantRequirements();
+    diagnoseRequirementErrors(ctx, redundancies,
                               /*allowConcreteGenericParams=*/false);
   }
 
@@ -673,8 +681,19 @@ InferredGenericSignatureRequestRQM::evaluate(
 
   if (ctx.LangOpts.RequirementMachineInferredSignatures ==
       RequirementMachineMode::Enabled) {
-    hadError |= diagnoseRequirementErrors(ctx, errors, allowConcreteGenericParams);
+    // Diagnose invalid requirements dropped during desugaring.
+    hadError |= diagnoseRequirementErrors(ctx, errors,
+                                          allowConcreteGenericParams);
+
+    // Diagnose trivially invalid requirements from the rewrite
+    // system.
     hadError |= diagnoseRequirementErrors(ctx, machine->System.getErrors(),
+                                          allowConcreteGenericParams);
+
+    // Diagnose redundant requirements found during signature
+    // minimization.
+    auto redundancies = machine->System.getRedundantRequirements();
+    hadError |= diagnoseRequirementErrors(ctx, redundancies,
                                           allowConcreteGenericParams);
   }
 

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -42,6 +42,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("redundant-rules", DebugFlags::RedundantRules)
       .Case("redundant-rules-detail", DebugFlags::RedundantRulesDetail)
       .Case("concrete-contraction", DebugFlags::ConcreteContraction)
+      .Case("propagate-requirement-ids", DebugFlags::PropagateRequirementIDs)
       .Default(None);
     if (!flag) {
       llvm::errs() << "Unknown debug flag in -debug-requirement-machine "

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -133,9 +133,11 @@ RequirementMachine *RewriteContext::getRequirementMachine(
   auto *newMachine = new rewriting::RequirementMachine(*this);
   machine = newMachine;
 
+  SmallVector<RequirementError, 4> errors;
+
   // This might re-entrantly invalidate 'machine', which is a reference
   // into Protos.
-  auto status = newMachine->initWithGenericSignature(sig);
+  auto status = newMachine->initWithGenericSignature(sig, errors);
   newMachine->checkCompletionResult(status.first);
 
   return newMachine;

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -133,11 +133,9 @@ RequirementMachine *RewriteContext::getRequirementMachine(
   auto *newMachine = new rewriting::RequirementMachine(*this);
   machine = newMachine;
 
-  SmallVector<RequirementError, 4> errors;
-
   // This might re-entrantly invalidate 'machine', which is a reference
   // into Protos.
-  auto status = newMachine->initWithGenericSignature(sig, errors);
+  auto status = newMachine->initWithGenericSignature(sig);
   newMachine->checkCompletionResult(status.first);
 
   return newMachine;

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -409,6 +409,9 @@ public:
 
   bool replaceRuleWithPath(unsigned ruleID, const RewritePath &path);
 
+  SmallVector<unsigned, 1> getRulesInEmptyContext(const MutableTerm &term,
+                                                  const RewriteSystem &system);
+
   void invert();
 
   bool computeFreelyReducedForm();

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -741,7 +741,8 @@ RewriteSystem::getRedundantRequirements() {
   for (unsigned ruleID : indices(getRules())) {
     auto &rule = getRules()[ruleID];
 
-    if (!rule.isExplicit() && !rule.isPermanent() && !rule.isRedundant())
+    if (!rule.isExplicit() && !rule.isPermanent() && !rule.isRedundant() &&
+        isInMinimizationDomain(rule.getLHS().getRootProtocol()))
       impliedRequirements.insert(ruleID);
 
     if (!rule.isExplicit())

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -498,7 +498,7 @@ bool RewriteSystem::addExplicitRule(MutableTerm lhs, MutableTerm rhs,
                                     Optional<unsigned> requirementID) {
   bool added = addRule(std::move(lhs), std::move(rhs));
   if (added) {
-    Rules.back().markExplicit();
+    Rules.back().markExplicit(requirementID);
   } else if (requirementID.hasValue()) {
     auto req = WrittenRequirements[requirementID.getValue()];
     Errors.push_back(
@@ -723,7 +723,15 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
 void RewriteSystem::dump(llvm::raw_ostream &out) const {
   out << "Rewrite system: {\n";
   for (const auto &rule : Rules) {
-    out << "- " << rule << "\n";
+    out << "- " << rule;
+    if (auto ID = rule.getRequirementID()) {
+      auto requirement = WrittenRequirements[*ID];
+      out << ", ";
+      requirement.req.dump(out);
+      out << " at ";
+      requirement.loc.print(out, Context.getASTContext().SourceMgr);
+    }
+    out << "\n";
   }
   out << "}\n";
   if (!Relations.empty()) {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -770,7 +770,7 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
     out << "- " << rule;
     if (auto ID = rule.getRequirementID()) {
       auto requirement = WrittenRequirements[*ID];
-      out << ", ";
+      out << ", ID: " << *ID << ", ";
       requirement.req.dump(out);
       out << " at ";
       requirement.loc.print(out, Context.getASTContext().SourceMgr);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -500,7 +500,8 @@ bool RewriteSystem::addExplicitRule(MutableTerm lhs, MutableTerm rhs,
                                     SmallVectorImpl<RequirementError> &errors) {
   bool added = addRule(std::move(lhs), std::move(rhs));
   if (added) {
-    Rules.back().markExplicit(requirementID);
+    Rules.back().markExplicit();
+    Rules.back().setRequirementID(requirementID);
   } else if (requirementID.hasValue()) {
     auto req = WrittenRequirements[requirementID.getValue()];
     errors.push_back(
@@ -742,12 +743,10 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
   for (unsigned ruleID : indices(getRules())) {
     auto &rule = getRules()[ruleID];
 
-    if (!rule.isExplicit() && !rule.isPermanent() && !rule.isRedundant() &&
+    if (!rule.getRequirementID().hasValue() &&
+        !rule.isPermanent() && !rule.isRedundant() &&
         isInMinimizationDomain(rule.getLHS().getRootProtocol()))
       impliedRequirements.insert(ruleID);
-
-    if (!rule.isExplicit())
-      continue;
 
     auto requirementID = rule.getRequirementID();
     if (!requirementID.hasValue())

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -46,6 +46,11 @@ class Rule final {
   Term LHS;
   Term RHS;
 
+  /// The written requirement ID, which can be used to index into the
+  /// \c WrittenRequirements array in the rewrite system to retrieve
+  /// the structural requirement.
+  Optional<unsigned> requirementID;
+
   /// A 'permanent' rule cannot be deleted by homotopy reduction. These
   /// do not correspond to generic requirements and are re-added when the
   /// rewrite system is built.
@@ -97,6 +102,10 @@ public:
 
   const Term &getLHS() const { return LHS; }
   const Term &getRHS() const { return RHS; }
+
+  Optional<unsigned> getRequirementID() const {
+    return requirementID;
+  }
 
   Optional<Symbol> isPropertyRule() const;
 
@@ -167,9 +176,10 @@ public:
     Permanent = true;
   }
 
-  void markExplicit() {
+  void markExplicit(Optional<unsigned> requirementID) {
     assert(!Explicit && !Permanent &&
            "Permanent and explicit are mutually exclusive");
+    this->requirementID = requirementID;
     Explicit = true;
   }
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -302,8 +302,7 @@ public:
   void initialize(bool recordLoops, ArrayRef<const ProtocolDecl *> protos,
                   ArrayRef<StructuralRequirement> writtenRequirements,
                   std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
-                  std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>> &&requirementRules,
-                  SmallVectorImpl<RequirementError> &errors);
+                  std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>> &&requirementRules);
 
   ArrayRef<const ProtocolDecl *> getProtocols() const {
     return Protos;
@@ -336,8 +335,7 @@ public:
   bool addPermanentRule(MutableTerm lhs, MutableTerm rhs);
 
   bool addExplicitRule(MutableTerm lhs, MutableTerm rhs,
-                       Optional<unsigned> requirementID,
-                       SmallVectorImpl<RequirementError> &errors);
+                       Optional<unsigned> requirementID);
 
   bool simplify(MutableTerm &term, RewritePath *path=nullptr) const;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -107,6 +107,11 @@ public:
     return requirementID;
   }
 
+  void setRequirementID(Optional<unsigned> requirementID) {
+    assert(!getRequirementID().hasValue());
+    this->requirementID = requirementID;
+  }
+
   Optional<Symbol> isPropertyRule() const;
 
   const ProtocolDecl *isProtocolConformanceRule() const;
@@ -176,12 +181,9 @@ public:
     Permanent = true;
   }
 
-  void markExplicit(Optional<unsigned> requirementID) {
-    assert((!Explicit || requirementID.hasValue()) &&
-           "Rule is already explicit");
-    assert(!Permanent &&
+  void markExplicit() {
+    assert(!Explicit && !Permanent &&
            "Permanent and explicit are mutually exclusive");
-    this->requirementID = requirementID;
     Explicit = true;
   }
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -296,10 +296,6 @@ public:
     return ProtocolMap;
   }
 
-  ArrayRef<RequirementError> getErrors() {
-    return Errors;
-  }
-
   DebugOptions getDebugOptions() const { return Debug; }
 
   void initialize(bool recordLoops, ArrayRef<const ProtocolDecl *> protos,
@@ -371,6 +367,18 @@ public:
   };
 
   void verifyRewriteRules(ValidityPolicy policy) const;
+
+  //////////////////////////////////////////////////////////////////////////////
+  ///
+  /// Diagnostics
+  ///
+  //////////////////////////////////////////////////////////////////////////////
+
+  ArrayRef<RequirementError> getErrors() {
+    return Errors;
+  }
+
+  std::vector<RequirementError> getRedundantRequirements();
 
 private:
   struct CriticalPair {

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -177,7 +177,9 @@ public:
   }
 
   void markExplicit(Optional<unsigned> requirementID) {
-    assert(!Explicit && !Permanent &&
+    assert((!Explicit || requirementID.hasValue()) &&
+           "Rule is already explicit");
+    assert(!Permanent &&
            "Permanent and explicit are mutually exclusive");
     this->requirementID = requirementID;
     Explicit = true;
@@ -504,6 +506,8 @@ private:
   std::vector<std::pair<unsigned, unsigned>> ConflictingRules;
 
   void propagateExplicitBits();
+
+  void propagateRedundantRequirementIDs();
 
   void processConflicts();
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -242,9 +242,6 @@ class RewriteSystem final {
   /// The requirements written in source code.
   std::vector<StructuralRequirement> WrittenRequirements;
 
-  /// The invalid requirements.
-  std::vector<RequirementError> Errors;
-
   /// The rules added so far, including rules from our client, as well
   /// as rules introduced by the completion procedure.
   std::vector<Rule> Rules;
@@ -303,7 +300,8 @@ public:
   void initialize(bool recordLoops, ArrayRef<const ProtocolDecl *> protos,
                   ArrayRef<StructuralRequirement> writtenRequirements,
                   std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
-                  std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>> &&requirementRules);
+                  std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>> &&requirementRules,
+                  SmallVectorImpl<RequirementError> &errors);
 
   ArrayRef<const ProtocolDecl *> getProtocols() const {
     return Protos;
@@ -336,7 +334,8 @@ public:
   bool addPermanentRule(MutableTerm lhs, MutableTerm rhs);
 
   bool addExplicitRule(MutableTerm lhs, MutableTerm rhs,
-                       Optional<unsigned> requirementID);
+                       Optional<unsigned> requirementID,
+                       SmallVectorImpl<RequirementError> &errors);
 
   bool simplify(MutableTerm &term, RewritePath *path=nullptr) const;
 
@@ -376,11 +375,7 @@ public:
   ///
   //////////////////////////////////////////////////////////////////////////////
 
-  ArrayRef<RequirementError> getErrors() {
-    return Errors;
-  }
-
-  std::vector<RequirementError> getRedundantRequirements();
+  void computeRedundantRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors);
 
 private:
   struct CriticalPair {

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -3,6 +3,7 @@
 class Base<T> { }
 class Derived: Base<Int> { }
 
+// expected-warning@+1 {{redundant superclass constraint 'T' : 'Base<Int>'}}
 func foo<T>(_ x: T) -> Derived where T: Base<Int>, T: Derived {
   return x
 }

--- a/test/Generics/rdar83308672.swift
+++ b/test/Generics/rdar83308672.swift
@@ -40,13 +40,13 @@ protocol G1 {
 // CHECK: rdar83308672.(file).G2@
 // CHECK-NEXT: Requirement signature: <Self where Self.[G2]T : A, Self.[G2]T.[A]X == Self.[G2]T.[A]Y>
 protocol G2 {
-  associatedtype T : A where T : B, T.X == T.Y
+  associatedtype T : A where T : B, T.X == T.Y // expected-warning {{redundant conformance constraint 'Self.T' : 'B'}}
 }
 
 // CHECK: rdar83308672.(file).G3@
 // CHECK-NEXT: Requirement signature: <Self where Self.[G3]T : A, Self.[G3]T.[A]X == Self.[G3]T.[A]Y>
 protocol G3 {
-  associatedtype T : A where T.X == T.Y, T : B
+  associatedtype T : A where T.X == T.Y, T : B // expected-warning {{redundant conformance constraint 'Self.T' : 'B'}}
 }
 
 // CHECK: rdar83308672.(file).G4@

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -111,3 +111,49 @@ protocol TrivialRedundantSameType where Self == Self {
   associatedtype T where T == T
   // expected-warning@-1 {{redundant same-type constraint 'Self.T' == 'Self.T'}}
 }
+
+struct G<T> { }
+
+protocol Pair {
+  associatedtype A
+  associatedtype B
+}
+
+func test1<T: Pair>(_: T) where T.A == G<Int>, T.A == G<T.B>, T.B == Int { }
+// expected-warning@-1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
+
+
+protocol P1 {
+  func p1()
+}
+
+protocol P2 : P1 { }
+
+protocol P3 {
+  associatedtype P3Assoc : P2
+}
+
+protocol P4 {
+  associatedtype P4Assoc : P1
+}
+
+func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
+// expected-warning@-1{{redundant conformance constraint 'U.P4Assoc' : 'P2'}}
+
+protocol P5 {
+  associatedtype Element
+}
+
+protocol P6 {
+  associatedtype AssocP6 : P5
+}
+
+protocol P7 : P6 {
+  associatedtype AssocP7: P6
+}
+
+extension P7 where AssocP6.Element : P6,
+        AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP7.AssocP6.Element' : 'P6'}}
+        AssocP6.Element == AssocP7.AssocP6.Element {
+  func nestedSameType1() { }
+}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -152,8 +152,28 @@ protocol P7 : P6 {
   associatedtype AssocP7: P6
 }
 
-extension P7 where AssocP6.Element : P6,
-        AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP7.AssocP6.Element' : 'P6'}}
+extension P7 where AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP6.Element' : 'P6'}}
+        AssocP7.AssocP6.Element : P6,
         AssocP6.Element == AssocP7.AssocP6.Element {
   func nestedSameType1() { }
 }
+
+protocol P8 {
+  associatedtype A
+  associatedtype B
+}
+
+protocol P9 : P8 {
+  associatedtype A
+  associatedtype B
+}
+
+protocol P10 {
+  associatedtype A
+  associatedtype C
+}
+
+class X3 { }
+
+func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
+// expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -152,7 +152,7 @@ protocol P7 : P6 {
   associatedtype AssocP7: P6
 }
 
-// FIXME: diagnose redundant requirement 'AssocP6.Element : P6'
+// expected-warning@+1{{redundant conformance constraint 'Self.AssocP6.Element' : 'P6'}}
 extension P7 where AssocP6.Element : P6,
         AssocP7.AssocP6.Element : P6,
         AssocP6.Element == AssocP7.AssocP6.Element {

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -82,3 +82,32 @@ func cascadingConflictingRequirement<T>(_: T) where DoesNotExist : EqualComparab
 
 func cascadingInvalidConformance<T>(_: T) where T : DoesNotExist { }
 // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
+
+func trivialRedundant1<T>(_: T) where T: P, T: P {}
+// expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
+
+func trivialRedundant2<T>(_: T) where T: AnyObject, T: AnyObject {}
+// expected-warning@-1 {{redundant constraint 'T' : 'AnyObject'}}
+
+func trivialRedundant3<T>(_: T) where T: C, T: C {}
+// expected-warning@-1 {{redundant superclass constraint 'T' : 'C'}}
+
+func trivialRedundant4<T>(_: T) where T == T {}
+// expected-warning@-1 {{redundant same-type constraint 'T' == 'T'}}
+
+protocol TrivialRedundantConformance: P, P {}
+// expected-warning@-1 {{redundant conformance constraint 'Self' : 'P'}}
+
+protocol TrivialRedundantLayout: AnyObject, AnyObject {}
+// expected-warning@-1 {{redundant constraint 'Self' : 'AnyObject'}}
+// expected-error@-2 {{duplicate inheritance from 'AnyObject'}}
+
+protocol TrivialRedundantSuperclass: C, C {}
+// expected-warning@-1 {{redundant superclass constraint 'Self' : 'C'}}
+// expected-error@-2 {{duplicate inheritance from 'C'}}
+
+protocol TrivialRedundantSameType where Self == Self {
+// expected-warning@-1 {{redundant same-type constraint 'Self' == 'Self'}}
+  associatedtype T where T == T
+  // expected-warning@-1 {{redundant same-type constraint 'Self.T' == 'Self.T'}}
+}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -152,7 +152,8 @@ protocol P7 : P6 {
   associatedtype AssocP7: P6
 }
 
-extension P7 where AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP6.Element' : 'P6'}}
+// FIXME: diagnose redundant requirement 'AssocP6.Element : P6'
+extension P7 where AssocP6.Element : P6,
         AssocP7.AssocP6.Element : P6,
         AssocP6.Element == AssocP7.AssocP6.Element {
   func nestedSameType1() { }

--- a/test/Generics/sr10752.swift
+++ b/test/Generics/sr10752.swift
@@ -9,6 +9,6 @@ protocol P {
 // CHECK: sr10752.(file).Q@
 // CHECK-NEXT: Requirement signature: <Self where Self.[Q]A == Self.[Q]C.[P]A, Self.[Q]C : P>
 protocol Q {
-  associatedtype A : P
+  associatedtype A : P // expected-warning {{redundant conformance constraint 'Self.A' : 'P'}}
   associatedtype C : P where A == C.A
 }

--- a/test/Generics/sr12120.swift
+++ b/test/Generics/sr12120.swift
@@ -6,8 +6,8 @@ protocol Swappable1 {
   associatedtype A
   associatedtype B
   associatedtype Swapped : Swappable1
-    where Swapped.B == A,
-          Swapped.A == B, // FIXME: Diagnose redundancy
+    where Swapped.B == A, // expected-warning {{redundant same-type constraint 'Self.Swapped.B' == 'Self.A'}}
+          Swapped.A == B,
           Swapped.Swapped == Self
 }
 

--- a/test/Generics/sr14485.swift
+++ b/test/Generics/sr14485.swift
@@ -3,6 +3,8 @@
 // CHECK: sr14485.(file).P@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P]Input == Self.[P]Output.[Numeric]Magnitude, Self.[P]Output : FixedWidthInteger, Self.[P]Output : SignedInteger>
 protocol P {
+  // expected-warning@+2 {{redundant conformance constraint 'Self.Input' : 'FixedWidthInteger'}}
+  // expected-warning@+1 {{redundant conformance constraint 'Self.Input' : 'UnsignedInteger'}}
   associatedtype Input: FixedWidthInteger & UnsignedInteger & BinaryInteger
   associatedtype Output: FixedWidthInteger & SignedInteger & BinaryInteger
     where Output.Magnitude == Input

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -11,14 +11,14 @@ protocol P2 {
 
 // CHECK: ExtensionDecl line={{.*}} base=P1
 // CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2>
-extension P1 where Self : P2, T == Int {
+extension P1 where Self : P2, T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
   func takeT11(_: T) {}
   func takeT12(_: Self.T) {}
 }
 
 // CHECK: ExtensionDecl line={{.*}} base=P1
 // CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2>
-extension P1 where Self : P2, Self.T == Int {
+extension P1 where Self : P2, Self.T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
   func takeT21(_: T) {}
   func takeT22(_: Self.T) {}
 }


### PR DESCRIPTION
Plumb source location info through the rewrite system by storing the structural requirements used to derive explicit rules, and store the structural requirement ID in the rule itself. Structural requirement IDs are propagated from redundant rules to their replacements via `RewriteSystem::propagateRedundantRequirementIDs` after homotopy reduction. `RewriteSystem::getRedundantRequirements` computes the set of redundant requirement diagnostics to be emitted from `RequirementSignatureRequestRQM` and  `InferredGenericSignatureRequestRQM`.

This change does not (yet) emit notes to show where a requirement is made redundant.

Resolves: rdar://88135415