### PR TITLE
[CodeCompletion] Complete code completion tokens after if-statement as top-level

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -225,7 +225,7 @@ public:
 
   virtual void completePlatformCondition() {};
 
-  virtual void completeAfterIfStmt(bool hasElse) {};
+  virtual void completeAfterIfStmtElse() {};
 
   virtual void completeGenericRequirement() {};
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -267,7 +267,7 @@ public:
   void completeAfterPoundDirective() override;
   void completePlatformCondition() override;
   void completeGenericRequirement() override;
-  void completeAfterIfStmt(bool hasElse) override;
+  void completeAfterIfStmtElse() override;
   void completeStmtLabel(StmtKind ParentKind) override;
   void completeForEachPatternBeginning(bool hasTry, bool hasAwait) override;
   void completeTypeAttrBeginning() override;
@@ -578,13 +578,9 @@ void CodeCompletionCallbacksImpl::completePlatformCondition() {
   Kind = CompletionKind::PlatformConditon;
 }
 
-void CodeCompletionCallbacksImpl::completeAfterIfStmt(bool hasElse) {
+void CodeCompletionCallbacksImpl::completeAfterIfStmtElse() {
   CurDeclContext = P.CurDeclContext;
-  if (hasElse) {
-    Kind = CompletionKind::AfterIfStmtElse;
-  } else {
-    Kind = CompletionKind::StmtOrExpr;
-  }
+  Kind = CompletionKind::AfterIfStmtElse;
 }
 
 void CodeCompletionCallbacksImpl::completeGenericRequirement() {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1807,18 +1807,13 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       ElseBody = parseStmtIf(LabeledStmtInfo(), implicitlyInsertIf);
     } else if (Tok.is(tok::code_complete)) {
       if (CodeCompletion)
-        CodeCompletion->completeAfterIfStmt(/*hasElse*/true);
+        CodeCompletion->completeAfterIfStmtElse();
       Status.setHasCodeCompletionAndIsError();
       consumeToken(tok::code_complete);
     } else {
       ElseBody = parseBraceItemList(diag::expected_lbrace_or_if_after_else);
     }
     Status |= ElseBody;
-  } else if (Tok.is(tok::code_complete)) {
-    if (CodeCompletion)
-      CodeCompletion->completeAfterIfStmt(/*hasElse*/false);
-    Status.setHasCodeCompletionAndIsError();
-    consumeToken(tok::code_complete);
   }
 
   return makeParserResult(

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -308,7 +308,10 @@ for _ in 1...10 {
   #^TOP_LEVEL_2?check=KW_DECL_STMT;check=KW_NO_RETURN^#
 }
 
-if true {} #^TOP_LEVEL_AFTER_IF_1?check=KW_DECL_STMT;check=KW_NO_RETURN^#
+if true {} #^TOP_LEVEL_AFTER_IF_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
+if true {} 
+#^TOP_LEVEL_AFTER_IF_2?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
+
 
 if true {} else #^TOP_LEVEL_AFTER_IF_ELSE_1?check=AFTER_IF_ELSE^# {}
 


### PR DESCRIPTION
Instead of setting the code completion position when parsing the if-statement, which doesn’t create a `CodeCompletionExpr`, parse it as a new top-level expression.

As far as test-cases are concerned, this removes the “RareKeyword” flair from top-level completions in the modified test case. This makes sense IMO.

---

I came across this while migrating expression completions to solver-based, which started having issues because we were completing `StmtOrExpr` without a `CodeCompletionExpr`.