### PR TITLE
[SR-15938] Error when referencing #dsohandle in a Swift test on Windows

### DIFF
--- a/test/Frontend/dsohandle-linkable.swift
+++ b/test/Frontend/dsohandle-linkable.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// (SR-15938) Error when referencing #dsohandle in a Swift test on Windows
+// This file tests that #dsohandle is fully usable from the built test. The
+// precise value of #dsohandle is uninteresting.
+
+import StdlibUnittest
+
+var tests = TestSuite("#dsohandle usable")
+
+tests.test("#dsohandle usable") {
+    expectNotNil(#dsohandle as UnsafeRawPointer?)
+}
+
+runAllTests()

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -9,7 +9,6 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: linux
-// XFAIL: windows
 
 import first
 import second


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change fixes an issue when building Swift tests on Windows where the use of `#dsohandle` causes a link-time error.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15938.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
