### PR TITLE
[cxx-interop] Fix looking up objc names when cxx-interop enabled

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -999,13 +999,13 @@ bool NameImporter::hasNamingConflict(const clang::NamedDecl *decl,
   lookupResult.setAllowHidden(true);
   lookupResult.suppressDiagnostics();
 
-  if (clangSema.LookupName(lookupResult, /*scope=*/nullptr)) {
+  if (clangSema.LookupName(lookupResult, clangSema.TUScope)) {
     if (std::any_of(lookupResult.begin(), lookupResult.end(), conflicts))
       return true;
   }
 
   lookupResult.clear(clang::Sema::LookupTagName);
-  if (clangSema.LookupName(lookupResult, /*scope=*/nullptr)) {
+  if (clangSema.LookupName(lookupResult, clangSema.TUScope)) {
     if (std::any_of(lookupResult.begin(), lookupResult.end(), conflicts))
       return true;
   }


### PR DESCRIPTION
This patch addresses SR-15908.

NameImporter::hasNamingConflict in ClangImporter relies on clang::Sema
to perform a lookup of names in a given clang module. The core of this
functionality is a call to `clang::Sema::LookupName()`, which takes a
`clang::Scope` as an argument. We are currently passing `nullptr` here,
presumably to indicate global scope. However this is a problem. In
`clang::LookupName`, the control flow path for when C++ is enabled only
performs an actual name search when the scope is not nullptr. This means
that when cxx-interop is enabled, we will never find a conflicting name
even if one exists. Concretely, a small program like this will fail:

import Foundation; public protocol Foo : NSObject {}

The failure is because the compiler cannot tell the difference between
the protocol NSObject (which should be renamed to NSObjectProtocol) and
the class NSObject. The code that performs the renaming from NSObject to
NSObjectProtocol depends on NameImporter::hasNamingConflict, so when
that function fails the renaming does not occur.

This fix works by passing `clangSema.TUScope` instead of `nullptr` to
`clang::Sema::LookupName()`.

cc @zoecarver @plotfi @hyp 