### PR TITLE
[swift-inspect][RemoteMirror] Decode job/task/actor flags.

### DIFF
--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -95,7 +95,7 @@ struct StackAllocator {
 
 template <typename Runtime>
 struct ActiveTaskStatusWithEscalation {
-  uint32_t Flags;
+  uint32_t Flags[1];
   uint32_t ExecutionLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
   typename Runtime::StoredPointer Record;
 };
@@ -104,6 +104,16 @@ template <typename Runtime>
 struct ActiveTaskStatusWithoutEscalation {
   uint32_t Flags[sizeof(typename Runtime::StoredPointer) == 8 ? 2 : 1];
   typename Runtime::StoredPointer Record;
+};
+
+struct ActiveTaskStatusFlags {
+  static const uint32_t PriorityMask = 0xFF;
+  static const uint32_t IsCancelled = 0x100;
+  static const uint32_t IsStatusRecordLocked = 0x200;
+  static const uint32_t IsEscalated = 0x400;
+  static const uint32_t IsRunning = 0x800;
+  static const uint32_t IsEnqueued = 0x1000;
+  static const uint32_t IsComplete = 0x2000;
 };
 
 template <typename Runtime, typename ActiveTaskStatus>
@@ -150,7 +160,7 @@ struct FutureAsyncContextPrefix {
 
 template <typename Runtime>
 struct ActiveActorStatusWithEscalation {
-  uint32_t Flags;
+  uint32_t Flags[1];
   uint32_t DrainLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
   typename Runtime::StoredPointer FirstJob;
 };

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -233,8 +233,21 @@ typedef struct swift_async_task_info {
   /// swift_reflection call on the given context.
   const char *Error;
 
-  uint32_t JobFlags;
-  uint64_t TaskStatusFlags;
+  unsigned Kind;
+  unsigned EnqueuePriority;
+  uint8_t IsChildTask;
+  uint8_t IsFuture;
+  uint8_t IsGroupChildTask;
+  uint8_t IsAsyncLetTask;
+
+  unsigned MaxPriority;
+  uint8_t IsCancelled;
+  uint8_t IsStatusRecordLocked;
+  uint8_t IsEscalated;
+  uint8_t HasIsRunning; // If false, the IsRunning flag is not valid.
+  uint8_t IsRunning;
+  uint8_t IsEnqueued;
+
   uint64_t Id;
   swift_reflection_ptr_t RunJob;
   swift_reflection_ptr_t AllocatorSlabPtr;

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -295,6 +295,10 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
 #endif
   };
 
+  // Note: this structure is mirrored by ActiveTaskStatusWithEscalation and
+  // ActiveTaskStatusWithoutEscalation in
+  // include/swift/Reflection/RuntimeInternals.h. Any changes to the layout here
+  // must also be made there.
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
   uint32_t Flags;
   dispatch_lock_t ExecutionLock;

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -875,9 +875,23 @@ swift_reflection_asyncTaskInfo(SwiftReflectionContextRef ContextRef,
     Result.Error = returnableCString(ContextRef, Error);
     return Result;
   }
-  Result.JobFlags = TaskInfo.JobFlags;
-  Result.TaskStatusFlags = TaskInfo.TaskStatusFlags;
+
+  Result.Kind = TaskInfo.Kind;
+  Result.EnqueuePriority = TaskInfo.EnqueuePriority;
+  Result.IsChildTask = TaskInfo.IsChildTask;
+  Result.IsFuture = TaskInfo.IsFuture;
+  Result.IsGroupChildTask = TaskInfo.IsGroupChildTask;
+  Result.IsAsyncLetTask = TaskInfo.IsAsyncLetTask;
+
+  Result.MaxPriority = TaskInfo.MaxPriority;
+  Result.IsCancelled = TaskInfo.IsCancelled;
+  Result.IsStatusRecordLocked = TaskInfo.IsStatusRecordLocked;
+  Result.IsEscalated = TaskInfo.IsEscalated;
+  Result.HasIsRunning = TaskInfo.HasIsRunning;
+  Result.IsRunning = TaskInfo.IsRunning;
+  Result.IsEnqueued = TaskInfo.IsEnqueued;
   Result.Id = TaskInfo.Id;
+
   Result.RunJob = TaskInfo.RunJob;
   Result.AllocatorSlabPtr = TaskInfo.AllocatorSlabPtr;
 

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -41,8 +41,19 @@ fileprivate class ConcurrencyDumper {
 
   struct TaskInfo {
     var address: swift_reflection_ptr_t
-    var jobFlags: UInt32
-    var taskStatusFlags: UInt64
+    var kind: UInt32
+    var enqueuePriority: UInt32
+    var isChildTask: Bool
+    var isFuture: Bool
+    var isGroupChildTask: Bool
+    var isAsyncLetTask: Bool
+    var maxPriority: UInt32
+    var isCancelled: Bool
+    var isStatusRecordLocked: Bool
+    var isEscalated: Bool
+    var hasIsRunning: Bool
+    var isRunning: Bool
+    var isEnqueued: Bool
     var id: UInt64
     var runJob: swift_reflection_ptr_t
     var allocatorSlabPtr: swift_reflection_ptr_t
@@ -185,8 +196,19 @@ fileprivate class ConcurrencyDumper {
 
     return TaskInfo(
       address: task,
-      jobFlags: reflectionInfo.JobFlags,
-      taskStatusFlags: reflectionInfo.TaskStatusFlags,
+      kind: reflectionInfo.Kind,
+      enqueuePriority: reflectionInfo.EnqueuePriority,
+      isChildTask: reflectionInfo.IsChildTask != 0,
+      isFuture: reflectionInfo.IsFuture != 0,
+      isGroupChildTask: reflectionInfo.IsGroupChildTask != 0,
+      isAsyncLetTask: reflectionInfo.IsAsyncLetTask != 0,
+      maxPriority: reflectionInfo.MaxPriority,
+      isCancelled: reflectionInfo.IsCancelled != 0,
+      isStatusRecordLocked: reflectionInfo.IsStatusRecordLocked != 0,
+      isEscalated: reflectionInfo.IsEscalated != 0,
+      hasIsRunning: reflectionInfo.HasIsRunning != 0,
+      isRunning: reflectionInfo.IsRunning != 0,
+      isEnqueued: reflectionInfo.IsEnqueued != 0,
       id: reflectionInfo.Id,
       runJob: reflectionInfo.RunJob,
       allocatorSlabPtr: reflectionInfo.AllocatorSlabPtr,
@@ -251,26 +273,20 @@ fileprivate class ConcurrencyDumper {
     return flagsStr
   }
 
-  func decodeTaskFlags(_ info: TaskInfo) -> (
-    priority: UInt32,
-    flags: String
-  ) {
-    let priority = (info.jobFlags >> 8) & 0xff
-    let jobFlags = flagsStrings(flags: info.jobFlags, strings: [
-      1 << 24: "childTask",
-      1 << 25: "future",
-      1 << 26: "groupChildTask",
-      1 << 28: "asyncLetTask"
-    ])
-    let taskFlags = flagsStrings(flags: info.taskStatusFlags, strings: [
-      0x100: "cancelled",
-      0x200: "locked",
-      0x400: "escalated",
-      0x800: "running"
-    ])
-    let allFlags = jobFlags + taskFlags
-    let flagsStr = allFlags.isEmpty ? "0" : allFlags.joined(separator: "|")
-    return (priority, flagsStr)
+  func decodeTaskFlags(_ info: TaskInfo) -> String {
+    var flags: [String] = []
+    if info.isChildTask { flags.append("childTask") }
+    if info.isFuture { flags.append("future") }
+    if info.isGroupChildTask { flags.append("groupChildTask") }
+    if info.isAsyncLetTask { flags.append("asyncLetTask") }
+    if info.isCancelled { flags.append("cancelled") }
+    if info.isStatusRecordLocked { flags.append("statusRecordLocked") }
+    if info.isEscalated { flags.append("escalated") }
+    if info.hasIsRunning && info.isRunning { flags.append("running") }
+    if info.isEnqueued { flags.append("enqueued") }
+
+    let flagsStr = flags.isEmpty ? "0" : flags.joined(separator: "|")
+    return flagsStr
   }
 
   func decodeActorFlags(_ flags: UInt64) -> (
@@ -301,6 +317,14 @@ fileprivate class ConcurrencyDumper {
 
   func dumpTasks() {
     print("TASKS")
+
+    let missingIsRunning = tasks.contains(where: { !$1.hasIsRunning })
+    if missingIsRunning {
+      print("warning: unable to decode is-running state of target tasks, running state and async backtraces will not be printed")
+    }
+
+    let taskToThread: [swift_addr_t: swift_reflection_ptr_t] =
+        Dictionary(threadCurrentTasks.map{ ($1, $0) }, uniquingKeysWith: { $1 })
 
     var lastChilds: [Bool] = []
 
@@ -339,7 +363,10 @@ fileprivate class ConcurrencyDumper {
 
       let flags = decodeTaskFlags(task)
 
-      output("Task \(hex: task.id) - flags=\(flags.flags) priority=\(hex: flags.priority) address=\(hex: task.address)")
+      output("Task \(hex: task.id) - flags=\(flags) enqueuePriority=\(hex: task.enqueuePriority) maxPriority=\(hex: task.maxPriority) address=\(hex: task.address)")
+      if let thread = taskToThread[task.address] {
+        output("current task on thread \(hex: thread)")
+      }
       if let parent = task.parent {
         output("parent: \(hex: parent)")
       }


### PR DESCRIPTION
Have RemoteMirror internally decode these flags fields and return them as separate fields in the task/actor info. Handle the structures both with and without task escalation support.

Also show when a task is the current task on a thread in swift-inspect's task listing.

rdar://88598003