### PR TITLE
Place Opened Archetypes in their Proper Generic Contexts

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1300,6 +1300,15 @@ public:
   /// Retrieve a generic signature with a single type parameter conforming
   /// to the given protocol or composition type, like <T: type>.
   CanGenericSignature getOpenedArchetypeSignature(Type type);
+  /// to the given protocol or composition type, like <T: P>.
+  ///
+  /// The opened archetype may have a different set of conformances from the
+  /// corresponding existential. The opened archetype conformances are dictated
+  /// by the ABI for generic arguments, while the existential value conformances
+  /// are dictated by their layout (see \c Type::getExistentialLayout()). In
+  /// particular, the opened archetype signature does not have requirements for
+  /// conformances inherited from superclass constraints while existential
+  /// values do.
 
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1308,7 +1308,7 @@ public:
   /// conformances inherited from superclass constraints while existential
   /// values do.
   CanGenericSignature getOpenedArchetypeSignature(Type type,
-                                                  const DeclContext *useDC);
+                                                  GenericSignature parentSig);
 
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1298,8 +1298,6 @@ public:
   CanGenericSignature getSingleGenericParameterSignature() const;
 
   /// Retrieve a generic signature with a single type parameter conforming
-  /// to the given protocol or composition type, like <T: type>.
-  CanGenericSignature getOpenedArchetypeSignature(Type type);
   /// to the given protocol or composition type, like <T: P>.
   ///
   /// The opened archetype may have a different set of conformances from the
@@ -1309,6 +1307,8 @@ public:
   /// particular, the opened archetype signature does not have requirements for
   /// conformances inherited from superclass constraints while existential
   /// values do.
+  CanGenericSignature getOpenedArchetypeSignature(Type type,
+                                                  const DeclContext *useDC);
 
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2693,7 +2693,8 @@ public:
   /// property, or the uncurried result type of a method/subscript, e.g.
   /// '() -> () -> Self'.
   GenericParameterReferenceInfo findExistentialSelfReferences(
-      Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
+      Type baseTy, const DeclContext *useDC,
+      bool treatNonResultCovariantSelfAsInvariant) const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -157,7 +157,14 @@ public:
   GenericEnvironment *getIncomplete(GenericSignature signature);
 
   /// Create a new generic environment for an opened existential.
-  static GenericEnvironment *forOpenedExistential(Type existential, UUID uuid);
+  ///
+  /// \param existential The subject existential type
+  /// \param useDC The decl context where this existential type is being opened
+  /// \param uuid The unique identifier for this opened existential
+  static GenericEnvironment *
+  forOpenedExistential(Type existential, const DeclContext *useDC, UUID uuid);
+  static GenericEnvironment *
+  forOpenedExistential(Type existential, GenericSignature signature, UUID uuid);
 
   /// Create a new generic environment for an opaque type with the given set of
   /// outer substitutions.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -158,13 +158,28 @@ public:
 
   /// Create a new generic environment for an opened existential.
   ///
+  /// This function uses the provided parent signature to construct a new
+  /// signature suitable for use with an opened archetype. If you have an
+  /// existing generic signature from e.g. deserialization use
+  /// \c GenericEnvironment::forOpenedArchetypeSignature instead.
+  ///
   /// \param existential The subject existential type
-  /// \param useDC The decl context where this existential type is being opened
+  /// \param parentSig The signature of the context where this existential type is being opened
   /// \param uuid The unique identifier for this opened existential
   static GenericEnvironment *
-  forOpenedExistential(Type existential, const DeclContext *useDC, UUID uuid);
+  forOpenedExistential(Type existential, GenericSignature parentSig, UUID uuid);
+
+  /// Create a new generic environment for an opened existential.
+  ///
+  /// It is unlikely you want to use this function.
+  /// Call \c GenericEnvironment::forOpenedExistential instead.
+  ///
+  /// \param existential The subject existential type
+  /// \param signature The signature of the opened archetype
+  /// \param uuid The unique identifier for this opened existential
   static GenericEnvironment *
-  forOpenedExistential(Type existential, GenericSignature signature, UUID uuid);
+  forOpenedArchetypeSignature(Type existential,
+                              GenericSignature signature, UUID uuid);
 
   /// Create a new generic environment for an opaque type with the given set of
   /// outer substitutions.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5747,6 +5747,15 @@ class OpenedArchetypeType final : public ArchetypeType,
          LayoutConstraint layout);
 
 public:
+  /// Compute the parameter that serves as the \c Self type for an opened
+  /// archetype from the given declaration context.
+  ///
+  /// For protocol extensions, this type is the context's \c Self type. For
+  /// all other contexts, this type is a generic parameter one level deeper
+  /// than the deepest generic context depth.
+  static Type getSelfInterfaceTypeFromContext(const DeclContext *useDC);
+
+public:
   /// Get or create an archetype that represents the opened type
   /// of an existential value.
   ///

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -765,7 +765,7 @@ public:
 
   /// Opens an existential instance or meta-type and returns the opened type.
   Type openAnyExistentialType(OpenedArchetypeType *&opened,
-                              const DeclContext *useDC);
+                              GenericSignature parentSig);
 
   /// Break an existential down into a set of constraints.
   ExistentialLayout getExistentialLayout();
@@ -5748,23 +5748,25 @@ class OpenedArchetypeType final : public ArchetypeType,
 
 public:
   /// Compute the parameter that serves as the \c Self type for an opened
-  /// archetype from the given declaration context.
+  /// archetype from the given outer generic signature.
   ///
-  /// For protocol extensions, this type is the context's \c Self type. For
-  /// all other contexts, this type is a generic parameter one level deeper
+  /// This type is a generic parameter one level deeper
   /// than the deepest generic context depth.
-  static Type getSelfInterfaceTypeFromContext(const DeclContext *useDC);
+  static Type getSelfInterfaceTypeFromContext(GenericSignature parentSig,
+                                              ASTContext &ctx);
 
 public:
   /// Get or create an archetype that represents the opened type
   /// of an existential value.
   ///
   /// \param existential The existential type to open.
+  /// \param parentSig The generic signature of the context opening
+  /// this existential.
   ///
   /// \param knownID When non-empty, the known ID of the archetype. When empty,
   /// a fresh archetype with a unique ID will be opened.
   static CanTypeWrapper<OpenedArchetypeType> get(CanType existential,
-                                                 const DeclContext *useDC,
+                                                 GenericSignature parentSig,
                                                  Optional<UUID> knownID = None);
 
   /// Get or create an archetype that represents the opened type
@@ -5772,27 +5774,41 @@ public:
   ///
   /// \param existential The existential type to open.
   /// \param interfaceType The interface type represented by this archetype.
+  /// \param parentSig The generic signature of the context opening
+  /// this existential.
   ///
   /// \param knownID When non-empty, the known ID of the archetype. When empty,
   /// a fresh archetype with a unique ID will be opened.
   static CanTypeWrapper<OpenedArchetypeType> get(CanType existential,
                                                  Type interfaceType,
-                                                 const DeclContext *useDC,
+                                                 GenericSignature parentSig,
                                                  Optional<UUID> knownID = None);
 
   /// Create a new archetype that represents the opened type
   /// of an existential value.
   ///
+  /// Use this function when you are unsure of whether the
+  /// \c existential type is a metatype or an instance type. This function
+  /// will unwrap any existential metatype containers.
+  ///
   /// \param existential The existential type or existential metatype to open.
   /// \param interfaceType The interface type represented by this archetype.
+  /// \param parentSig The generic signature of the context opening
+  /// this existential.
   static CanType getAny(CanType existential, Type interfaceType,
-                        const DeclContext *useDC);
+                        GenericSignature parentSig);
 
   /// Create a new archetype that represents the opened type
   /// of an existential value.
   ///
+  /// Use this function when you are unsure of whether the
+  /// \c existential type is a metatype or an instance type. This function
+  /// will unwrap any existential metatype containers.
+  ///
   /// \param existential The existential type or existential metatype to open.
-  static CanType getAny(CanType existential, const DeclContext *useDC);
+  /// \param parentSig The generic signature of the context opening
+  /// this existential.
+  static CanType getAny(CanType existential, GenericSignature parentSig);
 
   /// Retrieve the ID number of this opened existential.
   UUID getOpenedExistentialID() const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5272,7 +5272,6 @@ class ParameterizedProtocolType final : public TypeBase,
   friend TrailingObjects;
 
   ProtocolType *Base;
-  Type Arg;
 
 public:
   /// Retrieve an instance of a protocol composition type with the

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -507,7 +507,7 @@ public:
   /// Canonical protocol composition types are minimized only to a certain
   /// degree to preserve ABI compatibility. This routine enables performing
   /// slower, but stricter minimization at need (e.g. redeclaration checking).
-  CanType getMinimalCanonicalType() const;
+  CanType getMinimalCanonicalType(const DeclContext *useDC) const;
 
   /// Reconstitute type sugar, e.g., for array types, dictionary
   /// types, optionals, etc.
@@ -648,7 +648,8 @@ public:
 
   /// Replace opened archetypes with the given root with their most
   /// specific non-dependent upper bounds throughout this type.
-  Type typeEraseOpenedArchetypesWithRoot(const OpenedArchetypeType *root) const;
+  Type typeEraseOpenedArchetypesWithRoot(const OpenedArchetypeType *root,
+                                         const DeclContext *useDC) const;
 
   /// Given a declaration context, returns a function type with the 'self'
   /// type curried as the input if the declaration context describes a type.
@@ -763,7 +764,8 @@ public:
   bool isClassExistentialType();
 
   /// Opens an existential instance or meta-type and returns the opened type.
-  Type openAnyExistentialType(OpenedArchetypeType *&opened);
+  Type openAnyExistentialType(OpenedArchetypeType *&opened,
+                              const DeclContext *useDC);
 
   /// Break an existential down into a set of constraints.
   ExistentialLayout getExistentialLayout();
@@ -5189,7 +5191,7 @@ public:
   /// Canonical protocol composition types are minimized only to a certain
   /// degree to preserve ABI compatibility. This routine enables performing
   /// slower, but stricter minimization at need (e.g. redeclaration checking).
-  CanType getMinimalCanonicalType() const;
+  CanType getMinimalCanonicalType(const DeclContext *useDC) const;
 
   /// Retrieve the set of members composed to create this type.
   ///
@@ -5752,8 +5754,9 @@ public:
   ///
   /// \param knownID When non-empty, the known ID of the archetype. When empty,
   /// a fresh archetype with a unique ID will be opened.
-  static CanTypeWrapper<OpenedArchetypeType> get(
-      CanType existential, Optional<UUID> knownID = None);
+  static CanTypeWrapper<OpenedArchetypeType> get(CanType existential,
+                                                 const DeclContext *useDC,
+                                                 Optional<UUID> knownID = None);
 
   /// Get or create an archetype that represents the opened type
   /// of an existential value.
@@ -5763,21 +5766,24 @@ public:
   ///
   /// \param knownID When non-empty, the known ID of the archetype. When empty,
   /// a fresh archetype with a unique ID will be opened.
-  static CanTypeWrapper<OpenedArchetypeType> get(
-      CanType existential, Type interfaceType, Optional<UUID> knownID = None);
+  static CanTypeWrapper<OpenedArchetypeType> get(CanType existential,
+                                                 Type interfaceType,
+                                                 const DeclContext *useDC,
+                                                 Optional<UUID> knownID = None);
 
   /// Create a new archetype that represents the opened type
   /// of an existential value.
   ///
   /// \param existential The existential type or existential metatype to open.
   /// \param interfaceType The interface type represented by this archetype.
-  static CanType getAny(CanType existential, Type interfaceType);
+  static CanType getAny(CanType existential, Type interfaceType,
+                        const DeclContext *useDC);
 
   /// Create a new archetype that represents the opened type
   /// of an existential value.
   ///
   /// \param existential The existential type or existential metatype to open.
-  static CanType getAny(CanType existential);
+  static CanType getAny(CanType existential, const DeclContext *useDC);
 
   /// Retrieve the ID number of this opened existential.
   UUID getOpenedExistentialID() const;

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -252,12 +252,13 @@ public:
   void remapRootOpenedType(CanOpenedArchetypeType archetypeTy) {
     assert(archetypeTy->isRoot());
 
-    auto sig = archetypeTy->getGenericEnvironment()->getGenericSignature();
+    auto sig = Builder.getFunction().getGenericSignature();
     auto existentialTy = archetypeTy->getExistentialType()->getCanonicalType();
-    auto env = GenericEnvironment::forOpenedArchetypeSignature(
+    auto env = GenericEnvironment::forOpenedExistential(
         getOpASTType(existentialTy), sig, UUID::fromTime());
+    auto interfaceTy = OpenedArchetypeType::getSelfInterfaceTypeFromContext(sig, existentialTy->getASTContext());
     auto replacementTy =
-        env->mapTypeIntoContext(archetypeTy->getInterfaceType())
+        env->mapTypeIntoContext(interfaceTy)
             ->template castTo<OpenedArchetypeType>();
     registerOpenedExistentialRemapping(archetypeTy, replacementTy);
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -254,7 +254,7 @@ public:
 
     auto sig = archetypeTy->getGenericEnvironment()->getGenericSignature();
     auto existentialTy = archetypeTy->getExistentialType()->getCanonicalType();
-    auto env = GenericEnvironment::forOpenedExistential(
+    auto env = GenericEnvironment::forOpenedArchetypeSignature(
         getOpASTType(existentialTy), sig, UUID::fromTime());
     auto replacementTy =
         env->mapTypeIntoContext(archetypeTy->getInterfaceType())

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SIL_SILCLONER_H
 #define SWIFT_SIL_SILCLONER_H
 
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/DebugUtils.h"
@@ -251,10 +252,13 @@ public:
   void remapRootOpenedType(CanOpenedArchetypeType archetypeTy) {
     assert(archetypeTy->isRoot());
 
+    auto sig = archetypeTy->getGenericEnvironment()->getGenericSignature();
     auto existentialTy = archetypeTy->getExistentialType()->getCanonicalType();
-    auto replacementTy = OpenedArchetypeType::get(
-        getOpASTType(existentialTy),
-        archetypeTy->getInterfaceType());
+    auto env = GenericEnvironment::forOpenedExistential(
+        getOpASTType(existentialTy), sig, UUID::fromTime());
+    auto replacementTy =
+        env->mapTypeIntoContext(archetypeTy->getInterfaceType())
+            ->template castTo<OpenedArchetypeType>();
     registerOpenedExistentialRemapping(archetypeTy, replacementTy);
   }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1049,6 +1049,10 @@ public:
     GenericEnv = env;
   }
 
+  /// Retrieve the generic signature from the generic environment of this
+  /// function, if any. Else returns the null \c GenericSignature.
+  GenericSignature getGenericSignature() const;
+
   /// Map the given type, which is based on an interface SILFunctionType and may
   /// therefore be dependent, to a type based on the context archetypes of this
   /// SILFunction.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5585,7 +5585,8 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// the given type variable, type-erase occurences of that opened type
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
-                                         TypeVariableType *openedTypeVar);
+                                         TypeVariableType *openedTypeVar,
+                                         const DeclContext *useDC);
 
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5166,13 +5166,6 @@ CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
   return canonicalSig;
 }
 
-// Return the signature for an opened existential. The opened archetype may have
-// a different set of conformances from the corresponding existential. The
-// opened archetype conformances are dictated by the ABI for generic arguments,
-// while the existential value conformances are dictated by their layout (see
-// Type::getExistentialLayout()). In particular, the opened archetype signature
-// does not have requirements for conformances inherited from superclass
-// constraints while existential values do.
 CanGenericSignature ASTContext::getOpenedArchetypeSignature(Type type) {
   assert(type->isExistentialType());
   if (auto existential = type->getAs<ExistentialType>())

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4100,7 +4100,8 @@ GenericParameterReferenceInfo ValueDecl::findExistentialSelfReferences(
     return GenericParameterReferenceInfo();
 
   const auto sig =
-      getASTContext().getOpenedArchetypeSignature(baseTy, useDC);
+      getASTContext().getOpenedArchetypeSignature(baseTy,
+                                                  useDC->getGenericSignatureOfContext());
   auto genericParam = sig.getGenericParams().front();
   return findGenericParameterReferences(
       this, sig, genericParam, treatNonResultCovariantSelfAsInvariant, None);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2926,7 +2926,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
                                     /*topLevelFunction=*/true, isMethod,
                                     /*isInitializer=*/isa<ConstructorDecl>(afd),
                                     getNumCurryLevels())
-        ->getMinimalCanonicalType(afd);
+        ->getCanonicalType();
   }
 
   if (isa<AbstractStorageDecl>(this)) {
@@ -2942,7 +2942,7 @@ CanType ValueDecl::getOverloadSignatureType() const {
                                    /*topLevelFunction=*/true,
                                    /*isMethod=*/false,
                                    /*isInitializer=*/false, getNumCurryLevels())
-              ->getMinimalCanonicalType(getDeclContext());
+              ->getCanonicalType();
     }
 
     // We want to curry the default signature type with the 'self' type of the
@@ -2950,14 +2950,14 @@ CanType ValueDecl::getOverloadSignatureType() const {
     // is unique across different contexts, such as between a protocol extension
     // and struct decl.
     return defaultSignatureType->addCurriedSelfType(getDeclContext())
-        ->getMinimalCanonicalType(getDeclContext());
+        ->getCanonicalType();
   }
 
   if (isa<EnumElementDecl>(this)) {
     auto mappedType = mapSignatureFunctionType(
         getASTContext(), getInterfaceType(), /*topLevelFunction=*/false,
         /*isMethod=*/false, /*isInitializer=*/false, getNumCurryLevels());
-    return mappedType->getMinimalCanonicalType(getDeclContext());
+    return mappedType->getCanonicalType();
   }
 
   // Note: If you add more cases to this function, you should update the

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -472,7 +472,7 @@ bool GenericSignatureImpl::isValidTypeInContext(Type type) const {
 
 ArrayRef<CanTypeWrapper<GenericTypeParamType>>
 CanGenericSignature::getGenericParams() const {
-  auto params = getPointer()->getGenericParams().getOriginalArray();
+  auto params = this->GenericSignature::getGenericParams().getOriginalArray();
   auto base = static_cast<const CanTypeWrapper<GenericTypeParamType>*>(
                                                               params.data());
   return {base, params.size()};

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4017,7 +4017,12 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
   Type superclass;
   llvm::SmallVector<Type, 2> MinimalMembers;
   bool MinimalHasExplicitAnyObject = false;
+  auto ifaceTy = OpenedArchetypeType::getSelfInterfaceTypeFromContext(useDC);
   for (const auto &Req : Reqs) {
+    if (!Req.getFirstType()->isEqual(ifaceTy)) {
+      continue;
+    }
+
     switch (Req.getKind()) {
     case RequirementKind::Superclass:
       assert((!superclass || superclass->isEqual(Req.getSecondType()))
@@ -4035,7 +4040,7 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
     }
   }
 
-  // Ensure any superclass bounds appears first regardless of its order among
+  // Ensure superclass bounds appear first regardless of their order among
   // the signature's requirements.
   if (superclass)
     MinimalMembers.insert(MinimalMembers.begin(), superclass->getCanonicalType());

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2164,11 +2164,12 @@ void CompletionLookup::getValueExprCompletions(Type ExprType, ValueDecl *VD) {
     WasOptional = true;
   }
 
-  if (!ExprType->getMetatypeInstanceType()->isAnyObject())
-    if (ExprType->isAnyExistentialType())
+  if (!ExprType->getMetatypeInstanceType()->isAnyObject()) {
+    if (ExprType->isAnyExistentialType()) {
       ExprType = OpenedArchetypeType::getAny(ExprType->getCanonicalType(),
-                                             CurrDeclContext);
-
+                                             CurrDeclContext->getGenericSignatureOfContext());
+    }
+  }
   if (!IsSelfRefExpr && !IsSuperRefExpr && ExprType->getAnyNominal() &&
       ExprType->getAnyNominal()->isActor()) {
     IsCrossActorReference = true;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2166,7 +2166,8 @@ void CompletionLookup::getValueExprCompletions(Type ExprType, ValueDecl *VD) {
 
   if (!ExprType->getMetatypeInstanceType()->isAnyObject())
     if (ExprType->isAnyExistentialType())
-      ExprType = OpenedArchetypeType::getAny(ExprType->getCanonicalType());
+      ExprType = OpenedArchetypeType::getAny(ExprType->getCanonicalType(),
+                                             CurrDeclContext);
 
   if (!IsSelfRefExpr && !IsSuperRefExpr && ExprType->getAnyNominal() &&
       ExprType->getAnyNominal()->isActor()) {

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -52,7 +52,9 @@ namespace irgen {
                              CanType sourceFormalType,
                              SILType targetLoweredType,
                              CanType targetFormalType,
-                             CheckedCastMode mode, Explosion &out);
+                             CheckedCastMode mode,
+                             GenericSignature fnSig,
+                             Explosion &out);
 
   /// Convert a class object to the given destination type,
   /// using a runtime-checked cast.
@@ -71,9 +73,10 @@ namespace irgen {
 
   /// Convert the given value to the exact destination type.
   FailableCastResult emitClassIdenticalCast(IRGenFunction &IGF,
-                                                  llvm::Value *from,
-                                                  SILType fromType,
-                                                  SILType toType);
+                                            llvm::Value *from,
+                                            SILType fromType,
+                                            SILType toType,
+                                            GenericSignature fnSig);
 
   /// Emit a checked cast of a metatype.
   void emitMetatypeDowncast(IRGenFunction &IGF,
@@ -93,6 +96,7 @@ namespace irgen {
                                   SILType destType,
                                   CheckedCastMode mode,
                                   Optional<MetatypeRepresentation> metatypeKind,
+                                  GenericSignature fnSig,
                                   Explosion &ex);
 
   /// Emit a checked cast from a metatype to AnyObject.

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -57,7 +57,8 @@ namespace irgen {
 
   OwnedAddress projectPhysicalClassMemberAddress(
       IRGenFunction &IGF, llvm::Value *base,
-      SILType baseType, SILType fieldType, VarDecl *field);
+      SILType baseType, SILType fieldType, VarDecl *field,
+      GenericSignature fnSig);
 
   /// Return a strategy for accessing the given stored class property.
   ///
@@ -145,7 +146,8 @@ namespace irgen {
   /// Emit a projection from a class instance to the first tail allocated
   /// element.
   Address emitTailProjection(IRGenFunction &IGF, llvm::Value *Base,
-                                  SILType ClassType, SILType TailType);
+                             SILType ClassType, SILType TailType,
+                             GenericSignature fnSig);
 
   using TailArraysRef = llvm::ArrayRef<std::pair<SILType, llvm::Value *>>;
 
@@ -175,14 +177,17 @@ namespace irgen {
                                           TailArraysRef TailArrays);
 
   /// Emit class deallocation.
-  void emitClassDeallocation(IRGenFunction &IGF, SILType selfType,
-                             llvm::Value *selfValue);
+  void emitClassDeallocation(IRGenFunction &IGF,
+                             SILType selfType,
+                             llvm::Value *selfValue,
+                             GenericSignature fnSig);
 
   /// Emit class deallocation.
   void emitPartialClassDeallocation(IRGenFunction &IGF,
                                     SILType selfType,
                                     llvm::Value *selfValue,
-                                    llvm::Value *metadataValue);
+                                    llvm::Value *metadataValue,
+                                    GenericSignature fnSig);
 
   /// Emit the constant fragile offset of the given property inside an instance
   /// of the class.
@@ -218,6 +223,7 @@ namespace irgen {
   FunctionPointer emitVirtualMethodValue(IRGenFunction &IGF, llvm::Value *base,
                                          SILType baseType, SILDeclRef method,
                                          CanSILFunctionType methodType,
+                                         GenericSignature fnSig,
                                          bool useSuperVTable);
 
   /// Is the given class known to have Swift-compatible metadata?

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1699,7 +1699,8 @@ Address irgen::emitOpenExistentialBox(IRGenFunction &IGF,
 OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
                                   SILType destType,
                                   CanType formalSrcType,
-                                ArrayRef<ProtocolConformanceRef> conformances) {
+                                  ArrayRef<ProtocolConformanceRef> conformances,
+                                  GenericSignature sig) {
   // TODO: Non-Error boxed existentials.
   assert(destType.canUseExistentialRepresentation(
            ExistentialRepresentation::Boxed, Type()));
@@ -1727,7 +1728,7 @@ OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
   auto addr = IGF.Builder.CreateExtractValue(result, 1);
 
   auto archetype =
-      OpenedArchetypeType::get(destType.getASTType(), IGF.IGM.getSwiftModule());
+      OpenedArchetypeType::get(destType.getASTType(), sig);
   auto &srcTI = IGF.getTypeInfoForUnlowered(AbstractionPattern(archetype),
                                             formalSrcType);
   addr = IGF.Builder.CreateBitCast(addr,
@@ -1943,6 +1944,7 @@ void irgen::emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,
 void irgen::emitMetatypeOfClassExistential(IRGenFunction &IGF, Explosion &value,
                                            SILType metatypeTy,
                                            SILType existentialTy,
+                                           GenericSignature fnSig,
                                            Explosion &out) {
   assert(existentialTy.isClassExistentialType());
   auto &baseTI = IGF.getTypeInfo(existentialTy).as<ClassExistentialTypeInfo>();
@@ -1962,6 +1964,7 @@ void irgen::emitMetatypeOfClassExistential(IRGenFunction &IGF, Explosion &value,
 
   auto dynamicType = emitDynamicTypeOfHeapObject(IGF, instance, repr,
                                                  existentialTy,
+                                                 fnSig,
                                                  /*allow artificial*/ false);
   out.add(dynamicType);
 
@@ -1996,7 +1999,8 @@ llvm::Value *
 irgen::emitClassExistentialProjection(IRGenFunction &IGF,
                                       Explosion &base,
                                       SILType baseTy,
-                                      CanArchetypeType openedArchetype) {
+                                      CanArchetypeType openedArchetype,
+                                      GenericSignature sigFn) {
   assert(baseTy.isClassExistentialType());
   auto &baseTI = IGF.getTypeInfo(baseTy).as<ClassExistentialTypeInfo>();
 
@@ -2011,6 +2015,7 @@ irgen::emitClassExistentialProjection(IRGenFunction &IGF,
   auto metadata = emitDynamicTypeOfHeapObject(IGF, value,
                                               MetatypeRepresentation::Thick,
                                               baseTy,
+                                              sigFn,
                                               /*allow artificial*/ false);
   IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
                     wtables);
@@ -2344,7 +2349,8 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
 
 Address irgen::emitOpaqueBoxedExistentialProjection(
     IRGenFunction &IGF, OpenedExistentialAccess accessKind, Address base,
-    SILType existentialTy, CanArchetypeType openedArchetype) {
+    SILType existentialTy, CanArchetypeType openedArchetype,
+    GenericSignature fnSig) {
 
   assert(existentialTy.isExistentialType());
   if (existentialTy.isClassExistentialType()) {
@@ -2355,6 +2361,7 @@ Address irgen::emitOpaqueBoxedExistentialProjection(
     auto metadata = emitDynamicTypeOfHeapObject(IGF, value,
                                                 MetatypeRepresentation::Thick,
                                                 existentialTy,
+                                                fnSig,
                                                 /*allow artificial*/ false);
 
     // If we are projecting into an opened archetype, capture the

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1726,7 +1726,8 @@ OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
   auto box = IGF.Builder.CreateExtractValue(result, 0);
   auto addr = IGF.Builder.CreateExtractValue(result, 1);
 
-  auto archetype = OpenedArchetypeType::get(destType.getASTType());
+  auto archetype =
+      OpenedArchetypeType::get(destType.getASTType(), IGF.IGM.getSwiftModule());
   auto &srcTI = IGF.getTypeInfoForUnlowered(AbstractionPattern(archetype),
                                             formalSrcType);
   addr = IGF.Builder.CreateBitCast(addr,

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -69,7 +69,8 @@ namespace irgen {
   OwnedAddress emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
                                   SILType destType,
                                   CanType formalSrcType,
-                                 ArrayRef<ProtocolConformanceRef> conformances);
+                                  ArrayRef<ProtocolConformanceRef> conformances,
+                                  GenericSignature sig);
   
   /// Deallocate a boxed existential container with uninitialized space to hold
   /// a value of a given type.
@@ -97,7 +98,8 @@ namespace irgen {
                                                   Address existentialContainer);
   Address emitOpaqueBoxedExistentialProjection(
       IRGenFunction &IGF, OpenedExistentialAccess accessKind, Address base,
-      SILType existentialType, CanArchetypeType openedArchetype);
+      SILType existentialType, CanArchetypeType openedArchetype,
+      GenericSignature fnSig);
 
   /// Return the address of the reference values within a class existential.
   Address emitClassExistentialValueAddress(IRGenFunction &IGF,
@@ -111,7 +113,8 @@ namespace irgen {
   llvm::Value *emitClassExistentialProjection(IRGenFunction &IGF,
                                               Explosion &base,
                                               SILType baseTy,
-                                              CanArchetypeType openedArchetype);
+                                              CanArchetypeType openedArchetype,
+                                              GenericSignature sigFn);
 
   /// Extract the metatype pointer from an existential metatype value.
   ///
@@ -142,7 +145,9 @@ namespace irgen {
   /// Emit the existential metatype of a class existential value.
   void emitMetatypeOfClassExistential(IRGenFunction &IGF,
                                       Explosion &value, SILType metatypeType,
-                                      SILType existentialType, Explosion &out);
+                                      SILType existentialType,
+                                      GenericSignature fnSig,
+                                      Explosion &out);
 
   /// Emit the existential metatype of a boxed existential value.
   void emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -2020,7 +2020,8 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
   
   // Existentials use the encoding of the enclosed dynamic type.
   if (type->isAnyExistentialType()) {
-    return getIsaEncodingForType(IGM, OpenedArchetypeType::getAny(type));
+    return getIsaEncodingForType(
+        IGM, OpenedArchetypeType::getAny(type, IGM.getSwiftModule()));
   }
 
   if (auto archetype = dyn_cast<ArchetypeType>(type)) {

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1792,6 +1792,7 @@ llvm::Value *IRGenFunction::getDynamicSelfMetadata() {
     SelfValue = emitDynamicTypeOfHeapObject(*this, SelfValue,
                                 MetatypeRepresentation::Thick,
                                 SILType::getPrimitiveObjectType(SelfType),
+                                GenericSignature(),
                                 /*allow artificial*/ false);
     SelfKind = SwiftMetatype;
     break;
@@ -1893,12 +1894,15 @@ static llvm::Value *emitLoadOfHeapMetadataRef(IRGenFunction &IGF,
 llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                                      llvm::Value *object,
                                                      CanType objectType,
+                                                     GenericSignature sig,
                                                      bool suppressCast) {
   ClassDecl *theClass = objectType.getClassOrBoundGenericClass();
-  if (theClass && isKnownNotTaggedPointer(IGF.IGM, theClass))
+  if (theClass && isKnownNotTaggedPointer(IGF.IGM, theClass)) {
+    auto isaEncoding = getIsaEncodingForType(IGF.IGM, objectType, sig);
     return emitLoadOfHeapMetadataRef(IGF, object,
-                                     getIsaEncodingForType(IGF.IGM, objectType),
+                                     isaEncoding,
                                      suppressCast);
+  }
 
   // OK, ask the runtime for the class pointer of this potentially-ObjC object.
   return emitHeapMetadataRefForUnknownHeapObject(IGF, object);
@@ -1907,9 +1911,11 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
 llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                                      llvm::Value *object,
                                                      SILType objectType,
+                                                     GenericSignature sig,
                                                      bool suppressCast) {
   return emitHeapMetadataRefForHeapObject(IGF, object,
                                           objectType.getASTType(),
+                                          sig,
                                           suppressCast);
 }
 
@@ -1976,9 +1982,10 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                                 llvm::Value *object,
                                                 MetatypeRepresentation repr,
                                                 SILType objectType,
+                                                GenericSignature sig,
                                                 bool allowArtificialSubclasses){
   switch (auto isaEncoding =
-            getIsaEncodingForType(IGF.IGM, objectType.getASTType())) {
+            getIsaEncodingForType(IGF.IGM, objectType.getASTType(), sig)) {
   case IsaEncoding::Pointer:
     // Directly load the isa pointer from a pure Swift class.
     return emitLoadOfHeapMetadataRef(IGF, object, isaEncoding,
@@ -2005,7 +2012,8 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
 
 /// What isa encoding mechanism does a type have?
 IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
-                                         CanType type) {
+                                         CanType type,
+                                         GenericSignature outerSignature) {
   if (!IGM.ObjCInterop) return IsaEncoding::Pointer;
 
   // This needs to be kept up-to-date with hasKnownSwiftMetadata.
@@ -2021,13 +2029,15 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
   // Existentials use the encoding of the enclosed dynamic type.
   if (type->isAnyExistentialType()) {
     return getIsaEncodingForType(
-        IGM, OpenedArchetypeType::getAny(type, IGM.getSwiftModule()));
+        IGM, OpenedArchetypeType::getAny(type, outerSignature),
+        outerSignature);
   }
 
   if (auto archetype = dyn_cast<ArchetypeType>(type)) {
     // If we have a concrete superclass constraint, just recurse.
     if (auto superclass = archetype->getSuperclass()) {
-      return getIsaEncodingForType(IGM, superclass->getCanonicalType());
+      return getIsaEncodingForType(IGM, superclass->getCanonicalType(),
+                                   outerSignature);
     }
 
     // Otherwise, we must just have a class constraint.  Use the

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -153,6 +153,7 @@ llvm::Value *emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                          llvm::Value *object,
                                          MetatypeRepresentation rep,
                                          SILType objectType,
+                                         GenericSignature sig,
                                          bool allowArtificialSubclasses = false);
 
 /// Given a non-tagged object pointer, load a pointer to its class object.
@@ -169,6 +170,7 @@ llvm::Value *emitHeapMetadataRefForUnknownHeapObject(IRGenFunction &IGF,
 llvm::Value *emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                               llvm::Value *object,
                                               CanType objectType,
+                                              GenericSignature sig,
                                               bool suppressCast = false);
 
 /// Given a heap-object instance, with some heap-object type,
@@ -176,10 +178,12 @@ llvm::Value *emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
 llvm::Value *emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                               llvm::Value *object,
                                               SILType objectType,
+                                              GenericSignature sig,
                                               bool suppressCast = false);
 
 /// What isa-encoding mechanism does a type use?
-IsaEncoding getIsaEncodingForType(IRGenModule &IGM, CanType type);
+IsaEncoding getIsaEncodingForType(IRGenModule &IGM, CanType type,
+                                  GenericSignature sig);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -673,6 +673,7 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
       emitDynamicTypeOfHeapObject(IGF, instanceRef,
                                   MetatypeRepresentation::Thick,
                                   instanceType,
+                                  Fn.getGenericSignature(),
                                   /*allow artificial subclasses*/ true);
     IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                           MetadataState::Complete);
@@ -736,6 +737,7 @@ void BindPolymorphicParameter::emit(Explosion &nativeParam, unsigned paramIndex)
     emitDynamicTypeOfHeapObject(IGF, instanceRef,
                                 MetatypeRepresentation::Thick,
                                 instanceType,
+                                SubstFnType->getInvocationGenericSignature(),
                                 /* allow artificial subclasses */ true);
   IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                         MetadataState::Complete);

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -231,8 +231,11 @@ Callee IRGenThunk::lookupMethod() {
   if (selfTy.is<MetatypeType>()) {
     metadata = selfValue;
   } else {
+    auto &Types = IGF.IGM.getSILModule().Types;
+    auto *env = Types.getConstantGenericEnvironment(declRef);
+    auto sig = env ? env->getGenericSignature() : GenericSignature();
     metadata = emitHeapMetadataRefForHeapObject(IGF, selfValue, selfTy,
-                                                /*suppress cast*/ true);
+                                                sig, /*suppress cast*/ true);
   }
 
   // Find the method we're interested in.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -259,6 +259,10 @@ const SILFunction *SILFunction::getOriginOfSpecialization() const {
   return p;
 }
 
+GenericSignature SILFunction::getGenericSignature() const {
+  return GenericEnv ? GenericEnv->getGenericSignature() : GenericSignature();
+}
+
 void SILFunction::numberValues(llvm::DenseMap<const SILNode*, unsigned> &
                                  ValueToNumberMap) const {
   unsigned idx = 0;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5423,8 +5423,10 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         return true;
 
       // Lower the type at the abstraction level of the existential.
-      auto archetype = OpenedArchetypeType::get(Val->getType().getASTType())
-                           ->getCanonicalType();
+      auto archetype =
+          OpenedArchetypeType::get(Val->getType().getASTType(),
+                                   B.getModule().getSwiftModule())
+              ->getCanonicalType();
 
       auto &F = B.getFunction();
       SILType LoweredTy =

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5425,7 +5425,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       // Lower the type at the abstraction level of the existential.
       auto archetype =
           OpenedArchetypeType::get(Val->getType().getASTType(),
-                                   B.getModule().getSwiftModule())
+                                   B.getFunction().getGenericSignature())
               ->getCanonicalType();
 
       auto &F = B.getFunction();

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -200,7 +200,7 @@ void MemoryLocations::analyzeLocation(SILValue loc) {
   SubLocationMap subLocationMap;
   if (!analyzeLocationUsesRecursively(loc, currentLocIdx, collectedVals,
                                       subLocationMap)) {
-    locations.truncate(currentLocIdx);
+    //    locations.truncate(currentLocIdx);
     for (SILValue V : collectedVals) {
       addr2LocIdx.erase(V);
     }

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -200,7 +200,7 @@ void MemoryLocations::analyzeLocation(SILValue loc) {
   SubLocationMap subLocationMap;
   if (!analyzeLocationUsesRecursively(loc, currentLocIdx, collectedVals,
                                       subLocationMap)) {
-    //    locations.truncate(currentLocIdx);
+    locations.truncate(currentLocIdx);
     for (SILValue V : collectedVals) {
       addr2LocIdx.erase(V);
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2800,7 +2800,9 @@ public:
     if (auto *AEBI = dyn_cast<AllocExistentialBoxInst>(PEBI->getOperand())) {
       // The lowered type must be the properly-abstracted form of the AST type.
       SILType exType = AEBI->getExistentialType();
-      auto archetype = OpenedArchetypeType::get(exType.getASTType());
+      auto *DC = F.getDeclContext() ? F.getDeclContext()
+                                    : F.getModule().getSwiftModule();
+      auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
 
       auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                         AEBI->getFormalConcreteType())
@@ -3793,8 +3795,10 @@ public:
             "existential type");
     
     // The lowered type must be the properly-abstracted form of the AST type.
-    auto archetype = OpenedArchetypeType::get(exType.getASTType());
-    
+    auto *DC = F.getDeclContext() ? F.getDeclContext()
+                                  : F.getModule().getSwiftModule();
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
+
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       AEI->getFormalConcreteType())
                       .getAddressType();
@@ -3822,7 +3826,9 @@ public:
             "init_existential_value result must not be an address");
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto archetype = OpenedArchetypeType::get(exType.getASTType());
+    auto *DC = F.getDeclContext() ? F.getDeclContext()
+                                  : F.getModule().getSwiftModule();
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       IEI->getFormalConcreteType());
     requireSameType(
@@ -3854,7 +3860,9 @@ public:
     
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto archetype = OpenedArchetypeType::get(exType.getASTType());
+    auto *DC = F.getDeclContext() ? F.getDeclContext()
+                                  : F.getModule().getSwiftModule();
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       IEI->getFormalConcreteType());
     requireSameType(concreteType, loweredTy,

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2800,9 +2800,8 @@ public:
     if (auto *AEBI = dyn_cast<AllocExistentialBoxInst>(PEBI->getOperand())) {
       // The lowered type must be the properly-abstracted form of the AST type.
       SILType exType = AEBI->getExistentialType();
-      auto *DC = F.getDeclContext() ? F.getDeclContext()
-                                    : F.getModule().getSwiftModule();
-      auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
+      auto archetype = OpenedArchetypeType::get(exType.getASTType(),
+                                                F.getGenericSignature());
 
       auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                         AEBI->getFormalConcreteType())
@@ -3795,9 +3794,8 @@ public:
             "existential type");
     
     // The lowered type must be the properly-abstracted form of the AST type.
-    auto *DC = F.getDeclContext() ? F.getDeclContext()
-                                  : F.getModule().getSwiftModule();
-    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(),
+                                              F.getGenericSignature());
 
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       AEI->getFormalConcreteType())
@@ -3826,9 +3824,8 @@ public:
             "init_existential_value result must not be an address");
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto *DC = F.getDeclContext() ? F.getDeclContext()
-                                  : F.getModule().getSwiftModule();
-    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(),
+                                              F.getGenericSignature());
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       IEI->getFormalConcreteType());
     requireSameType(
@@ -3860,9 +3857,8 @@ public:
     
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto *DC = F.getDeclContext() ? F.getDeclContext()
-                                  : F.getModule().getSwiftModule();
-    auto archetype = OpenedArchetypeType::get(exType.getASTType(), DC);
+    auto archetype = OpenedArchetypeType::get(exType.getASTType(),
+                                              F.getGenericSignature());
     auto loweredTy = F.getLoweredType(Lowering::AbstractionPattern(archetype),
                                       IEI->getFormalConcreteType());
     requireSameType(concreteType, loweredTy,

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -732,7 +732,8 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
   // If the input argument is known to be an existential, save the runtime
   // some work by opening it.
   if (nativeType->isExistentialType()) {
-    auto openedType = OpenedArchetypeType::get(nativeType, SGF.FunctionDC);
+    auto openedType = OpenedArchetypeType::get(nativeType,
+                                               SGF.F.getGenericSignature());
 
     FormalEvaluationScope scope(SGF);
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -732,7 +732,7 @@ static ManagedValue emitNativeToCBridgedNonoptionalValue(SILGenFunction &SGF,
   // If the input argument is known to be an existential, save the runtime
   // some work by opening it.
   if (nativeType->isExistentialType()) {
-    auto openedType = OpenedArchetypeType::get(nativeType);
+    auto openedType = OpenedArchetypeType::get(nativeType, SGF.FunctionDC);
 
     FormalEvaluationScope scope(SGF);
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -297,7 +297,8 @@ static ManagedValue emitCastToReferenceType(SILGenFunction &SGF,
 
   // If the argument is existential, open it.
   if (argTy->isClassExistentialType()) {
-    auto openedTy = OpenedArchetypeType::get(argTy->getCanonicalType());
+    auto openedTy =
+        OpenedArchetypeType::get(argTy->getCanonicalType(), SGF.FunctionDC);
     SILType loweredOpenedTy = SGF.getLoweredLoadableType(openedTy);
     arg = SGF.B.createOpenExistentialRef(loc, arg, loweredOpenedTy);
   }
@@ -790,7 +791,8 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &SGF,
   
   // If the argument is existential, open it.
   if (sourceType->isClassExistentialType()) {
-    auto openedTy = OpenedArchetypeType::get(sourceType->getCanonicalType());
+    auto openedTy = OpenedArchetypeType::get(sourceType->getCanonicalType(),
+                                             SGF.FunctionDC);
     SILType loweredOpenedTy = SGF.getLoweredLoadableType(openedTy);
     ref = SGF.B.createOpenExistentialRef(loc, ref, loweredOpenedTy);
   }

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -298,7 +298,8 @@ static ManagedValue emitCastToReferenceType(SILGenFunction &SGF,
   // If the argument is existential, open it.
   if (argTy->isClassExistentialType()) {
     auto openedTy =
-        OpenedArchetypeType::get(argTy->getCanonicalType(), SGF.FunctionDC);
+        OpenedArchetypeType::get(argTy->getCanonicalType(),
+                                 SGF.F.getGenericSignature());
     SILType loweredOpenedTy = SGF.getLoweredLoadableType(openedTy);
     arg = SGF.B.createOpenExistentialRef(loc, arg, loweredOpenedTy);
   }
@@ -792,7 +793,7 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &SGF,
   // If the argument is existential, open it.
   if (sourceType->isClassExistentialType()) {
     auto openedTy = OpenedArchetypeType::get(sourceType->getCanonicalType(),
-                                             SGF.FunctionDC);
+                                             SGF.F.getGenericSignature());
     SILType loweredOpenedTy = SGF.getLoweredLoadableType(openedTy);
     ref = SGF.B.createOpenExistentialRef(loc, ref, loweredOpenedTy);
   }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1851,7 +1851,7 @@ RValue RValueEmitter::visitErasureExpr(ErasureExpr *E, SGFContext C) {
   auto concreteFormalType = E->getSubExpr()->getType()->getCanonicalType();
 
   auto archetype = OpenedArchetypeType::getAny(E->getType()->getCanonicalType(),
-                                               SGF.FunctionDC);
+                                               SGF.F.getGenericSignature());
   AbstractionPattern abstractionPattern(archetype);
   auto &concreteTL = SGF.getTypeLowering(abstractionPattern,
                                          concreteFormalType);
@@ -2625,7 +2625,8 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
     // new one (which we'll upcast immediately below) for a class member.
     ArchetypeType *opened;
     if (storage->getDeclContext()->getSelfClassDecl()) {
-      opened = OpenedArchetypeType::get(baseType, subSGF.FunctionDC);
+      opened = OpenedArchetypeType::get(baseType,
+                                        subSGF.F.getGenericSignature());
     } else {
       opened = subs.getReplacementTypes()[0]->castTo<ArchetypeType>();
     }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1850,8 +1850,8 @@ RValue RValueEmitter::visitErasureExpr(ErasureExpr *E, SGFContext C) {
   auto &existentialTL = SGF.getTypeLowering(E->getType());
   auto concreteFormalType = E->getSubExpr()->getType()->getCanonicalType();
 
-  auto archetype = OpenedArchetypeType::getAny(
-      E->getType()->getCanonicalType());
+  auto archetype = OpenedArchetypeType::getAny(E->getType()->getCanonicalType(),
+                                               SGF.FunctionDC);
   AbstractionPattern abstractionPattern(archetype);
   auto &concreteTL = SGF.getTypeLowering(abstractionPattern,
                                          concreteFormalType);
@@ -2625,7 +2625,7 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
     // new one (which we'll upcast immediately below) for a class member.
     ArchetypeType *opened;
     if (storage->getDeclContext()->getSelfClassDecl()) {
-      opened = OpenedArchetypeType::get(baseType);
+      opened = OpenedArchetypeType::get(baseType, subSGF.FunctionDC);
     } else {
       opened = subs.getReplacementTypes()[0]->castTo<ArchetypeType>();
     }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -202,7 +202,7 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
   FormalEvaluationScope scope(SGF);
 
   if (inputType->isAnyExistentialType()) {
-    CanType openedType = OpenedArchetypeType::getAny(inputType);
+    CanType openedType = OpenedArchetypeType::getAny(inputType, SGF.FunctionDC);
     SILType loweredOpenedType = SGF.getLoweredType(openedType);
 
     input = SGF.emitOpenExistential(loc, input,
@@ -588,7 +588,8 @@ ManagedValue Transform::transform(ManagedValue v,
 
     auto layout = instanceType.getExistentialLayout();
     if (layout.getSuperclass()) {
-      CanType openedType = OpenedArchetypeType::getAny(inputSubstType);
+      CanType openedType =
+          OpenedArchetypeType::getAny(inputSubstType, SGF.FunctionDC);
       SILType loweredOpenedType = SGF.getLoweredType(openedType);
 
       FormalEvaluationScope scope(SGF);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -202,7 +202,8 @@ static ManagedValue emitTransformExistential(SILGenFunction &SGF,
   FormalEvaluationScope scope(SGF);
 
   if (inputType->isAnyExistentialType()) {
-    CanType openedType = OpenedArchetypeType::getAny(inputType, SGF.FunctionDC);
+    CanType openedType = OpenedArchetypeType::getAny(inputType,
+                                                     SGF.F.getGenericSignature());
     SILType loweredOpenedType = SGF.getLoweredType(openedType);
 
     input = SGF.emitOpenExistential(loc, input,
@@ -589,7 +590,8 @@ ManagedValue Transform::transform(ManagedValue v,
     auto layout = instanceType.getExistentialLayout();
     if (layout.getSuperclass()) {
       CanType openedType =
-          OpenedArchetypeType::getAny(inputSubstType, SGF.FunctionDC);
+          OpenedArchetypeType::getAny(inputSubstType,
+                                      SGF.F.getGenericSignature());
       SILType loweredOpenedType = SGF.getLoweredType(openedType);
 
       FormalEvaluationScope scope(SGF);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -843,7 +843,7 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
 
   // Open the protocol type.
   auto openedType = OpenedArchetypeType::get(
-      protocol->getExistentialType()->getCanonicalType());
+      protocol->getExistentialType()->getCanonicalType(), SGM.SwiftModule);
 
   // Form the substitutions for calling the witness.
   auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -843,7 +843,7 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
 
   // Open the protocol type.
   auto openedType = OpenedArchetypeType::get(
-      protocol->getExistentialType()->getCanonicalType(), SGM.SwiftModule);
+      protocol->getExistentialType()->getCanonicalType(), GenericSignature());
 
   // Form the substitutions for calling the witness.
   auto witnessSubs = SubstitutionMap::getProtocolSubstitutions(protocol,

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -446,8 +446,11 @@ void ExistentialTransform::populateThunkBody() {
       OpenedArchetypeType *Opened;
       auto OrigOperand = ThunkBody->getArgument(ArgDesc.Index);
       auto SwiftType = ArgDesc.Arg->getType().getASTType();
+      auto *DC = F->getDeclContext() ? F->getDeclContext() : M.getSwiftModule();
       auto OpenedType =
-          SwiftType->openAnyExistentialType(Opened)->getCanonicalType();
+          SwiftType
+              ->openAnyExistentialType(Opened, DC)
+              ->getCanonicalType();
       auto OpenedSILType = NewF->getLoweredType(OpenedType);
       SILValue archetypeValue;
       auto ExistentialRepr =

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -446,10 +446,9 @@ void ExistentialTransform::populateThunkBody() {
       OpenedArchetypeType *Opened;
       auto OrigOperand = ThunkBody->getArgument(ArgDesc.Index);
       auto SwiftType = ArgDesc.Arg->getType().getASTType();
-      auto *DC = F->getDeclContext() ? F->getDeclContext() : M.getSwiftModule();
       auto OpenedType =
           SwiftType
-              ->openAnyExistentialType(Opened, DC)
+              ->openAnyExistentialType(Opened, F->getGenericSignature())
               ->getCanonicalType();
       auto OpenedSILType = NewF->getLoweredType(OpenedType);
       SILValue archetypeValue;

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -74,7 +74,8 @@ void emitDistributedActorSystemWitnessCall(
   // If the base is an existential open it.
   if (systemASTType->isAnyExistentialType()) {
     OpenedArchetypeType *opened;
-    systemASTType = systemASTType->openAnyExistentialType(opened, module)
+    systemASTType = systemASTType->openAnyExistentialType(opened,
+                                                          F.getGenericSignature())
                         ->getCanonicalType();
     base = B.createOpenExistentialAddr(
         loc, base, F.getLoweredType(systemASTType),

--- a/lib/SILOptimizer/Utils/DistributedActor.cpp
+++ b/lib/SILOptimizer/Utils/DistributedActor.cpp
@@ -74,8 +74,8 @@ void emitDistributedActorSystemWitnessCall(
   // If the base is an existential open it.
   if (systemASTType->isAnyExistentialType()) {
     OpenedArchetypeType *opened;
-    systemASTType =
-        systemASTType->openAnyExistentialType(opened)->getCanonicalType();
+    systemASTType = systemASTType->openAnyExistentialType(opened, module)
+                        ->getCanonicalType();
     base = B.createOpenExistentialAddr(
         loc, base, F.getLoweredType(systemASTType),
         OpenedExistentialAccess::Immutable);

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -256,7 +256,8 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
   // than their corresponding existential, ExistentialConformances needs to be
   // filtered when using it with this (phony) generic signature.
   CanGenericSignature ExistentialSig =
-      M->getASTContext().getOpenedArchetypeSignature(ExistentialType);
+      M->getASTContext().getOpenedArchetypeSignature(ExistentialType,
+                                                     M->getSwiftModule());
   ExistentialSubs = SubstitutionMap::get(
       ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },
       [&](CanType /*depType*/, Type /*replaceType*/,

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -257,7 +257,7 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
   // filtered when using it with this (phony) generic signature.
   CanGenericSignature ExistentialSig =
       M->getASTContext().getOpenedArchetypeSignature(ExistentialType,
-                                                     M->getSwiftModule());
+                                                     GenericSignature());
   ExistentialSubs = SubstitutionMap::get(
       ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },
       [&](CanType /*depType*/, Type /*replaceType*/,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -856,8 +856,8 @@ namespace {
       Type resultTy;
       resultTy = cs.getType(result);
       if (resultTy->hasOpenedExistentialWithRoot(record.Archetype)) {
-        Type erasedTy =
-            resultTy->typeEraseOpenedArchetypesWithRoot(record.Archetype);
+        Type erasedTy = resultTy->typeEraseOpenedArchetypesWithRoot(
+            record.Archetype, cs.DC);
         auto range = result->getSourceRange();
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion
@@ -1352,7 +1352,7 @@ namespace {
           // Erase opened existentials from the type of the thunk; we're
           // going to open the existential inside the thunk's body.
           containerTy = containerTy->typeEraseOpenedArchetypesWithRoot(
-              knownOpened->second);
+              knownOpened->second, cs.DC);
           selfTy = containerTy;
         }
       }
@@ -1412,7 +1412,7 @@ namespace {
         // existential.
         if (openedExistential) {
           refType = refType->typeEraseOpenedArchetypesWithRoot(
-              baseTy->castTo<OpenedArchetypeType>());
+              baseTy->castTo<OpenedArchetypeType>(), cs.DC);
         }
 
         cs.setType(ref, refType);
@@ -1551,10 +1551,10 @@ namespace {
                              getConstraintSystem().getConstraintLocator(
                                memberLocator));
         if (knownOpened != solution.OpenedExistentialTypes.end()) {
-          curryThunkTy =
-              curryThunkTy
-                  ->typeEraseOpenedArchetypesWithRoot(knownOpened->second)
-                  ->castTo<FunctionType>();
+          curryThunkTy = curryThunkTy
+                             ->typeEraseOpenedArchetypesWithRoot(
+                                 knownOpened->second, cs.DC)
+                             ->castTo<FunctionType>();
         }
 
         auto discriminator = AutoClosureExpr::InvalidDiscriminator;
@@ -5232,8 +5232,8 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType) {
   if (fromInstanceType->isExistentialType()) {
     // Coercion from superclass-constrained existential to its
     // concrete superclass.
-    auto fromArchetype = OpenedArchetypeType::getAny(
-        fromType->getCanonicalType());
+    auto fromArchetype =
+        OpenedArchetypeType::getAny(fromType->getCanonicalType(), cs.DC);
 
     auto *archetypeVal = cs.cacheType(new (ctx) OpaqueValueExpr(
         expr->getSourceRange(), fromArchetype));
@@ -5296,7 +5296,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType) {
 
   // For existential-to-existential coercions, open the source existential.
   if (fromType->isAnyExistentialType()) {
-    fromType = OpenedArchetypeType::getAny(fromType->getCanonicalType());
+    fromType = OpenedArchetypeType::getAny(fromType->getCanonicalType(), cs.DC);
 
     auto *archetypeVal = cs.cacheType(
         new (ctx) OpaqueValueExpr(expr->getSourceRange(), fromType));

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5233,7 +5233,8 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType) {
     // Coercion from superclass-constrained existential to its
     // concrete superclass.
     auto fromArchetype =
-        OpenedArchetypeType::getAny(fromType->getCanonicalType(), cs.DC);
+        OpenedArchetypeType::getAny(fromType->getCanonicalType(),
+                                    cs.DC->getGenericSignatureOfContext());
 
     auto *archetypeVal = cs.cacheType(new (ctx) OpaqueValueExpr(
         expr->getSourceRange(), fromArchetype));
@@ -5296,7 +5297,8 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType) {
 
   // For existential-to-existential coercions, open the source existential.
   if (fromType->isAnyExistentialType()) {
-    fromType = OpenedArchetypeType::getAny(fromType->getCanonicalType(), cs.DC);
+    fromType = OpenedArchetypeType::getAny(fromType->getCanonicalType(),
+                                           cs.DC->getGenericSignatureOfContext());
 
     auto *archetypeVal = cs.cacheType(
         new (ctx) OpaqueValueExpr(expr->getSourceRange(), fromType));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10121,7 +10121,8 @@ ConstraintSystem::simplifyOpenedExistentialOfConstraint(
     }
     assert(instanceTy->isExistentialType());
     Type openedTy =
-        OpenedArchetypeType::get(instanceTy->getCanonicalType(), DC);
+        OpenedArchetypeType::get(instanceTy->getCanonicalType(),
+                                 DC->getGenericSignatureOfContext());
     if (isMetatype)
       openedTy = MetatypeType::get(openedTy, getASTContext());
     return matchTypes(type1, openedTy, ConstraintKind::Bind, subflags, locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10120,7 +10120,8 @@ ConstraintSystem::simplifyOpenedExistentialOfConstraint(
       instanceTy = metaTy->getExistentialInstanceType();
     }
     assert(instanceTy->isExistentialType());
-    Type openedTy = OpenedArchetypeType::get(instanceTy->getCanonicalType());
+    Type openedTy =
+        OpenedArchetypeType::get(instanceTy->getCanonicalType(), DC);
     if (isMetatype)
       openedTy = MetatypeType::get(openedTy, getASTContext());
     return matchTypes(type1, openedTy, ConstraintKind::Bind, subflags, locator);
@@ -11119,7 +11120,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (result2->hasTypeVariable() && !openedExistentials.empty()) {
       for (const auto &opened : openedExistentials) {
         result2 = typeEraseOpenedExistentialReference(
-            result2, opened.second->getExistentialType(), opened.first);
+            result2, opened.second->getExistentialType(), opened.first, DC);
       }
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -681,7 +681,7 @@ ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
     // For value members, look at their type signatures.
     if (auto valueMember = dyn_cast<ValueDecl>(member)) {
       const auto info = valueMember->findExistentialSelfReferences(
-          decl->getDeclaredInterfaceType(),
+          decl->getDeclaredInterfaceType(), decl,
           /*treatNonResultCovariantSelfAsInvariant=*/false);
       if (info.selfRef > TypePosition::Covariant || info.assocTypeRef) {
         return true;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1043,7 +1043,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
         // the default witness for 'Collection.Iterator', which is defined
         // as 'IndexingIterator<Self>'.
         const auto selfRefInfo = req->findExistentialSelfReferences(
-            proto->getDeclaredInterfaceType(),
+            proto->getDeclaredInterfaceType(), dc,
             /*treatNonResultCovariantSelfAsInvariant=*/true);
         if (!selfRefInfo.assocTypeRef) {
           covariantSelf = classDecl;
@@ -4065,7 +4065,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   // Check whether this requirement uses Self in a way that might
   // prevent conformance from succeeding.
   const auto selfRefInfo = requirement->findExistentialSelfReferences(
-      Proto->getDeclaredInterfaceType(),
+      Proto->getDeclaredInterfaceType(), DC,
       /*treatNonResultCovariantSelfAsInvariant=*/true);
 
   if (selfRefInfo.selfRef == TypePosition::Invariant) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2757,7 +2757,8 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
     } else {
       ty = GenericEnvironment::mapTypeIntoContext(
                  resolution.getGenericSignature().getGenericEnvironment(), ty);
-      ty = OpenedArchetypeType::get(ty->getCanonicalType(), getDeclContext(),
+      ty = OpenedArchetypeType::get(ty->getCanonicalType(),
+                                    resolution.getGenericSignature(),
                                     attrs.OpenedID);
     }
     attrs.clearAttribute(TAK_opened);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2757,7 +2757,8 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
     } else {
       ty = GenericEnvironment::mapTypeIntoContext(
                  resolution.getGenericSignature().getGenericEnvironment(), ty);
-      ty = OpenedArchetypeType::get(ty->getCanonicalType(), attrs.OpenedID);
+      ty = OpenedArchetypeType::get(ty->getCanonicalType(), getDeclContext(),
+                                    attrs.OpenedID);
     }
     attrs.clearAttribute(TAK_opened);
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5625,13 +5625,27 @@ public:
                                                 StringRef blobData) {
     TypeID existentialID;
     TypeID interfaceID;
+    GenericSignatureID sigID;
 
-    decls_block::OpenedArchetypeTypeLayout::readRecord(scratch,
-                                                       existentialID,
-                                                       interfaceID);
+    decls_block::OpenedArchetypeTypeLayout::readRecord(scratch, existentialID,
+                                                       interfaceID, sigID);
 
-    return OpenedArchetypeType::get(MF.getType(existentialID)->getCanonicalType(),
-                                    MF.getType(interfaceID));
+    auto sigOrError = MF.getGenericSignatureChecked(sigID);
+    if (!sigOrError)
+      return sigOrError.takeError();
+
+    auto interfaceTypeOrError = MF.getTypeChecked(interfaceID);
+    if (!interfaceTypeOrError)
+      return interfaceTypeOrError.takeError();
+
+    auto existentialTypeOrError = MF.getTypeChecked(existentialID);
+    if (!existentialTypeOrError)
+      return existentialTypeOrError.takeError();
+
+    auto env = GenericEnvironment::forOpenedExistential(
+        existentialTypeOrError.get(), sigOrError.get(), UUID::fromTime());
+    return env->mapTypeIntoContext(interfaceTypeOrError.get())
+        ->castTo<OpenedArchetypeType>();
   }
       
   Expected<Type> deserializeOpaqueArchetypeType(ArrayRef<uint64_t> scratch,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5642,7 +5642,7 @@ public:
     if (!existentialTypeOrError)
       return existentialTypeOrError.takeError();
 
-    auto env = GenericEnvironment::forOpenedExistential(
+    auto env = GenericEnvironment::forOpenedArchetypeSignature(
         existentialTypeOrError.get(), sigOrError.get(), UUID::fromTime());
     return env->mapTypeIntoContext(interfaceTypeOrError.get())
         ->castTo<OpenedArchetypeType>();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 676; // Add IsSPI to @available
+const uint16_t SWIFTMODULE_VERSION_MINOR = 677; // Opaque archetypes carry a generic signature
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1077,10 +1077,11 @@ namespace decls_block {
 
   using OpenedArchetypeTypeLayout = BCRecordLayout<
     OPENED_ARCHETYPE_TYPE,
-    TypeIDField,         // the existential type
-    TypeIDField          // the interface type
+    TypeIDField,            // the existential type
+    TypeIDField,            // the interface type
+    GenericSignatureIDField // generic signature
   >;
-  
+
   using OpaqueArchetypeTypeLayout = BCRecordLayout<
     OPAQUE_ARCHETYPE_TYPE,
     DeclIDField,           // the opaque type decl

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4523,11 +4523,14 @@ public:
 
   void visitOpenedArchetypeType(const OpenedArchetypeType *archetypeTy) {
     using namespace decls_block;
+    auto sig = archetypeTy->getGenericEnvironment()->getGenericSignature();
     auto existentialTypeID = S.addTypeRef(archetypeTy->getExistentialType());
     auto interfaceTypeID = S.addTypeRef(archetypeTy->getInterfaceType());
+    auto sigID = S.addGenericSignatureRef(sig);
     unsigned abbrCode = S.DeclTypeAbbrCodes[OpenedArchetypeTypeLayout::Code];
     OpenedArchetypeTypeLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                          existentialTypeID, interfaceTypeID);
+                                          existentialTypeID, interfaceTypeID,
+                                          sigID);
   }
 
   void

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -84,9 +84,9 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Invariant Self, since type signature contains an associated type:
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP16hasDefaultTakesTyy1TQzFTW : $@convention(witness_method: HasDefaults) <τ_0_0 where τ_0_0 : Barable> (@in_guaranteed UsesDefaults<τ_0_0>, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP16hasDefaultTakesTyy1TQzFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed UsesDefaults<τ_1_0>, @in_guaranteed τ_0_0) -> ()
 // CHECK: [[FN:%.*]] = function_ref @$s15witnesses_class11HasDefaultsPAAE16hasDefaultTakesTyy1TQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0.T, @in_guaranteed τ_0_0) -> ()
-// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>>(
+// CHECK: apply [[FN]]<τ_0_0>(
 // CHECK: return
 
 // Covariant Self:
@@ -98,9 +98,9 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Invariant Self, since type signature contains an associated type:
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0 where τ_0_0 : Barable><τ_1_0 where τ_1_0 : Fooable> (@in_guaranteed UsesDefaults<τ_0_0>, @guaranteed τ_1_0, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@in_guaranteed UsesDefaults<τ_1_0>, @guaranteed τ_2_0, @in_guaranteed τ_0_0) -> ()
 // CHECK: [[FN:%.*]] = function_ref @$s15witnesses_class11HasDefaultsPAAE23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@in_guaranteed τ_0_0.T, @guaranteed τ_1_0, @in_guaranteed τ_0_0) -> ()
-// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>, τ_1_0>(
+// CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
 // CHECK: return
 
 protocol ReturnsCovariantSelf {


### PR DESCRIPTION
Part 1 of a refactoring intended to ultimately support a more generic representation of opened archetypes for parameterized protocol types.

This does a massive amount of plumbing to ensure that the `DeclContext` corresponding to the actual usage of an existential being opened is provided to abstractions dealing with opened archetypes. This allows us to extract any outer generic parameters and prepend them to the archetype's generic signature. This ultimately means that the `Self` parameter of an opened archetype no longer corresponds to `tau_0_0`, but instead resides at `generic context depth + 1` for most types. Protocol extensions are the exception as the `Self` type appears as `tau_0_0` in context anyways. Callers should use the new  `OpenedArchetypeType::getSelfInterfaceTypeFromContext` instead of constructing generic parameter types for `Self`.