### PR TITLE
Check unavailable from async in interface file

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -75,5 +75,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_special
 LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes, 0, "Primary associated types", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync", true)
+
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3002,6 +3002,19 @@ static void suppressingFeaturePrimaryAssociatedTypes(PrintOptions &options,
   options.PrintPrimaryAssociatedTypes = originalPrintPrimaryAssociatedTypes;
 }
 
+static bool usesFeatureUnavailableFromAsync(Decl *decl) {
+  return decl->getAttrs().hasAttribute<UnavailableFromAsyncAttr>();
+}
+
+static void
+suppressingFeatureUnavailableFromAsync(PrintOptions &options,
+                                       llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  options.ExcludeAttrList.push_back(DAK_UnavailableFromAsync);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -177,4 +177,12 @@ public func unsafeInheritExecutor() async {}
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func multipleSuppressible<T>(value: T) async {}
 
+// CHECK:      #if compiler(>=5.3) && $UnavailableFromAsync
+// CHECK-NEXT: @_unavailableFromAsync(message: "Test") public func unavailableFromAsyncFunc()
+// CHECK-NEXT: #else
+// CHECK-NEXT: public func unavailableFromAsyncFunc()
+// CHECK-NEXT: #endif
+@_unavailableFromAsync(message: "Test")
+public func unavailableFromAsyncFunc() { }
+
 // CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable


### PR DESCRIPTION
We need to check the feature availability of `_unavailableFromAsync`
before it gets picked up in the swift interface file. This updates the
compiler to provide the necessary wrappings for that check.

This should fix the issue where older compilers complain when they import interfaces from the new compiler that have `_unavailableFromAsync`.

Fixes: rdar://89838531