### PR TITLE
Remove trailing double tabs

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -476,33 +476,33 @@ public struct AutoreleasingUnsafeMutablePointer<Pointee /* TODO : class */>
     }
   }
 
-  /// Explicit construction from an UnsafeMutablePointer.		
-  ///		
-  /// This is inherently unsafe; UnsafeMutablePointer assumes the		
-  /// referenced memory has +1 strong ownership semantics, whereas		
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.		
-  ///		
-  /// - Warning: Accessing `pointee` as a type that is unrelated to		
-  ///   the underlying memory's bound type is undefined.		
-  @_transparent		
-  public init<U>(@_nonEphemeral _ from: UnsafeMutablePointer<U>) {		
-   self._rawValue = from._rawValue		
-  }		
+  /// Explicit construction from an UnsafeMutablePointer.
+  ///
+  /// This is inherently unsafe; UnsafeMutablePointer assumes the
+  /// referenced memory has +1 strong ownership semantics, whereas
+  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
+  ///
+  /// - Warning: Accessing `pointee` as a type that is unrelated to
+  ///   the underlying memory's bound type is undefined.
+  @_transparent
+  public init<U>(@_nonEphemeral _ from: UnsafeMutablePointer<U>) {
+   self._rawValue = from._rawValue
+  }
 
-  /// Explicit construction from an UnsafeMutablePointer.		
-  ///		
-  /// Returns nil if `from` is nil.		
-  ///		
-  /// This is inherently unsafe; UnsafeMutablePointer assumes the		
-  /// referenced memory has +1 strong ownership semantics, whereas		
-  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.		
-  ///		
-  /// - Warning: Accessing `pointee` as a type that is unrelated to		
-  ///   the underlying memory's bound type is undefined.		
-  @_transparent		
+  /// Explicit construction from an UnsafeMutablePointer.
+  ///
+  /// Returns nil if `from` is nil.
+  ///
+  /// This is inherently unsafe; UnsafeMutablePointer assumes the
+  /// referenced memory has +1 strong ownership semantics, whereas
+  /// AutoreleasingUnsafeMutablePointer implies +0 semantics.
+  ///
+  /// - Warning: Accessing `pointee` as a type that is unrelated to
+  ///   the underlying memory's bound type is undefined.
+  @_transparent
   public init?<U>(@_nonEphemeral _ from: UnsafeMutablePointer<U>?) {
-   guard let unwrapped = from else { return nil }		
-   self.init(unwrapped)		
+   guard let unwrapped = from else { return nil }
+   self.init(unwrapped)
   }
      
   /// Explicit construction from a UnsafePointer.

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -13,20 +13,20 @@
 public protocol LazyCollectionProtocol: Collection, LazySequenceProtocol 
 where Elements: Collection {	}
 
-extension LazyCollectionProtocol {		
-   // Lazy things are already lazy		
-   @inlinable // protocol-only		
-   public var lazy: LazyCollection<Elements> {		
-     return elements.lazy		
-   }		
- }		
-		
- extension LazyCollectionProtocol where Elements: LazyCollectionProtocol {		
-   // Lazy things are already lazy		
-   @inlinable // protocol-only		
-   public var lazy: Elements {		
-     return elements		
-   }		
+extension LazyCollectionProtocol {
+   // Lazy things are already lazy
+   @inlinable // protocol-only
+   public var lazy: LazyCollection<Elements> {
+     return elements.lazy
+   }
+ }
+
+ extension LazyCollectionProtocol where Elements: LazyCollectionProtocol {
+   // Lazy things are already lazy
+   @inlinable // protocol-only
+   public var lazy: Elements {
+     return elements
+   }
  }
 
 /// A collection containing the same elements as a `Base` collection,

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -583,25 +583,25 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     self.init(mutating: unwrapped)
   }
   
-  /// Creates an immutable typed pointer referencing the same memory as the		
-  /// given mutable pointer.		
-  ///		
-  /// - Parameter other: The pointer to convert.		
-  @_transparent		
+  /// Creates an immutable typed pointer referencing the same memory as the
+  /// given mutable pointer.
+  ///
+  /// - Parameter other: The pointer to convert.
+  @_transparent
   public init(@_nonEphemeral _ other: UnsafeMutablePointer<Pointee>) {
-   self._rawValue = other._rawValue		
-  }		
+   self._rawValue = other._rawValue
+  }
 
-  /// Creates an immutable typed pointer referencing the same memory as the		
-  /// given mutable pointer.		
-  ///		
-  /// - Parameter other: The pointer to convert. If `other` is `nil`, the		
-  ///   result is `nil`.		
-  @_transparent		
+  /// Creates an immutable typed pointer referencing the same memory as the
+  /// given mutable pointer.
+  ///
+  /// - Parameter other: The pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
+  @_transparent
   public init?(@_nonEphemeral _ other: UnsafeMutablePointer<Pointee>?) {
-   guard let unwrapped = other else { return nil }		
-   self.init(unwrapped)		
-  }		
+   guard let unwrapped = other else { return nil }
+   self.init(unwrapped)
+  }
   
 
   /// Allocates uninitialized memory for the specified number of instances of

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -235,31 +235,31 @@ public struct UnsafeRawPointer: _Pointer {
     _rawValue = unwrapped._rawValue
   }
 
-  /// Creates a new raw pointer from the given typed pointer.		
-  ///		
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`		
-  /// instance. This initializer creates a new pointer to the same address as		
-  /// `other` and performs no allocation or copying.		
-  ///		
-  /// - Parameter other: The typed pointer to convert.		
-  @_transparent		
+  /// Creates a new raw pointer from the given typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert.
+  @_transparent
   public init<T>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
-   _rawValue = other._rawValue		
-  }		
+   _rawValue = other._rawValue
+  }
 
-  /// Creates a new raw pointer from the given typed pointer.		
-  ///		
-  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`		
-  /// instance. This initializer creates a new pointer to the same address as		
-  /// `other` and performs no allocation or copying.		
-  ///		
-  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the		
-  ///   result is `nil`.		
-  @_transparent		
+  /// Creates a new raw pointer from the given typed pointer.
+  ///
+  /// Use this initializer to explicitly convert `other` to an `UnsafeRawPointer`
+  /// instance. This initializer creates a new pointer to the same address as
+  /// `other` and performs no allocation or copying.
+  ///
+  /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
+  ///   result is `nil`.
+  @_transparent
   public init?<T>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
-   guard let unwrapped = other else { return nil }		
-   _rawValue = unwrapped._rawValue		
-  }		
+   guard let unwrapped = other else { return nil }
+   _rawValue = unwrapped._rawValue
+  }
 
   /// Deallocates the previously allocated memory block referenced by this pointer.
   ///


### PR DESCRIPTION
Fix lines that ended with two horizontal tabs by removing that trailing whitespace.