### PR TITLE
[SourceKit] Report comment tags in 'indexsource' request

### DIFF
--- a/test/SourceKit/Indexing/index_commenttag.swift
+++ b/test/SourceKit/Indexing/index_commenttag.swift
@@ -1,0 +1,26 @@
+// RUN: %sourcekitd-test -req=index %s -- %s | %FileCheck %s
+
+
+/// - Tag: SomeTag
+/// - Tag: Other
+func testFunc() {}
+
+// CHECK-LABEL: key.entities: [
+
+// CHECK:     {
+// CHECK-DAG:   key.kind: source.lang.swift.commenttag
+// CHECK-DAG:   key.usr: "t:SomeTag"
+// CHECK:     }
+
+// CHECK:     {
+// CHECK-DAG:   key.kind: source.lang.swift.commenttag
+// CHECK-DAG:   key.usr: "t:Other"
+// CHECK:     }
+
+// CHECK:     {
+// CHECK-DAG:   key.kind: source.lang.swift.decl.function.free
+// CHECK-DAG:   key.name: "testFunc()"
+// CHECK-DAG:   key.effective_access: source.decl.effective_access.internal
+// CHECK:     }
+
+// CHECK: ]

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -131,7 +131,7 @@ private:
     info.IsImplicit = symbol.roles & (unsigned)SymbolRole::Implicit;
     info.IsTestCandidate = symbol.symInfo.Properties & SymbolProperty::UnitTest;
     std::vector<UIdent> uidAttrs;
-    if (!isRef) {
+    if (!isRef && symbol.decl) {
       uidAttrs = getDeclAttributeUIDs(symbol.decl);
       info.Attrs = uidAttrs;
       if (auto *VD = dyn_cast<ValueDecl>(symbol.decl)) {
@@ -194,7 +194,7 @@ private:
     info.IsDynamic = relation.roles & (unsigned)SymbolRole::Dynamic;
     info.IsTestCandidate = relation.symInfo.Properties & SymbolProperty::UnitTest;
     std::vector<UIdent> uidAttrs;
-    if (!isRef) {
+    if (!isRef && relation.decl) {
       uidAttrs = getDeclAttributeUIDs(relation.decl);
       info.Attrs = uidAttrs;
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -721,9 +721,12 @@ UIdent SwiftLangSupport::getUIDForSymbol(SymbolInfo sym, bool isRef) {
   case SymbolKind::Module:
     return KindRefModule;
 
+  case SymbolKind::CommentTag:
+    return KindCommentTag;
+
   default:
     // TODO: reconsider whether having a default case is a good idea.
-    return UIdent();
+    llvm_unreachable("unhandled symbol kind Swift doesn't use");
   }
 
 #undef SIMPLE_CASE

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -371,6 +371,7 @@ UID_KINDS = [
     KIND('DeclGenericTypeParam', 'source.lang.swift.decl.generic_type_param'),
     KIND('RefGenericTypeParam', 'source.lang.swift.ref.generic_type_param'),
     KIND('RefModule', 'source.lang.swift.ref.module'),
+    KIND('CommentTag', 'source.lang.swift.commenttag'),
     KIND('StmtForEach', 'source.lang.swift.stmt.foreach'),
     KIND('StmtFor', 'source.lang.swift.stmt.for'),
     KIND('StmtWhile', 'source.lang.swift.stmt.while'),


### PR DESCRIPTION
Comment tags weren't handled at all in SourceKit's `request.indexsource` request.

rdar://88728047 https://bugs.swift.org/browse/SR-15845
