### PR TITLE
NFC: Fix a number of warnings emitted when building swift-frontend

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2244,7 +2244,6 @@ struct ConstExprInfo {
 
 class ConstExtractor: public ASTWalker {
   SDKContext &SCtx;
-  ASTContext &Ctx;
   SourceManager &SM;
   std::vector<ConstExprInfo> allConsts;
 
@@ -2328,7 +2327,7 @@ class ConstExtractor: public ASTWalker {
     return { true, E };
   }
 public:
-  ConstExtractor(SDKContext &SCtx, ASTContext &Ctx): SCtx(SCtx), Ctx(Ctx),
+  ConstExtractor(SDKContext &SCtx, ASTContext &Ctx): SCtx(SCtx),
     SM(Ctx.SourceMgr) {}
   void extract(ModuleDecl *MD) { MD->walk(*this); }
   std::vector<ConstExprInfo> &getAllConstValues() { return allConsts; }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3330,7 +3330,6 @@ Type GenericSignatureBuilder::getCanonicalTypeParameter(Type type) {
   Type currentType = genericParamType;
   SmallVector<AssociatedTypeDecl *, 4> path(initialPath.getPath().begin(),
                                             initialPath.getPath().end());
-  bool simplified = false;
   do {
     CanType currentAnchor = currentType->getCanonicalType();
     if (auto rootNode = Impl->getRewriteTreeRootIfPresent(currentAnchor)) {
@@ -3366,7 +3365,6 @@ Type GenericSignatureBuilder::getCanonicalTypeParameter(Type type) {
         }
 
         // Move back to the beginning; we may have opened up other rewrites.
-        simplified = true;
         startIndex = 0;
         currentType = genericParamType;
         continue;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2174,7 +2174,6 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
                                  DeclContext *dc) {
   DirectlyReferencedTypeDecls current;
 
-  bool firstComponent = true;
   for (const auto &component : ident->getComponentRange()) {
     // If we already set a declaration, use it.
     if (auto typeDecl = component->getBoundDecl()) {
@@ -2194,7 +2193,6 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
       if (current.empty())
         return current;
 
-      firstComponent = false;
       continue;
     }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2259,8 +2259,9 @@ ClangImporter::Implementation::Implementation(
       IsReadingBridgingPCH(false),
       CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
       Walker(DiagnosticWalker(*this)),
+      BuffersForDiagnostics(ctx.SourceMgr),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
-      BuffersForDiagnostics(ctx.SourceMgr), platformAvailability(ctx.LangOpts),
+      platformAvailability(ctx.LangOpts),
       nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
       DWARFImporter(dwarfImporterDelegate) {}
@@ -4587,12 +4588,6 @@ synthesizeBaseClassFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
   casted->setType(baseStruct->getSelfInterfaceType());
   casted->setThrows(false);
 
-  // If the base class var has a clang decl, that means it's an access into a
-  // stored field. Otherwise, we're looking into another base class, so it's a
-  // another synthesized accessor.
-  AccessSemantics accessKind = baseClassVar->getClangDecl()
-                                   ? AccessSemantics::DirectToStorage
-                                   : AccessSemantics::DirectToImplementation;
   Expr *baseMember = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {
     auto paramDecl = getterDecl->getParameters()->get(0);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4454,8 +4454,6 @@ namespace {
       auto setterDecl = cast<AccessorDecl>(afd);
       auto setterImpl = static_cast<FuncDecl *>(context);
 
-      ASTContext &ctx = setterDecl->getASTContext();
-
       Expr *selfExpr = createSelfExpr(setterDecl);
       DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -429,8 +429,6 @@ namespace {
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
                           Size offset) const override {
-      auto &layout = ClangDecl->getASTContext().getASTRecordLayout(ClangDecl);
-
       forEachNonEmptyBase([&](clang::QualType type, clang::CharUnits offset,
                               clang::CharUnits) {
         lowering.addTypedData(type, offset);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -88,8 +88,8 @@ UniversalLinkageInfo::UniversalLinkageInfo(const llvm::Triple &triple,
                                            bool forcePublicDecls,
                                            bool isStaticLibrary)
     : IsELFObject(triple.isOSBinFormatELF()),
-      UseDLLStorage(useDllStorage(triple)), HasMultipleIGMs(hasMultipleIGMs),
-      Internalize(isStaticLibrary), ForcePublicDecls(forcePublicDecls) {}
+      UseDLLStorage(useDllStorage(triple)), Internalize(isStaticLibrary),
+      HasMultipleIGMs(hasMultipleIGMs), ForcePublicDecls(forcePublicDecls) {}
 
 /// Mangle this entity into the given buffer.
 void LinkEntity::mangle(SmallVectorImpl<char> &buffer) const {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2924,7 +2924,6 @@ bool ConformanceChecker::checkActorIsolation(
   // Ensure that the witness is not actor-isolated in a manner that makes it
   // unsuitable as a witness.
   bool isCrossActor = false;
-  bool witnessIsUnsafe = false;
   DiagnosticBehavior behavior = SendableCheckContext(
       Conformance->getDeclContext()).defaultDiagnosticBehavior();
   Type witnessGlobalActor;
@@ -3146,7 +3145,6 @@ bool ConformanceChecker::checkActorIsolation(
   }
 
   case ActorIsolationRestriction::GlobalActorUnsafe:
-    witnessIsUnsafe = true;
     LLVM_FALLTHROUGH;
 
   case ActorIsolationRestriction::GlobalActor: {
@@ -3167,13 +3165,11 @@ bool ConformanceChecker::checkActorIsolation(
 
   // Check whether the requirement requires some particular actor isolation.
   Type requirementGlobalActor;
-  bool requirementIsUnsafe = false;
   switch (auto requirementIsolation = getActorIsolation(requirement)) {
   case ActorIsolation::ActorInstance:
     llvm_unreachable("There are not actor protocols");
 
   case ActorIsolation::GlobalActorUnsafe:
-    requirementIsUnsafe = true;
     LLVM_FALLTHROUGH;
 
   case ActorIsolation::GlobalActor: {

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -58,7 +58,7 @@ void swift_get_time(
 #else
 #error Missing platform continuous time definition
 #endif
-      break;
+      return;
     }
     case swift_clock_id_suspending: {
 #if defined(__linux__) && HAS_TIME
@@ -87,11 +87,10 @@ void swift_get_time(
 #else
 #error Missing platform suspending time definition
 #endif
-      break;
+      return;
     }
-    default:
-      abort();
   }
+  abort(); // Invalid clock_id
 }
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
@@ -118,7 +117,7 @@ switch (clock_id) {
 #else
 #error Missing platform continuous time definition
 #endif
-      break;
+      return;
     }
     case swift_clock_id_suspending: {
       struct timespec suspending;
@@ -136,9 +135,8 @@ switch (clock_id) {
 #else
 #error Missing platform suspending time definition
 #endif
-      break;
+      return;
     }
-   default:
-     abort();
   }
+  abort(); // Invalid clock_id
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -298,7 +298,7 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
   uint32_t Flags;
   dispatch_lock_t ExecutionLock;
-  uint32_t Unused;
+  LLVM_ATTRIBUTE_UNUSED uint32_t Unused = {};
 #elif SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_8_BYTES
   uint32_t Flags;
   dispatch_lock_t ExecutionLock;
@@ -306,7 +306,7 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
   uint32_t Flags;
 #else /* !SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_8_BYTES */
   uint32_t Flags;
-  uint32_t Unused;
+  LLVM_ATTRIBUTE_UNUSED uint32_t Unused = {};
 #endif
   TaskStatusRecord *Record;
 

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -71,11 +71,11 @@ private:
   /// The first slab.
   Slab *firstSlab;
 
+  /// True if the first slab is pre-allocated.
   uint32_t firstSlabIsPreallocated:1;
   /// Used for unit testing.
-  uint32_t numAllocatedSlabs:31 = 0;
+  uint32_t numAllocatedSlabs:31;
 
-  /// True if the first slab is pre-allocated.
 
   /// The minimal alignment of allocated memory.
   static constexpr size_t alignment = MaximumAlignment;
@@ -278,7 +278,9 @@ private:
 
 public:
   /// Construct a StackAllocator without a pre-allocated first slab.
-  StackAllocator() : firstSlab(nullptr), firstSlabIsPreallocated(false) { }
+  StackAllocator()
+      : firstSlab(nullptr), firstSlabIsPreallocated(false),
+        numAllocatedSlabs(0) {}
 
   /// Construct a StackAllocator with a pre-allocated first slab.
   StackAllocator(void *firstSlabBuffer, size_t bufferCapacity) {
@@ -289,6 +291,7 @@ public:
            "buffer for first slab too small");
     firstSlab = new (start) Slab(end - start - Slab::headerSize());
     firstSlabIsPreallocated = true;
+    numAllocatedSlabs = 0;
   }
 
   ~StackAllocator() {

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -661,13 +661,12 @@ void *swift::swift_bridgeObjectRetain_n(void *object, int n) {
   auto const objectRef = toPlainObject_unTagged_bridgeObject(object);
 
 #if SWIFT_OBJC_INTEROP
-  void *objc_ret = nullptr;
   if (!isNonNative_unTagged_bridgeObject(object)) {
     swift_retain_n(static_cast<HeapObject *>(objectRef), n);
     return object;
   }
   for (int i = 0;i < n; ++i)
-    objc_ret = objc_retain(static_cast<id>(objectRef));
+    objc_retain(static_cast<id>(objectRef));
   return object;
 #else
   swift_retain_n(static_cast<HeapObject *>(objectRef), n);
@@ -702,13 +701,12 @@ void *swift::swift_nonatomic_bridgeObjectRetain_n(void *object, int n) {
   auto const objectRef = toPlainObject_unTagged_bridgeObject(object);
 
 #if SWIFT_OBJC_INTEROP
-  void *objc_ret = nullptr;
   if (!isNonNative_unTagged_bridgeObject(object)) {
     swift_nonatomic_retain_n(static_cast<HeapObject *>(objectRef), n);
     return object;
   }
   for (int i = 0;i < n; ++i)
-    objc_ret = objc_retain(static_cast<id>(objectRef));
+    objc_retain(static_cast<id>(objectRef));
   return object;
 #else
   swift_nonatomic_retain_n(static_cast<HeapObject *>(objectRef), n);


### PR DESCRIPTION
Address a number of warnings that are emitted when building the `swift-frontend` binary; mostly unused variables, initialization order issues, and usage of C++20 extensions.