### PR TITLE
[SE-0338] Contexts with the same actor isolation never execute concurrently

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -109,6 +109,19 @@ public:
   
   bool isIndependent() const { return kind == Independent; }
 
+  bool isActorIsolated() const {
+    switch (getKind()) {
+    case ActorInstance:
+    case GlobalActor:
+    case GlobalActorUnsafe:
+      return true;
+
+    case Unspecified:
+    case Independent:
+      return false;
+    }
+  }
+
   NominalTypeDecl *getActor() const {
     assert(getKind() == ActorInstance);
     return actor;


### PR DESCRIPTION
With the clarification in SE-0338, revise the definition of "may
execute concurrently with" to always be false when we're accessing a
value from a same-actor-isolated inner context.

Fixes rdar://82004833.
