### PR TITLE
Fix await in effect with async

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -804,6 +804,8 @@ ERROR(expected_dynamic_func_attr,none,
 ERROR(async_after_throws,none,
       "%select{'async'|'reasync'}0 must precede %select{'throws'|'rethrows'}1",
       (bool, bool))
+ERROR(await_in_function_type,none,
+      "expected async specifier; did you mean 'async'?", ())
 ERROR(duplicate_effects_specifier,none,
       "'%0' has already been specified", (StringRef))
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -926,6 +926,7 @@ bool Parser::isEffectsSpecifier(const Token &T) {
   //       'parseEffectsSpecifiers()'.
 
   if (T.isContextualKeyword("async") ||
+      (T.isContextualKeyword("await") && !T.isAtStartOfLine()) ||
       T.isContextualKeyword("reasync"))
     return true;
 
@@ -981,6 +982,13 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
           *reasync = isReasync;
         asyncLoc = Tok.getLoc();
       }
+      consumeToken();
+      continue;
+    }
+    // diagnose 'await'
+    if (Tok.isContextualKeyword("await") && !Tok.isAtStartOfLine()) {
+      diagnose(Tok, diag::await_in_function_type)
+        .fixItReplace(Tok.getLoc(), "async");
       consumeToken();
       continue;
     }

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -160,3 +160,7 @@ func fixitTry0<T>(a: T) try where T:ExpressibleByStringLiteral {} // expected-er
 func fixitTry1<T>(a: T) try {} // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{25-28=throws}}
 func fixitTry2() try {} // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{18-21=throws}}
 let fixitTry3 : () try -> Int // expected-error{{expected throwing specifier; did you mean 'throws'?}} {{20-23=throws}}
+
+func fixitAwait0() await { } // expected-error{{expected async specifier; did you mean 'async'?}}{{20-25=async}}
+func fixitAwait1() await -> Int { } // expected-error{{expected async specifier; did you mean 'async'?}}{{20-25=async}}
+func fixitAwait2() throws await -> Int { } // expected-error{{expected async specifier; did you mean 'async'?}}{{27-32=async}}


### PR DESCRIPTION
Typing `func foo() await {` is something that folks do from time-to-time.
The old error message was unintuitive and suggested adding a semicolon
between the parenthesis and the await, then proceeded to complain about
the opening brace. This wasn't very clear about what the error actually
was.

Pulling this in line with `try`, `throw`, and `throws`, this patch
suggests replacing `await` with `async` when in the function effect
position, and provides a nice fix-it.

rdar://76923022