### PR TITLE
Revert "Cleaning up _runAsyncMain a bit"

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -695,7 +695,7 @@ SIMPLE_DECL_ATTR(_noAllocation, NoAllocation,
 SIMPLE_DECL_ATTR(preconcurrency, Preconcurrency,
   OnFunc | OnConstructor | OnProtocol | OnGenericType | OnVar | OnSubscript |
   OnEnumElement | OnImport |
-  ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIBreakingToRemove,
+  ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   125)
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(_const, CompileTimeConst,

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -834,9 +834,7 @@ internal func _asyncMainDrainQueue() -> Never
 internal func _getMainExecutor() -> Builtin.Executor
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
-@_predatesConcurrency
-internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> ()) {
+public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
   Task.detached {
     do {
 #if !os(Windows)


### PR DESCRIPTION
Reverts apple/swift#40661

This caused `api-digester/stability-concurrency-abi.test` to start failing on CI https://ci.swift.org/job/oss-swift-pr-test-macoss/139/. Looks like a conflict with https://github.com/apple/swift/pull/41253.