### PR TITLE
Implement Swift version of SPI_AVAILABLE as @_spi_available

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -830,3 +830,10 @@ the compiler.
 
 This `async` function uses the pre-SE-0338 semantics of unsafely inheriting the caller's executor.  This is an underscored feature because the right way of inheriting an executor is to pass in the required executor and switch to it.  Unfortunately, there are functions in the standard library which need to inherit their caller's executor but cannot change their ABI because they were not defined as `@_alwaysEmitIntoClient` in the initial release.
 
+## `@_spi_available(platform, version)`
+
+Like `@available`, this attribute indicates a decl is available only as an SPI.
+This implies several behavioral changes comparing to regular `@available`:
+1. Type checker diagnoses when a client accidently exposes such a symbol in library APIs.
+2. When emitting public interfaces, `@_spi_available` is printed as `@available(platform, unavailable)`.
+3. ClangImporter imports ObjC macros `SPI_AVAILABLE` and `__SPI_AVAILABLE` to this attribute.

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -632,14 +632,16 @@ public:
                    const llvm::VersionTuple &Obsoleted,
                    SourceRange ObsoletedRange,
                    PlatformAgnosticAvailabilityKind PlatformAgnostic,
-                   bool Implicit)
+                   bool Implicit,
+                   bool IsSPI)
     : DeclAttribute(DAK_Available, AtLoc, Range, Implicit),
       Message(Message), Rename(Rename), RenameDecl(RenameDecl),
       INIT_VER_TUPLE(Introduced), IntroducedRange(IntroducedRange),
       INIT_VER_TUPLE(Deprecated), DeprecatedRange(DeprecatedRange),
       INIT_VER_TUPLE(Obsoleted), ObsoletedRange(ObsoletedRange),
       PlatformAgnostic(PlatformAgnostic),
-      Platform(Platform)
+      Platform(Platform),
+      IsSPI(IsSPI)
   {}
 
 #undef INIT_VER_TUPLE
@@ -684,6 +686,9 @@ public:
 
   /// The platform of the availability.
   const PlatformKind Platform;
+
+  /// Whether this is available as SPI.
+  const bool IsSPI;
 
   /// Whether this is a language-version-specific entity.
   bool isLanguageVersionSpecific() const;

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -209,9 +209,12 @@ public:
 /// [lattice]: http://mathworld.wolfram.com/Lattice.html
 class AvailabilityContext {
   VersionRange OSVersion;
+  llvm::Optional<bool> SPI;
 public:
   /// Creates a context that requires certain versions of the target OS.
-  explicit AvailabilityContext(VersionRange OSVersion) : OSVersion(OSVersion) {}
+  explicit AvailabilityContext(VersionRange OSVersion,
+                               llvm::Optional<bool> SPI = llvm::None)
+    : OSVersion(OSVersion), SPI(SPI) {}
 
   /// Creates a context that imposes the constraints of the ASTContext's
   /// deployment target.
@@ -290,6 +293,10 @@ public:
   /// multiple `#available` checks.
   void unionWith(AvailabilityContext other) {
     OSVersion.unionWith(other.getOSVersion());
+  }
+
+  bool isAvailableAsSPI() const {
+    return SPI && *SPI;
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1030,6 +1030,8 @@ public:
   // an @_spi context.
   bool isSPI() const;
 
+  bool isAvailableAsSPI() const;
+
   // List the SPI groups declared with @_spi or inherited by this decl.
   //
   // SPI groups are inherited from the parent contexts only if the local decl

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1542,6 +1542,9 @@ ERROR(optional_attribute_initializer,none,
 ERROR(unavailable_method_non_objc_protocol,none,
       "protocol members can only be marked unavailable in an @objc protocol",
       ())
+ERROR(spi_available_malformed,none,
+      "SPI available only supports introducing version on specific platform",
+      ())
 ERROR(missing_in_class_init_1,none,
       "stored property %0 requires an initial value%select{| or should be "
       "@NSManaged}1", (Identifier, bool))

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -64,6 +64,10 @@ constexpr static const StringLiteral BUILTIN_TYPE_NAME_PREFIX = "Builtin.";
 constexpr static const StringLiteral CLANG_MODULE_DEFUALT_SPI_GROUP_NAME =
   "OBJC_DEFAULT_SPI_GROUP";
 
+/// The attribute name for @_spi_available
+constexpr static const StringLiteral SPI_AVAILABLE_ATTRNAME =
+  "_spi_available";
+
 /// A composition class containing a StringLiteral for the names of
 /// Swift builtins. The reason we use this is to ensure that we when
 /// necessary slice off the "Builtin." prefix from these names in a

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/QuotedString.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -126,7 +127,7 @@ DeclAttrKind DeclAttribute::getAttrKindFromString(StringRef Str) {
 #define DECL_ATTR(X, CLASS, ...) .Case(#X, DAK_##CLASS)
 #define DECL_ATTR_ALIAS(X, CLASS) .Case(#X, DAK_##CLASS)
 #include "swift/AST/Attr.def"
-  .Case("_spi_available", DAK_Available)
+  .Case(SPI_AVAILABLE_ATTRNAME, DAK_Available)
   .Default(DAK_Count);
 }
 
@@ -982,7 +983,12 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       Printer << ", unavailable)";
       break;
     }
-    Printer.printAttrName(Attr->IsSPI ? "@_spi_available": "@available");
+    if (Attr->IsSPI) {
+      std::string atSPI = (llvm::Twine("@") + SPI_AVAILABLE_ATTRNAME).str();
+      Printer.printAttrName(atSPI);
+    } else {
+      Printer.printAttrName("@available");
+    }
     Printer << "(";
     printAvailableAttr(Attr, Printer, Options);
     Printer << ")";

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -371,6 +371,9 @@ static bool isShortAvailable(const DeclAttribute *DA) {
   if (!AvailAttr)
     return false;
 
+  if (AvailAttr->IsSPI)
+    return false;
+
   if (!AvailAttr->Introduced.hasValue())
     return false;
 
@@ -969,9 +972,18 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   }
 
   case DAK_Available: {
-    Printer.printAttrName("@available");
-    Printer << "(";
     auto Attr = cast<AvailableAttr>(this);
+    if (!Options.PrintSPIs && Attr->IsSPI) {
+      assert(Attr->hasPlatform());
+      assert(Attr->Introduced.hasValue());
+      Printer.printAttrName("@available");
+      Printer << "(";
+      Printer << Attr->platformString();
+      Printer << ", unavailable)";
+      break;
+    }
+    Printer.printAttrName(Attr->IsSPI ? "@_spi_available": "@available");
+    Printer << "(";
     printAvailableAttr(Attr, Printer, Options);
     Printer << ")";
     break;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -126,6 +126,7 @@ DeclAttrKind DeclAttribute::getAttrKindFromString(StringRef Str) {
 #define DECL_ATTR(X, CLASS, ...) .Case(#X, DAK_##CLASS)
 #define DECL_ATTR_ALIAS(X, CLASS) .Case(#X, DAK_##CLASS)
 #include "swift/AST/Attr.def"
+  .Case("_spi_available", DAK_Available)
   .Default(DAK_Count);
 }
 
@@ -1599,7 +1600,7 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
     NoVersion, SourceRange(),
     NoVersion, SourceRange(),
     Obsoleted, SourceRange(),
-    Kind, /* isImplicit */ false);
+    Kind, /* isImplicit */ false, /*SPI*/false);
 }
 
 AvailableAttr *AvailableAttr::createForAlternative(
@@ -1610,7 +1611,7 @@ AvailableAttr *AvailableAttr::createForAlternative(
     NoVersion, SourceRange(),
     NoVersion, SourceRange(),
     NoVersion, SourceRange(),
-    PlatformAgnosticAvailabilityKind::None, /*Implicit=*/true);
+    PlatformAgnosticAvailabilityKind::None, /*Implicit=*/true, /*SPI*/false);
 }
 
 bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
@@ -1628,7 +1629,8 @@ AvailableAttr *AvailableAttr::clone(ASTContext &C, bool implicit) const {
                                Obsoleted ? *Obsoleted : llvm::VersionTuple(),
                                implicit ? SourceRange() : ObsoletedRange,
                                PlatformAgnostic,
-                               implicit);
+                               implicit,
+                               IsSPI);
 }
 
 Optional<OriginallyDefinedInAttr::ActiveVersion>

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -573,7 +573,8 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
                 Deprecated.Version, Deprecated.Range,
                 Obsoleted.Version, Obsoleted.Range,
                 PlatformAgnostic,
-                /*Implicit=*/false);
+                /*Implicit=*/false,
+                AttrName == "_spi_available");
   return makeParserResult(Attr);
 
 }
@@ -858,7 +859,8 @@ bool Parser::parseAvailability(
           /*DeprecatedRange=*/SourceRange(),
           /*Obsoleted=*/llvm::VersionTuple(),
           /*ObsoletedRange=*/SourceRange(), PlatformAgnostic,
-          /*Implicit=*/false));
+          /*Implicit=*/false,
+          AttrName == "_spi_available"));
     }
 
     return true;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -21,6 +21,7 @@
 #include "swift/Parse/SyntaxParsingContext.h"
 #include "swift/Syntax/SyntaxKind.h"
 #include "swift/Subsystems.h"
+#include "swift/Strings.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/GenericParamList.h"
@@ -574,7 +575,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
                 Obsoleted.Version, Obsoleted.Range,
                 PlatformAgnostic,
                 /*Implicit=*/false,
-                AttrName == "_spi_available");
+                AttrName == SPI_AVAILABLE_ATTRNAME);
   return makeParserResult(Attr);
 
 }
@@ -860,7 +861,7 @@ bool Parser::parseAvailability(
           /*Obsoleted=*/llvm::VersionTuple(),
           /*ObsoletedRange=*/SourceRange(), PlatformAgnostic,
           /*Implicit=*/false,
-          AttrName == "_spi_available"));
+          AttrName == SPI_AVAILABLE_ATTRNAME));
     }
 
     return true;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1545,7 +1545,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
     }
     // Implementation-only imported, cannot be reexported.
     return DisallowedOriginKind::ImplementationOnly;
-  } else if (decl->isSPI() && !where.isSPI()) {
+  } else if ((decl->isSPI() || decl->isAvailableAsSPI()) && !where.isSPI()) {
     // SPI can only be exported in SPI.
     return where.getDeclContext()->getParentModule() == M ?
       DisallowedOriginKind::SPILocal :

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1611,6 +1611,13 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
   if (Ctx.LangOpts.DisableAvailabilityChecking)
     return;
 
+  while (attr->IsSPI) {
+    if (attr->hasPlatform() && attr->Introduced.hasValue())
+      break;
+    diagnoseAndRemoveAttr(attr, diag::spi_available_malformed);
+    break;
+  }
+
   if (auto *PD = dyn_cast<ProtocolDecl>(D->getDeclContext())) {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (VD->isProtocolRequirement()) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4344,6 +4344,7 @@ ProtocolConformance *GetImplicitSendableRequest::evaluate(
                                           NoVersion, SourceRange(),
                                           NoVersion, SourceRange(),
                                           PlatformAgnosticAvailabilityKind::Unavailable,
+                                          false,
                                           false);
 
       // Conformance availability is currently tied to the declaring extension.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4362,6 +4362,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   bool isUnavailable;
   bool isDeprecated;
   bool isPackageDescriptionVersionSpecific;
+  bool isSPI;
   DEF_VER_TUPLE_PIECES(Introduced);
   DEF_VER_TUPLE_PIECES(Deprecated);
   DEF_VER_TUPLE_PIECES(Obsoleted);
@@ -4371,7 +4372,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   // Decode the record, pulling the version tuple information.
   serialization::decls_block::AvailableDeclAttrLayout::readRecord(
       scratch, isImplicit, isUnavailable, isDeprecated,
-      isPackageDescriptionVersionSpecific, LIST_VER_TUPLE_PIECES(Introduced),
+      isPackageDescriptionVersionSpecific, isSPI, LIST_VER_TUPLE_PIECES(Introduced),
       LIST_VER_TUPLE_PIECES(Deprecated), LIST_VER_TUPLE_PIECES(Obsoleted),
       platform, renameDeclID, messageSize, renameSize);
 
@@ -4406,7 +4407,7 @@ DeclDeserializer::readAvailable_DECL_ATTR(SmallVectorImpl<uint64_t> &scratch,
   auto attr = new (ctx) AvailableAttr(
       SourceLoc(), SourceRange(), (PlatformKind)platform, message, rename,
       renameDecl, Introduced, SourceRange(), Deprecated, SourceRange(),
-      Obsoleted, SourceRange(), platformAgnostic, isImplicit);
+      Obsoleted, SourceRange(), platformAgnostic, isImplicit, isSPI);
   return attr;
 }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 675; // primary associated types
+const uint16_t SWIFTMODULE_VERSION_MINOR = 676; // Add IsSPI to @available
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1916,6 +1916,7 @@ namespace decls_block {
     BCFixed<1>, // is unconditionally unavailable?
     BCFixed<1>, // is unconditionally deprecated?
     BCFixed<1>, // is this PackageDescription version-specific kind?
+    BCFixed<1>, // is SPI?
     BC_AVAIL_TUPLE, // Introduced
     BC_AVAIL_TUPLE, // Deprecated
     BC_AVAIL_TUPLE, // Obsoleted

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2581,6 +2581,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           theAttr->isUnconditionallyUnavailable(),
           theAttr->isUnconditionallyDeprecated(),
           theAttr->isPackageDescriptionVersionSpecific(),
+          theAttr->IsSPI,
           LIST_VER_TUPLE_PIECES(Introduced),
           LIST_VER_TUPLE_PIECES(Deprecated),
           LIST_VER_TUPLE_PIECES(Obsoleted),

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -1,6 +1,6 @@
 // REQUIRES: OS=macosx
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -enable-clang-spi -verify -DNOT_UNDERLYING
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -module-name SPIContainer -import-underlying-module -enable-clang-spi -verify
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -verify -DNOT_UNDERLYING
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -module-name SPIContainer -import-underlying-module -verify
 
 #if NOT_UNDERLYING
 import SPIContainer

--- a/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=macosx
-// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/frameworks/SPIContainer.framework/Headers/SPIContainer.h -enable-clang-spi -verify
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/frameworks/SPIContainer.framework/Headers/SPIContainer.h -verify
 
 
 @_spi(a) public let a: SPIInterface1

--- a/test/ClangImporter/availability_spi_transitive.swift
+++ b/test/ClangImporter/availability_spi_transitive.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=macosx
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -enable-clang-spi -verify
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -verify
 
 import SPIContainerImporter
 

--- a/test/ModuleInterface/spi-available.swift
+++ b/test/ModuleInterface/spi-available.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.public.swiftmodule -module-name Foo
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.private.swiftinterface -o %t/Foo.private.swiftmodule -module-name Foo
 
-@_spi_available(macOS 10.10, *)
+@_spi_available(macOS 10.10, tvOS 14.0, *)
 @available(iOS 8.0, *)
 public class SPIClass {}
 
@@ -12,4 +12,7 @@ public class SPIClass {}
 // RUN: %FileCheck %s -check-prefix CHECK-PRIVATE < %t/Foo.private.swiftinterface
 
 // CHECK-PUBLIC: @available(macOS, unavailable)
+// CHECK-PUBLIC: @available(tvOS, unavailable)
+
 // CHECK-PRIVATE: @_spi_available(macOS, introduced: 10.10)
+// CHECK-PRIVATE: @_spi_available(tvOS, introduced: 14.0)

--- a/test/ModuleInterface/spi-available.swift
+++ b/test/ModuleInterface/spi-available.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library %s -emit-module -library-level=api -emit-module-path %t/Foo.swiftmodule -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface -emit-private-module-interface-path %t/Foo.private.swiftinterface
+
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.public.swiftmodule -module-name Foo
+// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.private.swiftinterface -o %t/Foo.private.swiftmodule -module-name Foo
+
+@_spi_available(macOS 10.10, *)
+@available(iOS 8.0, *)
+public class SPIClass {}
+
+// RUN: %FileCheck %s -check-prefix CHECK-PUBLIC < %t/Foo.swiftinterface
+// RUN: %FileCheck %s -check-prefix CHECK-PRIVATE < %t/Foo.private.swiftinterface
+
+// CHECK-PUBLIC: @available(macOS, unavailable)
+// CHECK-PRIVATE: @_spi_available(macOS, introduced: 10.10)

--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -1,0 +1,13 @@
+// REQUIRES: VENDOR=apple
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx11.9
+
+@_spi_available(macOS 10.4, *)
+public class MacOSSPIClass { public init() {} }
+
+@_spi_available(iOS 8.0, *)
+public class iOSSPIClass { public init() {} }
+
+@inlinable public func foo() {
+	_ = MacOSSPIClass() // expected-error {{class 'MacOSSPIClass' cannot be used in an '@inlinable' function because it is SPI}}
+	_ = iOSSPIClass()
+}

--- a/test/Sema/spi-available-local.swift
+++ b/test/Sema/spi-available-local.swift
@@ -1,3 +1,4 @@
+// REQUIRES: OS=ios
 // RUN: %empty-directory(%t)
 // RUN: not %target-swift-frontend -target %target-cpu-apple-macosx11.9 -parse-as-library %s -typecheck -library-level=api >& %t/macos.txt
 // RUN: %FileCheck %s < %t/macos.txt

--- a/test/Sema/spi-available-local.swift
+++ b/test/Sema/spi-available-local.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx11.9 -parse-as-library %s -typecheck -library-level=api >& %t/macos.txt
+// RUN: %FileCheck %s < %t/macos.txt
+
+// RUN: %target-swift-frontend -target arm64-apple-ios13.0  -parse-as-library %s -typecheck -library-level=api
+
+@_spi_available(macOS 10.10, *)
+@available(iOS 8.0, *)
+public class SPIClass {}
+
+public func foo(_ c: SPIClass) {}
+
+// CHECK: cannot use class 'SPIClass' here; it is SPI

--- a/test/Sema/spi-available-swift-module.swift
+++ b/test/Sema/spi-available-swift-module.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/macos)
+// RUN: %empty-directory(%t/ios)
+
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx11.9 -parse-as-library %s -emit-module -library-level=api -emit-module-path %t/macos/Foo.swiftmodule -module-name Foo -DFoo
+// RUN: %target-swift-frontend -target arm64-apple-ios13.0 -parse-as-library %s -emit-module -library-level=api -emit-module-path %t/ios/Foo.swiftmodule -module-name Foo -DFoo
+
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx11.9 -parse-as-library %s -typecheck -library-level=api -I %t/macos >& %t/macos.txt
+// RUN: %FileCheck %s < %t/macos.txt
+
+// RUN: %target-swift-frontend -target arm64-apple-ios13.0 -parse-as-library %s -typecheck -library-level=api -I %t/ios
+
+#if Foo
+
+@_spi_available(macOS 10.10, *)
+@available(iOS 8.0, *)
+public class SPIClass {}
+
+#else
+
+import Foo
+public func foo(_ c: SPIClass) {}
+
+#endif
+
+// CHECK: cannot use class 'SPIClass' here; it is an SPI imported from 'Foo'

--- a/test/Sema/spi-available-swift-module.swift
+++ b/test/Sema/spi-available-swift-module.swift
@@ -1,3 +1,4 @@
+// REQUIRES: OS=ios
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/macos)
 // RUN: %empty-directory(%t/ios)

--- a/test/attr/spi_available.swift
+++ b/test/attr/spi_available.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+@_spi_available(*, deprecated, renamed: "another") // expected-error {{SPI available only supports introducing version on specific platform}}
+public class SPIClass1 {}
+
+@_spi_available(*, unavailable) // expected-error {{SPI available only supports introducing version on specific platform}}
+public class SPIClass2 {}
+
+@_spi_available(AlienPlatform 5.2, *) // expected-warning {{unrecognized platform name 'AlienPlatform'}}
+public class SPIClass3 {}


### PR DESCRIPTION
Like `@available`, this attribute indicates a decl is available only as an SPI.
This implies several behavioral changes comparing to regular @available:
1. Type checker diagnoses when a client accidentally exposes such a symbol in library APIs.
2. When emitting public interfaces, `@_spi_available` is printed as `@available(platform, unavailable)`.
3. ClangImporter imports ObjC macros `SPI_AVAILABLE` and `__SPI_AVAILABLE` to this attribute.