### PR TITLE
[Diagnostics] Print `any` in diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -142,7 +142,7 @@ ERROR(could_not_use_instance_member_on_type,none,
       "%select{| instance of nested}3 type %0",
       (Type, DeclNameRef, Type, bool))
 ERROR(could_not_use_member_on_existential,none,
-      "member %1 cannot be used on value of protocol type %0; consider using a"
+      "member %1 cannot be used on value of type %0; consider using a"
       " generic constraint instead",
       (Type, DeclNameRef))
 FIXIT(replace_with_type,"%0",(Type))
@@ -1945,9 +1945,8 @@ ERROR(type_cannot_conform_to_nsobject,none,
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
 ERROR(type_cannot_conform, none,
-      "%select{type %1|protocol %1 as a type}0 cannot conform to "
-      "%select{%3|the protocol itself}2",
-      (bool, Type, bool, Type))
+      "type %0 cannot conform to %1",
+      (Type, Type))
 NOTE(only_concrete_types_conform_to_protocols,none,
      "only concrete types such as structs, enums and classes can conform to protocols",
      ())
@@ -3589,7 +3588,7 @@ ERROR(construct_protocol_value,none,
       "value of type %0 is a protocol; it cannot be instantiated",
       (Type))
 ERROR(construct_protocol_by_name,none,
-      "protocol type %0 cannot be instantiated",
+      "type %0 cannot be instantiated",
       (Type))
 
 // Operators

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2454,8 +2454,8 @@ ERROR(protocol_composition_one_class,none,
       "contains class %1", (Type, Type))
 
 ERROR(requires_conformance_nonprotocol,none,
-      "type %0 constrained to non-protocol, non-class type '%1'",
-      (Type, StringRef))
+      "type %0 constrained to non-protocol, non-class type %1",
+      (Type, Type))
 NOTE(requires_conformance_nonprotocol_fixit,none,
      "use '%0 == %1' to require '%0' to be '%1'",
      (StringRef, StringRef))
@@ -2776,9 +2776,9 @@ WARNING(anyobject_class_inheritance_deprecated,Deprecation,
 ERROR(multiple_inheritance,none,
   "multiple inheritance from classes %0 and %1", (Type, Type))
 ERROR(inheritance_from_non_protocol_or_class,none,
-  "inheritance from non-protocol, non-class type '%0'", (StringRef))
+  "inheritance from non-protocol, non-class type %0", (Type))
 ERROR(inheritance_from_non_protocol,none,
-  "inheritance from non-protocol type '%0'", (StringRef))
+  "inheritance from non-protocol type %0", (Type))
 ERROR(inheritance_from_anyobject,none,
   "only protocols can inherit from 'AnyObject'", ())
 ERROR(inheritance_from_parameterized_protocol,none,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -548,6 +548,13 @@ struct PrintOptions {
     return result;
   }
 
+  /// The print options used for formatting diagnostic arguments.
+  static PrintOptions forDiagnosticArguments() {
+    PrintOptions result;
+    result.PrintExplicitAny = true;
+    return result;
+  }
+
   /// Retrieve the set of options suitable for diagnostics printing.
   static PrintOptions printForDiagnostics(AccessLevel accessFilter,
                                           bool printFullConvention) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5330,7 +5330,7 @@ class ExistentialType final : public TypeBase {
         ConstraintType(constraintType) {}
 
 public:
-  static Type get(Type constraint);
+  static Type get(Type constraint, bool forceExistential = false);
 
   Type getConstraintType() const { return ConstraintType; }
 
@@ -6663,9 +6663,9 @@ inline bool TypeBase::hasSimpleTypeRepr() const {
     return false;
 
   case TypeKind::Metatype:
-  case TypeKind::ExistentialMetatype:
     return !cast<const AnyMetatypeType>(this)->hasRepresentation();
 
+  case TypeKind::ExistentialMetatype:
   case TypeKind::Existential:
     return false;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4260,15 +4260,17 @@ ProtocolType::ProtocolType(ProtocolDecl *TheDecl, Type Parent,
                            RecursiveTypeProperties properties)
   : NominalType(TypeKind::Protocol, &Ctx, TheDecl, Parent, properties) { }
 
-Type ExistentialType::get(Type constraint) {
+Type ExistentialType::get(Type constraint, bool forceExistential) {
   auto &C = constraint->getASTContext();
-  // FIXME: Any and AnyObject don't yet use ExistentialType.
-  if (constraint->isAny() || constraint->isAnyObject())
-    return constraint;
+  if (!forceExistential) {
+    // FIXME: Any and AnyObject don't yet use ExistentialType.
+    if (constraint->isAny() || constraint->isAnyObject())
+      return constraint;
 
-  // ExistentialMetatypeType is already an existential type.
-  if (constraint->is<ExistentialMetatypeType>())
-    return constraint;
+    // ExistentialMetatypeType is already an existential type.
+    if (constraint->is<ExistentialMetatypeType>())
+      return constraint;
+  }
 
   assert(constraint->isConstraintType());
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5158,6 +5158,9 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     } else if (auto existential = dyn_cast<ExistentialType>(T.getPointer())) {
       if (!Options.PrintExplicitAny)
         return isSimpleUnderPrintOptions(existential->getConstraintType());
+    } else if (auto existential = dyn_cast<ExistentialMetatypeType>(T.getPointer())) {
+      if (!Options.PrintExplicitAny)
+        return isSimpleUnderPrintOptions(existential->getInstanceType());
     }
     return T->hasSimpleTypeRepr();
   }
@@ -5578,10 +5581,32 @@ public:
       }
     }
 
-    if (T->is<ExistentialMetatypeType>() && Options.PrintExplicitAny)
-      Printer << "any ";
+    Type instanceType = T->getInstanceType();
+    if (Options.PrintExplicitAny) {
+      if (T->is<ExistentialMetatypeType>()) {
+        Printer << "any ";
 
-    printWithParensIfNotSimple(T->getInstanceType());
+        // FIXME: We need to replace nested existential metatypes so that
+        // we don't print duplicate 'any'. This will be unnecessary once
+        // ExistentialMetatypeType is split into ExistentialType(MetatypeType).
+        instanceType = Type(instanceType).transform([](Type type) -> Type {
+          if (auto existential = type->getAs<ExistentialMetatypeType>())
+            return MetatypeType::get(existential->getInstanceType());
+
+          return type;
+        });
+      } else if (instanceType->isAny() || instanceType->isAnyObject()) {
+        // FIXME: 'any' is needed to distinguish between '(any Any).Type'
+        // and 'any Any.Type'. However, this combined with the above hack
+        // to replace nested existential metatypes with metatypes causes
+        // a bug in printing nested existential metatypes for Any and AnyObject,
+        // e.g. 'any (any Any).Type.Type'. This will be fixed by using
+        // ExistentialType for Any and AnyObject.
+        instanceType = ExistentialType::get(instanceType, /*forceExistential=*/true);
+      }
+    }
+
+    printWithParensIfNotSimple(instanceType);
 
     // We spell normal metatypes of existential types as .Protocol.
     if (isa<MetatypeType>(T) &&
@@ -6281,7 +6306,11 @@ public:
       if (printNamedOpaque())
         return;
 
-      visit(T->getExistentialType());
+      auto constraint = T->getExistentialType();
+      if (auto existential = constraint->getAs<ExistentialType>())
+        constraint = existential->getConstraintType();
+
+      visit(constraint);
       return;
     }
     case PrintOptions::OpaqueReturnTypePrintingMode::StableReference: {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -670,10 +670,8 @@ static void formatDiagnosticArgument(StringRef Modifier,
     Type type;
     bool needsQualification = false;
 
-    // TODO: We should use PrintOptions::printForDiagnostic here, or we should
-    // rename that method.
-    PrintOptions printOptions{};
-
+    // Compute the appropriate print options for this argument.
+    auto printOptions = PrintOptions::forDiagnosticArguments();
     if (Arg.getKind() == DiagnosticArgumentKind::Type) {
       type = Arg.getAsType()->getWithoutParens();
       if (type.isNull()) {

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -547,16 +547,8 @@ bool swift::rewriting::diagnoseRequirementErrors(
       if (subjectType->hasError() || constraint->hasError())
         break;
 
-      // FIXME: The constraint string is printed directly here because
-      // the current default is to not print `any` for existential
-      // types, but this error message is super confusing without `any`
-      // if the user wrote it explicitly.
-      PrintOptions options;
-      options.PrintExplicitAny = true;
-      auto constraintString = constraint.getString(options);
-
       ctx.Diags.diagnose(loc, diag::requires_conformance_nonprotocol,
-                         subjectType, constraintString);
+                         subjectType, constraint);
       diagnosedError = true;
 
       auto getNameWithoutSelf = [&](std::string subjectTypeName) {
@@ -570,10 +562,12 @@ bool swift::rewriting::diagnoseRequirementErrors(
       };
 
       if (allowConcreteGenericParams) {
-        auto subjectTypeName = subjectType.getString();
+        auto options = PrintOptions::forDiagnosticArguments();
+        auto subjectTypeName = subjectType.getString(options);
         auto subjectTypeNameWithoutSelf = getNameWithoutSelf(subjectTypeName);
         ctx.Diags.diagnose(loc, diag::requires_conformance_nonprotocol_fixit,
-                           subjectTypeNameWithoutSelf, constraintString)
+                           subjectTypeNameWithoutSelf,
+                           constraint.getString(options))
              .fixItReplace(loc, " == ");
       }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -568,10 +568,7 @@ bool MissingConformanceFailure::diagnoseTypeCannotConform(
     constraintType = existential->getConstraintType();
 
   emitDiagnostic(diag::type_cannot_conform,
-                 nonConformingType->isExistentialType(), 
-                 nonConformingType, 
-                 constraintType->isEqual(protocolType),
-                 protocolType);
+                 nonConformingType, protocolType);
 
   bool emittedSpecializedNote = false;
   if (auto protoType = protocolType->getAs<ProtocolType>()) {
@@ -2369,9 +2366,7 @@ bool ContextualFailure::diagnoseAsError() {
         if (auto existential = constraintType->getAs<ExistentialType>())
           constraintType = existential->getConstraintType();
 
-        emitDiagnostic(diag::type_cannot_conform,
-                       /*isExistentialType=*/true, fromType, 
-                       constraintType->isEqual(toType), toType);
+        emitDiagnostic(diag::type_cannot_conform, fromType, toType);
         emitDiagnostic(diag::only_concrete_types_conform_to_protocols);
         return true;
       }
@@ -3123,7 +3118,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
   // Emit a diagnostic to inform the user that they need to conform to the
   // missing protocols.
   auto conformanceDiag =
-      emitDiagnostic(diag::assign_protocol_conformance_fix_it, unwrappedToType,
+      emitDiagnostic(diag::assign_protocol_conformance_fix_it, constraint,
                      nominal->getDescriptiveKind(), fromType);
   if (nominal->getInherited().size() > 0) {
     auto lastInherited = nominal->getInherited().back().getLoc();
@@ -3231,7 +3226,7 @@ bool ContextualFailure::isIntegerToStringIndexConversion() const {
 Optional<Diag<Type, Type>>
 ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
                                     Type contextualType) {
-  auto forProtocol = contextualType->isExistentialType();
+  auto forProtocol = contextualType->isConstraintType();
   switch (context) {
   case CTP_Initialization: {
     if (contextualType->isAnyObject())

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -335,19 +335,11 @@ static void checkInheritanceClause(
       }
     }
 
-    // FIXME: The inherited type is printed directly here because
-    // the current default is to not print `any` for existential
-    // types, but this error message is super confusing without `any`
-    // if the user wrote it explicitly.
-    PrintOptions options;
-    options.PrintExplicitAny = true;
-    auto inheritedTyString = inheritedTy.getString(options);
-
     // We can't inherit from a non-class, non-protocol type.
     decl->diagnose(canHaveSuperclass
                    ? diag::inheritance_from_non_protocol_or_class
                    : diag::inheritance_from_non_protocol,
-                   inheritedTyString);
+                   inheritedTy);
     // FIXME: Note pointing to the declaration 'inheritedTy' references?
   }
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5371,9 +5371,8 @@ void swift::diagnoseConformanceFailure(Type T,
       Type constraintType = T;
       if (auto existential = T->getAs<ExistentialType>())
         constraintType = existential->getConstraintType();
-      diags.diagnose(ComplainLoc, diag::type_cannot_conform, true,
-                     T, constraintType->isEqual(Proto->getDeclaredInterfaceType()),
-                     Proto->getDeclaredInterfaceType());
+      diags.diagnose(ComplainLoc, diag::type_cannot_conform,
+                     T, Proto->getDeclaredInterfaceType());
       diags.diagnose(ComplainLoc,
                      diag::only_concrete_types_conform_to_protocols);
       return;

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -93,7 +93,7 @@ func invalidDiffWrtClass(_ x: Class) -> Class {
 }
 
 protocol Proto {}
-// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'Proto' does not conform to 'Differentiable'}}
+// expected-error @+1 {{can only differentiate functions with results that conform to 'Differentiable', but 'any Proto' does not conform to 'Differentiable'}}
 @differentiable(reverse, wrt: x)
 func invalidDiffWrtExistential(_ x: Proto) -> Proto {
   return x

--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -16,7 +16,7 @@ func test2(_ queue: DispatchQueue) {
 
   // Make sure the dispatch types are actually distinct types!
   let _ = queue as DispatchSource // expected-error {{cannot convert value of type 'DispatchQueue' to type 'DispatchSource' in coercion}}
-  let _ = base as DispatchSource // expected-error {{'NSObjectProtocol' is not convertible to 'DispatchSource'}}
+  let _ = base as DispatchSource // expected-error {{'any NSObjectProtocol' is not convertible to 'DispatchSource'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
 }
 

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -65,12 +65,12 @@ func testFoundationOverlay() {
 func testProtocolNamingConflict() {
   let a: ConflictingName1?
   var b: ConflictingName1Protocol?
-  b = a // expected-error {{cannot assign value of type 'ConflictingName1?' to type 'ConflictingName1Protocol?'}}
+  b = a // expected-error {{cannot assign value of type 'ConflictingName1?' to type '(any ConflictingName1Protocol)?'}}
   _ = b
 
   let c: ConflictingName2?
   var d: ConflictingName2Protocol?
-  d = c // expected-error {{cannot assign value of type 'ConflictingName2?' to type 'ConflictingName2Protocol?'}}
+  d = c // expected-error {{cannot assign value of type 'ConflictingName2?' to type '(any ConflictingName2Protocol)?'}}
   _ = d
 }
 

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -202,7 +202,7 @@ func checkHive(_ hive: Hive, b: Bee) {
 // Protocols
 func testProtocols(_ b: B, bp: BProto) {
   var bp2 : BProto = b
-  var b2 : B = bp // expected-error{{cannot convert value of type 'BProto' to specified type 'B'}}
+  var b2 : B = bp // expected-error{{cannot convert value of type 'any BProto' to specified type 'B'}}
   bp.method(1, with: 2.5 as Float)
   bp.method(1, withFoo: 2.5) // expected-error{{incorrect argument label in call (have '_:withFoo:', expected '_:with:')}}
   bp2 = b.getAsProto()
@@ -210,7 +210,7 @@ func testProtocols(_ b: B, bp: BProto) {
   var c1 : Cat1Proto = b
   var bcat1 = b.getAsProtoWithCat()!
   c1 = bcat1
-  bcat1 = c1 // expected-error{{value of type 'Cat1Proto' does not conform to 'BProto' in assignment}}
+  bcat1 = c1 // expected-error{{value of type 'any Cat1Proto' does not conform to 'BProto' in assignment}}
 }
 
 // Methods only defined in a protocol
@@ -469,10 +469,10 @@ func testProtocolMappingDifferentModules(_ obj: ObjCParseExtrasToo.ProtoOrClass,
 
   let _: ProtoOrClass? // expected-error{{'ProtoOrClass' is ambiguous for type lookup in this context}}
 
-  _ = ObjCParseExtrasToo.ClassInHelper() // expected-error{{'ClassInHelper' cannot be constructed because it has no accessible initializers}}
+  _ = ObjCParseExtrasToo.ClassInHelper() // expected-error{{'any ClassInHelper' cannot be constructed because it has no accessible initializers}}
   _ = ObjCParseExtrasToo.ProtoInHelper()
   _ = ObjCParseExtrasTooHelper.ClassInHelper()
-  _ = ObjCParseExtrasTooHelper.ProtoInHelper() // expected-error{{'ProtoInHelper' cannot be constructed because it has no accessible initializers}}
+  _ = ObjCParseExtrasTooHelper.ProtoInHelper() // expected-error{{'any ProtoInHelper' cannot be constructed because it has no accessible initializers}}
 }
 
 func testProtocolClassShadowing(_ obj: ClassInHelper, p: ProtoInHelper) {
@@ -556,8 +556,8 @@ func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
   _ = cell as NSCopying
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{value of type 'NSObject' does not conform to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') in coercion}} 
-  _ = plainCell as CopyableSomeCell // expected-error {{value of type 'SomeCell' does not conform to 'CopyableSomeCell' (aka 'SomeCell & NSCopying') in coercion}}
+  _ = plainObj as CopyableNSObject // expected-error {{cannot convert value of type 'NSObject' to type 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') in coercion}}
+  _ = plainCell as CopyableSomeCell // expected-error {{cannot convert value of type 'SomeCell' to type 'CopyableSomeCell' (aka 'SomeCell & NSCopying') in coercion}}
 }
 
 extension Printing {

--- a/test/ClangImporter/protocol_metatype_object_conversion.swift
+++ b/test/ClangImporter/protocol_metatype_object_conversion.swift
@@ -13,5 +13,5 @@ func takesProtocol(_ x: Protocol) {}
 
 takesProtocol(ObjCProto.self)
 takesProtocol(ObjCProto2.self)
-takesProtocol(NonObjCProto.self) // expected-error{{cannot convert value of type 'NonObjCProto.Protocol' to expected argument type 'Protocol'}}
-takesProtocol(TwoObjCProtos.self) // expected-error{{cannot convert value of type 'TwoObjCProtos.Protocol' (aka '(ObjCProto & ObjCProto2).Protocol') to expected argument type 'Protocol'}}
+takesProtocol(NonObjCProto.self) // expected-error{{cannot convert value of type '(any NonObjCProto).Type' to expected argument type 'Protocol'}}
+takesProtocol(TwoObjCProtos.self) // expected-error{{cannot convert value of type '(any TwoObjCProtos).Type' (aka '(ObjCProto & ObjCProto2).Protocol') to expected argument type 'Protocol'}}

--- a/test/Compatibility/attr_override.swift
+++ b/test/Compatibility/attr_override.swift
@@ -324,7 +324,7 @@ class MismatchOptional : MismatchOptionalBase {
 
   override func functionParam(x: @escaping (Int) -> Int) {} // expected-error {{cannot override instance method parameter of type '((Int) -> Int)?' with non-optional type '(Int) -> Int'}} {{34-34=(}} {{56-56=)?}}
   override func tupleParam(x: (Int, Int)) {} // expected-error {{cannot override instance method parameter of type '(Int, Int)?' with non-optional type '(Int, Int)'}} {{41-41=?}}
-  override func compositionParam(x: P1 & P2) {} // expected-error {{cannot override instance method parameter of type '(P1 & P2)?' with non-optional type 'P1 & P2'}} {{37-37=(}} {{44-44=)?}}
+  override func compositionParam(x: P1 & P2) {} // expected-error {{cannot override instance method parameter of type '(any P1 & P2)?' with non-optional type 'any P1 & P2'}} {{37-37=(}} {{44-44=)?}}
 
   override func nameAndTypeMismatch(_: Int) {}
   // expected-error@-1 {{argument labels for method 'nameAndTypeMismatch' do not match those of overridden method 'nameAndTypeMismatch(label:)'}} {{37-37=label }}

--- a/test/Compatibility/protocol_composition.swift
+++ b/test/Compatibility/protocol_composition.swift
@@ -33,7 +33,7 @@ typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1
 
 // BEGIN swift4.swift
 
-func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class type 'P2.Type?' cannot be used within a protocol-constrained type}}
+func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class type '(any P2.Type)?' cannot be used within a protocol-constrained type}}
   let _: (P1 & P2).Type? = x
   let _: (P1 & P2).Type = x!
 
@@ -42,8 +42,8 @@ func foo(x: P1 & Any & P2.Type?) { // expected-error {{non-protocol, non-class t
 }
 
 func bar() -> ((P1 & P2)?).Type {
-  let x = (P1 & P2?).self // expected-error {{non-protocol, non-class type 'P2?' cannot be used within a protocol-constrained type}}
+  let x = (P1 & P2?).self // expected-error {{non-protocol, non-class type '(any P2)?' cannot be used within a protocol-constrained type}}
   return x
 }
 
-typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
+typealias A1 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'any P1.Type' cannot be used within a protocol-constrained type}}

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -99,7 +99,7 @@ func test_nonsendableContinuation() async throws {
 
   let _: NotSendable = try await withUnsafeThrowingContinuation { continuation in
     Task {
-      continuation.resume(returning: NotSendable()) // expected-warning{{capture of 'continuation' with non-sendable type 'UnsafeContinuation<NotSendable, Error>' in a `@Sendable` closure}}
+      continuation.resume(returning: NotSendable()) // expected-warning{{capture of 'continuation' with non-sendable type 'UnsafeContinuation<NotSendable, any Error>' in a `@Sendable` closure}}
     }
   }
 }

--- a/test/Constraints/ErrorBridging.swift
+++ b/test/Constraints/ErrorBridging.swift
@@ -34,14 +34,14 @@ var ns4 = compo as NSError
 
 // NSError conversion must be explicit.
 // TODO: fixit to insert 'as NSError'
-ns4 = compo // expected-error{{cannot assign value of type 'HairyError & Runcible' to type 'NSError'}}
+ns4 = compo // expected-error{{cannot assign value of type 'any HairyError & Runcible' to type 'NSError'}}
 
 let e1 = ns1 as? FooError
 let e1fix = ns1 as FooError // expected-error {{'NSError' is not convertible to 'FooError'}}
 // expected-note@-1{{did you mean to use 'as!' to force downcast?}} {{17-19=as!}}
 
 let esub = ns1 as Error
-let esub2 = ns1 as? Error // expected-warning{{conditional cast from 'NSError' to 'Error' always succeeds}}
+let esub2 = ns1 as? Error // expected-warning{{conditional cast from 'NSError' to 'any Error' always succeeds}}
 
 // SR-1562 / rdar://problem/26370984
 enum MyError : Error {

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -219,10 +219,10 @@ func joinWithNil<T>(s: String, a: Any, t: T, m: T.Type, p: Proto1 & Proto2, arr:
   let _: Int = a16 // expected-error{{value of type '[T.Type?]'}}
   
   let a17 = [p, nil]
-  let _: Int = a17 // expected-error{{value of type '[(Proto1 & Proto2)?]'}}
+  let _: Int = a17 // expected-error{{value of type '[(any Proto1 & Proto2)?]'}}
   
   let a18 = [nil, p]
-  let _: Int = a18 // expected-error{{value of type '[(Proto1 & Proto2)?]'}}
+  let _: Int = a18 // expected-error{{value of type '[(any Proto1 & Proto2)?]'}}
   
   let a19 = [arr, nil]
   let _: Int = a19 // expected-error{{value of type '[[Int]?]'}}

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -53,7 +53,7 @@ slice[7] = f // expected-error{{cannot assign value of type 'Y' to subscript of 
 
 slice[7] = nil // expected-error{{'nil' cannot be assigned to subscript of type 'X'}}
 
-ps[7] = i // expected-error{{value of type 'X' does not conform to 'Z' in subscript assignment}}
+ps[7] = i // expected-error{{cannot assign value of type 'X' to subscript of type 'any Z'}}
 
 slice[7] = _ // expected-error{{'_' can only appear in a pattern or on the left side of an assignment}}
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -308,7 +308,7 @@ func rdar20029786(_ ns: NSString?) {
 
 // Make sure more complicated cast has correct parenthesization
 func castMoreComplicated(anInt: Int?) {
-  let _: (NSObject & NSCopying)? = anInt // expected-error{{cannot convert value of type 'Int?' to specified type '(NSObject & NSCopying)?'}}{{41-41= as (NSObject & NSCopying)?}}
+  let _: (NSObject & NSCopying)? = anInt // expected-error{{cannot convert value of type 'Int?' to specified type '(any NSObject & NSCopying)?'}}{{41-41= as (any NSObject & NSCopying)?}}
 }
 
 
@@ -401,9 +401,9 @@ func SR15161_as(e: Error?) {
 }
 
 func SR15161_is(e: Error?) {
-  _ = e is NSError // expected-warning{{checking a value with optional type 'Error?' against type 'NSError' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
+  _ = e is NSError // expected-warning{{checking a value with optional type '(any Error)?' against type 'NSError' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
 }
 
 func SR15161_as_1(e: Error?) {
-  let _ = e as! NSError // expected-warning{{forced cast from 'Error?' to 'NSError' only unwraps and bridges; did you mean to use '!' with 'as'?}}
+  let _ = e as! NSError // expected-warning{{forced cast from '(any Error)?' to 'NSError' only unwraps and bridges; did you mean to use '!' with 'as'?}}
 }

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -111,12 +111,12 @@ func protocol_concrete_casts(_ p1: P1, p2: P2, p12: P1 & P2) {
 
   _ = p1 as! P1 & P2
 
-  _ = p2 as! S1 // expected-warning {{cast from 'P2' to unrelated type 'S1' always fails}}
+  _ = p2 as! S1 // expected-warning {{cast from 'any P2' to unrelated type 'S1' always fails}}
 
-  _ = p12 as! S1 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S1' always fails}}
-  _ = p12 as! S2 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S2' always fails}}
+  _ = p12 as! S1 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S1' always fails}}
+  _ = p12 as! S2 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S2' always fails}}
   _ = p12 as! S12
-  _ = p12 as! S3 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S3' always fails}}
+  _ = p12 as! S3 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S3' always fails}}
 
   // Type queries.
   var _:Bool = p1 is S1
@@ -126,12 +126,12 @@ func protocol_concrete_casts(_ p1: P1, p2: P2, p12: P1 & P2) {
 
   var _:Bool = p1 is P1 & P2
 
-  var _:Bool = p2 is S1 // expected-warning {{cast from 'P2' to unrelated type 'S1' always fails}}
+  var _:Bool = p2 is S1 // expected-warning {{cast from 'any P2' to unrelated type 'S1' always fails}}
 
-  var _:Bool = p12 is S1 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S1' always fails}}
-  var _:Bool = p12 is S2 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S2' always fails}}
+  var _:Bool = p12 is S1 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S1' always fails}}
+  var _:Bool = p12 is S2 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S2' always fails}}
   var _:Bool = p12 is S12
-  var _:Bool = p12 is S3 // expected-warning {{cast from 'P1 & P2' to unrelated type 'S3' always fails}}
+  var _:Bool = p12 is S3 // expected-warning {{cast from 'any P1 & P2' to unrelated type 'S3' always fails}}
 }
 
 func conditional_cast(_ b: B) -> D? {
@@ -478,15 +478,15 @@ func protocol_composition(_ c: ProtocolP & ProtocolQ, _ c1: ProtocolP & Composit
   _ = c as? ConcreteCPQ // Ok
   _ = c as? ConcreteP // Ok
   _ = c as? NotConforms // Ok
-  _ = c as? StructNotComforms // expected-warning {{cast from 'ProtocolP & ProtocolQ' to unrelated type 'StructNotComforms' always fails}}
-  _ = c as? NotConformsFinal // expected-warning {{cast from 'ProtocolP & ProtocolQ' to unrelated type 'NotConformsFinal' always fails}}
+  _ = c as? StructNotComforms // expected-warning {{cast from 'any ProtocolP & ProtocolQ' to unrelated type 'StructNotComforms' always fails}}
+  _ = c as? NotConformsFinal // expected-warning {{cast from 'any ProtocolP & ProtocolQ' to unrelated type 'NotConformsFinal' always fails}}
   _ = c1 as? ConcreteP // Ok
   _ = c1 as? ConcreteP1 // OK
   _ = c1 as? ConcretePQ1 // OK
   _ = c1 as? ConcretePPQ1 // Ok
   _ = c1 as? NotConforms // Ok
-  _ = c1 as? StructNotComforms // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
-  _ = c1 as? NotConformsFinal // expected-warning {{cast from 'ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
+  _ = c1 as? StructNotComforms // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
+  _ = c1 as? NotConformsFinal // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
 }
 
 // SR-13899

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -248,7 +248,7 @@ String().asdf  // expected-error {{value of type 'String' has no member 'asdf'}}
 // <rdar://problem/21553065> Spurious diagnostic: '_' can only appear in a pattern or on the left side of an assignment
 protocol r21553065Protocol {}
 class r21553065Class<T : AnyObject> {} // expected-note{{requirement specified as 'T' : 'AnyObject'}}
-_ = r21553065Class<r21553065Protocol>()  // expected-error {{'r21553065Class' requires that 'r21553065Protocol' be a class type}}
+_ = r21553065Class<r21553065Protocol>()  // expected-error {{'r21553065Class' requires that 'any r21553065Protocol' be a class type}}
 
 // Type variables not getting erased with nested closures
 struct Toe {
@@ -462,7 +462,7 @@ protocol r22020088P {}
 func r22020088Foo<T>(_ t: T) {}
 
 func r22020088bar(_ p: r22020088P?) {
-  r22020088Foo(p.fdafs) // expected-error {{value of type 'r22020088P?' has no member 'fdafs'}}
+  r22020088Foo(p.fdafs) // expected-error {{value of type '(any r22020088P)?' has no member 'fdafs'}}
 }
 
 // <rdar://problem/22288575> QoI: poor diagnostic involving closure, bad parameter label, and mismatch return type
@@ -1089,7 +1089,7 @@ class ListExpr_28456467 : AST_28456467, Expr_28456467 {
 
   override var hasStateDef: Bool {
     return elems.first(where: { $0.hasStateDef }) != nil
-    // expected-error@-1 {{value of type 'Expr_28456467' has no member 'hasStateDef'}}
+    // expected-error@-1 {{value of type 'any Expr_28456467' has no member 'hasStateDef'}}
   }
 }
 

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -212,7 +212,7 @@ type(of: obj).foo!(obj)(5) // expected-error{{instance member 'foo' cannot be us
 // Checked casts to AnyObject
 var p: P = Y()
 var obj3 : AnyObject = (p as! AnyObject)! // expected-error{{cannot force unwrap value of non-optional type 'AnyObject'}} {{41-42=}}
-// expected-warning@-1{{forced cast from 'P' to 'AnyObject' always succeeds; did you mean to use 'as'?}} {{27-30=as}}
+// expected-warning@-1{{forced cast from 'any P' to 'AnyObject' always succeeds; did you mean to use 'as'?}} {{27-30=as}}
 
 // Implicit force of an implicitly unwrapped optional
 let uopt : AnyObject! = nil
@@ -455,7 +455,7 @@ func test_dynamic_subscript_accepts_type_name_argument() {
 }
 
 func testAnyObjectConstruction(_ x: AnyObject) {
-  AnyObject() // expected-error {{protocol type 'AnyObject' cannot be instantiated}}
+  AnyObject() // expected-error {{type 'AnyObject' cannot be instantiated}}
 
   // FIXME(SR-15210): This should also be rejected.
   _ = type(of: x).init()

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -7,14 +7,14 @@ protocol Q {}
 protocol PP: P {}
 
 var qp: Q.Protocol
-var pp: P.Protocol = qp // expected-error{{cannot convert value of type 'Q.Protocol' to specified type 'P.Protocol'}}
+var pp: P.Protocol = qp // expected-error{{cannot convert value of type '(any Q).Type' to specified type '(any P).Type'}}
 
 var qt: Q.Type
-qt = qp // expected-error{{cannot assign value of type 'Q.Protocol' to type 'Q.Type'}}
-qp = qt // expected-error{{cannot assign value of type 'Q.Type' to type 'Q.Protocol'}}
-var pt: P.Type = qt // expected-error{{cannot convert value of type 'Q.Type' to specified type 'P.Type'}}
-pt = pp // expected-error{{cannot assign value of type 'P.Protocol' to type 'P.Type'}}
-pp = pt // expected-error{{cannot assign value of type 'P.Type' to type 'P.Protocol'}}
+qt = qp // expected-error{{cannot assign value of type '(any Q).Type' to type 'any Q.Type'}}
+qp = qt // expected-error{{cannot assign value of type 'any Q.Type' to type '(any Q).Type'}}
+var pt: P.Type = qt // expected-error{{cannot convert value of type 'any Q.Type' to specified type 'any P.Type'}}
+pt = pp // expected-error{{cannot assign value of type '(any P).Type' to type 'any P.Type'}}
+pp = pt // expected-error{{cannot assign value of type 'any P.Type' to type '(any P).Type'}}
 
 var pqt: (P & Q).Type
 pt = pqt
@@ -22,11 +22,11 @@ qt = pqt
 
 
 var pqp: (P & Q).Protocol
-pp = pqp // expected-error{{cannot assign value of type '(P & Q).Protocol' to type 'P.Protocol'}}
-qp = pqp // expected-error{{cannot assign value of type '(P & Q).Protocol' to type 'Q.Protocol'}}
+pp = pqp // expected-error{{cannot assign value of type '(any P & Q).Type' to type '(any P).Type'}}
+qp = pqp // expected-error{{cannot assign value of type '(any P & Q).Type' to type '(any Q).Type'}}
 
 var ppp: PP.Protocol
-pp = ppp // expected-error{{cannot assign value of type 'PP.Protocol' to type 'P.Protocol'}}
+pp = ppp // expected-error{{cannot assign value of type '(any PP).Type' to type '(any P).Type'}}
 
 var ppt: PP.Type
 pt = ppt
@@ -35,8 +35,8 @@ var at: Any.Type
 at = pt
 
 var ap: Any.Protocol
-ap = pp // expected-error{{cannot assign value of type 'P.Protocol' to type 'Any.Protocol'}}
-ap = pt // expected-error{{cannot assign value of type 'P.Type' to type 'Any.Protocol'}}
+ap = pp // expected-error{{cannot assign value of type '(any P).Type' to type '(any Any).Type'}}
+ap = pt // expected-error{{cannot assign value of type 'any P.Type' to type '(any Any).Type'}}
 
 // Meta-metatypes
 
@@ -46,12 +46,13 @@ class Dryer : WashingMachine {}
 class HairDryer {}
 
 let a: Toaster.Type.Protocol = Toaster.Type.self
-let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Type'}}
-let c: Any.Type.Protocol = Toaster.Type.self // expected-error {{cannot convert value of type 'Toaster.Type.Protocol' to specified type 'Any.Type.Protocol'}}
+// FIXME: the existential metatype below should be spelled 'any Any.Type.Type'
+let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type '(any Toaster.Type).Type' to specified type 'any (any Any).Type.Type'}}
+let c: Any.Type.Protocol = Toaster.Type.self // expected-error {{cannot convert value of type '(any Toaster.Type).Type' to specified type '(any Any.Type).Type'}}
 let d: Toaster.Type.Type = WashingMachine.Type.self
 let e: Any.Type.Type = WashingMachine.Type.self
 let f: Toaster.Type.Type = Dryer.Type.self
-let g: Toaster.Type.Type = HairDryer.Type.self // expected-error {{cannot convert value of type 'HairDryer.Type.Type' to specified type 'Toaster.Type.Type'}}
+let g: Toaster.Type.Type = HairDryer.Type.self // expected-error {{cannot convert value of type 'HairDryer.Type.Type' to specified type 'any Toaster.Type.Type'}}
 let h: WashingMachine.Type.Type = Dryer.Type.self // expected-error {{cannot convert value of type 'Dryer.Type.Type' to specified type 'WashingMachine.Type.Type'}}
 
 func generic<T : WashingMachine>(_ t: T.Type) {
@@ -69,7 +70,7 @@ extension P2 {
 }
 
 func testP2(_ pt: P2.Type) {
-  pt.init().elements // expected-warning {{expression of type '[P2]' is unused}}
+  pt.init().elements // expected-warning {{expression of type '[any P2]' is unused}}
 }
 
 // rdar://problem/21597711

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -95,7 +95,7 @@ func foo<T : P1>(_ t: T) -> P2 {
 }
 
 func foo2(_ p1: P1) -> P2 {
-  return p1 // expected-error{{return expression of type 'P1' does not conform to 'P2'}}
+  return p1 // expected-error{{return expression of type 'any P1' does not conform to 'P2'}}
 }
 
 // <rdar://problem/14005696>
@@ -188,7 +188,7 @@ func r22459135() {
 
 // <rdar://problem/19710848> QoI: Friendlier error message for "[] as Set"
 // <rdar://problem/22326930> QoI: "argument for generic parameter 'Element' could not be inferred" lacks context
-_ = [] as Set  // expected-error {{protocol 'Any' as a type cannot conform to 'Hashable'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+_ = [] as Set  // expected-error {{type 'Any' cannot conform to 'Hashable'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 // expected-note@-1 {{required by generic struct 'Set' where 'Element' = 'Any'}}
 
 
@@ -719,7 +719,7 @@ struct SR10694 {
     // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}
 
     Q.self(x) // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
-    // expected-error@-1 {{protocol type 'Q' cannot be instantiated}}
+    // expected-error@-1 {{type 'any Q' cannot be instantiated}}
 
     type(of: q)(x)  // expected-error {{initializer 'init(_:)' requires that 'T' conform to 'P'}}
     // expected-error@-1 {{initializing from a metatype value must reference 'init' explicitly}}

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -270,7 +270,7 @@ func rdar_60185506() {
 func rdar60727310() {
   func myAssertion<T>(_ a: T, _ op: ((T,T)->Bool), _ b: T) {}
   var e: Error? = nil
-  myAssertion(e, ==, nil) // expected-error {{binary operator '==' cannot be applied to two 'Error?' operands}}
+  myAssertion(e, ==, nil) // expected-error {{binary operator '==' cannot be applied to two '(any Error)?' operands}}
 }
 
 // FIXME(SR-12438): Bad diagnostic.

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -169,9 +169,9 @@ func testTernaryWithNil<T>(b: Bool, s: String, i: Int, a: Any, t: T, m: T.Type, 
   let t16 = b ? nil : m
   let _: Double = t16 // expected-error{{value of type 'T.Type?'}}
   let t17 = b ? p : nil
-  let _: Double = t17 // expected-error{{value of type '(Proto1 & Proto2)?'}}
+  let _: Double = t17 // expected-error{{value of type '(any Proto1 & Proto2)?'}}
   let t18 = b ? nil : p
-  let _: Double = t18 // expected-error{{value of type '(Proto1 & Proto2)?'}}
+  let _: Double = t18 // expected-error{{value of type '(any Proto1 & Proto2)?'}}
   let t19 = b ? arr : nil
   let _: Double = t19 // expected-error{{value of type '[Int]?'}}
   let t20 = b ? nil : arr
@@ -426,7 +426,7 @@ func test_force_unwrap_not_being_too_eager() {
 // rdar://problem/57097401
 func invalidOptionalChaining(a: Any) {
   a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
-  // expected-error@-1 {{protocol 'Any' as a type cannot conform to 'Equatable'}}
+  // expected-error@-1 {{type 'Any' cannot conform to 'Equatable'}}
   // expected-note@-2 {{requirement from conditional conformance of 'Any?' to 'Equatable'}} expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -118,11 +118,11 @@ case iPadHair<S>.HairForceOne:
   ()
 case iPadHair<E>.HairForceOne:
   ()
-case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is ambiguous without explicit generic parameters when matching value of type 'HairType'}}
+case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is ambiguous without explicit generic parameters when matching value of type 'any HairType'}}
   ()
-case Watch.Edition: // expected-warning {{cast from 'HairType' to unrelated type 'Watch' always fails}}
+case Watch.Edition: // expected-warning {{cast from 'any HairType' to unrelated type 'Watch' always fails}}
   ()
-case .HairForceOne: // expected-error{{type 'HairType' has no member 'HairForceOne'}}
+case .HairForceOne: // expected-error{{type 'any HairType' has no member 'HairForceOne'}}
   ()
 default:
   break

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -42,7 +42,7 @@ f0(b)
 f1(i)
 
 f1(f) // expected-error{{argument type 'Float' does not conform to expected type 'Fooable'}}
-f1(b) // expected-error{{argument type 'Barable' does not conform to expected type 'Fooable'}}
+f1(b) // expected-error{{argument type 'any Barable' does not conform to expected type 'Fooable'}}
 
 //===----------------------------------------------------------------------===//
 // Subtyping
@@ -50,13 +50,13 @@ f1(b) // expected-error{{argument type 'Barable' does not conform to expected ty
 g(f0) // okay (subtype)
 g(f1) // okay (exact match)
 
-g(f2) // expected-error{{cannot convert value of type '(Float) -> ()' to expected argument type '(Barable & Fooable) -> ()'}}
+g(f2) // expected-error{{cannot convert value of type '(Float) -> ()' to expected argument type '(any Barable & Fooable) -> ()'}}
 g(nilFunc ?? f0)
 
 gc(fc0) // okay
 gc(fc1) // okay
 gc(fc2) // okay
-gc(fc3) // expected-error{{cannot convert value of type '(SomeArbitraryClass) -> ()' to expected argument type '(Classable & Fooable) -> ()'}}
+gc(fc3) // expected-error{{cannot convert value of type '(SomeArbitraryClass) -> ()' to expected argument type '(any Classable & Fooable) -> ()'}}
 
 // rdar://problem/19600325
 func getAnyObject() -> AnyObject? {
@@ -184,17 +184,17 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
 
   let ppp: P = p.init()
 
-  _ = pp() // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
-  _ = pp().bar // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
-  _ = pp().bar(2) // expected-error{{value of type 'P.Protocol' is a protocol; it cannot be instantiated}}
+  _ = pp() // expected-error{{value of type '(any P).Type' is a protocol; it cannot be instantiated}}
+  _ = pp().bar // expected-error{{value of type '(any P).Type' is a protocol; it cannot be instantiated}}
+  _ = pp().bar(2) // expected-error{{value of type '(any P).Type' is a protocol; it cannot be instantiated}}
 
-  _ = pp.init() // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = pp.init().bar // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = pp.init().bar(3) // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = pp.init() // expected-error{{type 'any P' cannot be instantiated}}
+  _ = pp.init().bar // expected-error{{type 'any P' cannot be instantiated}}
+  _ = pp.init().bar(3) // expected-error{{type 'any P' cannot be instantiated}}
 
-  _ = P() // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = P().bar // expected-error{{protocol type 'P' cannot be instantiated}}
-  _ = P().bar(4) // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = P() // expected-error{{type 'any P' cannot be instantiated}}
+  _ = P().bar // expected-error{{type 'any P' cannot be instantiated}}
+  _ = P().bar(4) // expected-error{{type 'any P' cannot be instantiated}}
 
   // Instance member of metatype
   let _: (P) -> (Int) -> () = P.bar
@@ -215,8 +215,8 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   // expected-error@-1 {{cannot reference 'mutating' method as function value}}
 
   // Static member of metatype -- not allowed
-  _ = pp.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}
-  _ = P.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}
+  _ = pp.tum // expected-error{{static member 'tum' cannot be used on protocol metatype '(any P).Type'}}
+  _ = P.tum // expected-error{{static member 'tum' cannot be used on protocol metatype '(any P).Type'}}
 
   // Access typealias through protocol and existential metatypes
   _ = pp.E.self
@@ -234,10 +234,10 @@ protocol StaticP {
 }
 extension StaticP {
   func bar() {
-    _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype 'StaticP.Protocol'}} {{9-16=Self}}
+    _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype '(any StaticP).Type'}} {{9-16=Self}}
 
     func nested() {
-      _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype 'StaticP.Protocol'}} {{11-18=Self}}
+      _ = StaticP.foo(a:) // expected-error{{static member 'foo(a:)' cannot be used on protocol metatype '(any StaticP).Type'}} {{11-18=Self}}
     }
   }
 }
@@ -370,8 +370,8 @@ func testClonableExistential(_ v: Clonable, _ vv: Clonable.Type) {
   let _: (Bool) -> Clonable? = id(vv.returnSelfIUOStatic as (Bool) -> Clonable?)
   let _: Clonable! = id(vv.returnSelfIUOStatic(true))
 
-  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of protocol type 'Clonable'; consider using a generic constraint instead}}
-  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; consider using a generic constraint instead}}
+  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of type 'any Clonable'; consider using a generic constraint instead}}
+  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of type 'any Clonable'; consider using a generic constraint instead}}
 
 }
 

--- a/test/Constraints/sr13992.swift
+++ b/test/Constraints/sr13992.swift
@@ -15,7 +15,7 @@ struct S<T> {
 }
 
 extension S : P1 {}
-extension S : P2 where T: P3 { // expected-note {{requirement from conditional conformance of 'S<V>' to 'P2'}}
+extension S : P2 where T: P3 { // expected-note {{requirement from conditional conformance of 'S<any V>' to 'P2'}}
   func bar() -> V { fatalError() }
 }
 
@@ -23,7 +23,7 @@ struct Q {
   var foo: V
 
   func test() -> P1 & P2 {
-    S(foo: foo) // expected-error {{protocol 'V' as a type cannot conform to 'P3'}}
+    S(foo: foo) // expected-error {{type 'any V' cannot conform to 'P3'}}
     // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
   }
 }

--- a/test/Constraints/static_members_on_protocol_in_generic_context.swift
+++ b/test/Constraints/static_members_on_protocol_in_generic_context.swift
@@ -42,86 +42,86 @@ extension P {
 
 // References on protocol metatype are only allowed through a leading dot syntax
 
-_ = P.property // expected-error {{static member 'property' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.property // expected-error {{static member 'property' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'property' requires the types 'Self' and 'S' be equivalent}}
-_ = P.property.other // expected-error {{static member 'property' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.property.other // expected-error {{static member 'property' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'property' requires the types 'Self' and 'S' be equivalent}}
-_ = P.iuoProp // expected-error {{static member 'iuoProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.iuoProp // expected-error {{static member 'iuoProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'iuoProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.iuoProp.other // expected-error {{static member 'iuoProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.iuoProp.other // expected-error {{static member 'iuoProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'iuoProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.optProp // expected-error {{static member 'optProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.optProp // expected-error {{static member 'optProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'optProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.optProp?.other // expected-error {{static member 'optProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.optProp?.other // expected-error {{static member 'optProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'optProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.fnProp // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.fnProp // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.fnProp() // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.fnProp() // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.fnProp().other // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.fnProp().other // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-_ = P.method() // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.method() // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-_ = P.method   // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.method   // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-_ = P.method().other // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.method().other // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-_ = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<Int>' be equivalent}}
-_ = P.genericFn(42).other // expected-error {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.genericFn(42).other // expected-error {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<Int>' be equivalent}}
-_ = P[42] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P[42] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static subscript 'subscript(_:)' on 'P' requires the types 'Self' and 'S' be equivalent}}
-_ = P[42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P[42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static subscript 'subscript(_:)' on 'P' requires the types 'Self' and 'S' be equivalent}}
-_ = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<Int>' be equivalent}}
-_ = P[t: 42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P[t: 42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<Int>' be equivalent}}
 
-let _: S = P.property // expected-error {{static member 'property' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.property // expected-error {{static member 'property' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'property' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P.property.other // expected-error {{static member 'property' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.property.other // expected-error {{static member 'property' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'property' requires the types 'Self' and 'S' be equivalent}}
-let _: () -> S = P.fnProp // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+let _: () -> S = P.fnProp // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P.fnProp() // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.fnProp() // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P.fnProp().other // expected-error {{static member 'fnProp' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.fnProp().other // expected-error {{static member 'fnProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static property 'fnProp' requires the types 'Self' and 'S' be equivalent}}
-let _: () -> S = P.method // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+let _: () -> S = P.method // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P.method() // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.method() // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P.method().other // expected-error {{static member 'method' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P.method().other // expected-error {{static member 'method' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static method 'method()' on 'P' requires the types 'Self' and 'S' be equivalent}}
-let _: G<Int> = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G<Int> = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<Int>' be equivalent}}
-let _: G = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G = P.genericFn(42) // expected-error {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<Int>' be equivalent}}
 let _: G<String> = P.genericFn(42) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
-// expected-error@-1 {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{static method 'genericFn' requires the types 'Self' and 'G<String>' be equivalent}}
-let _: G<Int> = P.genericFn(42).other // expected-error {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G<Int> = P.genericFn(42).other // expected-error {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<Int>' be equivalent}}
 let _: G<String> = P.genericFn(42).other // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 // expected-error@-1 {{static method 'genericFn' requires the types 'Self' and 'G<String>' be equivalent}}
-// expected-error@-2 {{static member 'genericFn' cannot be used on protocol metatype 'P.Protocol'}}
-let _: S = P[42] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-2 {{static member 'genericFn' cannot be used on protocol metatype '(any P).Type'}}
+let _: S = P[42] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static subscript 'subscript(_:)' on 'P' requires the types 'Self' and 'S' be equivalent}}
-let _: S = P[42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+let _: S = P[42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{referencing static subscript 'subscript(_:)' on 'P' requires the types 'Self' and 'S' be equivalent}}
-let _: G<Int> = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G<Int> = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<Int>' be equivalent}}
-let _: G = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G = P[t: 42] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<Int>' be equivalent}}
 let _: G<String> = P[t: 42] // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
-// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<String>' be equivalent}}
-let _: G<Int> = P[t: 42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+let _: G<Int> = P[t: 42].other // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-1 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<Int>' be equivalent}}
 let _: G<String> = P[t: 42].other // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
-// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{static subscript 'subscript(t:)' requires the types 'Self' and 'G<String>' be equivalent}}
 
 func test<T: P>(_: T) {}
@@ -189,39 +189,39 @@ extension P { // expected-note 6 {{missing same-type requirement on 'Self'}}
   static subscript(q q: String) -> Int { get { 42 } }
 }
 
-_ = P.doesntExist // expected-error {{type 'P' has no member 'doesntExist'}}
-_ = P.selfProp // expected-error {{static member 'selfProp' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.doesntExist // expected-error {{type 'any P' has no member 'doesntExist'}}
+_ = P.selfProp // expected-error {{static member 'selfProp' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.invalidProp
-// expected-error@-1 {{static member 'invalidProp' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'invalidProp' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.invalidProp.other
-// expected-error@-1 {{static member 'invalidProp' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'invalidProp' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{value of type 'Int' has no member 'other'}}
 _ = P.invalidMethod // Partial application with an invalid base type
-// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.invalidMethod()
-// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.invalidMethod().other
-// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'invalidMethod' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{value of type 'Int' has no member 'other'}}
 _ = P.generic(42)
-// expected-error@-1 {{static member 'generic' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'generic' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.generic(42).other
-// expected-error@-1 {{static member 'generic' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'generic' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{value of type 'Int' has no member 'other'}}
-_ = P.generic(S()) // expected-error {{static member 'generic' cannot be used on protocol metatype 'P.Protocol'}}
-_ = P.generic(S()).other // expected-error {{static member 'generic' cannot be used on protocol metatype 'P.Protocol'}}
-_ = P.generic(G<Int>()) // expected-error {{static member 'generic' cannot be used on protocol metatype 'P.Protocol'}}
-_ = P.genericWithReqs([S()]) // expected-error {{static member 'genericWithReqs' cannot be used on protocol metatype 'P.Protocol'}}
+_ = P.generic(S()) // expected-error {{static member 'generic' cannot be used on protocol metatype '(any P).Type'}}
+_ = P.generic(S()).other // expected-error {{static member 'generic' cannot be used on protocol metatype '(any P).Type'}}
+_ = P.generic(G<Int>()) // expected-error {{static member 'generic' cannot be used on protocol metatype '(any P).Type'}}
+_ = P.genericWithReqs([S()]) // expected-error {{static member 'genericWithReqs' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.genericWithReqs([42])
-// expected-error@-1 {{static member 'genericWithReqs' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'genericWithReqs' cannot be used on protocol metatype '(any P).Type'}}
 _ = P.genericWithReqs(())
 // expected-error@-1 {{type '()' cannot conform to 'Collection'}} expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
-// expected-error@-2 {{static member 'genericWithReqs' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-2 {{static member 'genericWithReqs' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-3 {{generic parameter 'Q' could not be inferred}}
 _ = P[q: ""]
-// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 _ = P[q: ""].other
-// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype 'P.Protocol'}}
+// expected-error@-1 {{static member 'subscript' cannot be used on protocol metatype '(any P).Type'}}
 // expected-error@-2 {{value of type 'Int' has no member 'other'}}
 
 test(.doesntExist) // expected-error {{type 'P' has no member 'doesntExist'}}

--- a/test/Generics/class_constraint.swift
+++ b/test/Generics/class_constraint.swift
@@ -17,8 +17,8 @@ struct Y2<T: C> {
   let okay2: X<T>
 }
 
-let bad0: X<C & P> // expected-error{{'X' requires that 'C & P' be a class type}}
-let bad1: X<P> // expected-error{{'X' requires that 'P' be a class type}}
+let bad0: X<C & P> // expected-error{{'X' requires that 'any C & P' be a class type}}
+let bad1: X<P> // expected-error{{'X' requires that 'any P' be a class type}}
 let bad2: X<S> // expected-error{{'X' requires that 'S' be a class type}}
 
 struct Z<U> {
@@ -47,12 +47,12 @@ where T.B.A: AnyObject, U.B: AnyObject, T.B == T.B.A, U.B.A == U.B {
 }
 
 func test_class_constraint_diagnostics_with_contextual_type() {
-  func foo<T : AnyObject>(_: AnyObject) -> T {} // expected-note 2 {{where 'T' = 'P'}}
+  func foo<T : AnyObject>(_: AnyObject) -> T {} // expected-note 2 {{where 'T' = 'any P'}}
 
   class A : P {}
 
   // TODO(diagnostics): We could also add a note here that protocols do not conform to themselves
 
-  let _: P = foo(A() as AnyObject) // expected-error {{local function 'foo' requires that 'P' be a class type}}
-  let _: P = foo(A()) // expected-error {{local function 'foo' requires that 'P' be a class type}}
+  let _: P = foo(A() as AnyObject) // expected-error {{local function 'foo' requires that 'any P' be a class type}}
+  let _: P = foo(A()) // expected-error {{local function 'foo' requires that 'any P' be a class type}}
 }

--- a/test/Generics/conditional_conformances_literals.swift
+++ b/test/Generics/conditional_conformances_literals.swift
@@ -16,7 +16,7 @@ extension Array: Conforms where Element: Conforms {}
 // expected-note@-1 7 {{requirement from conditional conformance of '[Fails]' to 'Conforms'}}
 extension Dictionary: Conforms where Value: Conforms {}
 // expected-note@-1 5 {{requirement from conditional conformance of '[Int : Fails]' to 'Conforms'}}
-// expected-note@-2 2 {{requirement from conditional conformance of '[Int : Conforms]' to 'Conforms'}}
+// expected-note@-2 2 {{requirement from conditional conformance of '[Int : any Conforms]' to 'Conforms'}}
 
 let works = Works()
 let fails = Fails()
@@ -128,9 +128,9 @@ func combined() {
 
     // Needs self conforming protocols:
     let _: Conforms = [[0: [1 : [works]] as Conforms]]
-    // expected-error@-1 {{protocol 'Conforms' as a type cannot conform to the protocol itself}} expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
+    // expected-error@-1 {{type 'any Conforms' cannot conform to 'Conforms'}} expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
 
     let _: Conforms = [[0: [1 : [fails]] as Conforms]]
     // expected-error@-1 {{protocol 'Conforms' requires that 'Fails' conform to 'Conforms'}}
-    // expected-error@-2 {{protocol 'Conforms' as a type cannot conform to the protocol itself}} expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+    // expected-error@-2 {{type 'any Conforms' cannot conform to 'Conforms'}} expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -9,23 +9,23 @@ protocol CP : class { }
 }
 
 func fP<T : P>(_ t: T) { }
-// expected-note@-1 {{required by global function 'fP' where 'T' = 'P'}}
-// expected-note@-2 {{required by global function 'fP' where 'T' = 'OP & P'}}
+// expected-note@-1 {{required by global function 'fP' where 'T' = 'any P'}}
+// expected-note@-2 {{required by global function 'fP' where 'T' = 'any OP & P'}}
 func fOP<T : OP>(_ t: T) { }
-// expected-note@-1 {{required by global function 'fOP' where 'T' = 'OP & P'}}
+// expected-note@-1 {{required by global function 'fOP' where 'T' = 'any OP & P'}}
 func fOPE(_ t: OP) { }
 func fSP<T : SP>(_ t: T) { }
 func fAO<T : AnyObject>(_ t: T) { }
-// expected-note@-1 {{where 'T' = 'P'}}
-// expected-note@-2 {{where 'T' = 'CP'}}
-// expected-note@-3 {{where 'T' = 'OP & P'}}
+// expected-note@-1 {{where 'T' = 'any P'}}
+// expected-note@-2 {{where 'T' = 'any CP'}}
+// expected-note@-3 {{where 'T' = 'any OP & P'}}
 func fAOE(_ t: AnyObject) { }
 func fT<T>(_ t: T) { }
 
 func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, ao: AnyObject) {
-  fP(p) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
-  fAO(p) // expected-error{{global function 'fAO' requires that 'P' be a class type}}
-  fAOE(p) // expected-error{{argument type 'P' expected to be an instance of a class or class-constrained type}}
+  fP(p) // expected-error{{type 'any P' cannot conform to 'P'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  fAO(p) // expected-error{{global function 'fAO' requires that 'any P' be a class type}}
+  fAOE(p) // expected-error{{argument type 'any P' expected to be an instance of a class or class-constrained type}}
   fT(p)
 
   fOP(op)
@@ -33,18 +33,18 @@ func testPassExistential(_ p: P, op: OP, opp: OP & P, cp: CP, sp: SP, any: Any, 
   fAOE(op)
   fT(op)
 
-  fAO(cp) // expected-error{{global function 'fAO' requires that 'CP' be a class type}}
+  fAO(cp) // expected-error{{global function 'fAO' requires that 'any CP' be a class type}}
   fAOE(cp)
   fT(cp)
 
-  fP(opp) // expected-error{{protocol 'OP & P' as a type cannot conform to 'P'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
-  fOP(opp) // expected-error{{protocol 'OP & P' as a type cannot conform to 'OP'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
-  fAO(opp) // expected-error{{global function 'fAO' requires that 'OP & P' be a class type}}
+  fP(opp) // expected-error{{type 'any OP & P' cannot conform to 'P'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  fOP(opp) // expected-error{{type 'any OP & P' cannot conform to 'OP'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  fAO(opp) // expected-error{{global function 'fAO' requires that 'any OP & P' be a class type}}
   fAOE(opp)
   fT(opp)
 
   fOP(sp)
-  fSP(sp) // expected-error{{'SP' cannot be used as a type conforming to protocol 'SP' because 'SP' has static requirements}}
+  fSP(sp) // expected-error{{'any SP' cannot be used as a type conforming to protocol 'SP' because 'SP' has static requirements}}
   fAO(sp)
   fAOE(sp)
   fT(sp)
@@ -64,13 +64,13 @@ class GAO<T : AnyObject> {} // expected-note 2{{requirement specified as 'T' : '
 func blackHole(_ t: Any) {}
 
 func testBindExistential() {
-  blackHole(GP<P>()) // expected-error{{protocol 'P' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  blackHole(GP<P>()) // expected-error{{type 'any P' cannot conform to 'P'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
   blackHole(GOP<OP>())
-  blackHole(GCP<CP>()) // expected-error{{protocol 'CP' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
-  blackHole(GAO<P>()) // expected-error{{'GAO' requires that 'P' be a class type}}
+  blackHole(GCP<CP>()) // expected-error{{type 'any CP' cannot conform to 'CP'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  blackHole(GAO<P>()) // expected-error{{'GAO' requires that 'any P' be a class type}}
   blackHole(GAO<OP>())
-  blackHole(GAO<CP>()) // expected-error{{'GAO' requires that 'CP' be a class type}}
-  blackHole(GSP<SP>()) // expected-error{{'SP' cannot be used as a type conforming to protocol 'SP' because 'SP' has static requirements}}
+  blackHole(GAO<CP>()) // expected-error{{'GAO' requires that 'any CP' be a class type}}
+  blackHole(GSP<SP>()) // expected-error{{'any SP' cannot be used as a type conforming to protocol 'SP' because 'SP' has static requirements}}
   blackHole(GAO<AnyObject>())
 }
 
@@ -92,5 +92,5 @@ func foo() {
   // generic no overloads error path. The error should actually talk
   // about the return type, and this can happen in other contexts as well;
   // <rdar://problem/21900971> tracks improving QoI here.
-  allMine.takeAll() // expected-error{{protocol 'Mine' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  allMine.takeAll() // expected-error{{type 'any Mine' cannot conform to 'Mine'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -36,9 +36,9 @@ func min<T : MethodLessComparable>(_ x: T, y: T) -> T {
 func existential<T : EqualComparable, U : EqualComparable>(_ t1: T, t2: T, u: U) {
   var eqComp : EqualComparable = t1 // expected-warning {{protocol 'EqualComparable' as a type must be explicitly marked as 'any'}}
   eqComp = u
-  if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'EqualComparable' to expected argument type 'T'}}
+  if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'any EqualComparable' to expected argument type 'T'}}
   if eqComp.isEqual(t2) {}
-  // expected-error@-1 {{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'isEqual' cannot be used on value of type 'any EqualComparable'; consider using a generic constraint instead}}
 }
 
 protocol OtherEqualComparable {
@@ -47,14 +47,14 @@ protocol OtherEqualComparable {
 
 func otherExistential<T : EqualComparable>(_ t1: T) {
   var otherEqComp : OtherEqualComparable = t1 // expected-error{{value of type 'T' does not conform to specified type 'OtherEqualComparable'}}
-  otherEqComp = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
+  otherEqComp = t1 // expected-error{{cannot assign value of type 'T' to type 'any OtherEqualComparable'}}
   _ = otherEqComp
   
   var otherEqComp2 : any OtherEqualComparable // Ok
-  otherEqComp2 = t1 // expected-error{{value of type 'T' does not conform to 'OtherEqualComparable' in assignment}}
+  otherEqComp2 = t1 // expected-error{{cannot assign value of type 'T' to type 'any OtherEqualComparable'}}
   _ = otherEqComp2
 
-  _ = t1 as any EqualComparable & OtherEqualComparable // expected-error{{value of type 'T' does not conform to 'EqualComparable & OtherEqualComparable' in coercion}}
+  _ = t1 as any EqualComparable & OtherEqualComparable // expected-error{{cannot convert value of type 'T' to type 'any EqualComparable & OtherEqualComparable' in coercion}}
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -216,10 +216,10 @@ func g<T : Init & Derived>(_: T.Type) {
 struct G<T : Base> {}
 // expected-note@-1 2 {{requirement specified as 'T' : 'Base' [with T = Base & P]}}
 
-_ = G<Base & P>() // expected-error {{'G' requires that 'Base & P' inherit from 'Base'}}
+_ = G<Base & P>() // expected-error {{'G' requires that 'any Base & P' inherit from 'Base'}}
 
 func badClassConstrainedType(_: G<Base & P>) {}
-// expected-error@-1 {{'G' requires that 'Base & P' inherit from 'Base'}}
+// expected-error@-1 {{'G' requires that 'any Base & P' inherit from 'Base'}}
 
 // Reduced from CoreStore in source compat suite
 public protocol Pony {}

--- a/test/Parse/metatype_object_conversion.swift
+++ b/test/Parse/metatype_object_conversion.swift
@@ -13,13 +13,13 @@ func takesAnyObject(_ x: AnyObject) {}
 func concreteTypes() {
   takesAnyObject(C.self) 
   takesAnyObject(S.self) // expected-error{{argument type 'S.Type' expected to be an instance of a class or class-constrained type}}
-  takesAnyObject(ClassConstrainedProto.self) // expected-error{{argument type 'ClassConstrainedProto.Protocol' expected to be an instance of a class or class-constrained type}}
+  takesAnyObject(ClassConstrainedProto.self) // expected-error{{argument type '(any ClassConstrainedProto).Type' expected to be an instance of a class or class-constrained type}}
 }
 
 func existentialMetatypes(nonClass: NonClassProto.Type,
                           classConstrained: ClassConstrainedProto.Type,
                           compo: (NonClassProto & ClassConstrainedProto).Type) {
-  takesAnyObject(nonClass) // expected-error{{argument type 'NonClassProto.Type' expected to be an instance of a class or class-constrained type}}
+  takesAnyObject(nonClass) // expected-error{{argument type 'any NonClassProto.Type' expected to be an instance of a class or class-constrained type}}
   takesAnyObject(classConstrained)
   takesAnyObject(compo)
 }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -193,7 +193,7 @@ func meta_metatypes() {
   let _: P.Protocol = P.self
   _ = P.Type.self
   _ = P.Protocol.self
-  _ = P.Protocol.Protocol.self // expected-error{{cannot use 'Protocol' with non-protocol type 'P.Protocol'}}
+  _ = P.Protocol.Protocol.self // expected-error{{cannot use 'Protocol' with non-protocol type '(any P).Type'}}
   _ = P.Protocol.Type.self
   _ = B.Type.self
 }
@@ -262,14 +262,14 @@ protocol P2 {}
 protocol P3 {}
 func compositionType() {
   _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
-  _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type 'P1.Protocol' and 'P2.Protocol'}}
+  _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type '(any P1).Type' and '(any P2).Type'}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
-  _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(P2, P3)' cannot be used within a protocol-constrained type}}
+  _ = (P1 & (P2, P3)).self // expected-error {{non-protocol, non-class type '(any P2, any P3)' cannot be used within a protocol-constrained type}}
   _ = (P1 & Int).self // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
-  _ = (P1? & P2).self // expected-error {{non-protocol, non-class type 'P1?' cannot be used within a protocol-constrained type}}
+  _ = (P1? & P2).self // expected-error {{non-protocol, non-class type '(any P1)?' cannot be used within a protocol-constrained type}}
 
-  _ = (P1 & P2.Type).self // expected-error {{non-protocol, non-class type 'P2.Type' cannot be used within a protocol-constrained type}}
+  _ = (P1 & P2.Type).self // expected-error {{non-protocol, non-class type 'any P2.Type' cannot be used within a protocol-constrained type}}
 
   _ = P1 & P2 -> P3
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}

--- a/test/Sema/diag_ambiguous_overloads_swift4.swift
+++ b/test/Sema/diag_ambiguous_overloads_swift4.swift
@@ -6,6 +6,6 @@ class sr7295 {
   func doSomething(b: @escaping ((String, Error?, Bool) -> Void)) {}
   func a() {
     doSomething(a: nil, completion: { _ in })
-// expected-error@-1 {{contextual closure type '(String, Error?) -> Void' expects 2 arguments, but 1 was used in closure body}}
+// expected-error@-1 {{contextual closure type '(String, (any Error)?) -> Void' expects 2 arguments, but 1 was used in closure body}}
   }
 }

--- a/test/Sema/diag_type_conversion.swift
+++ b/test/Sema/diag_type_conversion.swift
@@ -38,7 +38,7 @@ protocol P1 {}
 struct S1 : P1 {}
 func foo9(s : S1) {}
 func foo10(p : P1) {
-  foo9(s : p) // expected-error {{cannot convert value of type 'P1' to expected argument type 'S1'}} {{13-13= as! S1}}
+  foo9(s : p) // expected-error {{cannot convert value of type 'any P1' to expected argument type 'S1'}} {{13-13= as! S1}}
 }
 
 func foo11(a : [AnyHashable]) {}

--- a/test/TypeCoercion/protocols.swift
+++ b/test/TypeCoercion/protocols.swift
@@ -47,11 +47,11 @@ func testPrintableCoercion(_ ip1: IsPrintable1,
   // expected-error@-1 {{value of type 'Book' does not conform to specified type 'MyPrintable'}}
   p = ip1 // okay
   p = ip2 // okay
-  p = inp1 // expected-error{{value of type 'IsNotPrintable1' does not conform to 'MyPrintable' in assignment}}
+  p = inp1 // expected-error{{cannot assign value of type 'IsNotPrintable1' to type 'any MyPrintable'}}
   let _: MyPrintable = inp1
   // expected-error@-1 {{value of type 'IsNotPrintable1' does not conform to specified type 'MyPrintable'}}
-  p = inp2 // expected-error{{value of type 'IsNotPrintable2' does not conform to 'MyPrintable' in assignment}}
-  p = op // expected-error{{value of type 'OtherPrintable' does not conform to 'MyPrintable' in assignment}}
+  p = inp2 // expected-error{{cannot assign value of type 'IsNotPrintable2' to type 'any MyPrintable'}}
+  p = op // expected-error{{value of type 'any OtherPrintable' does not conform to 'MyPrintable' in assignment}}
   _ = p
 }
 
@@ -61,8 +61,8 @@ func testTitledCoercion(_ ip1: IsPrintable1, book: Book, lackey: Lackey,
   t = ip1
   t = book
   t = lackey
-  t = number // expected-error{{value of type 'Number' does not conform to 'Titled' in assignment}}
-  t = ip2 // expected-error{{value of type 'IsPrintable2' does not conform to 'Titled' in assignment}}
+  t = number // expected-error{{cannot assign value of type 'Number' to type 'any Titled'}}
+  t = ip2 // expected-error{{cannot assign value of type 'IsPrintable2' to type 'any Titled'}}
   _ = t
 }
 
@@ -94,11 +94,11 @@ func testFormattedPrintableCoercion(_ ip1: IsPrintable1,
                                     op: inout OtherPrintable,
                                     nfp1: NotFormattedPrintable1) {
   fp = ip1
-  fp = ip2 // expected-error{{value of type 'IsPrintable2' does not conform to 'FormattedPrintable' in assignment}}
-  fp = nfp1 // expected-error{{value of type 'NotFormattedPrintable1' does not conform to 'FormattedPrintable' in assignment}}
+  fp = ip2 // expected-error{{cannot assign value of type 'IsPrintable2' to type 'any FormattedPrintable'}}
+  fp = nfp1 // expected-error{{cannot assign value of type 'NotFormattedPrintable1' to type 'any FormattedPrintable'}}
   p = fp
-  op = fp // expected-error{{value of type 'FormattedPrintable' does not conform to 'OtherPrintable' in assignment}}
-  fp = op // expected-error{{value of type 'OtherPrintable' does not conform to 'FormattedPrintable' in assignment}}
+  op = fp // expected-error{{value of type 'any FormattedPrintable' does not conform to 'OtherPrintable' in assignment}}
+  fp = op // expected-error{{value of type 'any OtherPrintable' does not conform to 'FormattedPrintable' in assignment}}
 }
 
 protocol Document : Titled, MyPrintable {
@@ -113,65 +113,65 @@ func testMethodsAndVars(_ fp: FormattedPrintable, f: TestFormat, doc: inout Docu
 
 func testDocumentCoercion(_ doc: inout Document, ip1: IsPrintable1, l: Lackey) {
   doc = ip1
-  doc = l // expected-error{{value of type 'Lackey' does not conform to 'Document' in assignment}}
+  doc = l // expected-error{{cannot assign value of type 'Lackey' to type 'any Document'}}
 }
 
 // Check coercion of references.
 func refCoercion(_ p: inout MyPrintable) { }
 var p : MyPrintable = IsPrintable1()
 var fp : FormattedPrintable = IsPrintable1()
-// expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{10-28=MyPrintable}}
+// expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{10-28=MyPrintable}}
 var ip1 : IsPrintable1
-// expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{11-23=MyPrintable}}
+// expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{11-23=MyPrintable}}
 
 refCoercion(&p)
 refCoercion(&fp)
-// expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+// expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
 refCoercion(&ip1)
-// expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'MyPrintable' instead}}
+// expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'any MyPrintable' instead}}
 
 do {
   var fp_2 = fp
-  // expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{11-11=: MyPrintable}}
+  // expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{11-11=: MyPrintable}}
   var ip1_2 = ip1
-  // expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{12-12=: MyPrintable}}
+  // expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{12-12=: MyPrintable}}
   refCoercion(&fp_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
   refCoercion(&ip1_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'any MyPrintable' instead}}
 }
 
 do {
   var fp_2 : FormattedPrintable = fp, ip1_2 = ip1
-  // expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{14-32=MyPrintable}}
-  // expected-note@-2{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{44-44=: MyPrintable}}
+  // expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{14-32=MyPrintable}}
+  // expected-note@-2{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{44-44=: MyPrintable}}
   refCoercion(&fp_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
   refCoercion(&ip1_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'any MyPrintable' instead}}
 }
 
 do {
   var fp_2, fp_3 : FormattedPrintable
-  // expected-note@-1{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{20-38=MyPrintable}}
-  // expected-note@-2{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{20-38=MyPrintable}}
+  // expected-note@-1{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{20-38=MyPrintable}}
+  // expected-note@-2{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{20-38=MyPrintable}}
   fp_2 = fp
   fp_3 = fp
   refCoercion(&fp_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
   refCoercion(&fp_3)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
 }
 
 do {
   func wrapRefCoercion1(fp_2: inout FormattedPrintable,
                         ip1_2: inout IsPrintable1) {
-    // expected-note@-2{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'FormattedPrintable'}} {{31-55=MyPrintable}}
-    // expected-note@-2{{change variable type to 'MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{32-50=MyPrintable}}
+    // expected-note@-2{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'any FormattedPrintable'}} {{31-55=MyPrintable}}
+    // expected-note@-2{{change variable type to 'any MyPrintable' if it doesn't need to be declared as 'IsPrintable1'}} {{32-50=MyPrintable}}
     refCoercion(&fp_2)
-    // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+    // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
     refCoercion(&ip1_2)
-    // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'MyPrintable' instead}}
+    // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'any MyPrintable' instead}}
   }
 }
 
@@ -179,16 +179,16 @@ do {
   // Make sure we don't add the fix-it for tuples:
   var (fp_2, ip1_2) = (fp, ip1)
   refCoercion(&fp_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
   refCoercion(&ip1_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'IsPrintable1'; use a value declared as type 'any MyPrintable' instead}}
 }
 
 do {
   // Make sure we don't add the fix-it for vars in different scopes:
   enum ParentScope { static var fp_2 = fp }
   refCoercion(&ParentScope.fp_2)
-  // expected-error@-1{{inout argument could be set to a value with a type other than 'FormattedPrintable'; use a value declared as type 'MyPrintable' instead}}
+  // expected-error@-1{{inout argument could be set to a value with a type other than 'any FormattedPrintable'; use a value declared as type 'any MyPrintable' instead}}
 }
 
 protocol IntSubscriptable {
@@ -215,8 +215,8 @@ func testIntSubscripting(i_s: inout IntSubscriptable,
   i_s[5] = 7 // expected-error{{cannot assign through subscript: subscript is get-only}}
 
   i_s = iis
-  i_s = ids // expected-error{{value of type 'IsDoubleSubscriptable' does not conform to 'IntSubscriptable' in assignment}}
-  i_s = iiss // expected-error{{value of type 'IsIntToStringSubscriptable' does not conform to 'IntSubscriptable' in assignment}}
+  i_s = ids // expected-error{{cannot assign value of type 'IsDoubleSubscriptable' to type 'any IntSubscriptable'}}
+  i_s = iiss // expected-error{{cannot assign value of type 'IsIntToStringSubscriptable' to type 'any IntSubscriptable'}}
 }
 
 protocol MyREPLPrintable {

--- a/test/TypeCoercion/protocols_library.swift
+++ b/test/TypeCoercion/protocols_library.swift
@@ -5,8 +5,8 @@ func refCoercion(_: inout CustomStringConvertible) {}
 // Make sure we don't add the fix-it for globals in non-script files
 var fp_2 = ""
 
-let x = refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'CustomStringConvertible' instead}}
+let x = refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'any CustomStringConvertible' instead}}
 
 func y() {
-  refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'CustomStringConvertible' instead}}
+  refCoercion(&fp_2) // expected-error{{inout argument could be set to a value with a type other than 'String'; use a value declared as type 'any CustomStringConvertible' instead}}
 }

--- a/test/TypeCoercion/subtyping.swift
+++ b/test/TypeCoercion/subtyping.swift
@@ -31,14 +31,14 @@ func protocolConformance(ac1: @autoclosure () -> CustomStringConvertible,
   // FIXME: closures make ABI conversions explicit. rdar://problem/19517003
   f1 = { f2($0) } // okay
   f1 = { f3($0) } // okay
-  f2 = f1 // expected-error{{cannot assign value of type '(FormattedPrintable) -> CustomStringConvertible' to type '(CustomStringConvertible) -> FormattedPrintable'}}
+  f2 = f1 // expected-error{{cannot assign value of type '(any FormattedPrintable) -> any CustomStringConvertible' to type '(any CustomStringConvertible) -> any FormattedPrintable'}}
 
   accept_creates_Printable(ac1)
   accept_creates_Printable({ ac2() })
   accept_creates_Printable({ ip1() })
-  accept_creates_FormattedPrintable(ac1) // expected-error{{cannot convert value of type '() -> CustomStringConvertible' to expected argument type '() -> FormattedPrintable'}}
+  accept_creates_FormattedPrintable(ac1) // expected-error{{cannot convert value of type '() -> any CustomStringConvertible' to expected argument type '() -> any FormattedPrintable'}}
   accept_creates_FormattedPrintable(ac2)
-  accept_creates_FormattedPrintable(ip1) // expected-error{{cannot convert value of type '() -> IsPrintable1' to expected argument type '() -> FormattedPrintable'}}
+  accept_creates_FormattedPrintable(ip1) // expected-error{{cannot convert value of type '() -> IsPrintable1' to expected argument type '() -> any FormattedPrintable'}}
 }
 
 func p_gen_to_fp(_: () -> CustomStringConvertible) -> FormattedPrintable {}
@@ -51,6 +51,6 @@ func nonTrivialNested() {
   let f3 : (_ : () -> FormattedPrintable) -> CustomStringConvertible = fp_gen_to_p
 
   f1 = { f2($0) } // okay
-  f1 = f3 // expected-error{{cannot assign value of type '(() -> FormattedPrintable) -> CustomStringConvertible' to type '(() -> CustomStringConvertible) -> CustomStringConvertible'}}
+  f1 = f3 // expected-error{{cannot assign value of type '(() -> any FormattedPrintable) -> any CustomStringConvertible' to type '(() -> any CustomStringConvertible) -> any CustomStringConvertible'}}
   _ = f1
 }

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -129,7 +129,7 @@ protocol NoKeywordProtocol {
 
 func testInvalidKeywordCall(x: NoKeyword, y: NoKeywordProtocol & AnyObject) {
   x(a: 1, b: 2) // expected-error {{@dynamicCallable type 'NoKeyword' cannot be applied with keyword arguments; missing 'dynamicCall(withKeywordArguments:)' method}} {{educational-notes=dynamic-callable-requirements}}
-  y(a: 1, b: 2) // expected-error {{@dynamicCallable type 'NoKeywordProtocol & AnyObject' cannot be applied with keyword arguments; missing 'dynamicCall(withKeywordArguments:)' method}} {{educational-notes=dynamic-callable-requirements}}
+  y(a: 1, b: 2) // expected-error {{@dynamicCallable type 'any NoKeywordProtocol & AnyObject' cannot be applied with keyword arguments; missing 'dynamicCall(withKeywordArguments:)' method}} {{educational-notes=dynamic-callable-requirements}}
 }
 
 // expected-error @+1 {{'@dynamicCallable' attribute cannot be applied to this declaration}}

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -391,7 +391,7 @@ class MismatchOptional : MismatchOptionalBase {
 
   override func functionParam(x: @escaping (Int) -> Int) {} // expected-error {{cannot override instance method parameter of type '((Int) -> Int)?' with non-optional type '(Int) -> Int'}} {{34-34=(}} {{56-56=)?}}
   override func tupleParam(x: (Int, Int)) {} // expected-error {{cannot override instance method parameter of type '(Int, Int)?' with non-optional type '(Int, Int)'}} {{41-41=?}}
-  override func compositionParam(x: P1 & P2) {} // expected-error {{cannot override instance method parameter of type '(P1 & P2)?' with non-optional type 'P1 & P2'}} {{37-37=(}} {{44-44=)?}}
+  override func compositionParam(x: P1 & P2) {} // expected-error {{cannot override instance method parameter of type '(any P1 & P2)?' with non-optional type 'any P1 & P2'}} {{37-37=(}} {{44-44=)?}}
 
   override func nameAndTypeMismatch(_: Int) {}
   // expected-error@-1 {{argument labels for method 'nameAndTypeMismatch' do not match those of overridden method 'nameAndTypeMismatch(label:)'}} {{37-37=label }}

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -169,19 +169,19 @@ unowned var weak9 : Class = Ty0()
 // expected-note@-3 {{'weak9' declared here}}
 
 weak
-var weak10 : NonClass? = Ty0() // expected-error {{'weak' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak10 : NonClass? = Ty0() // expected-error {{'weak' must not be applied to non-class-bound 'any NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak11 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak11 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'any NonClass'; consider adding a protocol conformance that has a class bound}}
 
 unowned
-var weak12 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak12 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'any NonClass'; consider adding a protocol conformance that has a class bound}}
 unowned
-var weak13 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'NonClass'; consider adding a protocol conformance that has a class bound}}
+var weak13 : NonClass = Ty0() // expected-error {{'unowned' must not be applied to non-class-bound 'any NonClass'; consider adding a protocol conformance that has a class bound}}
 
 weak
 var weak14 : Ty0 // expected-error {{'weak' variable should have optional type 'Ty0?'}}
 weak
-var weak15 : Class // expected-error {{'weak' variable should have optional type 'Class?'}}
+var weak15 : Class // expected-error {{'weak' variable should have optional type '(any Class)?'}}
 
 weak var weak16 : Class!
 

--- a/test/decl/protocol/conforms/error_self_conformance.swift
+++ b/test/decl/protocol/conforms/error_self_conformance.swift
@@ -1,9 +1,9 @@
 // RUN: %target-typecheck-verify-swift
 
 func wantsError<T: Error>(_: T) {}
-// expected-note@-1 {{required by global function 'wantsError' where 'T' = 'ErrorRefinement'}}
-// expected-note@-2 {{required by global function 'wantsError' where 'T' = 'Error & OtherProtocol'}}
-// expected-note@-3 {{required by global function 'wantsError' where 'T' = 'C & Error'}}
+// expected-note@-1 {{required by global function 'wantsError' where 'T' = 'any ErrorRefinement'}}
+// expected-note@-2 {{required by global function 'wantsError' where 'T' = 'any Error & OtherProtocol'}}
+// expected-note@-3 {{required by global function 'wantsError' where 'T' = 'any C & Error'}}
 
 func testSimple(error: Error) {
   wantsError(error)
@@ -11,15 +11,15 @@ func testSimple(error: Error) {
 
 protocol ErrorRefinement : Error {}
 func testErrorRefinment(error: ErrorRefinement) {
-  wantsError(error) // expected-error {{protocol 'ErrorRefinement' as a type cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  wantsError(error) // expected-error {{type 'any ErrorRefinement' cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 protocol OtherProtocol {}
 func testErrorComposition(error: Error & OtherProtocol) {
-  wantsError(error) // expected-error {{protocol 'Error & OtherProtocol' as a type cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  wantsError(error) // expected-error {{type 'any Error & OtherProtocol' cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 class C {}
 func testErrorCompositionWithClass(error: Error & C) {
-  wantsError(error) // expected-error {{protocol 'C & Error' as a type cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  wantsError(error) // expected-error {{type 'any C & Error' cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -220,9 +220,9 @@ protocol P11 {
 do {
   struct Conformer: P11 {
     // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P11'}}
-    // expected-error@-2 {{type 'P11' does not conform to protocol 'Equatable'}} // FIXME: Crappy diagnostics
-    // expected-error@-3 {{'P11' requires that 'P11' conform to 'Equatable'}}
-    // expected-note@-4 {{requirement specified as 'P11' : 'Equatable'}}
+    // expected-error@-2 {{type 'any P11' does not conform to protocol 'Equatable'}} // FIXME: Crappy diagnostics
+    // expected-error@-3 {{'P11' requires that 'any P11' conform to 'Equatable'}}
+    // expected-note@-4 {{requirement specified as 'any P11' : 'Equatable'}}
     // expected-note@-5 {{requirement from conditional conformance of 'Conformer.A' (aka 'Array<P11>') to 'Equatable'}}
     typealias A = Array<any P11>
   }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -323,137 +323,137 @@ do {
     let _: any P1 = arg.opaqueResultTypeProp
     let _: any P1 = arg[opaqueResultTypeSubscript: true]
 
-    arg.contravariantSelf1(0) // expected-error {{member 'contravariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf2(0) // expected-error {{member 'contravariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf3(0) // expected-error {{member 'contravariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf4(0) // expected-error {{member 'contravariantSelf4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf5(0) // expected-error {{member 'contravariantSelf5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf6(0) // expected-error {{member 'contravariantSelf6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf7() // expected-error {{member 'contravariantSelf7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf8() // expected-error {{member 'contravariantSelf8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf9(0) // expected-error {{member 'contravariantSelf9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf10() // expected-error {{member 'contravariantSelf10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelf11(0) // expected-error {{member 'contravariantSelf11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc1(0) // expected-error {{member 'contravariantAssoc1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc2(0) // expected-error {{member 'contravariantAssoc2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc3(0) // expected-error {{member 'contravariantAssoc3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc4(0) // expected-error {{member 'contravariantAssoc4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc5(0) // expected-error {{member 'contravariantAssoc5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc6(0) // expected-error {{member 'contravariantAssoc6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc7() // expected-error {{member 'contravariantAssoc7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc8() // expected-error {{member 'contravariantAssoc8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc9(0) // expected-error {{member 'contravariantAssoc9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc10() // expected-error {{member 'contravariantAssoc10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssoc11(0) // expected-error {{member 'contravariantAssoc11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf1(0) // expected-error {{member 'contravariantSelf1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf2(0) // expected-error {{member 'contravariantSelf2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf3(0) // expected-error {{member 'contravariantSelf3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf4(0) // expected-error {{member 'contravariantSelf4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf5(0) // expected-error {{member 'contravariantSelf5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf6(0) // expected-error {{member 'contravariantSelf6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf7() // expected-error {{member 'contravariantSelf7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf8() // expected-error {{member 'contravariantSelf8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf9(0) // expected-error {{member 'contravariantSelf9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf10() // expected-error {{member 'contravariantSelf10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelf11(0) // expected-error {{member 'contravariantSelf11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc1(0) // expected-error {{member 'contravariantAssoc1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc2(0) // expected-error {{member 'contravariantAssoc2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc3(0) // expected-error {{member 'contravariantAssoc3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc4(0) // expected-error {{member 'contravariantAssoc4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc5(0) // expected-error {{member 'contravariantAssoc5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc6(0) // expected-error {{member 'contravariantAssoc6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc7() // expected-error {{member 'contravariantAssoc7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc8() // expected-error {{member 'contravariantAssoc8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc9(0) // expected-error {{member 'contravariantAssoc9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc10() // expected-error {{member 'contravariantAssoc10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssoc11(0) // expected-error {{member 'contravariantAssoc11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
 
-    arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf4(0) // expected-error {{member 'invariantSelf4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf5() // expected-error {{member 'invariantSelf5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf6() // expected-error {{member 'invariantSelf6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf7(0) // expected-error {{member 'invariantSelf7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf8(0) // expected-error {{member 'invariantSelf8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf9(0) // expected-error {{member 'invariantSelf9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf10(0) // expected-error {{member 'invariantSelf10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelf11() // expected-error {{member 'invariantSelf11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc1(0) // expected-error {{member 'invariantAssoc1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc2(0) // expected-error {{member 'invariantAssoc2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc3(0) // expected-error {{member 'invariantAssoc3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc4(0) // expected-error {{member 'invariantAssoc4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc5() // expected-error {{member 'invariantAssoc5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc6() // expected-error {{member 'invariantAssoc6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc7(0) // expected-error {{member 'invariantAssoc7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc8(0) // expected-error {{member 'invariantAssoc8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc9(0) // expected-error {{member 'invariantAssoc9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc10(0) // expected-error {{member 'invariantAssoc10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssoc11() // expected-error {{member 'invariantAssoc11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelf1(0) // expected-error {{member 'invariantSelf1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf2(0) // expected-error {{member 'invariantSelf2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf3(0) // expected-error {{member 'invariantSelf3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf4(0) // expected-error {{member 'invariantSelf4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf5() // expected-error {{member 'invariantSelf5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf6() // expected-error {{member 'invariantSelf6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf7(0) // expected-error {{member 'invariantSelf7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf8(0) // expected-error {{member 'invariantSelf8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf9(0) // expected-error {{member 'invariantSelf9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf10(0) // expected-error {{member 'invariantSelf10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelf11() // expected-error {{member 'invariantSelf11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc1(0) // expected-error {{member 'invariantAssoc1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc2(0) // expected-error {{member 'invariantAssoc2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc3(0) // expected-error {{member 'invariantAssoc3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc4(0) // expected-error {{member 'invariantAssoc4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc5() // expected-error {{member 'invariantAssoc5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc6() // expected-error {{member 'invariantAssoc6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc7(0) // expected-error {{member 'invariantAssoc7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc8(0) // expected-error {{member 'invariantAssoc8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc9(0) // expected-error {{member 'invariantAssoc9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc10(0) // expected-error {{member 'invariantAssoc10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssoc11() // expected-error {{member 'invariantAssoc11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
 
-    arg.contravariantSelfProp1 // expected-error {{member 'contravariantSelfProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp2 // expected-error {{member 'contravariantSelfProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp3 // expected-error {{member 'contravariantSelfProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp4 // expected-error {{member 'contravariantSelfProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp5 // expected-error {{member 'contravariantSelfProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp6 // expected-error {{member 'contravariantSelfProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp7 // expected-error {{member 'contravariantSelfProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp8 // expected-error {{member 'contravariantSelfProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp9 // expected-error {{member 'contravariantSelfProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp10 // expected-error {{member 'contravariantSelfProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantSelfProp11 // expected-error {{member 'contravariantSelfProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp1 // expected-error {{member 'contravariantAssocProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp2 // expected-error {{member 'contravariantAssocProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp3 // expected-error {{member 'contravariantAssocProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp4 // expected-error {{member 'contravariantAssocProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp5 // expected-error {{member 'contravariantAssocProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp6 // expected-error {{member 'contravariantAssocProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp7 // expected-error {{member 'contravariantAssocProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp8 // expected-error {{member 'contravariantAssocProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp9 // expected-error {{member 'contravariantAssocProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp10 // expected-error {{member 'contravariantAssocProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.contravariantAssocProp11 // expected-error {{member 'contravariantAssocProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp1 // expected-error {{member 'contravariantSelfProp1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp2 // expected-error {{member 'contravariantSelfProp2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp3 // expected-error {{member 'contravariantSelfProp3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp4 // expected-error {{member 'contravariantSelfProp4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp5 // expected-error {{member 'contravariantSelfProp5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp6 // expected-error {{member 'contravariantSelfProp6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp7 // expected-error {{member 'contravariantSelfProp7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp8 // expected-error {{member 'contravariantSelfProp8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp9 // expected-error {{member 'contravariantSelfProp9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp10 // expected-error {{member 'contravariantSelfProp10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantSelfProp11 // expected-error {{member 'contravariantSelfProp11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp1 // expected-error {{member 'contravariantAssocProp1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp2 // expected-error {{member 'contravariantAssocProp2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp3 // expected-error {{member 'contravariantAssocProp3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp4 // expected-error {{member 'contravariantAssocProp4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp5 // expected-error {{member 'contravariantAssocProp5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp6 // expected-error {{member 'contravariantAssocProp6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp7 // expected-error {{member 'contravariantAssocProp7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp8 // expected-error {{member 'contravariantAssocProp8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp9 // expected-error {{member 'contravariantAssocProp9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp10 // expected-error {{member 'contravariantAssocProp10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.contravariantAssocProp11 // expected-error {{member 'contravariantAssocProp11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
 
-    arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp4 // expected-error {{member 'invariantSelfProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp5 // expected-error {{member 'invariantSelfProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp6 // expected-error {{member 'invariantSelfProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp7 // expected-error {{member 'invariantSelfProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp8 // expected-error {{member 'invariantSelfProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp9 // expected-error {{member 'invariantSelfProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp10 // expected-error {{member 'invariantSelfProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantSelfProp11 // expected-error {{member 'invariantSelfProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp1 // expected-error {{member 'invariantAssocProp1' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp2 // expected-error {{member 'invariantAssocProp2' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp3 // expected-error {{member 'invariantAssocProp3' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp4 // expected-error {{member 'invariantAssocProp4' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp5 // expected-error {{member 'invariantAssocProp5' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp6 // expected-error {{member 'invariantAssocProp6' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp7 // expected-error {{member 'invariantAssocProp7' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp8 // expected-error {{member 'invariantAssocProp8' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp9 // expected-error {{member 'invariantAssocProp9' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp10 // expected-error {{member 'invariantAssocProp10' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg.invariantAssocProp11 // expected-error {{member 'invariantAssocProp11' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp1 // expected-error {{member 'invariantSelfProp1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp2 // expected-error {{member 'invariantSelfProp2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp3 // expected-error {{member 'invariantSelfProp3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp4 // expected-error {{member 'invariantSelfProp4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp5 // expected-error {{member 'invariantSelfProp5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp6 // expected-error {{member 'invariantSelfProp6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp7 // expected-error {{member 'invariantSelfProp7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp8 // expected-error {{member 'invariantSelfProp8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp9 // expected-error {{member 'invariantSelfProp9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp10 // expected-error {{member 'invariantSelfProp10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantSelfProp11 // expected-error {{member 'invariantSelfProp11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp1 // expected-error {{member 'invariantAssocProp1' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp2 // expected-error {{member 'invariantAssocProp2' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp3 // expected-error {{member 'invariantAssocProp3' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp4 // expected-error {{member 'invariantAssocProp4' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp5 // expected-error {{member 'invariantAssocProp5' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp6 // expected-error {{member 'invariantAssocProp6' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp7 // expected-error {{member 'invariantAssocProp7' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp8 // expected-error {{member 'invariantAssocProp8' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp9 // expected-error {{member 'invariantAssocProp9' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp10 // expected-error {{member 'invariantAssocProp10' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg.invariantAssocProp11 // expected-error {{member 'invariantAssocProp11' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
 
-    arg[contravariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantSelfSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[contravariantAssocSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantSelfSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript2: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript3: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript7: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript9: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript10: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[contravariantAssocSubscript11: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
 
-    arg[invariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
-    arg[invariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantSelfSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript1: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript2: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript3: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript4: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript5: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript6: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript7: 0] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
+    arg[invariantAssocSubscript8: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1'; consider using a generic constraint instead}}
   }
 }
 
@@ -479,29 +479,29 @@ do {
             existMeta: any P1_TypeMemberOnInstanceAndViceVersa.Type,
             instance: any P1_TypeMemberOnInstanceAndViceVersa) {
     // P1_TypeMemberOnInstanceAndViceVersa.Protocol
-    protoMeta.static_invariantSelfMethod() // expected-error {{static member 'static_invariantSelfMethod' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
-    protoMeta.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
-    protoMeta[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'}}
+    protoMeta.static_invariantSelfMethod() // expected-error {{static member 'static_invariantSelfMethod' cannot be used on protocol metatype '(any P1_TypeMemberOnInstanceAndViceVersa).Type'}}
+    protoMeta.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on protocol metatype '(any P1_TypeMemberOnInstanceAndViceVersa).Type'}}
+    protoMeta[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on protocol metatype '(any P1_TypeMemberOnInstanceAndViceVersa).Type'}}
     _ = protoMeta.covariantSelfMethod // ok
-    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of protocol type '(P1_TypeMemberOnInstanceAndViceVersa).Protocol'; consider using a generic constraint instead}}
-    protoMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
-    protoMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
+    protoMeta.invariantSelfMethod // expected-error {{member 'invariantSelfMethod' cannot be used on value of type '(any P1_TypeMemberOnInstanceAndViceVersa).Type'; consider using a generic constraint instead}}
+    protoMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'any P1_TypeMemberOnInstanceAndViceVersa'}}
+    protoMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'any P1_TypeMemberOnInstanceAndViceVersa'}}
 
     // P1_TypeMemberOnInstanceAndViceVersa.Type
     _ = existMeta.static_covariantSelfMethod // ok
     _ = existMeta.static_covariantSelfProp // ok
     _ = existMeta[static_covariantSelfSubscript: ()] // ok
-    existMeta.static_invariantSelfMethod // expected-error {{member 'static_invariantSelfMethod' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
-    existMeta.static_invariantSelfProp // expected-error {{member 'static_invariantSelfProp' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
-    existMeta[static_invariantSelfSubscript: ()] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
+    existMeta.static_invariantSelfMethod // expected-error {{member 'static_invariantSelfMethod' cannot be used on value of type 'any P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
+    existMeta.static_invariantSelfProp // expected-error {{member 'static_invariantSelfProp' cannot be used on value of type 'any P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
+    existMeta[static_invariantSelfSubscript: ()] // expected-error {{member 'subscript' cannot be used on value of type 'any P1_TypeMemberOnInstanceAndViceVersa.Type'; consider using a generic constraint instead}}
     existMeta.invariantSelfMethod // expected-error {{instance member 'invariantSelfMethod' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     existMeta.invariantSelfProp // expected-error {{instance member 'invariantSelfProp' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
     existMeta[invariantSelfSubscript: ()] // expected-error {{instance member 'subscript' cannot be used on type 'P1_TypeMemberOnInstanceAndViceVersa'}}
 
     // P1_TypeMemberOnInstanceAndViceVersa
-    instance.static_invariantSelfMethod // expected-error {{static member 'static_invariantSelfMethod' cannot be used on instance of type 'P1_TypeMemberOnInstanceAndViceVersa'}}
-    instance.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on instance of type 'P1_TypeMemberOnInstanceAndViceVersa'}}
-    instance[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on instance of type 'P1_TypeMemberOnInstanceAndViceVersa'}}
+    instance.static_invariantSelfMethod // expected-error {{static member 'static_invariantSelfMethod' cannot be used on instance of type 'any P1_TypeMemberOnInstanceAndViceVersa'}}
+    instance.static_invariantSelfProp // expected-error {{static member 'static_invariantSelfProp' cannot be used on instance of type 'any P1_TypeMemberOnInstanceAndViceVersa'}}
+    instance[static_invariantSelfSubscript: ()] // expected-error {{static member 'subscript' cannot be used on instance of type 'any P1_TypeMemberOnInstanceAndViceVersa'}}
   }
 }
 
@@ -547,14 +547,14 @@ do {
   _ = exist.method3(false) // ok
   exist.method4(false)
   // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
-  // expected-error@-2 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
+  // expected-error@-2 {{member 'method4' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
   exist.method5(false)
   // expected-error@-1 {{instance method 'method5' requires that 'Bool' conform to 'Sequence'}}
-  // expected-error@-2 {{member 'method5' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
+  // expected-error@-2 {{member 'method5' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
 
   exist.method7(false)
   // expected-error@-1 {{instance method 'method7' requires that 'U' conform to 'UnfulfillableGenericRequirements'}}
-  // expected-error@-2 {{member 'method7' cannot be used on value of protocol type 'UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
+  // expected-error@-2 {{member 'method7' cannot be used on value of type 'any UnfulfillableGenericRequirements'; consider using a generic constraint instead}}
 }
 protocol UnfulfillableGenericRequirementsDerived1: UnfulfillableGenericRequirements where A == Bool {}
 protocol UnfulfillableGenericRequirementsDerived2: UnfulfillableGenericRequirements where A == Class<Self> {}
@@ -566,7 +566,7 @@ do {
   exist1.method4(false)
   // expected-error@-1 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>}}
   exist2.method4(false)
-  // expected-error@-1 {{member 'method4' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived2'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'method4' cannot be used on value of type 'any UnfulfillableGenericRequirementsDerived2'; consider using a generic constraint instead}}
   // expected-error@-2 {{instance method 'method4' requires that 'Bool' inherit from 'Class<Self.A>'}}
 }
 protocol UnfulfillableGenericRequirementsDerived3: UnfulfillableGenericRequirements where A: Sequence, A.Element: Sequence {}
@@ -581,7 +581,7 @@ do {
   // expected-error@-2 {{instance method 'method6' requires that 'Self.A' conform to 'Sequence'}}
   // expected-error@-3 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
   exist2.method6(false)
-  // expected-error@-1 {{member 'method6' cannot be used on value of protocol type 'UnfulfillableGenericRequirementsDerived3'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'method6' cannot be used on value of type 'any UnfulfillableGenericRequirementsDerived3'; consider using a generic constraint instead}}
   // expected-error@-2 {{instance method 'method6' requires that 'Bool' conform to 'UnfulfillableGenericRequirements'}}
 }
 
@@ -602,7 +602,7 @@ do {
   exist.method1() // expected-error {{instance method 'method1()' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method2(false) // expected-error {{instance method 'method2' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
   exist.method3(false, false) // expected-error {{instance method 'method3' requires that 'Self.A' conform to 'InvalidTypeParameters'}}
-  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'InvalidTypeParameters'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'method3' cannot be used on value of type 'any InvalidTypeParameters'; consider using a generic constraint instead}}
 }
 
 protocol GenericRequirementFailures {
@@ -622,7 +622,7 @@ do {
   exist.method1() // expected-error {{referencing instance method 'method1()' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
   exist.method2() // expected-error {{referencing instance method 'method2()' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
   exist.method3(false) // expected-error {{referencing instance method 'method3' on 'GenericRequirementFailures' requires the types 'Self.A' and 'Never' be equivalent}}
-  // expected-error@-1 {{member 'method3' cannot be used on value of protocol type 'GenericRequirementFailures'; consider using a generic constraint instead}}
+  // expected-error@-1 {{member 'method3' cannot be used on value of type 'any GenericRequirementFailures'; consider using a generic constraint instead}}
   exist.method4() // expected-error {{referencing instance method 'method4()' on 'GenericRequirementFailures' requires that 'Self.A' conform to 'GenericRequirementFailures'}}
 }
 protocol GenericRequirementFailuresDerived: GenericRequirementFailures where A: GenericRequirementFailures {}
@@ -641,9 +641,9 @@ protocol P2 {
 }
 func takesP2(p2: any P2) {
   _ = p2[]
-  // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P2'; consider using a generic constraint instead}}
+  // expected-error@-1{{member 'subscript' cannot be used on value of type 'any P2'; consider using a generic constraint instead}}
   _ = p2.prop
-  // expected-error@-1{{member 'prop' cannot be used on value of protocol type 'P2'; consider using a generic constraint instead}}
+  // expected-error@-1{{member 'prop' cannot be used on value of type 'any P2'; consider using a generic constraint instead}}
 }
 
 protocol MiscTestsProto {
@@ -659,7 +659,7 @@ do {
     var r: any Sequence & IteratorProtocol = arg.getR()
     r.makeIterator() // expected-warning {{result of call to 'makeIterator()' is unused}}
     r.next() // expected-warning {{result of call to 'next()' is unused}}
-    r.nonexistent() // expected-error {{value of type 'IteratorProtocol & Sequence' has no member 'nonexistent'}}
+    r.nonexistent() // expected-error {{value of type 'any IteratorProtocol & Sequence' has no member 'nonexistent'}}
 
     arg[] // expected-warning {{expression of type 'Any' is unused}}
     arg.getAssoc // expected-warning {{expression of type 'Any?' is unused}}
@@ -744,16 +744,16 @@ protocol ConcreteAssocTypes {
 }
 do {
   func test(arg: any ConcreteAssocTypes) {
-    _ = arg.method1 // expected-error {{member 'method1' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg.method2 // expected-error {{member 'method2' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.method1 // expected-error {{member 'method1' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.method2 // expected-error {{member 'method2' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     // Covariant 'Self' erasure works in conjunction with concrete associated types.
     let _: (Bool, any ConcreteAssocTypes) = arg.property2 // ok
-    _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
-    _ = arg[subscript3: false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
+    _ = arg[subscript3: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
 
     let _: (
       Struct<Bool>, (any ConcreteAssocTypes).Type, () -> Bool

--- a/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
@@ -13,186 +13,186 @@ protocol Q {}
 
 do {
   func test(p: P) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: ((P))) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:18--1:19=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:18--1:19=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: any P) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: (inout any P)) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{none}}
   }
 }
 do {
   func test(p: __shared (any P)) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:30--1:31=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:30--1:31=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: ((any P))) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: any (P)) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P)'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any (P)'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: any   P) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: (any  (P))) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P)'; consider using a generic constraint instead}} {{-1:23--1:24=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any (P)'; consider using a generic constraint instead}} {{-1:23--1:24=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: P.Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any P.Type'; consider using a generic constraint instead}} {{-1:16--1:17=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: (P).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P).Type'; consider using a generic constraint instead}} {{-1:17--1:18=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P).Type'; consider using a generic constraint instead}} {{-1:17--1:18=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: any P.Type) {
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   func test(p: any ((P).Type)) {
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P).Type'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P).Type'; consider using a generic constraint instead}} {{-1:22--1:23=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 
 do {
   func test(p: P & Q) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:16--1:21=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:16--1:21=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: ((P & Q))) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: any P & Q) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: inout any P & Q) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{none}}
   }
 }
 do {
   func test(p: __shared (any P & Q)) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:30--1:35=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:30--1:35=<#generic parameter name#>}} {{-1:26--1:30=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: ((any P & Q))) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:18--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: any (P & Q)) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P & Q)'; consider using a generic constraint instead}} {{-1:21--1:26=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any (P & Q)'; consider using a generic constraint instead}} {{-1:21--1:26=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: any   P & Q) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:22--1:27=<#generic parameter name#>}} {{-1:16--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: (any  (P & Q))) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type '(P & Q)'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any (P & Q)'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:17--1:22=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: (P & Q).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P & Q).Type'; consider using a generic constraint instead}} {{-1:16--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P & Q).Type'; consider using a generic constraint instead}} {{-1:16--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: ((P & Q)).Type) { // expected-warning {{protocol 'P' as a type must be explicitly marked as 'any'}}
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '((P & Q)).Type'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any ((P & Q)).Type'; consider using a generic constraint instead}} {{-1:18--1:23=<#generic parameter name#>}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: any (P & Q).Type) {
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '(P & Q).Type'; consider using a generic constraint instead}} {{-1:20--1:27=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P & Q).Type'; consider using a generic constraint instead}} {{-1:20--1:27=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 do {
   func test(p: any (((P & Q)).Type)) {
-    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of protocol type '((P & Q)).Type'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any ((P & Q)).Type'; consider using a generic constraint instead}} {{-1:23--1:28=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
   }
 }
 
 do {
   // With an existing generic parameter list.
   func test<T: Sequence>(t: T, p: any P) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:39--1:40=<#generic parameter name#>}} {{-1:35--1:39=}} {{-1:24--1:24=, <#generic parameter name#>: P}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:39--1:40=<#generic parameter name#>}} {{-1:35--1:39=}} {{-1:24--1:24=, <#generic parameter name#>: P}} {{none}}
   }
 }
 do {
   // With an subscript expression.
   func test(p: any P) {
-    p[false] // expected-error {{member 'subscript' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p[false] // expected-error {{member 'subscript' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 do {
   // With an initializer.
   func test(p: any P.Type) {
-    p.init(false) // expected-error {{member 'init' cannot be used on value of protocol type 'P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.init(false) // expected-error {{member 'init' cannot be used on value of type 'any P.Type'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
   }
 }
 
 // Inside initializers, accessors and subscripts.
 struct Test {
   init(p: any P) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:15--1:16=<#generic parameter name#>}} {{-1:11--1:15=}} {{-1:7--1:7=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:15--1:16=<#generic parameter name#>}} {{-1:11--1:15=}} {{-1:7--1:7=<<#generic parameter name#>: P>}} {{none}}
   }
 
   init<T: P>(p: any P, t: T) {
-    p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:17--1:21=}} {{-1:12--1:12=, <#generic parameter name#>: P}} {{none}}
+    p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:21--1:22=<#generic parameter name#>}} {{-1:17--1:21=}} {{-1:12--1:12=, <#generic parameter name#>: P}} {{none}}
   }
 
   subscript(p: any P) -> any P {
-    p.method(false)  // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
+    p.method(false)  // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:20--1:21=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P>}} {{none}}
     return p
   }
 
   subscript<T: P>(p: any P, t: T) -> any P {
     get {
-      p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-2:26--2:27=<#generic parameter name#>}} {{-2:22--2:26=}} {{-2:17--2:17=, <#generic parameter name#>: P}} {{none}}
+      p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-2:26--2:27=<#generic parameter name#>}} {{-2:22--2:26=}} {{-2:17--2:17=, <#generic parameter name#>: P}} {{none}}
       return p
     }
     set(value) {
-      p.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{-6:26--6:27=<#generic parameter name#>}} {{-6:22--6:26=}} {{-6:17--6:17=, <#generic parameter name#>: P}} {{none}}
-      value.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+      p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-6:26--6:27=<#generic parameter name#>}} {{-6:22--6:26=}} {{-6:17--6:17=, <#generic parameter name#>: P}} {{none}}
+      value.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{none}}
     }
   }
 
   subscript(p: any P & Q) -> any P {
-    _read { p.method(false) }   // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
-    _modify { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-2:20--2:25=<#generic parameter name#>}} {{-2:16--2:20=}} {{-2:12--2:12=<<#generic parameter name#>: P & Q>}} {{none}}
-    willSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-3:20--3:25=<#generic parameter name#>}} {{-3:16--3:20=}} {{-3:12--3:12=<<#generic parameter name#>: P & Q>}} {{none}}
-    didSet { p.method(false) }  // expected-error {{member 'method' cannot be used on value of protocol type 'P & Q'; consider using a generic constraint instead}} {{-4:20--4:25=<#generic parameter name#>}} {{-4:16--4:20=}} {{-4:12--4:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    _read { p.method(false) }   // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:20--1:25=<#generic parameter name#>}} {{-1:16--1:20=}} {{-1:12--1:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    _modify { p.method(false) } // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-2:20--2:25=<#generic parameter name#>}} {{-2:16--2:20=}} {{-2:12--2:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    willSet { p.method(false) } // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-3:20--3:25=<#generic parameter name#>}} {{-3:16--3:20=}} {{-3:12--3:12=<<#generic parameter name#>: P & Q>}} {{none}}
+    didSet { p.method(false) }  // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-4:20--4:25=<#generic parameter name#>}} {{-4:16--4:20=}} {{-4:12--4:12=<<#generic parameter name#>: P & Q>}} {{none}}
     // expected-error@-2 {{'willSet' is not allowed in subscripts}}
     // expected-error@-2 {{'didSet' is not allowed in subscripts}}
   }
@@ -200,7 +200,7 @@ struct Test {
   var property: any P {
     get {}
     set {
-      newValue.method(false) // expected-error {{member 'method' cannot be used on value of protocol type 'P'; consider using a generic constraint instead}} {{none}}
+      newValue.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{none}}
     }
   }
 }

--- a/test/decl/protocol/fixits_missing_protocols_in_context.swift
+++ b/test/decl/protocol/fixits_missing_protocols_in_context.swift
@@ -12,7 +12,7 @@ class C {
 
   func assign() {
     p = self
-    // expected-error@-1 {{cannot assign value of type 'C' to type 'P?'}}
+    // expected-error@-1 {{cannot assign value of type 'C' to type '(any P)?'}}
     // expected-note@-2 {{add missing conformance to 'P' to class 'C'}} {{8-8=: P}} {{10-10=\n    func method() {\n        <#code#>\n    \}\n\n    var property: Int\n}}
   }
 }
@@ -24,7 +24,7 @@ class C1 {
 
   func assign() {
     p = self
-    // expected-error@-1 {{cannot assign value of type 'C1' to type 'P?'}}
+    // expected-error@-1 {{cannot assign value of type 'C1' to type '(any P)?'}}
     // expected-note@-2 {{add missing conformance to 'P' to class 'C1'}} {{9-9=: P}} {{11-11=\n    var property: Int\n}}
   }
 
@@ -36,7 +36,7 @@ class C2 {
 
   func assign() {
     p = self
-    // expected-error@-1 {{cannot assign value of type 'C2' to type 'P?'}}
+    // expected-error@-1 {{cannot assign value of type 'C2' to type '(any P)?'}}
     // expected-note@-2 {{add missing conformance to 'P' to class 'C2'}} {{9-9=: P}}
   }
 

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -208,15 +208,15 @@ protocol ProtocolWithClassInits : ClassWithInits<Int> {}
 
 func useProtocolWithClassInits1() {
   _ = ProtocolWithClassInits(notRequiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolWithClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolWithClassInits' cannot be instantiated}}
 
   _ = ProtocolWithClassInits(requiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolWithClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolWithClassInits' cannot be instantiated}}
 }
 
 func useProtocolWithClassInits2(_ t: ProtocolWithClassInits.Type) {
   _ = t.init(notRequiredInit: ())
-  // expected-error@-1 {{constructing an object of class type 'ProtocolWithClassInits' with a metatype value must use a 'required' initializer}}
+  // expected-error@-1 {{constructing an object of class type 'any ProtocolWithClassInits' with a metatype value must use a 'required' initializer}}
 
   let _: ProtocolWithClassInits = t.init(requiredInit: ())
 }
@@ -237,15 +237,15 @@ protocol ProtocolRefinesClassInits : ProtocolWithClassInits {}
 
 func useProtocolRefinesClassInits1() {
   _ = ProtocolRefinesClassInits(notRequiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolRefinesClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolRefinesClassInits' cannot be instantiated}}
 
   _ = ProtocolRefinesClassInits(requiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolRefinesClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolRefinesClassInits' cannot be instantiated}}
 }
 
 func useProtocolRefinesClassInits2(_ t: ProtocolRefinesClassInits.Type) {
   _ = t.init(notRequiredInit: ())
-  // expected-error@-1 {{constructing an object of class type 'ProtocolRefinesClassInits' with a metatype value must use a 'required' initializer}}
+  // expected-error@-1 {{constructing an object of class type 'any ProtocolRefinesClassInits' with a metatype value must use a 'required' initializer}}
 
   let _: ProtocolRefinesClassInits = t.init(requiredInit: ())
 }

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -209,15 +209,15 @@ protocol ProtocolWithClassInits where Self : ClassWithInits<Int> {}
 
 func useProtocolWithClassInits1() {
   _ = ProtocolWithClassInits(notRequiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolWithClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolWithClassInits' cannot be instantiated}}
 
   _ = ProtocolWithClassInits(requiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolWithClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolWithClassInits' cannot be instantiated}}
 }
 
 func useProtocolWithClassInits2(_ t: ProtocolWithClassInits.Type) {
   _ = t.init(notRequiredInit: ())
-  // expected-error@-1 {{constructing an object of class type 'ProtocolWithClassInits' with a metatype value must use a 'required' initializer}}
+  // expected-error@-1 {{constructing an object of class type 'any ProtocolWithClassInits' with a metatype value must use a 'required' initializer}}
 
   let _: ProtocolWithClassInits = t.init(requiredInit: ())
 }
@@ -238,15 +238,15 @@ protocol ProtocolRefinesClassInits : ProtocolWithClassInits {}
 
 func useProtocolRefinesClassInits1() {
   _ = ProtocolRefinesClassInits(notRequiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolRefinesClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolRefinesClassInits' cannot be instantiated}}
 
   _ = ProtocolRefinesClassInits(requiredInit: ())
-  // expected-error@-1 {{protocol type 'ProtocolRefinesClassInits' cannot be instantiated}}
+  // expected-error@-1 {{type 'any ProtocolRefinesClassInits' cannot be instantiated}}
 }
 
 func useProtocolRefinesClassInits2(_ t: ProtocolRefinesClassInits.Type) {
   _ = t.init(notRequiredInit: ())
-  // expected-error@-1 {{constructing an object of class type 'ProtocolRefinesClassInits' with a metatype value must use a 'required' initializer}}
+  // expected-error@-1 {{constructing an object of class type 'any ProtocolRefinesClassInits' with a metatype value must use a 'required' initializer}}
 
   let _: ProtocolRefinesClassInits = t.init(requiredInit: ())
 }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -119,7 +119,7 @@ struct Circle {
 func testCircular(_ circle: Circle) {
   // FIXME: It would be nice if this failure were suppressed because the protocols
   // have circular definitions.
-  _ = circle as any CircleStart // expected-error{{value of type 'Circle' does not conform to 'CircleStart' in coercion}}
+  _ = circle as any CircleStart // expected-error{{cannot convert value of type 'Circle' to type 'any CircleStart' in coercion}}
 }
 
 // <rdar://problem/14750346>
@@ -284,7 +284,7 @@ struct StaticAndInstanceS : InstanceP {
 }
 func StaticProtocolFunc() {
   let a: StaticP = StaticS1()
-  a.f() // expected-error{{static member 'f' cannot be used on instance of type 'StaticP'}}
+  a.f() // expected-error{{static member 'f' cannot be used on instance of type 'any StaticP'}}
 }
 func StaticProtocolGenericFunc<t : StaticP>(_: t) {
   t.f()
@@ -419,7 +419,7 @@ protocol ShouldntCrash {
 // rdar://problem/18168866
 protocol FirstProtocol {
     // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
-    weak var delegate : SecondProtocol? { get } // expected-error{{'weak' must not be applied to non-class-bound 'SecondProtocol'; consider adding a protocol conformance that has a class bound}}
+    weak var delegate : SecondProtocol? { get } // expected-error{{'weak' must not be applied to non-class-bound 'any SecondProtocol'; consider adding a protocol conformance that has a class bound}}
 }
 
 protocol SecondProtocol {
@@ -434,7 +434,7 @@ func f<T : C1>(_ x : T) {
 
 class C2 {}
 func g<T : C2>(_ x : T) {
-  x as P2 // expected-error{{value of type 'T' does not conform to 'P2' in coercion}}
+  x as P2 // expected-error{{cannot convert value of type 'T' to type 'any P2' in coercion}}
 }
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}
@@ -443,7 +443,7 @@ func h<T : C3>(_ x : T) {
 }
 func i<T : C3>(_ x : T?) -> Bool {
   return x is any P1
-  // expected-warning@-1 {{checking a value with optional type 'T?' against type 'P1' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
+  // expected-warning@-1 {{checking a value with optional type 'T?' against type 'any P1' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
 }
 func j(_ x : C1) -> Bool {
   return x is P1 // expected-warning {{protocol 'P1' as a type must be explicitly marked as 'any'}}
@@ -497,7 +497,7 @@ class SR_11412_C1 {
   let c0 = SR_11412_C0()
 
   func conform() {
-    c0.foo1 = self // expected-error {{cannot assign value of type 'SR_11412_C1' to type 'SR_11412_P1?'}}
+    c0.foo1 = self // expected-error {{cannot assign value of type 'SR_11412_C1' to type '(any SR_11412_P1)?'}}
     // expected-note@-1 {{add missing conformance to 'SR_11412_P1' to class 'SR_11412_C1'}}{{18-18=: SR_11412_P1}}
   }
 }
@@ -508,7 +508,7 @@ class SR_11412_C2 {
   let c0 = SR_11412_C0()
 
   func conform() {
-    c0.foo2 = self // expected-error {{cannot assign value of type 'SR_11412_C2' to type '(SR_11412_P1 & SR_11412_P2)?'}}
+    c0.foo2 = self // expected-error {{cannot assign value of type 'SR_11412_C2' to type '(any SR_11412_P1 & SR_11412_P2)?'}}
     // expected-note@-1 {{add missing conformance to 'SR_11412_P1 & SR_11412_P2' to class 'SR_11412_C2'}}{{18-18=: SR_11412_P1 & SR_11412_P2}}
   }
 }
@@ -519,7 +519,7 @@ class SR_11412_C3: SR_11412_P3 {
   let c0 = SR_11412_C0()
 
   func conform() {
-    c0.foo1 = self // expected-error {{cannot assign value of type 'SR_11412_C3' to type 'SR_11412_P1?'}}
+    c0.foo1 = self // expected-error {{cannot assign value of type 'SR_11412_C3' to type '(any SR_11412_P1)?'}}
     // expected-note@-1 {{add missing conformance to 'SR_11412_P1' to class 'SR_11412_C3'}}{{31-31=, SR_11412_P1}}
   }
 }
@@ -530,7 +530,7 @@ class SR_11412_C4: SR_11412_P1 {
   let c0 = SR_11412_C0()
 
   func conform() {
-    c0.foo2 = self // expected-error {{cannot assign value of type 'SR_11412_C4' to type '(SR_11412_P1 & SR_11412_P2)?'}}
+    c0.foo2 = self // expected-error {{cannot assign value of type 'SR_11412_C4' to type '(any SR_11412_P1 & SR_11412_P2)?'}}
     // expected-note@-1 {{add missing conformance to 'SR_11412_P1 & SR_11412_P2' to class 'SR_11412_C4'}}{{31-31=, SR_11412_P2}}
   }
 }
@@ -541,6 +541,6 @@ struct SR_11412_S0 {
   let c0 = SR_11412_C0()
 
   func conform() {
-    c0.foo3 = self // expected-error {{cannot assign value of type 'SR_11412_S0' to type 'SR_11412_P4?'}}
+    c0.foo3 = self // expected-error {{cannot assign value of type 'SR_11412_S0' to type '(any SR_11412_P4)?'}}
   }
 }

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -107,7 +107,7 @@ protocol P12 {
 extension Int : P11 {}
 struct S3 : P12 { // expected-error {{type 'S3' does not conform to protocol 'P12'}}
     func bar() -> P11 { return 0 }
-    // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{19-19=some }}
+    // expected-note@-1 {{cannot infer 'A' = 'any P11' because 'any P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{19-19=some }}
 }
 
 protocol P13 {
@@ -116,7 +116,7 @@ protocol P13 {
 }
 struct S4: P13 { // expected-error {{type 'S4' does not conform to protocol 'P13'}}
   var bar: P11 { return 0 }
-  // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{12-12=some }}
+  // expected-note@-1 {{cannot infer 'A' = 'any P11' because 'any P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{12-12=some }}
 }
 
 protocol P14 {
@@ -125,7 +125,7 @@ protocol P14 {
 }
 struct S5: P14 { // expected-error {{type 'S5' does not conform to protocol 'P14'}}
   subscript(i: Int) -> P11 { return i }
-  // expected-note@-1 {{cannot infer 'A' = 'P11' because 'P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{24-24=some }}
+  // expected-note@-1 {{cannot infer 'A' = 'any P11' because 'any P11' as a type cannot conform to protocols; did you mean to use an opaque result type?}}{{24-24=some }}
 }
 
 // SR-12759

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1272,7 +1272,7 @@ class WeakFixItTest {
   // expected-error @+1 {{'weak' variable should have optional type 'WeakFixItTest?'}} {{31-31=?}}
   weak var foo : WeakFixItTest
 
-  // expected-error @+1 {{'weak' variable should have optional type '(WFI_P1 & WFI_P2)?'}} {{18-18=(}} {{33-33=)?}}
+  // expected-error @+1 {{'weak' variable should have optional type '(any WFI_P1 & WFI_P2)?'}} {{18-18=(}} {{33-33=)?}}
   weak var bar : WFI_P1 & WFI_P2
 }
 

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -56,7 +56,7 @@ var ao1 : AnyObject
 var ao2 = ao1
 
 var aot1 : AnyObject.Type
-var aot2 = aot1          // expected-warning {{variable 'aot2' inferred to have type 'AnyObject.Type', which may be unexpected}} \
+var aot2 = aot1          // expected-warning {{variable 'aot2' inferred to have type 'any AnyObject.Type', which may be unexpected}} \
                        // expected-note {{add an explicit type annotation to silence this warning}} {{9-9=: AnyObject.Type}}
 
 

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -118,10 +118,10 @@ func sr6022() -> Any { return 0 }
 func sr6022_1() { return; }
 protocol SR6022_P {}
 
-_ = sr6022 as! SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{11-11=()}}
-_ = sr6022 as? SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'}}{{11-11=()}}
-_ = sr6022_1 as! SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'SR6022_P' always fails}}
-_ = sr6022_1 as? SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'SR6022_P' always fails}}
+_ = sr6022 as! SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'any SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{11-11=()}}
+_ = sr6022 as? SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'any SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'}}{{11-11=()}}
+_ = sr6022_1 as! SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'any SR6022_P' always fails}}
+_ = sr6022_1 as? SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'any SR6022_P' always fails}}
 
 func testSR6022_P<T: SR6022_P>(_: T.Type) {
   _ = sr6022 as! T // expected-warning {{cast from '() -> Any' to unrelated type 'T' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{13-13=()}}

--- a/test/expr/cast/metatype_casts.swift
+++ b/test/expr/cast/metatype_casts.swift
@@ -43,11 +43,11 @@ use(c as! CP.Type)
 use(c as! CP.Protocol) // expected-warning{{always fails}}
 use(c as! Int.Type) // expected-warning{{always fails}}
 
-use(C.self as AnyObject.Protocol) // expected-error{{cannot convert value of type 'C.Type' to type 'AnyObject.Protocol' in coercion}}
+use(C.self as AnyObject.Protocol) // expected-error{{cannot convert value of type 'C.Type' to type '(any AnyObject).Type' in coercion}}
 use(C.self as AnyObject.Type)
-use(C.self as P.Type) // expected-error{{cannot convert value of type 'C.Type' to type 'P.Type' in coercion}} 
+use(C.self as P.Type) // expected-error{{cannot convert value of type 'C.Type' to type 'any P.Type' in coercion}}
 
-use(E.self as P.Protocol) // expected-error{{cannot convert value of type 'E.Type' to type 'P.Protocol' in coercion}}
+use(E.self as P.Protocol) // expected-error{{cannot convert value of type 'E.Type' to type '(any P).Type' in coercion}}
 use(E.self as P.Type)
 
 // SR-12946

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -760,10 +760,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns false}}
-_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns false}}
-_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns true}}
-_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns true}}
+_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'any Any.Type' to 'nil' always returns false}}
+_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'any Any.Type' to 'nil' always returns false}}
+_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'any Any.Type' to 'nil' always returns true}}
+_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'any Any.Type' to 'nil' always returns true}}
 
 // <rdar://problem/19032294> Disallow postfix ? when not chaining
 func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -113,11 +113,11 @@ protocol P2 {
 
 func constructExistentialValue(_ pm: P.Type) {
   _ = pm.init()
-  _ = P() // expected-error{{protocol type 'P' cannot be instantiated}}
+  _ = P() // expected-error{{type 'any P' cannot be instantiated}}
 }
 
 typealias P1_and_P2 = P & P2
 func constructExistentialCompositionValue(_ pm: (P & P2).Type) {
   _ = pm.init(int: 5)
-  _ = P1_and_P2(int: 5) // expected-error{{protocol type 'P1_and_P2' (aka 'P & P2') cannot be instantiated}}
+  _ = P1_and_P2(int: 5) // expected-error{{type 'any P1_and_P2' (aka 'P & P2') cannot be instantiated}}
 }

--- a/test/expr/postfix/dot/optional_context_member.swift
+++ b/test/expr/postfix/dot/optional_context_member.swift
@@ -82,7 +82,7 @@ protocol Horse {
 func rideAHorse(_ horse: Horse?) {}
 
 rideAHorse(.palomino)
-// expected-error@-1 {{static member 'palomino' cannot be used on protocol metatype 'Horse.Protocol'}}
+// expected-error@-1 {{static member 'palomino' cannot be used on protocol metatype '(any Horse).Type'}}
 
 // FIXME: This should work if the static member is part of a class though
 class Donkey {
@@ -92,4 +92,4 @@ class Donkey {
 func rideAMule(_ mule: (Horse & Donkey)?) {}
 
 rideAMule(.mule)
-// expected-error@-1 {{static member 'mule' cannot be used on protocol metatype '(Donkey & Horse).Protocol'}}
+// expected-error@-1 {{static member 'mule' cannot be used on protocol metatype '(any Donkey & Horse).Type'}}

--- a/test/expr/primary/selector/selector.swift
+++ b/test/expr/primary/selector/selector.swift
@@ -64,8 +64,8 @@ func testSelector(_ c1: C1, p1: P1, obj: AnyObject) {
   // Methods on a protocol.
   _ = #selector(P1.method4)
   _ = #selector(P1.method4(_:b:))
-  _ = #selector(P1.method5) // expected-error{{static member 'method5' cannot be used on protocol metatype 'P1.Protocol'}}
-  _ = #selector(P1.method5(_:b:)) // expected-error{{static member 'method5(_:b:)' cannot be used on protocol metatype 'P1.Protocol'}}
+  _ = #selector(P1.method5) // expected-error{{static member 'method5' cannot be used on protocol metatype '(any P1).Type'}}
+  _ = #selector(P1.method5(_:b:)) // expected-error{{static member 'method5(_:b:)' cannot be used on protocol metatype '(any P1).Type'}}
   _ = #selector(p1.method4)
   _ = #selector(p1.method4(_:b:))
   _ = #selector(type(of: p1).method5)

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -451,7 +451,7 @@ func testKeyPathSubscriptExistentialBase(concreteBase: inout B,
   _ = concreteBase[keyPath: pkp]
 
   concreteBase[keyPath: kp] = s // expected-error {{cannot assign through subscript: 'kp' is a read-only key path}}
-  concreteBase[keyPath: wkp] = s // expected-error {{key path with root type 'P' cannot be applied to a base of type 'B'}}
+  concreteBase[keyPath: wkp] = s // expected-error {{key path with root type 'any P' cannot be applied to a base of type 'B'}}
   concreteBase[keyPath: rkp] = s
   concreteBase[keyPath: pkp] = s // expected-error {{cannot assign through subscript: 'pkp' is a read-only key path}}
 
@@ -689,8 +689,8 @@ func testSubtypeKeypathClass(_ keyPath: ReferenceWritableKeyPath<Base, Int>) {
 
 func testSubtypeKeypathProtocol(_ keyPath: ReferenceWritableKeyPath<PP, Int>) {
   testSubtypeKeypathProtocol(\Base.i)
-  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to expected argument type 'ReferenceWritableKeyPath<PP, Int>'}}
-  // expected-note@-2 {{arguments to generic parameter 'Root' ('Base' and 'PP') are expected to be equal}}
+  // expected-error@-1 {{cannot convert value of type 'ReferenceWritableKeyPath<Base, Int>' to expected argument type 'ReferenceWritableKeyPath<any PP, Int>'}}
+  // expected-note@-2 {{arguments to generic parameter 'Root' ('Base' and 'any PP') are expected to be equal}}
 }
 
 // rdar://problem/32057712

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -189,7 +189,7 @@ class SR_6400_FakeViewController {}
 func sr_6400() throws {
   do {
     throw SR_6400_E.castError
-  } catch is SR_6400_S_1 { // expected-warning {{cast from 'Error' to unrelated type 'SR_6400_S_1' always fails}}
+  } catch is SR_6400_S_1 { // expected-warning {{cast from 'any Error' to unrelated type 'SR_6400_S_1' always fails}}
     print("Caught error")
   }
   
@@ -247,7 +247,7 @@ func sr_11402_func1(_ x: SR_11402_P) {
 final class SR_11402_Final {}
 
 func sr_11402_func2(_ x: SR_11402_P) {
-  if let y = x as? SR_11402_Final { // expected-warning {{cast from 'SR_11402_P' to unrelated type 'SR_11402_Final' always fails}}
+  if let y = x as? SR_11402_Final { // expected-warning {{cast from 'any SR_11402_P' to unrelated type 'SR_11402_Final' always fails}}
     print(y)
   }
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -177,7 +177,7 @@ func testOptionalSequence() {
 
 // FIXME: Should this be allowed?
 func testExistentialSequence(s: any Sequence) {
-  for x in s { // expected-error {{protocol 'Sequence' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  for x in s { // expected-error {{type 'any Sequence' cannot conform to 'Sequence'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
     _ = x
   }
 }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -266,15 +266,15 @@ class C : any Empty {} // expected-error {{inheritance from non-protocol, non-cl
 
 // FIXME: Diagnostics are not great in the enum case because we confuse this with a raw type
 
-enum E : any Empty { // expected-error {{raw type 'Empty' is not expressible by a string, integer, or floating-point literal}}
-// expected-error@-1 {{'E' declares raw type 'Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
-// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'Empty' is not Equatable}}
+enum E : any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'E' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
   case hack
 }
 
-enum EE : Equatable, any Empty { // expected-error {{raw type 'Empty' is not expressible by a string, integer, or floating-point literal}}
-// expected-error@-1 {{'EE' declares raw type 'Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
-// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'Empty' is not Equatable}}
-// expected-error@-3 {{raw type 'Empty' must appear first in the enum inheritance clause}}
+enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'EE' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
+// expected-error@-3 {{raw type 'any Empty' must appear first in the enum inheritance clause}}
   case hack
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -505,7 +505,7 @@ extension OpaqueProtocol {
 func takesOpaqueProtocol(existential: OpaqueProtocol) {
   // These are okay because we erase to the opaque type bound
   let a = existential.asSome
-  let _: Int = a // expected-error{{cannot convert value of type 'OpaqueProtocol' to specified type 'Int'}}
+  let _: Int = a // expected-error{{cannot convert value of type 'any OpaqueProtocol' to specified type 'Int'}}
   _ = existential.getAsSome()
   _ = existential[0]
 }

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -56,7 +56,7 @@ func testEquality() {
 
   let x7 : (_ : P1 & P3) -> ()
   let x8 : (_ : P2) -> ()
-  x7 = x8 // expected-error{{cannot assign value of type '(P2) -> ()' to type '(P1 & P3) -> ()'}}
+  x7 = x8 // expected-error{{cannot assign value of type '(any P2) -> ()' to type '(any P1 & P3) -> ()'}}
   _ = x7
 }
 
@@ -111,7 +111,7 @@ func testConversion() {
 
   // Conversions among existential types.
   var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
-  x2 = x // expected-error{{value of type 'FooProtocol & REPLPrintable' does not conform to 'SuperREPLPrintable' in assignment}}
+  x2 = x // expected-error{{value of type 'any FooProtocol & REPLPrintable' does not conform to 'SuperREPLPrintable' in assignment}}
   x = x2
 
   // Subtyping
@@ -143,10 +143,10 @@ typealias H = protocol<P1>! // expected-error {{'protocol<...>' composition synt
 typealias J = protocol<P1, P2>.Protocol // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-31=(P1 & P2)}}
 typealias K = protocol<P1, P2>? // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-32=(P1 & P2)?}}
 
-typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type 'P1.Protocol' cannot be used within a protocol-constrained type}}
-typealias T02 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'P1.Type' cannot be used within a protocol-constrained type}}
-typealias T03 = P1? & P2 // expected-error {{non-protocol, non-class type 'P1?' cannot be used within a protocol-constrained type}}
-typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type 'P2?' cannot be used within a protocol-constrained type}}
+typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type '(any P1).Type' cannot be used within a protocol-constrained type}}
+typealias T02 = P1.Type & P2 // expected-error {{non-protocol, non-class type 'any P1.Type' cannot be used within a protocol-constrained type}}
+typealias T03 = P1? & P2 // expected-error {{non-protocol, non-class type '(any P1)?' cannot be used within a protocol-constrained type}}
+typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type '(any P2)?' cannot be used within a protocol-constrained type}}
 // expected-warning@-1 {{using '!' is not allowed here; treating this as '?' instead}}
 typealias T05 = P1 & P2 -> P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{24-24=)}}
 typealias T06 = P1 -> P2 & P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{19-19=)}}
@@ -155,10 +155,10 @@ func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
 struct S01: P5 & P6 {}
-struct S02: P5? & P6 {} // expected-error {{non-protocol, non-class type 'P5?' cannot be used within a protocol-constrained type}}
-struct S03: Optional<P5> & P6 {} // expected-error {{non-protocol, non-class type 'Optional<P5>' cannot be used within a protocol-constrained type}}
+struct S02: P5? & P6 {} // expected-error {{non-protocol, non-class type '(any P5)?' cannot be used within a protocol-constrained type}}
+struct S03: Optional<P5> & P6 {} // expected-error {{non-protocol, non-class type 'Optional<any P5>' cannot be used within a protocol-constrained type}}
 struct S04<T : P5 & (P6)> {}
-struct S05<T> where T : P5? & P6 {} // expected-error {{non-protocol, non-class type 'P5?' cannot be used within a protocol-constrained type}}
+struct S05<T> where T : P5? & P6 {} // expected-error {{non-protocol, non-class type '(any P5)?' cannot be used within a protocol-constrained type}}
 
 // SR-3124 - Protocol Composition Often Migrated Incorrectly
 struct S3124<T: protocol<P1, P3>> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{17-34=P1 & P3>}}
@@ -174,8 +174,8 @@ takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
 takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
 takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{cannot find 'DoesNotExist' in scope}}
 takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}
-// expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and 'P1.Protocol'}}
-// expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and 'P2.Protocol'}}
+// expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P2).Type'}}
+// expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P1).Type'}}
 // expected-note@-3 2 {{overloads for '&' exist with these partially matching parameter lists}}
 // expected-error@-4 {{cannot call value of non-function type '[UInt8]'}}
 

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -111,15 +111,15 @@ func basicSubtyping(
   // Errors
   let _: Base & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
   let _: Base<Int> & P2 = base // expected-error {{value of type 'Base<Int>' does not conform to specified type 'P2'}}
-  let _: P3 = baseAndP1 // expected-error {{value of type 'Base<Int> & P1' does not conform to specified type 'P3'}}
-  let _: P3 = baseAndP2 // expected-error {{value of type 'Base<Int> & P2' does not conform to specified type 'P3'}}
-  let _: Derived = baseAndP1 // expected-error {{cannot convert value of type 'Base<Int> & P1' to specified type 'Derived'}}
-  let _: Derived = baseAndP2 // expected-error {{cannot convert value of type 'Base<Int> & P2' to specified type 'Derived'}}
-  let _: Derived & P2 = baseAndP2 // expected-error {{cannot convert value of type 'Base<Int> & P2' to specified type 'Derived'}}
+  let _: P3 = baseAndP1 // expected-error {{value of type 'any Base<Int> & P1' does not conform to specified type 'P3'}}
+  let _: P3 = baseAndP2 // expected-error {{value of type 'any Base<Int> & P2' does not conform to specified type 'P3'}}
+  let _: Derived = baseAndP1 // expected-error {{cannot convert value of type 'any Base<Int> & P1' to specified type 'Derived'}}
+  let _: Derived = baseAndP2 // expected-error {{cannot convert value of type 'any Base<Int> & P2' to specified type 'Derived'}}
+  let _: Derived & P2 = baseAndP2 // expected-error {{cannot convert value of type 'any Base<Int> & P2' to specified type 'Derived'}}
 
-  let _ = Unrelated() as Derived & P2 // expected-error {{value of type 'Unrelated' does not conform to 'Derived & P2' in coercion}}
+  let _ = Unrelated() as Derived & P2 // expected-error {{cannot convert value of type 'Unrelated' to type 'any Derived & P2' in coercion}}
   let _ = Unrelated() as? Derived & P2 // expected-warning {{always fails}}
-  let _ = baseAndP2 as Unrelated // expected-error {{cannot convert value of type 'Base<Int> & P2' to type 'Unrelated' in coercion}}
+  let _ = baseAndP2 as Unrelated // expected-error {{cannot convert value of type 'any Base<Int> & P2' to type 'Unrelated' in coercion}}
   let _ = baseAndP2 as? Unrelated // expected-warning {{always fails}}
 
   // Different behavior on Linux vs Darwin because of id-as-Any.
@@ -212,26 +212,26 @@ func basicSubtyping(
   let _: Base<Int> & P2 = baseAndP2.protocolSelfReturn()
 
   // Downcasts
-  let _ = baseAndP2 as Derived //expected-error {{'Base<Int> & P2' is not convertible to 'Derived'}}
+  let _ = baseAndP2 as Derived //expected-error {{'any Base<Int> & P2' is not convertible to 'Derived'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{21-23=as!}}
   let _ = baseAndP2 as? Derived
   
-  let _ = baseAndP2 as Derived & P3 // expected-error {{'Base<Int> & P2' is not convertible to 'Derived & P3'}}
+  let _ = baseAndP2 as Derived & P3 // expected-error {{'any Base<Int> & P2' is not convertible to 'any Derived & P3'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{21-23=as!}}
   let _ = baseAndP2 as? Derived & P3
 
-  let _ = base as Derived & P2 //expected-error {{'Base<Int>' is not convertible to 'Derived & P2'}}
+  let _ = base as Derived & P2 //expected-error {{'Base<Int>' is not convertible to 'any Derived & P2'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
   let _ = base as? Derived & P2
 
   // Invalid cases
-  let _ = derived as Other & P2 // expected-error {{value of type 'Derived' does not conform to 'Other & P2' in coercion}}
+  let _ = derived as Other & P2 // expected-error {{cannot convert value of type 'Derived' to type 'any Other & P2' in coercion}}
   let _ = derived as? Other & P2 // expected-warning {{always fails}}
 
-  let _ = derivedAndP3 as Other // expected-error {{cannot convert value of type 'Derived & P3' to type 'Other' in coercion}}
+  let _ = derivedAndP3 as Other // expected-error {{cannot convert value of type 'any Derived & P3' to type 'Other' in coercion}}
   let _ = derivedAndP3 as? Other // expected-warning {{always fails}}
 
-  let _ = derivedAndP3 as Other & P3 // expected-error {{value of type 'Derived & P3' does not conform to 'Other & P3' in coercion}}
+  let _ = derivedAndP3 as Other & P3 // expected-error {{cannot convert value of type 'any Derived & P3' to type 'any Other & P3' in coercion}}
   let _ = derivedAndP3 as? Other & P3 // expected-warning {{always fails}}
 
   let _ = derived as Other // expected-error {{cannot convert value of type 'Derived' to type 'Other' in coercion}}
@@ -314,9 +314,9 @@ func dependentMemberTypes<T : BaseIntAndP2>(
   _: BaseIntAndP2.FullyConcrete) {}
 
 func conformsToAnyObject<T : AnyObject>(_: T) {}
-// expected-note@-1 {{where 'T' = 'P1'}}
+// expected-note@-1 {{where 'T' = 'any P1'}}
 func conformsToP1<T : P1>(_: T) {}
-// expected-note@-1 {{required by global function 'conformsToP1' where 'T' = 'P1'}}
+// expected-note@-1 {{required by global function 'conformsToP1' where 'T' = 'any P1'}}
 func conformsToP2<T : P2>(_: T) {}
 func conformsToBaseIntAndP2<T : Base<Int> & P2>(_: T) {}
 // expected-note@-1 {{where 'T' = 'FakeDerived'}}
@@ -426,10 +426,10 @@ func conformsTo<T1 : P2, T2 : Base<Int> & P2>(
 
   // Errors
   conformsToAnyObject(p1)
-  // expected-error@-1 {{global function 'conformsToAnyObject' requires that 'P1' be a class type}}
+  // expected-error@-1 {{global function 'conformsToAnyObject' requires that 'any P1' be a class type}}
 
   conformsToP1(p1)
-  // expected-error@-1 {{protocol 'P1' as a type cannot conform to the protocol itself}}
+  // expected-error@-1 {{type 'any P1' cannot conform to 'P1'}}
   // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 
   // FIXME: Following diagnostics are not great because when
@@ -514,11 +514,11 @@ class ClassWithStaticMember {
 func staticMembers(
     m1: (ProtocolWithStaticMember & ClassWithStaticMember).Protocol,
     m2: (ProtocolWithStaticMember & ClassWithStaticMember).Type) {
-  _ = m1.staticProtocolMember() // expected-error {{static member 'staticProtocolMember' cannot be used on protocol metatype '(ClassWithStaticMember & ProtocolWithStaticMember).Protocol'}}
-  _ = m1.staticProtocolMember // expected-error {{static member 'staticProtocolMember' cannot be used on protocol metatype '(ClassWithStaticMember & ProtocolWithStaticMember).Protocol'}}
+  _ = m1.staticProtocolMember() // expected-error {{static member 'staticProtocolMember' cannot be used on protocol metatype '(any ClassWithStaticMember & ProtocolWithStaticMember).Type'}}
+  _ = m1.staticProtocolMember // expected-error {{static member 'staticProtocolMember' cannot be used on protocol metatype '(any ClassWithStaticMember & ProtocolWithStaticMember).Type'}}
 
-  _ = m1.staticClassMember() // expected-error {{static member 'staticClassMember' cannot be used on protocol metatype '(ClassWithStaticMember & ProtocolWithStaticMember).Protocol'}}
-  _ = m1.staticClassMember // expected-error {{static member 'staticClassMember' cannot be used on protocol metatype '(ClassWithStaticMember & ProtocolWithStaticMember).Protocol'}}
+  _ = m1.staticClassMember() // expected-error {{static member 'staticClassMember' cannot be used on protocol metatype '(any ClassWithStaticMember & ProtocolWithStaticMember).Type'}}
+  _ = m1.staticClassMember // expected-error {{static member 'staticClassMember' cannot be used on protocol metatype '(any ClassWithStaticMember & ProtocolWithStaticMember).Type'}}
 
   _ = m1.instanceProtocolMember
   _ = m1.instanceClassMember
@@ -548,7 +548,7 @@ struct DerivedBox<T : Derived> {}
 // expected-note@-1 {{requirement specified as 'T' : 'Derived' [with T = Derived & P3]}}
 
 func takesBoxWithP3(_: DerivedBox<Derived & P3>) {}
-// expected-error@-1 {{'DerivedBox' requires that 'Derived & P3' inherit from 'Derived'}}
+// expected-error@-1 {{'DerivedBox' requires that 'any Derived & P3' inherit from 'Derived'}}
 
 // A bit of a tricky setup -- the real problem is that matchTypes() did the
 // wrong thing when solving a Bind constraint where both sides were protocol

--- a/test/type/subclass_composition_objc.swift
+++ b/test/type/subclass_composition_objc.swift
@@ -24,13 +24,13 @@ class SomeMethods {
 
 // Test self-conformance
 
-func takesObjCClass<T : ObjCClass>(_: T) {} // expected-note {{where 'T' = 'ObjCProtocol'}}
+func takesObjCClass<T : ObjCClass>(_: T) {} // expected-note {{where 'T' = 'any ObjCProtocol'}}
 func takesObjCProtocol<T : ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCClass'}}
-func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'ObjCProtocol'}} expected-note {{where 'T' = 'ObjCClass'}}
+func takesObjCClassAndProtocol<T : ObjCClass & ObjCProtocol>(_: T) {} // expected-note {{where 'T' = 'any ObjCProtocol'}} expected-note {{where 'T' = 'ObjCClass'}}
 
 func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProtocol) {
   takesObjCClass(c)
-  takesObjCClass(p) // expected-error {{global function 'takesObjCClass' requires that 'ObjCProtocol' inherit from 'ObjCClass'}}
+  takesObjCClass(p) // expected-error {{global function 'takesObjCClass' requires that 'any ObjCProtocol' inherit from 'ObjCClass'}}
   takesObjCClass(cp)
 
   takesObjCProtocol(c) // expected-error {{global function 'takesObjCProtocol' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
@@ -39,7 +39,7 @@ func testSelfConformance(c: ObjCClass, p: ObjCProtocol, cp: ObjCClass & ObjCProt
 
   // FIXME: Bad diagnostics
   takesObjCClassAndProtocol(c) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'ObjCClass' conform to 'ObjCProtocol'}}
-  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'ObjCProtocol' inherit from 'ObjCClass'}}
+  takesObjCClassAndProtocol(p) // expected-error {{global function 'takesObjCClassAndProtocol' requires that 'any ObjCProtocol' inherit from 'ObjCClass'}}
   takesObjCClassAndProtocol(cp)
 }
 
@@ -51,7 +51,7 @@ func takesStaticObjCProtocol<T : StaticObjCProtocol>(_: T) {}
 
 func testSelfConformance(cp: ObjCClass & StaticObjCProtocol) {
   takesStaticObjCProtocol(cp)
-  // expected-error@-1 {{'ObjCClass & StaticObjCProtocol' cannot be used as a type conforming to protocol 'StaticObjCProtocol' because 'StaticObjCProtocol' has static requirements}}
+  // expected-error@-1 {{'any ObjCClass & StaticObjCProtocol' cannot be used as a type conforming to protocol 'StaticObjCProtocol' because 'StaticObjCProtocol' has static requirements}}
 }
 
 func testMetatypeSelfConformance(m1: (ObjCClass & ObjCProtocol).Protocol,
@@ -59,6 +59,6 @@ func testMetatypeSelfConformance(m1: (ObjCClass & ObjCProtocol).Protocol,
   _ = m1 as (ObjCClass & ObjCProtocol).Type
   _ = m1 as? (ObjCClass & ObjCProtocol).Type // expected-warning {{always succeeds}}
 
-  _ = m2 as (ObjCClass & StaticObjCProtocol).Type // expected-error {{cannot convert value of type '(ObjCClass & StaticObjCProtocol).Protocol' to type '(ObjCClass & StaticObjCProtocol).Type' in coercion}}
+  _ = m2 as (ObjCClass & StaticObjCProtocol).Type // expected-error {{cannot convert value of type '(any ObjCClass & StaticObjCProtocol).Type' to type 'any (ObjCClass & StaticObjCProtocol).Type' in coercion}}
   _ = m2 as? (ObjCClass & StaticObjCProtocol).Type // FIXME should 'always fail'
 }

--- a/validation-test/Sema/SwiftUI/sr14213.swift
+++ b/validation-test/Sema/SwiftUI/sr14213.swift
@@ -9,7 +9,7 @@ struct Experiment: View {
   var body: some View {
     HStack { // expected-error {{generic parameter 'Content' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}emacs
       Slider(value: <#T##Binding<BinaryFloatingPoint>#>, in: <#T##ClosedRange<BinaryFloatingPoint>#>, label: <#T##() -> _#>) // expected-error 3 {{editor placeholder in source file}}
-      // expected-error@-1 {{protocol 'BinaryFloatingPoint' as a type cannot conform to 'Comparable'}}
+      // expected-error@-1 {{type 'any BinaryFloatingPoint' cannot conform to 'Comparable'}}
       // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/0150-rdar39055736.swift
+++ b/validation-test/compiler_crashers_2_fixed/0150-rdar39055736.swift
@@ -12,5 +12,5 @@ import Foundation
 
 func baz(bar: Bar) {
   max(bar, bar.foo?.x ?? 0)
-  // expected-error@-1 {{cannot convert value of type 'Bar' to expected argument type 'Int'}}
+  // expected-error@-1 {{cannot convert value of type 'any Bar' to expected argument type 'Int'}}
 }

--- a/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
+++ b/validation-test/compiler_crashers_fixed/00017-llvm-foldingset-llvm-attributesetnode-nodeequals.swift
@@ -18,6 +18,6 @@ extension Bool : BooleanProtocol {
   var boolValue: Bool { return self }
 }
 func f<T : BooleanProtocol>(_ b: T) {}
-// expected-note@-1 {{required by global function 'f' where 'T' = 'BooleanProtocol'}}
+// expected-note@-1 {{required by global function 'f' where 'T' = 'any BooleanProtocol'}}
 
-f(true as BooleanProtocol) // expected-error {{protocol 'BooleanProtocol' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+f(true as BooleanProtocol) // expected-error {{type 'any BooleanProtocol' cannot conform to 'BooleanProtocol'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}


### PR DESCRIPTION
This change sets `PrintOptions.PrintExplicitAny` to true when printing diagnostic arguments.

Note that there's a bug when printing nested existential metatypes when the constraint type is `Any` or `AnyObject`. This will be fixed when `ExistentialType` is used for `Any` and `AnyObject`; I'll fix that in a follow-up PR.

Resolves: rdar://88941874