### PR TITLE
AST: address-of function is not compile-time

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -199,9 +199,8 @@ switch (getKind()) {                                                         \
   case ProtocolConformanceKind::Inherited:                                   \
     return cast<InheritedProtocolConformance>(this)->Method Args;            \
   case ProtocolConformanceKind::Builtin:                                     \
-    static_assert(&ProtocolConformance::Method !=                            \
-                    &BuiltinProtocolConformance::Method,                     \
-                  "Must override BuiltinProtocolConformance::" #Method);     \
+    assert(&ProtocolConformance::Method != &BuiltinProtocolConformance::Method \
+           && "Must override BuiltinProtocolConformance::" #Method);         \
     return cast<BuiltinProtocolConformance>(this)->Method Args;              \
 }                                                                            \
 llvm_unreachable("bad ProtocolConformanceKind");


### PR DESCRIPTION
This fixes a `static_assert` by converting it to an `assert`.  The
address-of on a function is not a compile time constant and can only be
checked at runtime.  This will reduce the check to !NDEBUG builds only
but actually performs the intended check.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
