### PR TITLE
Concurrency: clean up a log message (NFC)

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1537,7 +1537,7 @@ static void swift_job_runImpl(Job *job, ExecutorRef executor) {
   trackingInfo.enterAndShadow(executor);
   auto traceHandle = concurrency::trace::job_run_begin(job, &executor);
 
-  SWIFT_TASK_DEBUG_LOG("%s(%p)", __func__, job);
+  SWIFT_TASK_DEBUG_LOG("job %p", job);
   runJobInEstablishedExecutorContext(job);
 
   concurrency::trace::job_run_end(&executor, traceHandle);


### PR DESCRIPTION
This simply cleans up the logged message when debug tracing is enabled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
