### PR TITLE
visualc: clean up the module definition

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -11,24 +11,23 @@
 //===----------------------------------------------------------------------===//
 
 module visualc [system] {
+  export *
+
   module SAL {
     header "sal.h"
-    export *
   }
 
   module vcruntime {
     header "vcruntime.h"
-    export *
+    export SAL
   }
 
   module setjmp {
     header "setjmp.h"
-    export *
   }
 
   module stdint {
     header "stdint.h"
-    export *
   }
 }
 

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__linux__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && (defined(_MSC_VER) && !defined(__clang__)) && !defined(__linux__) && !defined(__OpenBSD__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__linux__) && !defined(__OpenBSD__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
Clean up the submodules in visualc to not export all imported modules.
The one special case is `vcruntime` which re-exports `SAL` due to a
dependency in the headers.  The import of `visualc` however will
re-export all submodules to keep the current behaviour.  This is
required to get the ARM64 SDK building on newer MSVC toolsets.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
