### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(
   OUTPUT
     ${features_file_dest}
   COMMAND
-    ${features_merger} -f ${features_file_swift_src} -p \"\" -f ${features_file_clang_src} -p clang- > ${features_file_dest}
+    $<TARGET_FILE:Python3::Interpreter> ${features_merger} -f ${features_file_swift_src} -p \"\" -f ${features_file_clang_src} -p clang- > ${features_file_dest}
   DEPENDS
     ${features_merger}
     ${features_file_swift_src}


### PR DESCRIPTION
Explicitly invoke the script executor rather than the script as running a script is meaningless.  Shebangs are not a portable manner of indicating the script executor and worse yet do not guarantee portability on such systems either.  Ideally the shebang line would be removed from the script.

Thanks to @pcbeard for reporting the issue!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
