### PR TITLE
[OSLog] Conditionally remove the dependency on `_Concurrency`

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(swift_oslog_darwin_dependencies "")
+if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
+    list(APPEND swift_oslog_darwin_dependencies "_Concurrency")
+endif ()
+
 add_swift_target_library(swiftOSLogTestHelper
   IS_SDK_OVERLAY
   SHARED
@@ -14,10 +19,10 @@ add_swift_target_library(swiftOSLogTestHelper
   OSLogPrivacy.swift
   OSLogFloatFormatting.swift
 
-  SWIFT_MODULE_DEPENDS_IOS Darwin
-  SWIFT_MODULE_DEPENDS_OSX Darwin
-  SWIFT_MODULE_DEPENDS_TVOS Darwin
-  SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+  SWIFT_MODULE_DEPENDS_IOS Darwin ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_OSX Darwin ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_TVOS Darwin ${swift_oslog_darwin_dependencies}
+  SWIFT_MODULE_DEPENDS_WATCHOS Darwin ${swift_oslog_darwin_dependencies}
   TARGET_SDKS ALL_APPLE_PLATFORMS
   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   INSTALL_IN_COMPONENT never_install


### PR DESCRIPTION
This fixes `error: compiled module was created by an older version of the compiler; rebuild '_Concurrency' and try again`.

rdar://89902675