### PR TITLE
core: map UnsignedLong to UInt32

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -28,7 +28,7 @@ public typealias CUnsignedShort = UInt16
 public typealias CUnsignedInt = UInt32
 
 /// The C 'unsigned long' type.
-#if os(Windows) && arch(x86_64)
+#if os(Windows) && (arch(x86_64) || arch(arm64))
 public typealias CUnsignedLong = UInt32
 #else
 public typealias CUnsignedLong = UInt


### PR DESCRIPTION
Windows ARM64 is a LLP64 platform, which means that `unsigned long` is a
32-bit value.  This was already mapped properly for x86_64, but somehow
had missed ARM64.  This repairs that which is required for building the
standard library.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
