### PR TITLE
[TypeChecker] NFC: Restrict type inference from defaults test to 64-b…

### DIFF
--- a/test/Constraints/type_inference_from_default_exprs_executable_test.swift
+++ b/test/Constraints/type_inference_from_default_exprs_executable_test.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-type-inference-from-defaults -parse-as-library -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx && CPU=x86_64
 
 protocol P {
   associatedtype X


### PR DESCRIPTION
…it x86 macOS

It sometimes fails in different configurations which are not very important for this
test, so let's restrict it to a 64-bit x86 macOS which is covered by a smoke test.

Resolves: rdar://89908188

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
