### PR TITLE
 [cxx-interop] Fix typo in getting started, and update example for creating the cxx module

### DIFF
--- a/docs/CppInteropability/GettingStartedWithC++Interop.md
+++ b/docs/CppInteropability/GettingStartedWithC++Interop.md
@@ -59,24 +59,23 @@ struct ContentView: View {
 ```
 
 ```
-//In Cxx.cpp
-
-#include "Cxx.hpp"
-int cxxFunction(int n) {
-    return n;
-}
-
-```
-
-```
 //In Cxx.hpp
 
 #ifndef Cxx_hpp
 #define Cxx_hpp
 
+int cxxFunction(int n) {
+    return n;
+}
+#endif
+```
+
+```
+//In Cxx.cpp
+
+#include "Cxx.hpp"
 int cxxFunction(int n);
 
-#endif
 
 ```
 
@@ -198,7 +197,7 @@ CxxInterop.main()
 
 ```
 
-- In your projects direcetoy, run `cmake` to generate the systems build files
+- In your project's directory, run `cmake` to generate the systems build files
 
 - To generate an Xcode project run `cmake -GXcode` 
 - To generate with Ninja run `cmake -GNinja`


### PR DESCRIPTION
Fixed the typo in the cmake section and updated the creating module section with a more accurate example. 

I found that when you create a C++ module, and defined file for header in the module doesnt contain the implimentation for the methods, an error is produced stating `Undefined symbol: _cxxFunction, clang: error: linker command failed with exit code 1 (use -v to see invocation)`

I updated the docs to have the implementation of methods in the header file, however we could change the example as seen below:

```
//In module.modulemap
module Cxx {
    header "Cxx.cpp"
}

// in Cxx.hpp
#ifndef Cxx_hpp
#define Cxx_hpp
int cxxFunction(int n);

#endif

//in Cxx.cpp
#include "Cxx.hpp"

int cxxFunction(int n) {
    return n;
}
```