### PR TITLE
Revert "visualc: clean up the module definition"

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -11,23 +11,24 @@
 //===----------------------------------------------------------------------===//
 
 module visualc [system] {
-  export *
-
   module SAL {
     header "sal.h"
+    export *
   }
 
   module vcruntime {
     header "vcruntime.h"
-    export SAL
+    export *
   }
 
   module setjmp {
     header "setjmp.h"
+    export *
   }
 
   module stdint {
     header "stdint.h"
+    export *
   }
 }
 

--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && (defined(_MSC_VER) && !defined(__clang__)) && !defined(__linux__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
Reverts apple/swift#41698

This seems to have broken the llbuild build; revert until that can be investigated.