### PR TITLE
[move-function] Rather than breaking block at the SIL level after moved dbg_value, do it late as an LLVM pass on llvm.dbg.addr

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -102,7 +102,6 @@ namespace swift {
     static char ID;
     InlineTreePrinter() : llvm::ModulePass(ID) {}
   };
-
 } // end namespace swift
 
 #endif

--- a/include/swift/LLVMPasses/PassesFwd.h
+++ b/include/swift/LLVMPasses/PassesFwd.h
@@ -25,6 +25,7 @@ namespace llvm {
   void initializeSwiftARCContractPass(PassRegistry &);
   void initializeInlineTreePrinterPass(PassRegistry &);
   void initializeSwiftMergeFunctionsPass(PassRegistry &);
+  void initializeSwiftDbgAddrBlockSplitterPass(PassRegistry &);
 }
 
 namespace swift {
@@ -33,6 +34,7 @@ namespace swift {
   llvm::ModulePass *createInlineTreePrinterPass();
   llvm::ModulePass *createSwiftMergeFunctionsPass(bool ptrAuthEnabled,
                                                   unsigned ptrAuthKey);
+  llvm::FunctionPass *createSwiftDbgAddrBlockSplitter();
   llvm::ImmutablePass *createSwiftAAWrapperPass();
   llvm::ImmutablePass *createSwiftRCIdentityPass();
 } // end namespace swift

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -146,6 +146,11 @@ static void addThreadSanitizerPass(const PassManagerBuilder &Builder,
   PM.add(createThreadSanitizerLegacyPassPass());
 }
 
+static void addSwiftDbgAddrBlockSplitterPass(const PassManagerBuilder &Builder,
+                                             legacy::PassManagerBase &PM) {
+  PM.add(createSwiftDbgAddrBlockSplitter());
+}
+
 static void addSanitizerCoveragePass(const PassManagerBuilder &Builder,
                                      legacy::PassManagerBase &PM) {
   const PassManagerBuilderWrapper &BuilderWrapper =
@@ -287,6 +292,13 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
           PM.add(createSwiftMergeFunctionsPass(schema.isEnabled(), key));
         }
       });
+  }
+
+  if (RunSwiftSpecificLLVMOptzns) {
+    PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
+                           addSwiftDbgAddrBlockSplitterPass);
+    PMBuilder.addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0,
+                           addSwiftDbgAddrBlockSplitterPass);
   }
 
   // Configure the function passes.

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -6,6 +6,7 @@ add_swift_host_library(swiftLLVMPasses STATIC
   LLVMARCContract.cpp
   LLVMInlineTree.cpp
   LLVMMergeFunctions.cpp
+  DbgAddrBlockSplitter.cpp
 
   LLVM_LINK_COMPONENTS
   analysis

--- a/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
+++ b/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
@@ -1,0 +1,79 @@
+//===--- DbgAddrBlockSplitter.cpp -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This simple pass runs late after all LLVM level optimization passes have
+/// completed and break blocks at llvm.dbg.addr when we are compiling at
+/// -Onone. This helps us avoid bad behavior in SelectionDAG where SelectionDAG
+/// in certain cases sink llvm.dbg.addr to the end of blocks.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/LLVMPasses/Passes.h"
+#include "swift/LLVMPasses/PassesFwd.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/Pass.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+using namespace llvm;
+
+namespace {
+
+struct SwiftDbgAddrBlockSplitter : FunctionPass {
+  static char ID;
+  SwiftDbgAddrBlockSplitter() : FunctionPass(ID) {}
+
+  bool runOnFunction(Function &fn) override;
+};
+
+} // namespace
+
+bool SwiftDbgAddrBlockSplitter::runOnFunction(Function &fn) {
+  SmallVector<Instruction *, 32> breakBlockPoints;
+
+  for (auto &block : fn) {
+    for (auto &inst : block) {
+      if (isa<DbgAddrIntrinsic>(&inst)) {
+        breakBlockPoints.push_back(&*std::next(inst.getIterator()));
+      }
+    }
+  }
+
+  if (breakBlockPoints.empty())
+    return false;
+
+  bool madeChange = false;
+
+  while (!breakBlockPoints.empty()) {
+    auto *i = breakBlockPoints.pop_back_val();
+    if (i->isTerminator())
+      continue;
+    SplitBlock(i->getParent(), i);
+    madeChange = true;
+  }
+
+  return madeChange;
+}
+
+char SwiftDbgAddrBlockSplitter::ID = 0;
+INITIALIZE_PASS_BEGIN(SwiftDbgAddrBlockSplitter,
+                      "swift-dbg-addr-block-splitter",
+                      "Swift pass that splits blocks after llvm.dbg.addr",
+                      false, false)
+INITIALIZE_PASS_END(SwiftDbgAddrBlockSplitter, "swift-dbg-addr-block-splitter",
+                    "Swift pass that splits blocks after llvm.dbg.addr", false,
+                    false)
+
+llvm::FunctionPass *swift::createSwiftDbgAddrBlockSplitter() {
+  initializeSwiftDbgAddrBlockSplitterPass(
+      *llvm::PassRegistry::getPassRegistry());
+  return new SwiftDbgAddrBlockSplitter();
+}

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -242,7 +242,7 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo23copyableValueCCFlowTestyyF"(
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k.debug, metadata ![[K_COPYABLE_LET_CCFLOW_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]+]]
-// CHECK-NEXT: br label %[[NEXT_BB:[0-9]+]],
+// CHECK-NEXT: br label %[[NEXT_BB:[a-z\.0-9]+]],
 //
 // CHECK: [[NEXT_BB]]:
 // CHECK:    br i1 {{%[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
@@ -261,7 +261,7 @@ public func copyableValueCCFlowTest() {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo037copyableVarTestCCFlowReinitOutOfBlockF0yyF"(
 // CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
-// CHECK-NEXT: br label %[[BB_NEXT:[0-9]+]],
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
 //
 // CHECK: [[BB_NEXT]]:
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
@@ -294,7 +294,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 // CHECK: entry:
 // CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
-// CHECK-NEXT: br label %[[BB_NEXT:[0-9]+]],
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
 //
 // CHECK: [[BB_NEXT]]:
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
@@ -303,10 +303,10 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 // CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
 // CHECK:      call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
-// CHECK-NEXT:      br label %[[BB_NEXT_2:[0-9]+]],
+// CHECK-NEXT:      br label %[[BB_NEXT_2:[a-z\.0-9]+]],
 //
 // CHECK: [[BB_NEXT_2]]:
-// CHECK:      br label %[[CONT_BB:[0-9]+]],
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
 // CHECK: [[RHS]]:
 // CHECK:      br label %[[CONT_BB]],
@@ -328,14 +328,14 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040addressOnlyVarTestCCFlowReinitOutOfBlockG0yyxmAA1PRzlF"(
 // CHECK: entry:
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP* %k, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
-// CHECK-NEXT: br label %[[BB_NEXT:[0-9]+]],
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
 //
 // CHECK: [[BB_NEXT]]:
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
 //
 // CHECK: [[LHS]]:
 // CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo1PP* undef, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
-// CHECK:      br label %[[CONT_BB:[0-9]+]],
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
 // CHECK: [[RHS]]:
 // CHECK:      br label %[[CONT_BB]],
@@ -360,7 +360,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo037addressOnlyVarTestCCFlowReinitInBlockG0yyxmAA1PRzlF"(
 // CHECK: entry:
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP* %k, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
-// CHECK-NEXT: br label %[[BB_NEXT:[0-9]+]],
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
 //
 // CHECK: [[BB_NEXT]]:
 // CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
@@ -369,10 +369,10 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 // CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo1PP* undef, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 // TODO: Should this be a deref like the original?
 // CHECK:      call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP* %k, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
-// CHECK-NEXT:      br label %[[BB_NEXT_2:[0-9]+]],
+// CHECK-NEXT:      br label %[[BB_NEXT_2:[a-z\.0-9]+]],
 //
 // CHECK: [[BB_NEXT_2]]:
-// CHECK:      br label %[[CONT_BB:[0-9]+]],
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
 //
 // CHECK: [[RHS]]:
 // CHECK:      br label %[[CONT_BB]],

--- a/test/SILGen/moveonly_builtin.swift
+++ b/test/SILGen/moveonly_builtin.swift
@@ -29,9 +29,6 @@ class Klass {}
 // CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyAA5KlassCADnF : $@convention(thin) (@owned Klass) -> @owned Klass {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value [moved]
-// CHECK-SIL-NEXT: br bb1
-//
-// CHECK-SIL: bb1
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
 // CHECK-SIL-NEXT: debug_value [moved] undef
@@ -66,8 +63,6 @@ func useMove(_ k: __owned Klass) -> Klass {
 // CHECK-SIL-LABEL: sil hidden @$s8moveonly7useMoveyxxnRlzClF : $@convention(thin) <T where T : AnyObject> (@owned T) -> @owned T {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value [moved]
-// CHECK-SIL-NEXT: br bb1
-// CHECK-SIL: bb1:
 // CHECK-SIL-NEXT: strong_retain
 // CHECK-SIL-NEXT: move_value
 // CHECK-SIL-NEXT: debug_value [moved] undef

--- a/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
+++ b/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
@@ -11,7 +11,6 @@ import Builtin
 
 // CHECK-LABEL: sil [ossa] @singleBlock : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK:   [[SRC_ADDR:%.*]] = alloc_stack [lexical] [moved] $Builtin.NativeObject, let, name "[[VAR_NAME:.*]]"
-// CHECK-NEXT: br
 // CHECK:   [[DEST_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK:   copy_addr [take] [[SRC_ADDR]] to [initialization] [[DEST_ADDR]]
 // CHECK-NEXT: debug_value [moved] undef
@@ -39,7 +38,6 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK-LABEL: sil [ossa] @multipleBlock : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0(
 // CHECK:   [[SRC_ADDR:%.*]] = alloc_stack [lexical] [moved] $Builtin.NativeObject, let, name "[[VAR_NAME:.*]]"
-// CHECK-NEXT: br
 // CHECK:   [[DEST_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK:   cond_br undef, [[LHS:bb[0-9]+]], [[RHS:bb[0-9]+]]
 //

--- a/test/SILOptimizer/move_function_kills_values_dbginfo.sil
+++ b/test/SILOptimizer/move_function_kills_values_dbginfo.sil
@@ -12,7 +12,6 @@ import Builtin
 // CHECK-LABEL: sil [ossa] @singleBlock : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: debug_value [moved] [[ARG]] : $Builtin.NativeObject, let, name "myName"
-// CHECK-NEXT: br bb1
 // CHECK: [[MOVED_VAL:%.*]] = move_value [[ARG]]
 // CHECK: debug_value [moved] undef : $Builtin.NativeObject, let, name "myName"
 // CHECK: } // end sil function 'singleBlock'
@@ -32,12 +31,9 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // we llvm.dbg.addr the shadow copy, we avoid bad LLVM behavior in SelectionDAG
 // that sinks llvm.dbg.addr to end of block.
 // CHECK:   debug_value [moved] [[ARG]]
-// CHECK-NEXT:   br bb1
+// CHECK:   cond_br undef, bb1, bb2
 //
 // CHECK: bb1:
-// CHECK:   cond_br undef, bb2, bb3
-//
-// CHECK: bb2:
 // CHECK:   [[MV:%.*]] = move_value [[ARG]]
 //
 // We don't break the block after the undefs since they become llvm.dbg.value


### PR DESCRIPTION
This has a few nice benefits:

1. The splitting happens after LLVM optimizations have run. This ensures that
LLVM will not join these blocks no matter what! The author of this commit has
found that in certain cases LLVM does this even at -Onone. By running this late,
we get the benefit we are looking for: working around the bad SelectionDAG
behavior.

2. This block splitting is just a workaround for the above mentioned unfortunate
SelectionDAG behavior. By doing this when we remove the workaround, we will not
have to update SIL level tests... instead we will just remove a small LLVM pass.

Some additional notes:

1. Only moved values will ever have llvm.dbg.addr emitted today, so we do not
have to worry about this impacting the rest of the language.

2. The pass's behavior is tested at the IR level by move_function_dbginfo.swift.
