### PR TITLE
[Concurrency][Distributed] Move AnyActor to Concurrency module

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020-2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,12 +13,29 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
+/// Common marker protocol providing a shared "base" for both (local) `Actor`
+/// and (potentially remote) `DistributedActor` types.
+///
+/// The `AnyActor` marker protocol generalizes over all actor types, including
+/// distributed ones. In practice, this protocol can be used to restrict
+/// protocols, or generic parameters to only be usable with actors, which
+/// provides the guarantee that calls may be safely made on instances of given
+/// type without worrying about the thread-safety of it -- as they are
+/// guaranteed to follow the actor-style isolation semantics.
+///
+/// While both local and distributed actors are conceptually "actors", there are
+/// some important isolation model differences between the two, which make it
+/// impossible for one to refine the other.
+@_marker
+@available(SwiftStdlib 5.1, *)
+public protocol AnyActor: AnyObject, Sendable {}
+
 /// Common protocol to which all actors conform.
 ///
-/// The `Actor` protocol generalizes over all actor types. Actor types
+/// The `Actor` protocol generalizes over all `actor` types. Actor types
 /// implicitly conform to this protocol.
 @available(SwiftStdlib 5.1, *)
-public protocol Actor: AnyObject, Sendable {
+public protocol Actor: AnyActor, Sendable {
 
   /// Retrieve the executor for this actor as an optimized, unowned
   /// reference.

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -13,17 +13,6 @@
 import Swift
 import _Concurrency
 
-// ==== Any Actor -------------------------------------------------------------
-
-/// Shared "base" protocol for both (local) `Actor` and (potentially remote)
-/// `DistributedActor`.
-///
-/// FIXME(distributed): We'd need Actor to also conform to this, but don't want to add that conformance in _Concurrency yet.
-@_marker
-@available(SwiftStdlib 5.7, *)
-public protocol AnyActor: Sendable, AnyObject {
-}
-
 // ==== Distributed Actor -----------------------------------------------------
 
 /// Common protocol to which all distributed actors conform implicitly.

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -22,14 +22,16 @@ class C: Actor, UnsafeSendable {
 }
 
 struct S: Actor {
-  // expected-error@-1{{non-class type 'S' cannot conform to class protocol 'Actor'}}
+  // expected-error@-1{{non-class type 'S' cannot conform to class protocol 'AnyActor'}}
+  // expected-error@-2{{non-class type 'S' cannot conform to class protocol 'Actor'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
 }
 
 struct E: Actor {
-  // expected-error@-1{{non-class type 'E' cannot conform to class protocol 'Actor'}}
+  // expected-error@-1{{non-class type 'E' cannot conform to class protocol 'AnyActor'}}
+  // expected-error@-2{{non-class type 'E' cannot conform to class protocol 'Actor'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -58,5 +58,7 @@ Func AsyncSequence.map(_:) is now with @preconcurrency
 Func AsyncSequence.prefix(while:) is now with @preconcurrency
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
+Protocol Actor has added inherited protocol AnyActor
+Protocol Actor has generic signature change from <Self : AnyObject, Self : Swift.Sendable> to <Self : _Concurrency.AnyActor>
 Struct CheckedContinuation has removed conformance to UnsafeSendable
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
Move `AnyActor` to concurrency module, now that SE-0336 was accepted