### PR TITLE
[Distributed] Implicit Codable conformance for distributed actors

### DIFF
--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -106,6 +106,7 @@ getDistributedSerializationRequirements(
 llvm::SmallPtrSet<ProtocolDecl *, 2>
 extractDistributedSerializationRequirements(
     ASTContext &C, ArrayRef<Requirement> allRequirements);
+
 }
 
 #endif /* SWIFT_DECL_TYPECHECKDISTRIBUTED_H */

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1039,6 +1039,30 @@ public:
     bool isCached() const { return true; }
 };
 
+/// Retrieve the implicit conformance for the given distributed actor type to
+/// the Codable protocol protocol.
+///
+/// Similar to 'GetImplicitSendableRequest'.
+class GetDistributedActorImplicitCodableRequest :
+    public SimpleRequest<GetDistributedActorImplicitCodableRequest,
+                         NormalProtocolConformance *(NominalTypeDecl *, KnownProtocolKind),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  NormalProtocolConformance *evaluate(
+      Evaluator &evaluator,
+      NominalTypeDecl *nominal,
+      KnownProtocolKind protoKind) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 /// Obtain the 'remoteCall' function of a 'DistributedActorSystem'.
 class GetDistributedActorSystemRemoteCallFunctionRequest :
     public SimpleRequest<GetDistributedActorSystemRemoteCallFunctionRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -107,6 +107,9 @@ SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDistributedActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetDistributedActorImplicitCodableRequest,
+               NormalProtocolConformance *(NominalTypeDecl *, KnownProtocolKind),
+               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorSystemRemoteCallFunctionRequest,
               AbstractFunctionDecl *(NominalTypeDecl *, bool),
               Cached, NoLocationInfo)

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -102,7 +102,7 @@ Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
 
   auto DA = C.getDistributedActorDecl();
   if (!DA)
-    return ErrorType::get(C);
+    return ErrorType::get(C); // FIXME(distributed): just use Type()
 
   // Dig out the actor system type.
   auto module = actor->getParentModule();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1349,10 +1349,10 @@ LookupConformanceInModuleRequest::evaluate(
       } else {
         return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
       }
+    } else {
+      // Was unable to infer the missing conformance.
+      return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
     }
-
-    // Was unable to infer the missing conformance.
-    return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
   }
 
   assert(!conformances.empty());

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/LazyResolver.h"
@@ -63,7 +64,12 @@ Witness::Witness(ValueDecl *decl, SubstitutionMap substitutions,
 void Witness::dump() const { dump(llvm::errs()); }
 
 void Witness::dump(llvm::raw_ostream &out) const {
-  // FIXME: Implement!
+  out << "Witness: ";
+  if (auto decl = this->getDecl()) {
+    decl->print(out);
+  } else {
+    out << "<no decl>\n";
+  }
 }
 
 ProtocolConformanceRef::ProtocolConformanceRef(ProtocolDecl *protocol,
@@ -1293,10 +1299,11 @@ void NominalTypeDecl::prepareConformanceTable() const {
 
   // Actor classes conform to the actor protocol.
   if (auto classDecl = dyn_cast<ClassDecl>(mutableThis)) {
-    if (classDecl->isDistributedActor())
+    if (classDecl->isDistributedActor()) {
       addSynthesized(KnownProtocolKind::DistributedActor);
-    else if (classDecl->isActor())
+    } else if (classDecl->isActor()) {
       addSynthesized(KnownProtocolKind::Actor);
+    }
   }
 
   // Global actors conform to the GlobalActor protocol.
@@ -1367,26 +1374,29 @@ IterableDeclContext::getLocalProtocols(ConformanceLookupKind lookupKind) const {
   return result;
 }
 
-/// Find a synthesized Sendable conformance in this declaration context,
-/// if there is one.
-static ProtocolConformance *findSynthesizedSendableConformance(
-    const DeclContext *dc) {
-  auto nominal = dc->getSelfNominalTypeDecl();
-  if (!nominal)
-    return nullptr;
 
-  if (isa<ProtocolDecl>(nominal))
+
+/// Find a synthesized conformance in this declaration context, if there is one.
+static ProtocolConformance *
+findSynthesizedConformance(
+    const DeclContext *dc,
+    KnownProtocolKind protoKind) {
+  auto nominal = dc->getSelfNominalTypeDecl();
+
+  // Perform some common checks
+  if (!nominal)
     return nullptr;
 
   if (dc->getParentModule() != nominal->getParentModule())
     return nullptr;
 
-  auto cvProto = nominal->getASTContext().getProtocol(
-      KnownProtocolKind::Sendable);
+  auto &C = nominal->getASTContext();
+  auto cvProto = C.getProtocol(protoKind);
   if (!cvProto)
     return nullptr;
 
-  auto conformance = dc->getParentModule()->lookupConformance(
+  auto module = dc->getParentModule();
+  auto conformance = module->lookupConformance(
       nominal->getDeclaredInterfaceType(), cvProto);
   if (!conformance || !conformance.isConcrete())
     return nullptr;
@@ -1403,6 +1413,43 @@ static ProtocolConformance *findSynthesizedSendableConformance(
     return nullptr;
 
   return normal;
+}
+
+/// Find any synthesized conformances for given decl context.
+///
+/// Some protocol conformances can be synthesized by the compiler,
+/// for those, we need to add them to "local conformances" because otherwise
+/// we'd get missing symbols while attempting to use these.
+static SmallVector<ProtocolConformance *, 2> findSynthesizedConformances(
+    const DeclContext *dc) {
+  auto nominal = dc->getSelfNominalTypeDecl();
+  if (!nominal)
+    return {};
+
+  // Try to find specific conformances
+  SmallVector<ProtocolConformance *, 2> result;
+
+  // Sendable may be synthesized for concrete types
+  if (!isa<ProtocolDecl>(nominal)) {
+    if (auto sendable =
+            findSynthesizedConformance(dc, KnownProtocolKind::Sendable)) {
+      result.push_back(sendable);
+    }
+  }
+
+  /// Distributed actors can synthesize Encodable/Decodable, so look for those
+  if (nominal->isDistributedActor()) {
+    if (auto conformance =
+            findSynthesizedConformance(dc, KnownProtocolKind::Encodable)) {
+      result.push_back(conformance);
+    }
+    if (auto conformance =
+            findSynthesizedConformance(dc, KnownProtocolKind::Decodable)) {
+      result.push_back(conformance);
+    }
+  }
+
+  return result;
 }
 
 std::vector<ProtocolConformance *>
@@ -1485,8 +1532,9 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
       // Look for a Sendable conformance globally. If it is synthesized
       // and matches this declaration context, use it.
       auto dc = getAsGenericContext();
-      if (auto conformance = findSynthesizedSendableConformance(dc))
+      for (auto conformance : findSynthesizedConformances(dc)) {
         result.push_back(conformance);
+      }
       break;
     }
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -836,8 +836,9 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
   }
 
   // Distributed actor initializers implicitly initialize their transport and id
-  if (isDesignatedDistActorInit)
-    emitDistActorImplicitPropertyInits(ctor, selfArg);
+  if (isDesignatedDistActorInit) {
+    emitDistributedActorImplicitPropertyInits(ctor, selfArg);
+  }
 
   // Prepare the end of initializer location.
   SILLocation endOfInitLoc = RegularLocation(ctor);

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -223,7 +223,7 @@ public:
 };
 } // end anonymous namespace
 
-void SILGenFunction::emitDistActorImplicitPropertyInits(
+void SILGenFunction::emitDistributedActorImplicitPropertyInits(
     ConstructorDecl *ctor, ManagedValue selfArg) {
   // Only designated initializers should perform this initialization.
   assert(ctor->isDesignatedInit());

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2048,7 +2048,7 @@ public:
 
   /// Initializes the implicit stored properties of a distributed actor that correspond to
   /// its transport and identity.
-  void emitDistActorImplicitPropertyInits(
+  void emitDistributedActorImplicitPropertyInits(
       ConstructorDecl *ctor, ManagedValue selfArg);
 
   /// Given a function representing a distributed actor factory, emits the

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -300,12 +300,13 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
     if (swift::ensureDistributedModuleLoaded(decl)) {
       // copy access level of distributed actor init from the nominal decl
       accessLevel = decl->getEffectiveAccess();
+      auto systemTy = getDistributedActorSystemType(classDecl);
 
       // Create the parameter.
       auto *arg = new (ctx) ParamDecl(SourceLoc(), Loc, ctx.Id_system, Loc,
                                       ctx.Id_system, decl);
       arg->setSpecifier(ParamSpecifier::Default);
-      arg->setInterfaceType(getDistributedActorSystemType(classDecl));
+      arg->setInterfaceType(systemTy);
       arg->setImplicit();
 
       params.push_back(arg);

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -15,7 +15,7 @@ import _Concurrency
 @available(SwiftStdlib 5.7, *)
 public protocol DistributedActorSystem: Sendable {
   /// The identity used by actors that communicate via this transport
-  associatedtype ActorID: Sendable & Hashable & Codable // TODO(distributed): make Codable conditional here
+  associatedtype ActorID: Sendable & Hashable
 
   associatedtype InvocationEncoder: DistributedTargetInvocationEncoder
   associatedtype InvocationDecoder: DistributedTargetInvocationDecoder

--- a/test/Distributed/Inputs/FakeCodableForDistributedTests.swift
+++ b/test/Distributed/Inputs/FakeCodableForDistributedTests.swift
@@ -367,3 +367,88 @@ fileprivate struct StringsSingleValueEncoding: SingleValueEncodingContainer {
     try value.encode(to: stringsEncoding)
   }
 }
+
+public final class FakeDecoder: Decoder {
+  public var codingPath: [CodingKey] = []
+  public var userInfo: [CodingUserInfoKey: Any] = [:]
+
+  var string: String = ""
+
+  public func decode<T>(_ string: String, as type: T.Type) throws -> T where T: Decodable {
+    self.string = string
+    return try type.init(from: self)
+  }
+
+  public func container<Key>(
+    keyedBy type: Key.Type
+  ) throws -> KeyedDecodingContainer<Key> {
+    fatalError("\(#function) not implemented")
+  }
+
+  public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+    fatalError("\(#function) not implemented")
+  }
+
+  public func singleValueContainer() throws -> SingleValueDecodingContainer {
+    return FakeSingleValueDecodingContainer(string: self.string)
+  }
+}
+
+public final class FakeSingleValueDecodingContainer: SingleValueDecodingContainer {
+  public var codingPath: [CodingKey] { [] }
+
+  let string: String
+
+  init(string: String) {
+    self.string = string
+  }
+
+  public func decodeNil() -> Bool {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Bool.Type) throws -> Bool {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: String.Type) throws -> String {
+    String(self.string.split(separator: ";").first!)
+  }
+  public func decode(_ type: Double.Type) throws -> Double {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Float.Type) throws -> Float {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Int.Type) throws -> Int {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Int8.Type) throws -> Int8 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Int16.Type) throws -> Int16 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Int32.Type) throws -> Int32 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: Int64.Type) throws -> Int64 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: UInt.Type) throws -> UInt {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: UInt8.Type) throws -> UInt8 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: UInt16.Type) throws -> UInt16 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: UInt32.Type) throws -> UInt32 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode(_ type: UInt64.Type) throws -> UInt64 {
+    fatalError("\(#function) not implemented")
+  }
+  public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
+    fatalError("\(#function) not implemented")
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_decode.swift
+++ b/test/Distributed/Runtime/distributed_actor_decode.swift
@@ -179,7 +179,7 @@ class TestEncoder: Encoder {
     }
   }
 
-  func encode<Act: DistributedActor>(_ actor: Act) throws -> String {
+  func encode<Act: DistributedActor>(_ actor: Act) throws -> String where Act.ID: Codable {
     try actor.encode(to: self)
     return self.data!
   }

--- a/test/Distributed/Runtime/distributed_actor_encode_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_encode_roundtrip.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// XXX: %target-build-swift -emit-silgen -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import _Distributed
+import FakeDistributedActorSystems
+import FakeCodableForDistributedTests
+
+distributed actor Worker: CustomStringConvertible {
+  nonisolated var description: Swift.String {
+    "Worker(\(id))"
+  }
+}
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+// ==== Execute ----------------------------------------------------------------
+@main struct Main {
+  static func main() async {
+    let system = DefaultDistributedActorSystem()
+
+    let actor = Worker(system: system)
+    // CHECK: assign id: ActorAddress(address: "<unique-id>") for Worker
+
+    // compilation check:
+    let _: Encodable = actor
+    let _: Decodable = actor
+
+    // round trip check:
+    let json = FakeEncoder()
+    let encoded = try! json.encode(actor)
+    print("encoded = \(encoded)")
+    // CHECK: encoded = <unique-id>;
+
+    let decoder = FakeDecoder()
+    decoder.userInfo[.actorSystemKey] = system
+    let back = try! decoder.decode(encoded, as: Worker.self)
+    // CHECK: | resolve ActorAddress(address: "<unique-id>")
+
+    print("back = \(back)")
+    // CHECK: back = Worker(ActorAddress(address: "<unique-id>"))
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -113,7 +113,6 @@ distributed actor Greeter {
   }
 }
 
-
 // ==== Fake Transport ---------------------------------------------------------
 struct ActorAddress: Sendable, Hashable, Codable {
   let address: String

--- a/test/Distributed/distributed_actor_implicit_codable.swift
+++ b/test/Distributed/distributed_actor_implicit_codable.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-distributed -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+distributed actor DA {
+}
+
+func take<A: Codable>(actor: A) {}
+
+func test(actorSystem: FakeActorSystem) {
+  take(actor: DA(system: actorSystem)) // ok
+}

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -9,7 +9,11 @@ import _Distributed
 distributed actor DA {
   // expected-error@-1{{distributed actor 'DA' does not declare ActorSystem it can be used with.}}
 
-  // expected-note@-3{{you can provide a module-wide default actor system by declaring:}}
+  // Since synthesis would have failed due to the missing ActorSystem:
+  // expected-error@-4{{type 'DA' does not conform to protocol 'Encodable'}}
+  // expected-error@-5{{type 'DA' does not conform to protocol 'Decodable'}}
+
+  // expected-note@-7{{you can provide a module-wide default actor system by declaring:}}
 
   // Note to add the typealias is diagnosed on the protocol:
   // _Distributed.DistributedActor:3:20: note: diagnostic produced elsewhere: protocol requires nested type 'ActorSystem'; do you want to add it?

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -22,6 +22,9 @@ distributed actor D2 {
 distributed actor D3 {
   // expected-error@-1{{type 'D3' does not conform to protocol 'Identifiable'}}
   // expected-error@-2{{type 'D3' does not conform to protocol 'DistributedActor'}}
+  // Codable synthesis also will fail since the ID mismatch:
+  // expected-error@-4{{type 'D3' does not conform to protocol 'Decodable'}}
+  // expected-error@-5{{type 'D3' does not conform to protocol 'Encodable'}}
 
   var id: Int { 0 }
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
@@ -35,6 +38,10 @@ distributed actor D4 {
   // expected-error@-1{{actor 'D4' has no initializers}}
   // expected-error@-2{{type 'D4' does not conform to protocol 'DistributedActor'}}
   // expected-error@-3{{type 'D4' does not conform to protocol 'Identifiable'}}
+  // Codable synthesis also will fail since the ID errors:
+  // expected-error@-5{{type 'D4' does not conform to protocol 'Decodable'}}
+  // expected-error@-6{{type 'D4' does not conform to protocol 'Encodable'}}
+
   let actorSystem: String
   // expected-error@-1{{invalid redeclaration of synthesized property 'actorSystem'}}
   // expected-error@-2{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}


### PR DESCRIPTION
Codable conformance is synthesized for any concrete DistributedActor when the ID it has is Codable.

This would not be implementable in "normal" swift due to the need to assign to self in the initializer.
