### PR TITLE
Opened existential cleanups

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3939,12 +3939,6 @@ public:
   /// due to a change.
   ConstraintList &getActiveConstraints() { return ActiveConstraints; }
 
-  void findConstraints(SmallVectorImpl<Constraint *> &found,
-                       llvm::function_ref<bool(const Constraint &)> pred) {
-    filterConstraints(ActiveConstraints, pred, found);
-    filterConstraints(InactiveConstraints, pred, found);
-  }
-
   /// Retrieve the representative of the equivalence class containing
   /// this type variable.
   TypeVariableType *getRepresentative(TypeVariableType *typeVar) const {
@@ -4116,16 +4110,6 @@ private:
   /// Introduce the constraints associated with the given type variable
   /// into the worklist.
   void addTypeVariableConstraintsToWorkList(TypeVariableType *typeVar);
-
-  static void
-  filterConstraints(ConstraintList &constraints,
-                    llvm::function_ref<bool(const Constraint &)> pred,
-                    SmallVectorImpl<Constraint *> &found) {
-    for (auto &constraint : constraints) {
-      if (pred(constraint))
-        found.push_back(&constraint);
-    }
-  }
 
 public:
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3733,11 +3733,9 @@ static bool generateInitPatternConstraints(
     return cs.generateWrappedPropertyTypeConstraints(
         wrappedVar, cs.getType(target.getAsExpr()), patternType);
 
-  if (!patternType->is<OpaqueTypeArchetypeType>()) {
-    // Add a conversion constraint between the types.
-    cs.addConstraint(ConstraintKind::Conversion, cs.getType(target.getAsExpr()),
-                     patternType, locator, /*isFavored*/true);
-  }
+  // Add a conversion constraint between the types.
+  cs.addConstraint(ConstraintKind::Conversion, cs.getType(target.getAsExpr()),
+                   patternType, locator, /*isFavored*/true);
 
   return false;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10128,18 +10128,8 @@ ConstraintSystem::simplifyOpenedExistentialOfConstraint(
   if (type2->isAnyExistentialType()) {
     // We have the existential side. Produce an opened archetype and bind
     // type1 to it.
-    bool isMetatype = false;
-    auto instanceTy = type2;
-    if (auto metaTy = type2->getAs<ExistentialMetatypeType>()) {
-      isMetatype = true;
-      instanceTy = metaTy->getExistentialInstanceType();
-    }
-    assert(instanceTy->isExistentialType());
-    Type openedTy =
-        OpenedArchetypeType::get(instanceTy->getCanonicalType(),
-                                 DC->getGenericSignatureOfContext());
-    if (isMetatype)
-      openedTy = MetatypeType::get(openedTy, getASTContext());
+    Type openedTy = openExistentialType(type2, getConstraintLocator(locator))
+        .first;
     return matchTypes(type1, openedTy, ConstraintKind::Bind, subflags, locator);
   }
   if (!type2->isTypeVariableOrMember())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1348,7 +1348,8 @@ namespace {
 static Optional<
     std::tuple<TypeVariableType *, Type, OpenedExistentialAdjustments>>
 shouldOpenExistentialCallArgument(
-    ValueDecl *callee, unsigned paramIdx, Type paramTy, Type argTy) {
+    ValueDecl *callee, unsigned paramIdx, Type paramTy, Type argTy,
+    Expr *argExpr, ConstraintSystem &cs) {
   if (!callee)
     return None;
 
@@ -1381,6 +1382,20 @@ shouldOpenExistentialCallArgument(
   // type inference won't be possible.
   if (!paramTy->hasTypeVariable())
     return None;
+
+  // An argument expression that explicitly coerces to an existential
+  // disables the implicit opening of the existential.
+  if (argExpr) {
+    if (auto argCoercion = dyn_cast<CoerceExpr>(
+            argExpr->getSemanticsProvidingExpr())) {
+      if (auto typeRepr = argCoercion->getCastTypeRepr()) {
+        if (auto toType = cs.getType(typeRepr)) {
+          if (toType->isAnyExistentialType())
+            return None;
+        }
+      }
+    }
+  }
 
   OpenedExistentialAdjustments adjustments;
 
@@ -1670,10 +1685,10 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       auto argTy = argument.getOldType();
 
       bool matchingAutoClosureResult = param.isAutoClosure();
+      auto *argExpr = getArgumentExpr(locator.getAnchor(), argIdx);
       if (param.isAutoClosure() && !isSynthesizedArgument(argument)) {
         auto &ctx = cs.getASTContext();
         auto *fnType = paramTy->castTo<FunctionType>();
-        auto *argExpr = getArgumentExpr(locator.getAnchor(), argIdx);
 
         // If this is a call to a function with a closure argument and the
         // parameter is an autoclosure, let's just increment the score here
@@ -1715,7 +1730,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       // If the argument is an existential type and the parameter is generic,
       // consider opening the existential type.
       if (auto existentialArg = shouldOpenExistentialCallArgument(
-              callee, paramIdx, paramTy, argTy)) {
+              callee, paramIdx, paramTy, argTy, argExpr, cs)) {
         // My kingdom for a decent "if let" in C++.
         TypeVariableType *openedTypeVar;
         Type existentialType;

--- a/test/Constraints/opened_existentials_suppression.swift
+++ b/test/Constraints/opened_existentials_suppression.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -enable-experimental-opened-existential-types -typecheck -dump-ast -parse-as-library %s | %FileCheck %s
+
+protocol P { }
+
+func acceptsBox<T>(_ value: T) { }
+
+// CHECK: passBox
+// CHECK-NOT: open_existential_expr
+func passBox(p: P) {
+  acceptsBox(p as P)
+}


### PR DESCRIPTION
A few cleanups and tweaks involving opened existentials:
* When implicitly opening existentials, have `as an P` disable the implicit opening of existentials
* Cleanup simplifyOpenedExistentialOfConstraint
* Delete some dead code