### PR TITLE
[SE-0326] Re-enable multi-statement closure inference by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -724,7 +724,7 @@ namespace swift {
 
     /// Enable experimental support for type inference through multi-statement
     /// closures.
-    bool EnableMultiStatementClosureInference = false;
+    bool EnableMultiStatementClosureInference = true;
 
     /// Enable experimental support for generic parameter inference in
     /// parameter positions from associated default expressions.

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1058,6 +1058,19 @@ public:
   }
 };
 
+class LocatorPathElt::PatternBindingElement final
+    : public StoredIntegerElement<1> {
+public:
+  PatternBindingElement(unsigned index)
+      : StoredIntegerElement(ConstraintLocator::PatternBindingElement, index) {}
+
+  unsigned getIndex() const { return getValue(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::PatternBindingElement;
+  }
+};
+
 namespace details {
   template <typename CustomPathElement>
   class PathElement {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -232,6 +232,9 @@ SIMPLE_LOCATOR_PATH_ELT(ImplicitDynamicMemberSubscript)
 /// The element of the closure body e.g. statement, declaration, or expression.
 CUSTOM_LOCATOR_PATH_ELT(ClosureBodyElement)
 
+/// The element of the pattern binding declaration.
+CUSTOM_LOCATOR_PATH_ELT(PatternBindingElement)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -388,8 +388,21 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   }
 
   if (Kind == ConstraintKind::ClosureBodyElement) {
-    Out << "closure body element ";
-    getClosureElement().dump(Out);
+    auto *locator = getLocator();
+    auto element = getClosureElement();
+
+    if (auto patternBindingElt =
+            locator
+                ->getLastElementAs<LocatorPathElt::PatternBindingElement>()) {
+      auto *patternBinding = cast<PatternBindingDecl>(element.get<Decl *>());
+      Out << "pattern binding element @ ";
+      Out << patternBindingElt->getIndex() << " : ";
+      patternBinding->getPattern(patternBindingElt->getIndex())->dump(Out);
+    } else {
+      Out << "closure body element ";
+      getClosureElement().dump(Out);
+    }
+
     return;
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -96,6 +96,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::ClosureBodyElement:
   case ConstraintLocator::PackType:
   case ConstraintLocator::PackElement:
+  case ConstraintLocator::PatternBindingElement:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -576,6 +577,14 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     case PackElement: {
       auto packElt = elt.castTo<LocatorPathElt::PackElement>();
       out << "pack element #" << llvm::utostr(packElt.getIndex());
+      break;
+    }
+
+    case PatternBindingElement: {
+      auto patternBindingElt =
+          elt.castTo<LocatorPathElt::PatternBindingElement>();
+      out << "pattern binding element #"
+          << llvm::utostr(patternBindingElt.getIndex());
       break;
     }
     }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -252,7 +252,7 @@ struct CC {}
 func callCC<U>(_ f: (CC) -> U) -> () {}
 
 func typeCheckMultiStmtClosureCrash() {
-  callCC { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
+  callCC {
     _ = $0
     return 1
   }
@@ -312,9 +312,8 @@ func testAcceptNothingToInt(ac1: @autoclosure () -> Int) {
 struct Thing {
   init?() {}
 }
-// This throws a compiler error
-let things = Thing().map { thing in  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{34-34=-> <#Result#> }}
-  // Commenting out this makes it compile
+
+let things = Thing().map { thing in
   _ = thing
   return thing
 }
@@ -322,14 +321,14 @@ let things = Thing().map { thing in  // expected-error {{cannot infer return typ
 
 // <rdar://problem/21675896> QoI: [Closure return type inference] Swift cannot find members for the result of inlined lambdas with branches
 func r21675896(file : String) {
-  let x: String = { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{20-20= () -> <#Result#> in }}
+  let x: String = {
     if true {
       return "foo"
     }
     else {
       return file
     }
-  }().pathExtension
+  }().pathExtension // expected-error {{value of type 'String' has no member 'pathExtension'}}
 }
 
 
@@ -360,7 +359,7 @@ func someGeneric19997471<T>(_ x: T) {
 
 
 // <rdar://problem/20921068> Swift fails to compile: [0].map() { _ in let r = (1,2).0; return r }
-[0].map {  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{5-5=-> <#Result#> }}
+let _ = [0].map {
   _ in
   let r =  (1,2).0
   return r
@@ -408,7 +407,7 @@ func r20789423() {
   print(p.f(p)())  // expected-error {{cannot convert value of type 'C' to expected argument type 'Int'}}
   // expected-error@-1:11 {{cannot call value of non-function type '()'}}
   
-  let _f = { (v: Int) in  // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{23-23=-> <#Result#> }}
+  let _f = { (v: Int) in
     print("a")
     return "hi"
   }
@@ -1127,7 +1126,7 @@ func rdar76058892() {
   func experiment(arr: [S]?) {
     test { // expected-error {{contextual closure type '() -> String' expects 0 arguments, but 1 was used in closure body}}
       if let arr = arr {
-        arr.map($0.test) // expected-note {{anonymous closure parameter '$0' is used here}}
+        arr.map($0.test) // expected-note {{anonymous closure parameter '$0' is used here}} // expected-error {{generic parameter 'T' could not be inferred}}
       }
     }
   }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -148,7 +148,7 @@ func ***~(_: Int, _: String) { }
 i ***~ i // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
 
 @available(*, unavailable, message: "call the 'map()' method on the sequence")
-public func myMap<C : Collection, T>(
+public func myMap<C : Collection, T>( // expected-note {{'myMap' has been explicitly marked unavailable here}}
   _ source: C, _ transform: (C.Iterator.Element) -> T
 ) -> [T] {
   fatalError("unavailable function can't be called")
@@ -161,7 +161,7 @@ public func myMap<T, U>(_ x: T?, _ f: (T) -> U) -> U? {
 
 // <rdar://problem/20142523>
 func rdar20142523() {
-  myMap(0..<10, { x in // expected-error{{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{21-21=-> <#Result#> }} {{educational-notes=complex-closure-inference}}
+  _ = myMap(0..<10, { x in // expected-error {{'myMap' is unavailable: call the 'map()' method on the sequence}}
     ()
     return x
   })

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -595,10 +595,10 @@ func rdar50679161() {
 
   func foo() {
     _ = { () -> Void in
+      // Missing `.self` or `init` is not diagnosed here because there are errors in
+      // `if let` statement and `MiscDiagnostics` only run if the body is completely valid.
       var foo = S
-      // expected-error@-1 {{expected member name or constructor call after type name}}
-      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
-      // expected-note@-3 {{use '.self' to reference the type object}}
+
       if let v = Int?(1) {
         var _ = Q(
           a: v + foo.w,
@@ -609,6 +609,14 @@ func rdar50679161() {
           // expected-error@-2 {{cannot convert value of type 'Point' to expected argument type 'Int'}}
         )
       }
+    }
+
+    _ = { () -> Void in
+      var foo = S
+      // expected-error@-1 {{expected member name or constructor call after type name}}
+      // expected-note@-2 {{add arguments after the type to construct a value of the type}}
+      // expected-note@-3 {{use '.self' to reference the type object}}
+      print(foo)
     }
   }
 }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -230,14 +230,14 @@ func good(_ a: A<EE>) -> Int {
 }
 
 func bad(_ a: A<EE>) {
-  a.map { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
+  let _ = a.map {
     let _: EE = $0
     return 1
   }
 }
 
 func ugly(_ a: A<EE>) {
-  a.map { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{none}}
+  let _ = a.map {
     switch $0 {
     case .A:
       return 1

--- a/test/Constraints/rdar46544601.swift
+++ b/test/Constraints/rdar46544601.swift
@@ -26,6 +26,6 @@ func crash(_ p: P, payload: [UInt8]) throws {
     p.foo(arr: arr, data: []).and(result: (id, arr))
   }.then { args0 in
     let (parentID, args1) = args0
-    p.bar(root: parentID, from: p).and(args1)
+    p.bar(root: parentID, from: p).and(result: args1)
   }.whenFailure { _ in }
 }

--- a/test/Constraints/rdar65320500.swift
+++ b/test/Constraints/rdar65320500.swift
@@ -31,13 +31,13 @@ test_builder {
 test_builder {
   test(doesntExist()) // expected-error {{cannot find 'doesntExist' in scope}}
 
-  if let result = doesntExist() {
+  if let result = doesntExist() { // expected-error {{cannot find 'doesntExist' in scope}}
   }
 
-  if bar = test(42) {}
+  if bar = test(42) {} // expected-error {{cannot find 'bar' in scope}}
 
-  let foo = bar()
+  let foo = bar() // expected-error {{cannot find 'bar' in scope}}
 
-  switch (doesntExist()) {
+  switch (doesntExist()) { // expected-error {{cannot find 'doesntExist' in scope}}
   }
 }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -78,7 +78,7 @@ struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf
   static func buildDo<T>(_ value: T) -> T { return value }
 }
 
-func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
+func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) { // expected-note {{in call to function 'tuplify(_:body:)'}}
   print(body(cond))
 }
 
@@ -307,21 +307,6 @@ struct MyTuplifiedStruct {
   }
 }
 
-func test_invalid_return_type_in_body() {
-  tuplify(true) { _ -> (Void, Int) in
-    tuplify(false) { condition in
-      if condition {
-        return 42 // expected-error {{cannot use explicit 'return' statement in the body of result builder 'TupleBuilder'}}
-        // expected-note@-1 {{remove 'return' statements to apply the result builder}} {{9-16=}}
-      } else {
-        1
-      }
-    }
-
-    42
-  }
-}
-
 // Check that we're performing syntactic use diagnostics.
 func acceptMetatype<T>(_: T.Type) -> Bool { true }
 
@@ -481,7 +466,7 @@ struct TestConstraintGenerationErrors {
   func buildTupleClosure() {
     tuplify(true) { _ in
       let a = nothing // expected-error {{cannot find 'nothing' in scope}}
-      String(nothing)
+      String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }
   }
 }
@@ -522,7 +507,7 @@ enum E3 {
 }
 
 func testCaseMutabilityMismatches(e: E3) {
-    tuplify(true) { c in
+   tuplify(true) { c in // expected-error {{generic parameter 'T' could not be inferred}}
     "testSwitch"
     switch e {
     case .a(let x, var y),

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -218,14 +218,14 @@ extension r25271859 {
   func map<U>(f: (T) -> U) -> r25271859<U> {
   }
 
-  func andThen<U>(f: (T) -> r25271859<U>) { // expected-note {{in call to function 'andThen(f:)'}}
+  func andThen<U>(f: (T) -> r25271859<U>) {
   }
 }
 
 func f(a : r25271859<(Float, Int)>) {
-  a.map { $0.0 } // expected-error {{generic parameter 'U' could not be inferred}} (This is related to how solver is setup with multiple statements)
+  a.map { $0.0 }
     .andThen { _ in
-      print("hello") // comment this out and it runs, leave any form of print in and it doesn't
+      print("hello")
       return r25271859<String>()
   }
 }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1407,9 +1407,17 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   }
 
   f2.forEach { block in
-  // expected-note@-1 2{{'block' declared here}}
+  // expected-note@-1 {{'block' declared here}}
     block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
+  }
+
+  f2.forEach { block in
+  // expected-note@-1 {{'block' declared here}}
     block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
+    block(c, c)
+  }
+
+  f2.forEach { block in
     block(c, c)
   }
 
@@ -1417,13 +1425,21 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> Void' to expected argument type '(@escaping (Bool, Bool) -> ()) throws -> Void'}}
     block(p)
     block((c, c))
+    block(c, c) // expected-error {{parameter 'block' expects a single parameter of type '(Bool, Bool)'}}
+  }
+
+  f2.forEach { (block: (Bool, Bool) -> ()) in
+  // expected-note@-1 {{'block' declared here}}
+    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
+  }
+
+  f2.forEach { (block: (Bool, Bool) -> ()) in
+    // expected-note@-1 {{'block' declared here}}
+    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 
   f2.forEach { (block: (Bool, Bool) -> ()) in
-  // expected-note@-1 2{{'block' declared here}}
-    block(p) // expected-error {{parameter 'block' expects 2 separate arguments}}
-    block((c, c)) // expected-error {{parameter 'block' expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{11-12=}} {{16-17=}}
     block(c, c)
   }
 }

--- a/test/Constraints/without_actually_escaping.swift
+++ b/test/Constraints/without_actually_escaping.swift
@@ -10,7 +10,7 @@ func escapeX(_ xx: (Int) -> Int, _ value: Int) { // expected-note* {{non-escapin
   withoutActuallyEscaping(xx) { escapableXX in
     x = xx // expected-error{{non-escaping parameter}}
     x = escapableXX
-    x = xx // expected-error{{non-escaping parameter}}
+    x = xx
 
     _ = x(value)
     _ = xx(value)

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -132,15 +132,13 @@ func SR12689(_ u: UnsafeBufferPointer<UInt16>) {}
 let array : [UInt16] = [1, 2]
 
 array.withUnsafeBufferPointer {
-  SR12689(UnsafeRawPointer($0).bindMemory(to: UInt16.self, capacity: 1)) // expected-error {{cannot convert value of type 'UnsafePointer<UInt16>' to expected argument type 'UnsafeBufferPointer<UInt16>'}}
-  // expected-error@-1 {{no exact matches in call to initializer}}
-  // expected-note@-2 {{candidate expects value of type 'UnsafeRawPointer' for parameter #1}}
-  // expected-note@-3 {{candidate expects value of type 'UnsafeMutableRawPointer' for parameter #1}}
+  _ = SR12689(UnsafeRawPointer($0).bindMemory(to: UInt16.self, capacity: 1)) // expected-error {{cannot convert value of type 'UnsafePointer<UInt16>' to expected argument type 'UnsafeBufferPointer<UInt16>'}}
+  // expected-error@-1 {{cannot convert value of type 'UnsafeBufferPointer<UInt16>' to expected argument type 'UnsafeMutableRawPointer'}}
+}
 
-  UnsafeRawPointer($0) as UnsafeBufferPointer<UInt16> // expected-error {{cannot convert value of type 'UnsafeRawPointer' to type 'UnsafeBufferPointer<UInt16>' in coercion}}
-  // expected-error@-1 {{no exact matches in call to initializer}}
-  // expected-note@-2 {{found candidate with type '(UnsafeRawPointer) -> UnsafeRawPointer'}}
-  // expected-note@-3 {{found candidate with type '(UnsafeMutableRawPointer) -> UnsafeRawPointer'}}
+array.withUnsafeBufferPointer {
+  _ = UnsafeRawPointer($0) as UnsafeBufferPointer<UInt16> // expected-error {{cannot convert value of type 'UnsafeRawPointer' to type 'UnsafeBufferPointer<UInt16>' in coercion}}
+  // expected-error@-1 {{cannot convert value of type 'UnsafeBufferPointer<UInt16>' to expected argument type 'UnsafeMutableRawPointer'}}
 }
 
 func SR12689_1(_ u: Int) -> String { "" } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -124,13 +124,6 @@ foo(b:
 // CHECK:             |                ^ note: Remove '=' to make 'x' a computed property [remove '= ' and replace 'let' with 'var']
 // CHECK: [[#LINE+1]] | }
 
-// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:9
-// CHECK: [[#LINE-1]] |
-// CHECK: [[#LINE]]   | let x = { () -> Result in
-// CHECK:             |          +++++++++++++++++
-// CHECK:             |         ^ error: cannot infer return type for closure with multiple statements; add explicit type to disambiguate
-// CHECK: [[#LINE+1]] |   let y = 1
-
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:8
 // CHECK: [[#LINE-1]] |
 // CHECK: [[#LINE]]   | struct B: Decodable {
@@ -148,12 +141,6 @@ foo(b:
 // CHECK:             |           ++++++~~~~------
 // CHECK:             |                       ^ error: argument 'a' must precede argument 'b' [remove ', a: 2' and insert 'a: 2, ']
 // CHECK: [[#LINE+1]] |
-
-// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:20
-// CHECK: [[#LINE-1]] |
-// CHECK: [[#LINE]]   | let 👍👍👍 = {
-// CHECK:    | --> error: cannot infer return type for closure with multiple statements; add explicit type to disambiguate [insert ' () -> <#Result#> in ']
-// CHECK: [[#LINE+1]] |   let y = 1
 
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:5
 // CHECK: [[#LINE-2]] | // Multi-line fix-its

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -29,11 +29,7 @@ func variadic() {
 
   takesVariadicGeneric({takesIntArray($0)})
 
-  // FIXME: Problem here is related to multi-statement closure body not being type-checked together with
-  // enclosing context. We could have inferred `$0` to be `[Int]` if `let` was a part of constraint system.
   takesVariadicGeneric({let _: [Int] = $0})
-  // expected-error@-1 {{unable to infer type of a closure parameter '$0' in the current context}}
-
   takesVariadicIntInt({_ = $0; takesIntArray($1)})
   takesVariadicIntInt({_ = $0; let _: [Int] = $1})
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -120,9 +120,8 @@ var selfRef = { selfRef() }
 // expected-note@-1 2{{through reference here}}
 // expected-error@-2 {{circular reference}}
 
-var nestedSelfRef = {
+var nestedSelfRef = { // expected-error {{circular reference}} expected-note 2 {{through reference here}}
   var recursive = { nestedSelfRef() }
-  // expected-warning@-1 {{variable 'recursive' was never mutated; consider changing to 'let' constant}}
   recursive()
 }
 
@@ -140,12 +139,11 @@ func anonymousClosureArgsInClosureWithArgs() {
   var a3 = { (z: Int) in $0 } // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{26-28=z}}
   var a4 = { (z: [Int], w: [Int]) in
     f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'z'?}} {{7-9=z}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
-    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}} expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
+    f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}}
   }
   var a5 = { (_: [Int], w: [Int]) in
     f($0.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments}}
     f($1.count) // expected-error {{anonymous closure arguments cannot be used inside a closure that has explicit arguments; did you mean 'w'?}} {{7-9=w}}
-    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'String'}}
   }
 }
 
@@ -403,7 +401,7 @@ Void(0) // expected-error{{argument passed to call that takes no arguments}}
 _ = {0}
 
 // <rdar://problem/22086634> "multi-statement closures require an explicit return type" should be an error not a note
-let samples = {   // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{16-16= () -> <#Result#> in }}
+let samples = {
           if (i > 10) { return true }
           else { return false }
         }()
@@ -485,8 +483,8 @@ func lvalueCapture<T>(c: GenericClass<T>) {
 }
 
 // Don't expose @lvalue-ness in diagnostics.
-let closure = { // expected-error {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}} {{16-16= () -> <#Result#> in }}
-  var helper = true
+let closure = {
+  var helper = true // expected-warning {{variable 'helper' was never mutated; consider changing to 'let' constant}}
   return helper
 }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -115,13 +115,14 @@ func t() {
 func f0(_ a: Any) -> Int { return 1 }
 assert(f0(1) == 1)
 
-
+// TODO(diagnostics): Bad diagnostic - should be `circular reference`
 var selfRef = { selfRef() }
-// expected-note@-1 2{{through reference here}}
-// expected-error@-2 {{circular reference}}
+// expected-error@-1 {{unable to infer closure type in the current context}}
 
-var nestedSelfRef = { // expected-error {{circular reference}} expected-note 2 {{through reference here}}
+// TODO: should be an error `circular reference` but it's diagnosed via overlapped requests
+var nestedSelfRef = {
   var recursive = { nestedSelfRef() }
+  // expected-warning@-1 {{variable 'recursive' was never mutated; consider changing to 'let' constant}}
   recursive()
 }
 

--- a/test/expr/closure/inference.swift
+++ b/test/expr/closure/inference.swift
@@ -34,10 +34,9 @@ func unnamed() {
 // Regression tests.
 
 var nestedClosuresWithBrokenInference = { f: Int in {} }
-    // expected-error@-1 {{closure expression is unused}} expected-note@-1 {{did you mean to use a 'do' statement?}} {{53-53=do }}
-    // expected-error@-2 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
-    // expected-error@-3 {{expected expression}}
-    // expected-error@-4 {{cannot find 'f' in scope}}
+    // expected-error@-1 {{consecutive statements on a line must be separated by ';'}} {{44-44=;}}
+    // expected-error@-2 {{expected expression}}
+    // expected-error@-3 {{cannot find 'f' in scope}}
 
 // SR-11540
 

--- a/test/expr/closure/let.swift
+++ b/test/expr/closure/let.swift
@@ -9,7 +9,7 @@ func foo() {
 
   _ = { frob(x: x) }() // expected-error{{'x' is a 'let'}}
   _ = { x = 0 }() // expected-error{{'x' is a 'let'}}
-  _ = { frob(x: x); x = 0 }() // expected-error 2 {{'x' is a 'let'}}
+  _ = { frob(x: x); x = 0 }() // expected-error {{'x' is a 'let'}}
 }
 
 let a: Int 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -246,9 +246,11 @@ func test_as_2() {
 func test_lambda() {
   // A simple closure.
   var a = { (value: Int) -> () in markUsed(value+1) }
+  // expected-warning@-1 {{initialization of variable 'a' was never used; consider replacing with assignment to '_' or removing it}}
 
   // A recursive lambda.
-  var fib = { (n: Int) -> Int in // expected-error {{circular reference}} expected-note 2 {{through reference here}}
+  var fib = { (n: Int) -> Int in
+    // expected-warning@-1 {{variable 'fib' was never mutated; consider changing to 'let' constant}}
     if (n < 2) {
       return n
     }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -246,11 +246,9 @@ func test_as_2() {
 func test_lambda() {
   // A simple closure.
   var a = { (value: Int) -> () in markUsed(value+1) }
-  // expected-warning@-1 {{initialization of variable 'a' was never used; consider replacing with assignment to '_' or removing it}}
 
   // A recursive lambda.
-  var fib = { (n: Int) -> Int in
-    // expected-warning@-1 {{variable 'fib' was never mutated; consider changing to 'let' constant}}
+  var fib = { (n: Int) -> Int in // expected-error {{circular reference}} expected-note 2 {{through reference here}}
     if (n < 2) {
       return n
     }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1093,8 +1093,6 @@ func rdar74711236() {
         // `isSupported` should be an invalid declaration to trigger a crash in `map(\.option)`
         let isSupported = context!.supported().contains(type)
         return (isSupported ? [type] : []).map(\.option)
-        // expected-error@-1 {{value of type 'Any' has no member 'option'}}
-        // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
       }
       return []
     }()

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -400,12 +400,19 @@ func test_is_as_patterns() {
 }
 
 // <rdar://problem/21387308> Fuzzing SourceKit: crash in Parser::parseStmtForEach(...)
-func matching_pattern_recursion() {
+func matching_pattern_recursion(zs: [Int]) { // expected-note {{'zs' declared here}}
   switch 42 {
   case {  // expected-error {{expression pattern of type '() -> ()' cannot match values of type 'Int'}}
       for i in zs {
       }
   }: break
+  }
+
+  switch 42 {
+  case {
+      for i in ws { // expected-error {{cannot find 'ws' in scope; did you mean 'zs'?}}
+      }
+    }: break
   }
 }
 

--- a/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
+++ b/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: objc_interop,no_asan
+
+import simd
+
+func test(_: () -> Void) {}
+
+test {
+  let a: simd_float2 = .init()
+  let b: simd_float2 = .init()
+  let c: simd_float2 = .init()
+  let d: simd_float2 = .init()
+
+  let width: Float = 2
+
+  let p = Int(max(20, min(1000, (simd_distance(a, b) + simd_distance(b, c) + simd_distance(c, d)) / width / 4)))
+  print(p)
+}

--- a/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
+++ b/validation-test/compiler_crashers_2_fixed/0119-rdar33613329.swift
@@ -17,7 +17,7 @@ struct M<L : P, R> {
   }
 }
 
-protocol P { // expected-note {{where 'Self' = 'M<WritableKeyPath<X, Int>, R>'}}
+protocol P { // expected-note {{where 'Self' = 'M<WritableKeyPath<X, Int>, Int>'}}
   associatedtype A
   associatedtype B
 
@@ -42,5 +42,4 @@ extension WritableKeyPath : P {
 struct X { var y: Int = 0 }
 var x = X()
 x ~> \X.y ≈> { a in a += 1; return 3 }
-// expected-error@-1 {{referencing operator function '~>' on 'P' requires that 'M<WritableKeyPath<X, Int>, R>' conform to 'P'}}
-// expected-error@-2 {{cannot infer return type for closure with multiple statements; add explicit type to disambiguate}}
+//expected-error@-1 {{referencing operator function '~>' on 'P' requires that 'M<WritableKeyPath<X, Int>, Int>' conform to 'P'}}


### PR DESCRIPTION
Fixes a performance regression related to `one-way` constraints and re-enables
multi-statement closure inference by default.

The changes include:

- New locator for each pattern binding element
- Recording a type of a named pattern declaration in a constraint system
- Solving pattern bindings declarations via conjunctions

Resolves: rdar://88205521
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
