### PR TITLE
[nfc] Use `^stdlib` not `stdlib` for lit regex filter.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2400,7 +2400,7 @@ native-llvm-tools-path=%(toolchain_path)s
 native-clang-tools-path=%(toolchain_path)s
 
 build-ninja
-lit-args=--filter=stdlib/ -v
+lit-args=--filter=':: stdlib/' -v
 only-executable-test
 
 [preset: stdlib_RD_standalone,build]


### PR DESCRIPTION
Otherwise this will pick up non-stdlib tests such as interop tests. Thesedon't work in the toolchain config because the test might rely on a recent fix to the compiler.

rdar://89980100