### PR TITLE
Add availability macro support to @_backDeploy

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1561,17 +1561,8 @@ ERROR(attr_availability_duplicate,none,
       (StringRef, StringRef))
 
 // originallyDefinedIn
-// FIXME(backDeploy): Refactor to share with back deployment attr
 ERROR(originally_defined_in_missing_rparen,none,
       "expected ')' in @_originallyDefinedIn argument list", ())
-
-// FIXME(backDeploy): Refactor to share with back deployment attr
-ERROR(originally_defined_in_unrecognized_platform,none,
-      "unrecognized platform name in @_originallyDefinedIn argument list", ())
-
-// FIXME: This is unused and can be removed
-ERROR(originally_defined_in_unrecognized_property,none,
-      "unrecognized property in @_originallyDefinedIn argument list", ())
 
 ERROR(originally_defined_in_need_original_module_name,none,
       "expected 'module: \"original\"' in the first argument to "
@@ -1579,27 +1570,6 @@ ERROR(originally_defined_in_need_original_module_name,none,
 
 ERROR(originally_defined_in_need_nonempty_module_name,none,
       "original module name cannot be empty in @_originallyDefinedIn", ())
-
-// FIXME(backDeploy): Refactor to share with back deployment attr
-ERROR(originally_defined_in_need_platform_version,none,
-     "expected at least one platform version in @_originallyDefinedIn", ())
-
-// FIXME(backDeploy): Refactor to share with back deployment attr
-WARNING(originally_defined_in_major_minor_only,none,
-        "@_originallyDefinedIn only uses major and minor version number", ())
-
-// FIXME(backDeploy): Refactor to share with back deployment attr
-WARNING(originally_defined_in_missing_platform_name,none,
-        "* as platform name has no effect", ())
-
-// FIXME(backDeploy): Refactor to share with back deployment attr
-WARNING(originally_defined_in_swift_version, none,
-        "Swift language version checks has no effect "
-        "in @_originallyDefinedIn", ())
-
-WARNING(originally_defined_in_package_description, none,
-        "PackageDescription version checks has no effect "
-        "in @_originallyDefinedIn", ())
 
 // backDeploy
 ERROR(attr_back_deploy_missing_rparen,none,

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -2,7 +2,9 @@
 
 // Ensure @_backDeploy attributes and function bodies are printed in
 // swiftinterface files.
-// RUN: %target-swiftc_driver -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -enable-library-evolution -verify-emitted-module-interface -module-name Test %s
+// RUN: %target-swiftc_driver -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface %s -enable-library-evolution -verify-emitted-module-interface -module-name Test \
+// RUN:   -Xfrontend -define-availability -Xfrontend "_macOS12_1:macOS 12.1" \
+// RUN:   -Xfrontend -define-availability -Xfrontend "_myProject 1.0:macOS 12.1, iOS 15.1"
 // RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
 
 // FIXME(backDeploy): Remove this step in favor of a test that exercises using
@@ -10,7 +12,9 @@
 
 // Ensure @_backDeploy attributes and function bodies are present after
 // deserializing .swiftmodule files.
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test \
+// RUN:   -define-availability "_macOS12_1:macOS 12.1" \
+// RUN:   -define-availability "_myProject 1.0:macOS 12.1, iOS 15.1"
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
 public struct TopLevelStruct {
@@ -66,10 +70,25 @@ public struct TopLevelStruct {
 }
 
 // CHECK: @_backDeploy(macOS 12.0)
-// FROMSOURCE: public func backDeployTopLevelFunc() -> Swift.Int { return 47 }
-// FROMMODULE: public func backDeployTopLevelFunc() -> Swift.Int
+// FROMSOURCE: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
+// FROMMODULE: public func backDeployTopLevelFunc1() -> Swift.Int
 @available(macOS 11.0, *)
 @_backDeploy(macOS 12.0)
-public func backDeployTopLevelFunc() -> Int { return 47 }
+public func backDeployTopLevelFunc1() -> Int { return 47 }
 
-// FIXME(backDeploy): Availability macros should be supported
+// MARK: - Availability macros
+
+// CHECK: @_backDeploy(macOS 12.1)
+// FROMSOURCE: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
+// FROMMODULE: public func backDeployTopLevelFunc2() -> Swift.Int
+@available(macOS 11.0, *)
+@_backDeploy(_macOS12_1)
+public func backDeployTopLevelFunc2() -> Int { return 48 }
+
+// CHECK: @_backDeploy(macOS 12.1)
+// CHECK: @_backDeploy(iOS 15.1)
+// FROMSOURCE: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
+// FROMMODULE: public func backDeployTopLevelFunc3() -> Swift.Int
+@available(macOS 11.0, iOS 14.0, *)
+@_backDeploy(_myProject 1.0)
+public func backDeployTopLevelFunc3() -> Int { return 49 }

--- a/test/Parse/original_defined_in_attr.swift
+++ b/test/Parse/original_defined_in_attr.swift
@@ -7,20 +7,21 @@ public func foo() {}
 @_originallyDefinedIn(modulename: "foo", OSX 13.13) // expected-error {{expected 'module: "original"' in the first argument to @_originallyDefinedIn}}
 public func foo1() {}
 
-@_originallyDefinedIn(module: "foo", OSX 13.13.3) // expected-warning {{@_originallyDefinedIn only uses major and minor version number}} expected-error {{'@_originallyDefinedIn' requires that 'ToplevelClass' have explicit availability for macOS}}
+@_originallyDefinedIn(module: "foo", OSX 13.13.3) // expected-warning {{'@_originallyDefinedIn' only uses major and minor version number}}
+// expected-error@-1 {{'@_originallyDefinedIn' requires that 'ToplevelClass' have explicit availability for macOS}}
 public class ToplevelClass {}
 
-@_originallyDefinedIn(module: "foo") // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
+@_originallyDefinedIn(module: "foo") // expected-error {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public class ToplevelClass1 {}
 
 @_originallyDefinedIn(OSX 13.13.3) // expected-error {{expected 'module: "original"' in the first argument to @_originallyDefinedIn}}
 public class ToplevelClass2 {}
 
-@_originallyDefinedIn(module: "foo", // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
-public class ToplevelClass3 {}
+@_originallyDefinedIn(module: "foo",
+public class ToplevelClass3 {} // expected-error {{expected platform in '@_originallyDefinedIn' attribute}}
 
 @available(OSX 13.10, *)
-@_originallyDefinedIn(module: "foo", * 13.13) // expected-warning {{* as platform name has no effect}} expected-error {{expected at least one platform version in @_originallyDefinedIn}}
+@_originallyDefinedIn(module: "foo", * 13.13) // expected-warning {{* as platform name has no effect}} expected-error {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0)
 @_originallyDefinedIn(module: "foo", OSX 13.14, * 7.0) // expected-warning {{* as platform name has no effect}} expected-error {{'@_originallyDefinedIn' contains multiple versions for macOS}}
 public class ToplevelClass4 {

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -17,11 +17,16 @@ public class C {
 public class D {}
 
 @available(macOS 10.9, *)
-@_originallyDefinedIn(module: "original", _myProject 2.0) // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
-// expected-error @-1 {{reference to undefined version '2.0' for availability macro '_myProject'}}
+@_originallyDefinedIn(module: "original", _myProject 2.0) // expected-error {{reference to undefined version '2.0' for availability macro '_myProject'}}
 public func macroVersionned() {}
 
 // Fallback to the default diagnostic when the macro is unknown.
 @available(macOS 10.9, *)
-@_originallyDefinedIn(module: "original", _unknownMacro) // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
+@_originallyDefinedIn(module: "original", _unknownMacro) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_originallyDefinedIn'}}
+// expected-error@-1 {{expected version number in '@_originallyDefinedIn' attribute}}
 public func macroUnknown() {}
+
+@available(macOS 10.9, *)
+@_originallyDefinedIn(module: "original", swift 5.1) // expected-warning {{unknown platform 'swift' for attribute '@_originallyDefinedIn'}}
+// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
+public func swiftVersionMacro() {}


### PR DESCRIPTION
Add availability macro support to `@_backDeploy` attribute parsing. Consolidate parsing code shared between `@_originallyDefinedIn` and `@_backDeploy`.

Resolves rdar://88651219