### PR TITLE
[CodeCompletion] Ensure synthesized members are available before lookup

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -491,6 +491,9 @@ void lookupVisibleMemberDecls(VisibleDeclConsumer &Consumer,
 
 namespace namelookup {
 
+/// Add semantic members to \p type before attempting a semantic lookup.
+void installSemanticMembersIfNeeded(Type type, DeclNameRef name);
+
 void extractDirectlyReferencedNominalTypes(
     Type type, SmallVectorImpl<NominalTypeDecl *> &decls);
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1592,6 +1592,32 @@ void namelookup::pruneLookupResultSet(const DeclContext *dc, NLOptions options,
   filterForDiscriminator(decls, M->getDebugClient());
 }
 
+// An unfortunate hack to kick the decl checker into adding semantic members to
+// the current type before we attempt a semantic lookup. The places this method
+// looks needs to be in sync with \c extractDirectlyReferencedNominalTypes.
+// See the note in \c synthesizeSemanticMembersIfNeeded about a better, more
+// just, and peaceful world.
+void namelookup::installSemanticMembersIfNeeded(Type type, DeclNameRef name) {
+  // Look-through class-bound archetypes to ensure we synthesize e.g.
+  // inherited constructors.
+  if (auto archetypeTy = type->getAs<ArchetypeType>()) {
+    if (auto super = archetypeTy->getSuperclass()) {
+      type = super;
+    }
+  }
+
+  if (type->isExistentialType()) {
+    auto layout = type->getExistentialLayout();
+    if (auto super = layout.explicitSuperclass) {
+      type = super;
+    }
+  }
+
+  if (auto *current = type->getAnyNominal()) {
+    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
+  }
+}
+
 /// Inspect the given type to determine which nominal type declarations it
 /// directly references, to facilitate name lookup into those types.
 void namelookup::extractDirectlyReferencedNominalTypes(

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/SourceFile.h"
@@ -363,6 +364,9 @@ static void collectPossibleCalleesByQualifiedLookup(
   auto baseInstanceTy = baseTy->getMetatypeInstanceType();
   if (!baseInstanceTy->mayHaveMembers())
     return;
+
+  // Make sure we've resolved implicit members.
+  namelookup::installSemanticMembersIfNeeded(baseInstanceTy, name);
 
   bool isOnMetaType = baseTy->is<AnyMetatypeType>();
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -273,32 +273,6 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclNameRef name,
   return result;
 }
 
-// An unfortunate hack to kick the decl checker into adding semantic members to
-// the current type before we attempt a semantic lookup. The places this method
-// looks needs to be in sync with \c extractDirectlyReferencedNominalTypes.
-// See the note in \c synthesizeSemanticMembersIfNeeded about a better, more
-// just, and peaceful world.
-static void installSemanticMembersIfNeeded(Type type, DeclNameRef name) {
-  // Look-through class-bound archetypes to ensure we synthesize e.g.
-  // inherited constructors.
-  if (auto archetypeTy = type->getAs<ArchetypeType>()) {
-    if (auto super = archetypeTy->getSuperclass()) {
-      type = super;
-    }
-  }
-
-  if (type->isExistentialType()) {
-    auto layout = type->getExistentialLayout();
-    if (auto super = layout.explicitSuperclass) {
-      type = super;
-    }
-  }
-
-  if (auto *current = type->getAnyNominal()) {
-    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
-  }
-}
-
 LookupResult
 TypeChecker::lookupUnqualifiedType(DeclContext *dc, DeclNameRef name,
                                    SourceLoc loc,
@@ -346,7 +320,7 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   subOptions &= ~NL_RemoveNonVisible;
 
   // Make sure we've resolved implicit members, if we need them.
-  installSemanticMembersIfNeeded(type, name);
+  namelookup::installSemanticMembersIfNeeded(type, name);
 
   LookupResultBuilder builder(result, dc, options);
   SmallVector<ValueDecl *, 4> lookupResults;
@@ -438,7 +412,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     subOptions |= NL_IncludeUsableFromInline;
 
   // Make sure we've resolved implicit members, if we need them.
-  installSemanticMembersIfNeeded(type, name);
+  namelookup::installSemanticMembersIfNeeded(type, name);
 
   if (!dc->lookupQualified(type, name, subOptions, decls))
     return result;

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1271,6 +1271,7 @@ func testSkippedCallArgInInvalidResultBuilderBody() {
     Other(action: 2) {
       MyImage(systemName: "", #^INVALID_RESULTBUILDER_ARG^#
     struct Invalid
+    }
   }
 
   // INVALID_RESULTBUILDER_ARG: Begin completions, 1 item
@@ -1398,4 +1399,18 @@ func testTopLevelFuncWithErrorParam() {
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#A#]; name=a
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM: End completions
+}
+
+struct Rdar89773376 {
+  var intVal: Int
+}
+extension Rdar89773376 {
+  init(string: String) { self.intVal = 1 }
+}
+func testRdar89773376(arry: [Int]) {
+  arry.map { Rdar89773376(#^RDAR89773376^#) }
+// RDAR89773376: Begin completions, 2 items
+// RDAR89773376-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#string: String#}[')'][#Rdar89773376#];
+// RDAR89773376-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#intVal: Int#}[')'][#Rdar89773376#];
+// RDAR89773376: End completions
 }


### PR DESCRIPTION
In `ExprContextAnalyzer`, when looking up members, some implicit members weren't populated. Ensure all implicit members available by calling 'gelAllMembers()' on the nominal type.

rdar://89773376
