### PR TITLE
[ClangImporter] Allow @Sendable on more params

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -89,6 +89,14 @@ WARNING(clang_error_code_must_be_sendable,none,
         "cannot make error code type '%0' non-sendable because Swift errors "
         "are always sendable", (StringRef))
 
+WARNING(clang_param_ignored_sendable_attr,none,
+        "cannot make parameter '%0' sendable type %1 cannot be made sendable "
+        "by adding '@Sendable' or '& Sendable'",
+        (StringRef, Type))
+NOTE(clang_param_should_be_implicitly_sendable,none,
+     "parameter should be implicitly 'Sendable' because it is a completion "
+     "handler", ())
+
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -124,3 +124,20 @@ import _Concurrency
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
 
 // CHECK: @MainActor @objc protocol TripleMainActor {
+
+// CHECK-LABEL: class NXSender :
+// CHECK-NEXT: func sendAny(_ obj: Sendable)
+// CHECK-NEXT: func sendOptionalAny(_ obj: Sendable?)
+// CHECK-NEXT: func sendSendable(_ sendable: SendableClass & Sendable)
+// CHECK-NEXT: func sendSendableSubclasses(_ sendableSubclass: NonSendableClass & Sendable)
+// CHECK-NEXT: func sendProto(_ obj: LabellyProtocol & Sendable)
+// CHECK-NEXT: func sendProtos(_ obj: LabellyProtocol & ObjCClub & Sendable)
+// CHECK-NEXT: func sendAnyArray(_ array: [Sendable])
+// CHECK-NEXT: func sendGeneric(_ generic: GenericObject<SendableClass> & Sendable)
+// CHECK-NEXT: func sendPtr(_ val: UnsafeMutableRawPointer)
+// CHECK-NEXT: func sendStringArray(_ obj: [String])
+// CHECK-NEXT: func sendAnyTypedef(_ obj: Sendable)
+// CHECK-NEXT: func sendAnyTypedefs(_ objs: [Sendable])
+// CHECK-NEXT: func sendBlockTypedef(_ block: @escaping @Sendable (Any) -> Void)
+// CHECK-NEXT: func sendBlockTypedefs(_ blocks: [@Sendable @convention(block) (Any) -> Void])
+// CHECK-NEXT: func sendUnbound(_ array: [Sendable])

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -267,4 +267,26 @@ typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE;
 
 ASSUME_NONSENDABLE_END
 
+typedef id ObjectTypedef;
+typedef void(^BlockTypedef)(id);
+
+@interface NXSender : NSObject
+
+- (void)sendAny:(SENDABLE id)obj;
+- (void)sendOptionalAny:(nullable SENDABLE id)obj;
+- (void)sendSendable:(SENDABLE SendableClass *)sendable;
+- (void)sendSendableSubclasses:(SENDABLE NonSendableClass *)sendableSubclass;
+- (void)sendProto:(SENDABLE id <LabellyProtocol>)obj;
+- (void)sendProtos:(SENDABLE id <LabellyProtocol, ObjCClub>)obj;
+- (void)sendAnyArray:(SENDABLE NSArray<id> *)array;
+- (void)sendGeneric:(SENDABLE GenericObject<SendableClass *> *)generic;
+- (void)sendPtr:(SENDABLE void *)val;    // bad
+- (void)sendStringArray:(SENDABLE NSArray<NSString *> *)obj;    // bad
+- (void)sendAnyTypedef:(SENDABLE ObjectTypedef)obj;
+- (void)sendAnyTypedefs:(SENDABLE NSArray<ObjectTypedef> *)objs;
+- (void)sendBlockTypedef:(SENDABLE BlockTypedef)block;
+- (void)sendBlockTypedefs:(SENDABLE NSArray<BlockTypedef> *)blocks;
+- (void)sendUnbound:(SENDABLE NSArray *)array;
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
When `__attribute__((swift_attr(“https://github.com/sendable”)))` is applied to a clang parameter Swift now attempts to make the type `Sendable` in a more comprehensive way than before:

* If it is a function type, it adds `@Sendable` to it.
* If it is a protocol composition type, it adds `& Sendable` to it.
* If it is a class, protocol, or generic class, it inserts it into a protocol composition and adds `& Sendable`.
* If it is a typealias, it *may* desugar it to a modified version of the underlying type.
* In various other cases, it recurses into the children of the type.

This allows Objective-C methods and functions to require that their arguments have a Sendable type without specifying a particular type they must belong to.

Fixes rdar://87727549.