### PR TITLE
Enable parallel boostrap for CMake

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -267,8 +267,10 @@ class CMake(object):
 
         cwd = os.getcwd()
         os.chdir(cmake_build_dir)
-        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui', '--',
-                                    '-DCMAKE_USE_OPENSSL=OFF'], echo=True)
+        shell.call_without_sleeping([cmake_bootstrap, '--no-qt-gui',
+                                     '--parallel=%s' % self.args.build_jobs,
+                                     '--', '-DCMAKE_USE_OPENSSL=OFF'],
+                                    echo=True)
         shell.call_without_sleeping(['make', '-j%s' % self.args.build_jobs],
                                     echo=True)
         os.chdir(cwd)


### PR DESCRIPTION
The CMake build is not being run parallelized, leading to a longer than necessary build time. This PR adds the `--parallel` flag to the invocation of `cmake_bootstrap` to remediate that.