### PR TITLE
Fix toolchain path when invoking build_script_helper.py

### DIFF
--- a/benchmark/scripts/build_script_helper.py
+++ b/benchmark/scripts/build_script_helper.py
@@ -53,7 +53,7 @@ def main():
     if not os.path.isdir(bin_dir):
         os.makedirs(bin_dir)
 
-    swiftbuild_path = os.path.join(args.toolchain, "usr", "bin", "swift-build")
+    swiftbuild_path = os.path.join(args.toolchain, "bin", "swift-build")
     perform_build(args, swiftbuild_path, "debug", "Benchmark_Onone", "-Onone")
     perform_build(args, swiftbuild_path, "release", "Benchmark_Osize", "-Osize")
     perform_build(args, swiftbuild_path, "release", "Benchmark_O", "-O")

--- a/tools/swift-inspect/build_script_helper.py
+++ b/tools/swift-inspect/build_script_helper.py
@@ -19,11 +19,11 @@ def perform_build(args, swiftbuild_path):
         "-Xswiftc",
         "-I",
         "-Xswiftc",
-        os.path.join(args.toolchain, 'usr', 'include', 'swift'),
+        os.path.join(args.toolchain, 'include', 'swift'),
         "-Xswiftc",
         "-L",
         "-Xswiftc",
-        os.path.join(args.toolchain, 'usr', 'lib', 'swift', 'macosx'),
+        os.path.join(args.toolchain, 'lib', 'swift', 'macosx'),
         "-Xswiftc",
         "-lswiftRemoteMirror"
     ]
@@ -49,7 +49,7 @@ def main():
     if not os.path.isdir(bin_dir):
         os.makedirs(bin_dir)
 
-    swiftbuild_path = os.path.join(args.toolchain, "usr", "bin", "swift-build")
+    swiftbuild_path = os.path.join(args.toolchain, "bin", "swift-build")
     perform_build(args, swiftbuild_path)
 
 

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -100,11 +100,17 @@ class Benchmarks(product.Product):
 
 
 def _get_toolchain_path(host_target, product, args):
-    # TODO check if we should prefer using product.install_toolchain_path
     # this logic initially was inside run_build_script_helper
     # and was factored out so it can be used in testing as well
 
-    toolchain_path = product.host_install_destdir(host_target)
+    install_destdir = args.install_destdir
+    if swiftpm.SwiftPM.has_cross_compile_hosts(args):
+        install_destdir = swiftpm.SwiftPM.get_install_destdir(args,
+                                                              host_target,
+                                                              product.build_dir)
+    toolchain_path = targets.toolchain_path(install_destdir,
+                                            args.install_prefix)
+
     if platform.system() == 'Darwin':
         # The prefix is an absolute path, so concatenate without os.path.
         toolchain_path += \


### PR DESCRIPTION
`build_script_helper.py` hardcodes a `usr` component in the toolchain path it builds, which broke a build with a non-`/usr` install destination.

Fix the script invoking `build_script_helper.py` to path a complete toolchain path, and remove the hardcoded `usr` path component. The logic to determine the toolchain path was lifted from another script, as this logic is repeated in several location, with slight variations. I picked the variant that seemed the most complete.

The first commit is tested in a Linux; the second commit fixes similar code in the vicinity and has not been exercised. It is possible that these changes break on macOS and require some slight tweaking (e.g. the toolchain path given to `build_script_helper.py` might need to include `usr` as its last path component).