### PR TITLE
[test] Small lit cleanups

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1886,6 +1886,18 @@ def configure_remote_run():
                      os.path.dirname(local_swift_reflection_test),
                      'bin/')
 
+        print("Contents of {0} on {1} after upload:".format(
+            remote_lib_dir, remote_run_host))
+        subprocess.check_call(
+            [
+                os.path.join(config.swift_utils, 'remote-run'),
+                '--remote-dir', remote_tmp_dir,
+            ] + remote_run_extra_args + [
+                remote_run_host,
+                '--',
+                'ls', '-l', remote_lib_dir
+            ])
+
     config.target_env_prefix = 'REMOTE_RUN_CHILD_'
     config.target_run = (
         "/usr/bin/env " +

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -940,6 +940,7 @@ config.target_cxx_lib = '-lc++'
 config.target_msvc_runtime_opt = ''
 config.target_static_library_prefix = 'lib'
 config.target_static_library_suffix = '.a'
+config.target_env_prefix = ''
 
 if run_vendor == 'apple':
     target_specific_module_triple = '{}-apple-{}'.format(
@@ -1080,6 +1081,8 @@ if run_vendor == 'apple':
            xcrun_sdk_name = "watchos"
            target_future_version = "9.99.0"
 
+       config.target_env_prefix = 'IOS_CHILD_'
+
        config.target_cc_options = (
            "-target %s %s" %
            (config.variant_triple, clang_mcp_opt))
@@ -1121,6 +1124,8 @@ if run_vendor == 'apple':
             target_future_version = "99.0"
 
         target_specific_module_triple += "-simulator"
+
+        config.target_env_prefix = 'SIMCTL_CHILD_'
 
         config.target_cc_options = (
             "-target %s %s" %
@@ -1330,6 +1335,7 @@ elif run_os in ['windows-msvc']:
     config.target_msvc_runtime_opt = '-%s -D_MT' % config.swift_stdlib_msvc_runtime
     if 'D' in config.swift_stdlib_msvc_runtime:
         config.target_msvc_runtime_opt += ' -D_DLL'
+    config.target_env_prefix = ''
 
     config.target_build_swift =                                                  \
             ('%r -target %s %s %s %s %s -libc %s' %                              \
@@ -1439,6 +1445,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "android"
       config.target_cc_options = "-fPIE"
+      config.target_env_prefix = 'ANDROID_CHILD_'
     else:
       lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"
@@ -1572,6 +1579,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"
+    config.target_env_prefix = 'ANDROID_CHILD_'
     config.resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
     # Since NDK r19, the headers and libraries are available in a unified
     # sysroot at $NDK_PATH/toolchains/llvm/prebuilt/$prebuilt_directory/sysroot,
@@ -1775,19 +1783,6 @@ config.substitutions.append(('%string_processing_module', string_processing_modu
 config.substitutions.append(('%/string_processing_module',
                              '/'.join(os.path.normpath(string_processing_module).split(os.sep))))
 
-# Different OS's require different prefixes for the environment variables to be
-# propagated to the calling contexts.
-# In order to make tests OS-agnostic, names of environment variables should be
-# prefixed with `%env-`, which is then expanded to the appropriate prefix.
-SIMULATOR_ENV_PREFIX = 'SIMCTL_CHILD_'
-ENV_VAR_PREFIXES = {
-    'iphonesimulator': SIMULATOR_ENV_PREFIX,
-    'watchsimulator': SIMULATOR_ENV_PREFIX,
-    'appletvsimulator': SIMULATOR_ENV_PREFIX,
-    'android': 'ANDROID_CHILD_'
-}
-TARGET_ENV_PREFIX = ENV_VAR_PREFIXES.get(config.target_sdk_name, "") if not kIsAndroid else ""
-
 back_deployment_runtime = lit_config.params.get('back_deployment_runtime', None)
 if back_deployment_runtime is not None:
     config.available_features.add('back_deployment_runtime')
@@ -1861,6 +1856,7 @@ if 'remote_run_host' in lit_config.params:
                      os.path.dirname(local_swift_reflection_test),
                      'bin/')
 
+    config.target_env_prefix = 'REMOTE_RUN_CHILD_'
     config.target_run = (
         "/usr/bin/env "
         "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
@@ -1874,10 +1870,14 @@ if 'remote_run_host' in lit_config.params:
                                               remote_run_host))
     config.target_swift_reflection_test = os.path.join(
         remote_tmp_dir, 'bin', swift_reflection_test_name)
-    TARGET_ENV_PREFIX = 'REMOTE_RUN_CHILD_'
     config.available_features.add('remote_run')
 
-config.substitutions.append(('%env-', TARGET_ENV_PREFIX))
+# Different OS's require different prefixes for the environment variables to be
+# propagated to the calling contexts.
+# In order to make tests OS-agnostic, names of environment variables should be
+# prefixed with `%env-`, which is then expanded to the appropriate prefix.
+config.substitutions.append(('%env-', config.target_env_prefix))
+
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 
 simulator_sdks = [
@@ -2410,7 +2410,7 @@ config.substitutions.append(('%import-static-libdispatch', getattr(config, 'impo
 config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'false'
 
 # Add this to the command which runs an executable to enable COW checks in the swift runtime.
-config.substitutions.append(('%enable-cow-checking', TARGET_ENV_PREFIX + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
+config.substitutions.append(('%enable-cow-checking', config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
 
 # We add an expansion to ensure that migrator tests can search for the api diff
 # data dir from the host compiler toolchain instead of the resource dir of the
@@ -2445,10 +2445,10 @@ if config.lldb_build_root != "":
 # Disable randomized hash seeding by default. Tests need to manually opt in to
 # random seeds by unsetting the SWIFT_DETERMINISTIC_HASHING environment
 # variable.
-config.environment[TARGET_ENV_PREFIX + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
+config.environment[config.target_env_prefix + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
 
 # Enable malloc scribble during tests by default.
-config.environment[TARGET_ENV_PREFIX + 'SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE'] = 'YES'
+config.environment[config.target_env_prefix + 'SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE'] = 'YES'
 
 # Run lsb_release on the target to be tested and return the results.
 def linux_get_lsb_release():

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -955,6 +955,7 @@ if run_vendor == 'apple':
         config.target_codesign = make_path(config.swift_utils, "swift-darwin-postprocess.py")
     else:
         config.target_codesign = "codesign -f -s -"
+    config.target_library_path_var = "DYLD_LIBRARY_PATH"
     config.target_runtime = "objc"
 
     config.available_features.add('libdispatch')
@@ -1453,6 +1454,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "linux"
       config.target_cc_options = "-fPIE"
+    config.target_library_path_var = "LD_LIBRARY_PATH"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
@@ -1579,6 +1581,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"
+    config.target_library_path_var = "LD_LIBRARY_PATH"
     config.target_env_prefix = 'ANDROID_CHILD_'
     config.resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
     # Since NDK r19, the headers and libraries are available in a unified
@@ -1792,7 +1795,32 @@ if run_vendor == 'apple':
     if 'back_deploy_concurrency' in config.available_features:
         concurrency_back_deploy_path = os.path.join(os.path.dirname(swift_obj_root), os.path.basename(swift_obj_root).replace("swift-", "backdeployconcurrency-"), 'lib', 'swift-5.5', run_os)
 
-if 'remote_run_host' in lit_config.params:
+def os_stdlib_paths():
+    if run_vendor == 'apple':
+        if run_os == 'maccatalyst':
+            return ["/System/iOSSupport/usr/lib/swift", "/usr/lib/swift"]
+        else:
+            return ["/usr/lib/swift"]
+    else:
+        lit_config.fatal("Unsupported platform for os_stdlib_paths")
+
+# This returns a shell variable assignment of the form <LIBRARY_PATH>=<VALUE>
+# where <LIBRARY_PATH> is whatever environment variable we need to set to
+# override dynamic library locations. (Usually DYLD_LIBRARY_PATH or
+# LD_LIBRARY_PATH, sometimes prefixed by a special annotation to tunnel the
+# setting through a helper tool.)
+#
+# The return value is designed to be passed to `/usr/bin/env` when executing a
+# binary on the test target.
+#
+# The single parameter is an array of directory paths that hold the libraries.
+def construct_library_path_env(dirs):
+    return "{0}{1}='{2}' ".format(
+        config.target_env_prefix,
+        config.target_library_path_var,
+        os.path.pathsep.join(dirs))
+
+def configure_remote_run():
     if 'remote_run_tmpdir' not in lit_config.params:
         lit_config.fatal("'remote_run_host' provided, but no "
                          "'remote_run_tmpdir'")
@@ -1800,16 +1828,18 @@ if 'remote_run_host' in lit_config.params:
     remote_run_host = lit_config.params['remote_run_host']
     remote_tmp_dir = lit_config.params['remote_run_tmpdir']
     remote_lib_dir = os.path.join(remote_tmp_dir, 'stdlib')
-    remote_run_lib_path = ''
-    if 'use_os_stdlib' not in lit_config.params:
-        remote_run_lib_path = remote_lib_dir
-    else:
+    remote_run_lib_path = [remote_lib_dir]
+    if 'use_os_stdlib' in lit_config.params:
         config.available_features.add('use_os_stdlib')
-        os_stdlib_path = ''
-        if run_vendor == 'apple':
-            #If we get swift-in-the-OS for non-Apple platforms, add a condition here
-            os_stdlib_path = "/usr/lib/swift"
-        remote_run_lib_path = os.path.pathsep.join((os_stdlib_path, remote_lib_dir))
+        remote_run_lib_path = os_stdlib_paths() + [remote_lib_dir]
+        lit_config.note('Remote testing with the standard libraries in the OS')
+    elif 'back_deployment_runtime' in lit_config.params:
+        lit_config.note('Remote testing with back deployment libraries')
+    else:
+        lit_config.note('Remote testing with the just-built libraries')
+
+    lit_config.note(
+        'Remote library load path: {0}'.format(os.path.pathsep.join(remote_run_lib_path)))
 
     remote_run_extra_args_param = lit_config.params.get('remote_run_extra_args')
     remote_run_extra_args = shlex.split(remote_run_extra_args_param or '')
@@ -1858,16 +1888,14 @@ if 'remote_run_host' in lit_config.params:
 
     config.target_env_prefix = 'REMOTE_RUN_CHILD_'
     config.target_run = (
-        "/usr/bin/env "
-        "REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='{0}' " # Apple option
-        "REMOTE_RUN_CHILD_LD_LIBRARY_PATH='{0}' " # Linux option
-        "'{1}'/remote-run --input-prefix '{2}' --output-prefix %t "
-        "--remote-dir '{3}'%t {4} {5}".format(remote_run_lib_path,
-                                              config.swift_utils,
-                                              config.swift_src_root,
-                                              remote_tmp_dir,
-                                              ' '.join(remote_run_extra_args),
-                                              remote_run_host))
+        "/usr/bin/env " +
+        construct_library_path_env(remote_run_lib_path) +
+        "'{0}'/remote-run ".format(config.swift_utils) +
+        "--input-prefix '{0}' ".format(config.src_root) +
+        "--output-prefix %t " +
+        "--remote-dir '{0}'%t ".format(remote_tmp_dir) +
+        "{0} ".format(' '.join(remote_run_extra_args)) + 
+        "{0}".format(remote_run_host))
     config.target_swift_reflection_test = os.path.join(
         remote_tmp_dir, 'bin', swift_reflection_test_name)
     config.available_features.add('remote_run')
@@ -2048,42 +2076,40 @@ if 'concurrency' in config.available_features:
     else:
         config.available_features.add('concurrency_runtime')
 
-# Set up testing with the standard libraries coming from the OS / just-built libraries
-# default Swift tests to use the just-built libraries
-target_stdlib_path = platform_dylib_dir
-if not kIsWindows:
-	libdispatch_path = getattr(config, 'libdispatch_artifact_dir', '')
-	if 'use_os_stdlib' not in lit_config.params:
-		if run_os == 'maccatalyst':
-		    # Under macCatalyst we need to have the unzippered twin dylib dir come before
-		    # the zippered/macosx dylib dir so that unzippered twins are picked upload_dylibs
-		    # before the macOS variant.
-		    target_stdlib_path = "{0}:{1}".format(platform_module_dir, target_stdlib_path)
-		lit_config.note('Testing with the just-built libraries at ' + target_stdlib_path)
-		config.target_run = (
-			"/usr/bin/env "
-			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
-			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(target_stdlib_path, libdispatch_path)) + config.target_run
-	else:
-		config.available_features.add('use_os_stdlib')
-		os_stdlib_path = ''
-		if run_vendor == 'apple':
-			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
-			os_stdlib_path = "/usr/lib/swift"
-			if run_os == 'maccatalyst':
-			    os_stdlib_path = "/System/iOSSupport/usr/lib/swift:/usr/lib/swift"
+# Set up testing with the standard libraries coming from either the OS, the back
+# deployment runtime or the just-built libraries. By default, we run tests with
+# the just-built libraries.
+target_stdlib_path = [platform_dylib_dir]
+if run_os == 'maccatalyst':
+    # Under macCatalyst we need to have the unzippered twin dylib dir come before
+    # the zippered/macosx dylib dir so that unzippered twins are picked upload_dylibs
+    # before the macOS variant.
+    target_stdlib_path = [platform_module_dir, platform_dylib_dir]
 
-		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, concurrency_back_deploy_path, target_stdlib_path))
+if run_vendor != 'apple':
+    libdispatch_path = getattr(config, 'libdispatch_artifact_dir', None)
+    if libdispatch_path is not None:
+       target_stdlib_path.append(libdispatch_path)
 
-		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
-		config.target_run = (
-			"/usr/bin/env "
-			"DYLD_LIBRARY_PATH='{0}' " # Apple option
-			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
-			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
-			.format(all_stdlib_path, libdispatch_path)) + config.target_run
+if 'remote-run-host' in lit_config.params:
+    configure_remote_run()
+elif not kIsWindows:
+    if 'use_os_stdlib' in lit_config.params:
+        config.available_features.add('use_os_stdlib')
+
+        target_stdlib_path = os_stdlib_paths() + [concurrency_back_deploy_path] + target_stdlib_path
+
+        lit_config.note('Testing with the standard libraries in the OS')
+    elif 'back_deployment_runtime' in lit_config.params:
+        lit_config.note('Testing with back deployment runtime libraries')
+    else:
+        lit_config.note('Testing with the just-built libraries')
+
+    lit_config.note('Library load path: {0}'.format(os.path.pathsep.join(target_stdlib_path)))
+    config.target_run = (
+        "/usr/bin/env " +
+        construct_library_path_env(target_stdlib_path) +
+        config.target_run)
 
 # When running with the JIT on Darwin, force the usage of the just built stdlib
 # when running the frontend. This is because we currently JIT in process


### PR DESCRIPTION
This PR slightly refactors how we set DYLD_LIBRARY_PATH/LD_LIBRARY_PATH in the `%target-run` pattern, so that we only set a single variable that is correct for the target platform and has the appropriate prefix (`SIMCTL_CHILD_`, `IOS_CHILD_`, `REMOTE_RUN_CHILD_` or nothing at all, depending on Various Things).

More importantly, this also improves what gets logged to build output, hopefully helping me to track down a potential configuration issue in some CI bots.

rdar://89786892
