### PR TITLE
AST: Fix mistake with generic signature in findExistentialSelfReferences()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2693,8 +2693,7 @@ public:
   /// property, or the uncurried result type of a method/subscript, e.g.
   /// '() -> () -> Self'.
   GenericParameterReferenceInfo findExistentialSelfReferences(
-      Type baseTy, const DeclContext *useDC,
-      bool treatNonResultCovariantSelfAsInvariant) const;
+      Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6107,7 +6107,7 @@ bool ConstraintSystem::isMemberAvailableOnExistential(
   // the actual signature of the opened archetype in context, rather it cares
   // about whether you can "hold" `baseTy.member` properly in the abstract.
   const auto info = member->findExistentialSelfReferences(
-      baseTy, DC->getModuleScopeContext(),
+      baseTy,
       /*treatNonResultCovariantSelfAsInvariant=*/false);
   if (info.selfRef > TypePosition::Covariant ||
       info.assocTypeRef > TypePosition::Covariant) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -681,7 +681,7 @@ ExistentialRequiresAnyRequest::evaluate(Evaluator &evaluator,
     // For value members, look at their type signatures.
     if (auto valueMember = dyn_cast<ValueDecl>(member)) {
       const auto info = valueMember->findExistentialSelfReferences(
-          decl->getDeclaredInterfaceType(), decl,
+          decl->getDeclaredInterfaceType(),
           /*treatNonResultCovariantSelfAsInvariant=*/false);
       if (info.selfRef > TypePosition::Covariant || info.assocTypeRef) {
         return true;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1043,7 +1043,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
         // the default witness for 'Collection.Iterator', which is defined
         // as 'IndexingIterator<Self>'.
         const auto selfRefInfo = req->findExistentialSelfReferences(
-            proto->getDeclaredInterfaceType(), dc,
+            proto->getDeclaredInterfaceType(),
             /*treatNonResultCovariantSelfAsInvariant=*/true);
         if (!selfRefInfo.assocTypeRef) {
           covariantSelf = classDecl;
@@ -4065,7 +4065,7 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   // Check whether this requirement uses Self in a way that might
   // prevent conformance from succeeding.
   const auto selfRefInfo = requirement->findExistentialSelfReferences(
-      Proto->getDeclaredInterfaceType(), DC,
+      Proto->getDeclaredInterfaceType(),
       /*treatNonResultCovariantSelfAsInvariant=*/true);
 
   if (selfRefInfo.selfRef == TypePosition::Invariant) {

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -84,9 +84,9 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Invariant Self, since type signature contains an associated type:
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP16hasDefaultTakesTyy1TQzFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed UsesDefaults<τ_1_0>, @in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP16hasDefaultTakesTyy1TQzFTW : $@convention(witness_method: HasDefaults) <τ_0_0 where τ_0_0 : Barable> (@in_guaranteed UsesDefaults<τ_0_0>, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
 // CHECK: [[FN:%.*]] = function_ref @$s15witnesses_class11HasDefaultsPAAE16hasDefaultTakesTyy1TQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0.T, @in_guaranteed τ_0_0) -> ()
-// CHECK: apply [[FN]]<τ_0_0>(
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>>(
 // CHECK: return
 
 // Covariant Self:
@@ -98,9 +98,9 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Invariant Self, since type signature contains an associated type:
 
-// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@in_guaranteed UsesDefaults<τ_1_0>, @guaranteed τ_2_0, @in_guaranteed τ_0_0) -> ()
+// // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0 where τ_0_0 : Barable><τ_1_0 where τ_1_0 : Fooable> (@in_guaranteed UsesDefaults<τ_0_0>, @guaranteed τ_1_0, @in_guaranteed UsesDefaults<τ_0_0>) -> ()
 // CHECK: [[FN:%.*]] = function_ref @$s15witnesses_class11HasDefaultsPAAE23hasDefaultGenericTakesTyy1TQz_qd__tAA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@in_guaranteed τ_0_0.T, @guaranteed τ_1_0, @in_guaranteed τ_0_0) -> ()
-// CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
+// CHECK: apply [[FN]]<UsesDefaults<τ_0_0>, τ_1_0>(
 // CHECK: return
 
 protocol ReturnsCovariantSelf {


### PR DESCRIPTION
We used to concatenate the DeclContext's generic signature with the
protocol requirement's signature, then look for occurrences of the
first generic parameter from the DeclContext's signature in the
requirement's type.

This almost worked, except when the first generic parameter from the
DeclContext's signature didn't conform to a protocol referenced by
an associated type. In that case, we would falsely report that there
are no 'Self' references.

Note that the CHECK lines in test/SILGen/witnesses_class.swift change
to what they were before https://github.com/apple/swift/commit/01d9d61cc8d1d12296f4e1e8836614604cb558ba.