### PR TITLE
[SSADestroyHoisting] Pointer handling.

### DIFF
--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -173,13 +173,11 @@ protected:
 
   bool visitUnknownUse(Operand *use) override {
     auto *user = use->getUser();
-    // Recognize any leaf users not already recognized by UniqueAddressUses.
-    //
-    // Destroy hoisting considers address_to_pointer to be a leaf use because
-    // any potential pointer access is already considered to be a
-    // deinitializtion barrier.
-    if (isa<PointerToAddressInst>(user)) {
-      storageUsers.insert(use->getUser());
+    if (isa<BuiltinRawPointerType>(use->get()->getType().getASTType())) {
+      // Destroy hoisting considers address_to_pointer to be a leaf use because
+      // any potential pointer access is already considered to be a
+      // deinitializtion barrier.  Consequently, any instruction that uses a
+      // value produced by address_to_pointer isn't regarded as a storage use.
       return true;
     }
     LLVM_DEBUG(llvm::dbgs() << "Unknown user " << *user);

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -365,6 +365,44 @@ entry(%addr : $*X, %instance : @owned $X):
   return %retval : $()
 }
 
+// Hoist up to a (transitive) use of an address_to_pointer instruction.  In
+// particular, do _some_ hoisting despite the fact that such an instruction is
+// a use.
+//
+// CHECK-LABEL: sil [ossa] @hoist_upto_address_to_pointer_use : {{.*}} {
+// CHECK:         address_to_pointer
+// CHECK:         pointer_to_address
+// CHECK:         load [copy]
+// CHECK:         destroy_addr
+// CHECK:         tuple
+// CHECK-LABEL: } // end sil function 'hoist_upto_address_to_pointer_use'
+sil [ossa] @hoist_upto_address_to_pointer_use : $@convention(thin) (@in X) -> (@owned X) {
+entry(%instance : $*X):
+  %pointer = address_to_pointer %instance : $*X to $Builtin.RawPointer
+  %addr = pointer_to_address %pointer : $Builtin.RawPointer to $*X
+  %value = load [copy] %addr : $*X
+  %retval = tuple ()
+  destroy_addr %instance : $*X
+  return %value : $X
+}
+
+// Hoist even if the pointerified address gets used.
+//
+// CHECK-LABEL: sil [ossa] @hoist_despite_use_of_pointer : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK-NEXT:    destroy_addr [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'hoist_despite_use_of_pointer'
+sil [ossa] @hoist_despite_use_of_pointer : $@convention(thin) (@inout X) -> () {
+entry(%instance : $*X):
+   %addr_for_pointer = alloc_stack $Builtin.RawPointer
+   %pointer = address_to_pointer %instance : $*X to $Builtin.RawPointer
+   store %pointer to [trivial] %addr_for_pointer : $*Builtin.RawPointer
+   %retval = tuple ()
+   destroy_addr %instance : $*X
+   dealloc_stack %addr_for_pointer : $*Builtin.RawPointer
+   return %retval : $()
+}
+
 // Fold destroy_addr and a load [copy] into a load [take] even when that
 // load [take] is guarded by an access scope.
 //


### PR DESCRIPTION
Previously, SSADestroyHoisting was attempting to check whether an unknown use of a variable was an address_to_pointer.  UniqueStorageUseVisitor, however, doesn't call back with that instruction.  Instead, it adds its uses to the stack of uses to visit.

Instead, we need to check whether the use was produced by an address_to_pointer or more generally whether it's a BuiltinRawPointerType.
