### PR TITLE
Allow MetadataReader to read context descriptor symbols from unresolved addresses with an offset

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1002,10 +1002,6 @@ public:
   readContextDescriptor(const RemoteAbsolutePointer &address) {
     // Map an unresolved pointer to an unresolved context ref.
     if (!address.isResolved()) {
-      // We can only handle references to a symbol without an offset currently.
-      if (address.getOffset() != 0) {
-        return ParentContextDescriptorRef();
-      }
       return ParentContextDescriptorRef(address.getSymbol());
     }
     

--- a/test/Reflection/Inputs/PropertyWrappers.swift
+++ b/test/Reflection/Inputs/PropertyWrappers.swift
@@ -1,0 +1,11 @@
+@propertyWrapper
+public struct Doubled {
+    private var value: Int
+    public var wrappedValue: Int {
+        get { value }
+        set { value = newValue * 2 }
+    }
+    public init(wrappedValue: Int) {
+        value = wrappedValue * 2
+    }
+}

--- a/test/Reflection/typeref_decoding_property_wrapper_field.swift
+++ b/test/Reflection/typeref_decoding_property_wrapper_field.swift
@@ -1,0 +1,42 @@
+// UNSUPPORTED: windows
+
+// Temporarily disable on AArch64 Linux (rdar://88451721)
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+
+// Temporarily disable on arm64e (rdar://88579818)
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/PropertyWrappers.swift -parse-as-library -emit-module -emit-library -module-name Wrapper -o %t/Wrapper
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %s -parse-as-library -emit-module -emit-library -module-name property_wrapper_test %t/Wrapper -I%t/ -o %t/property_wrapper_test
+// RUN: %target-swift-reflection-dump -binary-filename %t/property_wrapper_test | %FileCheck %s
+
+// CHECK: FIELDS:
+// CHECK-NEXT: =======
+// CHECK: property_wrapper_test.Foo
+// CHECK-NEXT: -------------------------
+// CHECK-DAG: _bar: Wrapper.Doubled
+// CHECK-NEXT: (struct Wrapper.Doubled)
+// CHECK-DAG: _baz: property_wrapper_test.Tripled
+// CHECK-NEXT: (struct property_wrapper_test.Tripled)
+
+import Wrapper
+@propertyWrapper
+public struct Tripled {
+    private var value: Int
+    public var wrappedValue: Int {
+        get { value }
+        set { value = newValue * 3 }
+    }
+    public init(wrappedValue: Int) {
+        value = wrappedValue * 3
+    }
+}
+
+struct Foo {
+    @Doubled
+    var bar: Int
+    @Tripled
+    var baz: Int
+}


### PR DESCRIPTION
As-is, the code assumes that we are able to read out the `SymbolicReference` context directly, which isn't true in the case when we are using the `ObjectMemoryReader`, for example. Then, we may have to ask the reader to resolve the context pointer to see if it points at an external symbol.

Resolves rdar://89966652
