### PR TITLE
Pass full package path when running lit

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3500,8 +3500,10 @@ function build_and_test_installable_package() {
 
             if [[ "${host}" == "macosx-"* ]] || [[ "${host}" == "merged-hosts" ]]; then
                 PKG_TESTS_SANDBOX="${PKG_TESTS_SANDBOX_PARENT}"/"${TOOLCHAIN_PREFIX}"
+		PKG_TESTS_PKG_DIR="${PKG_TESTS_SANDBOX}"
             else # Linux
                 PKG_TESTS_SANDBOX="${PKG_TESTS_SANDBOX_PARENT}"
+		PKG_TESTS_PKG_DIR="${PKG_TESTS_SANDBOX}/${host_install_prefix}"
             fi
 
             LIT_EXECUTABLE_PATH="${LLVM_SOURCE_DIR}/utils/lit/lit.py"
@@ -3516,7 +3518,7 @@ function build_and_test_installable_package() {
               TIMEOUT_ARGS=--timeout=1200 # 20 minutes
             fi
             with_pushd "${PKG_TESTS_SOURCE_DIR}" \
-                call python3 "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_SANDBOX}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}" ${TIMEOUT_ARGS}
+                call python3 "${LIT_EXECUTABLE_PATH}" . -sv --param package-path="${PKG_TESTS_PKG_DIR}" --param test-exec-root="${PKG_TESTS_TEMPS}" --param llvm-bin-dir="${LLVM_BIN_DIR}" ${TIMEOUT_ARGS}
         fi
     fi
 }


### PR DESCRIPTION
Fixes integration tests for non-/usr builds. Requires matching changes
to lit.cfg and tests to remove hardcoded usr path components, in swift-integration-tests PR apple/swift-integration-tests#97.