### PR TITLE
Ensure that we print @Sendable when printing TypeReprs.

### DIFF
--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -211,6 +211,8 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printSimpleAttr("@autoclosure") << " ";
   if (hasAttr(TAK_escaping))
     Printer.printSimpleAttr("@escaping") << " ";
+  if (hasAttr(TAK_Sendable))
+    Printer.printSimpleAttr("@Sendable") << " ";
   if (hasAttr(TAK_noDerivative))
     Printer.printSimpleAttr("@noDerivative") << " ";
 

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -14,6 +14,11 @@ public func reasyncFn(_: () async -> ()) reasync {
   fatalError()
 }
 
+@available(SwiftStdlib 5.5, *)
+public func takesSendable(
+  _ block: @Sendable @escaping () async throws -> Void
+) { }
+
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -I %t
 
 #else
@@ -29,3 +34,7 @@ func callFn() async {
 // CHECK: // swift-module-flags:{{.*}} -enable-experimental-concurrency
 // CHECK: public func fn() async
 // CHECK: public func reasyncFn(_: () async -> ()) reasync
+// CHECK: public func takesSendable(_ block: @escaping @Sendable () async throws ->
+
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -enable-experimental-concurrency -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s -module-interface-preserve-types-as-written
+// RUN: %FileCheck %s <%t/Library.swiftinterface


### PR DESCRIPTION
Fixes rdar://85453819.
