### PR TITLE
Make toplevel vars MainActor with `-warn-concurrency`

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9056,7 +9056,9 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
-    if (dc->isAsyncContext()) {
+    if (dc->isAsyncContext() ||
+        (dc->getASTContext().LangOpts.WarnConcurrency &&
+         dc->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel)) {
       if (Type mainActor = dc->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/false);
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -344,7 +344,9 @@ GlobalActorAttributeRequest::evaluate(
     if (auto var = dyn_cast<VarDecl>(storage)) {
 
       // ... but not if it's an async-context top-level global
-      if (var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext()) {
+      if (var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
+          var->isTopLevelGlobal() && (var->getDeclContext()->isAsyncContext()
+            || var->getASTContext().LangOpts.WarnConcurrency)) {
         var->diagnose(diag::global_actor_top_level_var)
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
@@ -3818,7 +3820,10 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
-    if (var->isTopLevelGlobal() && var->getDeclContext()->isAsyncContext()) {
+    if (var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
+        var->isTopLevelGlobal() &&
+        (var->getASTContext().LangOpts.WarnConcurrency ||
+         var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())
         return inferredIsolation(
             ActorIsolation::forGlobalActor(mainActor,

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-async-top-level -warn-concurrency -typecheck -verify %s
+
+var a = 10 // expected-note{{var declared here}}
+
+@MainActor
+var b = 15 // expected-error{{top-level code variables cannot have a global actor}}
+
+func unsafeAccess() { // expected-note{{add '@MainActor' to make global function 'unsafeAccess()' part of global actor 'MainActor'}}
+    print(a) // expected-error@:11{{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+}
+
+func unsafeAsyncAccess() async {
+    print(a) // expected-error@:5{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
+             // expected-note@-1:11{{property access is 'async'}}
+}
+
+@MainActor
+func safeAccess() {
+    print(a)
+}
+
+@MainActor
+func safeSyncAccess() async {
+    print(a)
+}
+
+func safeAsyncAccess() async {
+    await print(a)
+}
+
+print(a)


### PR DESCRIPTION
This is the last part to implement SE-0343. When `-warn-concurrency` is
passed to the compiler invocation, we want to protect top-level
variables behind the MainActor regardless of whether the top-level is an
asynchronous context. Note that this does not make the top-level an
asynchronous context, but it does put the top-level on the main actor,
so using main-actor-isolated variables is a synchronous operation from the top level.