### PR TITLE
[cxx-interop] Enable a test on Linux

### DIFF
--- a/test/Interop/Cxx/templates/define-referenced-inline.swift
+++ b/test/Interop/Cxx/templates/define-referenced-inline.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-exceptions)
 //
 // REQUIRES: executable_test
-//
-// Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
-// REQUIRES: OS=macosx
 
 import DefineReferencedInline
 import StdlibUnittest


### PR DESCRIPTION
This test doesn't actually rely on the C++ stdlib, I think it was disabled accidentally.

It currently passes on Linux.