### PR TITLE
Add testcase for fixed circular reference issue: rdar://89921930

### DIFF
--- a/test/Generics/rdar89921930.swift
+++ b/test/Generics/rdar89921930.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// This used to hit a circularity.
+
+public protocol P {}
+
+public struct G<T : P> {}
+
+public typealias A<T : P> = G<T>
+
+public protocol Circle {
+  associatedtype X : P
+  associatedtype Y where Y == A<X>
+}
+
+


### PR DESCRIPTION
This was fixed by b32694e7365e6061caf3e0e7a63708ced39d3a13.