### PR TITLE
[DNM] Parse `/.../` regex literals

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -94,6 +94,9 @@ ERROR(forbidden_extended_escaping_string,none,
 ERROR(regex_literal_parsing_error,none,
       "%0", (StringRef))
 
+ERROR(prefix_slash_not_allowed,none,
+      "prefix slash not allowed", ())
+
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -531,6 +531,9 @@ public:
     void operator=(const SILBodyRAII&) = delete;
   };
 
+  /// Attempt to re-lex a regex literal with forward slashes `/.../`.
+  bool tryLexAsForwardSlashRegexLiteral(State S);
+
 private:
   /// Nul character meaning kind.
   enum class NulCharacterKind {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -559,6 +559,11 @@ public:
     return f(backtrackScope);
   }
 
+  /// Discard the current token. This will avoid interface hashing or updating
+  /// the previous loc. Only should be used if you've completely re-lexed
+  /// a different token at that position.
+  SourceLoc discardToken();
+
   /// Consume a token that we created on the fly to correct the original token
   /// stream from lexer.
   void consumeExtraToken(Token K);
@@ -1745,7 +1750,10 @@ public:
   ParserResult<Expr>
   parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind);
 
+  UnresolvedDeclRefExpr *makeExprOperator(Token opToken);
   UnresolvedDeclRefExpr *parseExprOperator();
+
+  void tryLexRegexLiteral();
 
   void validateCollectionElement(ParserResult<Expr> element);
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -183,9 +183,12 @@ Lexer::Lexer(const PrincipalTag &, const LangOptions &LangOpts,
              HashbangMode HashbangAllowed, CommentRetentionMode RetainComments,
              TriviaRetentionMode TriviaRetention)
     : LangOpts(LangOpts), SourceMgr(SourceMgr), BufferID(BufferID),
-      Diags(Diags), LexMode(LexMode),
+      LexMode(LexMode),
       IsHashbangAllowed(HashbangAllowed == HashbangMode::Allowed),
-      RetainComments(RetainComments), TriviaRetention(TriviaRetention) {}
+      RetainComments(RetainComments), TriviaRetention(TriviaRetention) {
+  if (Diags)
+    DiagQueue.emplace(*Diags);
+}
 
 void Lexer::initialize(unsigned Offset, unsigned EndOffset) {
   assert(Offset <= EndOffset);
@@ -245,7 +248,7 @@ Lexer::Lexer(const LangOptions &Options, const SourceManager &SourceMgr,
 
 Lexer::Lexer(Lexer &Parent, State BeginState, State EndState)
     : Lexer(PrincipalTag(), Parent.LangOpts, Parent.SourceMgr, Parent.BufferID,
-            Parent.Diags, Parent.LexMode,
+            Parent.getUnderlyingDiags(), Parent.LexMode,
             Parent.IsHashbangAllowed
                 ? HashbangMode::Allowed
                 : HashbangMode::Disallowed,
@@ -261,7 +264,7 @@ Lexer::Lexer(Lexer &Parent, State BeginState, State EndState)
 }
 
 InFlightDiagnostic Lexer::diagnose(const char *Loc, Diagnostic Diag) {
-  if (Diags)
+  if (auto *Diags = getTokenDiags())
     return Diags->diagnose(getSourceLoc(Loc), Diag);
   
   return InFlightDiagnostic();
@@ -272,7 +275,7 @@ Token Lexer::getTokenAt(SourceLoc Loc) {
                          SourceMgr.findBufferContainingLoc(Loc)) &&
          "location from the wrong buffer");
 
-  Lexer L(LangOpts, SourceMgr, BufferID, Diags, LexMode,
+  Lexer L(LangOpts, SourceMgr, BufferID, getUnderlyingDiags(), LexMode,
           HashbangMode::Allowed, CommentRetentionMode::None,
           TriviaRetentionMode::WithoutTrivia);
   L.restoreState(State(Loc));
@@ -330,6 +333,7 @@ void Lexer::formStringLiteralToken(const char *TokStart,
     return;
   NextToken.setStringLiteral(IsMultilineString, CustomDelimiterLen);
 
+  auto *Diags = getTokenDiags();
   if (IsMultilineString && Diags)
     validateMultilineIndents(NextToken, Diags);
 }
@@ -416,7 +420,8 @@ static bool advanceToEndOfLine(const char *&CurPtr, const char *BufferEnd,
 }
 
 void Lexer::skipToEndOfLine(bool EatNewline) {
-  bool isEOL = advanceToEndOfLine(CurPtr, BufferEnd, CodeCompletionPtr, Diags);
+  bool isEOL =
+      advanceToEndOfLine(CurPtr, BufferEnd, CodeCompletionPtr, getTokenDiags());
   if (EatNewline && isEOL) {
     ++CurPtr;
     NextToken.setAtStartOfLine(true);
@@ -514,8 +519,8 @@ static bool skipToEndOfSlashStarComment(const char *&CurPtr,
 /// skipSlashStarComment - /**/ comments are skipped (treated as whitespace).
 /// Note that (unlike in C) block comments can be nested.
 void Lexer::skipSlashStarComment() {
-  bool isMultiline =
-      skipToEndOfSlashStarComment(CurPtr, BufferEnd, CodeCompletionPtr, Diags);
+  bool isMultiline = skipToEndOfSlashStarComment(
+      CurPtr, BufferEnd, CodeCompletionPtr, getTokenDiags());
   if (isMultiline)
     NextToken.setAtStartOfLine(true);
 }
@@ -1360,7 +1365,7 @@ unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
       if (!IsMultilineString && !CustomDelimiterLen)
         return ~0U;
 
-      DiagnosticEngine *D = EmitDiagnostics ? Diags : nullptr;
+      DiagnosticEngine *D = EmitDiagnostics ? getTokenDiags() : nullptr;
       auto TmpPtr = CurPtr;
       if (IsMultilineString &&
           !advanceIfMultilineDelimiter(CustomDelimiterLen, TmpPtr, D))
@@ -1385,7 +1390,7 @@ unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
     return CurPtr[-1];
   case '\\':  // Escapes.
     if (!delimiterMatches(CustomDelimiterLen, CurPtr,
-                          EmitDiagnostics ? Diags : nullptr))
+                          EmitDiagnostics ? getTokenDiags() : nullptr))
       return '\\';
     break;
   }
@@ -1799,7 +1804,7 @@ static void validateMultilineIndents(const Token &Str,
 void Lexer::diagnoseSingleQuoteStringLiteral(const char *TokStart,
                                              const char *TokEnd) {
   assert(*TokStart == '\'' && TokEnd[-1] == '\'');
-  if (!Diags) // or assert?
+  if (!getTokenDiags()) // or assert?
     return;
 
   auto startLoc = Lexer::getSourceLoc(TokStart);
@@ -1836,7 +1841,8 @@ void Lexer::diagnoseSingleQuoteStringLiteral(const char *TokStart,
   replacement.append(OutputPtr, Ptr - 1);
   replacement.push_back('"');
 
-  Diags->diagnose(startLoc, diag::lex_single_quote_string)
+  getTokenDiags()
+      ->diagnose(startLoc, diag::lex_single_quote_string)
       .fixItReplaceChars(startLoc, endLoc, replacement);
 }
 
@@ -1852,8 +1858,8 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
   // diagnostics about changing them to double quotes.
   assert((QuoteChar == '"' || QuoteChar == '\'') && "Unexpected start");
 
-  bool IsMultilineString = advanceIfMultilineDelimiter(CustomDelimiterLen,
-                                                       CurPtr, Diags, true);
+  bool IsMultilineString = advanceIfMultilineDelimiter(
+      CustomDelimiterLen, CurPtr, getTokenDiags(), true);
   if (IsMultilineString && *CurPtr != '\n' && *CurPtr != '\r')
     diagnose(CurPtr, diag::lex_illegal_multiline_string_start)
         .fixItInsert(Lexer::getSourceLoc(CurPtr), "\n");
@@ -2437,6 +2443,11 @@ void Lexer::lexImpl() {
   assert(CurPtr >= BufferStart &&
          CurPtr <= BufferEnd && "Current pointer out of range!");
 
+  // If we're re-lexing, clear out any previous diagnostics that weren't
+  // emitted.
+  if (DiagQueue)
+    DiagQueue->clear();
+
   const char *LeadingTriviaStart = CurPtr;
   if (CurPtr == BufferStart) {
     if (BufferStart < ContentStart) {
@@ -2524,8 +2535,9 @@ void Lexer::lexImpl() {
   case ':': return formToken(tok::colon, TokStart);
   case '\\': return formToken(tok::backslash, TokStart);
 
-  case '#':
+  case '#': {
     // Try lex a raw string literal.
+    auto *Diags = getTokenDiags();
     if (unsigned CustomDelimiterLen = advanceIfCustomDelimiter(CurPtr, Diags))
       return lexStringLiteral(CustomDelimiterLen);
 
@@ -2536,8 +2548,8 @@ void Lexer::lexImpl() {
 
     // Otherwise try lex a magic pound literal.
     return lexHash();
-
-      // Operator characters.
+  }
+  // Operator characters.
   case '/':
     if (CurPtr[0] == '/') {  // "//"
       skipSlashSlashComment(/*EatNewline=*/true);
@@ -2713,7 +2725,7 @@ Restart:
   case 0:
     switch (getNulCharacterKind(CurPtr - 1)) {
     case NulCharacterKind::Embedded: {
-      diagnoseEmbeddedNul(Diags, CurPtr - 1);
+      diagnoseEmbeddedNul(getTokenDiags(), CurPtr - 1);
       goto Restart;
     }
     case NulCharacterKind::CodeCompletion:

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1997,6 +1997,63 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
   return true;
 }
 
+bool Lexer::tryLexAsForwardSlashRegexLiteral(State S) {
+  auto priorState = getStateForBeginningOfToken(NextToken, LeadingTrivia);
+
+  // Re-lex from the given state.
+  restoreState(S);
+
+  // While we restored state, that would have re-advanced the lexer. This is
+  // good in that it's filled in all the interesting properties of the token
+  // (trivia, is on new line, etc), but we need to rewind to re-lex the actual
+  // kind.
+  auto *TokStart = getBufferPtrForSourceLoc(NextToken.getLoc());
+  assert(*TokStart == '/');
+  CurPtr = TokStart + 1;
+
+  auto bail = [&]() -> bool {
+    restoreState(priorState);
+    return false;
+  };
+
+  // We need to ban these characters at the start of a regex to avoid ambiguity
+  // with unapplied operator references, e.g 'arr.reduce(0, /) / 5'. This
+  // doesn't totally save us from e.g 'foo(/, /)', but it should help.
+  switch (*CurPtr) {
+  case ' ': case '\t': case ')':
+    return bail();
+  default:
+    break;
+  }
+
+  while (true) {
+    uint32_t CharValue = validateUTF8CharacterAndAdvance(CurPtr, BufferEnd);
+    if (CharValue == ~0U)
+      return bail();
+
+    // Regex literals cannot span multiple lines.
+    if (CharValue == '\n' || CharValue == '\r')
+      return bail();
+
+    if (CharValue == '\\' && *CurPtr == '/') {
+      // Skip escaped delimiter and advance.
+      CurPtr++;
+    } else if (CharValue == '/') {
+      // End of literal, stop.
+      break;
+    }
+  }
+  // We've ended on the opening of a comment, bail.
+  // TODO: We could treat such cases as postfix operators on a regex literal,
+  // but it seems more likely the user has written a comment and is in the
+  // middle of editing the text before it.
+  if (*CurPtr == '*' || *CurPtr == '/')
+    return bail();
+
+  formToken(tok::regex_literal, TokStart);
+  return true;
+}
+
 /// lexEscapedIdentifier:
 ///   identifier ::= '`' identifier '`'
 ///

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8603,6 +8603,11 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                    Tok.getRawText().front() == '!'))
       diagnose(Tok, diag::postfix_operator_name_cannot_start_with_unwrap);
 
+  if (Attributes.hasAttribute<PrefixAttr>()) {
+    if (Tok.getText().contains("/"))
+      diagnose(Tok, diag::prefix_slash_not_allowed);
+  }
+
   // A common error is to try to define an operator with something in the
   // unicode plane considered to be an operator, or to try to define an
   // operator like "not".  Analyze and diagnose this specifically.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -540,6 +540,8 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
     Tok.setKind(tok::oper_prefix);
     LLVM_FALLTHROUGH;
   case tok::oper_prefix:
+    if (Tok.getText().contains("/"))
+      diagnose(Tok, diag::prefix_slash_not_allowed);
     Operator = parseExprOperator();
     break;
   case tok::oper_binary_spaced:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -511,6 +511,10 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   SyntaxParsingContext UnaryContext(SyntaxContext, SyntaxContextKind::Expr);
   UnresolvedDeclRefExpr *Operator;
+
+  // First check to see if we have the start of a regex literal /.../.
+  tryLexRegexLiteral();
+
   switch (Tok.getKind()) {
   default:
     // If the next token is not an operator, just parse this as expr-postfix.
@@ -532,18 +536,31 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   case tok::backslash:
     return parseExprKeyPath();
 
-  case tok::oper_postfix:
+  case tok::oper_postfix: {
     // Postfix operators cannot start a subexpression, but can happen
     // syntactically because the operator may just follow whatever precedes this
     // expression (and that may not always be an expression).
     diagnose(Tok, diag::invalid_postfix_operator);
     Tok.setKind(tok::oper_prefix);
-    LLVM_FALLTHROUGH;
-  case tok::oper_prefix:
-    if (Tok.getText().contains("/"))
-      diagnose(Tok, diag::prefix_slash_not_allowed);
     Operator = parseExprOperator();
     break;
+  }
+  case tok::oper_prefix: {
+    // Check to see if we can split a prefix operator containing '/', e.g '!/',
+    // which might be a prefix operator on a regex literal.
+    auto slashIdx = Tok.getText().find("/");
+    if (slashIdx != StringRef::npos) {
+      auto prefix = Tok.getText().take_front(slashIdx);
+      if (!prefix.empty()) {
+        Operator = makeExprOperator({Tok.getKind(), prefix});
+        consumeStartingCharacterOfCurrentToken(Tok.getKind(), prefix.size());
+        break;
+      }
+      diagnose(Tok, diag::prefix_slash_not_allowed);
+    }
+    Operator = parseExprOperator();
+    break;
+  }
   case tok::oper_binary_spaced:
   case tok::oper_binary_unspaced: {
     // For recovery purposes, accept an oper_binary here.
@@ -862,17 +879,48 @@ static DeclRefKind getDeclRefKindForOperator(tok kind) {
   }
 }
 
-/// parseExprOperator - Parse an operator reference expression.  These
-/// are not "proper" expressions; they can only appear in binary/unary
-/// operators.
-UnresolvedDeclRefExpr *Parser::parseExprOperator() {
+UnresolvedDeclRefExpr *Parser::makeExprOperator(Token Tok) {
   assert(Tok.isAnyOperator());
   DeclRefKind refKind = getDeclRefKindForOperator(Tok.getKind());
   SourceLoc loc = Tok.getLoc();
   DeclNameRef name(Context.getIdentifier(Tok.getText()));
-  consumeToken();
   // Bypass local lookup.
   return new (Context) UnresolvedDeclRefExpr(name, refKind, DeclNameLoc(loc));
+}
+
+/// parseExprOperator - Parse an operator reference expression.  These
+/// are not "proper" expressions; they can only appear in binary/unary
+/// operators.
+UnresolvedDeclRefExpr *Parser::parseExprOperator() {
+  auto *op = makeExprOperator(Tok);
+  consumeToken();
+  return op;
+}
+
+void Parser::tryLexRegexLiteral() {
+  // Check to see if we have the start of a regex literal /.../.
+  switch (Tok.getKind()) {
+  case tok::oper_prefix:
+  case tok::oper_binary_spaced:
+  case tok::oper_binary_unspaced: {
+    if (!Tok.getText().startswith("/"))
+      break;
+
+    // Try re-lex as a /.../ regex literal.
+    if (!L->tryLexAsForwardSlashRegexLiteral(getParserPosition().LS))
+      break;
+
+    // Discard the operator token, which will be replaced by the regex literal
+    // token.
+    discardToken();
+
+    assert(Tok.getText().startswith("/"));
+    assert(Tok.is(tok::regex_literal));
+    break;
+  }
+  default:
+    break;
+  }
 }
 
 /// parseExprSuper
@@ -3148,6 +3196,10 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     Identifier FieldName;
     SourceLoc FieldNameLoc;
     parseOptionalArgumentLabel(FieldName, FieldNameLoc);
+
+    // First check to see if we have the start of a regex literal /.../. We
+    // need to do this before handling unapplied operator references.
+    tryLexRegexLiteral();
 
     // See if we have an operator decl ref '(<op>)'. The operator token in
     // this case lexes as a binary operator because it neither leads nor

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -32,7 +32,15 @@ using namespace swift::syntax;
 
 ParserResult<Expr> Parser::parseExprRegexLiteral() {
   assert(Tok.is(tok::regex_literal));
-  assert(regexLiteralParsingFn);
+
+  // Bail if '-enable-experimental-string-processing' is not enabled.
+  if (!Context.LangOpts.EnableExperimentalStringProcessing ||
+      !regexLiteralParsingFn) {
+    diagnose(Tok, diag::regex_literal_parsing_error,
+             "regex literal requires '-enable-experimental-string-processing'");
+    auto loc = consumeToken();
+    return makeParserResult(new (Context) ErrorExpr(loc));
+  }
 
   SyntaxParsingContext LocalContext(SyntaxContext,
                                     SyntaxKind::RegexLiteralExpr);

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -39,6 +39,16 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
 
   auto regexText = Tok.getText();
 
+  // The Swift library doesn't know about `/.../` regexes, let's pretend it's
+  // `#/.../#` instead.
+  if (regexText[0] == '/') {
+    SmallString<32> scratch;
+    scratch.append("#");
+    scratch.append(regexText);
+    scratch.append("#");
+    regexText = Context.AllocateCopy(StringRef(scratch));
+  }
+
   // Let the Swift library parse the contents, returning an error, or null if
   // successful.
   // TODO: We need to be able to pass back a source location to emit the error

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -579,13 +579,16 @@ const Token &Parser::peekToken() {
   return L->peekNextToken();
 }
 
-SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
-  SourceLoc Loc = Tok.getLoc();
+SourceLoc Parser::discardToken() {
   assert(Tok.isNot(tok::eof) && "Lexing past eof!");
-
-  recordTokenHash(Tok);
-
+  SourceLoc Loc = Tok.getLoc();
   L->lex(Tok, LeadingTrivia, TrailingTrivia);
+  return Loc;
+}
+
+SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
+  recordTokenHash(Tok);
+  auto Loc = discardToken();
   PreviousLoc = Loc;
   return Loc;
 }

--- a/test/StringProcessing/Parse/forward-slash-regex-default.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-default.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+let _ = /x/ // expected-error {{regex literal requires '-enable-experimental-string-processing'}}
+
+prefix operator /  // expected-error {{prefix slash not allowed}}
+prefix operator ^/ // expected-error {{prefix slash not allowed}}
+
+_ = /x
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+// expected-error@-3 {{cannot find 'x' in scope}}
+
+_ = !/x/ // expected-error {{regex literal requires '-enable-experimental-string-processing'}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -1,0 +1,290 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// REQUIRES: swift_in_compiler
+// REQUIRES: concurrency
+
+precedencegroup P {
+  associativity: left
+}
+
+// Fine.
+infix operator /^/ : P
+func /^/ (lhs: Int, rhs: Int) -> Int { 0 }
+
+let i = 0 /^/ 1/^/3
+
+prefix operator /  // expected-error {{prefix slash not allowed}}
+prefix operator ^/ // expected-error {{prefix slash not allowed}}
+
+let x = /abc/
+_ = /abc/
+_ = /x/.self
+_ = /\//
+
+// These unfortunately become infix `=/`. We could likely improve the diagnostic
+// though.
+let z=/0/
+// expected-error@-1 {{type annotation missing in pattern}}
+// expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
+// expected-error@-3 {{expected expression after unary operator}}
+// expected-error@-4 {{cannot find operator '=/' in scope}}
+// expected-error@-5 {{'/' is not a postfix unary operator}}
+_=/0/
+// expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
+// expected-error@-2 {{cannot find operator '=/' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+_ = /x
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+_ = !/x/
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = /x/! // expected-error {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+_ = /x/ + /y/ // expected-error {{binary operator '+' cannot be applied to two 'Regex<Substring>' operands}}
+
+_ = /x/+/y/
+// expected-error@-1 {{cannot find operator '+/' in scope}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x/?.blah
+// expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+_ = /x/!.blah
+// expected-error@-1 {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x /? // expected-error {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+  .blah // expected-error {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = 0; /x / // expected-warning {{regular expression literal is unused}}
+
+_ = /x / ? 0 : 1 // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+_ = .random() ? /x / : .blah // expected-error {{type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x/ ?? /x/ // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+_ = /x / ?? /x / // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+
+_ = /x/??/x/ // expected-error {{'/' is not a postfix unary operator}}
+
+_ = /x/ ... /y/ // expected-error {{referencing operator function '...' on 'Comparable' requires that 'Regex<Substring>' conform to 'Comparable'}}
+
+_ = /x/.../y/
+// expected-error@-1 {{missing whitespace between '...' and '/' operators}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x /...
+// expected-error@-1 {{unary operator '...' cannot be applied to an operand of type 'Regex<Substring>'}}
+// expected-note@-2 {{overloads for '...' exist with these partially matching parameter lists}}
+
+do {
+  _ = true / false /; // expected-error {{expected expression after operator}}
+}
+
+_ = "\(/x/)"
+
+func defaulted(x: Regex<Substring> = /x/) {}
+
+func foo<T>(_ x: T, y: T) {}
+foo(/abc/, y: /abc /)
+
+func bar<T>(_ x: inout T) {}
+
+// TODO: We split this into a prefix '&', but inout is handled specially when
+// parsing an argument list. This shouldn't matter anyway, but we should at
+// least have a custom diagnostic.
+bar(&/x/)
+// expected-error@-1 {{'&' is not a prefix unary operator}}
+
+struct S {
+  subscript(x: Regex<Substring>) -> Void { () }
+}
+
+func testSubscript(_ x: S) {
+  x[/x/]
+  x[/x /]
+}
+
+func testReturn() -> Regex<Substring> {
+  if .random() {
+    return /x/
+  }
+  return /x /
+}
+
+func testThrow() throws {
+  throw /x / // expected-error {{thrown expression type 'Regex<Substring>' does not conform to 'Error'}}
+}
+
+_ = [/abc/, /abc /]
+_ = [/abc/:/abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc/ : /abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /:/abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /: /abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = (/abc/, /abc /)
+_ = ((/abc /))
+
+_ = { /abc/ }
+_ = {
+  /abc/
+}
+
+let _: () -> Int = {
+  0
+  / 1 /
+  2
+}
+
+_ = {
+  0 // expected-warning {{integer literal is unused}}
+  /1 / // expected-warning {{regular expression literal is unused}}
+  2 // expected-warning {{integer literal is unused}}
+}
+
+// Operator chain, as a regex literal may not start with space.
+_ = 2
+/ 1 / .bitWidth
+
+_ = 2
+/1/ .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+_ = 2
+/ 1 /
+  .bitWidth
+
+_ = 2
+/1 /
+  .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+let z =
+/y/
+
+// While '.' is technically an operator character, it seems more likely that
+// the user hasn't written the member name yet.
+_ = 0. / 1 / 2 // expected-error {{expected member name following '.'}}
+_ = 0 . / 1 / 2 // expected-error {{expected member name following '.'}}
+
+switch "" {
+case /x/:
+  // expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'String'}}
+  // expected-note@-2 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
+  break
+case _ where /x /:
+  // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+  break
+default:
+  break
+}
+
+do {} catch /x / {}
+// expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'any Error'}}
+// expected-error@-2 {{binary operator '~=' cannot be applied to two 'any Error' operands}}
+// expected-warning@-3 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+
+switch /x / {
+default:
+  break
+}
+
+if /x / {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+if /x /.smth {} // expected-error {{value of type 'Regex<Substring>' has no member 'smth'}}
+
+func testGuard() {
+  guard /x/ else { return } // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+}
+
+for x in [0] where /x/ {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+
+typealias Magic<T> = T
+_ = /x/ as Magic
+_ = /x/ as! String // expected-warning {{cast from 'Regex<Substring>' to unrelated type 'String' always fails}}
+
+_ = type(of: /x /)
+
+do {
+  let /x / // expected-error {{expected pattern}}
+}
+
+_ = try /x/; _ = try /x /
+// expected-warning@-1 2{{no calls to throwing functions occur within 'try' expression}}
+
+// TODO: `try?` and `try!` are currently broken.
+// _ = try? /x/; _ = try? / x /
+// _ = try! /x/; _ = try! / x /
+
+_ = await /x / // expected-warning {{no 'async' operations occur within 'await' expression}}
+
+/x/ = 0 // expected-error {{cannot assign to value: literals are not mutable}}
+/x/() // expected-error {{cannot call value of non-function type 'Regex<Substring>'}}
+
+// TODO: We could allow this (and treat the last '/' as postfix), though it
+// seems more likely the user has written a comment and is still in the middle
+// of writing the characters before it.
+/x//
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+/x //
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+/x/**/
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+// These become regex literals, unless surrounded in parens.
+func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 2{{'baz' declared here}}
+baz(/, /)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{missing argument for parameter #2 in call}}
+baz(/,/)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{missing argument for parameter #2 in call}}
+baz((/), /)
+
+func qux<T>(_ x: (Int, Int) -> Int, _ y: T) -> Int { 0 }
+do {
+  _ = qux(/, 1) / 2
+  // expected-error@-1 {{cannot parse regular expression: closing ')' does not balance any groups openings}}
+  // expected-error@-2 {{expected ',' separator}}
+}
+do {
+  _ = qux(/, "(") / 2
+  // expected-error@-1 {{cannot convert value of type 'Regex<(Substring, Substring)>' to expected argument type '(Int, Int) -> Int'}}
+  // expected-error@-2 {{expected ',' separator}}
+}
+_ = qux(/, 1) // this comment tests to make sure we don't try and end the regex on the starting '/' of '//'.
+
+let arr: [Double] = [2, 3, 4]
+_ = arr.reduce(1, /) / 3
+_ = arr.reduce(1, /) + arr.reduce(1, /)
+
+// Fine.
+_ = /./
+
+// You need to escape if you want a regex literal to start with these characters.
+// TODO: Better recovery
+_ = /\ /
+do { _ = / / }
+// expected-error@-1 2{{unary operator cannot be separated from its operand}}
+// expected-error@-2 {{expected expression in assignment}}
+
+_ = /\)/
+do { _ = /)/ }
+// expected-error@-1 {{expected expression after unary operator}}
+// expected-error@-2 {{expected expression in assignment}}
+
+_ = /,/
+_ = /}/
+_ = /]/
+_ = /:/
+_ = /;/
+
+// TODO: Need to delay diagnostics for these.
+_ = /0xG/ // expected-error {{'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal}}
+_ = /0oG/ // expected-error {{'G' is not a valid octal digit (0-7) in integer literal}}
+_ = /"/ // expected-error {{unterminated string literal}}
+_ = /'/ // expected-error {{unterminated string literal}}
+_ = /<#placeholder#>/ // expected-error {{editor placeholder in source file}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -282,9 +282,9 @@ _ = /]/
 _ = /:/
 _ = /;/
 
-// TODO: Need to delay diagnostics for these.
-_ = /0xG/ // expected-error {{'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal}}
-_ = /0oG/ // expected-error {{'G' is not a valid octal digit (0-7) in integer literal}}
-_ = /"/ // expected-error {{unterminated string literal}}
-_ = /'/ // expected-error {{unterminated string literal}}
-_ = /<#placeholder#>/ // expected-error {{editor placeholder in source file}}
+// Don't emit diagnostics here, as we re-lex.
+_ = /0xG/
+_ = /0oG/
+_ = /"/
+_ = /'/
+_ = /<#placeholder#>/

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -804,6 +804,9 @@ TEST_F(LexerTest, DiagnoseEmbeddedNul) {
           LexerMode::Swift, HashbangMode::Disallowed,
           CommentRetentionMode::None, TriviaRetentionMode::WithTrivia);
 
+  Token Tok;
+  L.lex(Tok);
+
   ASSERT_TRUE(containsPrefix(DiagConsumer.messages,
                              "1, 2: nul character embedded in middle of file"));
   ASSERT_TRUE(containsPrefix(DiagConsumer.messages,


### PR DESCRIPTION
Try to lex regex literals with `/.../` delimiters when in an expression context in the parser, with a rule that it may not start with a space, tab or `)` character.