### PR TITLE
[Distributed] NFC: Re-enable XFAIL'ed tests on Linux

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -14,9 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 
 final class Obj: @unchecked Sendable, Codable  {}

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
@@ -16,9 +16,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -8,9 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import _Concurrency
 


### PR DESCRIPTION
Resolves: rdar://90078069

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
