### PR TITLE
RequirementMachine: Overhaul handling of protocol typealiases with concrete underlying type

### DIFF
--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -265,6 +265,9 @@ bool RequirementMachine::isCanonicalTypeInContext(Type type) const {
     explicit Walker(const RequirementMachine &self) : Self(self) {}
 
     Action walkToTypePre(Type component) override {
+      if (!component->hasTypeParameter())
+        return Action::SkipChildren;
+
       if (!component->isTypeParameter())
         return Action::Continue;
 
@@ -305,6 +308,9 @@ Type RequirementMachine::getCanonicalTypeInContext(
     TypeArrayView<GenericTypeParamType> genericParams) const {
 
   return type.transformRec([&](Type t) -> Optional<Type> {
+    if (!t->hasTypeParameter())
+      return t;
+
     if (!t->isTypeParameter())
       return None;
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -239,7 +239,8 @@ RequirementMachine::getLongestValidPrefix(const MutableTerm &term) const {
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
     case Symbol::Kind::ConcreteConformance:
-      llvm_unreachable("Property symbol cannot appear in a type term");
+      llvm::errs() <<"Invalid symbol in a type term: " << term << "\n";
+      abort();
     }
 
     // This symbol is valid, add it to the longest prefix.

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -910,9 +910,14 @@ void RewriteSystem::minimizeRewriteSystem() {
   }
 
   performHomotopyReduction([&](unsigned loopID, unsigned ruleID) -> bool {
+    const auto &loop = Loops[loopID];
     const auto &rule = getRule(ruleID);
 
-    if (!rule.isAnyConformanceRule())
+    if (rule.isProtocolTypeAliasRule())
+      return true;
+
+    if (!loop.hasConcreteTypeAliasRule(*this) &&
+        !rule.isAnyConformanceRule())
       return true;
 
     return false;

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -311,7 +311,8 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end, Type root,
       case Symbol::Kind::Superclass:
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
-        llvm_unreachable("Term has invalid root symbol");
+        llvm::errs() << "Invalid root symbol: " << MutableTerm(begin, end) << "\n";
+        abort();
       }
     }
 

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -365,7 +365,8 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
     break;
   }
 
-  llvm_unreachable("Bad symbol kind");
+  llvm::errs() << "Bad symbol in " << lhs << "\n";
+  abort();
 }
 
 /// Collect conformance rules and parent paths, and record an initial

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -55,9 +55,6 @@ class RewriteContext final {
   /// Cache for associated type declarations.
   llvm::DenseMap<Symbol, AssociatedTypeDecl *> AssocTypes;
 
-  /// Cache for merged associated type symbols.
-  llvm::DenseMap<std::pair<Symbol, Symbol>, Symbol> MergedAssocTypes;
-
   /// Requirement machines built from generic signatures.
   llvm::DenseMap<GenericSignature, RequirementMachine *> Machines;
 

--- a/lib/AST/RequirementMachine/RewriteLoop.h
+++ b/lib/AST/RequirementMachine/RewriteLoop.h
@@ -457,6 +457,9 @@ private:
   /// Cached value for getDecomposeCount().
   unsigned DecomposeCount : 15;
 
+  /// Cached value for hasConcreteTypeAliasRule().
+  unsigned HasConcreteTypeAliasRule : 1;
+
   /// A useful loop contains at least one rule in empty context, even if that
   /// rule appears multiple times or also in non-empty context. The only loops
   /// that are elimination candidates contain a rule in empty context *exactly
@@ -478,6 +481,7 @@ public:
     : Basepoint(basepoint), Path(path) {
     ProjectionCount = 0;
     DecomposeCount = 0;
+    HasConcreteTypeAliasRule = 0;
     Useful = 0;
     Deleted = 0;
 
@@ -508,6 +512,8 @@ public:
   unsigned getProjectionCount(const RewriteSystem &system) const;
 
   unsigned getDecomposeCount(const RewriteSystem &system) const;
+
+  bool hasConcreteTypeAliasRule(const RewriteSystem &system) const;
 
   void findProtocolConformanceRules(
       llvm::SmallDenseMap<const ProtocolDecl *,

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -174,8 +174,13 @@ Optional<Identifier> Rule::isProtocolTypeAliasRule() const {
     //
     // We shouldn't have unresolved symbols on the right hand side;
     // they should have been simplified away.
-    if (RHS.containsUnresolvedSymbols())
-      return None;
+    if (RHS.containsUnresolvedSymbols()) {
+      if (RHS.size() != 2 ||
+          RHS[0] != LHS[0] ||
+          RHS[1].getKind() != Symbol::Kind::Name) {
+        return None;
+      }
+    }
   } else {
     // This is the case where the underlying type is concrete.
     assert(LHS.size() == 3);

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -660,6 +660,28 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
     for (unsigned index : indices(lhs)) {
       auto symbol = lhs[index];
 
+      // The left hand side can contain a single name symbol if it has the form
+      // T.N or T.N.[p], where T is some prefix that does not contain name
+      // symbols, N is a name symbol, and [p] is an optional property symbol.
+      //
+      // In the latter case, we have a protocol typealias, or a rule derived
+      // via resolving a critical pair involving a protocol typealias.
+      //
+      // Any other valid occurrence of a name symbol should have been reduced by
+      // an associated type introduction rule [P].N, marking the rule as
+      // LHS-simplified.
+      if (!rule.isLHSSimplified() &&
+          (rule.isPropertyRule()
+           ? index != lhs.size() - 2
+           : index != lhs.size() - 1)) {
+        // This is only true if the input requirements were valid.
+        if (policy == DisallowInvalidRequirements) {
+          ASSERT_RULE(symbol.getKind() != Symbol::Kind::Name);
+        } else {
+          // FIXME: Assert that we diagnosed an error
+        }
+      }
+
       if (index != lhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Layout);
         ASSERT_RULE(!symbol.hasSubstitutions());
@@ -677,14 +699,18 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
     for (unsigned index : indices(rhs)) {
       auto symbol = rhs[index];
 
-      // RHS-simplified rules might have unresolved name symbols on the
-      // right hand side. Also, completion can introduce rules of the
-      // form T.X.[concrete: C] => T.X, where T is some resolved term,
-      // and X is a name symbol for a protocol typealias.
-      if (!rule.isLHSSimplified() &&
-          !rule.isRHSSimplified() &&
-          !(rule.isPropertyRule() &&
-            index == rhs.size() - 1)) {
+      // The right hand side can contain a single name symbol if it has the form
+      // T.N, where T is some prefix that does not contain name symbols, and
+      // N is a name symbol.
+      //
+      // In this case, we have a protocol typealias, or a rule derived via
+      // resolving a critical pair involving a protocol typealias.
+      //
+      // Any other valid occurrence of a name symbol should have been reduced by
+      // an associated type introduction rule [P].N, marking the rule as
+      // RHS-simplified.
+      if (!rule.isRHSSimplified() &&
+          index != rhs.size() - 1) {
         // This is only true if the input requirements were valid.
         if (policy == DisallowInvalidRequirements) {
           ASSERT_RULE(symbol.getKind() != Symbol::Kind::Name);

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -506,13 +506,15 @@ private:
 
   void processConflicts();
 
+  using EliminationPredicate = llvm::function_ref<bool(unsigned loopID,
+                                                       unsigned ruleID)>;
+
   Optional<std::pair<unsigned, unsigned>>
-  findRuleToDelete(llvm::function_ref<bool(unsigned)> isRedundantRuleFn);
+  findRuleToDelete(EliminationPredicate isRedundantRuleFn);
 
   void deleteRule(unsigned ruleID, const RewritePath &replacementPath);
 
-  void performHomotopyReduction(
-      llvm::function_ref<bool(unsigned)> isRedundantRuleFn);
+  void performHomotopyReduction(EliminationPredicate isRedundantRuleFn);
 
   void computeMinimalConformances(
       llvm::DenseSet<unsigned> &redundantConformances);

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -596,7 +596,8 @@ Symbol Symbol::withConcreteSubstitutions(
     break;
   }
 
-  llvm_unreachable("Bad symbol kind");
+  llvm::errs() << "Bad symbol kind: " << *this << "\n";
+  abort();
 }
 
 /// For a superclass or concrete type symbol

--- a/test/Generics/concrete_protocol_typealias_minimization.swift
+++ b/test/Generics/concrete_protocol_typealias_minimization.swift
@@ -1,0 +1,92 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+
+protocol P1a {
+  typealias X = Int
+}
+
+// CHECK-LABEL: .P1b@
+// CHECK-NEXT: Requirement signature: <Self where Self : P1a, Self.[P1b]X == Int>
+protocol P1b : P1a {
+  associatedtype X
+}
+
+protocol P2a {
+  associatedtype A
+  typealias B = Int
+}
+
+// CHECK-LABEL: .P2b@
+// CHECK-NEXT: <Self where Self : P2a, Self.[P2a]A == Int>
+protocol P2b : P2a where Self.A == Self.B {}
+
+struct G<X> {}
+
+protocol P3a {
+  typealias T = G<X>
+  associatedtype X
+}
+
+protocol P3b {
+  typealias T = G<Y>
+  associatedtype Y
+}
+
+// CHECK-LABEL: .P3c@
+// CHECK-NEXT: <Self where Self : P3a, Self : P3b, Self.[P3a]X == Self.[P3b]Y>
+protocol P3c : P3a, P3b {}
+
+protocol P4a {
+  typealias T = G<X>
+  associatedtype X
+}
+
+// CHECK-LABEL: .P4b@
+// CHECK-NEXT: <Self where Self : P4a, Self.[P4b]A == G<Self.[P4b]B>, Self.[P4b]B == Self.[P4a]X>
+protocol P4b : P4a where A == T, A == G<B> {
+  associatedtype A
+  associatedtype B
+}
+
+// CHECK-LABEL: .P5@
+// CHECK-NEXT: <Self where Self.[P5]B == Int>
+protocol P5 {
+  typealias A = Int
+  associatedtype B where B == A
+}
+
+protocol P6a {
+  typealias A = Int
+  typealias B = A
+}
+
+// CHECK-LABEL: .P6b@
+// CHECK-NEXT: <Self where Self : P6a, Self.[P6b]C == Int>
+protocol P6b : P6a where C == B {
+  associatedtype C
+}
+
+protocol P7a {
+  typealias A = Int
+}
+
+protocol P7b : P7a {
+  typealias B = A
+}
+
+// CHECK-LABEL: .P7c@
+// CHECK-NEXT: <Self where Self : P7b, Self.[P7c]C == Int>
+protocol P7c : P7b {
+  associatedtype C where C == B
+}
+
+protocol P8a {
+  associatedtype C
+}
+
+// CHECK-LABEL: .f1@
+// CHECK-NEXT: <T, U where T : P8a, U : P7b, T.[P8a]C == Int>
+func f1<T : P8a, U : P7b>(_: T, _: U) where T.C == U.B {}
+
+// CHECK-LABEL: .f2@
+// CHECK-NEXT: <T, U where T : P7b, U : P8a, U.[P8a]C == Int>
+func f2<T : P7b, U : P8a>(_: T, _: U) where T.B == U.C {}

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -1,9 +1,5 @@
-// FIXME: Once the Requirement Machine can emit diagnostics, run this test with
-// it enabled unconditionally.
-
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on > %t.dump 2>&1
-// RUN: %FileCheck %s < %t.dump
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify > %t.dump 2>&1
 
 
 func sameType<T>(_: T.Type, _: T.Type) {}
@@ -107,7 +103,7 @@ protocol P7 {
 }
 
 // CHECK-LABEL: .P7a@
-// CHECK: Requirement signature: <Self where Self : P7>
+// CHECK: Requirement signature: <Self where Self : P7, Self.[P7a]A == Int>
 protocol P7a : P7 {
   associatedtype A   // expected-warning{{associated type 'A' is redundant with type 'A' declared in inherited protocol 'P7'}}
 }

--- a/test/Generics/protocol_typealias_same_type_requirement.swift
+++ b/test/Generics/protocol_typealias_same_type_requirement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A
@@ -41,7 +41,7 @@ protocol P7 {
 }
 
 // CHECK-LABEL: protocol_typealias_same_type_requirement.(file).P8@
-// CHECK-LABEL: Requirement signature: <Self where Self : P6, Self : P7>
+// CHECK-LABEL: Requirement signature: <Self where Self : P6, Self : P7, Self.[P7]X == Int>
 protocol P8 : P6, P7 {}
 
 func testP8<T : P8>(_: T, x: T.X) -> Int { return x }

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -9,20 +9,24 @@ protocol P2 {
   associatedtype T
 }
 
+// Note: the warnings should probably be emitted.
+
 // CHECK: ExtensionDecl line={{.*}} base=P1
-// CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2>
+// CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2, Self.[P2]T == Int>
 extension P1 where Self : P2, T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
   func takeT11(_: T) {}
   func takeT12(_: Self.T) {}
 }
 
 // CHECK: ExtensionDecl line={{.*}} base=P1
-// CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2>
+// CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2, Self.[P2]T == Int>
 extension P1 where Self : P2, Self.T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
   func takeT21(_: T) {}
   func takeT22(_: Self.T) {}
 }
 
+// CHECK: ExtensionDecl line={{.*}} base=P1
+// CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2, Self.[P2]T == Int>
 extension P1 where Self : P2 {
   func takeT31(_: T) {}
   func takeT32(_: Self.T) {}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
 
 // Tests for typealias inside protocols
 
@@ -262,9 +262,9 @@ protocol P10 {
 
   @available(*, deprecated, message: "just use Int, silly")
   typealias V = Int
-}
 
-extension P10 {
+  // FIXME: This used to be in a protocol extension, but the Requirement Machine does
+  // not permit `where` clauses to reference typealiases in protocol extensions.
   typealias U = Float
 }
 


### PR DESCRIPTION
Consider this example:

```
protocol P {
  typealias A = Int
  associatedtype B
}

<T where T : P, T.A == T.B>
```

Recall that the concrete typealias introduces a rule of the form:

```
[P].A.[concrete: Int] => [P].A
```

This overlaps with the conformance rule (`T.[P] => T`) on the term `T.[P].A` to produce the rule `T.A.[concrete: Int] => T.A`.

Now the generic signature equates the associated type `T.[P:B]` with the typealias `T.A` via an abstract same-type requirement, which introduces a rewrite rule of the form:

```
T.A => T.[P:B]
```

This overlaps with `T.A.[concrete: Int] => T.A` on `T.A.[concrete: Int]`, so we get a new rule:

```
T.[P:B].[concrete: Int] => T.[P:B]
```

For compatibility with the GenericSignatureBuilder, this final rule is the one we want to turn into a requirement in the minimal signature (T.B == Int); we don't want to keep (T.B == T.A) around.

To get this behavior, don't consider eliminating (`T.[P:B].[concrete: Int] => T.[P:B]`) via a rewrite loop containing any protocol typealias rules, in this case, (`[P].A.[concrete: Int] => [P].A`).

This trick only works because the left hand side of a protocol typelias rule is always greater than an associated type in the reduction order, since terms with name symbols are always greater than terms without name symbols.

There is a more general problem here where we fail to produce a signature compatible with the GenericSignatureBuilder in other similar cases that do not involve protocol typealiases, for example here we should transform `U.Element == Character`:

```
<T, U where T : Collection, U : Collection, T.SubSequence == Substring, T.Element == U.Element>
```

A solution to the above problem will subsume this hack, but for now, let's land it to move forward.

Fixes https://bugs.swift.org/browse/SR-15924 / rdar://problem/89641526.