### PR TITLE
[Distributed] NFC: Allow 64-bit distributed test only on x86_64 and arm64

### DIFF
--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -6,6 +6,8 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
+// REQUIRES: CPU=x86_64 || CPU=arm64
+
 // UNSUPPORTED: OS=windows-msvc
 
 import _Distributed


### PR DESCRIPTION
Resolves:  rdar://90127754

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
