### PR TITLE
Make map's initializers inlinable instead of just usable from inline

### DIFF
--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -55,6 +55,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps the given closure over the asynchronous
 /// sequence’s elements.
 @available(SwiftStdlib 5.1, *)
+@frozen
 public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -83,6 +84,7 @@ extension AsyncMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -62,7 +62,7 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let transform: (Base.Element) async -> Transformed
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async -> Transformed
@@ -90,7 +90,7 @@ extension AsyncMapSequence: AsyncSequence {
     @usableFromInline
     let transform: (Base.Element) async -> Transformed
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async -> Transformed

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -68,7 +68,6 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps the given error-throwing closure over the
 /// asynchronous sequence’s elements.
 @available(SwiftStdlib 5.1, *)
-@frozen
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -75,7 +75,7 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let transform: (Base.Element) async throws -> Transformed
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async throws -> Transformed
@@ -106,7 +106,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async throws -> Transformed

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -68,6 +68,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps the given error-throwing closure over the
 /// asynchronous sequence’s elements.
 @available(SwiftStdlib 5.1, *)
+@frozen
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -96,6 +97,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator


### PR DESCRIPTION
This is a strange way of saying the type is frozen, without saying it is frozen. It grants a 10x throughput performance improvement to AsyncMapSequence while leaving the initializer not inlined to the client (because the solution is less than ideal hygienically)