### PR TITLE
[DI] Fixup alloc_box borrow scope ends.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/rdar89984216.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar89984216.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null
+
+// For OSLogTestHelper.
+// REQUIRES: VENDOR=apple
+
+import OSLogTestHelper
+
+struct Thing {
+  let guts: AnyObject
+}
+
+func getThings() -> [Thing] { [] }
+
+func run() {
+  var things: [Thing]
+  while(true) {
+    things = getThings()
+    OSLogMessage("count: \(things.count)")
+  }
+}
+


### PR DESCRIPTION
After https://github.com/apple/swift/pull/40793, `alloc_boxes` all have their lifetimes protected by a lexical borrow scope.  In that PR, DI had been updated to see through `begin_borrow` instructions from a `project_box` to a `mark_uninitialized`.  It did not, however, correct the `end_borrow` instructions when `destroy_value`s of `mark_uninitialized`s were replaced with `destroy_addr`s of `project_box`es.  That is done here.

In a bit more detail, in the following context

```
%box = alloc_box
%mark_uninit = mark_uninitialized %box
%lifetime = begin_borrow [lexical] %mark_uninit
%proj_box = project_box %lifetime
```

When it is not statically known whether a field is initialized, we arereplacing the instruction

```
// before
destroy_value %mark_uninit
// after
```

with the following diamond

```
  // before
  %initialized = load
  cond_br %initialized, yes, no

yes:
  destroy_addr %proj_box
  br bottom

no:
  br bottom

bottom:
  dealloc_box %box
  br keep_going

keep_going:
  // after
```

Doing so is problematic, though, because by SILGen construction the `destroy_value` is always preceded by an `end_borrow`:

```
end_borrow %lifetime
destroy_value %mark_uninit
```

Previously, that end_borrow remained above the

```
%initialized = load
```

instruction in the above.  That was invalid because the the newly introduced

```
destroy_addr %proj_box
```

was a use of the borrow scope (`%proj_box` is a projection of the `begin_borrow`) and consequently must be within the borrow scope.

Note also that it would not be sufficient to simply emit the diamond before the `end_borrow`.  The `end_borrow` must come before the destruction of the value whose lifetime it is protecting (`%box`), and the diamond contains the instruction to destroy that value (`dealloc_box`) in its bottom block.

To resolve this issue, just move the `end_borrow` instruction from where it was to before the dealloc box.  (This is actually done by moving it to the top of the diamond's "continue" block prior to the emission of that `dealloc_box` instruction.)

rdar://89984216
