### PR TITLE
[cxx-interop] Import const-refs as value types when importing clang function types.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -671,8 +671,13 @@ namespace {
           paramImportKind = ImportTypeKind::CompletionHandlerResultParameter;
         }
 
+        auto paramQualType = *param;
+        if (paramQualType->isReferenceType() &&
+            paramQualType->getPointeeType().isConstQualified())
+          paramQualType = paramQualType->getPointeeType();
+
         auto swiftParamTy = Impl.importTypeIgnoreIUO(
-            *param, paramImportKind, AllowNSUIntegerAsInt, Bridging,
+            paramQualType, paramImportKind, AllowNSUIntegerAsInt, Bridging,
             OTK_Optional);
         if (!swiftParamTy)
           return Type();

--- a/test/Interop/Cxx/reference/Inputs/closures.h
+++ b/test/Interop/Cxx/reference/Inputs/closures.h
@@ -1,0 +1,14 @@
+#ifndef TEST_INTEROP_CXX_CLOSURES_INPUTS_REFERENCE_H
+#define TEST_INTEROP_CXX_CLOSURES_INPUTS_REFERENCE_H
+
+inline void invokeWith42ConstRef(void (^fn)(const int&)) {
+  int i = 42;
+  fn(i);
+}
+
+inline void invokeWith42Ref(void (^fn)(int&)) {
+  int i = 42;
+  fn(i);
+}
+
+#endif // TEST_INTEROP_CXX_CLOSURES_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -2,3 +2,8 @@ module Reference {
   header "reference.h"
   requires cplusplus
 }
+
+module Closures {
+  header "closures.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/reference/closures-module-interface.swift
+++ b/test/Interop/Cxx/reference/closures-module-interface.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Closures -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: func invokeWith42ConstRef(_ fn: ((Int32) -> Void)!)
+// CHECK: func invokeWith42Ref(_ fn: ((UnsafeMutablePointer<Int32>) -> Void)!)

--- a/test/Interop/Cxx/reference/closures.swift
+++ b/test/Interop/Cxx/reference/closures.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clangxx -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
+// RUN: %target-codesign %t/reference
+// RUN: %target-run %t/reference
+//
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Closures
+import StdlibUnittest
+
+var ClosuresTestSuite = TestSuite("Closures")
+
+ClosuresTestSuite.test("const reference closure") {
+  var x: CInt = 0
+  invokeWith42ConstRef { x = $0 }
+  expectEqual(42, x)
+}
+
+ClosuresTestSuite.test("mutable reference closure") {
+  var x: CInt = 0
+  invokeWith42Ref { x = $0.pointee }
+  expectEqual(42, x)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -96,7 +96,7 @@ ReferenceTestSuite.test("reference to template") {
 }
 
 ReferenceTestSuite.test("const reference to template") {
-  var val: CInt = 53
+  let val: CInt = 53
   let ref = constRefToTemplate(val)
   expectEqual(53, ref.pointee)
 }


### PR DESCRIPTION
Otherwise, it will pass the value as a pointer.
