### PR TITLE
[Distributed] IRGen: Don't emit accessor for distributed thunk specia…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2239,7 +2239,7 @@ void IRGenSILFunction::emitSILFunction() {
 
   // Emit distributed accessor, and mark the thunk as accessible
   // by name at runtime through it.
-  if (CurSILFn->isDistributed() && CurSILFn->isThunk()) {
+  if (CurSILFn->isDistributed() && CurSILFn->isThunk() == IsThunk) {
     IGM.emitDistributedTargetAccessor(CurSILFn);
     IGM.addAccessibleFunction(CurSILFn);
   }

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -14,12 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
-// FIXME(distributed): optimized builds optimize too aggressively somewhere
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -14,12 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
-// FIXME(distributed): optimized builds optimize too aggressively somewhere
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -14,12 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
-// FIXME(distributed): optimized builds optimize too aggressively somewhere
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -14,12 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
-// FIXME(distributed): optimized builds optimize too aggressively somewhere
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Distributed
 
 final class Obj: @unchecked Sendable, Codable  {}

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
@@ -16,9 +16,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
 import _Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -8,12 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME(distributed): rdar://90078069
-// UNSUPPORTED: linux
-
-// FIXME(distributed): optimized builds optimize too aggressively somewhere
-// REQUIRES: swift_test_mode_optimize_none
-
 import _Distributed
 import _Concurrency
 


### PR DESCRIPTION
…lizations

Only synthesized `async throws` version is directly accessible remotely.

Resolves: rdar://90129442


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
