### PR TITLE
Stop mapping opened archetypes "out of context".

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1320,9 +1320,15 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
       // type ::= archetype
     case TypeKind::PrimaryArchetype:
-    case TypeKind::OpenedArchetype:
     case TypeKind::SequenceArchetype:
       llvm_unreachable("Cannot mangle free-standing archetypes");
+
+    case TypeKind::OpenedArchetype: {
+      // Opened archetypes have always been mangled via their interface type,
+      // although those manglings aren't used in any stable manner.
+      auto openedType = cast<OpenedArchetypeType>(tybase);
+      return appendType(openedType->getInterfaceType(), sig, forDecl);
+    }
 
     case TypeKind::OpaqueTypeArchetype: {
       auto opaqueType = cast<OpaqueTypeArchetypeType>(tybase);

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -242,7 +242,11 @@ Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
   auto archetype = cast<ArchetypeType>(type);
   if (isa<OpaqueTypeArchetypeType>(archetype->getRoot()))
     return Type();
-  
+
+  // Leave opened archetypes alone; they're handled contextually.
+  if (isa<OpenedArchetypeType>(archetype))
+    return Type(type);
+
   return archetype->getInterfaceType();
 }
 


### PR DESCRIPTION
These opened archetypes need to be bound within their context, so any mapping out of
the context will need to be explicit and map to newly-created generic parameters.
