### PR TITLE
[CodeCompletion] Remove a hack adding type matching nominal types

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2634,22 +2634,6 @@ void CompletionLookup::getValueCompletionsInDeclContext(SourceLoc Loc,
       RequestedResultsTy::toplevelResults().withModuleQualifier(
           ModuleQualifier));
 
-  // Manually add any expected nominal types from imported modules so that
-  // they get their expected type relation. Don't include protocols, since
-  // they can't be initialized from the type name.
-  // FIXME: this does not include types that conform to an expected protocol.
-  // FIXME: this creates duplicate results.
-  for (auto T : expectedTypeContext.getPossibleTypes()) {
-    if (auto NT = T->getAs<NominalType>()) {
-      if (auto NTD = NT->getDecl()) {
-        if (!isa<ProtocolDecl>(NTD) && NTD->getModuleContext() != CurrModule) {
-          addNominalTypeRef(NT->getDecl(),
-                            DeclVisibilityKind::VisibleAtTopLevel, {});
-        }
-      }
-    }
-  }
-
   if (CompletionContext) {
     // FIXME: this is an awful simplification that says all and only enums can
     // use implicit member syntax (leading dot). Computing the accurate answer

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -2041,3 +2041,11 @@ func testProtocolMetatype(protoProto: MetaProto.Protocol, protoType: MetaProto.T
 // PROTOCOLMETA_3: End completions
 }
 
+func testRdar90136020() {
+    let a: Int64 = #^RDAR90136020^#
+// RDAR90136020: Begin completions
+// RDAR90136020-NOT: name=Int64{{$}}
+// RDAR90136020: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int64[#Int64#]; name=Int64
+// RDAR90136020-NOT: name=Int64{{$}}
+// RDAR90136020: End completions
+}


### PR DESCRIPTION
Previously we didn't give any type relations to cached imported symbols. So there was a hack to add the type matching nominal type with type relation manually, which caused duplicated candidates, one from the cache, one added manually.

Now that we have type relations for cached symbols so we don't need this hack anymore.

rdar://90136020
