### PR TITLE
SILGen: Fix accessor functions with `@_backDeploy`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6315,7 +6315,8 @@ public:
   ///         diagnosed errors during type checking.
   FuncDecl *getDistributedThunk() const;
   
-  /// Returns 'true' if the function has the @c @_backDeploy attribute.
+  /// Returns 'true' if the function has (or inherits) the @c @_backDeploy
+  /// attribute.
   bool isBackDeployed() const;
 
   PolymorphicEffectKind getPolymorphicEffectKind(EffectKind kind) const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6313,5 +6313,9 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
+ERROR(back_deploy_not_on_coroutine,none,
+      "'%0' is not supported on coroutine %1",
+      (DeclAttribute, DescriptiveDeclKind))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -386,6 +386,12 @@ Decl::getBackDeployBeforeOSVersion(PlatformKind Kind) const {
       }
     }
   }
+
+  // Accessors may inherit `@_backDeploy`.
+  if (getKind() == DeclKind::Accessor) {
+    return cast<AccessorDecl>(this)->getStorage()->getBackDeployBeforeOSVersion(Kind);
+  }
+
   return None;
 }
 
@@ -7649,7 +7655,16 @@ bool AbstractFunctionDecl::isSendable() const {
 }
 
 bool AbstractFunctionDecl::isBackDeployed() const {
-  return getAttrs().hasAttribute<BackDeployAttr>();
+  if (getAttrs().hasAttribute<BackDeployAttr>())
+    return true;
+
+  // Property and subscript accessors inherit the attribute.
+  if (auto *AD = dyn_cast<AccessorDecl>(this)) {
+    if (AD->getStorage()->getAttrs().hasAttribute<BackDeployAttr>())
+      return true;
+  }
+
+  return false;
 }
 
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3533,6 +3533,21 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
       }
     }
 
+    // FIXME(backDeploy): support coroutines rdar://90111169
+    auto diagnoseCoroutineIfNecessary = [&](AccessorDecl *AD) {
+      if (AD->isCoroutine())
+        diagnose(Attr->getLocation(), diag::back_deploy_not_on_coroutine,
+                 Attr, AD->getDescriptiveKind());
+    };
+    if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+      ASD->visitEmittedAccessors([&](AccessorDecl *AD) {
+        diagnoseCoroutineIfNecessary(AD);
+      });
+    }
+    if (auto *AD = dyn_cast<AccessorDecl>(D)) {
+      diagnoseCoroutineIfNecessary(AD);
+    }
+
     auto AtLoc = Attr->AtLoc;
     auto Platform = Attr->Platform;
 

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -45,27 +45,23 @@ public struct TopLevelStruct {
   // CHECK: @_backDeploy(macOS 12.0)
   // FROMSOURCE: public var backDeployedPropertyWithAccessors: Swift.Int {
   // FROMSOURCE:   get { 45 }
-  // FROMSOURCE:   set(newValue) { print("set property") }
   // FROMSOURCE: }
   // FROMMODULE: public var backDeployedPropertyWithAccessors: Swift.Int
   @available(macOS 11.0, *)
   @_backDeploy(macOS 12.0)
   public var backDeployedPropertyWithAccessors: Int {
     get { 45 }
-    set(newValue) { print("set property") }
   }
 
   // CHECK: @_backDeploy(macOS 12.0)
   // FROMSOURCE: public subscript(index: Swift.Int) -> Swift.Int {
   // FROMSOURCE:   get { 46 }
-  // FROMSOURCE:   set(newValue) { print("set subscript") }
   // FROMSOURCE: }
   // FROMMODULE: public subscript(index: Swift.Int) -> Swift.Int
   @available(macOS 11.0, *)
   @_backDeploy(macOS 12.0)
   public subscript(index: Int) -> Int {
     get { 46 }
-    set(newValue) { print("set subscript") }
   }
 }
 

--- a/test/SILGen/back_deploy_attribute_accessor.swift
+++ b/test/SILGen/back_deploy_attribute_accessor.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+@available(macOS 10.50, *)
+public struct TopLevelStruct {
+  // -- Fallback definition for TopLevelStruct.property.getter
+  // CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwB : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK: bb0([[SELF:%.*]] : $TopLevelStruct):
+  // CHECK:   return [[SELF]] : $TopLevelStruct
+
+  // -- Back deployment thunk for TopLevelStruct.property.getter
+  // CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+  //
+  // CHECK: [[UNAVAIL_BB]]:
+  // CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwB : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK:   [[FALLBACKRES:%.*]] = apply [[FALLBACKFN]]([[BB0_ARG]]) : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK:   br [[RETURN_BB:bb[0-9]+]]([[FALLBACKRES]] : $TopLevelStruct)
+  //
+  // CHECK: [[AVAIL_BB]]:
+  // CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK:   [[ORIGRES:%.*]] = apply [[ORIGFN]]([[BB0_ARG]]) : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK:   br [[RETURN_BB]]([[ORIGRES]] : $TopLevelStruct)
+  //
+  // CHECK: [[RETURN_BB]]([[RETURN_BB_ARG:%.*]] : $TopLevelStruct)
+  // CHECK:   return [[RETURN_BB_ARG]] : $TopLevelStruct
+
+  // -- Original definition of TopLevelStruct.property.getter
+  // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  @available(macOS 10.51, *)
+  @_backDeploy(macOS 10.52)
+  public var property: TopLevelStruct { self }
+}
+
+// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK: bb0([[STRUCT_ARG:%.*]] : $TopLevelStruct):
+@available(macOS 10.51, *)
+func caller(_ s: TopLevelStruct) {
+  // -- Verify the thunk is called
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  _ = s.property
+}

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -14,7 +14,7 @@ public func backDeployedTopLevelFunc() {}
 @usableFromInline
 internal func backDeployedUsableFromInlineTopLevelFunc() {}
 
-// OK: function decls in a struct
+// OK: function/property/subscript decls in a struct
 public struct TopLevelStruct {
   @available(macOS 11.0, *)
   @_backDeploy(macOS 12.0)
@@ -23,6 +23,10 @@ public struct TopLevelStruct {
   @available(macOS 11.0, *)
   @_backDeploy(macOS 12.0)
   public var backDeployedComputedProperty: Int { 98 }
+
+  @available(macOS 11.0, *)
+  @_backDeploy(macOS 12.0)
+  public subscript(_ index: Int) -> Int { index }
 }
 
 // OK: final function decls in a non-final class
@@ -127,6 +131,33 @@ protocol CannotBackDeployProtocol {}
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
+
+// FIXME(backDeploy): support coroutines rdar://90111169
+public struct CannotBackDeployCoroutines {
+  @available(macOS 11.0, *)
+  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+  public var readWriteProperty: Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  @available(macOS 11.0, *)
+  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+  public subscript(at index: Int) -> Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  public var explicitReadAndModify: Int {
+    @available(macOS 11.0, *)
+    @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _read accessor}}
+    _read { yield 42 }
+
+    @available(macOS 11.0, *)
+    @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+    _modify {}
+  }
+}
 
 // MARK: - Incompatible declarations
 


### PR DESCRIPTION
Previously, the `@_backDeploy` attribute was ignored when generating SIL for accessors on declarations with the attribute since the accessor decls themselves were not directly annotated.

Also, emit an error when `@_backDeploy` is applied to coroutine accessors since they are not supported yet.

Resolves rdar://90112441
