### PR TITLE
Add a nullptr check

### DIFF
--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -2412,6 +2412,11 @@ public:
 const TypeInfo *
 TypeConverter::getTypeInfo(const TypeRef *TR,
                            remote::TypeInfoProvider *ExternalTypeInfo) {
+  if (!TR) {
+    DEBUG_LOG(fprintf(stderr, "null TypeRef"));
+    return nullptr;
+  }
+
   // See if we already computed the result
   auto found = Cache.find({TR, ExternalTypeInfo});
   if (found != Cache.end())


### PR DESCRIPTION
I've seen an LLDB crash log that suggests that this can happen, but I don't have
a reproducer for it.

rdar://89177494
