### PR TITLE
    [cxx-interop][test] add %check-interop-cxx-header-in-clang test command substitution to parse and validate generated C++ header in multiple C++ language modes

### DIFF
--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/empty.h
-// RUN: %FileCheck %s < %t/empty.h
+// RUN: %target-swift-frontend %s -typecheck -module-name CdeclFunctions -emit-cxx-header-path %t/cdecl.h
+// RUN: %FileCheck %s < %t/cdecl.h
 
-// RUN: %check-cxx-header-in-clang -std=c++14 %t/empty.h
-// RUN: %check-cxx-header-in-clang -std=c++17 %t/empty.h
+// RUN: %check-interop-cxx-header-in-clang(%t/cdecl.h)
 
 // CHECK-LABEL: namespace CdeclFunctions {
 

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -2,8 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-cxx-header-in-clang -std=c++14 %t/functions.h
-// RUN: %check-cxx-header-in-clang -std=c++17 %t/functions.h
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
 // CHECK-LABEL: namespace Functions {
 

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -2,8 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -emit-cxx-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-cxx-header-in-clang -std=c++14 %t/functions.h
-// RUN: %check-cxx-header-in-clang -std=c++17 %t/functions.h
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
 // CHECK-LABEL: namespace Functions {
 

--- a/test/Interop/SwiftToCxx/module/module-to-namespace.swift
+++ b/test/Interop/SwiftToCxx/module/module-to-namespace.swift
@@ -2,8 +2,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -module-name Test -emit-cxx-header-path %t/empty.h
 // RUN: %FileCheck %s < %t/empty.h
 
-// RUN: %check-cxx-header-in-clang -std=c++14 %t/empty.h
-// RUN: %check-cxx-header-in-clang -std=c++17 %t/empty.h
+// RUN: %check-interop-cxx-header-in-clang(%t/empty.h)
 
 // CHECK-LABEL: namespace Test {
 // CHECK:       } // namespace Test

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -22,3 +22,9 @@ config.substitutions.insert(0, ('%target-interop-build-swift',
                                 '%target-build-swift -Xfrontend -enable-cxx-interop '))
 # Build C++ files with matching link settings, if required by the target.
 config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx ' + clang_opt))
+
+# Test parsing of the generated C++ header in different C++ language modes.
+config.substitutions.insert(0, ('%check-interop-cxx-header-in-clang\(([^)]+)\)',
+                             SubstituteCaptures(r'%check-cxx-header-in-clang -std=c++14 \1 && '
+                                                r'%check-cxx-header-in-clang -std=c++17 \1 && '
+                                                r'%check-cxx-header-in-clang -std=c++20 \1')))

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -6,16 +6,19 @@ def get_target_os():
     (run_cpu, run_vendor, run_os, run_version) = re.match('([^-]+)-([^-]+)-([^0-9]+)(.*)', config.variant_triple).groups()
     return run_os
 
-libc_opt = ''
 clang_opt = ''
 
 if get_target_os() in ['windows-msvc']:
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
-    #libc_opt = '-libc MT '
+    # Clang should build object files with link settings equivalent to -libc MD
+    # when building for the MSVC target.
     clang_opt = '-D_MT -D_DLL -Xclang --dependent-lib=msvcrt -Xclang --dependent-lib=oldnames '
 else:
     # FIXME(compnerd) do all the targets we currently support use SysV ABI?
     config.substitutions.insert(0, ('%target-abi', 'SYSV'))
 
-config.substitutions.insert(0, ('%target-interop-build-swift', '%target-build-swift -Xfrontend -enable-cxx-interop ' + libc_opt))
+# Enable C++ interop when compiling Swift sources.
+config.substitutions.insert(0, ('%target-interop-build-swift',
+                                '%target-build-swift -Xfrontend -enable-cxx-interop '))
+# Build C++ files with matching link settings, if required by the target.
 config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx ' + clang_opt))


### PR DESCRIPTION
This ensures that we validate C++14, C++17, and C++20