### PR TITLE
sema: reject enum element call with payloads as compile-time constant

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1146,7 +1146,9 @@ bool NotCompileTimeConst::diagnose(const Solution &solution, bool asNote) const 
   // Referencing an enum element directly is considered a compile-time literal.
   if (auto *d = solution.resolveLocatorToDecl(locator).getDecl()) {
     if (isa<EnumElementDecl>(d)) {
-      return true;
+      if (!d->hasParameterList()) {
+        return true;
+      }
     }
   }
   NotCompileTimeConstFailure failure(solution, locator);

--- a/test/Sema/const_enum_elements.swift
+++ b/test/Sema/const_enum_elements.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 enum CarKind {
+	static let wagon = "Wagon"
 	case coupe
 	case sedan
 	case other(String)
@@ -21,7 +22,8 @@ func main() {
 	drive(.sedan, k2: .coupe)
 	drive(CarKind.coupe, k2: CarKind.sedan)
 	drive(CarKind.sedan, k2: CarKind.coupe)
-	drive(.other(""), k2: .sedan)
+	drive(.other(""), k2: .sedan) // expected-error {{expect a compile-time constant literal}}
+	drive(.other(CarKind.wagon), k2: .sedan) // expected-error {{expect a compile-time constant literal}}
 
 	drive(.myCoupe, k2: .sedan) // expected-error {{expect a compile-time constant literal}}
 	drive(.coupe, k2: .myCoupe) // expected-error {{expect a compile-time constant literal}}


### PR DESCRIPTION
rdar://90168664
