### PR TITLE
[stdlib] Fix nullability logic of `memcmp`

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -60,10 +60,11 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || defined(_WIN32)
-  extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
+// FIXME: Is there a way to identify Glibc specifically?
+#if defined(__gnu_linux__)
+  extern int memcmp(const void * _Nonnull, const void * _Nonnull, __swift_size_t);
 #else
-  extern int memcmp(const void *, const void *, __swift_size_t);
+  extern int memcmp(const void * _Null_unspecified, const void * _Null_unspecified, __swift_size_t);
 #endif
   return memcmp(s1, s2, n);
 }

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -60,7 +60,7 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__)
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || defined(_WIN32)
   extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
 #else
   extern int memcmp(const void *, const void *, __swift_size_t);


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix the nullability judging logic for `extern int memcmp` in `LibcShims.h`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Should resolve SR-15946.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
