### PR TITLE
[cxx-interop] use language-agnostic macros for Swift function prototypes in generated header

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -843,7 +843,7 @@ private:
     Mangle::ASTMangler mangler;
     FuncionSwiftABIInformation funcABI(FD, mangler);
 
-    os << "extern \"C\" ";
+    os << "SWIFT_EXTERN ";
     printFunctionDeclAsCFunctionDecl(FD, funcABI.getSymbolName(), resultTy);
     // Swift functions can't throw exceptions, we can only
     // throw them from C++ when emitting C++ inline thunks for the Swift

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -848,7 +848,7 @@ private:
     // Swift functions can't throw exceptions, we can only
     // throw them from C++ when emitting C++ inline thunks for the Swift
     // functions.
-    os << " noexcept";
+    os << " SWIFT_NOEXCEPT";
     if (!funcABI.useCCallingConvention())
       os << " SWIFT_CALL";
     printAvailability(FD);

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -272,6 +272,12 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
     out << "#endif\n";
   };
   emitMacro("SWIFT_CALL", "__attribute__((swiftcall))");
+  // SWIFT_NOEXCEPT applies 'noexcept' in C++ mode only.
+  out << "#if defined(__cplusplus)\n";
+  emitMacro("SWIFT_NOEXCEPT", "noexcept");
+  out << "#else\n";
+  emitMacro("SWIFT_NOEXCEPT", "");
+  out << "#endif\n";
   static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,
               "need to add SIMD typedefs here if max elements is increased");
 }

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -7,7 +7,7 @@
 // CHECK-LABEL: namespace CdeclFunctions {
 
 // CHECK: namespace _impl {
-// CHECK: extern "C" int cfuncPassTwo(int x, int y) SWIFT_NOEXCEPT;
+// CHECK: SWIFT_EXTERN int cfuncPassTwo(int x, int y) SWIFT_NOEXCEPT;
 // CHECK: }
 
 @_cdecl("cfuncPassTwo")

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -7,7 +7,7 @@
 // CHECK-LABEL: namespace CdeclFunctions {
 
 // CHECK: namespace _impl {
-// CHECK: extern "C" int cfuncPassTwo(int x, int y) noexcept;
+// CHECK: extern "C" int cfuncPassTwo(int x, int y) SWIFT_NOEXCEPT;
 // CHECK: }
 
 @_cdecl("cfuncPassTwo")

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -8,11 +8,11 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: extern "C" void $s9Functions16alwaysDeprecatedyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED; // alwaysDeprecated()
-// CHECK: extern "C" void $s9Functions19alwaysDeprecatedTwoyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED_MSG("it should not be used"); // alwaysDeprecatedTwo()
-// CHECK: extern "C" void $s9Functions17alwaysUnavailableyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE; // alwaysUnavailable()
-// CHECK: extern "C" void $s9Functions24alwaysUnavailableMessageyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE_MSG("stuff happened"); // alwaysUnavailableMessage()
-// CHECK: extern "C" void $s9Functions22singlePlatAvailabilityyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_AVAILABILITY(macos,introduced=11); // singlePlatAvailability()
+// CHECK: SWIFT_EXTERN void $s9Functions16alwaysDeprecatedyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED; // alwaysDeprecated()
+// CHECK: SWIFT_EXTERN void $s9Functions19alwaysDeprecatedTwoyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED_MSG("it should not be used"); // alwaysDeprecatedTwo()
+// CHECK: SWIFT_EXTERN void $s9Functions17alwaysUnavailableyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE; // alwaysUnavailable()
+// CHECK: SWIFT_EXTERN void $s9Functions24alwaysUnavailableMessageyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE_MSG("stuff happened"); // alwaysUnavailableMessage()
+// CHECK: SWIFT_EXTERN void $s9Functions22singlePlatAvailabilityyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_AVAILABILITY(macos,introduced=11); // singlePlatAvailability()
 
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -8,11 +8,11 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: extern "C" void $s9Functions16alwaysDeprecatedyyF(void) noexcept SWIFT_CALL SWIFT_DEPRECATED; // alwaysDeprecated()
-// CHECK: extern "C" void $s9Functions19alwaysDeprecatedTwoyyF(void) noexcept SWIFT_CALL SWIFT_DEPRECATED_MSG("it should not be used"); // alwaysDeprecatedTwo()
-// CHECK: extern "C" void $s9Functions17alwaysUnavailableyyF(void) noexcept SWIFT_CALL SWIFT_UNAVAILABLE; // alwaysUnavailable()
-// CHECK: extern "C" void $s9Functions24alwaysUnavailableMessageyyF(void) noexcept SWIFT_CALL SWIFT_UNAVAILABLE_MSG("stuff happened"); // alwaysUnavailableMessage()
-// CHECK: extern "C" void $s9Functions22singlePlatAvailabilityyyF(void) noexcept SWIFT_CALL SWIFT_AVAILABILITY(macos,introduced=11); // singlePlatAvailability()
+// CHECK: extern "C" void $s9Functions16alwaysDeprecatedyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED; // alwaysDeprecated()
+// CHECK: extern "C" void $s9Functions19alwaysDeprecatedTwoyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_DEPRECATED_MSG("it should not be used"); // alwaysDeprecatedTwo()
+// CHECK: extern "C" void $s9Functions17alwaysUnavailableyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE; // alwaysUnavailable()
+// CHECK: extern "C" void $s9Functions24alwaysUnavailableMessageyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_UNAVAILABLE_MSG("stuff happened"); // alwaysUnavailableMessage()
+// CHECK: extern "C" void $s9Functions22singlePlatAvailabilityyyF(void) SWIFT_NOEXCEPT SWIFT_CALL SWIFT_AVAILABILITY(macos,introduced=11); // singlePlatAvailability()
 
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-execution.cpp
@@ -14,6 +14,10 @@
 #include "functions.h"
 
 int main() {
+  static_assert(noexcept(Functions::passVoidReturnVoid()), "noexcept function");
+  static_assert(noexcept(Functions::_impl::$s9Functions014passVoidReturnC0yyF()),
+                "noexcept function");
+
   Functions::passVoidReturnVoid();
   Functions::passIntReturnVoid(-1);
   assert(Functions::passTwoIntReturnIntNoArgLabel(1, 2) == 42);

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -8,11 +8,11 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: extern "C" void $s9Functions17passIntReturnVoid1xys5Int32V_tF(int x) SWIFT_NOEXCEPT SWIFT_CALL; // passIntReturnVoid(x:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(int x, int y) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnInt(x:y:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(int, int) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabel(_:_:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(int x2, int y2) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabelParamName(_:_:)
-// CHECK: extern "C" void $s9Functions014passVoidReturnC0yyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // passVoidReturnVoid()
+// CHECK: SWIFT_EXTERN void $s9Functions17passIntReturnVoid1xys5Int32V_tF(int x) SWIFT_NOEXCEPT SWIFT_CALL; // passIntReturnVoid(x:)
+// CHECK: SWIFT_EXTERN int $s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(int x, int y) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnInt(x:y:)
+// CHECK: SWIFT_EXTERN int $s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(int, int) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabel(_:_:)
+// CHECK: SWIFT_EXTERN int $s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(int x2, int y2) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabelParamName(_:_:)
+// CHECK: SWIFT_EXTERN void $s9Functions014passVoidReturnC0yyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // passVoidReturnVoid()
 
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -8,11 +8,11 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: extern "C" void $s9Functions17passIntReturnVoid1xys5Int32V_tF(int x) noexcept SWIFT_CALL; // passIntReturnVoid(x:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(int x, int y) noexcept SWIFT_CALL; // passTwoIntReturnInt(x:y:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(int, int) noexcept SWIFT_CALL; // passTwoIntReturnIntNoArgLabel(_:_:)
-// CHECK: extern "C" int $s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(int x2, int y2) noexcept SWIFT_CALL; // passTwoIntReturnIntNoArgLabelParamName(_:_:)
-// CHECK: extern "C" void $s9Functions014passVoidReturnC0yyF(void) noexcept SWIFT_CALL; // passVoidReturnVoid()
+// CHECK: extern "C" void $s9Functions17passIntReturnVoid1xys5Int32V_tF(int x) SWIFT_NOEXCEPT SWIFT_CALL; // passIntReturnVoid(x:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(int x, int y) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnInt(x:y:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(int, int) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabel(_:_:)
+// CHECK: extern "C" int $s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(int x2, int y2) SWIFT_NOEXCEPT SWIFT_CALL; // passTwoIntReturnIntNoArgLabelParamName(_:_:)
+// CHECK: extern "C" void $s9Functions014passVoidReturnC0yyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // passVoidReturnVoid()
 
 // CHECK: }
 


### PR DESCRIPTION
This change is a step towards generating a unified header, usable from C/C++/ObjC++. This change will allow these functions to be used from C once the unified header is generated.

