### PR TITLE
RequirementMachine: Cleanups and fixes to make more validation-tests pass with inferred-signatures=verify

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4389,6 +4389,7 @@ class ProtocolDecl final : public NominalTypeDecl {
   friend class ProtocolDependenciesRequest;
   friend class RequirementSignatureRequest;
   friend class RequirementSignatureRequestRQM;
+  friend class RequirementSignatureRequestGSB;
   friend class ProtocolRequiresClassRequest;
   friend class ExistentialConformsToSelfRequest;
   friend class ExistentialRequiresAnyRequest;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -529,6 +529,29 @@ GenericSignature buildGenericSignature(
     SmallVector<GenericTypeParamType *, 2> addedParameters,
     SmallVector<Requirement, 2> addedRequirements);
 
+/// Summary of error conditions detected by the Requirement Machine.
+enum class GenericSignatureErrorFlags {
+  /// The original requirements referenced a non-existent type parameter.
+  HasUnresolvedType = (1<<0),
+
+  /// The original requirements were in conflict with each other, meaning
+  /// there are no possible concrete substitutions which statisfy the
+  /// generic signature.
+  HasConflict = (1<<1),
+
+  /// The Knuth-Bendix completion procedure failed to construct a confluent
+  /// rewrite system.
+  CompletionFailed = (1<<2)
+};
+
+using GenericSignatureErrors = OptionSet<GenericSignatureErrorFlags>;
+
+/// AbstractGenericSignatureRequest and InferredGenericSignatureRequest
+/// return this type, which stores a GenericSignature together with the
+/// above set of error flags.
+using GenericSignatureWithError = llvm::PointerIntPair<GenericSignature, 3,
+                                                       GenericSignatureErrors>;
+
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/AST/RequirementSignature.h
+++ b/include/swift/AST/RequirementSignature.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_REQUIREMENT_SIGNATURE_H
 #define SWIFT_AST_REQUIREMENT_SIGNATURE_H
 
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Type.h"
 
 namespace swift {
@@ -42,13 +43,16 @@ public:
 class RequirementSignature final {
   ArrayRef<Requirement> Requirements;
   ArrayRef<ProtocolTypeAlias> TypeAliases;
+  GenericSignatureErrors Errors;
 
 public:
-  RequirementSignature() = default;
+  RequirementSignature(GenericSignatureErrors errors = GenericSignatureErrors())
+    : Errors(errors) {}
 
   RequirementSignature(ArrayRef<Requirement> requirements,
-                       ArrayRef<ProtocolTypeAlias> typeAliases)
-    : Requirements(requirements), TypeAliases(typeAliases) {}
+                       ArrayRef<ProtocolTypeAlias> typeAliases,
+                       GenericSignatureErrors errors = GenericSignatureErrors())
+    : Requirements(requirements), TypeAliases(typeAliases), Errors(errors) {}
 
   /// The requirements including any inherited protocols and conformances for
   /// associated types that are introduced in this protocol.
@@ -64,6 +68,10 @@ public:
 
   ArrayRef<ProtocolTypeAlias> getTypeAliases() const {
     return TypeAliases;
+  }
+
+  GenericSignatureErrors getErrors() const {
+    return Errors;
   }
 };
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1747,12 +1747,6 @@ public:
 
 void simple_display(llvm::raw_ostream &out, AncestryFlags value);
 
-/// AbstractGenericSignatureRequest and InferredGenericSignatureRequest
-/// return this type, which stores a GenericSignature together with a bit
-/// indicating if there were any errors detected in the original
-/// requirements.
-using GenericSignatureWithError = llvm::PointerIntPair<GenericSignature, 1>;
-
 class AbstractGenericSignatureRequest :
     public SimpleRequest<AbstractGenericSignatureRequest,
                          GenericSignatureWithError (const GenericSignatureImpl *,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -493,6 +493,27 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Compute a protocol's requirement signature using the GenericSignatureBuilder.
+/// This is temporary; once the GenericSignatureBuilder goes away this will
+/// be removed.
+class RequirementSignatureRequestGSB :
+    public SimpleRequest<RequirementSignatureRequestGSB,
+                         RequirementSignature(ProtocolDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  RequirementSignature
+  evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Compute the requirements that describe a protocol.
 class RequirementSignatureRequest :
     public SimpleRequest<RequirementSignatureRequest,
@@ -1793,6 +1814,37 @@ public:
   }
 };
 
+/// Build a generic signature using the GenericSignatureBuilder. This is temporary;
+/// once the GenericSignatureBuilder goes away this will be removed.
+class AbstractGenericSignatureRequestGSB :
+    public SimpleRequest<AbstractGenericSignatureRequestGSB,
+                         GenericSignatureWithError (const GenericSignatureImpl *,
+                                                    SmallVector<GenericTypeParamType *, 2>,
+                                                    SmallVector<Requirement, 2>),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  GenericSignatureWithError
+  evaluate(Evaluator &evaluator,
+           const GenericSignatureImpl *baseSignature,
+           SmallVector<GenericTypeParamType *, 2> addedParameters,
+           SmallVector<Requirement, 2> addedRequirements) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+
+  /// Abstract generic signature requests never have source-location info.
+  SourceLoc getNearestLoc() const {
+    return SourceLoc();
+  }
+};
+
 class InferredGenericSignatureRequest :
     public SimpleRequest<InferredGenericSignatureRequest,
                          GenericSignatureWithError (ModuleDecl *,
@@ -1838,6 +1890,48 @@ public:
 /// InferredGenericSignatureRequest.
 class InferredGenericSignatureRequestRQM :
     public SimpleRequest<InferredGenericSignatureRequestRQM,
+                         GenericSignatureWithError (ModuleDecl *,
+                                                    const GenericSignatureImpl *,
+                                                    GenericParamList *,
+                                                    WhereClauseOwner,
+                                                    SmallVector<Requirement, 2>,
+                                                    SmallVector<TypeLoc, 2>,
+                                                    bool),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  GenericSignatureWithError
+  evaluate(Evaluator &evaluator,
+           ModuleDecl *parentModule,
+           const GenericSignatureImpl *baseSignature,
+           GenericParamList *genericParams,
+           WhereClauseOwner whereClause,
+           SmallVector<Requirement, 2> addedRequirements,
+           SmallVector<TypeLoc, 2> inferenceSources,
+           bool allowConcreteGenericParams) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+
+  /// Inferred generic signature requests don't have source-location info.
+  SourceLoc getNearestLoc() const {
+    return SourceLoc();
+  }
+
+  // Cycle handling.
+  void noteCycleStep(DiagnosticEngine &diags) const;
+};
+
+/// Build a generic signature using the GenericSignatureBuilder. This is temporary;
+/// once the GenericSignatureBuilder goes away this will be removed.
+class InferredGenericSignatureRequestGSB :
+    public SimpleRequest<InferredGenericSignatureRequestGSB,
                          GenericSignatureWithError (ModuleDecl *,
                                                     const GenericSignatureImpl *,
                                                     GenericParamList *,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -25,6 +25,11 @@ SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequestRQM,
                                          SmallVector<GenericTypeParamType *, 2>,
                                          SmallVector<Requirement, 2>),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequestGSB,
+              GenericSignatureWithError (const GenericSignatureImpl *,
+                                         SmallVector<GenericTypeParamType *, 2>,
+                                         SmallVector<Requirement, 2>),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ApplyAccessNoteRequest,
               evaluator::SideEffect(ValueDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedResultBuilderRequest,
@@ -192,6 +197,14 @@ SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequestRQM,
                                          SmallVector<Requirement, 2>,
                                          SmallVector<TypeLoc, 2>, bool),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequestGSB,
+              GenericSignatureWithError (ModuleDecl *,
+                                         const GenericSignatureImpl *,
+                                         GenericParamList *,
+                                         WhereClauseOwner,
+                                         SmallVector<Requirement, 2>,
+                                         SmallVector<TypeLoc, 2>, bool),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, DistributedModuleIsAvailableRequest,
               bool(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InheritedTypeRequest,
@@ -286,6 +299,9 @@ SWIFT_REQUEST(TypeChecker, ProtocolDependenciesRequest,
               ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
               HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, RequirementSignatureRequestRQM,
+              RequirementSignature(ProtocolDecl *), Cached,
+              NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RequirementSignatureRequestGSB,
               RequirementSignature(ProtocolDecl *), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest,

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -87,6 +87,7 @@ add_swift_host_library(swiftAST STATIC
   RequirementMachine/PropertyMap.cpp
   RequirementMachine/PropertyRelations.cpp
   RequirementMachine/PropertyUnification.cpp
+  RequirementMachine/RequirementBuilder.cpp
   RequirementMachine/RequirementLowering.cpp
   RequirementMachine/RequirementMachine.cpp
   RequirementMachine/RequirementMachineRequests.cpp

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8275,7 +8275,8 @@ AbstractGenericSignatureRequest::evaluate(
     if (!rqmResult.getPointer() && !gsbResult.getPointer())
       return rqmResult;
 
-    if (!rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
+    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
       opts.ProtocolQualifiedDependentMemberTypes = true;
 
@@ -8487,7 +8488,8 @@ InferredGenericSignatureRequest::evaluate(
     if (!rqmResult.getPointer() && !gsbResult.getPointer())
       return rqmResult;
 
-    if (!rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
+    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
       opts.ProtocolQualifiedDependentMemberTypes = true;
 
@@ -8689,7 +8691,9 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
-    if (!compare(rqmResult.getRequirements(), gsbResult.getRequirements())) {
+    if (!rqmResult.getErrors().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !compare(rqmResult.getRequirements(),
+                 gsbResult.getRequirements())) {
       PrintOptions opts;
       opts.ProtocolQualifiedDependentMemberTypes = true;
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8224,6 +8224,79 @@ GenericSignature GenericSignatureBuilder::computeGenericSignature(
   return sig;
 }
 
+GenericSignatureWithError
+AbstractGenericSignatureRequest::evaluate(
+         Evaluator &evaluator,
+         const GenericSignatureImpl *baseSignatureImpl,
+         SmallVector<GenericTypeParamType *, 2> addedParameters,
+         SmallVector<Requirement, 2> addedRequirements) const {
+  GenericSignature baseSignature = GenericSignature{baseSignatureImpl};
+  // If nothing is added to the base signature, just return the base
+  // signature.
+  if (addedParameters.empty() && addedRequirements.empty())
+    return GenericSignatureWithError(baseSignature, /*hadError=*/false);
+
+  ASTContext &ctx = addedParameters.empty()
+      ? addedRequirements.front().getFirstType()->getASTContext()
+      : addedParameters.front()->getASTContext();
+
+  auto buildViaGSB = [&]() {
+    return evaluateOrDefault(
+        ctx.evaluator,
+        AbstractGenericSignatureRequestGSB{
+          baseSignatureImpl,
+          std::move(addedParameters),
+          std::move(addedRequirements)},
+        GenericSignatureWithError());
+  };
+
+  auto buildViaRQM = [&]() {
+    return evaluateOrDefault(
+        ctx.evaluator,
+        AbstractGenericSignatureRequestRQM{
+          baseSignatureImpl,
+          std::move(addedParameters),
+          std::move(addedRequirements)},
+        GenericSignatureWithError());
+  };
+
+  switch (ctx.LangOpts.RequirementMachineAbstractSignatures) {
+  case RequirementMachineMode::Disabled:
+    return buildViaGSB();
+
+  case RequirementMachineMode::Enabled:
+    return buildViaRQM();
+
+  case RequirementMachineMode::Verify:
+  case RequirementMachineMode::Check: {
+    auto rqmResult = buildViaRQM();
+    auto gsbResult = buildViaGSB();
+
+    if (!rqmResult.getPointer() && !gsbResult.getPointer())
+      return rqmResult;
+
+    if (!rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
+      PrintOptions opts;
+      opts.ProtocolQualifiedDependentMemberTypes = true;
+
+      llvm::errs() << "RequirementMachine generic signature minimization is broken:\n";
+      llvm::errs() << "RequirementMachine says:      ";
+      rqmResult.getPointer()->print(llvm::errs(), opts);
+      llvm::errs() << "\n";
+      llvm::errs() << "GenericSignatureBuilder says: ";
+      gsbResult.getPointer()->print(llvm::errs(), opts);
+      llvm::errs() << "\n";
+
+      if (ctx.LangOpts.RequirementMachineAbstractSignatures
+          == RequirementMachineMode::Verify)
+        abort();
+    }
+
+    return rqmResult;
+  }
+  }
+}
+
 /// Check whether the inputs to the \c AbstractGenericSignatureRequest are
 /// all canonical.
 static bool isCanonicalRequest(GenericSignature baseSignature,
@@ -8246,7 +8319,7 @@ static bool isCanonicalRequest(GenericSignature baseSignature,
 }
 
 GenericSignatureWithError
-AbstractGenericSignatureRequest::evaluate(
+AbstractGenericSignatureRequestGSB::evaluate(
          Evaluator &evaluator,
          const GenericSignatureImpl *baseSignatureImpl,
          SmallVector<GenericTypeParamType *, 2> addedParameters,
@@ -8295,7 +8368,7 @@ AbstractGenericSignatureRequest::evaluate(
     // Build the canonical signature.
     auto canSignatureResult = evaluateOrDefault(
         ctx.evaluator,
-        AbstractGenericSignatureRequest{
+        AbstractGenericSignatureRequestGSB{
           canBaseSignature.getPointer(), std::move(canAddedParameters),
           std::move(canAddedRequirements)},
         GenericSignatureWithError());
@@ -8336,72 +8409,24 @@ AbstractGenericSignatureRequest::evaluate(
         canSignatureResult.getInt());
   }
 
-  auto buildViaGSB = [&]() {
-    // Create a generic signature that will form the signature.
-    GenericSignatureBuilder builder(ctx);
-    if (baseSignature)
-      builder.addGenericSignature(baseSignature);
+  // Create a generic signature that will form the signature.
+  GenericSignatureBuilder builder(ctx);
+  if (baseSignature)
+    builder.addGenericSignature(baseSignature);
 
-    auto source =
-      GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
+  auto source =
+    GenericSignatureBuilder::FloatingRequirementSource::forAbstract();
 
-    for (auto param : addedParameters)
-      builder.addGenericParameter(param);
+  for (auto param : addedParameters)
+    builder.addGenericParameter(param);
 
-    for (const auto &req : addedRequirements)
-      builder.addRequirement(req, source, nullptr);
+  for (const auto &req : addedRequirements)
+    builder.addRequirement(req, source, nullptr);
 
-    bool hadError = builder.hadAnyError();
-    auto result = std::move(builder).computeGenericSignature(
-        /*allowConcreteGenericParams=*/true);
-    return GenericSignatureWithError(result, hadError);
-  };
-
-  auto buildViaRQM = [&]() {
-    return evaluateOrDefault(
-        ctx.evaluator,
-        AbstractGenericSignatureRequestRQM{
-          baseSignature.getPointer(),
-          std::move(addedParameters),
-          std::move(addedRequirements)},
-        GenericSignatureWithError());
-  };
-
-  switch (ctx.LangOpts.RequirementMachineAbstractSignatures) {
-  case RequirementMachineMode::Disabled:
-    return buildViaGSB();
-
-  case RequirementMachineMode::Enabled:
-    return buildViaRQM();
-
-  case RequirementMachineMode::Verify:
-  case RequirementMachineMode::Check: {
-    auto rqmResult = buildViaRQM();
-    auto gsbResult = buildViaGSB();
-
-    if (!rqmResult.getPointer() && !gsbResult.getPointer())
-      return rqmResult;
-
-    if (!rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
-      PrintOptions opts;
-      opts.ProtocolQualifiedDependentMemberTypes = true;
-
-      llvm::errs() << "RequirementMachine generic signature minimization is broken:\n";
-      llvm::errs() << "RequirementMachine says:      ";
-      rqmResult.getPointer()->print(llvm::errs(), opts);
-      llvm::errs() << "\n";
-      llvm::errs() << "GenericSignatureBuilder says: ";
-      gsbResult.getPointer()->print(llvm::errs(), opts);
-      llvm::errs() << "\n";
-
-      if (ctx.LangOpts.RequirementMachineAbstractSignatures
-          == RequirementMachineMode::Verify)
-        abort();
-    }
-
-    return rqmResult;
-  }
-  }
+  bool hadError = builder.hadAnyError();
+  auto result = std::move(builder).computeGenericSignature(
+      /*allowConcreteGenericParams=*/true);
+  return GenericSignatureWithError(result, hadError);
 }
 
 GenericSignatureWithError
@@ -8414,124 +8439,22 @@ InferredGenericSignatureRequest::evaluate(
         SmallVector<Requirement, 2> addedRequirements,
         SmallVector<TypeLoc, 2> inferenceSources,
         bool allowConcreteGenericParams) const {
-  auto buildViaGSB = [&]() {
-    GenericSignatureBuilder builder(parentModule->getASTContext());
-        
-    // If there is a parent context, add the generic parameters and requirements
-    // from that context.
-    builder.addGenericSignature(parentSig);
-
-    DeclContext *lookupDC = nullptr;
-
-    const auto visitRequirement = [&](const Requirement &req,
-                                      RequirementRepr *reqRepr) {
-      const auto source = FloatingRequirementSource::forExplicit(
-        reqRepr->getSeparatorLoc());
-
-      // If we're extending a protocol and adding a redundant requirement,
-      // for example, `extension Foo where Self: Foo`, then emit a
-      // diagnostic.
-
-      if (auto decl = lookupDC->getAsDecl()) {
-        if (auto extDecl = dyn_cast<ExtensionDecl>(decl)) {
-          auto extType = extDecl->getDeclaredInterfaceType();
-          auto extSelfType = extDecl->getSelfInterfaceType();
-          auto reqLHSType = req.getFirstType();
-          auto reqRHSType = req.getSecondType();
-
-          if (extType->isExistentialType() &&
-              reqLHSType->isEqual(extSelfType) &&
-              reqRHSType->isEqual(extType)) {
-
-            auto &ctx = extDecl->getASTContext();
-            ctx.Diags.diagnose(extDecl->getLoc(),
-                               diag::protocol_extension_redundant_requirement,
-                               extType->getString(),
-                               extSelfType->getString(),
-                               reqRHSType->getString());
-          }
-        }
-      }
-
-      builder.addRequirement(req, reqRepr, source,
-                             lookupDC->getParentModule());
-      return false;
-    };
-
-    if (genericParams) {
-      // Extensions never have a parent signature.
-      if (genericParams->getOuterParameters())
-        assert(parentSig == nullptr);
-
-      // Type check the generic parameters, treating all generic type
-      // parameters as dependent, unresolved.
-      SmallVector<GenericParamList *, 2> gpLists;
-      for (auto *outerParams = genericParams;
-           outerParams != nullptr;
-           outerParams = outerParams->getOuterParameters()) {
-        gpLists.push_back(outerParams);
-      }
-
-      // The generic parameter lists MUST appear from innermost to outermost.
-      // We walk them backwards to order outer requirements before
-      // inner requirements.
-      for (auto &genericParams : llvm::reverse(gpLists)) {
-        assert(genericParams->size() > 0 &&
-               "Parsed an empty generic parameter list?");
-
-        // First, add the generic parameters to the generic signature builder.
-        // Do this before checking the inheritance clause, since it may
-        // itself be dependent on one of these parameters.
-        for (const auto param : *genericParams)
-          builder.addGenericParameter(param);
-
-        // Add the requirements for each of the generic parameters to the builder.
-        // Now, check the inheritance clauses of each parameter.
-        for (const auto param : *genericParams)
-          builder.addGenericParameterRequirements(param);
-
-        // Determine where and how to perform name lookup.
-        lookupDC = genericParams->begin()[0]->getDeclContext();
-
-        // Add the requirements clause to the builder.
-        WhereClauseOwner(lookupDC, genericParams)
-          .visitRequirements(TypeResolutionStage::Structural,
-                             visitRequirement);
-      }
-    }
-
-    if (whereClause) {
-      lookupDC = whereClause.dc;
-      std::move(whereClause).visitRequirements(
-          TypeResolutionStage::Structural, visitRequirement);
-    }
-        
-    /// Perform any remaining requirement inference.
-    for (auto sourcePair : inferenceSources) {
-      auto *typeRepr = sourcePair.getTypeRepr();
-      auto source =
-        FloatingRequirementSource::forInferred(
-          typeRepr ? typeRepr->getStartLoc() : SourceLoc());
-
-      builder.inferRequirements(*parentModule,
-                                sourcePair.getType(),
-                                source);
-    }
-    
-    // Finish by adding any remaining requirements.
-    auto source =
-      FloatingRequirementSource::forInferred(SourceLoc());
-        
-    for (const auto &req : addedRequirements)
-      builder.addRequirement(req, source, parentModule);
-
-    bool hadError = builder.hadAnyError();
-    auto result = std::move(builder).computeGenericSignature(
-        allowConcreteGenericParams);
-    return GenericSignatureWithError(result, hadError);
-  };
 
   auto &ctx = parentModule->getASTContext();
+
+  auto buildViaGSB = [&]() {
+    return evaluateOrDefault(
+        ctx.evaluator,
+        InferredGenericSignatureRequestGSB{
+          parentModule,
+          parentSig,
+          genericParams,
+          whereClause,
+          addedRequirements,
+          inferenceSources,
+          allowConcreteGenericParams},
+        GenericSignatureWithError());
+  };
 
   auto buildViaRQM = [&]() {
     return evaluateOrDefault(
@@ -8584,55 +8507,142 @@ InferredGenericSignatureRequest::evaluate(
   }
 }
 
+GenericSignatureWithError
+InferredGenericSignatureRequestGSB::evaluate(
+        Evaluator &evaluator,
+        ModuleDecl *parentModule,
+        const GenericSignatureImpl *parentSig,
+        GenericParamList *genericParams,
+        WhereClauseOwner whereClause,
+        SmallVector<Requirement, 2> addedRequirements,
+        SmallVector<TypeLoc, 2> inferenceSources,
+        bool allowConcreteGenericParams) const {
+  GenericSignatureBuilder builder(parentModule->getASTContext());
+      
+  // If there is a parent context, add the generic parameters and requirements
+  // from that context.
+  builder.addGenericSignature(parentSig);
+
+  DeclContext *lookupDC = nullptr;
+
+  const auto visitRequirement = [&](const Requirement &req,
+                                    RequirementRepr *reqRepr) {
+    const auto source = FloatingRequirementSource::forExplicit(
+      reqRepr->getSeparatorLoc());
+
+    // If we're extending a protocol and adding a redundant requirement,
+    // for example, `extension Foo where Self: Foo`, then emit a
+    // diagnostic.
+
+    if (auto decl = lookupDC->getAsDecl()) {
+      if (auto extDecl = dyn_cast<ExtensionDecl>(decl)) {
+        auto extType = extDecl->getDeclaredInterfaceType();
+        auto extSelfType = extDecl->getSelfInterfaceType();
+        auto reqLHSType = req.getFirstType();
+        auto reqRHSType = req.getSecondType();
+
+        if (extType->isExistentialType() &&
+            reqLHSType->isEqual(extSelfType) &&
+            reqRHSType->isEqual(extType)) {
+
+          auto &ctx = extDecl->getASTContext();
+          ctx.Diags.diagnose(extDecl->getLoc(),
+                             diag::protocol_extension_redundant_requirement,
+                             extType->getString(),
+                             extSelfType->getString(),
+                             reqRHSType->getString());
+        }
+      }
+    }
+
+    builder.addRequirement(req, reqRepr, source,
+                           lookupDC->getParentModule());
+    return false;
+  };
+
+  if (genericParams) {
+    // Extensions never have a parent signature.
+    if (genericParams->getOuterParameters())
+      assert(parentSig == nullptr);
+
+    // Type check the generic parameters, treating all generic type
+    // parameters as dependent, unresolved.
+    SmallVector<GenericParamList *, 2> gpLists;
+    for (auto *outerParams = genericParams;
+         outerParams != nullptr;
+         outerParams = outerParams->getOuterParameters()) {
+      gpLists.push_back(outerParams);
+    }
+
+    // The generic parameter lists MUST appear from innermost to outermost.
+    // We walk them backwards to order outer requirements before
+    // inner requirements.
+    for (auto &genericParams : llvm::reverse(gpLists)) {
+      assert(genericParams->size() > 0 &&
+             "Parsed an empty generic parameter list?");
+
+      // First, add the generic parameters to the generic signature builder.
+      // Do this before checking the inheritance clause, since it may
+      // itself be dependent on one of these parameters.
+      for (const auto param : *genericParams)
+        builder.addGenericParameter(param);
+
+      // Add the requirements for each of the generic parameters to the builder.
+      // Now, check the inheritance clauses of each parameter.
+      for (const auto param : *genericParams)
+        builder.addGenericParameterRequirements(param);
+
+      // Determine where and how to perform name lookup.
+      lookupDC = genericParams->begin()[0]->getDeclContext();
+
+      // Add the requirements clause to the builder.
+      WhereClauseOwner(lookupDC, genericParams)
+        .visitRequirements(TypeResolutionStage::Structural,
+                           visitRequirement);
+    }
+  }
+
+  if (whereClause) {
+    lookupDC = whereClause.dc;
+    std::move(whereClause).visitRequirements(
+        TypeResolutionStage::Structural, visitRequirement);
+  }
+      
+  /// Perform any remaining requirement inference.
+  for (auto sourcePair : inferenceSources) {
+    auto *typeRepr = sourcePair.getTypeRepr();
+    auto source =
+      FloatingRequirementSource::forInferred(
+        typeRepr ? typeRepr->getStartLoc() : SourceLoc());
+
+    builder.inferRequirements(*parentModule,
+                              sourcePair.getType(),
+                              source);
+  }
+  
+  // Finish by adding any remaining requirements.
+  auto source =
+    FloatingRequirementSource::forInferred(SourceLoc());
+      
+  for (const auto &req : addedRequirements)
+    builder.addRequirement(req, source, parentModule);
+
+  bool hadError = builder.hadAnyError();
+  auto result = std::move(builder).computeGenericSignature(
+      allowConcreteGenericParams);
+  return GenericSignatureWithError(result, hadError);
+}
+
 RequirementSignature
 RequirementSignatureRequest::evaluate(Evaluator &evaluator,
                                       ProtocolDecl *proto) const {
   ASTContext &ctx = proto->getASTContext();
 
-  // First check if we have a deserializable requirement signature.
-  if (proto->hasLazyRequirementSignature()) {
-    ++NumLazyRequirementSignaturesLoaded;
-    // FIXME: (transitional) increment the redundant "always-on" counter.
-    if (ctx.Stats)
-      ++ctx.Stats->getFrontendCounters().NumLazyRequirementSignaturesLoaded;
-
-    auto contextData = static_cast<LazyProtocolData *>(
-        ctx.getOrCreateLazyContextData(proto, nullptr));
-
-    SmallVector<Requirement, 2> requirements;
-    SmallVector<ProtocolTypeAlias, 2> typeAliases;
-    contextData->loader->loadRequirementSignature(
-        proto, contextData->requirementSignatureData,
-        requirements, typeAliases);
-    return RequirementSignature(ctx.AllocateCopy(requirements),
-                                ctx.AllocateCopy(typeAliases));
-  }
-
   auto buildViaGSB = [&]() {
-    GenericSignatureBuilder builder(proto->getASTContext(),
-                                    /*requirementSignature=*/true);
-
-    // Add all of the generic parameters.
-    for (auto gp : *proto->getGenericParams())
-      builder.addGenericParameter(gp);
-
-    // Add the conformance of 'self' to the protocol.
-    auto selfType =
-      proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
-    auto requirement =
-      Requirement(RequirementKind::Conformance, selfType,
-                  proto->getDeclaredInterfaceType());
-
-    builder.addRequirement(
-            requirement,
-            GenericSignatureBuilder::RequirementSource::forRequirementSignature(
-                                                        builder, selfType, proto),
-            nullptr);
-
-    auto reqSignature = std::move(builder).computeGenericSignature(
-                          /*allowConcreteGenericParams=*/false,
-                          /*requirementSignatureSelfProto=*/proto);
-    return RequirementSignature(reqSignature.getRequirements(), None);
+    return evaluateOrDefault(
+        ctx.evaluator,
+        RequirementSignatureRequestGSB{const_cast<ProtocolDecl *>(proto)},
+        RequirementSignature());
   };
 
   auto buildViaRQM = [&]() {
@@ -8704,4 +8714,54 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     return rqmResult;
   }
   }
+}
+
+RequirementSignature
+RequirementSignatureRequestGSB::evaluate(Evaluator &evaluator,
+                                         ProtocolDecl *proto) const {
+  ASTContext &ctx = proto->getASTContext();
+
+  // First check if we have a deserializable requirement signature.
+  if (proto->hasLazyRequirementSignature()) {
+    ++NumLazyRequirementSignaturesLoaded;
+    // FIXME: (transitional) increment the redundant "always-on" counter.
+    if (ctx.Stats)
+      ++ctx.Stats->getFrontendCounters().NumLazyRequirementSignaturesLoaded;
+
+    auto contextData = static_cast<LazyProtocolData *>(
+        ctx.getOrCreateLazyContextData(proto, nullptr));
+
+    SmallVector<Requirement, 2> requirements;
+    SmallVector<ProtocolTypeAlias, 2> typeAliases;
+    contextData->loader->loadRequirementSignature(
+        proto, contextData->requirementSignatureData,
+        requirements, typeAliases);
+    return RequirementSignature(ctx.AllocateCopy(requirements),
+                                ctx.AllocateCopy(typeAliases));
+  }
+
+  GenericSignatureBuilder builder(proto->getASTContext(),
+                                  /*requirementSignature=*/true);
+
+  // Add all of the generic parameters.
+  for (auto gp : *proto->getGenericParams())
+    builder.addGenericParameter(gp);
+
+  // Add the conformance of 'self' to the protocol.
+  auto selfType =
+    proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
+  auto requirement =
+    Requirement(RequirementKind::Conformance, selfType,
+                proto->getDeclaredInterfaceType());
+
+  builder.addRequirement(
+          requirement,
+          GenericSignatureBuilder::RequirementSource::forRequirementSignature(
+                                                      builder, selfType, proto),
+          nullptr);
+
+  auto reqSignature = std::move(builder).computeGenericSignature(
+                        /*allowConcreteGenericParams=*/false,
+                        /*requirementSignatureSelfProto=*/proto);
+  return RequirementSignature(reqSignature.getRequirements(), None);
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8276,6 +8276,7 @@ AbstractGenericSignatureRequest::evaluate(
       return rqmResult;
 
     if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !rqmResult.getInt().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
       opts.ProtocolQualifiedDependentMemberTypes = true;
@@ -8489,6 +8490,7 @@ InferredGenericSignatureRequest::evaluate(
       return rqmResult;
 
     if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !rqmResult.getInt().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
       opts.ProtocolQualifiedDependentMemberTypes = true;
@@ -8692,6 +8694,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     auto gsbResult = buildViaGSB();
 
     if (!rqmResult.getErrors().contains(GenericSignatureErrorFlags::HasConflict) &&
+        !rqmResult.getErrors().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !compare(rqmResult.getRequirements(),
                  gsbResult.getRequirements())) {
       PrintOptions opts;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8234,7 +8234,7 @@ AbstractGenericSignatureRequest::evaluate(
   // If nothing is added to the base signature, just return the base
   // signature.
   if (addedParameters.empty() && addedRequirements.empty())
-    return GenericSignatureWithError(baseSignature, /*hadError=*/false);
+    return GenericSignatureWithError(baseSignature, GenericSignatureErrors());
 
   ASTContext &ctx = addedParameters.empty()
       ? addedRequirements.front().getFirstType()->getASTContext()
@@ -8328,7 +8328,7 @@ AbstractGenericSignatureRequestGSB::evaluate(
   // If nothing is added to the base signature, just return the base
   // signature.
   if (addedParameters.empty() && addedRequirements.empty())
-    return GenericSignatureWithError(baseSignature, /*hadError=*/false);
+    return GenericSignatureWithError(baseSignature, GenericSignatureErrors());
 
   ASTContext &ctx = addedParameters.empty()
       ? addedRequirements.front().getFirstType()->getASTContext()
@@ -8343,7 +8343,7 @@ AbstractGenericSignatureRequestGSB::evaluate(
 
     auto result = GenericSignature::get(addedParameters,
                                         baseSignature.getRequirements());
-    return GenericSignatureWithError(result, /*hadError=*/false);
+    return GenericSignatureWithError(result, GenericSignatureErrors());
   }
 
   // If the request is non-canonical, we won't need to build our own
@@ -8423,10 +8423,12 @@ AbstractGenericSignatureRequestGSB::evaluate(
   for (const auto &req : addedRequirements)
     builder.addRequirement(req, source, nullptr);
 
-  bool hadError = builder.hadAnyError();
+  GenericSignatureErrors errorFlags;
+  if (builder.hadAnyError())
+    errorFlags |= GenericSignatureErrorFlags::HasUnresolvedType;
   auto result = std::move(builder).computeGenericSignature(
       /*allowConcreteGenericParams=*/true);
-  return GenericSignatureWithError(result, hadError);
+  return GenericSignatureWithError(result, errorFlags);
 }
 
 GenericSignatureWithError
@@ -8627,10 +8629,12 @@ InferredGenericSignatureRequestGSB::evaluate(
   for (const auto &req : addedRequirements)
     builder.addRequirement(req, source, parentModule);
 
-  bool hadError = builder.hadAnyError();
+  GenericSignatureErrors errorFlags;
+  if (builder.hadAnyError())
+    errorFlags |= GenericSignatureErrorFlags::HasUnresolvedType;
   auto result = std::move(builder).computeGenericSignature(
       allowConcreteGenericParams);
-  return GenericSignatureWithError(result, hadError);
+  return GenericSignatureWithError(result, errorFlags);
 }
 
 RequirementSignature

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -152,17 +152,8 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       // There is no relation between P and C here.
       //
       // With concrete types, a missing conformance is a conflict.
-      if (requirementKind == RequirementKind::SameType) {
-        // FIXME: Diagnose conflict
-        auto &concreteRule = System.getRule(concreteRuleID);
-        if (concreteRule.getRHS().size() == key.size())
-          concreteRule.markConflicting();
-
-        auto &conformanceRule = System.getRule(conformanceRuleID);
-        if (!conformanceRule.isIdentityConformanceRule() &&
-            conformanceRule.getRHS().size() == key.size())
-          conformanceRule.markConflicting();
-      }
+      if (requirementKind == RequirementKind::SameType)
+        System.recordConflict(conformanceRuleID, concreteRuleID);
 
       if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "^^ " << concreteType << " does not conform to "

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -83,8 +83,7 @@ void RewriteLoop::recompute(const RewriteSystem &system) {
       Useful |= (!step.isInContext() && !evaluator.isInContext());
 
       const auto &rule = system.getRule(step.getRuleID());
-      if (rule.isProtocolTypeAliasRule() &&
-          rule.getLHS().size() == 3)
+      if (rule.isDerivedFromConcreteProtocolTypeAliasRule())
         HasConcreteTypeAliasRule = 1;
 
       break;

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -228,7 +228,6 @@ void PropertyMap::recordSuperclassRelation(Term key,
 void PropertyMap::addSuperclassProperty(
     Term key, Symbol property, unsigned ruleID) {
   auto *props = getOrCreateProperties(key);
-  auto &newRule = System.getRule(ruleID);
   bool debug = Debug.contains(DebugFlags::ConcreteUnification);
 
   const auto *superclassDecl = property.getConcreteType()
@@ -345,8 +344,9 @@ void PropertyMap::addSuperclassProperty(
                    << props->SuperclassDecl->getName() << "\n";
     }
 
-    // FIXME: Record the conflict better
-    newRule.markConflicting();
+    auto &req = props->Superclasses[props->SuperclassDecl];
+    for (const auto &pair : req.SuperclassRules)
+      System.recordConflict(pair.second, ruleID);
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -1,0 +1,360 @@
+//===--- RequirementBuilder.cpp - Building requirements from rules --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the final step in generic signature minimization,
+// building requirements from a set of minimal, canonical rewrite rules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "RequirementMachine.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/Requirement.h"
+#include "swift/AST/RequirementSignature.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include <vector>
+
+using namespace swift;
+using namespace rewriting;
+
+namespace {
+
+/// Represents a set of types related by same-type requirements, and an
+/// optional concrete type requirement.
+struct ConnectedComponent {
+  llvm::SmallVector<Type, 2> Members;
+  llvm::SmallVector<Identifier, 1> Aliases;
+  Type ConcreteType;
+
+  void buildRequirements(Type subjectType,
+                         std::vector<Requirement> &reqs,
+                         std::vector<ProtocolTypeAlias> &aliases);
+};
+
+/// Case 1: A set of rewrite rules of the form:
+///
+///   B => A
+///   C => A
+///   D => A
+///
+/// Become a series of same-type requirements
+///
+///   A == B, B == C, C == D
+///
+/// Case 2: A set of rewrite rules of the form:
+///
+///   A.[concrete: X] => A
+///   B => A
+///   C => A
+///   D => A
+///
+/// Become a series of same-type requirements
+///
+///   A == X, B == X, C == X, D == X
+void ConnectedComponent::buildRequirements(Type subjectType,
+                                           std::vector<Requirement> &reqs,
+                                           std::vector<ProtocolTypeAlias> &aliases) {
+  std::sort(Members.begin(), Members.end(),
+            [](Type first, Type second) -> bool {
+              return compareDependentTypes(first, second) < 0;
+            });
+
+  if (!ConcreteType) {
+    for (auto name : Aliases) {
+      aliases.emplace_back(name, subjectType);
+    }
+
+    for (auto constraintType : Members) {
+      reqs.emplace_back(RequirementKind::SameType,
+                        subjectType, constraintType);
+      subjectType = constraintType;
+    }
+
+  // For compatibility with the old GenericSignatureBuilder, drop requirements
+  // containing ErrorTypes.
+  } else if (!ConcreteType->hasError()) {
+    // If there are multiple protocol typealiases in the connected component,
+    // lower them all to a series of identical concrete-type aliases.
+    for (auto name : Aliases) {
+      aliases.emplace_back(name, ConcreteType);
+    }
+
+    // If the most canonical representative in the connected component is an
+    // unresolved DependentMemberType, it must be of the form 'Self.A'
+    // where 'A' is an alias. Emit the concrete-type alias itself.
+    if (auto *memberTy = subjectType->getAs<DependentMemberType>()) {
+      if (memberTy->getAssocType() == nullptr) {
+        auto *paramTy = memberTy->getBase()->castTo<GenericTypeParamType>();
+        assert(paramTy->getDepth() == 0 && paramTy->getIndex() == 0);
+        (void) paramTy;
+
+        aliases.emplace_back(memberTy->getName(), ConcreteType);
+
+        assert(Members.empty());
+        return;
+      }
+    }
+
+    // Otherwise, the most canonical representative must be a resolved
+    // associated type. Emit a requirement.
+    reqs.emplace_back(RequirementKind::SameType,
+                      subjectType, ConcreteType);
+
+    // Finally, emit a concrete type requirement for all resolved type members
+    // of the connected component.
+    for (auto constraintType : Members) {
+      reqs.emplace_back(RequirementKind::SameType,
+                        constraintType, ConcreteType);
+    }
+  }
+}
+
+/// Once we're done with minimization, we turn the minimal rules into requirements.
+/// This is in a sense the inverse of RuleBuilder in RequirementLowering.cpp.
+class RequirementBuilder {
+  // Input parameters.
+  const RewriteSystem &System;
+  const PropertyMap &Map;
+  TypeArrayView<GenericTypeParamType> GenericParams;
+  bool Debug;
+
+  // Temporary state populated by addRequirementRules() and
+  // addTypeAliasRules().
+  llvm::SmallDenseMap<TypeBase *, ConnectedComponent> Components;
+
+public:
+  // Results.
+  std::vector<Requirement> Reqs;
+  std::vector<ProtocolTypeAlias> Aliases;
+
+  RequirementBuilder(const RewriteSystem &system, const PropertyMap &map,
+                     TypeArrayView<GenericTypeParamType> genericParams)
+    : System(system), Map(map), GenericParams(genericParams),
+      Debug(System.getDebugOptions().contains(DebugFlags::Minimization)) {}
+
+  void addRequirementRules(ArrayRef<unsigned> rules);
+  void addTypeAliasRules(ArrayRef<unsigned> rules);
+
+  void processConnectedComponents();
+
+  void sortRequirements();
+  void sortTypeAliases();
+};
+
+}  // end namespace
+
+void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
+  // Convert a rewrite rule into a requirement.
+  auto createRequirementFromRule = [&](const Rule &rule) {
+    if (auto prop = rule.isPropertyRule()) {
+      auto subjectType = Map.getTypeForTerm(rule.getRHS(), GenericParams);
+
+      switch (prop->getKind()) {
+      case Symbol::Kind::Protocol:
+        Reqs.emplace_back(RequirementKind::Conformance,
+                          subjectType,
+                          prop->getProtocol()->getDeclaredInterfaceType());
+        return;
+
+      case Symbol::Kind::Layout:
+        Reqs.emplace_back(RequirementKind::Layout,
+                          subjectType,
+                          prop->getLayoutConstraint());
+        return;
+
+      case Symbol::Kind::Superclass: {
+        // Requirements containing unresolved name symbols originate from
+        // invalid code and should not appear in the generic signature.
+        for (auto term : prop->getSubstitutions()) {
+          if (term.containsUnresolvedSymbols())
+            return;
+        }
+
+        // Requirements containing error types originate from invalid code
+        // and should not appear in the generic signature.
+        if (prop->getConcreteType()->hasError())
+          return;
+
+        auto superclassType = Map.getTypeFromSubstitutionSchema(
+                                prop->getConcreteType(),
+                                prop->getSubstitutions(),
+                                GenericParams, MutableTerm());
+
+        Reqs.emplace_back(RequirementKind::Superclass,
+                          subjectType, superclassType);
+        return;
+      }
+
+      case Symbol::Kind::ConcreteType: {
+        // Requirements containing unresolved name symbols originate from
+        // invalid code and should not appear in the generic signature.
+        for (auto term : prop->getSubstitutions()) {
+          if (term.containsUnresolvedSymbols())
+            return;
+        }
+
+        // Requirements containing error types originate from invalid code
+        // and should not appear in the generic signature.
+        if (prop->getConcreteType()->hasError())
+          return;
+
+        auto concreteType = Map.getTypeFromSubstitutionSchema(
+                                prop->getConcreteType(),
+                                prop->getSubstitutions(),
+                                GenericParams, MutableTerm());
+
+        auto &component = Components[subjectType.getPointer()];
+        assert(!component.ConcreteType);
+        component.ConcreteType = concreteType;
+        return;
+      }
+
+      case Symbol::Kind::ConcreteConformance:
+        // "Concrete conformance requirements" are not recorded in the generic
+        // signature.
+        return;
+
+      case Symbol::Kind::Name:
+      case Symbol::Kind::AssociatedType:
+      case Symbol::Kind::GenericParam:
+        break;
+      }
+
+      llvm_unreachable("Invalid symbol kind");
+    }
+
+    assert(rule.getLHS().back().getKind() != Symbol::Kind::Protocol);
+    auto constraintType = Map.getTypeForTerm(rule.getLHS(), GenericParams);
+    auto subjectType = Map.getTypeForTerm(rule.getRHS(), GenericParams);
+
+    Components[subjectType.getPointer()].Members.push_back(constraintType);
+  };
+
+  if (Debug) {
+    llvm::dbgs() << "\nMinimized rules:\n";
+  }
+
+  // Build the list of requirements, storing same-type requirements off
+  // to the side.
+  for (unsigned ruleID : rules) {
+    const auto &rule = System.getRule(ruleID);
+
+    if (Debug) {
+      llvm::dbgs() << "- " << rule << "\n";
+    }
+
+    createRequirementFromRule(rule);
+  }
+}
+
+void RequirementBuilder::addTypeAliasRules(ArrayRef<unsigned> rules) {
+  for (unsigned ruleID : rules) {
+    const auto &rule = System.getRule(ruleID);
+    auto name = *rule.isProtocolTypeAliasRule();
+    Type underlyingType;
+
+    auto subjectType = Map.getTypeForTerm(rule.getRHS(), GenericParams);
+
+    if (auto prop = rule.isPropertyRule()) {
+      assert(prop->getKind() == Symbol::Kind::ConcreteType);
+
+      // Requirements containing unresolved name symbols originate from
+      // invalid code and should not appear in the generic signature.
+      for (auto term : prop->getSubstitutions()) {
+        if (term.containsUnresolvedSymbols())
+          continue;
+      }
+
+      // Requirements containing error types originate from invalid code
+      // and should not appear in the generic signature.
+      if (prop->getConcreteType()->hasError())
+        continue;
+
+      auto concreteType = Map.getTypeFromSubstitutionSchema(
+                               prop->getConcreteType(),
+                               prop->getSubstitutions(),
+                               GenericParams, MutableTerm());
+      auto &component = Components[subjectType.getPointer()];
+      assert(!component.ConcreteType);
+      Components[subjectType.getPointer()].ConcreteType = concreteType;
+    } else {
+      Components[subjectType.getPointer()].Aliases.push_back(name);
+    }
+  }
+}
+
+void RequirementBuilder::processConnectedComponents() {
+  // Now, convert each connected component into a series of same-type
+  // requirements.
+  for (auto &pair : Components) {
+    pair.second.buildRequirements(pair.first, Reqs, Aliases);
+  }
+}
+
+void RequirementBuilder::sortRequirements() {
+  llvm::array_pod_sort(Reqs.begin(), Reqs.end(),
+                       [](const Requirement *lhs, const Requirement *rhs) -> int {
+                         return lhs->compare(*rhs);
+                       });
+
+  if (Debug) {
+    llvm::dbgs() << "Requirements:\n";
+    for (const auto &req : Reqs) {
+      req.dump(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
+  }
+}
+
+void RequirementBuilder::sortTypeAliases() {
+  llvm::array_pod_sort(Aliases.begin(), Aliases.end(),
+                       [](const ProtocolTypeAlias *lhs,
+                          const ProtocolTypeAlias *rhs) -> int {
+                         return lhs->getName().compare(rhs->getName());
+                       });
+
+  if (Debug) {
+    llvm::dbgs() << "\nMinimized type aliases:\n";
+    for (const auto &alias : Aliases) {
+      PrintOptions opts;
+      opts.ProtocolQualifiedDependentMemberTypes = true;
+
+      llvm::dbgs() << "- " << alias.getName() << " == ";
+      alias.getUnderlyingType().print(llvm::dbgs(), opts);
+      llvm::dbgs() << "\n";
+    }
+  }
+}
+
+/// Convert a list of non-permanent, non-redundant rewrite rules into a list of
+/// requirements sorted in canonical order. The \p genericParams are used to
+/// produce sugared types.
+void
+RequirementMachine::buildRequirementsFromRules(
+    ArrayRef<unsigned> requirementRules,
+    ArrayRef<unsigned> typeAliasRules,
+    TypeArrayView<GenericTypeParamType> genericParams,
+    std::vector<Requirement> &reqs,
+    std::vector<ProtocolTypeAlias> &aliases) const {
+  RequirementBuilder builder(System, Map, genericParams);
+
+  builder.addRequirementRules(requirementRules);
+  builder.addTypeAliasRules(typeAliasRules);
+  builder.processConnectedComponents();
+  builder.sortRequirements();
+  builder.sortTypeAliases();
+
+  reqs = std::move(builder.Reqs);
+  aliases = std::move(builder.Aliases);
+}

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -105,9 +105,6 @@ static void desugarSameTypeRequirement(Type lhs, Type rhs, SourceLoc loc,
     }
   } matcher(loc, result, errors);
 
-  if (lhs->hasError() || rhs->hasError())
-    return;
-
   (void) matcher.match(lhs, rhs);
 
   // If neither side is directly a type parameter, the type parameter

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -504,9 +504,37 @@ void swift::rewriting::realizeInheritedRequirements(
     Type inheritedType
       = evaluateOrDefault(ctx.evaluator,
                           InheritedTypeRequest{decl, index,
-                            TypeResolutionStage::Structural},
+                          TypeResolutionStage::Structural},
                           Type());
     if (!inheritedType) continue;
+
+    // The GenericSignatureBuilder allowed an associated type's inheritance
+    // clause to reference a protocol typealias whose underlying type was a
+    // protocol or class.
+    //
+    // Since protocol typealiases resolve to DependentMemberTypes in
+    // ::Structural mode, this relied on the GSB's "delayed requirements"
+    // mechanism.
+    //
+    // The RequirementMachine does not have an equivalent, and cannot really
+    // support that because we need to collect the protocols mentioned on
+    // the right hand sides of conformance requirements ahead of time.
+    //
+    // However, we can support it in simple cases where the typealias is
+    // defined in the protocol itself and is accessed as a member of 'Self'.
+    if (auto *assocTypeDecl = dyn_cast<AssociatedTypeDecl>(decl)) {
+      if (auto memberType = inheritedType->getAs<DependentMemberType>()) {
+        if (memberType->getBase()->isEqual(
+            assocTypeDecl->getProtocol()->getSelfInterfaceType())) {
+          inheritedType
+            = evaluateOrDefault(ctx.evaluator,
+                                InheritedTypeRequest{decl, index,
+                                TypeResolutionStage::Interface},
+                                Type());
+          if (!inheritedType) continue;
+        }
+      }
+    }
 
     auto *typeRepr = inheritedTypes[index].getTypeRepr();
     SourceLoc loc = (typeRepr ? typeRepr->getStartLoc() : SourceLoc());

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -294,10 +294,9 @@ bool RequirementMachine::isComplete() const {
   return Complete;
 }
 
-bool RequirementMachine::hadError() const {
-  // FIXME: Implement other checks here
-  // FIXME: Assert if hadError() is true but we didn't emit any diagnostics?
-  return System.hadError();
+GenericSignatureErrors RequirementMachine::getErrors() const {
+  // FIXME: Assert if we had errors but we didn't emit any diagnostics?
+  return System.getErrors();
 }
 
 void RequirementMachine::dump(llvm::raw_ostream &out) const {

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -108,13 +108,12 @@ class RequirementMachine final {
 
   MutableTerm getLongestValidPrefix(const MutableTerm &term) const;
 
-  std::vector<Requirement> buildRequirementsFromRules(
-    ArrayRef<unsigned> rules,
-    TypeArrayView<GenericTypeParamType> genericParams) const;
-
-  std::vector<ProtocolTypeAlias> buildProtocolTypeAliasesFromRules(
-    ArrayRef<unsigned> rules,
-    TypeArrayView<GenericTypeParamType> genericParams) const;
+  void buildRequirementsFromRules(
+    ArrayRef<unsigned> requirementRules,
+    ArrayRef<unsigned> typeAliasRules,
+    TypeArrayView<GenericTypeParamType> genericParams,
+    std::vector<Requirement> &reqs,
+    std::vector<ProtocolTypeAlias> &aliases) const;
 
   TypeArrayView<GenericTypeParamType> getGenericParams() const {
     return TypeArrayView<GenericTypeParamType>(

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -112,6 +112,7 @@ class RequirementMachine final {
     ArrayRef<unsigned> requirementRules,
     ArrayRef<unsigned> typeAliasRules,
     TypeArrayView<GenericTypeParamType> genericParams,
+    bool reconstituteSugar,
     std::vector<Requirement> &reqs,
     std::vector<ProtocolTypeAlias> &aliases) const;
 
@@ -149,7 +150,8 @@ public:
   llvm::DenseMap<const ProtocolDecl *, RequirementSignature>
   computeMinimalProtocolRequirements();
 
-  std::vector<Requirement> computeMinimalGenericSignatureRequirements();
+  std::vector<Requirement>
+  computeMinimalGenericSignatureRequirements(bool reconstituteSugar);
 
   std::string getRuleAsStringForDiagnostics(unsigned ruleID) const;
 

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -155,7 +155,7 @@ public:
 
   std::string getRuleAsStringForDiagnostics(unsigned ruleID) const;
 
-  bool hadError() const;
+  GenericSignatureErrors getErrors() const;
 
   void verify(const MutableTerm &term) const;
   void dump(llvm::raw_ostream &out) const;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -522,7 +522,8 @@ InferredGenericSignatureRequestRQM::evaluate(
                        diag::requirement_machine_completion_rule,
                        rule);
 
-    auto result = GenericSignature::get(genericParams, {});
+    auto result = GenericSignature::get(genericParams,
+                                        parentSig.getRequirements());
     return GenericSignatureWithError(
         result, GenericSignatureErrorFlags::CompletionFailed);
   }

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -193,6 +193,29 @@ Optional<Identifier> Rule::isProtocolTypeAliasRule() const {
   return LHS[1].getName();
 }
 
+/// A rule was derived from a concrete protocol typealias if it
+/// takes the following form:
+///
+/// T.A.[concrete: C] => T.A
+///
+/// Where the prefix term T does not contain any name symbols, and
+/// A is a name symbol.
+bool Rule::isDerivedFromConcreteProtocolTypeAliasRule() const {
+  auto optSymbol = isPropertyRule();
+  if (!optSymbol || optSymbol->getKind() != Symbol::Kind::ConcreteType)
+    return false;
+
+  for (unsigned i = 0, e = RHS.size() - 1; i < e; ++i) {
+    if (RHS[i].getKind() == Symbol::Kind::Name)
+      return false;
+  }
+
+  if (RHS.back().getKind() != Symbol::Kind::Name)
+    return false;
+
+  return true;
+}
+
 /// Returns the length of the left hand side.
 unsigned Rule::getDepth() const {
   auto result = LHS.size();

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -864,10 +864,11 @@ void RewriteSystem::dump(llvm::raw_ostream &out) const {
     out << "- " << rule;
     if (auto ID = rule.getRequirementID()) {
       auto requirement = WrittenRequirements[*ID];
-      out << ", ID: " << *ID << ", ";
+      out << " [ID: " << *ID << " - ";
       requirement.req.dump(out);
       out << " at ";
       requirement.loc.print(out, Context.getASTContext().SourceMgr);
+      out << "]";
     }
     out << "\n";
   }

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -160,6 +160,8 @@ public:
 
   Optional<Identifier> isProtocolTypeAliasRule() const;
 
+  bool isDerivedFromConcreteProtocolTypeAliasRule() const;
+
   void markLHSSimplified() {
     assert(!LHSSimplified);
     LHSSimplified = true;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -14,6 +14,7 @@
 #define SWIFT_REWRITESYSTEM_H
 
 #include "swift/AST/Requirement.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/PointerUnion.h"
 
@@ -537,7 +538,7 @@ public:
 
   void minimizeRewriteSystem();
 
-  bool hadError() const;
+  GenericSignatureErrors getErrors() const;
 
   struct MinimizedProtocolRules {
     std::vector<unsigned> Requirements;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -797,6 +797,14 @@ void InferredGenericSignatureRequest::noteCycleStep(DiagnosticEngine &d) const {
   // into this request.  See rdar://55263708
 }
 
+void InferredGenericSignatureRequestGSB::noteCycleStep(DiagnosticEngine &d) const {
+  // For now, the GSB does a better job of describing the exact structure of
+  // the cycle.
+  //
+  // FIXME: We should consider merging the circularity handling the GSB does
+  // into this request.  See rdar://55263708
+}
+
 void InferredGenericSignatureRequestRQM::noteCycleStep(DiagnosticEngine &d) const {
   // For now, the GSB does a better job of describing the exact structure of
   // the cycle.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2690,12 +2690,20 @@ public:
       llvm::errs() << "\n";
     }
 
-
-#ifndef NDEBUG
-    // In asserts builds, also verify some invariants of the requirement
-    // signature.
-    PD->getGenericSignature().verify(reqSig);
-#endif
+    if (getASTContext().LangOpts.RequirementMachineProtocolSignatures ==
+        RequirementMachineMode::Disabled) {
+  #ifndef NDEBUG
+      // The GenericSignatureBuilder outputs incorrectly-minimized signatures
+      // sometimes, so only check invariants in asserts builds.
+      PD->getGenericSignature().verify(reqSig);
+  #endif
+    } else {
+      // When using the Requirement Machine, always verify signatures.
+      // An incorrect signature indicates a serious problem which can cause
+      // miscompiles or inadvertent ABI dependencies on compiler bugs, so
+      // we really want to avoid letting one slip by.
+      PD->getGenericSignature().verify(reqSig);
+    }
 
     (void) reqSig;
 

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P {}
 
@@ -17,10 +18,14 @@ extension S where T == Float { // expected-note {{requirement specified as 'T' =
 
 class A<T, U> {}
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=A
+// CHECK-NEXT: Generic signature: <T, U where T == [U], U : P>
 extension A where T == [U], U: P {
   typealias S1 = Int
 }
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=A
+// CHECK-NEXT: Generic signature: <T, U where T == [Int], U == Int>
 extension A where T == [U], U == Int {
 // expected-note@-1 {{requirement specified as 'T' == '[Int]' [with T = [String]]}}
   typealias S2 = Int

--- a/test/Generics/concrete_conflict.swift
+++ b/test/Generics/concrete_conflict.swift
@@ -36,7 +36,7 @@ class Class<T> {}
 
 extension Class where T == Bool {
   // CHECK-LABEL: .badRequirement()@
-  // CHECK-NEXT: <T where T == Bool>
+  // CHECK-NEXT: <T>
   func badRequirement() where T == Int { }
   // expected-error@-1 {{generic parameter 'T' cannot be equal to both 'Int' and 'Bool'}}
 }

--- a/test/Generics/conditional_requirement_inference_in_protocol.swift
+++ b/test/Generics/conditional_requirement_inference_in_protocol.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Good@
-// CHECK-LABEL: Requirement signature: <Self where Self.[Good]T == Array<Self.[Good]U>, Self.[Good]U : Equatable>
+// CHECK-LABEL: Requirement signature: <Self where Self.[Good]T == [Self.[Good]U], Self.[Good]U : Equatable>
 
 protocol Good {
   associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Self.T' : 'Equatable'}}
@@ -10,7 +10,7 @@ protocol Good {
 }
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Bad@
-// CHECK-LABEL: Requirement signature: <Self where Self.[Bad]T == Array<Self.[Bad]U>>
+// CHECK-LABEL: Requirement signature: <Self where Self.[Bad]T == [Self.[Bad]U]>
 
 protocol Bad {
   associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Self.T' : 'Equatable'}}

--- a/test/Generics/minimize_superclass_unification_generic_2.swift
+++ b/test/Generics/minimize_superclass_unification_generic_2.swift
@@ -59,7 +59,7 @@ protocol Pba {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pac]A1 == String,
-// CHECK-SAME: Self.[Pac]A2 == (Self.[Pac]C1) -> Array<Self.[Pac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pac]A2 == (Self.[Pac]C1) -> [Self.[Pac]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pac]A3 == Int,
 
 // CHECK-SAME: Self.[Pac]C2 : Sequence,
@@ -82,7 +82,7 @@ protocol Pac {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pca]A1 == String,
-// CHECK-SAME: Self.[Pca]A2 == (Self.[Pca]C1) -> Array<Self.[Pca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pca]A2 == (Self.[Pca]C1) -> [Self.[Pca]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pca]A3 == Int,
 
 // CHECK-SAME: Self.[Pca]C2 : Sequence,
@@ -106,7 +106,7 @@ protocol Pca {
 
 // CHECK-SAME: Self.[Pbc]B1 == String,
 // CHECK-SAME: Self.[Pbc]B2 == Self.[Pbc]C1,
-// CHECK-SAME: Self.[Pbc]B3 == Array<Self.[Pbc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbc]B3 == [Self.[Pbc]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pbc]B4 == Self.[Pbc]C3,
 
 // CHECK-SAME: Self.[Pbc]C2 : Sequence,
@@ -131,7 +131,7 @@ protocol Pbc {
 
 // CHECK-SAME: Self.[Pcb]B1 == String,
 // CHECK-SAME: Self.[Pcb]B2 == Self.[Pcb]C1,
-// CHECK-SAME: Self.[Pcb]B3 == Array<Self.[Pcb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcb]B3 == [Self.[Pcb]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pcb]B4 == Self.[Pcb]C3,
 
 // CHECK-SAME: Self.[Pcb]C2 : Sequence,
@@ -160,12 +160,12 @@ protocol Pcb {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pabc]A1 == String,
-// CHECK-SAME: Self.[Pabc]A2 == (Self.[Pabc]B2) -> Array<Self.[Pabc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pabc]A2 == (Self.[Pabc]B2) -> [Self.[Pabc]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pabc]A3 == Int,
 
 // CHECK-SAME: Self.[Pabc]B1 == String,
 // CHECK-SAME: Self.[Pabc]B2 == Self.[Pabc]C1,
-// CHECK-SAME: Self.[Pabc]B3 == Array<Self.[Pabc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pabc]B3 == [Self.[Pabc]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pabc]B4 == Self.[Pabc]C3,
 
 // CHECK-SAME: Self.[Pabc]C2 : Sequence,
@@ -193,12 +193,12 @@ protocol Pabc {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pacb]A1 == String,
-// CHECK-SAME: Self.[Pacb]A2 == (Self.[Pacb]B2) -> Array<Self.[Pacb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pacb]A2 == (Self.[Pacb]B2) -> [Self.[Pacb]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pacb]A3 == Int,
 
 // CHECK-SAME: Self.[Pacb]B1 == String,
 // CHECK-SAME: Self.[Pacb]B2 == Self.[Pacb]C1,
-// CHECK-SAME: Self.[Pacb]B3 == Array<Self.[Pacb]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pacb]B3 == [Self.[Pacb]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pacb]B4 == Self.[Pacb]C3,
 
 // CHECK-SAME: Self.[Pacb]C2 : Sequence,
@@ -226,12 +226,12 @@ protocol Pacb {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pbac]A1 == String,
-// CHECK-SAME: Self.[Pbac]A2 == (Self.[Pbac]B2) -> Array<Self.[Pbac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbac]A2 == (Self.[Pbac]B2) -> [Self.[Pbac]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pbac]A3 == Int,
 
 // CHECK-SAME: Self.[Pbac]B1 == String,
 // CHECK-SAME: Self.[Pbac]B2 == Self.[Pbac]C1,
-// CHECK-SAME: Self.[Pbac]B3 == Array<Self.[Pbac]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbac]B3 == [Self.[Pbac]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pbac]B4 == Self.[Pbac]C3,
 
 // CHECK-SAME: Self.[Pbac]C2 : Sequence,
@@ -259,12 +259,12 @@ protocol Pbac {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pbca]A1 == String,
-// CHECK-SAME: Self.[Pbca]A2 == (Self.[Pbca]B2) -> Array<Self.[Pbca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbca]A2 == (Self.[Pbca]B2) -> [Self.[Pbca]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pbca]A3 == Int,
 
 // CHECK-SAME: Self.[Pbca]B1 == String,
 // CHECK-SAME: Self.[Pbca]B2 == Self.[Pbca]C1,
-// CHECK-SAME: Self.[Pbca]B3 == Array<Self.[Pbca]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pbca]B3 == [Self.[Pbca]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pbca]B4 == Self.[Pbca]C3,
 
 // CHECK-SAME: Self.[Pbca]C2 : Sequence,
@@ -292,12 +292,12 @@ protocol Pbca {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pcab]A1 == String,
-// CHECK-SAME: Self.[Pcab]A2 == (Self.[Pcab]B2) -> Array<Self.[Pcab]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcab]A2 == (Self.[Pcab]B2) -> [Self.[Pcab]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pcab]A3 == Int,
 
 // CHECK-SAME: Self.[Pcab]B1 == String,
 // CHECK-SAME: Self.[Pcab]B2 == Self.[Pcab]C1,
-// CHECK-SAME: Self.[Pcab]B3 == Array<Self.[Pcab]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcab]B3 == [Self.[Pcab]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pcab]B4 == Self.[Pcab]C3,
 
 // CHECK-SAME: Self.[Pcab]C2 : Sequence,
@@ -325,12 +325,12 @@ protocol Pcab {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[Pcba]A1 == String,
-// CHECK-SAME: Self.[Pcba]A2 == (Self.[Pcba]B2) -> Array<Self.[Pcba]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcba]A2 == (Self.[Pcba]B2) -> [Self.[Pcba]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pcba]A3 == Int,
 
 // CHECK-SAME: Self.[Pcba]B1 == String,
 // CHECK-SAME: Self.[Pcba]B2 == Self.[Pcba]C1,
-// CHECK-SAME: Self.[Pcba]B3 == Array<Self.[Pcba]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[Pcba]B3 == [Self.[Pcba]C2.[Sequence]Element],
 // CHECK-SAME: Self.[Pcba]B4 == Self.[Pcba]C3,
 
 // CHECK-SAME: Self.[Pcba]C2 : Sequence,
@@ -438,7 +438,7 @@ protocol PaQc {
 // CHECK-NEXT: Requirement signature: <Self where
 
 // CHECK-SAME: Self.[PcQa]A1 == String,
-// CHECK-SAME: Self.[PcQa]A2 == (Self.[PcQa]T.[Pc]C1) -> Array<Self.[PcQa]T.[Pc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[PcQa]A2 == (Self.[PcQa]T.[Pc]C1) -> [Self.[PcQa]T.[Pc]C2.[Sequence]Element],
 // CHECK-SAME: Self.[PcQa]A3 == Int,
 
 // CHECK-SAME: Self.[PcQa]T : Pc>
@@ -473,7 +473,7 @@ protocol PbQc {
 
 // CHECK-SAME: Self.[PcQb]B1 == String,
 // CHECK-SAME: Self.[PcQb]B2 == Self.[PcQb]T.[Pc]C1,
-// CHECK-SAME: Self.[PcQb]B3 == Array<Self.[PcQb]T.[Pc]C2.[Sequence]Element>,
+// CHECK-SAME: Self.[PcQb]B3 == [Self.[PcQb]T.[Pc]C2.[Sequence]Element],
 // CHECK-SAME: Self.[PcQb]B4 == Self.[PcQb]T.[Pc]C3,
 
 // CHECK-SAME: Self.[PcQb]T : Pc>

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify
-// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify > %t.dump 2>&1
 
 
 func sameType<T>(_: T.Type, _: T.Type) {}

--- a/test/Generics/protocol_typealias_concrete_unification.swift
+++ b/test/Generics/protocol_typealias_concrete_unification.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P1 {
   typealias T = Array<U>
@@ -9,4 +9,17 @@ protocol P2 {
   typealias T = Array<Int>
 }
 
+// Note that the GenericSignatureBuilder did not record the 'T.[P1]U == Int'
+// requirement. But I believe this is too aggressive.
+
+// CHECK-LABEL: .foo(_:u:)@
+// CHECK-NEXT: Generic signature: <T where T : P1, T : P2, T.[P1]U == Int>
 func foo<T : P1 & P2>(_: T, u: T.U) -> Int { return u }
+
+// CHECK-LABEL: .P3@
+// CHECK-NEXT: Requirement signature: <Self where Self : P1, Self : P2, Self.[P1]U == Int>
+protocol P3 : P1, P2 {}
+
+// This conformance should succeed, and associated type inference should infer
+// 'S.U == Int'.
+struct S : P3 {}

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype X : P
@@ -7,26 +7,22 @@ protocol P {
 
 // Anything that mentions 'T : P' and 'U : P' minimizes to 'U : P'.
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol1<T, U>(_: T, _: U) where T : P, U : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol1
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol2<T, U>(_: T, _: U) where U : P, T : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol2
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol3<T, U>(_: T, _: U) where T : P, T.X == U, U : P, U.X == T {}
 // CHECK-LABEL: oneProtocol3
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
 // CHECK-LABEL: oneProtocol4
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
@@ -59,38 +55,43 @@ protocol P2 {
   associatedtype Y : P1
 }
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols1<T, U>(_: T, _: U) where T : P1, U : P2, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols1
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols2<T, U>(_: T, _: U) where U : P2, T : P1, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols2
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols3<T, U>(_: T, _: U) where T : P1, T.X == U, U : P2, U.Y == T {}
 // CHECK-LABEL: twoProtocols3
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols4<T, U>(_: T, _: U) where U : P2, T.X == U, T : P1, U.Y == T {}
 // CHECK-LABEL: twoProtocols4
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols5<T, U>(_: T, _: U) where T : P1, T.X == U, U.Y == T, U : P2 {}
 // CHECK-LABEL: twoProtocols5
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+2 {{redundant conformance constraint 'T' : 'P1'}}
-// expected-note@+1 {{conformance constraint 'T' : 'P1' implied here}}
+// The GenericSignatureBuilder minimized this signature down to
+// <T, U where T == U.[P2]Y, U : P2, U == T.[P1]X>.
+//
+// The Requirement Machine instead emits
+// <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>.
+//
+// This is a hypothetical ABI break, but it is such a silly edge case that
+// it shouldn't matter in practice. Given that either of the two conformance
+// requirements here are redundant, the user can omit one or the other to
+// specify the result that they desire.
+
+// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols6<T, U>(_: T, _: U) where U : P2, T.X == U, U.Y == T, T : P1 {}
 // CHECK-LABEL: twoProtocols6
-// CHECK: Generic signature: <T, U where T == U.[P2]Y, U : P2, U == T.[P1]X>
+// CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>

--- a/test/Generics/rdar80503090.swift
+++ b/test/Generics/rdar80503090.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 

--- a/test/Generics/rdar90219229.swift
+++ b/test/Generics/rdar90219229.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: .P@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P]T : C>
+protocol P {
+  typealias A = C
+
+  associatedtype T : A
+}
+
+class C {}
+
+protocol PBad {
+  typealias A = C
+
+  associatedtype B : P
+
+  associatedtype T1 : B.A
+  // expected-error@-1 {{type 'Self.T1' constrained to non-protocol, non-class type 'Self.B.A'}}
+
+  associatedtype T2 where T2 : A
+  // expected-error@-1 {{type 'Self.T2' constrained to non-protocol, non-class type 'Self.A'}}
+}
+
+// FIXME: Terrible diagnostics.
+
+protocol PWorse {
+// expected-error@-1 2{{circular reference}}
+// expected-note@-2 4{{through reference here}}
+  typealias A = C
+
+  associatedtype T : Self.A
+// expected-note@-1 2{{while resolving type 'Self.A'}}
+// expected-note@-2 2{{through reference here}}
+}

--- a/test/Generics/reconstitute_sugar.swift
+++ b/test/Generics/reconstitute_sugar.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+// The Requirement Machine works with canonical types internally, so make sure
+// we reconstitute sugar in trivial cases before surfacing the generic
+// signature to the user.
+
+struct G<X, Y, Z> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X == Y?>
+extension G where X == Optional<Y> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X == [Y]>
+extension G where X == Array<Y> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X == [Y : Z], Y : Hashable>
+extension G where X == Dictionary<Y, Z> {}
+
+// We don't do () => Swift.Void.
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X == ()>
+extension G where X == () {}
+
+// Now make sure we do the same for superclass requirements.
+
+class C<T> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X : C<Y?>>
+extension G where X : C<Optional<Y>> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X : C<[Y]>>
+extension G where X : C<Array<Y>> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X : C<[Y : Z]>, Y : Hashable>
+extension G where X : C<Dictionary<Y, Z>> {}
+
+// We don't do () => Swift.Void.
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <X, Y, Z where X : C<()>>
+extension G where X : C<()> {}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump -requirement-machine-protocol-signatures=verify 2>&1
-// RUN: %FileCheck %s < %t.dump
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=off
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P1 { 
   func p1()
@@ -203,7 +202,7 @@ struct X8 : P12 {
 
 struct X9<T: P12, U: P12> where T.B == U.B {
   // CHECK-LABEL: X9.upperSameTypeConstraint
-	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.[P12]B == X8.B>
+	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.[P12]B == X7>
   // CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 == X8, τ_0_1 : P12, τ_0_1.[P12]B == X7>
 	func upperSameTypeConstraint<V>(_: V) where T == X8 { }
 }
@@ -219,7 +218,7 @@ struct X10: P11, P12 {
 
 struct X11<T: P12, U: P12> where T.B == U.B.A {
 	// CHECK-LABEL: X11.upperSameTypeConstraint
-	// CHECK: Generic signature: <T, U, V where T : P12, U == X10, T.[P12]B == X10.A>
+	// CHECK: Generic signature: <T, U, V where T : P12, U == X10, T.[P12]B == X10>
 	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 : P12, τ_0_1 == X10, τ_0_0.[P12]B == X10>
 	func upperSameTypeConstraint<V>(_: V) where U == X10 { }
 }
@@ -270,7 +269,7 @@ struct X18: P18, P17 {
 }
 
 // CHECK-LABEL: .X19.foo@
-// CHECK: Generic signature: <T, U where T == X18.A>
+// CHECK: Generic signature: <T, U where T == X18>
 struct X19<T: P18> where T == T.A {
   func foo<U>(_: U) where T == X18 { }
 }

--- a/test/Generics/sr14917.swift
+++ b/test/Generics/sr14917.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+
+protocol P {
+  associatedtype A
+  associatedtype AS: Q where AS.B == A
+}
+
+protocol Q {
+  associatedtype B
+}
+
+struct S1<T : P> where T.AS.B == T.A {}
+// expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+
+struct S2<T: P> {
+  struct Nested where T.AS.B == T.A {}
+  // expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+}
+
+extension S2 where T.AS.B == T.A {}
+// expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+
+extension P where AS.B == A {}
+// expected-warning@-1 {{redundant same-type constraint 'Self.AS.B' == 'Self.A'}}
+
+extension P where Self : P {}
+// expected-warning@-1 {{redundant conformance constraint 'Self' : 'P'}}

--- a/test/Generics/superclass_and_concrete_requirement.swift
+++ b/test/Generics/superclass_and_concrete_requirement.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
 
 class C {}
 
@@ -8,18 +9,26 @@ struct S {}
 // CHECK-NEXT: Requirement signature: <Self where Self.[P1]T == C>
 protocol P1 {
   associatedtype T where T : C, T == C
+  // expected-warning@-1 {{redundant superclass constraint 'Self.T' : 'C'}}
+  // expected-note@-2 {{superclass constraint 'Self.T' : 'C' implied here}}
 }
 
 // CHECK-LABEL: .P2@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P2]T == S>
 protocol P2 {
   associatedtype T where T : C, T == S
+  // expected-error@-1 {{'Self.T' requires that 'S' inherit from 'C'}}
+  // expected-note@-2 {{superclass constraint 'Self.T' : 'C' implied here}}
+  // expected-note@-3 {{same-type constraint 'Self.T' == 'S' implied here}}
 }
 
 // CHECK-LABEL: .P3@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P3]T == S>
 protocol P3 {
   associatedtype T where T == S, T : C
+  // expected-error@-1 {{'Self.T' requires that 'S' inherit from 'C'}}
+  // expected-note@-2 {{same-type constraint 'Self.T' == 'S' implied here}}
+  // expected-note@-3 {{superclass constraint 'Self.T' : 'C' implied here}}
 }
 
 protocol P4a {
@@ -30,4 +39,16 @@ protocol P4a {
 // CHECK-NEXT: Requirement signature: <Self where Self.[P4]T : P4>
 protocol P4 {
   associatedtype T : P4 where T.T == S
+  // expected-error@-1 2{{same-type constraint type 'S' does not conform to required protocol 'P4'}}
+}
+
+class D {}
+
+// CHECK-LABEL: .P5@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P5]T == D>
+protocol P5 {
+  associatedtype T where T : C, T == D
+  // expected-error@-1 {{'Self.T' requires that 'D' inherit from 'C'}}
+  // expected-note@-2 {{superclass constraint 'Self.T' : 'C' implied here}}
+  // expected-note@-3 {{same-type constraint 'Self.T' == 'D' implied here}}
 }

--- a/test/Generics/superclass_and_concrete_requirement.swift
+++ b/test/Generics/superclass_and_concrete_requirement.swift
@@ -14,7 +14,7 @@ protocol P1 {
 }
 
 // CHECK-LABEL: .P2@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P2]T == S>
+// CHECK-NEXT: Requirement signature: <Self>
 protocol P2 {
   associatedtype T where T : C, T == S
   // expected-error@-1 {{'Self.T' requires that 'S' inherit from 'C'}}
@@ -23,7 +23,7 @@ protocol P2 {
 }
 
 // CHECK-LABEL: .P3@
-// CHECK-NEXT: Requirement signature: <Self where Self.[P3]T == S>
+// CHECK-NEXT: Requirement signature: <Self>
 protocol P3 {
   associatedtype T where T == S, T : C
   // expected-error@-1 {{'Self.T' requires that 'S' inherit from 'C'}}

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name AccessFilter
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name AccessFilter -requirement-machine-inferred-signatures=on
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
@@ -245,12 +245,12 @@ internal typealias InternalAlias_BAD = PublicAliasBase
 
 internal typealias ReallyInternalAlias_BAD = ReallyInternalAliasBase_BAD
 
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAlias {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAliasBase {{[{]$}}
 extension GenericStruct where T == PublicAlias {
   // CHECK-NEXT: public func constrainedToPublicAlias(){{$}}
   public func constrainedToPublicAlias() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIAlias {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAliasBase {{[{]$}}
 extension GenericStruct where T == UFIAlias {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIAlias(){{$}}

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name Test -typecheck -emit-module-interface-path - -enable-experimental-bound-generic-extensions %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name Test -typecheck -emit-module-interface-path - -enable-experimental-bound-generic-extensions %s -requirement-machine-inferred-signatures=on | %FileCheck %s
 
 public struct Tree<T> {
   public struct Branch<B> {
@@ -23,7 +23,7 @@ extension Tree<Int>.Branch.Nest.Egg { public static func twoot() {} }
 // CHECK: }
 extension Tree<Int>.Branch<String>.Nest.Egg { public static func twote() {} }
 
-// CHECK: extension Test.Tree.Branch.Nest.Egg where T == Swift.Int, B == Swift.String, N == Swift.Void {
+// CHECK: extension Test.Tree.Branch.Nest.Egg where T == Swift.Int, B == Swift.String, N == () {
 // CHECK:   public static func twite()
 // CHECK: }
 extension Tree<Int>.Branch<String>.Nest<Void>.Egg { public static func twite() {} }

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -2,7 +2,7 @@
 
 // Cannot use -parse-as-library here because that would compile also the
 // #if VERIFY path, which contains top-level code.
-// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module -enable-objc-interop %s | %FileCheck -check-prefix CHECK-VTABLE %s
+// RUN: %target-swift-frontend -emit-sil -o - -emit-module-path %t/Lib.swiftmodule -module-name Lib -I %S/Inputs/custom-modules -disable-objc-attr-requires-foundation-module -enable-objc-interop %s -requirement-machine-inferred-signatures=on | %FileCheck -check-prefix CHECK-VTABLE %s
 
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
@@ -126,7 +126,7 @@ open class User {
   // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() (vtable entries: 1) */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
-  // CHECK: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == UnwrappedInt
+  // CHECK: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
   // CHECK-RECOVERY: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
   public func constrainedUnwrapped<T: HasAssoc>(_: T) where T.Assoc == UnwrappedInt { fatalError() }
   // CHECK: func constrainedWrapped<T>(_: T) where T : HasAssoc, T.Assoc == WrappedInt

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
 // RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' | %FileCheck %s
 
 struct S<T> {}
@@ -54,8 +54,10 @@ class G<T> {
   // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
   // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
   @_specialize(where T == S<T>) // expected-error{{same-type constraint 'T' == 'S<T>' is recursive}}
-  // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
-  // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
+  // expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
+  // expected-note@-2 {{failed rewrite rule is τ_0_0.[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0}}
+  // expected-error@-3 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+  // expected-note@-4 {{missing constraint for 'T' in '_specialize' attribute}}
   @_specialize(where T == Int, U == Int) // expected-error{{cannot find type 'U' in scope}}
 
   func noGenericParams() {}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -177,6 +177,8 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 // expected-warning@-3{{redundant constraint 'T' : '_Trivial'}}
 // expected-note@-4 {{constraint 'T' : '_Trivial' implied here}}
 // expected-note@-5 2{{constraint conflicts with 'T' : '_Trivial(32)'}}
+// expected-error@-6 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+// expected-note@-7 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: _Trivial, T: _Trivial(64))
 // expected-warning@-1{{redundant constraint 'T' : '_Trivial'}}
 // expected-note@-2 1{{constraint 'T' : '_Trivial' implied here}}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -1,16 +1,20 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
 
 protocol SomeProtocol {
 	associatedtype T
 }
 
 extension SomeProtocol where T == Optional<T> { } // expected-error{{same-type constraint 'Self.T' == 'Optional<Self.T>' is recursive}}
+// expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is τ_0_0.[SomeProtocol:T].[concrete: Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<τ_0_0.[SomeProtocol:T]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0.[SomeProtocol:T]}}
 
 // rdar://problem/19840527
 
 class X<T> where T == X { // expected-error{{same-type constraint 'T' == 'X<T>' is recursive}}
-// expected-error@-1{{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-2 3{{generic class 'X' has self-referential generic requirements}}
+// expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is τ_0_0.[concrete: X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0}}
+// expected-error@-3{{same-type requirement makes generic parameter 'T' non-generic}}
+// expected-error@-4 6{{generic class 'X' has self-referential generic requirements}}
     var type: T { return Swift.type(of: self) } // expected-error{{cannot convert return expression of type 'X<T>.Type' to return type 'T'}}
 }
 
@@ -45,7 +49,7 @@ public protocol P {
 }
 
 public struct S<A: P> where A.T == S<A> {
-// expected-error@-1 3{{generic struct 'S' has self-referential generic requirements}}
+// expected-error@-1 6{{generic struct 'S' has self-referential generic requirements}}
   func f(a: A.T) {
     g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
     _ = A.T.self
@@ -70,7 +74,7 @@ protocol PI {
 }
 
 struct SI<A: PI> : I where A : I, A.T == SI<A> {
-// expected-error@-1 3{{generic struct 'SI' has self-referential generic requirements}}
+// expected-error@-1 6{{generic struct 'SI' has self-referential generic requirements}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }
@@ -97,9 +101,9 @@ struct S5<A: PI> : I where A : I, A.T == S4<A> { }
 
 // Used to hit ArchetypeBuilder assertions
 struct SU<A: P> where A.T == SU {
-// expected-error@-1 3{{generic struct 'SU' has self-referential generic requirements}}
+// expected-error@-1 6{{generic struct 'SU' has self-referential generic requirements}}
 }
 
 struct SIU<A: PI> : I where A : I, A.T == SIU {
-// expected-error@-1 3{{generic struct 'SIU' has self-referential generic requirements}}
+// expected-error@-1 6{{generic struct 'SIU' has self-referential generic requirements}}
 }

--- a/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
+++ b/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
@@ -2,6 +2,7 @@
 
 protocol P {
     associatedtype A : P where A.X == Self
+    // expected-error@-1{{'X' is not a member type of type 'Self.A'}}
     associatedtype X : P where P.A == Self
     // expected-error@-1{{associated type 'A' can only be used with a concrete type or generic parameter base}}
 }

--- a/validation-test/compiler_crashers_2_fixed/sr9584.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr9584.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 struct S<N> {}
 
@@ -9,6 +9,10 @@ protocol P {
 
 extension S: P where N: P {
   static func f<X: P>(_ x: X) -> S<X.A> where A == X, X.A == N {
+  // expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
+  // expected-note@-2 {{failed rewrite rule is τ_0_0.[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<τ_0_0>>>>>>>>>>>>] => τ_0_0.[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A].[P:A] [subst↓]}}
+  // expected-error@-3 {{'A' is not a member type of type 'X'}}
+  // expected-error@-4 {{'A' is not a member type of type 'X'}}
     return S<X.A>()
   }
 }

--- a/validation-test/compiler_crashers_fixed/00228-swift-clangimporter-loadextensions.swift
+++ b/validation-test/compiler_crashers_fixed/00228-swift-clangimporter-loadextensions.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-inferred-signatures=on
 func s() -> o {
         r q {
 }

--- a/validation-test/compiler_crashers_fixed/00237-swift-declrefexpr-setspecialized.swift
+++ b/validation-test/compiler_crashers_fixed/00237-swift-declrefexpr-setspecialized.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-inferred-signatures=on
 func b(c) -> <d>(() -> d) {
 }
 struct d<f : e, g: e where g.h == f.h> {

--- a/validation-test/compiler_crashers_fixed/00365-getselftypeforcontainer.swift
+++ b/validation-test/compiler_crashers_fixed/00365-getselftypeforcontainer.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-inferred-signatures=on
 class d<j : i, f : i where j.i == f> : e {
 }
 class d<j, f> {

--- a/validation-test/compiler_crashers_fixed/01107-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01107-std-function-func-swift-type-subst.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-inferred-signatures=on
 func b<d {
 class d<j : i, f : i where j.i == f> : e {
 }

--- a/validation-test/compiler_crashers_fixed/01177-std-function-func-swift-type-subst.swift
+++ b/validation-test/compiler_crashers_fixed/01177-std-function-func-swift-type-subst.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -typecheck
+// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-inferred-signatures=on
 class d<j : i, f : i where j.i == f> : e {
 }
 class d<j, f> {

--- a/validation-test/compiler_crashers_fixed/28839-genericsig.swift
+++ b/validation-test/compiler_crashers_fixed/28839-genericsig.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir -requirement-machine-protocol-signatures=on
 class a{
 class a<a:A
 protocol A:a{typealias wh:Self.a


### PR DESCRIPTION
- Another fix for protocol typealiases
- Reconstitute Optional/Array/Dictionary sugar in minimized generic signatures
- Refactor {RequirementSignature,AbstractSignature,InferredSignature}Request to plumb through error flags
- Consolidate conflict handling
- Relax 'verify' mode checks to ignore mismatches if there were conflicting requirements, or if completion failed to produce a rewrite system

Only 3 validation-test failures remain:

```
  Swift(macosx-x86_64) :: Generics/unify_superclass_types_2.swift
  Swift(macosx-x86_64) :: Generics/unify_superclass_types_3.swift
  Swift(macosx-x86_64) :: attr/accessibility.swift
```