### PR TITLE
RequirementMachine: Hack to allow protocol typealiases to appear in associated type inheritance clauses

### DIFF
--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -504,9 +504,37 @@ void swift::rewriting::realizeInheritedRequirements(
     Type inheritedType
       = evaluateOrDefault(ctx.evaluator,
                           InheritedTypeRequest{decl, index,
-                            TypeResolutionStage::Structural},
+                          TypeResolutionStage::Structural},
                           Type());
     if (!inheritedType) continue;
+
+    // The GenericSignatureBuilder allowed an associated type's inheritance
+    // clause to reference a protocol typealias whose underlying type was a
+    // protocol or class.
+    //
+    // Since protocol typealiases resolve to DependentMemberTypes in
+    // ::Structural mode, this relied on the GSB's "delayed requirements"
+    // mechanism.
+    //
+    // The RequirementMachine does not have an equivalent, and cannot really
+    // support that because we need to collect the protocols mentioned on
+    // the right hand sides of conformance requirements ahead of time.
+    //
+    // However, we can support it in simple cases where the typealias is
+    // defined in the protocol itself and is accessed as a member of 'Self'.
+    if (auto *assocTypeDecl = dyn_cast<AssociatedTypeDecl>(decl)) {
+      if (auto memberType = inheritedType->getAs<DependentMemberType>()) {
+        if (memberType->getBase()->isEqual(
+            assocTypeDecl->getProtocol()->getSelfInterfaceType())) {
+          inheritedType
+            = evaluateOrDefault(ctx.evaluator,
+                                InheritedTypeRequest{decl, index,
+                                TypeResolutionStage::Interface},
+                                Type());
+          if (!inheritedType) continue;
+        }
+      }
+    }
 
     auto *typeRepr = inheritedTypes[index].getTypeRepr();
     SourceLoc loc = (typeRepr ? typeRepr->getStartLoc() : SourceLoc());

--- a/test/Generics/rdar90219229.swift
+++ b/test/Generics/rdar90219229.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: .P@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P]T : C>
+protocol P {
+  typealias A = C
+
+  associatedtype T : A
+}
+
+class C {}
+
+protocol PBad {
+  typealias A = C
+
+  associatedtype B : P
+
+  associatedtype T1 : B.A
+  // expected-error@-1 {{type 'Self.T1' constrained to non-protocol, non-class type 'Self.B.A'}}
+
+  associatedtype T2 where T2 : A
+  // expected-error@-1 {{type 'Self.T2' constrained to non-protocol, non-class type 'Self.A'}}
+}
+
+// FIXME: Terrible diagnostics.
+
+protocol PWorse {
+// expected-error@-1 2{{circular reference}}
+// expected-note@-2 4{{through reference here}}
+  typealias A = C
+
+  associatedtype T : Self.A
+// expected-note@-1 2{{while resolving type 'Self.A'}}
+// expected-note@-2 2{{through reference here}}
+}

--- a/validation-test/compiler_crashers_fixed/28839-genericsig.swift
+++ b/validation-test/compiler_crashers_fixed/28839-genericsig.swift
@@ -6,7 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir -requirement-machine-protocol-signatures=on
 class a{
 class a<a:A
 protocol A:a{typealias wh:Self.a


### PR DESCRIPTION
If you have something like

    protocol P {
      typealias A = C

      associatedtype T : A
    }

    class C {}

Then ::Structural resolution of 'A' in the inheritance clause will
produce a DependentMemberType 'Self.A'. Check for this case and
attempt ::Interface resolution to get the correct underlying type.

Fixes rdar://problem/90219229.