### PR TITLE
Revert "[test] Disable debug_value_addr.swift on arm64"

### DIFF
--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -1,9 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
 // RUN: %target-swift-frontend %s -emit-sil -g -o - | %FileCheck -check-prefix=CHECK-SIL %s
 
-// Temporarily disable on arm64 (rdar://89237318)
-// UNSUPPORTED: CPU=arm64
-
 // Verify that -Onone shadow copies are emitted for debug_value_addr
 // instructions.
 


### PR DESCRIPTION
This reverts commit 0a7a976d31edb7bd052b8dfaa25d8ed5bb59381e.

The problem here is related to no-asserts rather than architecture.