### PR TITLE
[Distributed] Remove mangled names from API, move to RemoteCallTarget and pretty print it

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1101,6 +1101,15 @@ swift_getTypeName(const Metadata *type, bool qualified);
 ///   -> (UnsafePointer<UInt8>, Int)
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 TypeNamePair
+swift_getFunctionFullNameFromMangledName(
+        const char *mangledNameStart, uintptr_t mangledNameLength);
+
+/// Return the human-readable full name of the mangled function name passed in.
+/// func _getMangledTypeName(_ mangledName: UnsafePointer<UInt8>,
+///                          mangledNameLength: UInt)
+///   -> (UnsafePointer<UInt8>, Int)
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+TypeNamePair
 swift_getMangledTypeName(const Metadata *type);
 
 } // end namespace swift

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -43,8 +43,6 @@ using namespace Lowering;
 ///          or the subsequent cast to VarDecl failed.
 static VarDecl* lookupProperty(NominalTypeDecl *decl, DeclName name) {
   assert(decl && "decl was null");
-  auto &C = decl->getASTContext();
-  
   if (auto clazz = dyn_cast<ClassDecl>(decl)) {
     auto refs = decl->lookupDirect(name);
     if (refs.size() != 1)

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -564,7 +564,6 @@ addDistributedActorCodableConformance(
   assert(proto->isSpecificProtocol(swift::KnownProtocolKind::Decodable) ||
          proto->isSpecificProtocol(swift::KnownProtocolKind::Encodable));
   auto &C = actor->getASTContext();
-  auto DC = actor->getDeclContext();
   auto module = actor->getParentModule();
 
   // === Only Distributed actors can gain this implicit conformance

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -721,13 +721,13 @@ GetDistributedRemoteCallTargetInitFunctionRequest::evaluate(
     if (params->size() != 1)
       return nullptr;
 
-    if (params->get(0)->getArgumentName() == C.getIdentifier("_mangledName"))
+    // _ identifier
+    if (params->get(0)->getArgumentName().empty())
       return ctor;
 
     return nullptr;
   }
 
-  // TODO(distributed): make a Request for it?
   return nullptr;
 }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -310,7 +310,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     }
     if (checkAdHocRequirementAccessControl(decl, Proto, recordArgumentDecl))
       anyMissingAdHocRequirements = true;
-    
+
     // - recordReturnType
     auto recordReturnTypeDecl = C.getRecordReturnTypeOnDistributedInvocationEncoder(decl);
     if (!recordReturnTypeDecl) {

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -310,22 +310,7 @@ bool swift::checkDistributedActorSystemAdHocProtocolRequirements(
     }
     if (checkAdHocRequirementAccessControl(decl, Proto, recordArgumentDecl))
       anyMissingAdHocRequirements = true;
-
-    // - recordErrorType
-    auto recordErrorTypeDecl = C.getRecordErrorTypeOnDistributedInvocationEncoder(decl);
-    if (!recordErrorTypeDecl) {
-      auto identifier = C.Id_recordErrorType;
-      decl->diagnose(
-          diag::distributed_actor_system_conformance_missing_adhoc_requirement,
-          decl->getDescriptiveKind(), decl->getName(), identifier);
-      decl->diagnose(diag::note_distributed_actor_system_conformance_missing_adhoc_requirement,
-                     decl->getName(), identifier,
-                     "mutating func recordErrorType<Err: Error>(_ errorType: Err.Type) throws\n");
-      anyMissingAdHocRequirements = true;
-    }
-    if (checkAdHocRequirementAccessControl(decl, Proto, recordErrorTypeDecl))
-      anyMissingAdHocRequirements = true;
-
+    
     // - recordReturnType
     auto recordReturnTypeDecl = C.getRecordReturnTypeOnDistributedInvocationEncoder(decl);
     if (!recordReturnTypeDecl) {

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -172,23 +172,18 @@ extension DistributedActorSystem {
   /// latency sensitive-use-cases.
   public func executeDistributedTarget<Act, ResultHandler>(
     on actor: Act,
-    mangledTargetName: String,
+    target: RemoteCallTarget,
     invocationDecoder: inout InvocationDecoder,
     handler: ResultHandler
   ) async throws where Act: DistributedActor,
                        // Act.ID == ActorID, // FIXME(distributed): can we bring this back?
                        ResultHandler: DistributedTargetInvocationResultHandler {
-    // NOTE: this implementation is not the most efficient, nor final, version of this func
-    // we end up demangling the name multiple times, perform more heap allocations than
-    // we truly need to etc. We'll eventually move this implementation to a specialized one
-    // avoiding these issues.
-    guard mangledTargetName.count > 0 && mangledTargetName.first == "$" else {
-      throw ExecuteDistributedTargetError(
-        message: "Illegal mangledTargetName detected, must start with '$'")
-    }
-
     // Get the expected parameter count of the func
-    let nameUTF8 = Array(mangledTargetName.utf8)
+    guard let targetName = target.identifier else {
+      throw ExecuteDistributedTargetError(
+        message: "Unable to extract target identifier from remote call target: \(target)")
+    }
+    let nameUTF8 = Array(targetName.utf8)
 
     // Gen the generic environment (if any) associated with the target.
     let genericEnv = nameUTF8.withUnsafeBufferPointer { nameUTF8 in
@@ -207,7 +202,9 @@ extension DistributedActorSystem {
 
     if let genericEnv = genericEnv {
       let subs = try invocationDecoder.decodeGenericSubstitutions()
-
+      for item in subs {
+        print("SUB: \(item)")
+      }
       if subs.isEmpty {
         throw ExecuteDistributedTargetError(
           message: "Cannot call generic method without generic argument substitutions")
@@ -224,7 +221,7 @@ extension DistributedActorSystem {
                                                                      genericArguments: substitutionsBuffer!)
       if numWitnessTables < 0 {
         throw ExecuteDistributedTargetError(
-          message: "Generic substitutions \(subs) do not satisfy generic requirements of \(mangledTargetName)")
+          message: "Generic substitutions \(subs) do not satisfy generic requirements of \(target) (\(targetName))")
       }
     }
 
@@ -237,7 +234,7 @@ extension DistributedActorSystem {
         message: """
                  Failed to decode distributed invocation target expected parameter count,
                  error code: \(paramCount)
-                 mangled name: \(mangledTargetName)
+                 mangled name: \(targetName)
                  """)
     }
 
@@ -262,7 +259,7 @@ extension DistributedActorSystem {
         message: """
                  Failed to decode the expected number of params of distributed invocation target, error code: \(decodedNum)
                  (decoded: \(decodedNum), expected params: \(paramCount)
-                 mangled name: \(mangledTargetName)
+                 mangled name: \(targetName)
                  """)
     }
 
@@ -280,7 +277,7 @@ extension DistributedActorSystem {
       return UnsafeRawPointer(UnsafeMutablePointer<R>.allocate(capacity: 1))
     }
 
-    guard let returnTypeFromTypeInfo: Any.Type = _getReturnTypeInfo(mangledMethodName: mangledTargetName,
+    guard let returnTypeFromTypeInfo: Any.Type = _getReturnTypeInfo(mangledMethodName: targetName,
                                                                     genericEnv: genericEnv,
                                                                     genericArguments: substitutionsBuffer) else {
       throw ExecuteDistributedTargetError(
@@ -307,7 +304,7 @@ extension DistributedActorSystem {
       // Execute the target!
       try await _executeDistributedTarget(
         on: actor,
-        mangledTargetName, UInt(mangledTargetName.count),
+        targetName, UInt(targetName.count),
         argumentDecoder: &invocationDecoder,
         argumentTypes: argumentTypesBuffer.baseAddress!._rawValue,
         resultBuffer: resultBuffer._rawValue,
@@ -326,6 +323,52 @@ extension DistributedActorSystem {
   }
 }
 
+/// Represents a 'target' of a distributed call, such as a `distributed func` or
+/// `distributed` computed property. Identification schemes may vary between
+/// systems, and are subject to evolution.
+///
+/// Actor systems generally should treat the `identifier` as an opaque string,
+/// and pass it along to the remote system for in their `remoteCall`
+/// implementation. Alternative approaches are possible, where the identifiers
+/// are either compressed, cached, or represented in other ways, as long as the
+/// recipient system is able to determine which target was intended to be
+/// invoked.
+///
+/// The string representation will attempt to pretty print the target identifier,
+/// however its exact format is not specified and may change in future versions.
+@available(SwiftStdlib 5.7, *)
+public struct RemoteCallTarget: CustomStringConvertible {
+  private let _storage: _Storage
+  private enum _Storage {
+    case mangledName(String)
+  }
+
+  // Only intended to be created by the _Distributed library.
+  // TODO(distributed): make this internal and only allow calling by the synthesized code?
+  public init(_mangledName: String) {
+    self._storage = .mangledName(_mangledName)
+  }
+
+  /// The underlying identifier of the target, returned as-is.
+  public var identifier: String? {
+    switch self._storage {
+    case .mangledName(let name):
+      return name
+    }
+  }
+
+  public var description: String {
+    switch self._storage {
+    case .mangledName(let mangledName):
+      if let name = _getFunctionFullNameFromMangledName(mangledName: mangledName) {
+        return name
+      } else {
+        return "\(mangledName)"
+      }
+    }
+  }
+}
+
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_distributed_execute_target")
 func _executeDistributedTarget<D: DistributedTargetInvocationDecoder>(
@@ -338,29 +381,6 @@ func _executeDistributedTarget<D: DistributedTargetInvocationDecoder>(
   witnessTables: UnsafeRawPointer?,
   numWitnessTables: UInt
 ) async throws
-
-// ==== ----------------------------------------------------------------------------------------------------------------
-// MARK: Support types
-/// A distributed 'target' can be a `distributed func` or `distributed` computed property.
-@available(SwiftStdlib 5.7, *)
-public struct RemoteCallTarget { // TODO: ship this around always; make printing nice
-  let _mangledName: String // TODO: StaticString would be better here; no arc, codesize of cleanups
-
-  // Only intended to be created by the _Distributed library.
-  // TODO(distributed): make this internal and only allow calling by the synthesized code?
-  public init(_mangledName: String) {
-    self._mangledName = _mangledName
-  }
-
-  public var mangledName: String {
-    _mangledName
-  }
-
-  // <module>.Base.hello(hi:)
-  public var fullName: String { // TODO: make description
-    fatalError("NOT IMPLEMENTED YET: \(#function)")
-  }
-}
 
 /// Used to encode an invocation of a distributed target (method or computed property).
 ///

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -407,11 +407,9 @@ public protocol DistributedTargetInvocationEncoder {
 //  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument) throws
   // TODO(distributed): offer recordArgument(label:type:)
 
-//  /// Ad-hoc requirement
-//  ///
-//  /// Record the error type of the distributed method.
-//  /// This method will not be invoked if the target is not throwing.
-//  mutating func recordErrorType<E: Error>(_ type: E.Type) throws // TODO: make not adhoc
+  /// Record the error type of the distributed method.
+  /// This method will not be invoked if the target is not throwing.
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws
 
 //  /// Ad-hoc requirement
 //  ///

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -185,10 +185,7 @@ extension DistributedActorSystem {
     // pretty formatted name of the call target, but perhaps we can do better.
 
     // Get the expected parameter count of the func
-    guard let targetName = target.identifier else {
-      throw ExecuteDistributedTargetError(
-        message: "Unable to extract target identifier from remote call target: \(target)")
-    }
+    let targetName = target.identifier
     let nameUTF8 = Array(targetName.utf8)
 
     // Gen the generic environment (if any) associated with the target.
@@ -351,7 +348,7 @@ public struct RemoteCallTarget: CustomStringConvertible {
   }
 
   /// The underlying identifier of the target, returned as-is.
-  public var identifier: String? {
+  public var identifier: String {
     return _identifier
   }
 

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -146,12 +146,18 @@ using TypeNameCacheKey = llvm::PointerIntPair<const Metadata *, 2, TypeNameKind>
 
 #if SWIFT_CASTING_SUPPORTS_MUTEX
 static StaticReadWriteLock TypeNameCacheLock;
+static StaticReadWriteLock MangledToPrettyFunctionNameCacheLock;
 #endif
 
 /// Cache containing rendered names for Metadata.
 /// Access MUST be protected using `TypeNameCacheLock`.
 static Lazy<llvm::DenseMap<TypeNameCacheKey, std::pair<const char *, size_t>>>
   TypeNameCache;
+
+/// Cache containing rendered human-readable names for incoming mangled names.
+static Lazy<llvm::DenseMap<llvm::StringRef, std::pair<const char *, size_t>>>
+/// Access MUST be protected using `MangledToPrettyFunctionNameCache`.
+  MangledToPrettyFunctionNameCache;
 
 TypeNamePair
 swift::swift_getTypeName(const Metadata *type, bool qualified) {
@@ -251,6 +257,141 @@ swift::swift_getMangledTypeName(const Metadata *type) {
 
     cache.insert({key, {result, size}});
 
+    return TypeNamePair{result, size};
+  }
+}
+
+
+TypeNamePair
+swift::swift_getFunctionFullNameFromMangledName(
+    const char *mangledNameStart, uintptr_t mangledNameLength) {
+  llvm::StringRef mangledName(mangledNameStart, mangledNameLength);
+
+  auto &cache = MangledToPrettyFunctionNameCache.get();
+  // Attempt read-only lookup of cache entry.
+  {
+    #if SWIFT_CASTING_SUPPORTS_MUTEX
+    StaticScopedReadLock guard(MangledToPrettyFunctionNameCacheLock);
+    #endif
+
+    auto found = cache.find(mangledName);
+    if (found != cache.end()) {
+      auto result = found->second;
+      return TypeNamePair{result.first, result.second};
+    }
+  }
+
+  for (char c : mangledName) {
+    if (c >= '\x01' && c <= '\x1F')
+      return TypeNamePair{nullptr, 0};
+  }
+
+  // Read-only lookup failed, we may need to demangle and cache the entry.
+  // We have to copy the string to be able to refer to it "forever":
+  auto copy = (char *)malloc(mangledNameLength);
+  memcpy(copy, mangledNameStart, mangledNameLength);
+  mangledName = StringRef(copy, mangledNameLength);
+
+  std::string demangled;
+  StackAllocatedDemangler<1024> Dem;
+  NodePointer node = Dem.demangleSymbol(mangledName);
+  if (!node) {
+    return TypeNamePair{nullptr, 0};
+  }
+
+  // Form the demangled string from the node tree.
+  node = node->findByKind(Demangle::Node::Kind::Function, /*maxDepth=*/3);
+  if (!node || node->getNumChildren() < 3) {
+    // we normally expect Class/Identifier/Type, but don't need `Type`
+    return TypeNamePair{nullptr, 0};
+  }
+
+  // Class identifier:
+  auto clazz = node->findByKind(Demangle::Node::Kind::Class, 1);
+  if (clazz) {
+    if (auto module = clazz->findByKind(Demangle::Node::Kind::Module, 1)) {
+      demangled += module->getText();
+      demangled += ".";
+    }
+    if (auto clazzIdent = clazz->findByKind(Demangle::Node::Kind::Identifier, 1)) {
+      demangled += clazzIdent->getText();
+      demangled += ".";
+    }
+  }
+
+  // Function identifier:
+  NodePointer funcIdent = nullptr; // node == Function
+  for (size_t i = 0; i < node->getNumChildren(); ++i) {
+    if (node->getChild(i)->getKind() == Demangle::Node::Kind::Identifier) {
+      funcIdent = node->getChild(i);
+    }
+  }
+
+  // We always expect to work with functions here and they must have idents
+  if (!funcIdent) {
+    return TypeNamePair{nullptr, 0};
+  }
+  assert(funcIdent->getKind() == Demangle::Node::Kind::Identifier);
+  demangled += funcIdent->getText();
+  demangled += "(";
+
+  if (auto labelList = node->findByKind(Demangle::Node::Kind::LabelList, /*maxDepth=*/1)) {
+    if (labelList->getNumChildren()) {
+      size_t paramIdx = 0;
+      while (paramIdx < labelList->getNumChildren()) {
+        auto labelIdentifier = labelList->getChild(paramIdx++);
+        if (labelIdentifier) {
+          if (labelIdentifier->getKind() == Demangle::Node::Kind::Identifier) {
+            demangled += labelIdentifier->getText();
+            demangled += ":";
+          } else if (labelIdentifier->getKind() ==
+                     Demangle::Node::Kind::FirstElementMarker) {
+            demangled += "_:";
+          }
+        }
+      }
+    } else if (auto argumentTuple = node->findByKind(
+                   Demangle::Node::Kind::ArgumentTuple, /*maxDepth=*/5)) {
+      // LabelList was empty.
+        //
+        // The function has no labels at all, but could have some parameters...
+        // we need to check for their count, and render it as e.g. (::) for two
+        // anonymous parameters.
+        auto params = argumentTuple->getFirstChild();
+        if (auto paramsType = params->getFirstChild()) {
+          if (paramsType->getKind() != Demangle::Node::Kind::Tuple) {
+            // was a single, unnamed, parameter
+            demangled += "_:";
+          } else {
+            // there are a few parameters; find out how many
+            while (params && params->getFirstChild() &&
+                   params->getFirstChild()->getKind() !=
+                       Demangle::Node::Kind::TupleElement) {
+              params = params->getFirstChild();
+            }
+            if (params) {
+              for (size_t i = 0; i < params->getNumChildren(); ++i) {
+                demangled += "_:";
+              }
+            }
+          }
+        }
+    }
+  }
+  demangled += ")";
+
+  // We have to copy the string to be able to refer to it;
+  auto size = demangled.size();
+  auto result = (char *)malloc(size + 1);
+  memcpy(result, demangled.data(), size);
+  result[size] = 0; // 0-terminated string
+
+  {
+    #if SWIFT_CASTING_SUPPORTS_MUTEX
+    StaticScopedWriteLock guard(MangledToPrettyFunctionNameCacheLock);
+    #endif
+
+    cache.insert({mangledName, {result, size}});
     return TypeNamePair{result, size};
   }
 }

--- a/test/Distributed/Inputs/BadDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/BadDistributedActorSystems.swift
@@ -87,7 +87,7 @@ public struct MissingRemoteCallVoidActorSystem: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
 //  func remoteCallVoid<Act, Err>(
@@ -99,7 +99,7 @@ public struct MissingRemoteCallVoidActorSystem: DistributedActorSystem {
 //    where Act: DistributedActor,
 //          Act.ID == ActorID,
 //          Err: Error {
-//    throw ExecuteDistributedTargetError(message: "Not implemented.")
+//    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
 //  }
 }
 
@@ -177,7 +177,7 @@ public final class FakeRoundtripActorSystem: DistributedActorSystem, @unchecked 
       }
       try await executeDistributedTarget(
         on: active,
-        mangledTargetName: target.mangledName,
+        target: target,
         invocationDecoder: invocation.makeDecoder(),
         handler: resultHandler
       )
@@ -224,7 +224,7 @@ public final class FakeRoundtripActorSystem: DistributedActorSystem, @unchecked 
       }
       try await executeDistributedTarget(
         on: active,
-        mangledTargetName: target.mangledName,
+        target: target,
         invocationDecoder: invocation.makeDecoder(),
         handler: resultHandler
       )

--- a/test/Distributed/Inputs/FakeDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/FakeDistributedActorSystems.swift
@@ -87,7 +87,7 @@ public struct FakeActorSystem: DistributedActorSystem, CustomStringConvertible {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public func remoteCallVoid<Act, Err>(
@@ -99,7 +99,7 @@ public struct FakeActorSystem: DistributedActorSystem, CustomStringConvertible {
     where Act: DistributedActor,
           Act.ID == ActorID,
           Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public nonisolated var description: Swift.String {
@@ -184,7 +184,7 @@ public final class FakeRoundtripActorSystem: DistributedActorSystem, @unchecked 
 
       try await executeDistributedTarget(
         on: active,
-        mangledTargetName: target.mangledName,
+        target: target,
         invocationDecoder: &decoder,
         handler: resultHandler
       )
@@ -234,7 +234,7 @@ public final class FakeRoundtripActorSystem: DistributedActorSystem, @unchecked 
 
       try await executeDistributedTarget(
         on: active,
-        mangledTargetName: target.mangledName,
+        target: target,
         invocationDecoder: &decoder,
         handler: resultHandler
       )

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
@@ -32,7 +32,7 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   let reply = try await ref.echo(name: "Caplin")
-  // CHECK: >> remoteCall: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC4echo4nameS2S_tYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.echo(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
 
   // CHECK: << remoteCall return: Echo: Caplin
   print("reply: \(reply)")

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
@@ -31,7 +31,7 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   try await ref.empty()
-  // CHECK: >> remoteCallVoid: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC5emptyyyYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: nil, errorType: nil), throwing:Swift.Never
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.empty(), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: nil, errorType: nil), throwing:Swift.Never
   // CHECK: << onReturn: ()
 }
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -43,7 +43,7 @@ func test() async throws {
   // CHECK: > encode argument: Caplin
   // CHECK: > encode return type: Swift.String
   // CHECK: > done recording
-  // CHECK: >> remoteCall: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC7genericySSxYaKSeRzSERzlFTE"), invocation:FakeInvocationEncoder(genericSubs: [Swift.String], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.generic(_:), invocation:FakeInvocationEncoder(genericSubs: [Swift.String], arguments: ["Caplin"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
   print("reply: \(r1)")
   // CHECK: reply: Caplin
 
@@ -59,7 +59,7 @@ func test() async throws {
   // CHECK: > encode argument: [1, 2, 3]
   // CHECK: > encode return type: Swift.String
   // CHECK: > done recording
-  // CHECK: >> remoteCall: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC8generic26strict__SSSd_xSayq_GtYaKSeRzSERzSeR_SER_r0_lFTE"), invocation:FakeInvocationEncoder(genericSubs: [Swift.String, Swift.Int], arguments: [2.0, "Caplin", [1, 2, 3]], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.generic2(strict:_:_:), invocation:FakeInvocationEncoder(genericSubs: [Swift.String, Swift.Int], arguments: [2.0, "Caplin", [1, 2, 3]], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
   print("reply: \(r2)")
   // CHECK: reply: Caplin
 }

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
@@ -32,7 +32,7 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   let response = try await ref.hello()
-  // CHECK: >> remoteCall: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC5helloSSyYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.hello(), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
 
   print("response: \(response)")
   // CHECK: response: Hello, World!

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -32,7 +32,7 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   try await ref.take(name: "Caplin")
-  // CHECK: >> remoteCallVoid: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC4take4nameySS_tYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: nil, errorType: nil), throwing:Swift.Never
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.take(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin"], returnType: nil, errorType: nil), throwing:Swift.Never
   // CHECK: take: Caplin
 
 }

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
@@ -35,7 +35,7 @@ func test() async throws {
 
   do {
     let value = try await ref.takeThrowReturn(name: "Example")
-    // CHECK: >> remoteCall: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC15takeThrowReturn4nameS2S_tYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Example"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.takeThrowReturn(name:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Example"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
 
     print("did not throw")
     // CHECK-NOT: did not throw

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -38,7 +38,7 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   try await ref.take(name: "Caplin", int: 1337)
-  // CHECK: >> remoteCallVoid: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC4take4name3intySS_SitYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin", 1337], returnType: nil, errorType: nil), throwing:Swift.Never
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.take(name:int:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Caplin", 1337], returnType: nil, errorType: nil), throwing:Swift.Never
 
   // try await ref.take(name: "Caplin", int: 1337, clazz: .init()) // FIXME(distributed): crashes
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
@@ -35,7 +35,7 @@ func test() async throws {
 
   do {
     try await ref.maybeThrows()
-    // CHECK: >> remoteCallVoid: on:main.Greeter, target:RemoteCallTarget(_mangledName: "$s4main7GreeterC11maybeThrowsyyYaKFTE"), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: nil, errorType: Optional(Swift.Error)), throwing:Swift.Error
+    // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.maybeThrows(), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: nil, errorType: Optional(Swift.Error)), throwing:Swift.Error
 
     print("did not throw")
     // CHECK-NOT: did not throw

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -304,7 +304,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: emptyName),
+      target: RemoteCallTarget(emptyName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -312,7 +312,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: helloName),
+      target: RemoteCallTarget(helloName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -320,7 +320,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: answerName),
+      target: RemoteCallTarget(answerName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -328,7 +328,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: largeResultName),
+      target: RemoteCallTarget(largeResultName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -336,7 +336,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: enumResultName),
+      target: RemoteCallTarget(enumResultName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -350,7 +350,7 @@ func test() async throws {
   var echoDecoder = echoInvocation.makeDecoder()
   try await system.executeDistributedTarget(
       on: local,
-      target: RemoteCallTarget(_mangledName: echoName),
+      target: RemoteCallTarget(echoName),
       invocationDecoder: &echoDecoder,
       handler: FakeResultHandler()
   )
@@ -365,7 +365,7 @@ func test() async throws {
   var generic1Decoder = generic1Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: generic1Name),
+    target: RemoteCallTarget(generic1Name),
     invocationDecoder: &generic1Decoder,
     handler: FakeResultHandler()
   )
@@ -383,7 +383,7 @@ func test() async throws {
   var generic2Decoder = generic2Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: generic2Name),
+    target: RemoteCallTarget(generic2Name),
     invocationDecoder: &generic2Decoder,
     handler: FakeResultHandler()
   )
@@ -404,7 +404,7 @@ func test() async throws {
   var generic3Decoder = generic3Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: generic3Name),
+    target: RemoteCallTarget(generic3Name),
     invocationDecoder: &generic3Decoder,
     handler: FakeResultHandler()
   )
@@ -426,7 +426,7 @@ func test() async throws {
   var generic4Decoder = generic4Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: generic4Name),
+    target: RemoteCallTarget(generic4Name),
     invocationDecoder: &generic4Decoder,
     handler: FakeResultHandler()
   )
@@ -450,7 +450,7 @@ func test() async throws {
   var generic5Decoder = generic5Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: generic5Name),
+    target: RemoteCallTarget(generic5Name),
     invocationDecoder: &generic5Decoder,
     handler: FakeResultHandler()
   )
@@ -473,7 +473,7 @@ func test() async throws {
   var genericOptDecoder = genericOptInvocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: genericOptionalName),
+    target: RemoteCallTarget(genericOptionalName),
     invocationDecoder: &genericOptDecoder,
     handler: FakeResultHandler()
   )
@@ -488,7 +488,7 @@ func test() async throws {
   var decodeErrDecoder = decodeErrInvocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    target: RemoteCallTarget(_mangledName: expectsDecodeErrorName),
+    target: RemoteCallTarget(expectsDecodeErrorName),
     invocationDecoder: &decodeErrDecoder,
     handler: FakeResultHandler()
   )

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
-// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift -o %t/a.out
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
@@ -304,7 +304,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: emptyName,
+      target: RemoteCallTarget(_mangledName: emptyName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -312,7 +312,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: helloName,
+      target: RemoteCallTarget(_mangledName: helloName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -320,7 +320,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: answerName,
+      target: RemoteCallTarget(_mangledName: answerName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -328,7 +328,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: largeResultName,
+      target: RemoteCallTarget(_mangledName: largeResultName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -336,7 +336,7 @@ func test() async throws {
 
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: enumResultName,
+      target: RemoteCallTarget(_mangledName: enumResultName),
       invocationDecoder: &emptyInvocation,
       handler: FakeResultHandler()
   )
@@ -350,7 +350,7 @@ func test() async throws {
   var echoDecoder = echoInvocation.makeDecoder()
   try await system.executeDistributedTarget(
       on: local,
-      mangledTargetName: echoName,
+      target: RemoteCallTarget(_mangledName: echoName),
       invocationDecoder: &echoDecoder,
       handler: FakeResultHandler()
   )
@@ -365,7 +365,7 @@ func test() async throws {
   var generic1Decoder = generic1Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: generic1Name,
+    target: RemoteCallTarget(_mangledName: generic1Name),
     invocationDecoder: &generic1Decoder,
     handler: FakeResultHandler()
   )
@@ -383,7 +383,7 @@ func test() async throws {
   var generic2Decoder = generic2Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: generic2Name,
+    target: RemoteCallTarget(_mangledName: generic2Name),
     invocationDecoder: &generic2Decoder,
     handler: FakeResultHandler()
   )
@@ -404,7 +404,7 @@ func test() async throws {
   var generic3Decoder = generic3Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: generic3Name,
+    target: RemoteCallTarget(_mangledName: generic3Name),
     invocationDecoder: &generic3Decoder,
     handler: FakeResultHandler()
   )
@@ -426,7 +426,7 @@ func test() async throws {
   var generic4Decoder = generic4Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: generic4Name,
+    target: RemoteCallTarget(_mangledName: generic4Name),
     invocationDecoder: &generic4Decoder,
     handler: FakeResultHandler()
   )
@@ -450,7 +450,7 @@ func test() async throws {
   var generic5Decoder = generic5Invocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: generic5Name,
+    target: RemoteCallTarget(_mangledName: generic5Name),
     invocationDecoder: &generic5Decoder,
     handler: FakeResultHandler()
   )
@@ -473,7 +473,7 @@ func test() async throws {
   var genericOptDecoder = genericOptInvocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: genericOptionalName,
+    target: RemoteCallTarget(_mangledName: genericOptionalName),
     invocationDecoder: &genericOptDecoder,
     handler: FakeResultHandler()
   )
@@ -488,7 +488,7 @@ func test() async throws {
   var decodeErrDecoder = decodeErrInvocation.makeDecoder()
   try await system.executeDistributedTarget(
     on: local,
-    mangledTargetName: expectsDecodeErrorName,
+    target: RemoteCallTarget(_mangledName: expectsDecodeErrorName),
     invocationDecoder: &decodeErrDecoder,
     handler: FakeResultHandler()
   )

--- a/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import _Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Greeter {
+  distributed func noParams() {}
+  distributed func noParamsThrows() throws {}
+  distributed func noLabel(_ value: String) {}
+  distributed func noLabels2(_ value: String, _ value2: String) {}
+  distributed func noLabels3(_ value: String, _ value2: String, _ value3: String) {}
+  distributed func oneLabel(value: String, _ value2: String, _ value3: String) {}
+  distributed func parameterSingle(first: String) {}
+  distributed func parameterPair(first: String, second: Int) {}
+  // FIXME(distributed): rdar://90293494 fails to get
+//  distributed func generic<A: Codable & Sendable>(first: A) {}
+//  distributed func genericNoLabel<A: Codable & Sendable>(_ first: A) {}
+}
+extension Greeter {
+  distributed func parameterTriple(first: String, second: Int, third: Double) {}
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+  let g = Greeter(system: system)
+  let greeter = try Greeter.resolve(id: g.id, using: system)
+
+  try await greeter.noParams()
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.noParams()
+
+  _ = try await greeter.parameterSingle(first: "X")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterSingle(first:)
+
+  try await greeter.noLabel("")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.noLabel(_:)
+
+  try await greeter.noLabels2("", "")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.noLabels2(_:_:)
+
+  try await greeter.noLabels3("", "", "")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.noLabels3(_:_:_:)
+
+  try await greeter.oneLabel(value: "", "", "")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.oneLabel(value:_:_:)
+
+  _ = try await greeter.parameterPair(first: "X", second: 2)
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterPair(first:second:)
+
+  _ = try await greeter.parameterTriple(first: "X", second: 2, third: 3.0)
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterTriple(first:second:third:)
+
+  // FIXME: rdar://90293494 seems to fail getting the substitutions?
+//  _ = try await greeter.generic(first: "X")
+//  // TODO: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterTriple(first:second:third:)
+
+  print("done")
+  // CHECK: done
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -128,11 +128,11 @@ struct FakeActorSystem: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    guard target.mangledName != "$s4main28SomeSpecificDistributedActorC24helloThrowsTransportBoomSSyYaKFTE" else {
+    guard "\(target)" != "main.SomeSpecificDistributedActor.helloThrowsTransportBoom()" else {
       throw Boom("system")
     }
 
-    return "remote(\(target.mangledName))" as! Res
+    return "remote(\(target))" as! Res
   }
 
   func remoteCallVoid<Act, Err>(
@@ -234,18 +234,12 @@ func test_remote_invoke(address: ActorAddress, system: FakeActorSystem) async {
   print("remote isRemote: \(__isRemoteActor(remote))")
   // CHECK: remote isRemote: true
   await check(actor: remote)
-  // TODO(distributed): remote - helloAsyncThrows: remote(_remote_impl_helloAsyncThrows())
-  // CHECK: remote - helloAsyncThrows: remote($s4main28SomeSpecificDistributedActorC16helloAsyncThrowsSSyYaKFTE)
-  // TODO(distributed): remote - helloAsync: remote()
-  // CHECK: remote - helloAsync: remote($s4main28SomeSpecificDistributedActorC10helloAsyncSSyYaKFTE)
-  // TODO(distributed): remote - helloThrows: remote(_remote_impl_helloThrows())
-  // CHECK: remote - helloThrows: remote($s4main28SomeSpecificDistributedActorC11helloThrowsSSyYaKFTE)
-  // TODO(distributed): remote - hello: remote(_remote_impl_hello())
-  // CHECK: remote - hello: remote($s4main28SomeSpecificDistributedActorC5helloSSyYaKFTE)
-  // TODO(distributed): remote - callTaskSelf: remote(_remote_impl_callTaskSelf())
-  // CHECK: remote - callTaskSelf: remote($s4main28SomeSpecificDistributedActorC12callTaskSelfSSyYaKFTE)
-  // TODO(distributed): remote - callDetachedSelf: remote(_remote_impl_callDetachedSelf())
-  // CHECK: remote - callDetachedSelf: remote($s4main28SomeSpecificDistributedActorC16callDetachedSelfSSyYaKFTE)
+  // CHECK: remote - helloAsyncThrows: remote(main.SomeSpecificDistributedActor.helloAsyncThrows())
+  // CHECK: remote - helloAsync: remote(main.SomeSpecificDistributedActor.helloAsync())
+  // CHECK: remote - helloThrows: remote(main.SomeSpecificDistributedActor.helloThrows())
+  // CHECK: remote - hello: remote(main.SomeSpecificDistributedActor.hello())
+  // CHECK: remote - callTaskSelf: remote(main.SomeSpecificDistributedActor.callTaskSelf())
+  // CHECK: remote - callDetachedSelf: remote(main.SomeSpecificDistributedActor.callDetachedSelf())
   // CHECK: remote - helloThrowsTransportBoom: Boom(whoFailed: "system")
 
   print(local)

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -139,7 +139,7 @@ struct Error_wrongReturn: DistributedActorSystem {
     Act.ID == ActorID,
     Err: Error,
     Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public func remoteCall<Act, Err, Res>(
@@ -153,7 +153,7 @@ struct Error_wrongReturn: DistributedActorSystem {
     Act.ID == ActorID,
     Err: Error,
     Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public func remoteCallVoid<Act, Err>(
@@ -165,7 +165,7 @@ struct Error_wrongReturn: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -209,7 +209,7 @@ struct BadRemoteCall_param: DistributedActorSystem {
     Act.ID == ActorID,
     Err: Error,
     Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public func remoteCallVoid<Act, Err>(
@@ -221,7 +221,7 @@ struct BadRemoteCall_param: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -260,7 +260,7 @@ public struct BadRemoteCall_notPublic: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   // expected-error@+1{{method 'remoteCallVoid(on:target:invocation:throwing:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
@@ -273,7 +273,7 @@ public struct BadRemoteCall_notPublic: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -314,7 +314,7 @@ public struct BadRemoteCall_badResultConformance: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SomeProtocol { // ERROR: bad, this must be SerializationRequirement
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   public func remoteCallVoid<Act, Err>(
@@ -326,7 +326,7 @@ public struct BadRemoteCall_badResultConformance: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -366,7 +366,7 @@ struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   func remoteCallVoid<Act, Err>(
@@ -378,7 +378,7 @@ struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -419,7 +419,7 @@ struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: Distr
           Act.ID == ActorID,
           Err: Error,
           Res: SomeProtocol { // ERROR: missing Codable!!!
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   func remoteCallVoid<Act, Err>(
@@ -431,7 +431,7 @@ struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: Distr
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -469,7 +469,7 @@ struct BadRemoteCall_anySerializationRequirement: DistributedActorSystem {
           Act.ID == ActorID,
           Err: Error,
           Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 
   func remoteCallVoid<Act, Err>(
@@ -481,7 +481,7 @@ struct BadRemoteCall_anySerializationRequirement: DistributedActorSystem {
     where Act: DistributedActor,
     Act.ID == ActorID,
     Err: Error {
-    throw ExecuteDistributedTargetError(message: "Not implemented.")
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
   }
 }
 
@@ -573,8 +573,7 @@ struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocati
 }
 
 struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordErrorType' is missing witness for protocol requirement 'recordErrorType'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordErrorType' requires function 'recordErrorType' with signature:}}
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -613,8 +612,7 @@ struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvoca
 }
 
 struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordErrorType_wrongType' is missing witness for protocol requirement 'recordErrorType'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordErrorType_wrongType' requires function 'recordErrorType' with signature:}}
+  //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
   typealias SerializationRequirement = Codable
 
   mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
@@ -622,6 +620,7 @@ struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocat
   mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
   mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
   mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
+  //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
   mutating func doneRecording() throws {}
 }
 


### PR DESCRIPTION
This does a number of things based on review rounds:

- remove mangled names from any API at all, even tho it was just a name and we could have accepted otehr things, the name was bad
- move to accepting `RemoteCallTarget`
- remove `mangledName` on and rather provide an unmangled representation if we're able to

TODO: needs more "bad case" tests.