### PR TITLE
SE-0343: De-experimentalify async top-level context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 ## Swift 5.7
 
+* [SE-0343][]:
+
+Top-level scripts support asynchronous calls.
+
+Using an `await` by calling an asynchronous function or accessing an isolated
+variable transitions the top-level to an asynchronous context. As an
+asynchronous context, top-level variables are `@MainActor`-isolated and the
+top-level is run on the `@MainActor`.
+
+Note that the transition affects function overload resolution and starts an
+implicit run loop to drive the concurrency machinery.
+
+Unmodified scripts are not affected by this change unless `-warn-concurrency` is
+passed to the compiler invocation. With `-warn-concurrency`, variables in the
+top-level are isolated to the main actor and the top-level context is isolated
+to the main actor, but is not an asynchronous context.
+
 * [SE-0336][]:
 
 It is now possible to declare `distributed actor` and `distributed func`s inside of them.
@@ -9065,6 +9082,7 @@ Swift 1.0
 [SE-0335]: <https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md>
 [SE-0341]: <https://github.com/apple/swift-evolution/blob/main/proposals/0341-opaque-parameters.md>
 [SE-0336]: <https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md>
+[SE-0343]: <https://github.com/apple/swift-evolution/blob/main/proposals/0343-top-level-concurrency.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -420,6 +420,8 @@ ERROR(error_nonexistent_output_dir,none,
 REMARK(interface_file_backup_used,none,
       "building module from '%0' failed; retrying building module from '%1'", (StringRef, StringRef))
 
+WARNING(warn_flag_deprecated,none, "flag '%0' is deprecated", (StringRef))
+
 // Dependency Verifier Diagnostics
 ERROR(missing_member_dependency,none,
       "expected "

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -407,9 +407,6 @@ namespace swift {
     /// cases.
     bool EnableNonFrozenEnumExhaustivityDiagnostics = false;
 
-    /// Enable making top-level code support concurrency
-    bool EnableExperimentalAsyncTopLevel = false;
-
     /// Regex for the passes that should report passed and missed optimizations.
     ///
     /// These are shared_ptrs so that this class remains copyable.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9090,7 +9090,9 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
     if (dc->isAsyncContext() || dc->getASTContext().LangOpts.WarnConcurrency) {
       if (Type mainActor = dc->getASTContext().getMainActorType())
-        return ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/false);
+        return ActorIsolation::forGlobalActor(
+            mainActor,
+            /*unsafe=*/!dc->getASTContext().isSwiftVersionAtLeast(6));
     }
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9088,9 +9088,7 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
-    if (dc->isAsyncContext() ||
-        (dc->getASTContext().LangOpts.WarnConcurrency &&
-         dc->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel)) {
+    if (dc->isAsyncContext() || dc->getASTContext().LangOpts.WarnConcurrency) {
       if (Type mainActor = dc->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(mainActor, /*unsafe=*/false);
     }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1239,12 +1239,10 @@ bool DeclContext::isAsyncContext() const {
     return false;
   case DeclContextKind::FileUnit:
     if (const SourceFile *sf = dyn_cast<SourceFile>(this))
-      return getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
-             sf->isAsyncTopLevelSourceFile();
+      return sf->isAsyncTopLevelSourceFile();
     return false;
   case DeclContextKind::TopLevelCodeDecl:
-    return getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
-           getParent()->isAsyncContext();
+    return getParent()->isAsyncContext();
   case DeclContextKind::AbstractClosureExpr:
     return cast<AbstractClosureExpr>(this)->isBodyAsync();
   case DeclContextKind::AbstractFunctionDecl: {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -487,16 +487,15 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 
-  Opts.EnableExperimentalAsyncTopLevel |=
-    Args.hasArg(OPT_enable_experimental_async_top_level);
-
   /// experimental distributed also implicitly enables experimental concurrency
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_distributed);
-  Opts.EnableExperimentalConcurrency |=
-    Args.hasArg(OPT_enable_experimental_async_top_level);
+
+  if (Args.hasArg(OPT_enable_experimental_async_top_level))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-enable-experimental-async-top-level");
 
   Opts.DiagnoseInvalidEphemeralnessAsError |=
       Args.hasArg(OPT_enable_invalid_ephemeralness_as_error);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -344,14 +344,14 @@ GlobalActorAttributeRequest::evaluate(
     if (auto var = dyn_cast<VarDecl>(storage)) {
 
       // ... but not if it's an async-context top-level global
-      if (var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
-          var->isTopLevelGlobal() && (var->getDeclContext()->isAsyncContext()
-            || var->getASTContext().LangOpts.WarnConcurrency)) {
+      if (var->isTopLevelGlobal() &&
+          (var->getDeclContext()->isAsyncContext() ||
+           var->getASTContext().LangOpts.WarnConcurrency)) {
         var->diagnose(diag::global_actor_top_level_var)
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
       }
-      
+
       // ... and not if it's local property
       if (var->getDeclContext()->isLocalContext()) {
         var->diagnose(diag::global_actor_on_local_variable, var->getName())
@@ -3869,8 +3869,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
-    if (var->getASTContext().LangOpts.EnableExperimentalAsyncTopLevel &&
-        var->isTopLevelGlobal() &&
+    if (var->isTopLevelGlobal() &&
         (var->getASTContext().LangOpts.WarnConcurrency ||
          var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency -parse-as-library
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
@@ -6,10 +6,10 @@ import Foundation
 import ObjCConcurrency
 // expected-remark@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
-if #available(SwiftStdlib 5.5, *) {
-
+@available(SwiftStdlib 5.5, *)
 @MainActor func onlyOnMainActor() { }
 
+@available(SwiftStdlib 5.5, *)
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
   let _: Bool = await slowServer.checkAvailability()
@@ -62,6 +62,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
   _ = await slowServer.runOnMainThread()
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSlowServerSynchronous(slowServer: SlowServer) {
   // synchronous version
   let _: Int = slowServer.doSomethingConflicted("thinking")
@@ -88,6 +89,7 @@ func testSlowServerSynchronous(slowServer: SlowServer) {
   let _: Int = slowServer.overridableButRunsOnMainThread // expected-error{{cannot convert value of type '(((String) -> Void)?) -> Void' to specified type 'Int'}}
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSlowServerOldSchool(slowServer: SlowServer) {
   slowServer.doSomethingSlow("mail") { i in
     _ = i
@@ -96,6 +98,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
   _ = slowServer.allOperations
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSendable(fn: () -> Void) {
   doSomethingConcurrently(fn) // okay, due to implicit @preconcurrency
   doSomethingConcurrentlyButUnsafe(fn) // okay, @Sendable not part of the type
@@ -107,6 +110,7 @@ func testSendable(fn: () -> Void) {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSendableInAsync() async {
   var x = 17
   doSomethingConcurrentlyButUnsafe {
@@ -115,6 +119,7 @@ func testSendableInAsync() async {
   print(x)
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSendableAttrs(
   sendableClass: SendableClass, nonSendableClass: NonSendableClass,
   sendableEnum: SendableEnum, nonSendableEnum: NonSendableEnum,
@@ -150,8 +155,10 @@ func testSendableAttrs(
 }
 
 // Check import of attributes
+@available(SwiftStdlib 5.5, *)
 func globalAsync() async { }
 
+@available(SwiftStdlib 5.5, *)
 actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
   func syncMethod() { } // expected-note 2{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
 
@@ -177,13 +184,16 @@ func testCV(r: NSRange) {
 
 // Global actor (unsafe) isolation.
 
+@available(SwiftStdlib 5.5, *)
 actor SomeActor { }
 
+@available(SwiftStdlib 5.5, *)
 @globalActor
 struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
+@available(SwiftStdlib 5.5, *)
 class MyButton : NXButton {
   @MainActor func testMain() {
     onButtonPress() // okay
@@ -198,17 +208,19 @@ class MyButton : NXButton {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 func testButtons(mb: MyButton) {
   mb.onButtonPress()
 }
 
-
+@available(SwiftStdlib 5.5, *)
 func testMirrored(instance: ClassWithAsync) async {
   await instance.instanceAsync()
   await instance.protocolMethod()
   await instance.customAsyncName()
 }
 
+@available(SwiftStdlib 5.5, *)
 @MainActor class MyToolbarButton : NXButton {
   var count = 5
 
@@ -220,6 +232,7 @@ func testMirrored(instance: ClassWithAsync) async {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 @MainActor class MyView: NXView {
   func f() {
     Task {
@@ -231,13 +244,17 @@ func testMirrored(instance: ClassWithAsync) async {
 }
 
 
+
+@available(SwiftStdlib 5.5, *)
 @MainActor func mainActorFn() {}
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func sgActorFn() {}
 
 // Check inferred isolation for overridden decls from ObjC.
 // Note that even if the override is not present, it
 // can have an affect. -- rdar://87217618 / SR-15694
 @MainActor
+@available(SwiftStdlib 5.5, *)
 class FooFrame: PictureFrame {
   init() {
     super.init(size: 0)
@@ -252,6 +269,7 @@ class FooFrame: PictureFrame {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 class BarFrame: PictureFrame {
   init() {
     super.init(size: 0)
@@ -266,6 +284,7 @@ class BarFrame: PictureFrame {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor
 class BazFrame: NotIsolatedPictureFrame {
   init() {
@@ -285,6 +304,7 @@ class BazFrame: NotIsolatedPictureFrame {
 class BazFrameIso: PictureFrame { // expected-error {{global actor 'SomeGlobalActor'-isolated class 'BazFrameIso' has different actor isolation from main actor-isolated superclass 'PictureFrame'}}
 }
 
+@available(SwiftStdlib 5.5, *)
 func check() async {
   _ = await BarFrame()
   _ = await FooFrame()
@@ -347,5 +367,3 @@ func testSender(
   sender.sendPtr(ptr)
   sender.sendStringArray(stringArray)
 }
-
-} // SwiftStdlib 5.5

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency -parse-as-library
 // REQUIRES: concurrency
 
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
-// RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency
+// RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency -parse-as-library
 // REQUIRES: concurrency
 
 import OtherActors // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@preconcurrency }}

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-concurrency
+// RUN: %target-typecheck-verify-swift -warn-concurrency -parse-as-library
 // REQUIRES: concurrency
 
 class GlobalCounter {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency -parse-as-library
 // REQUIRES: concurrency
 
 class NotConcurrent { } // expected-note 27{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}

--- a/test/Concurrency/property_initializers_swift6.swift
+++ b/test/Concurrency/property_initializers_swift6.swift
@@ -3,17 +3,21 @@
 
 // REQUIRES: asserts
 
-@MainActor
-func mainActorFn() -> Int { return 0 } // expected-note 2 {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
-
-@MainActor
-class C {
-  var x: Int = mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous nonisolated context}}
-
-  lazy var y: Int = mainActorFn()
-
-  static var z: Int = mainActorFn()
+@globalActor
+actor GlobalActor {
+    static let shared = GlobalActor()
 }
 
-@MainActor
-var x: Int = mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous nonisolated context}}
+@GlobalActor
+func globalActorFn() -> Int { return 0 } // expected-note 2 {{calls to global function 'globalActorFn()' from outside of its actor context are implicitly asynchronous}}
+
+@GlobalActor
+class C {
+  var x: Int = globalActorFn() // expected-error {{call to global actor 'GlobalActor'-isolated global function 'globalActorFn()' in a synchronous nonisolated context}}
+
+  lazy var y: Int = globalActorFn()
+
+  static var z: Int = globalActorFn()
+}
+
+var x: Int = globalActorFn() // expected-error {{call to global actor 'GlobalActor'-isolated global function 'globalActorFn()' in a synchronous main actor-isolated context}}

--- a/test/stmt/async.swift
+++ b/test/stmt/async.swift
@@ -2,9 +2,14 @@
 
 // REQUIRES: concurrency
 
+@_silgen_name("omnomInt")
+func omnom(_ x: Int)
+
 func f() async -> Int { 0 }
 
-_ = await f() // expected-error{{'async' call in a function that does not support concurrency}}
-
-async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
-// expected-error@-1{{'async' call in a function that does not support concurrency}}
+func syncContext() {        // expected-note 4 {{add 'async' to function 'syncContext()' to make it asynchronous}}
+    _ = await f()           // expected-error{{'async' call in a function that does not support concurrency}}
+    async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
+                            // expected-error@-1{{'async' call in a function that does not support concurrency}}
+    await omnom(y)          // expected-error{{'async let' in a function that does not support concurrency}}
+}


### PR DESCRIPTION
This PR deprecates `-enable-experimental-async-top-level`, removes gating the asynchronous top-level context on `-enable-experimental-async-top-level`, adjusts affected tests, and adds the changes to the changelog.

I'm not sure if there is a better way to deprecate and eventually remove unused flags, but I'm emitting a warning saying it's deprecated if you try to use it.

rdar://71966476