### PR TITLE
[MemAccessUtils] Add two utilties.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1267,6 +1267,18 @@ template <> struct DenseMapInfo<swift::AccessPathWithBase> {
   }
 };
 
+// Allow AccessPath::PathNode to be used as a pointer-like template argument.
+template<>
+struct PointerLikeTypeTraits<swift::AccessPath::PathNode> {
+  static inline void *getAsVoidPointer(swift::AccessPath::PathNode node) {
+    return (void *)node.node;
+  }
+  static inline swift::AccessPath::PathNode getFromVoidPointer(void *pointer) {
+    return swift::AccessPath::PathNode((swift::IndexTrieNode *)pointer);
+  }
+  enum { NumLowBitsAvailable =
+         PointerLikeTypeTraits<swift::IndexTrieNode *>::NumLowBitsAvailable };
+};
 } // end namespace llvm
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1209,6 +1209,16 @@ struct AccessPathWithBase {
   void dump() const;
 };
 
+// Visits all the "product leaves" of the type tree of the specified value and
+// invokes provided visitor, identifying the leaf by its path node and
+// providing its type.
+//
+// The "product leaves" are the leaves obtained by only looking through type
+// products (structs and tuples) and NOT type sums (enums).
+void visitProductLeafAccessPathNodes(
+    SILValue address, TypeExpansionContext tec, SILModule &module,
+    std::function<void(AccessPath::PathNode, SILType)> visitor);
+
 inline AccessPath AccessPath::compute(SILValue address) {
   return AccessPathWithBase::compute(address).accessPath;
 }

--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -238,14 +238,14 @@ public:
     addr2LocIdx[projection] = locIdx;
   }
 
-  /// Sets the location bits os \p addr in \p bits, if \p addr is associated
+  /// Sets the location bits of \p addr in \p bits, if \p addr is associated
   /// with a location.
   void setBits(Bits &bits, SILValue addr) const {
     if (auto *loc = getLocation(addr))
       bits |= loc->subLocations;
   }
 
-  /// Clears the location bits os \p addr in \p bits, if \p addr is associated
+  /// Clears the location bits of \p addr in \p bits, if \p addr is associated
   /// with a location.
   void clearBits(Bits &bits, SILValue addr) const {
     if (auto *loc = getLocation(addr))
@@ -307,7 +307,7 @@ private:
                                       SubLocationMap &subLocationMap);
 
   /// Helper function called by analyzeLocation to create a sub-location for
-  /// and address projection and check all of its uses.
+  /// an address projection and check all of its uses.
   bool analyzeAddrProjection(
     SingleValueInstruction *projection, unsigned parentLocIdx,unsigned fieldNr,
     SmallVectorImpl<SILValue> &collectedVals, SubLocationMap &subLocationMap);

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -484,7 +484,7 @@ static_assert(sizeof(Projection) == sizeof(uintptr_t),
 /// The main purpose of this class is to enable one to reason about iterated
 /// chains of projections. Some example usages are:
 ///
-/// 1. Converting value projections to aggregate projections or vis-a-versa.
+/// 1. Converting value projections to aggregate projections or vice versa.
 /// 2. Performing tuple operations on two paths (using the mathematical
 ///    definition of tuples as ordered sets).
 class ProjectionPath {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -75,7 +75,7 @@ static void buildTypeDependentOperands(
     bool hasDynamicSelf, SmallVectorImpl<SILValue> &TypeDependentOperands,
     SILFunction &F) {
 
-  for (const auto archetype : RootOpenedArchetypes) {
+  for (const auto &archetype : RootOpenedArchetypes) {
     SILValue def = F.getModule().getRootOpenedArchetypeDef(archetype, &F);
     assert(def->getFunction() == &F &&
            "def of root opened archetype is in wrong function");

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -125,7 +125,8 @@ public:
       phiArg->getIncomingPhiValues(pointerWorklist);
   }
 
-  void visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper) {
+  void visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper,
+                        AccessStorageCast) {
     // Allow conversions to/from pointers and addresses on disjoint phi paths
     // only if the underlying useDefVisitor allows it.
     if (storageCastTy == IgnoreStorageCast)
@@ -209,7 +210,8 @@ public:
     return this->asImpl().visitNonAccess(phiArg);
   }
 
-  SILValue visitStorageCast(SingleValueInstruction *, Operand *sourceAddr) {
+  SILValue visitStorageCast(SingleValueInstruction *, Operand *sourceAddr,
+                            AccessStorageCast cast) {
     assert(storageCastTy == IgnoreStorageCast);
     return sourceAddr->get();
   }
@@ -331,11 +333,12 @@ public:
   }
 
   // Override visitStorageCast to avoid seeing through arbitrary address casts.
-  SILValue visitStorageCast(SingleValueInstruction *cast, Operand *sourceAddr) {
+  SILValue visitStorageCast(SingleValueInstruction *svi, Operand *sourceAddr,
+                            AccessStorageCast cast) {
     if (storageCastTy == StopAtStorageCast)
-      return visitNonAccess(cast);
+      return visitNonAccess(svi);
 
-    return SuperTy::visitStorageCast(cast, sourceAddr);
+    return SuperTy::visitStorageCast(svi, sourceAddr, cast);
   }
 };
 
@@ -1062,11 +1065,13 @@ namespace {
 // AccessStorage object for all projection paths.
 class FindAccessStorageVisitor
     : public FindAccessVisitorImpl<FindAccessStorageVisitor> {
+  using SuperTy = FindAccessVisitorImpl<FindAccessStorageVisitor>;
 
 public:
   struct Result {
     Optional<AccessStorage> storage;
     SILValue base;
+    Optional<AccessStorageCast> seenCast;
   };
 
 private:
@@ -1102,6 +1107,8 @@ public:
   // may be multiple global_addr bases for identical storage.
   SILValue getBase() const { return result.base; }
 
+  Optional<AccessStorageCast> getCast() const { return result.seenCast; }
+
   // MARK: AccessPhiVisitor::UseDefVisitor implementation.
 
   // A valid result requires valid storage, but not a valid base.
@@ -1128,22 +1135,41 @@ public:
     invalidateResult();
     return SILValue();
   }
+
+  SILValue visitStorageCast(SingleValueInstruction *svi, Operand *sourceOper,
+                            AccessStorageCast cast) {
+    result.seenCast = result.seenCast ? std::max(*result.seenCast, cast) : cast;
+    return SuperTy::visitStorageCast(svi, sourceOper, cast);
+  }
 };
 
 } // end anonymous namespace
 
+RelativeAccessStorageWithBase
+RelativeAccessStorageWithBase::compute(SILValue address) {
+  FindAccessStorageVisitor visitor(NestedAccessType::IgnoreAccessBegin);
+  visitor.findStorage(address);
+  return {
+      address, {visitor.getStorage(), visitor.getBase()}, visitor.getCast()};
+}
+
+RelativeAccessStorageWithBase
+RelativeAccessStorageWithBase::computeInScope(SILValue address) {
+  FindAccessStorageVisitor visitor(NestedAccessType::StopAtAccessBegin);
+  visitor.findStorage(address);
+  return {
+      address, {visitor.getStorage(), visitor.getBase()}, visitor.getCast()};
+}
+
 AccessStorageWithBase
 AccessStorageWithBase::compute(SILValue sourceAddress) {
-  FindAccessStorageVisitor visitor(NestedAccessType::IgnoreAccessBegin);
-  visitor.findStorage(sourceAddress);
-  return {visitor.getStorage(), visitor.getBase()};
+  return RelativeAccessStorageWithBase::compute(sourceAddress).storageWithBase;
 }
 
 AccessStorageWithBase
 AccessStorageWithBase::computeInScope(SILValue sourceAddress) {
-  FindAccessStorageVisitor visitor(NestedAccessType::StopAtAccessBegin);
-  visitor.findStorage(sourceAddress);
-  return {visitor.getStorage(), visitor.getBase()};
+  return RelativeAccessStorageWithBase::computeInScope(sourceAddress)
+      .storageWithBase;
 }
 
 AccessStorage AccessStorage::compute(SILValue sourceAddress) {

--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -264,7 +264,7 @@ public:
   }
 
   void visitStorageCast(SingleValueInstruction *projectedAddr,
-                        Operand *parentAddr) {
+                        Operand *parentAddr, AccessStorageCast cast) {
     return next(parentAddr->get());
   }
 


### PR DESCRIPTION
The two primary commits in this PR are

(1) [MemAccessUtils] Visit product type tree of addr.

Added a function that visits the leaves of the type/projection tree of the specified address and calls its visitor with the path node to and type of each.

(2) [MemAccessUtils] Added RelativeAccessStorageWithBase.

The new "relative" version of AccessStorageWithBase carries additional information about the walk from the specified address back to the base.  For now, that includes the original address and the most transformative sort of cast that was encountered.

These additions were motivated by SSADestroyHoisting but can committed separately.
