### PR TITLE
[CSApply] Use decl context of target when applying solution to it

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2281,7 +2281,8 @@ namespace {
     ExprRewriter(ConstraintSystem &cs, Solution &solution,
                  Optional<SolutionApplicationTarget> target,
                  bool suppressDiagnostics)
-        : cs(cs), dc(cs.DC), solution(solution), target(target),
+        : cs(cs), dc(target ? target->getDeclContext() : cs.DC),
+          solution(solution), target(target),
           SuppressDiagnostics(suppressDiagnostics) {}
 
     ConstraintSystem &getConstraintSystem() const { return cs; }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -233,3 +233,19 @@ func test_local_function_capturing_vars() {
     }
   }
 }
+
+func test_taps_type_checked_with_correct_decl_context() {
+  struct Path {
+    func contains<T>(_: T) -> Bool where T: StringProtocol { return false }
+  }
+
+  let paths: [Path] = []
+  let strs: [String] = []
+
+  _ = paths.filter { path in
+    for str in strs where path.contains("\(str).hello") {
+      return true
+    }
+    return false
+  }
+}


### PR DESCRIPTION
Solution application target can have its declaration context differ
from one used for constraint system, since target could be e.g. a
pattern associated with pattern binding declaration, a statement or
a sub-element of one (e.g. where clause) used in a closure etc.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
