### PR TITLE
[Concurrency] Decode actor/task flags in signposts, make task_wait an interval.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -107,8 +107,6 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
   auto queueHead = fragment->waitQueue.load(std::memory_order_acquire);
   bool contextIntialized = false;
   while (true) {
-    concurrency::trace::task_wait(
-        waitingTask, this, static_cast<uintptr_t>(queueHead.getStatus()));
     switch (queueHead.getStatus()) {
     case Status::Error:
     case Status::Success:
@@ -123,6 +121,8 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       SWIFT_TASK_DEBUG_LOG("task %p waiting on task %p, going to sleep",
                            waitingTask, this);
       _swift_tsan_release(static_cast<Job *>(waitingTask));
+      concurrency::trace::task_wait(
+          waitingTask, this, static_cast<uintptr_t>(queueHead.getStatus()));
       // Task is not complete. We'll need to add ourselves to the queue.
       break;
     }
@@ -232,6 +232,8 @@ void AsyncTask::completeFuture(AsyncContext *context) {
     }
 
     _swift_tsan_acquire(static_cast<Job *>(waitingTask));
+
+    concurrency::trace::task_resume(waitingTask);
 
     // Enqueue the waiter on the global executor.
     // TODO: allow waiters to fill in a suggested executor
@@ -470,23 +472,27 @@ const void
         reinterpret_cast<void *>(task_future_wait_resume_adapter);
 
 const void *AsyncTask::getResumeFunctionForLogging() {
+  const void *result = reinterpret_cast<const void *>(ResumeTask);
+
   if (ResumeTask == non_future_adapter) {
     auto asyncContextPrefix = reinterpret_cast<AsyncContextPrefix *>(
         reinterpret_cast<char *>(ResumeContext) - sizeof(AsyncContextPrefix));
-    return reinterpret_cast<const void *>(asyncContextPrefix->asyncEntryPoint);
+    result =
+        reinterpret_cast<const void *>(asyncContextPrefix->asyncEntryPoint);
   } else if (ResumeTask == future_adapter) {
     auto asyncContextPrefix = reinterpret_cast<FutureAsyncContextPrefix *>(
         reinterpret_cast<char *>(ResumeContext) -
         sizeof(FutureAsyncContextPrefix));
-    return reinterpret_cast<const void *>(asyncContextPrefix->asyncEntryPoint);
+    result =
+        reinterpret_cast<const void *>(asyncContextPrefix->asyncEntryPoint);
   } else if (ResumeTask == task_wait_throwing_resume_adapter) {
     auto context = static_cast<TaskFutureWaitAsyncContext *>(ResumeContext);
-    return reinterpret_cast<const void *>(context->ResumeParent);
+    result = reinterpret_cast<const void *>(context->ResumeParent);
   } else if (ResumeTask == task_future_wait_resume_adapter) {
-    return reinterpret_cast<const void *>(ResumeContext->ResumeParent);
+    result = reinterpret_cast<const void *>(ResumeContext->ResumeParent);
   }
 
-  return reinterpret_cast<const void *>(ResumeTask);
+  return __ptrauth_swift_runtime_function_entry_strip(result);
 }
 
 JobPriority swift::swift_task_currentPriority(AsyncTask *task)
@@ -653,7 +659,7 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
      basePriority = JobPriority::Default;
   }
 
-  SWIFT_TASK_DEBUG_LOG("Task's base priority = %#x", basePriority);
+  SWIFT_TASK_DEBUG_LOG("Task's base priority = %#zx", basePriority);
 
   // Figure out the size of the header.
   size_t headerSize = sizeof(AsyncTask);
@@ -788,7 +794,9 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
     futureAsyncContextPrefix->indirectResult = futureFragment->getStoragePtr();
   }
 
-  SWIFT_TASK_DEBUG_LOG("creating task %p with parent %p at base pri %zu", task, parent, basePriority);
+  SWIFT_TASK_DEBUG_LOG("creating task %p ID %" PRIu64
+                       " with parent %p at base pri %zu",
+                       task, task->getTaskId(), parent, basePriority);
 
   // Initialize the task-local allocator.
   initialContext->ResumeParent = reinterpret_cast<TaskContinuationFunction *>(
@@ -1059,6 +1067,8 @@ static AsyncTask *swift_continuation_initImpl(ContinuationAsyncContext *context,
   task->ResumeContext = context;
   task->ResumeTask = context->ResumeParent;
 
+  concurrency::trace::task_continuation_init(task, context);
+
   return task;
 }
 
@@ -1070,6 +1080,8 @@ static void swift_continuation_awaitImpl(ContinuationAsyncContext *context) {
   assert(task->ResumeContext == context);
   assert(task->ResumeTask == context->ResumeParent);
 #endif
+
+  concurrency::trace::task_continuation_await(context);
 
   auto &sync = context->AwaitSynchronization;
 
@@ -1157,12 +1169,14 @@ static void resumeTaskAfterContinuation(AsyncTask *task,
 SWIFT_CC(swift)
 static void swift_continuation_resumeImpl(AsyncTask *task) {
   auto context = static_cast<ContinuationAsyncContext*>(task->ResumeContext);
+  concurrency::trace::task_continuation_resume(context, false);
   resumeTaskAfterContinuation(task, context);
 }
 
 SWIFT_CC(swift)
 static void swift_continuation_throwingResumeImpl(AsyncTask *task) {
   auto context = static_cast<ContinuationAsyncContext*>(task->ResumeContext);
+  concurrency::trace::task_continuation_resume(context, false);
   resumeTaskAfterContinuation(task, context);
 }
 
@@ -1171,6 +1185,7 @@ SWIFT_CC(swift)
 static void swift_continuation_throwingResumeWithErrorImpl(AsyncTask *task,
                                                 /* +1 */ SwiftError *error) {
   auto context = static_cast<ContinuationAsyncContext*>(task->ResumeContext);
+  concurrency::trace::task_continuation_resume(context, true);
   context->ErrorResult = error;
   resumeTaskAfterContinuation(task, context);
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -507,7 +507,9 @@ public:
   }
 
   void traceStatusChanged(AsyncTask *task) {
-    concurrency::trace::task_status_changed(task, Flags);
+    concurrency::trace::task_status_changed(
+        task, static_cast<uint8_t>(getStoredPriority()), isCancelled(),
+        isStoredPriorityEscalated(), isRunning(), isEnqueued());
   }
 };
 
@@ -771,7 +773,10 @@ inline void AsyncTask::flagAsAndEnqueueOnExecutor(ExecutorRef newExecutor) {
 
   // Set up task for enqueue to next location by setting the Job priority field
   Flags.setPriority(newStatus.getStoredPriority());
-  concurrency::trace::task_flags_changed(this, Flags.getOpaqueValue());
+  concurrency::trace::task_flags_changed(
+      this, static_cast<uint8_t>(Flags.getPriority()), Flags.task_isChildTask(),
+      Flags.task_isFuture(), Flags.task_isGroupChildTask(),
+      Flags.task_isAsyncLetTask());
 
   swift_task_enqueue(this, newExecutor);
 }

--- a/stdlib/public/Concurrency/Tracing.h
+++ b/stdlib/public/Concurrency/Tracing.h
@@ -22,6 +22,7 @@
 namespace swift {
 class AsyncLet;
 class AsyncTask;
+class ContinuationAsyncContext;
 class ExecutorRef;
 struct HeapObject;
 class Job;
@@ -43,10 +44,13 @@ void actor_enqueue(HeapObject *actor, Job *job);
 
 void actor_dequeue(HeapObject *actor, Job *job);
 
-// The `flags` parameter is the raw values of the actor's
-// DefaultActorImpl::State::Flags.
+// State values are:
+// Idle = 0, Scheduled = 1, Running = 2, Zombie_ReadyForDeallocation = 3,
+// invalid/unknown = 255
 void actor_state_changed(HeapObject *actor, Job *firstJob,
-                         bool needsPreprocessing, uintptr_t flags);
+                         bool needsPreprocessing, uint8_t state,
+                         bool isDistributedRemote, bool isPriorityEscalated,
+                         uint8_t maxPriority);
 
 void actor_note_job_queue(HeapObject *actor, Job *first,
                           Job *(*getNext)(Job *));
@@ -58,16 +62,27 @@ void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
 
 void task_destroy(AsyncTask *task);
 
-// The `flags` parameter is the raw value of the ActiveTaskStatus::Flags field
-// in the task.
-void task_status_changed(AsyncTask *task, uintptr_t flags);
+void task_status_changed(AsyncTask *task, uint8_t maxPriority, bool isCancelled,
+                         bool isEscalated, bool isRunning, bool isEnqueued);
 
-// The `flags` parameter is the raw value of Job::Flags.
-void task_flags_changed(AsyncTask *task, uint32_t flags);
+void task_flags_changed(AsyncTask *task, uint8_t jobPriority, bool isChildTask,
+                        bool isFuture, bool isGroupChildTask,
+                        bool isAsyncLetTask);
 
 // The `status` parameter is the value of the corresponding
 // FutureFragment::Status.
 void task_wait(AsyncTask *task, AsyncTask *waitingOn, uintptr_t status);
+
+void task_resume(AsyncTask *task);
+
+// The context parameter is the context pointer used to create the continuation.
+// This same pointer will be passed to the corresponding call to
+// task_continuation_await and task_continuation_resume.
+void task_continuation_init(AsyncTask *task, ContinuationAsyncContext *context);
+
+void task_continuation_await(ContinuationAsyncContext *context);
+
+void task_continuation_resume(ContinuationAsyncContext *context, bool error);
 
 void job_enqueue_global(Job *job);
 

--- a/stdlib/public/Concurrency/TracingStubs.h
+++ b/stdlib/public/Concurrency/TracingStubs.h
@@ -34,7 +34,10 @@ inline void actor_enqueue(HeapObject *actor, Job *job) {}
 inline void actor_dequeue(HeapObject *actor, Job *job) {}
 
 inline void actor_state_changed(HeapObject *actor, Job *firstJob,
-                                bool needsPreprocessing, uintptr_t flags) {}
+                                bool needsPreprocessing, uint8_t state,
+                                bool isDistributedRemote,
+                                bool isPriorityEscalated, uint8_t maxPriority) {
+}
 
 inline void actor_note_job_queue(HeapObject *actor, Job *first,
                                  Job *(*getNext)(Job *)) {}
@@ -44,15 +47,26 @@ inline void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
 
 inline void task_destroy(AsyncTask *task) {}
 
-inline void task_status_changed(AsyncTask *task, TaskStatusRecord *record,
-                                uintptr_t flags) {}
-
 inline void task_wait(AsyncTask *task, AsyncTask *waitingOn, uintptr_t status) {
 }
 
-inline void task_status_changed(AsyncTask *task, uintptr_t flags) {}
+inline void task_resume(AsyncTask *task) {}
 
-inline void task_flags_changed(AsyncTask *task, uint32_t flags) {}
+inline void task_status_changed(AsyncTask *task, uint8_t maxPriority,
+                                bool isCancelled, bool isEscalated,
+                                bool isRunning, bool isEnqueued) {}
+
+inline void task_flags_changed(AsyncTask *task, uint8_t jobPriority,
+                               bool isChildTask, bool isFuture,
+                               bool isGroupChildTask, bool isAsyncLetTask) {}
+
+inline void task_continuation_init(AsyncTask *task,
+                                   ContinuationAsyncContext *context) {}
+
+inline void task_continuation_await(ContinuationAsyncContext *context) {}
+
+inline void task_continuation_resume(ContinuationAsyncContext *context,
+                                     bool error) {}
 
 inline void job_enqueue_global(Job *job) {}
 


### PR DESCRIPTION
Decode all fields from the various flags values, pass each field as a separate argument to the various signposts. We were just passing the raw value of the flags and requiring the signpost client to decode them, which was ugly and required the client to know details they shouldn't need to know.

Strip ptrauth bits from the task resume function when signposting, when ptrauth is supported.

Add signpost events for continuation init/await/resume events.

We also make task_wait into an interval, rather than a single event. The interval ends when the task resumes. As part of this change, we also skip emitting the interval when the wait completed immediately and the task didn't have to suspend.

While we're in there, clean up a few SWIFT_TASK_DEBUG_LOG lines that emitted warnings when built with the logging enabled.

rdar://88658803
rdar://88597345