### PR TITLE
Separate out Duration-based APIs so they aren't in the back-deployment libs

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -58,4 +58,11 @@ set(swift_concurrency_extra_sources
   "../stubs/SwiftNativeNSObject.mm")
 set(swift_concurrency_async_fp_mode "never")
 
+set(LLVM_OPTIONAL_SOURCES
+  Clock.cpp
+  Clock.swift
+  ContinuousClock.swift
+  SuspendingClock.swift
+  TaskSleepDuration.swift)
+
 add_subdirectory(../Concurrency stdlib/public/BackDeployConcurrency)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -11,7 +11,12 @@
 #===----------------------------------------------------------------------===#
 
 if(NOT swift_concurrency_extra_sources)
-  set(swift_concurrency_extra_sources)
+  set(swift_concurrency_extra_sources
+    Clock.cpp
+    Clock.swift
+    ContinuousClock.swift
+    SuspendingClock.swift
+    TaskSleepDuration.swift)
 endif()
 
 if(NOT swift_concurrency_install_component)
@@ -113,10 +118,6 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncThrowingStream.swift
   AsyncStream.cpp
   Deque.swift
-  Clock.cpp
-  Clock.swift
-  ContinuousClock.swift
-  SuspendingClock.swift
   ${swift_concurrency_extra_sources}
   linker-support/magic-symbols-for-install-name.c
 

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -31,10 +31,10 @@ extension Task where Success == Never, Failure == Never {
 
   /// The type of continuation used in the implementation of
   /// sleep(nanoseconds:).
-  private typealias SleepContinuation = UnsafeContinuation<(), Error>
+  typealias SleepContinuation = UnsafeContinuation<(), Error>
 
   /// Describes the state of a sleep() operation.
-  private enum SleepState {
+  enum SleepState {
     /// The sleep continuation has not yet begun.
     case notStarted
 
@@ -106,7 +106,7 @@ extension Task where Success == Never, Failure == Never {
 
   /// Called when the sleep(nanoseconds:) operation woke up without being
   /// canceled.
-  private static func onSleepWake(
+  static func onSleepWake(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
     while true {
@@ -150,7 +150,7 @@ extension Task where Success == Never, Failure == Never {
 
   /// Called when the sleep(nanoseconds:) operation has been canceled before
   /// the sleep completed.
-  private static func onSleepCancel(
+  static func onSleepCancel(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
     while true {
@@ -293,134 +293,5 @@ extension Task where Success == Never, Failure == Never {
       // still running.
       throw error
     }
-  }
-
-  @available(SwiftStdlib 5.7, *)
-  internal static func _sleep(
-    until seconds: Int64, _ nanoseconds: Int64,
-    tolerance: Duration?,
-    clock: _ClockID
-  ) async throws {
-    // Allocate storage for the storage word.
-    let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)
-
-    // Initialize the flag word to "not started", which means the continuation
-    // has neither been created nor completed.
-    Builtin.atomicstore_seqcst_Word(
-        wordPtr._rawValue, SleepState.notStarted.word._builtinWordValue)
-
-    do {
-      // Install a cancellation handler to resume the continuation by
-      // throwing CancellationError.
-      try await withTaskCancellationHandler {
-        let _: () = try await withUnsafeThrowingContinuation { continuation in
-          while true {
-            let state = SleepState(loading: wordPtr)
-            switch state {
-            case .notStarted:
-              // The word that describes the active continuation state.
-              let continuationWord =
-                SleepState.activeContinuation(continuation).word
-
-              // Try to swap in the continuation word.
-              let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
-                  wordPtr._rawValue,
-                  state.word._builtinWordValue,
-                  continuationWord._builtinWordValue)
-              if !Bool(_builtinBooleanLiteral: won) {
-                // Keep trying!
-                continue
-              }
-
-              // Create a task that resumes the continuation normally if it
-              // finishes first. Enqueue it directly with the delay, so it fires
-              // when we're done sleeping.
-              let sleepTaskFlags = taskCreateFlags(
-                priority: nil, isChildTask: false, copyTaskLocals: false,
-                inheritContext: false, enqueueJob: false,
-                addPendingGroupTaskUnconditionally: false)
-              let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
-                onSleepWake(wordPtr)
-              }
-              let toleranceSeconds: Int64
-              let toleranceNanoseconds: Int64
-              if let components = tolerance?.components {
-                toleranceSeconds = components.seconds
-                toleranceNanoseconds = components.attoseconds / 1_000_000_000
-              } else {
-                toleranceSeconds = 0
-                toleranceNanoseconds = -1
-              }
-
-              _enqueueJobGlobalWithDeadline(
-                  seconds, nanoseconds,
-                  toleranceSeconds, toleranceNanoseconds,
-                  clock.rawValue, Builtin.convertTaskToJob(sleepTask))
-              return
-
-            case .activeContinuation, .finished:
-              fatalError("Impossible to have multiple active continuations")
-
-            case .cancelled:
-              fatalError("Impossible to have cancelled before we began")
-
-            case .cancelledBeforeStarted:
-              // Finish the continuation normally. We'll throw later, after
-              // we clean up.
-              continuation.resume()
-              return
-          }
-        }
-        }
-      } onCancel: {
-        onSleepCancel(wordPtr)
-      }
-
-      // Determine whether we got cancelled before we even started.
-      let cancelledBeforeStarted: Bool
-      switch SleepState(loading: wordPtr) {
-      case .notStarted, .activeContinuation, .cancelled:
-        fatalError("Invalid state for non-cancelled sleep task")
-
-      case .cancelledBeforeStarted:
-        cancelledBeforeStarted = true
-
-      case .finished:
-        cancelledBeforeStarted = false
-      }
-
-      // We got here without being cancelled, so deallocate the storage for
-      // the flag word and continuation.
-      wordPtr.deallocate()
-
-      // If we got cancelled before we even started, through the cancellation
-      // error now.
-      if cancelledBeforeStarted {
-        throw _Concurrency.CancellationError()
-      }
-    } catch {
-      // The task was cancelled; propagate the error. The "on wake" task is
-      // responsible for deallocating the flag word and continuation, if it's
-      // still running.
-      throw error
-    }
-  }
-
-  /// Suspends the current task until the given deadline within a tolerance.
-  ///
-  /// If the task is canceled before the time ends, this function throws 
-  /// `CancellationError`.
-  ///
-  /// This function doesn't block the underlying thread.
-  ///
-  ///       try await Task.sleep(until: .now + .seconds(3), clock: .continuous)
-  ///
-  @available(SwiftStdlib 5.7, *)
-  public static func sleep<C: Clock>(
-    until deadline: C.Instant,
-    tolerance: C.Instant.Duration? = nil,
-    clock: C
-  ) async throws {
-    try await clock.sleep(until: deadline, tolerance: tolerance)
   }
 }

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -1,0 +1,145 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+@available(SwiftStdlib 5.7, *)
+extension Task where Success == Never, Failure == Never {
+  @available(SwiftStdlib 5.7, *)
+  internal static func _sleep(
+    until seconds: Int64, _ nanoseconds: Int64,
+    tolerance: Duration?,
+    clock: _ClockID
+  ) async throws {
+    // Allocate storage for the storage word.
+    let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)
+
+    // Initialize the flag word to "not started", which means the continuation
+    // has neither been created nor completed.
+    Builtin.atomicstore_seqcst_Word(
+        wordPtr._rawValue, SleepState.notStarted.word._builtinWordValue)
+
+    do {
+      // Install a cancellation handler to resume the continuation by
+      // throwing CancellationError.
+      try await withTaskCancellationHandler {
+        let _: () = try await withUnsafeThrowingContinuation { continuation in
+          while true {
+            let state = SleepState(loading: wordPtr)
+            switch state {
+            case .notStarted:
+              // The word that describes the active continuation state.
+              let continuationWord =
+                SleepState.activeContinuation(continuation).word
+
+              // Try to swap in the continuation word.
+              let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+                  wordPtr._rawValue,
+                  state.word._builtinWordValue,
+                  continuationWord._builtinWordValue)
+              if !Bool(_builtinBooleanLiteral: won) {
+                // Keep trying!
+                continue
+              }
+
+              // Create a task that resumes the continuation normally if it
+              // finishes first. Enqueue it directly with the delay, so it fires
+              // when we're done sleeping.
+              let sleepTaskFlags = taskCreateFlags(
+                priority: nil, isChildTask: false, copyTaskLocals: false,
+                inheritContext: false, enqueueJob: false,
+                addPendingGroupTaskUnconditionally: false)
+              let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
+                onSleepWake(wordPtr)
+              }
+              let toleranceSeconds: Int64
+              let toleranceNanoseconds: Int64
+              if let components = tolerance?.components {
+                toleranceSeconds = components.seconds
+                toleranceNanoseconds = components.attoseconds / 1_000_000_000
+              } else {
+                toleranceSeconds = 0
+                toleranceNanoseconds = -1
+              }
+
+              _enqueueJobGlobalWithDeadline(
+                  seconds, nanoseconds,
+                  toleranceSeconds, toleranceNanoseconds,
+                  clock.rawValue, Builtin.convertTaskToJob(sleepTask))
+              return
+
+            case .activeContinuation, .finished:
+              fatalError("Impossible to have multiple active continuations")
+
+            case .cancelled:
+              fatalError("Impossible to have cancelled before we began")
+
+            case .cancelledBeforeStarted:
+              // Finish the continuation normally. We'll throw later, after
+              // we clean up.
+              continuation.resume()
+              return
+          }
+        }
+        }
+      } onCancel: {
+        onSleepCancel(wordPtr)
+      }
+
+      // Determine whether we got cancelled before we even started.
+      let cancelledBeforeStarted: Bool
+      switch SleepState(loading: wordPtr) {
+      case .notStarted, .activeContinuation, .cancelled:
+        fatalError("Invalid state for non-cancelled sleep task")
+
+      case .cancelledBeforeStarted:
+        cancelledBeforeStarted = true
+
+      case .finished:
+        cancelledBeforeStarted = false
+      }
+
+      // We got here without being cancelled, so deallocate the storage for
+      // the flag word and continuation.
+      wordPtr.deallocate()
+
+      // If we got cancelled before we even started, through the cancellation
+      // error now.
+      if cancelledBeforeStarted {
+        throw _Concurrency.CancellationError()
+      }
+    } catch {
+      // The task was cancelled; propagate the error. The "on wake" task is
+      // responsible for deallocating the flag word and continuation, if it's
+      // still running.
+      throw error
+    }
+  }
+
+  /// Suspends the current task until the given deadline within a tolerance.
+  ///
+  /// If the task is canceled before the time ends, this function throws 
+  /// `CancellationError`.
+  ///
+  /// This function doesn't block the underlying thread.
+  ///
+  ///       try await Task.sleep(until: .now + .seconds(3), clock: .continuous)
+  ///
+  @available(SwiftStdlib 5.7, *)
+  public static func sleep<C: Clock>(
+    until deadine: C.Instant,
+    tolerance: C.Instant.Duration? = nil,
+    clock: C
+  ) async throws {
+    try await clock.sleep(until: deadine, tolerance: tolerance)
+  }
+}

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -136,10 +136,10 @@ extension Task where Success == Never, Failure == Never {
   ///
   @available(SwiftStdlib 5.7, *)
   public static func sleep<C: Clock>(
-    until deadine: C.Instant,
+    until deadline: C.Instant,
     tolerance: C.Instant.Duration? = nil,
     clock: C
   ) async throws {
-    try await clock.sleep(until: deadine, tolerance: tolerance)
+    try await clock.sleep(until: deadline, tolerance: tolerance)
   }
 }


### PR DESCRIPTION
The back-deployed Swift Concurrency library should not contain anything
based on clocks or durations, which aren't always available in the
underlying system. Move that functionality to separate files that are
excluded from the back-deployed concurrency libraries.

This is a partial step to better approximate the back-deployment
libraries. At some point, we'll stop building the back-deployment
libraries entirely and instead use the binaries provided by the
toolchain.

Fixes rdar://89237163.