### PR TITLE
[cxx-interop] Bail on parameter that are reference types to dependent types.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2206,6 +2206,14 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
           findGenericTypeInGenericDecls(templateParamType, genericParams);
     } else {
       if (auto refType = dyn_cast<clang::ReferenceType>(paramTy)) {
+        // We don't support reference type to a dependent type, just bail.
+        if (refType->getPointeeType()->isDependentType()) {
+          addImportDiagnostic(
+              param, Diagnostic(diag::parameter_type_not_imported, param),
+              param->getSourceRange().getBegin());
+          return nullptr;
+        }
+
         paramTy = refType->getPointeeType();
         if (!paramTy.isConstQualified())
           isInOut = true;

--- a/test/Interop/Cxx/reference/Inputs/reference.h
+++ b/test/Interop/Cxx/reference/Inputs/reference.h
@@ -34,4 +34,7 @@ T &refToTemplate(T &t) { return t; }
 template<class T>
 const T &constRefToTemplate(const T &t) { return t; }
 
+template<class T>
+void refToDependentParam(ClassTemplate<T> &param) { }
+
 #endif // TEST_INTEROP_CXX_REFERENCE_INPUTS_REFERENCE_H

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -16,4 +16,5 @@
 // CHECK: func constRefToTemplate<T>(_ t: T) -> UnsafePointer<T>
 
 // CHECK-NOT: refToDependent
+// CHECK-NOT: refToDependentParam
 // CHECK-NOT: dontImportAtomicRef

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -19,5 +19,8 @@
 // with the fact that the template type paramaters are defaulted.
 // TODO: reenable the following checks: (rdar://90587703)
 // TODO-CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: UnsafeMutablePointer<T>)
-// TODO-CHECK: func defaultedTemplatePointerReferenceTypeParam<T>(_ t: inout OpaquePointer!)
 // TODO-CHECK: func defaultedTemplatePointerPointerTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>!)
+
+// CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: UnsafeMutablePointer<T>)
+// We don't support references to dependent types (rdar://89034440).
+// CHECK-NOT: defaultedTemplatePointerReferenceTypeParam

--- a/test/Interop/Cxx/templates/dependent-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/dependent-types-module-interface.swift
@@ -7,5 +7,6 @@
 // CHECK: func multipleDependentArgsInferred<T, U>(_ a: Any, _ b: Any, _ c: T, _ d: U) -> Any
 // CHECK: func multipleDependentArgs<T, U>(_ a: Any, _ b: Any, T: T.Type, U: U.Type) -> Any
 // CHECK: func refToDependent<T>(_ a: inout T) -> Any
-// CHECK: func dependentRef<T>(_ a: inout Any, T: T.Type) -> Any
-// CHECK: func dependentRefAndRefInferred<T>(_ a: Any, _ b: inout T) -> Any
+// We don't support references to dependent types (rdar://89034440).
+// CHECK-NOT: dependentRef
+// CHECK-NOT: dependentRefAndRefInferred


### PR DESCRIPTION
Currently, just like for return types, we can't import references to dependent types. Refs https://github.com/apple/swift/pull/41660.