### PR TITLE
Sema: Diagnose use of availability macros in conditional statements in @_backDeploy functions

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -212,6 +212,9 @@ struct FragileFunctionKind {
     return (lhs.kind == rhs.kind &&
             lhs.allowUsableFromInline == rhs.allowUsableFromInline);
   }
+
+  /// Casts to `unsigned` for diagnostic %selects.
+  unsigned getSelector() { return static_cast<unsigned>(kind); }
 };
 
 /// A DeclContext is an AST object which acts as a semantic container

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5631,10 +5631,6 @@ WARNING(public_decl_needs_availability, none,
         "public declarations should have an availability attribute when building "
         "with -require-explicit-availability", ())
 
-ERROR(availability_macro_in_inlinable, none,
-      "availability macro cannot be used in inlinable %0",
-      (DescriptiveDeclKind))
-
 ERROR(attr_requires_decl_availability_for_platform,none,
       "'%0' requires that %1 have explicit availability for %2",
       (DeclAttribute, DeclName, StringRef))
@@ -5731,7 +5727,8 @@ ERROR(usable_from_inline_attr_in_protocol,none,
   "an '@inlinable' function|" \
   "an '@_alwaysEmitIntoClient' function|" \
   "a default argument value|" \
-  "a property initializer in a '@frozen' type}"
+  "a property initializer in a '@frozen' type|" \
+  "a '@_backDeploy' function'}"
 
 #define DECL_OR_ACCESSOR "%select{%0|%0 for}"
 
@@ -5755,6 +5752,10 @@ ERROR(inlinable_decl_ref_from_hidden_module,
       "it is an SPI imported from %3|"
       "it is SPI}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
+
+ERROR(availability_macro_in_inlinable, none,
+      "availability macro cannot be used in " FRAGILE_FUNC_KIND "0",
+      (unsigned))
 
 #undef FRAGILE_FUNC_KIND
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements diagnostics for @inlinable.
+// This file implements diagnostics for fragile functions, like those with
+// @inlinable, @_alwaysEmitIntoClient, or @_backDeploy.
 //
 //===----------------------------------------------------------------------===//
 
@@ -91,12 +92,9 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   if (downgradeToWarning == DowngradeToWarning::Yes)
     diagID = diag::resilience_decl_unavailable_warn;
 
-  Context.Diags.diagnose(
-           loc, diagID,
-           D->getDescriptiveKind(), diagName,
-           D->getFormalAccessScope().accessLevelForDiagnostics(),
-           static_cast<unsigned>(fragileKind.kind),
-           isAccessor);
+  Context.Diags.diagnose(loc, diagID, D->getDescriptiveKind(), diagName,
+                         D->getFormalAccessScope().accessLevelForDiagnostics(),
+                         fragileKind.getSelector(), isAccessor);
 
   if (fragileKind.allowUsableFromInline) {
     Context.Diags.diagnose(D, diag::resilience_decl_declared_here,
@@ -150,8 +148,7 @@ TypeChecker::diagnoseDeclRefExportability(SourceLoc loc,
   } else {
     ctx.Diags.diagnose(loc, diag::inlinable_decl_ref_from_hidden_module,
                        D->getDescriptiveKind(), D->getName(),
-                       static_cast<unsigned>(fragileKind.kind),
-                       definingModule->getName(),
+                       fragileKind.getSelector(), definingModule->getName(),
                        static_cast<unsigned>(originKind));
   }
   return true;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2268,7 +2268,7 @@ public:
     auto kind = DC->getFragileFunctionKind();
     if (kind.kind != FragileFunctionKind::None) {
       NTD->diagnose(diag::local_type_in_inlinable_function, NTD->getName(),
-                    static_cast<unsigned>(kind.kind));
+                    kind.getSelector());
     }
 
     // We don't support protocols outside the top level of a file.

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -68,20 +68,31 @@ func client() {
 
 @inlinable
 public func forbidMacrosInInlinableCode() {
-  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
 }
 
 @_alwaysEmitIntoClient
 public func forbidMacrosInInlinableCode1() {
-  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in inlinable global function}}
-  if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in inlinable global function}}
+  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+}
+
+@available(_iOS8Aligned, *)
+@_backDeploy(_iOS9Aligned)
+public func forbidMacrosInInlinableCode2() {
+  if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  if #available(iOS 9.0, _macOS10_11, tvOS 9.0, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
 }

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -159,6 +159,28 @@ public struct CannotBackDeployCoroutines {
   }
 }
 
+// MARK: - Function body diagnostics
+
+public struct FunctionBodyDiagnostics {
+  public func publicFunc() {}
+  @usableFromInline func usableFromInlineFunc() {}
+  func internalFunc() {} // expected-note {{instance method 'internalFunc()' is not '@usableFromInline' or public}}
+  fileprivate func fileprivateFunc() {} // expected-note {{instance method 'fileprivateFunc()' is not '@usableFromInline' or public}}
+  private func privateFunc() {} // expected-note {{instance method 'privateFunc()' is not '@usableFromInline' or public}}
+
+  @available(macOS 11.0, *)
+  @_backDeploy(macOS 12.0)
+  public func backDeployedMethod() {
+    struct Nested {} // expected-error {{type 'Nested' cannot be nested inside a '@_backDeploy' function}}
+
+    publicFunc()
+    usableFromInlineFunc()
+    internalFunc() // expected-error {{instance method 'internalFunc()' is internal and cannot be referenced from a '@_backDeploy' function}}
+    fileprivateFunc() // expected-error {{instance method 'fileprivateFunc()' is fileprivate and cannot be referenced from a '@_backDeploy' function}}
+    privateFunc() // expected-error {{instance method 'privateFunc()' is private and cannot be referenced from a '@_backDeploy' function}}
+  }
+}
+
 // MARK: - Incompatible declarations
 
 @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' may not be used on fileprivate declarations}}


### PR DESCRIPTION
Diagnose use of availability macros in conditional statements in `@_backDeploy` functions since availability macros are currently not expanded when printing a `.swiftinterface` and therefore the conditionals cannot be interpreted correctly by clients:

```
@available(_iOS8Aligned, *)
@_backDeploy(_iOS9Aligned)
public func foo() {
   if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
}
```

Also, add a test verifying that expected diagnostics are emitted when referencing non-public declarations from a `@_backDeploy` function body.

Resolves rdar://90270100
