### PR TITLE
Stabilize VarDecl::isLet for ParamDecls

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5248,9 +5248,8 @@ public:
   
   /// Is this an immutable 'let' property?
   ///
-  /// If this is a ParamDecl, isLet() is true iff
-  /// getSpecifier() == Specifier::Default.
-  bool isLet() const { return getIntroducer() == Introducer::Let; }
+  /// For \c ParamDecl instances, using \c isImmutable is preferred.
+  bool isLet() const;
 
   /// Is this an "async let" property?
   bool isAsyncLet() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5060,6 +5060,13 @@ protected:
           SourceLoc nameLoc, Identifier name, DeclContext *dc,
           StorageIsMutable_t supportsMutation);
 
+protected:
+  // Only \c ParamDecl::setSpecifier is allowed to flip this - and it's also
+  // on the way out of that business.
+  void setIntroducer(Introducer value) {
+    Bits.VarDecl.Introducer = uint8_t(value);
+  }
+
 public:
   VarDecl(bool isStatic, Introducer introducer,
           SourceLoc nameLoc, Identifier name, DeclContext *dc)
@@ -5261,10 +5268,6 @@ public:
 
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);
-  }
-
-  void setIntroducer(Introducer value) {
-    Bits.VarDecl.Introducer = uint8_t(value);
   }
 
   CaptureListExpr *getParentCaptureList() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6373,6 +6373,19 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   return true;
 }
 
+bool VarDecl::isLet() const {
+  // An awful hack that stabilizes the value of 'isLet' for ParamDecl instances.
+  //
+  // All of the callers in SIL are actually looking for the semantic
+  // "is immutable" predicate (present on ParamDecl) and should be migrated to
+  // a high-level request. Once this is done, all callers of the introducer and
+  // specifier setters can be removed.
+  if (auto *PD = dyn_cast<ParamDecl>(this)) {
+    return PD->isImmutable();
+  }
+  return getIntroducer() == Introducer::Let;
+}
+
 bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>();
 }

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -73,8 +73,6 @@ static VarDecl *addImplicitDistributedActorIDProperty(
       C, StaticSpellingKind::None, propPat, /*InitExpr*/ nullptr,
       nominal);
 
-  propDecl->setIntroducer(VarDecl::Introducer::Let);
-
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
       new (C) NonisolatedAttr(/*IsImplicit=*/true));

--- a/lib/Sema/DerivedConformanceActor.cpp
+++ b/lib/Sema/DerivedConformanceActor.cpp
@@ -138,10 +138,10 @@ static ValueDecl *deriveActor_unownedExecutor(DerivedConformance &derived) {
   }
   Type executorType = executorDecl->getDeclaredInterfaceType();
 
-  auto propertyPair =
-    derived.declareDerivedProperty(ctx.Id_unownedExecutor,
-                                   executorType, executorType,
-                                   /*static*/ false, /*final*/ false);
+  auto propertyPair = derived.declareDerivedProperty(
+      DerivedConformance::SynthesizedIntroducer::Var, ctx.Id_unownedExecutor,
+      executorType, executorType,
+      /*static*/ false, /*final*/ false);
   auto property = propertyPair.first;
   property->setSynthesized(true);
   property->getAttrs().add(new (ctx) SemanticsAttr(SEMANTICS_DEFAULT_ACTOR,

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -302,7 +302,8 @@ static ValueDecl *deriveAdditiveArithmetic_zero(DerivedConformance &derived) {
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_zero, returnInterfaceTy, returnTy, /*isStatic*/ true,
+      DerivedConformance::SynthesizedIntroducer::Var, C.Id_zero,
+      returnInterfaceTy, returnTy, /*isStatic*/ true,
       /*isFinal*/ true);
 
   // Create property getter.

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -98,9 +98,9 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl) =
-      declareDerivedProperty(Context.Id_allCases, returnTy, returnTy,
-                             /*isStatic=*/true, /*isFinal=*/true);
+  std::tie(propDecl, pbDecl) = declareDerivedProperty(
+      SynthesizedIntroducer::Var, Context.Id_allCases, returnTy, returnTy,
+      /*isStatic=*/true, /*isFinal=*/true);
 
   // Define the getter.
   auto *getterDecl = addGetterToReadOnlyDerivedProperty(propDecl, returnTy);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -160,9 +160,9 @@ static ValueDecl *deriveProperty(DerivedConformance &derived, Type type,
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl) =
-      derived.declareDerivedProperty(name, type, type,
-                                     /*isStatic=*/false, /*isFinal=*/false);
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      DerivedConformance::SynthesizedIntroducer::Var, name, type, type,
+      /*isStatic=*/false, /*isFinal=*/false);
 
   // Define the getter.
   auto *getterDecl = derived.addGetterToReadOnlyDerivedProperty(

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -112,8 +112,8 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_id,
-      propertyType, propertyType,
+      DerivedConformance::SynthesizedIntroducer::Let, C.Id_id, propertyType,
+      propertyType,
       /*isStatic=*/false, /*isFinal=*/true);
 
   // mark as nonisolated, allowing access to it from everywhere
@@ -141,7 +141,7 @@ static ValueDecl *deriveDistributedActor_actorSystem(
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_actorSystem,
+      DerivedConformance::SynthesizedIntroducer::Let, C.Id_actorSystem,
       propertyType, propertyType,
       /*isStatic=*/false, /*isFinal=*/true);
 

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -116,8 +116,6 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
       propertyType, propertyType,
       /*isStatic=*/false, /*isFinal=*/true);
 
-  propDecl->setIntroducer(VarDecl::Introducer::Let);
-
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
       new (C) NonisolatedAttr(/*IsImplicit=*/true));
@@ -146,8 +144,6 @@ static ValueDecl *deriveDistributedActor_actorSystem(
       C.Id_actorSystem,
       propertyType, propertyType,
       /*isStatic=*/false, /*isFinal=*/true);
-
-  propDecl->setIntroducer(VarDecl::Introducer::Let);
 
   // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -97,6 +97,7 @@ deriveBridgedNSError_enum_nsErrorDomain(
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      DerivedConformance::SynthesizedIntroducer::Var,
       derived.Context.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
       /*isFinal=*/true);
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -165,7 +165,8 @@ static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
   std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
-      C.Id_rawValue, rawInterfaceType, rawType, /*isStatic=*/false,
+      DerivedConformance::SynthesizedIntroducer::Var, C.Id_rawValue,
+      rawInterfaceType, rawType, /*isStatic=*/false,
       /*isFinal=*/false);
 
   // Define the getter.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -498,16 +498,27 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
   return getterDecl;
 }
 
+static VarDecl::Introducer
+mapIntroducer(DerivedConformance::SynthesizedIntroducer intro) {
+  switch (intro) {
+  case DerivedConformance::SynthesizedIntroducer::Let:
+    return VarDecl::Introducer::Let;
+  case DerivedConformance::SynthesizedIntroducer::Var:
+    return VarDecl::Introducer::Var;
+  }
+  llvm_unreachable("Invalid synthesized introducer!");
+}
+
 std::pair<VarDecl *, PatternBindingDecl *>
-DerivedConformance::declareDerivedProperty(Identifier name,
+DerivedConformance::declareDerivedProperty(SynthesizedIntroducer intro,
+                                           Identifier name,
                                            Type propertyInterfaceType,
                                            Type propertyContextType,
                                            bool isStatic, bool isFinal) {
   auto parentDC = getConformanceContext();
 
-  VarDecl *propDecl = new (Context)
-      VarDecl(/*IsStatic*/ isStatic, VarDecl::Introducer::Var,
-              SourceLoc(), name, parentDC);
+  VarDecl *propDecl = new (Context) VarDecl(
+      /*IsStatic*/ isStatic, mapIntroducer(intro), SourceLoc(), name, parentDC);
   propDecl->setImplicit();
   propDecl->setSynthesized();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -50,6 +50,9 @@ class VarDecl;
 
 class DerivedConformance {
 public:
+  enum class SynthesizedIntroducer : bool { Let, Var };
+
+public:
   ASTContext &Context;
   Decl *ConformanceDecl;
   NominalTypeDecl *Nominal;
@@ -335,8 +338,9 @@ public:
 
   /// Declare a read-only property.
   std::pair<VarDecl *, PatternBindingDecl *>
-  declareDerivedProperty(Identifier name, Type propertyInterfaceType,
-                         Type propertyContextType, bool isStatic, bool isFinal);
+  declareDerivedProperty(SynthesizedIntroducer intro, Identifier name,
+                         Type propertyInterfaceType, Type propertyContextType,
+                         bool isStatic, bool isFinal);
 
   /// Add a getter to a derived property.  The property becomes read-only.
   static AccessorDecl *

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -28,7 +28,7 @@ func use<T>(_ t : T) {}
 // CHECK-SIL: sil hidden @$s16debug_value_addr11GenericSelfV1xACyxGx_tcfC : $@convention(method) <T> (@in T, @thin GenericSelf<T>.Type) -> GenericSelf<T> {
 // CHECK-SIL: bb0(%0 : $*T, %1 : $@thin GenericSelf<T>.Type):
 //
-// CHECK-SIL-NEXT:  alloc_stack [lexical] $GenericSelf<T>, {{var|let}}, name "self", implicit, loc {{.*}}
+// CHECK-SIL-NEXT:  alloc_stack [lexical] $GenericSelf<T>, var, name "self", implicit, loc {{.*}}
 // CHECK-SIL-NEXT:  debug_value %0 : $*T, let, name "x", argno 1, expr op_deref, loc {{.*}}
 struct GenericSelf<T> {
   init(x: T) {

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -227,10 +227,10 @@ public struct Pair {
 // have invalidated a part of pair. We can be less restrictive in the future.
 //
 // TODO: Why are we emitting two uses here.
-public func performMoveOnOneEltOfPair(_ p: __owned Pair) {
+public func performMoveOnOneEltOfPair(_ p: __owned Pair) { // expected-error {{'p' used after being moved}}
     let _ = p.z
-    let _ = _move(p.x) // expected-error {{_move applied to value that the compiler does not support checking}}
-    nonConsumingUse(p.y)
+    let _ = _move(p.x) // expected-note {{move here}}
+    nonConsumingUse(p.y) // expected-note 2 {{use here}}
 }
 
 public class KlassPair {


### PR DESCRIPTION
For ParamDecl instances, the value of this property is not just a function of the introducer (let/var which is a poorly-defined concept for parameters), it's a function of the specifier (inout/__owned/__shared etc). However, computing the specifier also has the side effect of flipping the introducer bits. This appears to be because while the AST uses `isLet` in a syntactic sense "did the user write 'let'?", SIL uses it in a semantic sense "is this property semantically immutable?". These two queries need to be split from one another and the callers migrated. But that is a much larger task for a later time. For now, provide the value of `ParamDecl::isImmutable` to callers since that's the more conservative of the two behaviors.

The bug here is that it's possible for `getSpecifier` to *not* be called before `isLet` is called (usually in SIL). This manifested as a test output divergence on the non-asserts bots since the ASTVerifier was always calling getSpecifier, and most engineers do not build without asserts on at their desk.

rdar://89237318