### PR TITLE
Diagnose 'case nil' in Non-Optional Switches

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1294,8 +1294,11 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       } else {
         // ...but for non-optional types it can never match! Diagnose it.
         diags.diagnose(NLE->getLoc(),
-                       diag::value_type_comparison_with_nil_illegal, type);
-        return nullptr;
+                       diag::value_type_comparison_with_nil_illegal, type)
+             .warnUntilSwiftVersion(6);
+
+        if (type->getASTContext().isSwiftVersionAtLeast(6))
+          return nullptr;
       }
     }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1269,10 +1269,10 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
   case PatternKind::Expr: {
     assert(cast<ExprPattern>(P)->isResolved()
            && "coercing unresolved expr pattern!");
+    auto *EP = cast<ExprPattern>(P);
     if (type->isBool()) {
       // The type is Bool.
       // Check if the pattern is a Bool literal
-      auto EP = cast<ExprPattern>(P);
       if (auto *BLE = dyn_cast<BooleanLiteralExpr>(
               EP->getSubExpr()->getSemanticsProvidingExpr())) {
         P = new (Context) BoolPattern(BLE->getLoc(), BLE->getValue());
@@ -1282,9 +1282,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     }
 
     // case nil is equivalent to .none when switching on Optionals.
-    if (type->getOptionalObjectType()) {
-      auto EP = cast<ExprPattern>(P);
-      if (auto *NLE = dyn_cast<NilLiteralExpr>(EP->getSubExpr())) {
+    if (auto *NLE = dyn_cast<NilLiteralExpr>(EP->getSubExpr())) {
+      if (type->getOptionalObjectType()) {
         auto *NoneEnumElement = Context.getOptionalNoneDecl();
         auto *BaseTE = TypeExpr::createImplicit(type, Context);
         P = new (Context) EnumElementPattern(
@@ -1292,10 +1291,15 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
             NoneEnumElement->createNameRef(), NoneEnumElement, nullptr);
         return TypeChecker::coercePatternToType(
             pattern.forSubPattern(P, /*retainTopLevel=*/true), type, options);
+      } else {
+        // ...but for non-optional types it can never match! Diagnose it.
+        diags.diagnose(NLE->getLoc(),
+                       diag::value_type_comparison_with_nil_illegal, type);
+        return nullptr;
       }
     }
 
-    if (TypeChecker::typeCheckExprPattern(cast<ExprPattern>(P), dc, type))
+    if (TypeChecker::typeCheckExprPattern(EP, dc, type))
       return nullptr;
 
     return P;

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -826,3 +826,30 @@ func test_redeclations() {
     let (foo, foo) = (5, 6) // expected-error {{invalid redeclaration of 'foo'}} expected-note {{'foo' previously declared here}}
   }
 }
+
+func test_rdar89742267() {
+  @resultBuilder
+  struct Builder {
+    static func buildBlock<T>(_ t: T) -> T { t }
+    static func buildEither<T>(first: T) -> T { first }
+    static func buildEither<T>(second: T) -> T { second }
+  }
+
+  struct S {}
+
+  enum Hey {
+    case listen
+  }
+
+  struct MyView {
+    var entry: Hey
+
+    @Builder var body: S {
+      switch entry {
+      case .listen: S()
+      case nil: S() // expected-warning {{type 'Hey' is not optional, value can never be nil; this is an error in Swift 6}}
+      default: S()
+      }
+    }
+  }
+}

--- a/test/stmt/switch_nil.swift
+++ b/test/stmt/switch_nil.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Hey {
+  case listen
+}
+
+func test() {
+  switch Hey.listen {
+  case nil: // expected-error{{type 'Hey' is not optional, value can never be nil}}
+    break
+  default:
+    break
+  }
+}
+

--- a/test/stmt/switch_nil.swift
+++ b/test/stmt/switch_nil.swift
@@ -6,10 +6,9 @@ enum Hey {
 
 func test() {
   switch Hey.listen {
-  case nil: // expected-error{{type 'Hey' is not optional, value can never be nil}}
+  case nil: // expected-warning {{type 'Hey' is not optional, value can never be nil}}
     break
   default:
     break
   }
 }
-


### PR DESCRIPTION
This is an anti-pattern since the resulting value will never compare equal to `nil`, and the entire switch-case is dead. This appears to be a misfeature as the subject value is simply type-checked against an optional which produces an injection which matches the global ~= for Optionals.

Effectively, `case nil:` becomes `case $match ~= nil`.

rdar://89742267