### PR TITLE
RequirementMachine: Rule sharing

### DIFF
--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -562,8 +562,8 @@ void PropertyMap::inferConditionalRequirements(
           llvm::dbgs() << "@@@ Unknown protocol: "<< proto->getName() << "\n";
         }
 
-        RuleBuilder builder(Context, System.getProtocolMap());
-        builder.addProtocol(proto, /*initialComponent=*/false);
+        RuleBuilder builder(Context, System.getReferencedProtocols());
+        builder.addReferencedProtocol(proto);
         builder.collectRulesFromReferencedProtocols();
 
         for (const auto &rule : builder.PermanentRules)

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -682,7 +682,8 @@ RewriteSystem::getMinimizedProtocolRules() const {
   assert(!Protos.empty());
 
   llvm::DenseMap<const ProtocolDecl *, MinimizedProtocolRules> rules;
-  for (unsigned ruleID : indices(Rules)) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
+       ruleID < e; ++ruleID) {
     const auto &rule = getRule(ruleID);
 
     if (rule.isPermanent() ||
@@ -713,7 +714,8 @@ RewriteSystem::getMinimizedGenericSignatureRules() const {
   assert(Protos.empty());
 
   std::vector<unsigned> rules;
-  for (unsigned ruleID : indices(Rules)) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
+       ruleID < e; ++ruleID) {
     const auto &rule = getRule(ruleID);
 
     if (rule.isPermanent() ||
@@ -768,7 +770,8 @@ void RewriteSystem::verifyMinimizedRules(
     const llvm::DenseSet<unsigned> &redundantConformances) const {
   unsigned redundantRuleCount = 0;
 
-  for (unsigned ruleID : indices(Rules)) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
+       ruleID < e; ++ruleID) {
     const auto &rule = getRule(ruleID);
 
     // Ignore the rewrite rule if it is not part of our minimization domain.

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -301,7 +301,7 @@ RewriteSystem::computeConfluentCompletion(unsigned maxRuleCount,
     ruleCount = Rules.size();
 
     // For every rule, looking for other rules that overlap with this rule.
-    for (unsigned i = 0, e = Rules.size(); i < e; ++i) {
+    for (unsigned i = FirstLocalRule, e = Rules.size(); i < e; ++i) {
       const auto &lhs = getRule(i);
       if (lhs.isLHSSimplified() ||
           lhs.isRHSSimplified() ||

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/TypeRepr.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SetVector.h"
 #include "RequirementMachine.h"
 #include "RewriteContext.h"
 #include "RewriteSystem.h"
@@ -1014,7 +1015,7 @@ ArrayRef<ProtocolDecl *>
 ProtocolDependenciesRequest::evaluate(Evaluator &evaluator,
                                       ProtocolDecl *proto) const {
   auto &ctx = proto->getASTContext();
-  SmallVector<ProtocolDecl *, 4> result;
+  SmallSetVector<ProtocolDecl *, 4> result;
 
   // If we have a serialized requirement signature, deserialize it and
   // look at conformance requirements.
@@ -1026,7 +1027,7 @@ ProtocolDependenciesRequest::evaluate(Evaluator &evaluator,
         == RequirementMachineMode::Disabled)) {
     for (auto req : proto->getRequirementSignature().getRequirements()) {
       if (req.getKind() == RequirementKind::Conformance) {
-        result.push_back(req.getProtocolDecl());
+        result.insert(req.getProtocolDecl());
       }
     }
 
@@ -1038,7 +1039,7 @@ ProtocolDependenciesRequest::evaluate(Evaluator &evaluator,
   // signature. Look at the structural requirements instead.
   for (auto req : proto->getStructuralRequirements()) {
     if (req.req.getKind() == RequirementKind::Conformance)
-      result.push_back(req.req.getProtocolDecl());
+      result.insert(req.req.getProtocolDecl());
   }
 
   return ctx.AllocateCopy(result);

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -1047,7 +1047,13 @@ ProtocolDependenciesRequest::evaluate(Evaluator &evaluator,
 // Building rewrite rules from desugared requirements.
 //
 
-void RuleBuilder::addRequirements(ArrayRef<Requirement> requirements) {
+/// For building a rewrite system for a generic signature from canonical
+/// requirements.
+void RuleBuilder::initWithGenericSignatureRequirements(
+    ArrayRef<Requirement> requirements) {
+  assert(!Initialized);
+  Initialized = 1;
+
   // Collect all protocols transitively referenced from these requirements.
   for (auto req : requirements) {
     if (req.getKind() == RequirementKind::Conformance) {
@@ -1062,7 +1068,13 @@ void RuleBuilder::addRequirements(ArrayRef<Requirement> requirements) {
     addRequirement(req, /*proto=*/nullptr, /*requirementID=*/None);
 }
 
-void RuleBuilder::addRequirements(ArrayRef<StructuralRequirement> requirements) {
+/// For building a rewrite system for a generic signature from user-written
+/// requirements.
+void RuleBuilder::initWithWrittenRequirements(
+    ArrayRef<StructuralRequirement> requirements) {
+  assert(!Initialized);
+  Initialized = 1;
+
   // Collect all protocols transitively referenced from these requirements.
   for (auto req : requirements) {
     if (req.req.getKind() == RequirementKind::Conformance) {
@@ -1080,7 +1092,11 @@ void RuleBuilder::addRequirements(ArrayRef<StructuralRequirement> requirements) 
 /// For building a rewrite system for a protocol connected component from
 /// user-written requirements. Used when actually building requirement
 /// signatures.
-void RuleBuilder::addProtocols(ArrayRef<const ProtocolDecl *> protos) {
+void RuleBuilder::initWithProtocolWrittenRequirements(
+    ArrayRef<const ProtocolDecl *> protos) {
+  assert(!Initialized);
+  Initialized = 1;
+
   for (auto *proto : protos) {
     ReferencedProtocols.insert(proto);
   }

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -125,6 +125,7 @@ struct RuleBuilder {
 
   void initWithGenericSignatureRequirements(ArrayRef<Requirement> requirements);
   void initWithWrittenRequirements(ArrayRef<StructuralRequirement> requirements);
+  void initWithProtocolSignatureRequirements(ArrayRef<const ProtocolDecl *> proto);
   void initWithProtocolWrittenRequirements(ArrayRef<const ProtocolDecl *> proto);
   void addReferencedProtocol(const ProtocolDecl *proto);
   void collectRulesFromReferencedProtocols();

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -111,16 +111,21 @@ struct RuleBuilder {
 
   /// Enables debugging output. Controlled by the -dump-requirement-machine
   /// frontend flag.
-  bool Dump;
+  unsigned Dump : 1;
+
+  /// Used to ensure the initWith*() methods are only called once.
+  unsigned Initialized : 1;
 
   RuleBuilder(RewriteContext &ctx,
               llvm::DenseSet<const ProtocolDecl *> &referencedProtocols)
-      : Context(ctx), ReferencedProtocols(referencedProtocols),
-        Dump(ctx.getASTContext().LangOpts.DumpRequirementMachine) {}
+      : Context(ctx), ReferencedProtocols(referencedProtocols) {
+    Dump = ctx.getASTContext().LangOpts.DumpRequirementMachine;
+    Initialized = 0;
+  }
 
-  void addRequirements(ArrayRef<Requirement> requirements);
-  void addRequirements(ArrayRef<StructuralRequirement> requirements);
-  void addProtocols(ArrayRef<const ProtocolDecl *> proto);
+  void initWithGenericSignatureRequirements(ArrayRef<Requirement> requirements);
+  void initWithWrittenRequirements(ArrayRef<StructuralRequirement> requirements);
+  void initWithProtocolWrittenRequirements(ArrayRef<const ProtocolDecl *> proto);
   void addReferencedProtocol(const ProtocolDecl *proto);
   void collectRulesFromReferencedProtocols();
 

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -15,7 +15,7 @@
 
 #include "swift/AST/Type.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 #include "Diagnostics.h"
@@ -76,24 +76,22 @@ getRuleForRequirement(const Requirement &req,
 struct RuleBuilder {
   RewriteContext &Context;
 
-  /// The keys are the unique protocols we've added so far. The value indicates
-  /// whether the protocol's SCC is an initial component for the rewrite system.
-  ///
-  /// A rewrite system built from a generic signature does not have any initial
-  /// protocols.
-  ///
-  /// A rewrite system built from a protocol SCC has the protocols of the SCC
-  /// itself as initial protocols.
-  ///
-  /// If a protocol is an initial protocol, we use its structural requirements
-  /// instead of its requirement signature as the basis of its rewrite rules.
-  ///
-  /// This is what breaks the cycle in requirement signature computation for a
-  /// group of interdependent protocols.
-  llvm::DenseMap<const ProtocolDecl *, bool> &ProtocolMap;
+  /// The transitive closure of all protocols appearing on the right hand
+  /// side of conformance requirements.
+  llvm::DenseSet<const ProtocolDecl *> &ReferencedProtocols;
 
-  /// The keys of the above map in insertion order.
-  std::vector<const ProtocolDecl *> Protocols;
+  /// A subset of the above in insertion order, consisting of the protocols
+  /// whose rules we are going to import.
+  ///
+  /// If this is a rewrite system built from a generic signature, this vector
+  /// contains all elements in the above set.
+  ///
+  /// If this is a rewrite system built from a strongly connected component
+  /// of the protocol, this vector contains all elements in the above set
+  /// except for the protocols belonging to the component representing the
+  /// rewrite system itself; those protocols are added directly instead of
+  /// being imported.
+  std::vector<const ProtocolDecl *> ProtocolsToImport;
 
   /// New rules to add which will be marked 'permanent'. These are rules for
   /// introducing associated types, and relationships between layout,
@@ -116,18 +114,18 @@ struct RuleBuilder {
   bool Dump;
 
   RuleBuilder(RewriteContext &ctx,
-              llvm::DenseMap<const ProtocolDecl *, bool> &protocolMap)
-      : Context(ctx), ProtocolMap(protocolMap),
+              llvm::DenseSet<const ProtocolDecl *> &referencedProtocols)
+      : Context(ctx), ReferencedProtocols(referencedProtocols),
         Dump(ctx.getASTContext().LangOpts.DumpRequirementMachine) {}
 
   void addRequirements(ArrayRef<Requirement> requirements);
   void addRequirements(ArrayRef<StructuralRequirement> requirements);
   void addProtocols(ArrayRef<const ProtocolDecl *> proto);
-  void addProtocol(const ProtocolDecl *proto,
-                   bool initialComponent);
+  void addReferencedProtocol(const ProtocolDecl *proto);
   void collectRulesFromReferencedProtocols();
 
 private:
+  void addPermanentProtocolRules(const ProtocolDecl *proto);
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
   void addRequirement(const Requirement &req,

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -125,6 +125,9 @@ struct RuleBuilder {
   void addProtocols(ArrayRef<const ProtocolDecl *> proto);
   void addProtocol(const ProtocolDecl *proto,
                    bool initialComponent);
+  void collectRulesFromReferencedProtocols();
+
+private:
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
   void addRequirement(const Requirement &req,
@@ -134,7 +137,6 @@ struct RuleBuilder {
                       const ProtocolDecl *proto);
   void addTypeAlias(const ProtocolTypeAlias &alias,
                     const ProtocolDecl *proto);
-  void collectRulesFromReferencedProtocols();
 };
 
 // Defined in ConcreteContraction.cpp.

--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include "Diagnostics.h"
 #include "RewriteContext.h"
+#include "Rule.h"
 #include "Symbol.h"
 #include "Term.h"
 
@@ -92,6 +93,10 @@ struct RuleBuilder {
   /// rewrite system itself; those protocols are added directly instead of
   /// being imported.
   std::vector<const ProtocolDecl *> ProtocolsToImport;
+
+  /// The rules representing a complete rewrite system for the above vector,
+  /// pulled in by collectRulesFromReferencedProtocols().
+  std::vector<Rule> ImportedRules;
 
   /// New rules to add which will be marked 'permanent'. These are rules for
   /// introducing associated types, and relationships between layout,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -91,6 +91,7 @@ RequirementMachine::initWithProtocolSignatureRequirements(
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true, protos,
                     std::move(builder.WrittenRequirements),
+                    std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 
@@ -137,6 +138,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
   System.initialize(/*recordLoops=*/false,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
+                    std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 
@@ -181,6 +183,7 @@ RequirementMachine::initWithProtocolWrittenRequirements(
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true, protos,
                     std::move(builder.WrittenRequirements),
+                    std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 
@@ -229,6 +232,7 @@ RequirementMachine::initWithWrittenRequirements(
   System.initialize(/*recordLoops=*/true,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
                     std::move(builder.WrittenRequirements),
+                    std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -91,7 +91,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.addRequirements(sig.getRequirements());
+  builder.initWithGenericSignatureRequirements(sig.getRequirements());
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/false,
@@ -135,7 +135,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
   }
 
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.addProtocols(protos);
+  builder.initWithProtocolWrittenRequirements(protos);
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true, protos,
@@ -182,7 +182,7 @@ RequirementMachine::initWithWrittenRequirements(
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.addRequirements(requirements);
+  builder.initWithWrittenRequirements(requirements);
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true,

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -90,7 +90,7 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RuleBuilder builder(Context, System.getProtocolMap());
+  RuleBuilder builder(Context, System.getReferencedProtocols());
   builder.addRequirements(sig.getRequirements());
 
   // Add the initial set of rewrite rules to the rewrite system.
@@ -134,7 +134,7 @@ RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
     llvm::dbgs() << " {\n";
   }
 
-  RuleBuilder builder(Context, System.getProtocolMap());
+  RuleBuilder builder(Context, System.getReferencedProtocols());
   builder.addProtocols(protos);
 
   // Add the initial set of rewrite rules to the rewrite system.
@@ -181,7 +181,7 @@ RequirementMachine::initWithWrittenRequirements(
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RuleBuilder builder(Context, System.getProtocolMap());
+  RuleBuilder builder(Context, System.getReferencedProtocols());
   builder.addRequirements(requirements);
 
   // Add the initial set of rewrite rules to the rewrite system.

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -335,6 +335,10 @@ std::string RequirementMachine::getRuleAsStringForDiagnostics(
   return out.str();
 }
 
+ArrayRef<Rule> RequirementMachine::getLocalRules() const {
+  return System.getLocalRules();
+}
+
 bool RequirementMachine::isComplete() const {
   return Complete;
 }

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -123,7 +123,8 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
 ///
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
-RequirementMachine::initWithProtocols(ArrayRef<const ProtocolDecl *> protos) {
+RequirementMachine::initWithProtocolWrittenRequirements(
+    ArrayRef<const ProtocolDecl *> protos) {
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 
   if (Dump) {

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -94,7 +94,8 @@ class RequirementMachine final {
   initWithGenericSignature(CanGenericSignature sig);
 
   std::pair<CompletionResult, unsigned>
-  initWithProtocols(ArrayRef<const ProtocolDecl *> protos);
+  initWithProtocolWrittenRequirements(
+      ArrayRef<const ProtocolDecl *> protos);
 
   std::pair<CompletionResult, unsigned>
   initWithWrittenRequirements(

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -91,6 +91,10 @@ class RequirementMachine final {
   void checkCompletionResult(CompletionResult result) const;
 
   std::pair<CompletionResult, unsigned>
+  initWithProtocolSignatureRequirements(
+      ArrayRef<const ProtocolDecl *> protos);
+
+  std::pair<CompletionResult, unsigned>
   initWithGenericSignature(CanGenericSignature sig);
 
   std::pair<CompletionResult, unsigned>

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -158,6 +158,8 @@ public:
   std::vector<Requirement>
   computeMinimalGenericSignatureRequirements(bool reconstituteSugar);
 
+  ArrayRef<Rule> getLocalRules() const;
+
   std::string getRuleAsStringForDiagnostics(unsigned ruleID) const;
 
   GenericSignatureErrors getErrors() const;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -116,7 +116,7 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
 
   SmallVector<RequirementError, 4> errors;
 
-  auto status = machine->initWithProtocols(component);
+  auto status = machine->initWithProtocolWrittenRequirements(component);
   if (status.first != CompletionResult::Success) {
     // All we can do at this point is diagnose and give each protocol an empty
     // requirement signature.

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -337,7 +337,7 @@ bool RewriteSystem::addExplicitRule(MutableTerm lhs, MutableTerm rhs,
 void RewriteSystem::simplifyLeftHandSides() {
   assert(Complete);
 
-  for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
     if (rule.isLHSSimplified())
       continue;
@@ -380,7 +380,7 @@ void RewriteSystem::simplifyLeftHandSides() {
 void RewriteSystem::simplifyRightHandSides() {
   assert(Complete);
 
-  for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
     if (rule.isRHSSimplified())
       continue;
@@ -478,7 +478,7 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
     abort(); \
   }
 
-  for (const auto &rule : Rules) {
+  for (const auto &rule : getLocalRules()) {
     const auto &lhs = rule.getLHS();
     const auto &rhs = rule.getRHS();
 
@@ -585,7 +585,8 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
   // Collect non-explicit requirements that are not redundant.
   llvm::SmallDenseSet<unsigned, 2> impliedRequirements;
 
-  for (unsigned ruleID : indices(getRules())) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
+       ruleID < e; ++ruleID) {
     auto &rule = getRules()[ruleID];
 
     if (!rule.getRequirementID().hasValue() &&

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -72,6 +72,8 @@ class RewriteSystem final {
   /// as rules introduced by the completion procedure.
   std::vector<Rule> Rules;
 
+  unsigned FirstLocalRule = 0;
+
   /// A prefix trie of rule left hand sides to optimize lookup. The value
   /// type is an index into the Rules array defined above.
   Trie<unsigned, MatchKind::Shortest> Trie;
@@ -122,8 +124,10 @@ public:
 
   DebugOptions getDebugOptions() const { return Debug; }
 
-  void initialize(bool recordLoops, ArrayRef<const ProtocolDecl *> protos,
+  void initialize(bool recordLoops,
+                  ArrayRef<const ProtocolDecl *> protos,
                   ArrayRef<StructuralRequirement> writtenRequirements,
+                  std::vector<Rule> &&importedRules,
                   std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
                   std::vector<std::tuple<MutableTerm, MutableTerm, Optional<unsigned>>> &&requirementRules);
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -76,16 +76,15 @@ class RewriteSystem final {
   /// type is an index into the Rules array defined above.
   Trie<unsigned, MatchKind::Shortest> Trie;
 
-  /// The set of protocols known to this rewrite system. The boolean associated
-  /// with each key is true if the protocol is part of the 'Protos' set above,
-  /// otherwies it is false.
+  /// The set of protocols known to this rewrite system.
   ///
-  /// See RuleBuilder::ProtocolMap for a more complete explanation. For the most
-  /// part, this is only used while building the rewrite system, but conditional
-  /// requirement inference forces us to be able to add new protocols to the
-  /// rewrite system after the fact, so this little bit of RuleBuilder state
-  /// outlives the initialization phase.
-  llvm::DenseMap<const ProtocolDecl *, bool> ProtocolMap;
+  /// See RuleBuilder::ReferencedProtocols for a more complete explanation.
+  ///
+  /// For the most part, this is only used while building the rewrite system,
+  /// but conditional requirement inference forces us to be able to add new
+  /// protocols to the rewrite system after the fact, so this little bit of
+  /// RuleBuilder state outlives the initialization phase.
+  llvm::DenseSet<const ProtocolDecl *> ReferencedProtocols;
 
   DebugOptions Debug;
 
@@ -117,8 +116,8 @@ public:
   /// Return the rewrite context used for allocating memory.
   RewriteContext &getRewriteContext() const { return Context; }
 
-  llvm::DenseMap<const ProtocolDecl *, bool> &getProtocolMap() {
-    return ProtocolMap;
+  llvm::DenseSet<const ProtocolDecl *> &getReferencedProtocols() {
+    return ReferencedProtocols;
   }
 
   DebugOptions getDebugOptions() const { return Debug; }
@@ -133,7 +132,7 @@ public:
   }
 
   bool isKnownProtocol(const ProtocolDecl *proto) const {
-    return ProtocolMap.find(proto) != ProtocolMap.end();
+    return ReferencedProtocols.count(proto) > 0;
   }
 
   unsigned getRuleID(const Rule &rule) const {

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -144,10 +144,19 @@ public:
     return (unsigned)(&rule - &*Rules.begin());
   }
 
+  /// Get an array of all rewrite rules.
   ArrayRef<Rule> getRules() const {
     return Rules;
   }
 
+  /// Get an array of rewrite rules, not including rewrite rules imported
+  /// from referenced protocols.
+  ArrayRef<Rule> getLocalRules() const {
+    return getRules().slice(FirstLocalRule);
+  }
+
+  /// Get the rewrite rule at the given index. Note that this is an index
+  /// into getRules(), *NOT* getLocalRules().
   Rule &getRule(unsigned ruleID) {
     return Rules[ruleID];
   }

--- a/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
+++ b/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
@@ -378,7 +378,7 @@ RewriteSystem::simplifySubstitutions(Term baseTerm, Symbol symbol,
 /// is built, and a final simplification pass is performed with \p map set to
 /// the new property map.
 void RewriteSystem::simplifyLeftHandSideSubstitutions(const PropertyMap *map) {
-  for (unsigned ruleID = 0, e = Rules.size(); ruleID < e; ++ruleID) {
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size(); ruleID < e; ++ruleID) {
     auto &rule = getRule(ruleID);
     if (rule.isSubstitutionSimplified())
       continue;

--- a/test/Generics/rdar79564324.swift
+++ b/test/Generics/rdar79564324.swift
@@ -26,14 +26,14 @@ public func test<T : P>(_ t: T) where T == T.A {
 // CHECK-NEXT: - [P].[P] => [P] [permanent]
 // CHECK-NEXT: - [P].A => [P:A] [permanent]
 // CHECK-NEXT: - [P:A].[P] => [P:A]
+// CHECK-NEXT: - [P].[P:A] => [P:A]
+// CHECK-NEXT: - [P:A].A => [P:A].[P:A]
 // CHECK-NEXT: - τ_0_0.[P:A] => τ_0_0
 // CHECK-NEXT: - τ_0_1.[P] => τ_0_1
 // CHECK-NEXT: - τ_0_1.[P:A] => τ_0_0
-// CHECK-NEXT: - [P].[P:A] => [P:A]
-// CHECK-NEXT: - [P:A].A => [P:A].[P:A]
 // CHECK-NEXT: - τ_0_0.[P] => τ_0_0
-// CHECK-NEXT: - τ_0_1.A => τ_0_0
 // CHECK-NEXT: - τ_0_0.A => τ_0_0
+// CHECK-NEXT: - τ_0_1.A => τ_0_0
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P] => { conforms_to: [P] }

--- a/test/Generics/rdar90219229.swift
+++ b/test/Generics/rdar90219229.swift
@@ -26,11 +26,11 @@ protocol PBad {
 // FIXME: Terrible diagnostics.
 
 protocol PWorse {
-// expected-error@-1 2{{circular reference}}
-// expected-note@-2 4{{through reference here}}
+// expected-error@-1 4{{circular reference}}
+// expected-note@-2 6{{through reference here}}
   typealias A = C
 
   associatedtype T : Self.A
-// expected-note@-1 2{{while resolving type 'Self.A'}}
-// expected-note@-2 2{{through reference here}}
+// expected-note@-1 4{{while resolving type 'Self.A'}}
+// expected-note@-2 4{{through reference here}}
 }

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -17,10 +17,10 @@ extension P where Self : Derived {
 // CHECK-NEXT: Rewrite system: {
 // CHECK-NEXT: - [P].[P] => [P] [permanent]
 // CHECK-NEXT: - [P].[superclass: Base] => [P]
+// CHECK-NEXT: - [P].[layout: _NativeClass] => [P]
 // CHECK-NEXT: - τ_0_0.[superclass: Derived] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[P] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[superclass: Base] => τ_0_0
-// CHECK-NEXT: - [P].[layout: _NativeClass] => [P]
 // CHECK-NEXT: - τ_0_0.[layout: _NativeClass] => τ_0_0
 // CHECK-NEXT: }
 // CHECK: Property map: {

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -40,8 +40,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
-// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, [P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<[P2:A2], String, [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, String, τ_0_0.[P1:B1]>] }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -32,9 +32,9 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-NEXT: Rewrite system: {
-// CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
 // CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
+// CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
@@ -44,8 +44,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK:      }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
-// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<[P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<[P2:A2], String, [P2:B2]>] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -36,21 +36,21 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
 // CHECK-NEXT: Rewrite system: {
 // CHECK:      - [P1:X].[superclass: Base<[P1:A1]>] => [P1:X] [explicit]
+// CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
 // CHECK:      - [P2:X].[superclass: Derived<[P2:A2]>] => [P2:X] [explicit]
+// CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
 // CHECK:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Derived<τ_0_0.[P2:A2]>] => τ_0_0.[P1:X]
-// CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
-// CHECK:      - [P2:X].[layout: _NativeClass] => [P2:X]
 // CHECK:      - τ_0_0.[P1:X].[superclass: Base<τ_0_0.[P2:A2].[Q:T]>] => τ_0_0.[P1:X]
 // CHECK:      - τ_0_0.[P2:A2].[Q:T] => τ_0_0.[P1:A1]
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
-// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
-// CHECK-NEXT:   [Q] => { conforms_to: [Q] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<[P1:A1]>] }
+// CHECK-NEXT:   [P2] => { conforms_to: [P2] }
 // CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<[P2:A2]>] }
+// CHECK-NEXT:   [Q] => { conforms_to: [Q] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0.[P2:A2]>] }
 // CHECK-NEXT: }


### PR DESCRIPTION
Right now, each Requirement Machine instance is constructed in a self-contained manner; we start with the requirements in a generic signature (or user-written requirements in a `where` clause, etc, if we're doing minimization); then we walk over all conformance requirements, collecting protocols referenced from the right hand side. We add each requirement in each referenced protocol's requirement signature, and repeat the process until fixed point, collecting a full set of requirements. These requirements are converted into rewrite rules by the RuleBuilder.

This ends up duplicating work, because the Knuth-Bendix algorithm essentially has to recompute the confluent completion of each protocol's rewrite rules in every Requirement Machine where this protocol appears.

It turns out we can do much better, and I've carefully designed for this outcome from the start.

Recall that a protocol P has a _dependency_ on a protocol Q if Q appears on the right hand side of a conformance requirement in P. The protocol dependency graph as the graph whose vertices are all protocols, with a directed edge connecting one protocol to another if that protocol has a dependency on the other protocol.

If two protocols have a dependency on each other, they are part of a connected component in the protocol dependency graph. The connected components of the graph form a directed acyclic graph.

If a valid term contains an occurrence of a protocol P at position i (meaning the ith element is either a protocol symbol `[P]` or an associated type symbol `[P:T]`) and an occurrence of a protocol Q at position j with `i < j`, then it follows that P has a dependency on the protocol Q.

This means a rule from a protocol P can only overlap with a rule in protocol Q if P has a dependency on Q. Therefore, we can build a confluent rewrite system for each connected component in our directed acyclic graph bottom-up; the rules in each component have to be checked for overlap against any downstream components, but not vice versa.

When building the rewrite system for a component (or a top-level generic signature), we can then import the rewrite rules wholesale from the set of downstream components (taking care not to import the same rule twice if it comes from a component further down the dependency graph that is reachable via multiple paths). These imported rules are guaranteed to form a confluent rewrite system. Only the "local" rules in each component (or top-level generic signature) have to be checked for overlap.

There are some future directions here that will make this optimization even more profitable:

- The property map can use a similar optimization; today we still rebuild a full property map from all rules, including imported rules, in each requirement machine.
- We don't have to copy rules into the RewriteSystem::Rules array at all; the RewriteSystem's Tries can share node structure. I'm going to hold off on doing this until everything else is bulletproof because the memory management gets a tad tricky!
- Various places where we iterate over getRules() and skip rules where isInMinimizationDomain() answers return false can instead just iterate over getLocalRules() instead.