### PR TITLE
[SILOpt] Print functions during inlining.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -167,7 +167,7 @@ static llvm::cl::opt<DebugOnlyPassNumberOpt, true,
               llvm::cl::location(DebugOnlyPassNumberOptLoc),
               llvm::cl::ValueRequired);
 
-static bool isFunctionSelectedForPrinting(SILFunction *F) {
+bool isFunctionSelectedForPrinting(SILFunction *F) {
   if (!SILPrintFunction.empty() && SILPrintFunction.end() ==
       std::find(SILPrintFunction.begin(), SILPrintFunction.end(), F->getName()))
     return false;


### PR DESCRIPTION
Enable caller and callee to be printed as inlining runs.  The printing is filtered based on -sil-print-function/-sil-print-functions and includes finer-grained info than those do already.  The caller before (`-Xllvm -sil-print-inlining-caller-before`) and after (`-Xllvm -sil-print-inlining-caller-after`) each callee is inlined can be printed as well as the callee on its own (`-Xllvm -sil-print-inlining-callee`) as it exists when inlining occurs.
