### PR TITLE
[CSDiagnostics] Contextual failure could result in optional chain hav…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2351,7 +2351,9 @@ bool ContextualFailure::diagnoseAsError() {
     if (isExpr<OptionalTryExpr>(anchor) ||
         isExpr<OptionalEvaluationExpr>(anchor)) {
       auto objectType = fromType->getOptionalObjectType();
-      if (objectType->isEqual(toType)) {
+      // Cannot assume that `fromType` is always optional here since
+      // it could assume a type from context.
+      if (objectType && objectType->isEqual(toType)) {
         MissingOptionalUnwrapFailure failure(getSolution(), getType(anchor),
                                              toType,
                                              getConstraintLocator(anchor));

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar85516390.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar85516390.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+}
+
+struct MyThing : P {
+  var myVar: String? { "" }
+}
+
+struct Test {
+  func test(thing: MyThing?) -> P {
+    return thing?.myVar
+    // expected-error@-1 {{return expression of type 'String' does not conform to 'P'}}
+    // expected-error@-2 {{value of optional type 'String?' must be unwrapped to a value of type 'String'}}
+    // expected-note@-3 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-4 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+}


### PR DESCRIPTION
…ing non-optional type

Fixes a crash during diagnostics by not assuming that optional chain
would always produce an optional type, which is not true because in
error scenarios it could get assigned an invalid type from context.

Resolves: rdar://85516390

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
