### PR TITLE
Rewrite ClosureScopeAnalysis for generality.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -169,6 +169,10 @@ public:
     FOREACH_IMPL_RETURN(getCalleeFunction());
   }
 
+  bool isCalleeDynamicallyReplaceable() const {
+    FOREACH_IMPL_RETURN(isCalleeDynamicallyReplaceable());
+  }
+
   /// Return the referenced function if the callee is a function_ref
   /// instruction.
   SILFunction *getReferencedFunctionOrNull() const {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -224,6 +224,10 @@ private:
   /// For details see BasicBlockBitfield::bitfieldID;
   unsigned currentBitfieldID = 1;
 
+  /// Unique identifier for vector indexing and deterministic sorting.
+  /// May be reused when zombie functions are recovered.
+  unsigned index;
+
   /// The function's set of semantics attributes.
   ///
   /// TODO: Why is this using a std::string? Why don't we use uniqued
@@ -445,6 +449,8 @@ public:
     auto fnType = getLoweredFunctionTypeInContext(getTypeExpansionContext());
     return SILFunctionConventions(fnType, getModule());
   }
+
+  unsigned getIndex() const { return index; }
 
   SILProfiler *getProfiler() const { return Profiler; }
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -345,6 +345,10 @@ private:
   /// The options passed into this SILModule.
   const SILOptions &Options;
 
+  /// The number of functions created in this module, which will be the index of
+  /// the next function.
+  unsigned nextFunctionIndex = 0;
+
   /// Set if the SILModule was serialized already. It is used
   /// to ensure that the module is serialized only once.
   bool serialized;
@@ -448,6 +452,12 @@ public:
 
   /// Called after an instruction is moved from one function to another.
   void notifyMovedInstruction(SILInstruction *inst, SILFunction *fromFunction);
+
+  unsigned getNewFunctionIndex() { return nextFunctionIndex++; }
+
+  // This may be larger that the number of live functions in the 'functions'
+  // linked list because it includes the indices of zombie functions.
+  unsigned getNumFunctionIndices() const { return nextFunctionIndex; }
 
   /// Set a serialization action.
   void setSerializeSILAction(ActionCallback SerializeSILAction);

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -150,8 +150,9 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          IsDynamicallyReplaceable_t isDynamic,
                          IsExactSelfClass_t isExactSelfClass,
                          IsDistributed_t isDistributed)
-    : SwiftObjectHeader(functionMetatype),
-      Module(Module), Availability(AvailabilityContext::alwaysAvailable())  {
+    : SwiftObjectHeader(functionMetatype), Module(Module),
+      index(Module.getNewFunctionIndex()),
+      Availability(AvailabilityContext::alwaysAvailable()) {
   init(Linkage, Name, LoweredType, genericEnv, Loc, isBareSILFunction, isTrans,
        isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy,
        E, DebugScope, isDynamic, isExactSelfClass, isDistributed);

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -162,6 +162,9 @@ static bool hasExpectedUsesOfNoEscapePartialApply(Operand *partialApplyUse) {
   if (user->getModule().getASTContext().hadError())
     return true;
 
+  if (isIncidentalUse(user))
+    return true;
+
   // It is fine to call the partial apply
   switch (user->getKind()) {
   case SILInstructionKind::ApplyInst:
@@ -205,10 +208,6 @@ static bool hasExpectedUsesOfNoEscapePartialApply(Operand *partialApplyUse) {
   case SILInstructionKind::CopyValueInst:
     return llvm::all_of(cast<CopyValueInst>(user)->getUses(),
                         hasExpectedUsesOfNoEscapePartialApply);
-
-  // End borrow is always ok.
-  case SILInstructionKind::EndBorrowInst:
-    return true;
 
   case SILInstructionKind::IsEscapingClosureInst:
   case SILInstructionKind::StoreInst:

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -12,202 +12,391 @@
 ///
 /// Implementation of ClosureScopeAnalysis.
 ///
+/// The "scope" of a closure is the function body that refers to the closure.
+///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "closure-scope"
 
-#include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/ClosureScope.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/SILModule.h"
+#include "llvm/ADT/iterator.h"
 
 namespace swift {
 
-class ClosureScopeData {
-  using IndexRange = ClosureScopeAnalysis::IndexRange;
-  using IndexLookupFunc = ClosureScopeAnalysis::IndexLookupFunc;
-  using ScopeRange = ClosureScopeAnalysis::ScopeRange;
+// A function is a node in this graph if it either refers to a closure or is
+// itself a closure.
+//
+// The graph is represented with two vectors. One for forward edges from "scope
+// functions" to closures. Another with backward edges from closures to
+// "scope functions".
+class ClosureGraph {
+  struct Edge {
+    SILFunction *from;
+    SILFunction *to;
 
-private:
-  // Map an index to each SILFunction with a closure scope.
-  std::vector<SILFunction *> indexedScopes;
+    bool operator<(const Edge &other) const {
+      unsigned from1 = from->getIndex();
+      unsigned from2 = other.from->getIndex();
+      if (from1 != from2)
+        return from1 < from2;
 
-  // Map each SILFunction with a closure scope to an index.
-  llvm::DenseMap<SILFunction *, int> scopeToIndexMap;
+      return to->getIndex() < other.to->getIndex();
+    }
+  };
 
-  // A list of all indices for the SILFunctions that partially apply this
-  // closure. The indices index into the `indexedScopes` vector. If the indexed
-  // scope is nullptr, then that function has been deleted.
-  using ClosureScopes = llvm::SmallVector<int, 1>;
+  using EdgePos = std::vector<Edge>::iterator;
+  using EdgeRange = llvm::iterator_range<EdgePos>;
 
-  // Map each closure to its parent scopes.
-  llvm::DenseMap<SILFunction *, ClosureScopes> closureToScopesMap;
+  struct NodeIterator
+      : llvm::iterator_adaptor_base<
+            NodeIterator, EdgePos, std::random_access_iterator_tag,
+            SILFunction *, ptrdiff_t, SILFunction *, SILFunction *> {
+
+    NodeIterator() = default;
+
+    explicit NodeIterator(EdgePos pos) : iterator_adaptor_base(pos) {}
+
+    EdgePos edgeIter() const { return I; }
+
+    SILFunction *operator*() const { return I->from; }
+  };
+
+  // Compare the node identified by the from index of \p edge with the node
+  // identified by \p functionIndex.
+  struct NodeCompare {
+    bool operator()(SILFunction *node1, SILFunction *node2) {
+      return node1->getIndex() < node2->getIndex();
+    }
+  };
+
+  // A set of edges in the relational mapping from a function to the set of
+  // nonescaping closures that are referenced within its body.
+  //
+  // from: parent function
+  //   to: nonescaping child closure
+  std::vector<Edge> functionToClosures;
+
+  // Map every nonescaping closure to the parent function that refers to it.
+  //
+  // from: nonescaping child closure
+  //   to: parent function
+  //
+  // A closure almost always has a single parent. A local function, however, may
+  // be referenced recursively, even within a different closure. Notice that
+  // capturedInt is captured from the outer-most function, but is passed down
+  //
+  //   func localFunc(b: Apply) {
+  //     capturedInt += 1
+  //     let closure = { (c: Apply) in
+  //       c.apply(localFunc)
+  //     }
+  //     b.apply(closure)
+  //   }
+  //   a.apply(localFunc)
+  std::vector<Edge> closureToFunctions;
 
 public:
-  void reset() {
-    indexedScopes.clear();
-    scopeToIndexMap.clear();
-    closureToScopesMap.clear();
-  }
+  ClosureGraph() = default;
 
-  void erase(SILFunction *F) {
-    // If this function is a mapped closure scope, remove it, leaving a nullptr
-    // sentinel.
-    auto indexPos = scopeToIndexMap.find(F);
-    if (indexPos != scopeToIndexMap.end()) {
-      indexedScopes[indexPos->second] = nullptr;
-      scopeToIndexMap.erase(F);
-    }
-    // If this function is a closure, remove it.
-    closureToScopesMap.erase(F);
-  }
+  /// Visit the parent scopes of \p closure if it has any. If \p visitor returns
+  /// false, exit early and return false. Otherwise return true.
+  bool visitClosureScopes(SILFunction *closure,
+                          std::function<bool(SILFunction *scopeFunc)> visitor);
 
-  // Record all closure scopes in this module.
+  /// Visit the closures directly referenced by \p scopeFunc.
+  bool visitClosures(SILFunction *scopeFunc,
+                     std::function<bool(SILFunction *closure)> visitor);
+
+  /// Called when a \p function is removed from this module.
+  void erase(SILFunction *function);
+
+  /// Record all closure scopes in this module.
   void compute(SILModule *M);
 
-  bool isClosureScope(SILFunction *F) { return scopeToIndexMap.count(F); }
-
-  // Return a range of scopes for the given closure. The elements of the
-  // returned range have type `SILFunction *` and are non-null. Return an empty
-  // range for a SILFunction that is not a closure or is a dead closure.
-  ScopeRange getClosureScopes(SILFunction *ClosureF) {
-    IndexRange indexRange(nullptr, nullptr);
-    auto closureScopesPos = closureToScopesMap.find(ClosureF);
-    if (closureScopesPos != closureToScopesMap.end()) {
-      auto &indexedScopes = closureScopesPos->second;
-      indexRange = IndexRange(indexedScopes.begin(), indexedScopes.end());
-    }
-    return makeOptionalTransformRange(indexRange,
-                                      IndexLookupFunc(indexedScopes));
-  }
-
-  void recordScope(PartialApplyInst *PAI) {
-    // Only track scopes of non-escaping closures.
-    auto closureTy = PAI->getCallee()->getType().castTo<SILFunctionType>();
-    // FIXME: isCalleeDynamicallyReplaceable should not be true but can today
-    // because local functions can be marked dynamic.
-    if (!isNonEscapingClosure(closureTy) ||
-        PAI->isCalleeDynamicallyReplaceable())
-      return;
-
-    auto closureFunc = PAI->getCalleeFunction();
-    assert(closureFunc && "non-escaping closure needs a direct partial_apply.");
-
-    auto scopeFunc = PAI->getFunction();
-    int scopeIdx = lookupScopeIndex(scopeFunc);
-
-    // Passes may assume that a deserialized function can only refer to
-    // deserialized closures. For example, AccessEnforcementSelection skips
-    // deserialized functions but assumes all a closure's parent scope have been
-    // processed.
-    assert(scopeFunc->wasDeserializedCanonical()
-           == closureFunc->wasDeserializedCanonical() &&
-           "A closure cannot be serialized in a different module than its "
-           "parent context");
-
-    auto &indices = closureToScopesMap[closureFunc];
-    if (std::find(indices.begin(), indices.end(), scopeIdx) != indices.end())
-      return;
-
-    indices.push_back(scopeIdx);
-  }
-
 protected:
-  int lookupScopeIndex(SILFunction *scopeFunc) {
-    auto indexPos = scopeToIndexMap.find(scopeFunc);
-    if (indexPos != scopeToIndexMap.end())
-      return indexPos->second;
+  ClosureGraph(const ClosureGraph &) = delete;
+  ClosureGraph &operator=(const ClosureGraph &) = delete;
 
-    int scopeIdx = indexedScopes.size();
-    scopeToIndexMap[scopeFunc] = scopeIdx;
-    indexedScopes.push_back(scopeFunc);
-    return scopeIdx;
+  EdgeRange getEdgeRange(SILFunction *node, std::vector<Edge> &edges) {
+    auto it = std::lower_bound(NodeIterator(edges.begin()),
+                               NodeIterator(edges.end()),
+                               node, NodeCompare());
+    auto next = it.edgeIter();
+    for (auto end = edges.end(); next != end; ++next) {
+      if (next->from != node)
+        break;
+    }
+    return EdgeRange(it.edgeIter(), next);
   }
+  
+  EdgeRange getFunctionToClosureEdges(SILFunction *scopeFunc) {
+    return getEdgeRange(scopeFunc, functionToClosures);
+  }
+
+  EdgeRange getClosureToFunctionEdges(SILFunction *closure) {
+    return getEdgeRange(closure, closureToFunctions);
+  }
+
+  void recordScope(ApplySite apply);
+
+  void finalize();
+
+  SWIFT_ASSERT_ONLY_DECL(void dump());
 };
 
-void ClosureScopeData::compute(SILModule *M) {
+bool ClosureGraph::visitClosureScopes(
+    SILFunction *closure, std::function<bool(SILFunction *scopeFunc)> visitor) {
+  for (ClosureGraph::Edge &edge : getClosureToFunctionEdges(closure)) {
+    if (!visitor(edge.to))
+      return false;
+  }
+  return true;
+}
+
+bool ClosureGraph::visitClosures(
+    SILFunction *scopeFunc, std::function<bool(SILFunction *closure)> visitor) {
+  for (ClosureGraph::Edge &edge : getFunctionToClosureEdges(scopeFunc)) {
+    if (!visitor(edge.to))
+      return false;
+  }
+  return true;
+}
+
+void ClosureGraph::erase(SILFunction *function) {
+  struct RefersToFunction {
+    SILFunction *function;
+
+    bool operator()(const Edge &edge) {
+      return edge.from == function || edge.to == function;
+    }
+  };
+  llvm::erase_if(functionToClosures, RefersToFunction{function});
+  llvm::erase_if(closureToFunctions, RefersToFunction{function});
+}
+
+// Handle both partial_apply and directly applied closures of the form:
+//   %f = function_ref @... : $(...inout_aliasable...) -> ...
+//   apply %f(...)
+void ClosureGraph::recordScope(ApplySite apply) {
+  // Only track scopes of non-escaping closures.
+  auto closureTy = apply.getCallee()->getType().castTo<SILFunctionType>();
+
+  // FIXME: isCalleeDynamicallyReplaceable should not be true but can today
+  // because local functions can be marked dynamic.
+  if (!isNonEscapingClosure(closureTy)
+      || apply.isCalleeDynamicallyReplaceable()) {
+    return;
+  }
+  auto closureFunc = apply.getCalleeFunction();
+  assert(closureFunc && "non-escaping closure needs a direct partial_apply.");
+
+  auto scopeFunc = apply.getFunction();
+  // Passes may assume that a deserialized function can only refer to
+  // deserialized closures. For example, AccessEnforcementSelection skips
+  // deserialized functions but assumes all a closure's parent scope have been
+  // processed.
+  assert(scopeFunc->wasDeserializedCanonical() ==
+             closureFunc->wasDeserializedCanonical() &&
+         "A closure cannot be serialized in a different module than its "
+         "parent context");
+
+  functionToClosures.push_back({scopeFunc, closureFunc});
+  closureToFunctions.push_back({closureFunc, scopeFunc});
+}
+
+void ClosureGraph::finalize() {
+  llvm::stable_sort(functionToClosures);
+  llvm::stable_sort(closureToFunctions);
+
+  LLVM_DEBUG(dump());
+}
+
+#ifndef NDEBUG
+static void dumpFunctionName(SILFunction *function) {
+  llvm::dbgs() << Demangle::demangleSymbolAsString(
+    function->getName(),
+    Demangle::DemangleOptions::SimplifiedUIDemangleOptions())
+               << " '" << function->getName() << "'\n";
+}
+
+void ClosureGraph::dump() {
+  llvm::dbgs() << "\n";
+  SILFunction *currentFunc = nullptr;
+  for (auto &edge : functionToClosures) {
+    auto *scopeFunc = edge.from;
+    if (currentFunc != scopeFunc) {
+      currentFunc = scopeFunc;
+      llvm::dbgs() << "SCOPE: ";
+      dumpFunctionName(scopeFunc);
+    }
+    llvm::dbgs() << "    CLOSURE: ";
+    dumpFunctionName(edge.to);
+  }
+  currentFunc = nullptr;
+  for (auto &edge : closureToFunctions) {
+    auto *closure = edge.from;
+    if (currentFunc != closure) {
+      currentFunc = closure;
+      llvm::dbgs() << "CLOSURE: ";
+      dumpFunctionName(closure);
+    }
+    llvm::dbgs() << "    SCOPE: ";
+    dumpFunctionName(edge.to);
+  }
+}
+#endif
+
+void ClosureGraph::compute(SILModule *M) {
   for (auto &F : *M) {
     for (auto &BB : F) {
       for (auto &I : BB) {
-        if (auto *PAI = dyn_cast<PartialApplyInst>(&I)) {
-          recordScope(PAI);
+        if (auto apply = ApplySite::isa(&I)) {
+          recordScope(apply);
         }
       }
     }
   }
+  finalize();
 }
 
 ClosureScopeAnalysis::ClosureScopeAnalysis(SILModule *M)
-    : SILAnalysis(SILAnalysisKind::ClosureScope), M(M), scopeData(nullptr) {}
+    : SILAnalysis(SILAnalysisKind::ClosureScope), M(M), scopeGraph(nullptr) {}
 
 ClosureScopeAnalysis::~ClosureScopeAnalysis() = default;
 
-bool ClosureScopeAnalysis::isClosureScope(SILFunction *scopeFunc) {
-  return getOrComputeScopeData()->isClosureScope(scopeFunc);
+bool ClosureScopeAnalysis::visitClosureScopes(
+    SILFunction *closure, std::function<bool(SILFunction *scopeFunc)> visitor) {
+  return getOrComputeGraph()->visitClosureScopes(closure, visitor);
 }
 
-ClosureScopeAnalysis::ScopeRange
-ClosureScopeAnalysis::getClosureScopes(SILFunction *closureFunc) {
-  return getOrComputeScopeData()->getClosureScopes(closureFunc);
+bool ClosureScopeAnalysis::visitClosures(
+    SILFunction *scopeFunc, std::function<bool(SILFunction *closure)> visitor) {
+  return getOrComputeGraph()->visitClosures(scopeFunc, visitor);
 }
 
 void ClosureScopeAnalysis::invalidate() {
-  if (scopeData) scopeData->reset();
+  scopeGraph.reset();
 }
 
 void ClosureScopeAnalysis::notifyWillDeleteFunction(SILFunction *F) {
-  if (scopeData) scopeData->erase(F);
+  if (scopeGraph)
+    scopeGraph->erase(F);
 }
 
-ClosureScopeData *ClosureScopeAnalysis::getOrComputeScopeData() {
-  if (!scopeData) {
-    scopeData = std::make_unique<ClosureScopeData>();
-    scopeData->compute(M);
+ClosureGraph *ClosureScopeAnalysis::getOrComputeGraph() {
+  if (!scopeGraph) {
+    scopeGraph = std::make_unique<ClosureGraph>();
+    scopeGraph->compute(M);
   }
-  return scopeData.get();
+  return scopeGraph.get();
 }
 
 SILAnalysis *createClosureScopeAnalysis(SILModule *M) {
   return new ClosureScopeAnalysis(M);
 }
 
-void TopDownClosureFunctionOrder::visitFunctions(
-    llvm::function_ref<void(SILFunction *)> visitor) {
-  auto markVisited = [&](SILFunction *F) {
-    bool visitOnce = visited.insert(F).second;
-    assert(visitOnce);
-    (void)visitOnce;
+class ClosureFunctionOrder::ClosureDFS {
+  ClosureFunctionOrder &functionOrder;
+
+  llvm::SmallBitVector visited;
+  llvm::SmallBitVector finished;
+
+  SmallVector<SILFunction *, 4> postorderClosures;
+
+public:
+  ClosureDFS(ClosureFunctionOrder &functionOrder)
+    : functionOrder(functionOrder),
+      visited(functionOrder.csa->getModule()->getNumFunctionIndices()),
+      finished(functionOrder.csa->getModule()->getNumFunctionIndices())
+  {}
+
+  bool isVisited(SILFunction *function) const {
+    return visited.test(function->getIndex());
+  }
+
+  void performDFS(SILFunction *root) {
+    postorderClosures.clear();
+
+    recursiveDFS(root);
+
+    // Closures are discovered in postorder, bottom-up.
+    // Reverse-append them onto the top-down function list.
+    llvm::append_range(functionOrder.topDownFunctions,
+                       llvm::reverse(postorderClosures));
+  }
+
+protected:
+  void recursiveDFS(SILFunction *function) {
+    unsigned index = function->getIndex();
+    if (visited.test(index)) {
+      if (!finished.test(index)) {
+        // Cycle in the closure graph.
+        functionOrder.closureCycleHeads.insert(function);
+      }
+      return;
+    }
+    visited.set(index);
+
+    functionOrder.csa->visitClosures(function, [this](SILFunction *closure) {
+      recursiveDFS(closure);
+      return true;
+    });
+    finished.set(index);
+    postorderClosures.push_back(function);
   };
-  auto allScopesVisited = [&](SILFunction *closureF) {
-    return llvm::all_of(CSA->getClosureScopes(closureF),
-                        [this](SILFunction *F) { return visited.count(F); });
-  };
-  for (auto &F : *CSA->getModule()) {
-    if (!allScopesVisited(&F)) {
-      closureWorklist.insert(&F);
+};
+
+void ClosureFunctionOrder::compute() {
+  auto *module = csa->getModule();
+
+  assert(topDownFunctions.empty() && closureCycleHeads.empty() &&
+         "attempting to recompute");
+  topDownFunctions.reserve(module->getNumFunctionIndices());
+
+  ClosureDFS dfs(*this);
+  SmallVector<SILFunction *, 4> closureWorklist;
+
+  unsigned numFunctions = 0;
+  for (auto &function : module->getFunctionList()) {
+    ++numFunctions;
+    if (dfs.isVisited(&function))
+      continue;
+
+    if (csa->isReachableClosure(&function)) {
+      // This is a closure, reachable from some other function. Reaching this
+      // point is rare, because closures typically follow their parent in the
+      // function list.
+      //
+      // A closure at the head of a cycle might only be reachable from other
+      // closures. So use a worklist to visit them once more as DFS roots after
+      // finishing DFS from all acyclic functions.
+      closureWorklist.push_back(&function);
       continue;
     }
-    markVisited(&F);
-    visitor(&F);
+    dfs.performDFS(&function);
   }
-  unsigned numClosures = closureWorklist.size();
-  while (numClosures) {
-    unsigned prevNumClosures = numClosures;
-    for (auto &closureNode : closureWorklist) {
-      // skip erased closures.
-      if (!closureNode)
-        continue;
+  // Revisit closures in forward order. DFS will immediately return except in
+  // the unlikely event that this is an orphaned closure.
+  for (auto *closure : closureWorklist) {
+    dfs.performDFS(closure);
+  }
+  LLVM_DEBUG(dump());
+  assert(numFunctions == topDownFunctions.size() && "DFS missed a function");
+}
 
-      auto closureF = closureNode.getValue();
-      if (!allScopesVisited(closureF))
-        continue;
+#ifndef NDEBUG
+void ClosureFunctionOrder::dump() {
+  llvm::dbgs() << "\nRPO function order:\n";
+  for (auto *function : getTopDownFunctions()) {
+    llvm::dbgs() << "[" << function->getIndex() << "] ";
+    if (isHeadOfClosureCycle(function))
+      llvm::dbgs() << "CYCLE HEAD: ";
 
-      markVisited(closureF);
-      visitor(closureF);
-      closureWorklist.erase(closureF);
-      --numClosures;
-    }
-    assert(numClosures < prevNumClosures && "Cyclic closures scopes");
-    (void)prevNumClosures;
+    dumpFunctionName(function);
   }
 }
+#endif
 
 } // namespace swift

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -32,6 +32,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-enforcement-selection"
+#include "swift/Basic/Defer.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILFunction.h"
@@ -98,12 +99,16 @@ raw_ostream &operator<<(raw_ostream &os, const AddressCapture &capture) {
 // For each non-escaping closure, record the indices of arguments that
 // require dynamic enforcement.
 class DynamicCaptures {
+  const ClosureFunctionOrder &closureOrder;
+
+  // This only maps functions that have at least one inout_aliasable argument.
   llvm::DenseMap<SILFunction *, SmallVector<unsigned, 4>> dynamicCaptureMap;
 
   DynamicCaptures(DynamicCaptures &) = delete;
 
 public:
-  DynamicCaptures() = default;
+  DynamicCaptures(const ClosureFunctionOrder &closureOrder):
+    closureOrder(closureOrder) {}
 
   void recordCapture(AddressCapture capture) {
     LLVM_DEBUG(llvm::dbgs() << "Dynamic Capture: " << capture);
@@ -121,6 +126,11 @@ public:
   }
 
   bool isDynamic(SILFunctionArgument *arg) const {
+    // If the current function is a local function that directly or indirectly
+    // refers to itself, then conservatively assume dynamic enforcement.
+    if (closureOrder.isHeadOfClosureCycle(arg->getFunction()))
+      return true;
+
     auto pos = dynamicCaptureMap.find(arg->getFunction());
     if (pos == dynamicCaptureMap.end())
       return false;
@@ -576,16 +586,15 @@ struct SourceAccess {
 ///
 /// TODO: Make this a "ClosureTransform". See the file-level comments above.
 class AccessEnforcementSelection : public SILModuleTransform {
-  // Reference back to the known dynamically enforced non-escaping closure
+  // Track the known dynamically enforced non-escaping closure
   // arguments in this module. Parent scopes are processed before the closures
   // they reference.
-  DynamicCaptures dynamicCaptures;
+  std::unique_ptr<DynamicCaptures> dynamicCaptures;
 
 #ifndef NDEBUG
   // Per-function book-keeping to verify that a box is processed before all of
   // its accesses and captures are seen.
   llvm::DenseSet<AllocBoxInst *> handledBoxes;
-  llvm::DenseSet<SILFunction *> visited;
 #endif
 
 public:
@@ -601,34 +610,24 @@ protected:
 
 void AccessEnforcementSelection::run() {
   auto *CSA = getAnalysis<ClosureScopeAnalysis>();
-  TopDownClosureFunctionOrder closureOrder(CSA);
-  closureOrder.visitFunctions(
-      [this](SILFunction *F) { this->processFunction(F); });
+  ClosureFunctionOrder closureOrder(CSA);
+  closureOrder.compute();
+
+  dynamicCaptures = std::make_unique<DynamicCaptures>(closureOrder);
+  SWIFT_DEFER { dynamicCaptures.release(); };
+
+  for (SILFunction *function : closureOrder.getTopDownFunctions()) {
+    this->processFunction(function);
+  }
 }
 
-void AccessEnforcementSelection::processFunction(SILFunction *F) {
+void AccessEnforcementSelection::
+processFunction(SILFunction *F) {
   if (F->isExternalDeclaration())
     return;
 
   LLVM_DEBUG(llvm::dbgs() << "Access Enforcement Selection in " << F->getName()
                           << "\n");
-
-  // This ModuleTransform needs to analyze closures and their parent scopes in
-  // the same pass, and the parent needs to be analyzed before the closure.
-#ifndef NDEBUG
-  auto *CSA = getAnalysis<ClosureScopeAnalysis>();
-  if (isNonEscapingClosure(F->getLoweredFunctionType())) {
-    for (auto *scopeF : CSA->getClosureScopes(F)) {
-      LLVM_DEBUG(llvm::dbgs() << "  Parent scope: " << scopeF->getName()
-                              << "\n");
-      assert(visited.count(scopeF));
-      // Closures must be defined in the same module as their parent scope.
-      assert(scopeF->wasDeserializedCanonical()
-             == F->wasDeserializedCanonical());
-    }
-  }
-  visited.insert(F);
-#endif
 
   // Deserialized functions, which have been mandatory inlined, no longer meet
   // the structural requirements on access markers required by this pass.
@@ -646,7 +645,7 @@ void AccessEnforcementSelection::processFunction(SILFunction *F) {
       // may still have captures that require dynamic enforcement because the
       // box has escaped prior to the capture.
       if (auto box = dyn_cast<AllocBoxInst>(inst)) {
-        SelectEnforcement(dynamicCaptures, box).run();
+        SelectEnforcement(*dynamicCaptures, box).run();
         assert(handledBoxes.insert(box).second);
 
       } else if (auto access = dyn_cast<BeginAccessInst>(inst))
@@ -703,7 +702,7 @@ SourceAccess AccessEnforcementSelection::getSourceAccess(SILValue address) {
       return SourceAccess::getStaticAccess();
 
     case SILArgumentConvention::Indirect_InoutAliasable:
-      if (dynamicCaptures.isDynamic(arg))
+      if (dynamicCaptures->isDynamic(arg))
         return SourceAccess::getDynamicAccess();
 
       return SourceAccess::getStaticAccess();
@@ -754,7 +753,7 @@ void AccessEnforcementSelection::handleApply(ApplySite apply) {
       // there's no need to track it.
       break;
     case SourceAccess::DynamicAccess: {
-      dynamicCaptures.recordCapture(capture);
+      dynamicCaptures->recordCapture(capture);
       break;
     }
     case SourceAccess::BoxAccess:

--- a/test/SILOptimizer/closure_scope_analysis.swift
+++ b/test/SILOptimizer/closure_scope_analysis.swift
@@ -1,0 +1,77 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-sil -O -Xllvm -debug-only=closure-scope -module-name main -o /dev/null 2>&1 | %FileCheck %s
+
+public protocol Apply {
+  func apply(_ body: (Apply) -> ())
+}
+
+public func testRecursiveClosure(a: Apply, x: inout Int) {
+  func localFunc(b: Apply) {
+    x += 1
+    let closure = { (c: Apply) in
+      c.apply(localFunc)
+    }
+    b.apply(closure)
+  }
+  a.apply(localFunc)
+}
+
+public func testDeadClosureCycle(a: Apply, x: inout Int) {
+  func localFunc(b: Apply) {
+    x += 1
+    let closure = { (c: Apply) in
+      c.apply(localFunc)
+    }
+    b.apply(closure)
+  }
+}
+
+// The order of the top-level SCOPE nodes is sensitive to the module's
+// function list ordering. It may change. The important thing is that:
+//
+// - the closure scope graph has the same shape
+// - the localFunc is marked CYCLE_HEAD
+// - the RPO function order does not change
+
+// testRecursiveClosure scopes:
+//
+// CHECK: SCOPE: testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF'
+// CHECK:     CLOSURE: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK: SCOPE: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK:     CLOSURE: closure #1 in localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK: SCOPE: closure #1 in localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK:     CLOSURE: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+
+// testDeadClosureCycle scopes:
+//
+// CHECK: SCOPE: localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK:     CLOSURE: closure #1 in localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK: SCOPE: closure #1 in localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK:     CLOSURE: localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+
+// testRecursiveClosure closures:
+//
+// CHECK: CLOSURE: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK:     SCOPE: testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF'
+// CHECK:     SCOPE: closure #1 in localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK: CLOSURE: closure #1 in localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK:     SCOPE: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+
+// testDeadClosureCycle closures:
+//
+// CHECK: CLOSURE: localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK:     SCOPE: closure #1 in localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK: CLOSURE: closure #1 in localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK:     SCOPE: localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+
+// CHECK: RPO function order:
+
+// CHECK: main 'main'
+// CHECK: testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF'
+// CHECK: CYCLE HEAD: localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK: closure #1 in localFunc #1 (b:) in testRecursiveClosure(a:x:) '$s4main20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'
+// CHECK: Int.init(_builtinIntegerLiteral:) '$sSi22_builtinIntegerLiteralSiBI_tcfC'
+// CHECK: static Int.+= infix(_:_:) '$sSi2peoiyySiz_SitFZ'
+
+// CHECK: testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF'
+// CHECK: CYCLE HEAD: localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
+// CHECK: closure #1 in localFunc #1 (b:) in testDeadClosureCycle(a:x:) '$s4main20testDeadClosureCycle1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tFyAaE_pcfU_'


### PR DESCRIPTION
Handle recursive non-escaping local functions.

Previously, it was thought that recursion would force a closure to be
escaping. This is not necessarilly true.

Update AccessEnforcementSelection to conservatively handle closure cycles.

Fixes rdar://88726092 (Compiler hangs when building)