### PR TITLE
[cxx-interop] Test for apinotes fix in llvm-project.

### DIFF
--- a/test/Interop/Cxx/apinotes/Inputs/SomeModule.apinotes
+++ b/test/Interop/Cxx/apinotes/Inputs/SomeModule.apinotes
@@ -1,0 +1,5 @@
+---
+Name: SomeModule
+Classes:
+- Name: NSSomeClass
+  SwiftName: SomeClass

--- a/test/Interop/Cxx/apinotes/Inputs/SomeModule.h
+++ b/test/Interop/Cxx/apinotes/Inputs/SomeModule.h
@@ -1,0 +1,4 @@
+@interface NSSomeClass
+  -(instancetype)init;
+@end
+

--- a/test/Interop/Cxx/apinotes/Inputs/module.modulemap
+++ b/test/Interop/Cxx/apinotes/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module SomeModule [extern_c] {
+  requires objc
+  header "SomeModule.h"
+}

--- a/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
+++ b/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=SomeModule -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
+// RUN: %swift-frontend -c -enable-cxx-interop -enable-objc-interop -I %S/Inputs %s -o - -emit-sil | %FileCheck %s
+
+import SomeModule
+
+// CHECK: @objc @_inheritsConvenienceInitializers class MyClass : SomeClass
+// CHECK-IDE-TEST: typealias NSSomeClass = SomeClass
+// CHECK-IDE-TEST-NEXT: class SomeClass
+class MyClass : SomeClass { }


### PR DESCRIPTION
This is the test that goes with https://github.com/apple/llvm-project/pull/4074

In the PR to apple/llvm-project we were bailing on DeclContexts that
were not isFileContext == true. This is problematic because with
C++-Interop enabled we can end up with a DeclContext that is an extern
"C". This test makes sure that the APINote is applied and that the code
from the 4074 PR no longer bails out.

Note: The llvm-project change is in apple/llvm-project rather than llvm/llvm-project because the file clang/lib/Sema/SemaAPINotes.cpp has not been upstreamed to llvm.org yet.