### PR TITLE
[Diagnostic][Sema] Drop OptionalPayload locator element in contextual conformance failure diagnostics

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3407,7 +3407,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
           if (last.is<LocatorPathElt::ApplyArgToParam>()) {
             auto *fix = AllowArgumentMismatch::create(
-                *this, type1, proto, getConstraintLocator(locator));
+                *this, type1, proto, getConstraintLocator(anchor, path));
 
             // Impact is 2 here because there are two failures
             // 1 - missing conformance and 2 - incorrect argument type.
@@ -3443,14 +3443,14 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
 
         if (isExpr<CoerceExpr>(anchor)) {
           auto *fix = ContextualMismatch::create(
-              *this, type1, type2, getConstraintLocator(locator));
+              *this, type1, type2, getConstraintLocator(anchor, path));
           if (recordFix(fix))
             return getTypeMatchFailure(locator);
           break;
         }
 
         auto *fix = MissingConformance::forContextual(
-            *this, type1, proto, getConstraintLocator(locator));
+            *this, type1, proto, getConstraintLocator(anchor, path));
 
         if (recordFix(fix))
           return getTypeMatchFailure(locator);

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -519,3 +519,15 @@ case test(cond: Bool, v: Int64)
     }
   }
 }
+
+// SR-15970
+protocol SR15970_P {}
+struct SR15970_S {}
+
+func SR15970_F(x: Int) -> SR15970_P {
+  return SR15970_S() // expected-error{{return expression of type 'SR15970_S' does not conform to 'SR15970_P'}}
+}
+
+func SR15970_F1(x: Int) -> SR15970_P? {
+  return SR15970_S() // expected-error{{return expression of type 'SR15970_S' does not conform to 'SR15970_P'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Dropping `OptionalPayload` in `MissingContextualConformanceFailure` since at this point is not relevant to diagnostic.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15970.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
