### PR TITLE
[RequirementMachine] Suppress redundant requirement warnings for inferred requirements.

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -571,6 +571,10 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
     auto requirement = WrittenRequirements[requirementID];
     auto pairIt = rulesPerRequirement.find(requirementID);
 
+    // Inferred requirements can be re-stated without warning.
+    if (requirement.inferred)
+      continue;
+
     // If there are no rules for this structural requirement, then
     // the requirement was never added to the rewrite system because
     // it is trivially redundant.

--- a/lib/AST/RequirementMachine/Rule.h
+++ b/lib/AST/RequirementMachine/Rule.h
@@ -97,7 +97,6 @@ public:
   }
 
   void setRequirementID(Optional<unsigned> requirementID) {
-    assert(!getRequirementID().hasValue());
     this->requirementID = requirementID;
   }
 

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -178,3 +178,19 @@ class X3 { }
 
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
 // expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
+
+
+// Redundant requirement warnings are suppressed for inferred requirements.
+
+protocol P11 {
+ associatedtype X
+ associatedtype Y
+ associatedtype Z
+}
+
+func inferred1<T : Hashable>(_: Set<T>) {}
+func inferred2<T>(_: Set<T>) where T: Hashable {}
+func inferred3<T : P11>(_: T) where T.X : Hashable, T.Z == Set<T.Y>, T.X == T.Y {}
+func inferred4<T : P11>(_: T) where T.Z == Set<T.Y>, T.X : Hashable, T.X == T.Y {}
+func inferred5<T : P11>(_: T) where T.Z == Set<T.X>, T.Y : Hashable, T.X == T.Y {}
+func inferred6<T : P11>(_: T) where T.Y : Hashable, T.Z == Set<T.X>, T.X == T.Y {}


### PR DESCRIPTION
This is done by propagating redundant requirement IDs to rewrite rules derived from inferred requirements. This effectively means that inferred requirements are always considered redundant, which makes it easy to skip over them when recording diagnostics in `RewriteSystem::computeRedundantRequirementDiagnostics`.

Resolves: rdar://90192896