### PR TITLE
[stdlib] tolerate empty source buffers in `UMRBP.copyMemory`

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -438,7 +438,9 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func copyMemory(from source: UnsafeRawBufferPointer) {
     _debugPrecondition(source.count <= self.count,
       "${Self}.copyMemory source has too many elements")
-    baseAddress?.copyMemory(from: source.baseAddress!, byteCount: source.count)
+    if let baseAddress = baseAddress, let sourceAddress = source.baseAddress {
+      baseAddress.copyMemory(from: sourceAddress, byteCount: source.count)
+    }
   }
 
   /// Copies from a collection of `UInt8` into this buffer's memory.

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -179,6 +179,30 @@ ${SelfName}TestSuite.test("nilBaseAddress") {
   expectEqualSequence([], emptyBuffer)
 }
 
+% if IsMutable:
+${SelfName}TestSuite.test("copyFromEmptyBuffer") {
+% if IsRaw:
+  var memory: UnsafeMutableRawPointer
+  let empty = UnsafeRawBufferPointer(start: nil, count: 0)
+% else:
+  var memory: UnsafeMutablePointer<Float>
+  let empty = UnsafeBufferPointer<Float>(start: nil, count: 0)
+% end
+
+  let count = 4
+  memory = allocateFor${Raw}Buffer(count: count)
+  defer { deallocateFor${Raw}Buffer(memory, count: count) }
+
+  let buffer = UnsafeMutable${Raw}BufferPointer(start: memory, count: count)
+
+% if IsRaw:
+  buffer.copyMemory(from: empty)
+% else:
+  _ = buffer.initialize(from: empty)
+% end
+}
+% end
+
 ${SelfName}TestSuite.test("nonNilButEmpty") {
   let emptyAllocated = UnsafeMutablePointer<Float>.allocate(capacity: 0)
   defer { emptyAllocated.deallocate() }


### PR DESCRIPTION
The implementation previously trapped when the source buffer was empty and the source's `baseAddress` was nil. That behaviour is neither documented nor necessary. The real precondition is that the source buffer cannot be larger than the destination. When the source buffer is empty, that precondition is necessarily met.

This updated version of `UnsafeMutableRawBufferPointer.copyMemory` simply returns when the source buffer is empty.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15994 (rdar://90350360).
