### PR TITLE
[DNM] Parse `/.../` regex literals (by re-lexing)

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -94,6 +94,9 @@ ERROR(forbidden_extended_escaping_string,none,
 ERROR(regex_literal_parsing_error,none,
       "%0", (StringRef))
 
+ERROR(prefix_slash_not_allowed,none,
+      "prefix slash not allowed", ())
+
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -531,6 +531,9 @@ public:
     void operator=(const SILBodyRAII&) = delete;
   };
 
+  /// Attempt to re-lex a regex literal with forward slashes `/.../`.
+  bool tryLexAsForwardSlashRegexLiteral(State S);
+
 private:
   /// Nul character meaning kind.
   enum class NulCharacterKind {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -559,6 +559,11 @@ public:
     return f(backtrackScope);
   }
 
+  /// Discard the current token. This will avoid interface hashing or updating
+  /// the previous loc. Only should be used if you've completely re-lexed
+  /// a different token at that position.
+  SourceLoc discardToken();
+
   /// Consume a token that we created on the fly to correct the original token
   /// stream from lexer.
   void consumeExtraToken(Token K);
@@ -1723,6 +1728,7 @@ public:
   ParserResult<Expr>
   parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind);
 
+  UnresolvedDeclRefExpr *makeExprOperator(Token opToken);
   UnresolvedDeclRefExpr *parseExprOperator();
 
   void validateCollectionElement(ParserResult<Expr> element);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8524,6 +8524,11 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                    Tok.getRawText().front() == '!'))
       diagnose(Tok, diag::postfix_operator_name_cannot_start_with_unwrap);
 
+  if (Attributes.hasAttribute<PrefixAttr>()) {
+    if (Tok.getText().contains("/"))
+      diagnose(Tok, diag::prefix_slash_not_allowed);
+  }
+
   // A common error is to try to define an operator with something in the
   // unicode plane considered to be an operator, or to try to define an
   // operator like "not".  Analyze and diagnose this specifically.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -540,6 +540,8 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
     Tok.setKind(tok::oper_prefix);
     LLVM_FALLTHROUGH;
   case tok::oper_prefix:
+    if (Tok.getText().contains("/"))
+      diagnose(Tok, diag::prefix_slash_not_allowed);
     Operator = parseExprOperator();
     break;
   case tok::oper_binary_spaced:

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -32,7 +32,15 @@ using namespace swift::syntax;
 
 ParserResult<Expr> Parser::parseExprRegexLiteral() {
   assert(Tok.is(tok::regex_literal));
-  assert(regexLiteralParsingFn);
+
+  // Bail if '-enable-experimental-string-processing' is not enabled.
+  if (!Context.LangOpts.EnableExperimentalStringProcessing ||
+      !regexLiteralParsingFn) {
+    diagnose(Tok, diag::regex_literal_parsing_error,
+             "regex literal requires '-enable-experimental-string-processing'");
+    auto loc = consumeToken();
+    return makeParserResult(new (Context) ErrorExpr(loc));
+  }
 
   SyntaxParsingContext LocalContext(SyntaxContext,
                                     SyntaxKind::RegexLiteralExpr);

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -39,6 +39,16 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
 
   auto regexText = Tok.getText();
 
+  // The Swift library doesn't know about `/.../` regexes, let's pretend it's
+  // `#/.../#` instead.
+  if (regexText[0] == '/') {
+    SmallString<32> scratch;
+    scratch.append("#");
+    scratch.append(regexText);
+    scratch.append("#");
+    regexText = Context.AllocateCopy(StringRef(scratch));
+  }
+
   // Let the Swift library parse the contents, returning an error, or null if
   // successful.
   // TODO: We need to be able to pass back a source location to emit the error

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -579,13 +579,16 @@ const Token &Parser::peekToken() {
   return L->peekNextToken();
 }
 
-SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
-  SourceLoc Loc = Tok.getLoc();
+SourceLoc Parser::discardToken() {
   assert(Tok.isNot(tok::eof) && "Lexing past eof!");
-
-  recordTokenHash(Tok);
-
+  SourceLoc Loc = Tok.getLoc();
   L->lex(Tok, LeadingTrivia, TrailingTrivia);
+  return Loc;
+}
+
+SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
+  recordTokenHash(Tok);
+  auto Loc = discardToken();
   PreviousLoc = Loc;
   return Loc;
 }

--- a/test/StringProcessing/Parse/forward-slash-regex-default.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-default.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+let _ = /x/ // expected-error {{regex literal requires '-enable-experimental-string-processing'}}
+
+prefix operator /  // expected-error {{prefix slash not allowed}}
+prefix operator ^/ // expected-error {{prefix slash not allowed}}
+
+_ = /x
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+// expected-error@-3 {{cannot find 'x' in scope}}
+
+_ = !/x/ // expected-error {{regex literal requires '-enable-experimental-string-processing'}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -1,0 +1,283 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// REQUIRES: swift_in_compiler
+// REQUIRES: concurrency
+
+precedencegroup P {
+  associativity: left
+}
+
+// Fine.
+infix operator /^/ : P
+func /^/ (lhs: Int, rhs: Int) -> Int { 0 }
+
+let i = 0 /^/ 1/^/3
+
+prefix operator /  // expected-error {{prefix slash not allowed}}
+prefix operator ^/ // expected-error {{prefix slash not allowed}}
+
+let x = /abc/
+_ = /abc/
+_ = /x/.self
+_ = /\//
+
+// These unfortunately become infix `=/`. We could likely improve the diagnostic
+// though.
+let z=/0/
+// expected-error@-1 {{type annotation missing in pattern}}
+// expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
+// expected-error@-3 {{expected expression after unary operator}}
+// expected-error@-4 {{cannot find operator '=/' in scope}}
+// expected-error@-5 {{'/' is not a postfix unary operator}}
+_=/0/
+// expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
+// expected-error@-2 {{cannot find operator '=/' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+_ = /x
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+_ = !/x/
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = /x/! // expected-error {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+_ = /x/ + /y/ // expected-error {{binary operator '+' cannot be applied to two 'Regex<Substring>' operands}}
+
+_ = /x/+/y/
+// expected-error@-1 {{cannot find operator '+/' in scope}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x/?.blah
+// expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+_ = /x/!.blah
+// expected-error@-1 {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x /? // expected-error {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+  .blah // expected-error {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = 0; /x / // expected-warning {{regular expression literal is unused}}
+
+_ = /x / ? 0 : 1 // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+_ = .random() ? /x / : .blah // expected-error {{type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x/ ?? /x/ // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+_ = /x / ?? /x / // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+
+_ = /x/??/x/ // expected-error {{'/' is not a postfix unary operator}}
+
+_ = /x/ ... /y/ // expected-error {{referencing operator function '...' on 'Comparable' requires that 'Regex<Substring>' conform to 'Comparable'}}
+
+_ = /x/.../y/
+// expected-error@-1 {{missing whitespace between '...' and '/' operators}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x /...
+// expected-error@-1 {{unary operator '...' cannot be applied to an operand of type 'Regex<Substring>'}}
+// expected-note@-2 {{overloads for '...' exist with these partially matching parameter lists}}
+
+do {
+  _ = true / false /; // expected-error {{expected expression after operator}}
+}
+
+_ = "\(/x/)"
+
+func defaulted(x: Regex<Substring> = /x/) {}
+
+func foo<T>(_ x: T, y: T) {}
+foo(/abc/, y: /abc /)
+
+func bar<T>(_ x: inout T) {}
+
+// TODO: We split this into a prefix '&', but inout is handled specially when
+// parsing an argument list. This shouldn't matter anyway, but we should at
+// least have a custom diagnostic.
+bar(&/x/)
+// expected-error@-1 {{'&' is not a prefix unary operator}}
+
+struct S {
+  subscript(x: Regex<Substring>) -> Void { () }
+}
+
+func testSubscript(_ x: S) {
+  x[/x/]
+  x[/x /]
+}
+
+func testReturn() -> Regex<Substring> {
+  if .random() {
+    return /x/
+  }
+  return /x /
+}
+
+func testThrow() throws {
+  throw /x / // expected-error {{thrown expression type 'Regex<Substring>' does not conform to 'Error'}}
+}
+
+_ = [/abc/, /abc /]
+_ = [/abc/:/abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc/ : /abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /:/abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /: /abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = (/abc/, /abc /)
+_ = ((/abc /))
+
+_ = { /abc/ }
+_ = {
+  /abc/
+}
+
+let _: () -> Int = {
+  0
+  / 1 /
+  2
+}
+
+_ = {
+  0 // expected-warning {{integer literal is unused}}
+  /1 / // expected-warning {{regular expression literal is unused}}
+  2 // expected-warning {{integer literal is unused}}
+}
+
+// Operator chain, as a regex literal may not start with space.
+_ = 2
+/ 1 / .bitWidth
+
+_ = 2
+/1/ .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+_ = 2
+/ 1 /
+  .bitWidth
+
+_ = 2
+/1 /
+  .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+let z =
+/y/
+
+// While '.' is technically an operator character, it seems more likely that
+// the user hasn't written the member name yet.
+_ = 0. / 1 / 2 // expected-error {{expected member name following '.'}}
+_ = 0 . / 1 / 2 // expected-error {{expected member name following '.'}}
+
+switch "" {
+case /x/:
+  // expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'String'}}
+  // expected-note@-2 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
+  break
+case _ where /x /:
+  // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+  break
+default:
+  break
+}
+
+do {} catch /x / {}
+// expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'any Error'}}
+// expected-error@-2 {{binary operator '~=' cannot be applied to two 'any Error' operands}}
+// expected-warning@-3 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+
+switch /x / {
+default:
+  break
+}
+
+if /x / {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+if /x /.smth {} // expected-error {{value of type 'Regex<Substring>' has no member 'smth'}}
+
+func testGuard() {
+  guard /x/ else { return } // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+}
+
+for x in [0] where /x/ {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+
+typealias Magic<T> = T
+_ = /x/ as Magic
+_ = /x/ as! String // expected-warning {{cast from 'Regex<Substring>' to unrelated type 'String' always fails}}
+
+_ = type(of: /x /)
+
+do {
+  let /x / // expected-error {{expected pattern}}
+}
+
+_ = try /x/; _ = try /x /
+// expected-warning@-1 2{{no calls to throwing functions occur within 'try' expression}}
+
+// TODO: `try?` and `try!` are currently broken.
+// _ = try? /x/; _ = try? / x /
+// _ = try! /x/; _ = try! / x /
+
+_ = await /x / // expected-warning {{no 'async' operations occur within 'await' expression}}
+
+/x/ = 0 // expected-error {{cannot assign to value: literals are not mutable}}
+/x/() // expected-error {{cannot call value of non-function type 'Regex<Substring>'}}
+
+// TODO: We could allow this (and treat the last '/' as postfix), though it
+// seems more likely the user has written a comment and is still in the middle
+// of writing the characters before it.
+/x//
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+/x //
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+/x/**/
+// expected-error@-1 {{prefix slash not allowed}}
+// expected-error@-2 {{'/' is not a prefix unary operator}}
+
+// Make sure we continue parsing these as operators, as they are not right
+// bound.
+func foo(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {}
+foo(/, /)
+foo(/,/)
+foo((/), (/))
+
+func bar<T>(_ x: (Int, Int) -> Int, _ y: T) -> Int { 0 }
+_ = bar(/, 1) / 2
+_ = bar(/, "(") / 2
+_ = bar(/, 1) // comment
+
+let arr: [Double] = [2, 3, 4]
+_ = arr.reduce(1, /) / 3
+_ = arr.reduce(1, /) + arr.reduce(1, /)
+
+// Fine.
+_ = /./
+
+// You need to escape if you want a regex literal to start with these characters.
+// TODO: Better recovery
+_ = /\ /
+do { _ = / / }
+// expected-error@-1 2{{unary operator cannot be separated from its operand}}
+// expected-error@-2 {{expected expression in assignment}}
+
+_ = /\)/
+do { _ = /)/ }
+// expected-error@-1 {{expected expression after unary operator}}
+// expected-error@-2 {{expected expression in assignment}}
+
+_ = /\,/
+do { _ = /,/ }
+// expected-error@-1 {{expected expression after unary operator}}
+// expected-error@-2 {{expected expression in assignment}}
+
+_ = /}/
+_ = /]/
+_ = /:/
+_ = /;/
+
+// TODO: Need to delay diagnostics for these.
+_ = /0xG/ // expected-error {{'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal}}
+_ = /0oG/ // expected-error {{'G' is not a valid octal digit (0-7) in integer literal}}
+_ = /"/ // expected-error {{unterminated string literal}}
+_ = /'/ // expected-error {{unterminated string literal}}
+_ = /<#placeholder#>/ // expected-error {{editor placeholder in source file}}


### PR DESCRIPTION
https://github.com/apple/swift/pull/41767, but implemented by re-lexing when we encounter a `/` in the parser. Also implements the rule where a regex may not start with space, tab, `)`, or `,`.