### PR TITLE
Re-enable swift docc tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1340,8 +1340,6 @@ mixin-preset=
 
 # SKIP LLDB TESTS (67923799)
 skip-test-lldb
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
 skip-test-playgroundsupport
 
 [preset: buildbot_osx_package,use_os_runtime]

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -668,9 +668,6 @@ skip-build-benchmarks
 # Skip playground tests
 skip-test-playgroundsupport
 
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
-
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
 build-subdir=buildbot_incremental
@@ -1608,9 +1605,6 @@ sil-verify-all-macos-only
 # faster.
 skip-test-ios-host
 skip-test-watchos-host
-
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
 
 
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
rdar://90181251

This re-enables Swift-DocC tests in toolchain builds.
