### PR TITLE
Tests: Disable distributed_actor_localSystem on watchOS

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_localSystem.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem.swift
@@ -10,6 +10,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://90373022
+// UNSUPPORTED: OS=watchos
+
 import Distributed
 
 distributed actor Worker {


### PR DESCRIPTION
Disable `distributed_actor_localSystem` on watchOS until its failure on that platform can be investigated.