### PR TITLE
[SSADestroyHoisting] Fold into sequences.

### DIFF
--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -729,6 +729,12 @@ bool hoistDestroys(SILValue root, bool ignoreDeinitBarriers,
   // The algorithm assumes no critical edges.
   assert(function->hasOwnership() && "requires OSSA");
 
+  // If lexical lifetimes aren't enabled, then deinit barriers aren't respected.
+  auto &module = function->getModule();
+  auto enableLexicalLifetimes =
+      module.getASTContext().SILOpts.supportsLexicalLifetimes(module);
+  ignoreDeinitBarriers = ignoreDeinitBarriers || !enableLexicalLifetimes;
+
   return HoistDestroys(root, ignoreDeinitBarriers, remainingDestroyAddrs,
                        deleter)
       .perform();

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -89,6 +89,7 @@
 
 #define DEBUG_TYPE "ssa-destroy-hoisting"
 
+#include "swift/AST/Type.h"
 #include "swift/Basic/GraphNodeWorklist.h"
 #include "swift/Basic/SmallPtrSetVector.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
@@ -496,6 +497,9 @@ bool DeinitBarriers::DestroyReachability::checkReachablePhiBarrier(
 /// object.
 class HoistDestroys {
   SILValue storageRoot;
+  SILFunction *function;
+  SILModule &module;
+  TypeExpansionContext typeExpansionContext;
   bool ignoreDeinitBarriers;
   SmallPtrSetImpl<SILInstruction *> &remainingDestroyAddrs;
   InstructionDeleter &deleter;
@@ -509,7 +513,9 @@ public:
   HoistDestroys(SILValue storageRoot, bool ignoreDeinitBarriers,
                 SmallPtrSetImpl<SILInstruction *> &remainingDestroyAddrs,
                 InstructionDeleter &deleter)
-      : storageRoot(storageRoot), ignoreDeinitBarriers(ignoreDeinitBarriers),
+      : storageRoot(storageRoot), function(storageRoot->getFunction()),
+        module(function->getModule()), typeExpansionContext(*function),
+        ignoreDeinitBarriers(ignoreDeinitBarriers),
         remainingDestroyAddrs(remainingDestroyAddrs), deleter(deleter),
         destroyMergeBlocks(getFunction()) {}
 
@@ -518,10 +524,19 @@ public:
 protected:
   SILFunction *getFunction() const { return storageRoot->getFunction(); }
 
-  bool foldBarrier(SILInstruction *barrier, SILValue accessScope);
-
-  bool foldBarrier(SILInstruction *barrier, const KnownStorageUses &knownUses,
+  bool foldBarrier(SILInstruction *barrier, const AccessStorage &storage,
                    const DeinitBarriers &deinitBarriers);
+
+  bool foldBarrier(SILInstruction *barrier, const AccessStorage &storage,
+                   const KnownStorageUses &knownUses,
+                   const DeinitBarriers &deinitBarriers);
+
+  bool checkFoldingBarrier(SILInstruction *instruction,
+                           SmallVectorImpl<LoadInst *> &loads,
+                           SmallVectorImpl<CopyAddrInst *> &copies,
+                           SmallPtrSetImpl<AccessPath::PathNode> &leaves,
+                           const AccessStorage &storage,
+                           const DeinitBarriers &deinitBarriers);
 
   void insertDestroy(SILInstruction *barrier, SILInstruction *insertBefore,
                      const KnownStorageUses &knownUses);
@@ -531,7 +546,8 @@ protected:
 
   void createSuccessorDestroys(SILBasicBlock *barrierBlock);
 
-  bool rewriteDestroys(const KnownStorageUses &knownUses,
+  bool rewriteDestroys(const AccessStorage &storage,
+                       const KnownStorageUses &knownUses,
                        const DeinitBarriers &deinitBarriers);
 
   void mergeDestroys(SILBasicBlock *mergeBlock);
@@ -553,16 +569,17 @@ bool HoistDestroys::perform() {
   deinitBarriers.compute();
 
   // No SIL changes happen before rewriting.
-  return rewriteDestroys(knownUses, deinitBarriers);
+  return rewriteDestroys(storage, knownUses, deinitBarriers);
 }
 
-bool HoistDestroys::rewriteDestroys(const KnownStorageUses &knownUses,
+bool HoistDestroys::rewriteDestroys(const AccessStorage &storage,
+                                    const KnownStorageUses &knownUses,
                                     const DeinitBarriers &deinitBarriers) {
   // Place a new destroy after each barrier instruction.
   for (SILInstruction *barrier : deinitBarriers.barriers) {
     auto *barrierBlock = barrier->getParent();
     if (barrier != barrierBlock->getTerminator()) {
-      if (!foldBarrier(barrier, knownUses, deinitBarriers))
+      if (!foldBarrier(barrier, storage, knownUses, deinitBarriers))
         insertDestroy(barrier, barrier->getNextInstruction(), knownUses);
       continue;
     }
@@ -610,30 +627,220 @@ bool HoistDestroys::rewriteDestroys(const KnownStorageUses &knownUses,
   return deleter.hadCallbackInvocation();
 }
 
-bool HoistDestroys::foldBarrier(SILInstruction *barrier, SILValue storageRoot) {
-  if (auto *load = dyn_cast<LoadInst>(barrier)) {
-    if (stripAccessMarkers(load->getOperand()) ==
-        stripAccessMarkers(storageRoot)) {
+/// Try to fold the destroy_addr with the specified barrier, or a backwards
+/// sequence of instructions that it begins.
+///
+/// Do the following kinds of folds:
+///
+/// - loads:
+///   given: load [copy] %addr
+///          destroy_addr %addr
+///   yield: load [take]
+/// - copy_addrs:
+///   given: copy_addr %addr to ...
+///          destroy_addr %addr
+///   yield: copy_addr [take] %addr
+///
+/// Additionally, generalize this to subobjects.  If there is a sequence of
+/// copy_addrs and loads that covers all the subobjects of %addr.  Given
+/// projections %subobject_1 and %subobject_2 out of %addr which fully cover all
+/// the non-trivial fields of the recursive type-tree of %addr, fold
+///
+///     load [copy] %subobject_1
+///     copy_addr %subobject_2 to ...
+///     destroy_addr %addr
+///
+/// into
+///
+///     load [take] %subobject_1
+///     copy_addr [take] %subobject_2 to ...
+///
+/// so long as all the loads and copy_addrs occur within the same block.
+bool HoistDestroys::foldBarrier(SILInstruction *barrier,
+                                const AccessStorage &storage,
+                                const DeinitBarriers &deinitBarriers) {
+
+  // The load [copy]s which will be folded into load [take]s if folding is
+  // possible.
+  llvm::SmallVector<LoadInst *, 4> loads;
+  // The copy_addrs which will be folded into copy_addr [take]s if folding is
+  // possible.
+  llvm::SmallVector<CopyAddrInst *, 4> copies;
+
+  // The non-trivial storage leaves of the root storage all of which must be
+  // destroyed exactly once in the sequence of instructions prior to the
+  // destroy_addr in order for folding to occur.
+  llvm::SmallPtrSet<AccessPath::PathNode, 16> leaves;
+
+  visitProductLeafAccessPathNodes(storageRoot, typeExpansionContext, module,
+                                  [&](AccessPath::PathNode node, SILType ty) {
+                                    if (ty.isTrivial(*function))
+                                      return;
+                                    leaves.insert(node);
+                                  });
+
+  for (auto *instruction = barrier; instruction != nullptr;
+       instruction = instruction->getPreviousInstruction()) {
+    if (checkFoldingBarrier(instruction, loads, copies, leaves, storage,
+                            deinitBarriers))
+      return false;
+
+    // If we have load [copy]s or copy_addrs of projections out of the root
+    // storage that cover all non-trivial product leaves, then we can fold!
+    //
+    // Stop looking for instructions to fold.
+    if (leaves.empty())
+      break;
+  }
+
+  if (!leaves.empty())
+    return false;
+
+  for (auto *load : loads) {
+    assert(load->getOwnershipQualifier() == LoadOwnershipQualifier::Copy);
+    load->setOwnershipQualifier(LoadOwnershipQualifier::Take);
+  }
+  for (auto *copy : copies) {
+    assert(!copy->isTakeOfSrc());
+    copy->setIsTakeOfSrc(IsTake);
+  }
+
+  return true;
+}
+
+/// Whether the specified instruction is a barrier to folding.
+///
+/// TODO: This is a bit more conservative that it needs to be in a couple of
+/// ways:
+///
+/// (1) even if we've already seen a leaf, we could still fold, in certain
+/// cases, we should be able to fold anyway.  For example, given projections
+/// %p1 and %p2 of some root storage %a, in the following scenario:
+///
+///    %p1 = <PROJECT> %a
+///    %p2 = <PROJECT> %a
+///    %v1 = load [copy] %p1
+///    %v2_1 = load [copy] %p2
+///    %v2_1 = load [copy] %p2
+///    destroy_addr %a
+///
+/// we could fold destroy_addr %a into the first load [copy] %p2 and the
+/// load [copy] %p1:
+///
+///     %v1 = load [take] %p1
+///     %v2_1 = load [copy] %p2
+///     %v2_2 = load [take] %p1
+///
+/// And indeed we can do that for loads from a subprojection %p2_sub of
+/// %p2; the following
+///
+///     %v1 = load [copy] %p1
+///     %v2_sub = load [copy] %p2_sub
+///     %v2 = load [copy] %p2
+///
+/// could be folded to
+///
+///     %v1 = load [take] %p1
+///     %v2_sub = load [copy] %p2_sub
+///     %v2 = load [take] %p2
+///
+/// (2) We should be able to continue folding over a load [trivial] so long as
+/// the instructions that we're folding with don't destroy an aggregate that
+/// contains the projection which is the target of the load [trivial].  For
+/// example, given
+///
+///     %addr = alloc_stack %(X, I)
+///     %x_addr = tuple_element_addr %addr : $*(X, I), 0
+///     %i_addr = tuple_element_addr %addr : $*(X, I), 1
+///     %x = load [copy] %x_addr : $*X
+///     %i = load [trivial] %i_addr : $*I
+///     destroy_addr %addr
+///
+/// we should be able to fold the destroy_addr of the tuple with the load [copy]
+/// and ignore the load [trivial].
+///
+/// Doing this is complicated by the fact that we can't ignore the load
+/// [trivial] if the load [copy] is of the whole tuple.  If we have instead
+///
+///     %addr = alloc_stack %(X, I)
+///     %x_addr = tuple_element_addr %addr : $*(X, I), 0
+///     %i_addr = tuple_element_addr %addr : $*(X, I), 1
+///     %x = load [copy] %addr : $*(X, I)
+///     %i = load [trivial] %i_addr : $*I
+///     destroy_addr %addr
+///
+/// then we cannot fold.  If we did, we would end up with invalid SIL:
+///
+///     %x = load [take] %addr
+///     %i = load [trivial] %i_addr
+bool HoistDestroys::checkFoldingBarrier(
+    SILInstruction *instruction, SmallVectorImpl<LoadInst *> &loads,
+    SmallVectorImpl<CopyAddrInst *> &copies,
+    SmallPtrSetImpl<AccessPath::PathNode> &leaves, const AccessStorage &storage,
+    const DeinitBarriers &deinitBarriers) {
+  // The address of a projection out of the root storage which would be
+  // folded if folding is possible.
+  //
+  // If no such address is found, we need to check whether the instruction
+  // is a barrier.
+  SILValue address;
+  if (auto *load = dyn_cast<LoadInst>(instruction)) {
+    auto loadee = load->getOperand();
+    auto accessPath = AccessPath::compute(loadee);
+    if (accessPath.getStorage().hasIdenticalStorage(storage)) {
       if (load->getOwnershipQualifier() == LoadOwnershipQualifier::Copy) {
-        load->setOwnershipQualifier(LoadOwnershipQualifier::Take);
-        return true;
+        address = loadee;
+        loads.push_back(load);
       } else {
-        assert(load->getOperand()->getType().isTrivial(*load->getFunction()));
-        return false;
+        assert(loadee->getType().isTrivial(*load->getFunction()));
+        return true;
       }
     }
+  } else if (auto *copy = dyn_cast<CopyAddrInst>(instruction)) {
+    auto source = copy->getSrc();
+    auto accessPath = AccessPath::compute(source);
+    if (accessPath.getStorage().hasIdenticalStorage(storage)) {
+      address = source;
+      copies.push_back(copy);
+    }
   }
-  if (auto *copy = dyn_cast<CopyAddrInst>(barrier)) {
-    if (stripAccessMarkers(copy->getSrc()) == stripAccessMarkers(storageRoot)) {
-      assert(!copy->isTakeOfSrc());
-      copy->setIsTakeOfSrc(IsTake);
+  if (address) {
+    // We found a relevant instruction that is operating on a projection out
+    // of the root storage which would be folded if folding were possible.
+    // Find its nontrivial product leaves and remove them from the set of
+    // leaves of the root storage which we're wating to see.
+    bool alreadySawLeaf = false;
+    visitProductLeafAccessPathNodes(address, typeExpansionContext, module,
+                                    [&](AccessPath::PathNode node, SILType ty) {
+                                      if (ty.isTrivial(*function))
+                                        return;
+                                      bool erased = leaves.erase(node);
+                                      alreadySawLeaf =
+                                          alreadySawLeaf || !erased;
+                                    });
+    if (alreadySawLeaf) {
+      // We saw this non-trivial product leaf already.  That means there are
+      // multiple load [copy]s or copy_addrs of at least one product leaf
+      // before (walking backwards from the hoisting point) there are
+      // instructions that load or copy from all the non-trivial leaves.
+      // Give up on folding.
       return true;
     }
+  } else if (deinitBarriers.isBarrier(instruction)) {
+    // We didn't find an instruction that was both
+    // - relevant (i.e. a copy_addr or a load [take])
+    // - operating on a projection of the root storage
+    // Additionally:
+    // - we can't ignore whether it's a barrier
+    // - and it IS a barrier.
+    // We can't fold.
+    return true;
   }
   return false;
 }
 
 bool HoistDestroys::foldBarrier(SILInstruction *barrier,
+                                const AccessStorage &storage,
                                 const KnownStorageUses &knownUses,
                                 const DeinitBarriers &deinitBarriers) {
   if (auto *eai = dyn_cast<EndAccessInst>(barrier)) {
@@ -645,13 +852,13 @@ bool HoistDestroys::foldBarrier(SILInstruction *barrier,
     while ((instruction = instruction->getPreviousInstruction())) {
       if (instruction == bai)
         return false;
-      if (foldBarrier(instruction, storageRoot))
+      if (foldBarrier(instruction, storage, deinitBarriers))
         return true;
       if (deinitBarriers.isBarrier(instruction))
         return false;
     }
   }
-  return foldBarrier(barrier, storageRoot);
+  return foldBarrier(barrier, storage, deinitBarriers);
 }
 
 // \p barrier may be null if the destroy is at function entry.
@@ -848,8 +1055,7 @@ void SSADestroyHoisting::run() {
   // We assume that the function is in reverse post order so visiting the
   // blocks and pushing begin_access as we see them and then popping them off
   // the end will result in hoisting inner begin_access' destroy_addrs first.
-  while (!bais.empty()) {
-    auto *bai = bais.pop_back_val();
+  for (auto *bai : llvm::reverse(bais)) {
     changed |= hoistDestroys(bai, /*ignoreDeinitBarriers=*/true,
                              remainingDestroyAddrs, deleter);
   }

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -52,6 +52,24 @@ struct Int {
     @_hasStorage var _value : Builtin.Int64
 }
 
+struct I {
+  var value: Builtin.Int64
+}
+
+typealias TXXI = (X, X, I)
+
+struct SXXI {
+  var x_1: X
+  var x_2: X
+  var i: I
+}
+
+struct STXXITXXII {
+  var txxi_1: TXXI
+  var txxi_2: TXXI
+  var i: I
+}
+
 sil @unknown : $@convention(thin) () -> ()
 sil @use_S : $@convention(thin) (@in_guaranteed S) -> ()
 
@@ -372,8 +390,7 @@ entry(%addr : $*X, %instance : @owned $X):
 // CHECK-LABEL: sil [ossa] @hoist_upto_address_to_pointer_use : {{.*}} {
 // CHECK:         address_to_pointer
 // CHECK:         pointer_to_address
-// CHECK:         load [copy]
-// CHECK:         destroy_addr
+// CHECK:         load [take]
 // CHECK:         tuple
 // CHECK-LABEL: } // end sil function 'hoist_upto_address_to_pointer_use'
 sil [ossa] @hoist_upto_address_to_pointer_use : $@convention(thin) (@in X) -> (@owned X) {
@@ -444,12 +461,12 @@ entry(%instance : @owned $S):
   return %value : $S
 }
 
-// Don't fold with a copy_addr of a struct_element_addr.
+// Fold with a copy_addr of a struct_element_addr.
 //
-// CHECK-LABEL: sil [ossa] @nofold_scoped_copy_addr_projection : {{.*}} {
-// CHECK:         load [copy]
-// CHECK-LABEL: // end sil function 'nofold_scoped_copy_addr_projection'
-sil [ossa] @nofold_scoped_copy_addr_projection : $@convention(thin) (@owned S) -> (@owned S) {
+// CHECK-LABEL: sil [ossa] @fold_scoped_copy_addr_projection : {{.*}} {
+// CHECK:         load [take]
+// CHECK-LABEL: // end sil function 'fold_scoped_copy_addr_projection'
+sil [ossa] @fold_scoped_copy_addr_projection : $@convention(thin) (@owned S) -> (@owned S) {
 entry(%instance : @owned $S):
   %addr = alloc_stack $S
   %store_scope = begin_access [modify] [static] %addr : $*S
@@ -465,12 +482,12 @@ entry(%instance : @owned $S):
   return %value : $S
 }
 
-// Don't fold destroy of outer scope with struct_element_addr of inner scope.
+// Fold destroy of outer scope with struct_element_addr of inner scope.
 //
-// CHECK-LABEL: sil [ossa] @nofold_with_copy_addr_projection : {{.*}} {
-// CHECK:         copy_addr {{%[^,]+}}
-// CHECK-LABEL: // end sil function 'nofold_with_copy_addr_projection'
-sil [ossa] @nofold_with_copy_addr_projection : $@convention(thin) (@owned S) -> (@owned S) {
+// CHECK-LABEL: sil [ossa] @fold_with_copy_addr_projection : {{.*}} {
+// CHECK:         copy_addr [take] {{%[^,]+}}
+// CHECK-LABEL: // end sil function 'fold_with_copy_addr_projection'
+sil [ossa] @fold_with_copy_addr_projection : $@convention(thin) (@owned S) -> (@owned S) {
 entry(%instance : @owned $S):
   %addr = alloc_stack $S
   %addr_2 = alloc_stack $S
@@ -492,7 +509,7 @@ entry(%instance : @owned $S):
   return %value : $S
 }
 
-// Don't fold destroy of outer scope with struct_element_addr of inner scope.
+// Fold destroy of outer scope with struct_element_addr of inner scope.
 //
 // CHECK-LABEL: sil [ossa] @fold_scoped_destroy_with_scoped_copy_addr : {{.*}} {
 // CHECK:         copy_addr [take] {{%[^,]+}}
@@ -574,4 +591,207 @@ entry(%instance : @owned $X):
   dealloc_stack %addr_inner : $*X
   dealloc_stack %addr_outer : $*X
   return %value : $X
+}
+
+// Fold with loads of immediate leaves of a tuple.
+//
+// CHECK-LABEL: sil [ossa] @fold_tuple_field_loads : {{.*}} {
+// CHECK:         load [take]
+// CHECK:         load [take]
+// CHECK-LABEL: } // end sil function 'fold_tuple_field_loads'
+sil [ossa] @fold_tuple_field_loads : $@convention(thin) (@owned (X, X, I)) -> @owned (X, X) {
+entry(%instance : @owned $(X, X, I)):
+  %addr = alloc_stack $(X, X, I)
+  store %instance to [init] %addr : $*(X, X, I)
+  %first_addr = tuple_element_addr %addr : $*(X, X, I), 0
+  %second_addr = tuple_element_addr %addr : $*(X, X, I), 1
+  %first = load [copy] %first_addr : $*X
+  %second = load [copy] %second_addr : $*X
+  destroy_addr %addr : $*(X, X, I)
+  dealloc_stack %addr : $*(X, X, I)
+  %retval = tuple (%first : $X, %second : $X)
+  return %retval : $(X, X)
+}
+
+// Fold with copy_addrs of immediate leaves of a struct.
+//
+// CHECK-LABEL: sil [ossa] @fold_struct_field_copy_addrs : $@convention(thin) (@owned SXXI) -> () {
+// CHECK:         copy_addr [take]
+// CHECK:         copy_addr [take]
+// CHECK-LABEL: } // end sil function 'fold_struct_field_copy_addrs'
+sil [ossa] @fold_struct_field_copy_addrs : $@convention(thin) (@owned SXXI) -> () {
+entry(%instance : @owned $SXXI):
+    %addr = alloc_stack $SXXI
+    %x_1_alone = alloc_stack $X
+    %x_2_alone = alloc_stack $X
+    store %instance to [init] %addr : $*SXXI
+    %x_1_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_1
+    %x_2_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_2
+    copy_addr %x_1_addr to [initialization] %x_1_alone : $*X
+    copy_addr %x_2_addr to [initialization] %x_2_alone : $*X
+    destroy_addr %addr : $*SXXI
+    %barrier = function_ref @unknown : $@convention(thin) () -> ()
+    apply %barrier() : $@convention(thin) () -> ()
+
+    destroy_addr %x_1_alone : $*X
+    destroy_addr %x_2_alone : $*X
+    dealloc_stack %x_2_alone : $*X
+    dealloc_stack %x_1_alone : $*X
+    dealloc_stack %addr : $*SXXI
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Fold with a mix of both copy_addrs and load [copy]s which are dealing
+// exclusively non-trivial leaves.
+//
+// CHECK-LABEL: sil [ossa] @fold_struct_enclosing_tuples_leaf_fields_mixed_insts : {{.*}} {
+// CHECK:         copy_addr [take]
+// CHECK:         load [take]
+// CHECK:         copy_addr [take]
+// CHECK:         load [take]
+// CHECK-LABEL: } // end sil function 'fold_struct_enclosing_tuples_leaf_fields_mixed_insts'
+sil [ossa] @fold_struct_enclosing_tuples_leaf_fields_mixed_insts : $@convention(thin) (@owned STXXITXXII) -> @owned (X, X) {
+entry(%instance : @owned $STXXITXXII):
+    %addr = alloc_stack $STXXITXXII
+    %txxi_1_alone = alloc_stack $X
+    %txxi_2_alone = alloc_stack $X
+    store %instance to [init] %addr : $*STXXITXXII
+    %txxi_1_addr = struct_element_addr %addr : $*STXXITXXII, #STXXITXXII.txxi_1
+    %txxi_2_addr = struct_element_addr %addr : $*STXXITXXII, #STXXITXXII.txxi_2
+    %txxi_1_x_0_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 0
+    %txxi_1_x_1_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 1
+    %txxi_2_x_0_addr = tuple_element_addr %txxi_2_addr : $*(X, X, I), 0
+    %txxi_2_x_1_addr = tuple_element_addr %txxi_2_addr : $*(X, X, I), 1
+
+    copy_addr %txxi_1_x_0_addr to [initialization] %txxi_1_alone : $*X
+    %x1x1 = load [copy] %txxi_1_x_1_addr : $*X
+    copy_addr %txxi_2_x_0_addr to [initialization] %txxi_2_alone : $*X
+    %x2x1 = load [copy] %txxi_2_x_1_addr : $*X
+    destroy_addr %addr : $*STXXITXXII
+    %barrier = function_ref @unknown : $@convention(thin) () -> ()
+    apply %barrier() : $@convention(thin) () -> ()
+
+    destroy_addr %txxi_1_alone : $*X
+    destroy_addr %txxi_2_alone : $*X
+    dealloc_stack %txxi_2_alone : $*X
+    dealloc_stack %txxi_1_alone : $*X
+    dealloc_stack %addr : $*STXXITXXII
+    %retval = tuple (%x1x1 : $X, %x2x1 : $X)
+    return %retval : $(X, X)
+}
+
+// Fold with a mix of both copy_addrs and load [copy]s which are dealing with
+// a mix of both leaves and intermediate nodes.
+//
+// CHECK-LABEL: sil [ossa] @fold_struct_enclosing_tuples_mixed_fields_mixed_insts : {{.*}} {
+// CHECK:         copy_addr [take]
+// CHECK:         load [take]
+// CHECK:         load [take]
+// CHECK-LABEL: } // end sil function 'fold_struct_enclosing_tuples_mixed_fields_mixed_insts'
+sil [ossa] @fold_struct_enclosing_tuples_mixed_fields_mixed_insts : $@convention(thin) (@owned STXXITXXII) -> @owned (X, (X, X, I)) {
+entry(%instance : @owned $STXXITXXII):
+    %addr = alloc_stack $STXXITXXII
+    %txxi_1_alone = alloc_stack $X
+    store %instance to [init] %addr : $*STXXITXXII
+    %txxi_1_addr = struct_element_addr %addr : $*STXXITXXII, #STXXITXXII.txxi_1
+    %txxi_2_addr = struct_element_addr %addr : $*STXXITXXII, #STXXITXXII.txxi_2
+    %txxi_1_x_0_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 0
+    %txxi_1_x_1_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 1
+
+    copy_addr %txxi_1_x_0_addr to [initialization] %txxi_1_alone : $*X
+    %x1x1 = load [copy] %txxi_1_x_1_addr : $*X
+    %txxi2 = load [copy] %txxi_2_addr : $*(X, X, I)
+    destroy_addr %addr : $*STXXITXXII
+
+    %barrier = function_ref @unknown : $@convention(thin) () -> ()
+    apply %barrier() : $@convention(thin) () -> ()
+    destroy_addr %txxi_1_alone : $*X
+    dealloc_stack %txxi_1_alone : $*X
+    dealloc_stack %addr : $*STXXITXXII
+    %retval = tuple (%x1x1 : $X, %txxi2 : $(X, X, I))
+    return %retval : $(X, (X, X, I))
+}
+
+// When walking backwards from the hoisting point, if we encounter multiple
+// loads of the same nontrivial leaf/leaves BEFORE encountering all nontrivial
+// leaves, we can't fold.
+//
+// TODO: Allow folding with the last of them if possible.
+// CHECK-LABEL: sil [ossa] @nofold_multiple_nontrivial_leaf_loads : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $SXXI):
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack
+// CHECK:         load [copy]
+// CHECK:         load [copy]
+// CHECK:         load [copy]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK-LABEL: } // end sil function 'nofold_multiple_nontrivial_leaf_loads'
+sil [ossa] @nofold_multiple_nontrivial_leaf_loads : $@convention(thin) (@owned SXXI) -> @owned (X, X, X) {
+entry(%instance : @owned $SXXI):
+    %addr = alloc_stack $SXXI
+    store %instance to [init] %addr : $*SXXI
+
+    %x_1_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_1
+    %x_2_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_2
+
+    %x_1 = load [copy] %x_1_addr : $*X
+    %x_2_1 = load [copy] %x_2_addr : $*X
+    %x_2_2 = load [copy] %x_2_addr : $*X
+    destroy_addr %addr : $*SXXI
+
+    dealloc_stack %addr : $*SXXI
+    %retval = tuple (%x_1 : $X, %x_2_1 : $X, %x_2_2 : $X)
+    return %retval : $(X, X, X)
+}
+
+// When walking backwards from the hoisting point, fold even if we encounter
+// multiple loads of the same TRIVIAL leaf/leaves BEFORE encountering all
+// nontrivial leaves.  Contrast to nofold_multiple_nontrivial_leaf_loads.
+//
+// CHECK-LABEL: sil [ossa] @nofold_multiple_trivial_leaf_loads : {{.*}} {
+// CHECK:         load [copy]
+// CHECK:         load [copy]
+// CHECK:         load [trivial]
+// CHECK:         load [trivial]
+// CHECK:         destroy_addr
+// CHECK-LABEL: } // end sil function 'nofold_multiple_trivial_leaf_loads'
+sil [ossa] @nofold_multiple_trivial_leaf_loads : $@convention(thin) (@owned SXXI) -> @owned (I, I, X, X) {
+entry(%instance : @owned $SXXI):
+    %addr = alloc_stack $SXXI
+    store %instance to [init] %addr : $*SXXI
+
+    %x_1_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_1
+    %x_2_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_2
+    %i_addr = struct_element_addr %addr : $*SXXI, #SXXI.i
+
+    %x_1 = load [copy] %x_1_addr : $*X
+    %x_2 = load [copy] %x_2_addr : $*X
+    %i_1 = load [trivial] %i_addr : $*I
+    %i_2 = load [trivial] %i_addr : $*I
+    destroy_addr %addr : $*SXXI
+
+    dealloc_stack %addr : $*SXXI
+    %retval = tuple (%i_1 : $I, %i_2 : $I, %x_1 : $X, %x_2 : $X)
+    return %retval : $(I, I, X, X)
+}
+
+// CHECK-LABEL: sil [ossa] @nofold_over_trivial_load_into_tuple_load_copy : {{.*}} {
+// CHECK:         load [copy]
+// CHECK:         load [trivial]
+// CHECK:         destroy_addr
+// CHECK-LABEL: } // end sil function 'nofold_over_trivial_load_into_tuple_load_copy'
+sil [ossa] @nofold_over_trivial_load_into_tuple_load_copy : $@convention(thin) (@owned (X, I)) -> @owned ((X, I), I) {
+entry(%instance : @owned $(X, I)):
+    %addr = alloc_stack $(X, I)
+    store %instance to [init] %addr : $*(X, I)
+
+    %i_addr = tuple_element_addr %addr : $*(X, I), 1
+
+    %copy = load [copy] %addr : $*(X, I)
+    %i_2 = load [trivial] %i_addr : $*I
+    destroy_addr %addr : $*(X, I)
+
+    dealloc_stack %addr : $*(X, I)
+    %retval = tuple (%copy : $(X, I), %i_2 : $I)
+    return %retval : $((X, I), I)
 }

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -7,6 +7,8 @@ sil_stage canonical
 
 import Builtin
 
+typealias AnyObject = Builtin.AnyObject
+
 class X {
 }
 
@@ -390,7 +392,8 @@ entry(%addr : $*X, %instance : @owned $X):
 // CHECK-LABEL: sil [ossa] @hoist_upto_address_to_pointer_use : {{.*}} {
 // CHECK:         address_to_pointer
 // CHECK:         pointer_to_address
-// CHECK:         load [take]
+// CHECK:         load [copy]
+// CHECK:         destroy_addr
 // CHECK:         tuple
 // CHECK-LABEL: } // end sil function 'hoist_upto_address_to_pointer_use'
 sil [ossa] @hoist_upto_address_to_pointer_use : $@convention(thin) (@in X) -> (@owned X) {
@@ -794,4 +797,41 @@ entry(%instance : @owned $(X, I)):
     dealloc_stack %addr : $*(X, I)
     %retval = tuple (%copy : $(X, I), %i_2 : $I)
     return %retval : $((X, I), I)
+}
+
+// Don't fold a destroy_addr of underlying storage into the copy_addr of a
+// bitcast of that address.
+//
+// CHECK-LABEL: sil [ossa] @nofold_destroy_addr_original_into_copy_addr_cast : {{.*}} {
+// CHECK:         copy_addr {{%[^,]+}}
+// CHECK:         destroy_addr
+// CHECK-LABEL: } // end sil function 'nofold_destroy_addr_original_into_copy_addr_cast'
+sil [ossa] @nofold_destroy_addr_original_into_copy_addr_cast : $@convention(thin) <T> (@owned AnyObject) -> @out T {
+entry(%out : $*T, %instance : @owned $AnyObject):
+    %addr = alloc_stack $AnyObject
+    store %instance to [init] %addr : $*AnyObject
+    %cast_addr = unchecked_addr_cast %addr : $*AnyObject to $*T
+    copy_addr %cast_addr to [initialization] %out : $*T
+    destroy_addr %addr : $*AnyObject
+    dealloc_stack %addr : $*AnyObject
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't fold a destroy_addr of underlying storage into the load [copy] of a 
+// bitcast of that address.
+//
+// CHECK-LABEL: sil [ossa] @nofold_destroy_addr_original_into_load_cast : {{.*}} {
+// CHECK:         load [copy]
+// CHECK:         destroy_addr
+// CHECK-LABEL: } // end sil function 'nofold_destroy_addr_original_into_load_cast'
+sil [ossa] @nofold_destroy_addr_original_into_load_cast : $@convention(thin) (@owned AnyObject) -> @owned X {
+entry(%instance : @owned $AnyObject):
+    %addr = alloc_stack $AnyObject
+    store %instance to [init] %addr : $*AnyObject
+    %cast_addr = unchecked_addr_cast %addr : $*AnyObject to $*X
+    %cast = load [copy] %cast_addr : $*X
+    destroy_addr %addr : $*AnyObject
+    dealloc_stack %addr : $*AnyObject
+    return %cast : $X
 }


### PR DESCRIPTION
Make loads and copy_addrs of casts of the underlying storage barriers to folding.  Destroying the target address may not be equivalent to destroying the source address: for example, if the target address is a generic and the source address is AnyObject, specialization may turn the generic into a trivial type; the destruction of that trivial type fails to destroy the original stored AnyObject, resulting in a leak.

[SSADestroyHoisting] Fold into sequences.

Previously, destroy_addrs were folded into copy_addrs and load [copy]s to produce copy_addr [take]s and load [take]s respectively, but only if the source of the load/copy was exactly the address being destroyed.

Generalize that to a single-block sequence of copy_addrs and load [copy]s of projections of the address being destroyed.
