### PR TITLE
Do not escape UNICODE when writing out target info.

### DIFF
--- a/include/swift/Basic/StringExtras.h
+++ b/include/swift/Basic/StringExtras.h
@@ -515,6 +515,10 @@ public:
   int compare(NullTerminatedStringRef RHS) const { return Ref.compare(RHS); }
 };
 
+/// A variant of write_escaped that does not escape Unicode characters - useful for generating JSON,
+/// where escaped Unicode characters lead to malformed/invalid JSON.
+void writeEscaped(llvm::StringRef Str, llvm::raw_ostream &OS);
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_STRINGEXTRAS_H

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 
 using namespace swift;
@@ -1391,4 +1392,28 @@ Optional<StringRef> swift::stripWithCompletionHandlerSuffix(StringRef name) {
   }
 
   return None;
+}
+
+void swift::writeEscaped(llvm::StringRef Str, llvm::raw_ostream &OS) {
+  for (unsigned i = 0, e = Str.size(); i != e; ++i) {
+    unsigned char c = Str[i];
+
+    switch (c) {
+      case '\\':
+        OS << '\\' << '\\';
+        break;
+      case '\t':
+        OS << '\\' << 't';
+        break;
+      case '\n':
+        OS << '\\' << 'n';
+        break;
+      case '"':
+        OS << '\\' << '"';
+        break;
+      default:
+        OS << c;
+        break;
+    }
+  }
 }

--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -13,6 +13,7 @@
 #include "swift/Basic/TargetInfo.h"
 #include "swift/Basic/Version.h"
 #include "swift/Basic/Platform.h"
+#include "swift/Basic/StringExtras.h"
 #include "swift/Frontend/Frontend.h"
 
 #include "llvm/Support/raw_ostream.h"
@@ -35,11 +36,11 @@ static void printCompatibilityLibrary(
   out << "      {\n";
 
   out << "        \"libraryName\": \"";
-  out.write_escaped(libraryName);
+  swift::writeEscaped(libraryName, out);
   out << "\",\n";
 
   out << "        \"filter\": \"";
-  out.write_escaped(filter);
+  swift::writeEscaped(filter, out);
   out << "\"\n";
   out << "      }";
 
@@ -53,8 +54,7 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
 
   // Compiler version, as produced by --version.
   out << "  \"compilerVersion\": \"";
-  out.write_escaped(version::getSwiftFullVersion(
-                                                 version::Version::getCurrentLanguageVersion()));
+  writeEscaped(version::getSwiftFullVersion(version::Version::getCurrentLanguageVersion()), out);
   out << "\",\n";
 
   // Target triple and target variant triple.
@@ -77,7 +77,7 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
 
   if (!searchOpts.getSDKPath().empty()) {
     out << "    \"sdkPath\": \"";
-    out.write_escaped(searchOpts.getSDKPath());
+    writeEscaped(searchOpts.getSDKPath(), out);
     out << "\",\n";
   }
 
@@ -85,7 +85,7 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
     out << "    \"" << name << "\": [\n";
     llvm::interleave(paths, [&out](const std::string &path) {
       out << "      \"";
-      out.write_escaped(path);
+      writeEscaped(path, out);
       out << "\"";
     }, [&out] {
       out << ",\n";
@@ -98,7 +98,7 @@ void targetinfo::printTargetInfo(const CompilerInvocation &invocation,
               searchOpts.getRuntimeLibraryImportPaths());
 
   out << "    \"runtimeResourcePath\": \"";
-  out.write_escaped(searchOpts.RuntimeResourcePath);
+  writeEscaped(searchOpts.RuntimeResourcePath, out);
   out << "\"\n";
 
   out << "  }\n";
@@ -113,20 +113,20 @@ void targetinfo::printTripleInfo(const llvm::Triple &triple,
   out << "{\n";
 
   out << "    \"triple\": \"";
-  out.write_escaped(triple.getTriple());
+  writeEscaped(triple.getTriple(), out);
   out << "\",\n";
 
   out << "    \"unversionedTriple\": \"";
-  out.write_escaped(getUnversionedTriple(triple).getTriple());
+  writeEscaped(getUnversionedTriple(triple).getTriple(), out);
   out << "\",\n";
 
   out << "    \"moduleTriple\": \"";
-  out.write_escaped(getTargetSpecificModuleTriple(triple).getTriple());
+  writeEscaped(getTargetSpecificModuleTriple(triple).getTriple(), out);
   out << "\",\n";
 
   if (runtimeVersion) {
     out << "    \"swiftRuntimeCompatibilityVersion\": \"";
-    out.write_escaped(runtimeVersion->getAsString());
+    writeEscaped(runtimeVersion->getAsString(), out);
     out << "\",\n";
 
     // Compatibility libraries that need to be linked.

--- a/test/Driver/print_target_info_unicode.swift
+++ b/test/Driver/print_target_info_unicode.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -print-target-info -target arm64-apple-ios12.0 -sdk /Applications🙉/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk | %FileCheck %s
+
+// CHECK: "target": {
+// CHECK-NEXT: "triple": "arm64-apple-ios12.0",
+// CHECK: "sdkPath": "/Applications🙉/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk",

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -194,8 +194,6 @@ sourcekitd_response_t createErrorRequestCancelled();
 sourcekitd_uid_t SKDUIDFromUIdent(SourceKit::UIdent UID);
 SourceKit::UIdent UIdentFromSKDUID(sourcekitd_uid_t uid);
 
-void writeEscaped(llvm::StringRef Str, llvm::raw_ostream &OS);
-
 static inline sourcekitd_variant_t makeNullVariant() {
   return {{ 0, 0, 0 }};
 }

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/RequestResponsePrinterBase.h
@@ -15,6 +15,7 @@
 
 #include "sourcekitd/sourcekitd.h"
 #include "sourcekitd/Logging.h"
+#include "swift/Basic/StringExtras.h"
 #include <vector>
 
 namespace llvm {
@@ -92,7 +93,7 @@ public:
     OS << '\"';
     // Avoid raw_ostream's write_escaped, we don't want to escape unicode
     // characters because it will be invalid JSON.
-    writeEscaped(Str, OS);
+    swift::writeEscaped(Str, OS);
     OS << '\"';
   }
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -16,6 +16,7 @@
 #include "sourcekitd/RequestResponsePrinterBase.h"
 #include "SourceKit/Support/Logging.h"
 #include "SourceKit/Support/UIdent.h"
+#include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -132,30 +133,6 @@ public:
     : RequestResponsePrinterBase(OS, Indent, PrintAsJSON) { }
 };
 } // end anonymous namespace
-
-void sourcekitd::writeEscaped(llvm::StringRef Str, llvm::raw_ostream &OS) {
-  for (unsigned i = 0, e = Str.size(); i != e; ++i) {
-    unsigned char c = Str[i];
-
-    switch (c) {
-    case '\\':
-      OS << '\\' << '\\';
-      break;
-    case '\t':
-      OS << '\\' << 't';
-      break;
-    case '\n':
-      OS << '\\' << 'n';
-      break;
-    case '"':
-      OS << '\\' << '"';
-      break;
-    default:
-      OS << c;
-      break;
-    }
-  }
-}
 
 static void printError(sourcekitd_response_t Err, raw_ostream &OS) {
   OS << "error response (";

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -23,6 +23,7 @@
 #include "SourceKit/Core/LLVM.h"
 #include "SourceKit/Support/UIdent.h"
 #include "swift/Basic/ThreadSafeRefCounted.h"
+#include "swift/Basic/StringExtras.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
@@ -405,7 +406,7 @@ public:
     OS << '\"';
     // Avoid raw_ostream's write_escaped, we don't want to escape unicode
     // characters because it will be invalid JSON.
-    writeEscaped(Str, OS);
+    swift::writeEscaped(Str, OS);
     OS << '\"';
   }
   


### PR DESCRIPTION
Escaping unicode characters results in invalid JSON.
Refactor `writeEscaped` routine into `StringExtras` because it is also used in `sourcekitd`.

Resolves rdar://90108531
