### PR TITLE
[CodeCompletion] Call sawSolution when type checking a result builder

### DIFF
--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SEMA_COMPLETIONCONTEXTFINDER_H
 #define SWIFT_SEMA_COMPLETIONCONTEXTFINDER_H
 
+#include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Expr.h"
 #include "swift/Sema/CodeCompletionTypeChecking.h"
@@ -49,10 +50,10 @@ class CompletionContextFinder : public ASTWalker {
 
 public:
   /// Finder for completion contexts within the provided initial expression.
-  CompletionContextFinder(Expr *initialExpr, DeclContext *DC)
-      : InitialExpr(initialExpr), InitialDC(DC) {
+  CompletionContextFinder(ASTNode initialNode, DeclContext *DC)
+      : InitialExpr(initialNode.dyn_cast<Expr *>()), InitialDC(DC) {
     assert(DC);
-    initialExpr->walk(*this);
+    initialNode.walk(*this);
   };
 
   /// Finder for completion contexts within the outermost non-closure context of

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -29,10 +29,11 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/TypeRefinementContext.h"
-#include "swift/Parse/Lexer.h"
 #include "swift/Basic/OptionSet.h"
-#include "swift/Sema/ConstraintSystem.h"
 #include "swift/Config.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Sema/CompletionContextFinder.h"
+#include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include <functional>
@@ -570,6 +571,12 @@ FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                           Identifier opName,
                                           DeclRefKind refKind,
                                           ConcreteDeclRef &refdDecl);
+
+/// Remove any solutions from the provided vector that require more fixes than
+/// the best score or don't contain a type for the code completion token.
+void filterSolutionsForCodeCompletion(
+    SmallVectorImpl<constraints::Solution> &solutions,
+    CompletionContextFinder &contextAnalyzer);
 
 /// Type check the given expression and provide results back to code completion
 /// via specified callback.


### PR DESCRIPTION
Before, we weren’t calling `sawSolution` when performing solver based completion inside a result builder. That was no good because we always ended up in the fallback case. 

This also contains some minor restructuring how solutions are filtered that I carried over from the argument-completion-to-solver-based PR.