### PR TITLE
[ConstraintSystem] Implement simplification for all locator elements

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -566,6 +566,13 @@ template <typename T = Decl> T *getAsDecl(ASTNode node) {
   return nullptr;
 }
 
+template <typename T = Stmt>
+T *getAsStmt(ASTNode node) {
+  if (auto *S = node.dyn_cast<Stmt *>())
+    return dyn_cast_or_null<T>(S);
+  return nullptr;
+}
+
 SourceLoc getLoc(ASTNode node);
 SourceRange getSourceRange(ASTNode node);
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3809,7 +3809,10 @@ bool MissingMemberFailure::diagnoseForDynamicCallable() const {
 }
 
 bool MissingMemberFailure::diagnoseInLiteralCollectionContext() const {
-  auto *expr = castToExpr(getAnchor());
+  auto *expr = getAsExpr(getAnchor());
+  if (!expr)
+    return false;
+
   auto *parentExpr = findParentExpr(expr);
   auto &solution = getSolution();
 
@@ -5918,8 +5921,11 @@ void MissingGenericArgumentsFailure::emitGenericSignatureNote(
     return (type == params.end()) ? Type() : type->second;
   };
 
+  auto baseType = anchor.dyn_cast<TypeRepr *>();
+  if (!baseType)
+    return;
+
   SmallString<64> paramsAsString;
-  auto baseType = anchor.get<TypeRepr *>();
   if (TypeChecker::getDefaultGenericArgumentsString(paramsAsString, GTD,
                                                     getPreferredType)) {
     auto diagnostic = emitDiagnosticAt(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4893,6 +4893,9 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::GenericParameter:
       break;
 
+    case ConstraintLocator::KeyPathRoot:
+    case ConstraintLocator::KeyPathValue:
+      break;
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4857,6 +4857,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
       continue;
     }
 
+    case ConstraintLocator::ClosureBodyElement: {
+      auto bodyElt = path[0].castTo<LocatorPathElt::ClosureBodyElement>();
+      anchor = bodyElt.getElement();
+      path = path.slice(1);
+      continue;
+    }
+
     case ConstraintLocator::PatternMatch: {
       auto patternElt = path[0].castTo<LocatorPathElt::PatternMatch>();
       anchor = patternElt.getPattern();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4885,6 +4885,11 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::FunctionArgument:
     case ConstraintLocator::SynthesizedArgument:
       break;
+
+    case ConstraintLocator::DynamicLookupResult:
+    case ConstraintLocator::KeyPathComponentResult:
+      break;
+
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4758,6 +4758,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
         path = path.slice(1);
         continue;
       }
+
+      if (anchor.is<Pattern *>()) {
+        path = path.slice(1);
+        continue;
+      }
+
       break;
 
     case ConstraintLocator::SubscriptMember:
@@ -4847,6 +4853,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::UnresolvedMemberChainResult: {
       auto *resultExpr = castToExpr<UnresolvedMemberChainResultExpr>(anchor);
       anchor = resultExpr->getSubExpr();
+      path = path.slice(1);
+      continue;
+    }
+
+    case ConstraintLocator::PatternMatch: {
+      auto patternElt = path[0].castTo<LocatorPathElt::PatternMatch>();
+      anchor = patternElt.getPattern();
       path = path.slice(1);
       continue;
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4871,8 +4871,14 @@ void constraints::simplifyLocator(ASTNode &anchor,
       continue;
     }
 
-    default:
-      // FIXME: Lots of other cases to handle.
+    case ConstraintLocator::PackType:
+    case ConstraintLocator::ParentType:
+    case ConstraintLocator::KeyPathType:
+    case ConstraintLocator::InstanceType:
+    case ConstraintLocator::PlaceholderType:
+    case ConstraintLocator::SequenceElementType:
+    case ConstraintLocator::ConstructorMemberType:
+    case ConstraintLocator::ExistentialSuperclassType:
       break;
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4906,6 +4906,20 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::ConformanceRequirement:
     case ConstraintLocator::TypeParameterRequirement:
       break;
+
+    case ConstraintLocator::PackElement:
+      break;
+
+    case ConstraintLocator::PatternBindingElement: {
+      auto pattern = path[0].castTo<LocatorPathElt::PatternBindingElement>();
+      auto *patternBinding = cast<PatternBindingDecl>(anchor.get<Decl *>());
+      anchor = patternBinding->getInit(pattern.getIndex());
+      // If this pattern is uninitialized, let's use it as anchor.
+      if (!anchor)
+        anchor = patternBinding->getPattern(pattern.getIndex());
+      path = path.slice(1);
+      continue;
+    }
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4900,6 +4900,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::KeyPathRoot:
     case ConstraintLocator::KeyPathValue:
       break;
+
+    case ConstraintLocator::ProtocolRequirement:
+    case ConstraintLocator::ConditionalRequirement:
+    case ConstraintLocator::ConformanceRequirement:
+    case ConstraintLocator::TypeParameterRequirement:
+      break;
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -76,6 +76,11 @@ ExpressionTimer::~ExpressionTimer() {
   if (!PrintWarning)
     return;
 
+  const auto WarnLimit = getWarnLimit();
+
+  if (WarnLimit == 0 || elapsedMS < WarnLimit)
+    return;
+
   ASTNode anchor;
   if (auto *locator = Anchor.dyn_cast<ConstraintLocator *>()) {
     anchor = simplifyLocatorToAnchor(locator);
@@ -87,9 +92,7 @@ ExpressionTimer::~ExpressionTimer() {
     anchor = Anchor.get<Expr *>();
   }
 
-  const auto WarnLimit = getWarnLimit();
-  if (WarnLimit != 0 && elapsedMS >= WarnLimit &&
-      anchor.getStartLoc().isValid()) {
+  if (anchor.getStartLoc().isValid()) {
     Context.Diags
         .diagnose(anchor.getStartLoc(), diag::debug_long_expression, elapsedMS,
                   WarnLimit)

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4935,6 +4935,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
 
     case ConstraintLocator::ImplicitConversion:
       break;
+
+    case ConstraintLocator::Witness:
+    case ConstraintLocator::WrappedValue:
+    case ConstraintLocator::OptionalPayload:
+    case ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice:
+      break;
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4880,6 +4880,11 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::ConstructorMemberType:
     case ConstraintLocator::ExistentialSuperclassType:
       break;
+
+    case ConstraintLocator::GenericArgument:
+    case ConstraintLocator::FunctionArgument:
+    case ConstraintLocator::SynthesizedArgument:
+      break;
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4920,6 +4920,9 @@ void constraints::simplifyLocator(ASTNode &anchor,
       path = path.slice(1);
       continue;
     }
+
+    case ConstraintLocator::ImplicitConversion:
+      break;
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4890,6 +4890,9 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::KeyPathComponentResult:
       break;
 
+    case ConstraintLocator::GenericParameter:
+      break;
+
     }
 
     // If we get here, we couldn't simplify the path further.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4893,6 +4893,10 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::GenericParameter:
       break;
 
+    case ConstraintLocator::OpenedGeneric:
+    case ConstraintLocator::OpenedOpaqueArchetype:
+      break;
+
     case ConstraintLocator::KeyPathRoot:
     case ConstraintLocator::KeyPathValue:
       break;


### PR DESCRIPTION
Remove the `default` in `simplifyLocatorToAnchor` and implement simplification
logic for all missing elements. This makes `simplifyLocatorToAnchor` future-proof.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
