### PR TITLE
[DNM][stdlib] Move to arch-specific directory on Unix

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1388,8 +1388,8 @@ void ToolChain::getClangLibraryPath(const ArgList &Args,
                                          : getPlatformNameForTriple(T));
 }
 
-/// Get the runtime library link path, which is platform-specific and found
-/// relative to the compiler.
+/// Get the runtime library link path, which is platform-specific and arch-
+/// specific, found relative to the compiler.
 void ToolChain::getResourceDirPath(SmallVectorImpl<char> &resourceDirPath,
                                    const llvm::opt::ArgList &args,
                                    bool shared) const {
@@ -1411,6 +1411,9 @@ void ToolChain::getResourceDirPath(SmallVectorImpl<char> &resourceDirPath,
   if (tripleIsMacCatalystEnvironment(getTriple()))
     libSubDir = "maccatalyst";
   llvm::sys::path::append(resourceDirPath, libSubDir);
+  if (!getTriple().isOSDarwin())
+    llvm::sys::path::append(resourceDirPath,
+                            getMajorArchitectureName(getTriple()));
 }
 
 // Get the secondary runtime library link path given the primary path.
@@ -1419,6 +1422,15 @@ void ToolChain::getResourceDirPath(SmallVectorImpl<char> &resourceDirPath,
 void ToolChain::getSecondaryResourceDirPath(
     SmallVectorImpl<char> &secondaryResourceDirPath,
     StringRef primaryPath) const {
+  if (!getTriple().isOSDarwin()) {
+    // For non-Darwin platforms, the secondary runtime library path is the
+    // non arch-specific library path. The compiler will find bundled Swift
+    // frameworks and other arch-irrelevant resources here.
+    secondaryResourceDirPath.append(primaryPath.begin(), primaryPath.end());
+    llvm::sys::path::remove_filename(secondaryResourceDirPath);
+    return;
+  }
+ 
   if (!tripleIsMacCatalystEnvironment(getTriple()))
     return;
 

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -241,8 +241,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
 
   SmallString<128> swiftrtPath = SharedResourceDirPath;
-  llvm::sys::path::append(swiftrtPath,
-                          swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(swiftrtPath, "swiftrt.o");
   Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
 

--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -117,8 +117,6 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/false);
 
   SmallString<128> swiftrtPath = SharedResourceDirPath;
-  llvm::sys::path::append(swiftrtPath,
-                          swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(swiftrtPath, "swiftrt.o");
   Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
 

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -118,18 +118,13 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   for (auto path : RuntimeLibPaths) {
     Arguments.push_back("-L");
-    // Since Windows has separate libraries per architecture, link against the
-    // architecture specific version of the static library.
-    Arguments.push_back(context.Args.MakeArgString(path + "/" +
-                                                   getTriple().getArchName()));
+    Arguments.push_back(context.Args.MakeArgString(path));
   }
 
   SmallString<128> SharedResourceDirPath;
   getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
 
   SmallString<128> swiftrtPath = SharedResourceDirPath;
-  llvm::sys::path::append(swiftrtPath,
-                          swift::getMajorArchitectureName(getTriple()));
   llvm::sys::path::append(swiftrtPath, "swiftrt.obj");
   Arguments.push_back(context.Args.MakeArgString(swiftrtPath));
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2191,10 +2191,12 @@ function(add_swift_target_library name)
       return()
     endif()
 
+    # Determine the subdirectory where this library will be installed.
     set(library_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
     if(maccatalyst_build_flavor STREQUAL "ios-like")
       set(library_subdir "${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}")
     endif()
+    precondition(library_subdir)
 
     if(NOT SWIFTLIB_OBJECT_LIBRARY)
       # Determine the name of the universal library.
@@ -2239,14 +2241,6 @@ function(add_swift_target_library name)
         ${lipo_target}
         CACHE INTERNAL "UNIVERSAL_LIBRARY_NAMES_${library_subdir}")
 
-      # Determine the subdirectory where this library will be installed.
-      set(resource_dir_sdk_subdir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
-      if(maccatalyst_build_flavor STREQUAL "ios-like")
-        set(resource_dir_sdk_subdir "${SWIFT_SDK_MACCATALYST_LIB_SUBDIR}")
-      endif()
-
-      precondition(resource_dir_sdk_subdir)
-
       if(SWIFTLIB_SHARED OR SWIFTLIB_INSTALL_WITH_SHARED)
         set(resource_dir "swift")
         set(file_permissions
@@ -2267,46 +2261,55 @@ function(add_swift_target_library name)
         set(optional_arg "OPTIONAL")
       endif()
 
-      if(sdk STREQUAL WINDOWS AND CMAKE_SYSTEM_NAME STREQUAL Windows)
-        add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH})
-        swift_install_in_component(TARGETS ${name}-windows-${SWIFT_PRIMARY_VARIANT_ARCH}
-                                   RUNTIME
-                                     DESTINATION "bin"
-                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
-                                   LIBRARY
-                                     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
-                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
-                                   ARCHIVE
-                                     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${SWIFT_PRIMARY_VARIANT_ARCH}"
-                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
-                                   PERMISSIONS ${file_permissions})
+      if (SWIFTLIB_BACK_DEPLOYMENT_LIBRARY)
+        # Back-deployment libraries get installed into a versioned directory.
+        set(install_dest "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}-${SWIFTLIB_BACK_DEPLOYMENT_LIBRARY}/${library_subdir}")
       else()
+        set(install_dest "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${library_subdir}")
+      endif()
+
+      if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "MACHO")
         # NOTE: ${UNIVERSAL_LIBRARY_NAME} is the output associated with the target
         # ${lipo_target}
         add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${lipo_target})
-
-        if (SWIFTLIB_BACK_DEPLOYMENT_LIBRARY)
-          # Back-deployment libraries get installed into a versioned directory.
-          set(install_dest "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}-${SWIFTLIB_BACK_DEPLOYMENT_LIBRARY}/${resource_dir_sdk_subdir}")
-        else()
-          set(install_dest "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}")
-        endif()
 
         swift_install_in_component(FILES "${UNIVERSAL_LIBRARY_NAME}"
                                    DESTINATION ${install_dest}
                                    COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
                                    PERMISSIONS ${file_permissions}
                                    "${optional_arg}")
-      endif()
-      if(sdk STREQUAL WINDOWS)
-        foreach(arch ${SWIFT_SDK_WINDOWS_ARCHITECTURES})
-          if(TARGET ${name}-windows-${arch}_IMPLIB)
-            get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
-            add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-windows-${arch}_IMPLIB)
-            swift_install_in_component(FILES ${import_library}
-                                       DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${resource_dir}/${resource_dir_sdk_subdir}/${arch}"
-                                       COMPONENT ${SWIFTLIB_INSTALL_IN_COMPONENT}
-                                       PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+      else()
+        # SDK target doesn't support Universal Binary, so install to arch-specific dir
+        foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+          if(TARGET ${name}-${library_subdir}-${arch})
+            add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-${library_subdir}-${arch})
+            if(sdk STREQUAL WINDOWS)
+              swift_install_in_component(TARGETS ${name}-${library_subdir}-${arch}
+                                         RUNTIME
+                                           DESTINATION "bin"
+                                           COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                         LIBRARY
+                                           DESTINATION "${install_dest}/${arch}"
+                                           COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                         ARCHIVE
+                                           DESTINATION "${install_dest}/${arch}"
+                                           COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                         PERMISSIONS ${file_permissions})
+              if(TARGET ${name}-windows-${arch}_IMPLIB)
+                get_target_property(import_library ${name}-windows-${arch}_IMPLIB IMPORTED_LOCATION)
+                add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-windows-${arch}_IMPLIB)
+                swift_install_in_component(FILES ${import_library}
+                                           DESTINATION "${install_dest}/${arch}"
+                                           COMPONENT ${SWIFTLIB_INSTALL_IN_COMPONENT}
+                                           PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+              endif()
+            else()
+              swift_install_in_component(TARGETS ${name}-${library_subdir}-${arch}
+                                         DESTINATION "${install_dest}/${arch}"
+                                         COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                         PERMISSIONS ${file_permissions}
+                                         "${optional_arg}")
+            endif()
           endif()
         endforeach()
       endif()
@@ -2365,11 +2368,11 @@ function(add_swift_target_library name)
           set(install_subdir "swift_static")
           set(universal_subdir ${SWIFTSTATICLIB_DIR})
         endif()
+        set(install_dest "lib${LLVM_LIBDIR_SUFFIX}/${install_subdir}/${library_subdir}")
 
-        set(lipo_target_static
-            "${name}-${library_subdir}-static")
         set(UNIVERSAL_LIBRARY_NAME
             "${universal_subdir}/${library_subdir}/${CMAKE_STATIC_LIBRARY_PREFIX}${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(lipo_target_static "${name}-${library_subdir}-static")
         _add_swift_lipo_target(SDK
                                  ${sdk}
                                TARGET
@@ -2377,15 +2380,31 @@ function(add_swift_target_library name)
                                OUTPUT
                                  "${UNIVERSAL_LIBRARY_NAME}"
                                ${THIN_INPUT_TARGETS_STATIC})
-        add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${lipo_target_static})
-        swift_install_in_component(FILES "${UNIVERSAL_LIBRARY_NAME}"
-                                   DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/${install_subdir}/${resource_dir_sdk_subdir}"
-                                   PERMISSIONS
-                                     OWNER_READ OWNER_WRITE
-                                     GROUP_READ
-                                     WORLD_READ
-                                   COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
-                                   "${optional_arg}")
+        if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "MACHO")
+          add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${lipo_target_static})
+          swift_install_in_component(FILES "${UNIVERSAL_LIBRARY_NAME}"
+                                     DESTINATION "${install_dest}"
+                                     PERMISSIONS
+                                       OWNER_READ OWNER_WRITE
+                                       GROUP_READ
+                                       WORLD_READ
+                                     COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                     "${optional_arg}")
+        else()
+          foreach(arch ${SWIFT_SDK_${sdk}_ARCHITECTURES})
+            if(TARGET ${name}-${library_subdir}-${arch}-static)
+              add_dependencies(${SWIFTLIB_INSTALL_IN_COMPONENT} ${name}-${library_subdir}-${arch}-static)
+              swift_install_in_component(TARGETS ${name}-${library_subdir}-${arch}-static
+                                         DESTINATION "${install_dest}/${arch}"
+                                         PERMISSIONS
+                                           OWNER_READ OWNER_WRITE
+                                           GROUP_READ
+                                           WORLD_READ
+                                         COMPONENT "${SWIFTLIB_INSTALL_IN_COMPONENT}"
+                                         "${optional_arg}")
+            endif()
+          endforeach()
+        endif()
       endif()
 
       # Add Swift standard library targets as dependencies to the top-level


### PR DESCRIPTION
<!-- What's in this pull request? -->
On Unix we don't have Universal binary, so shared libraries of different architectures will conflict with each other. Move them to arch-specific directory to resolve such conflict and enable multi-arch SDK on these platforms.
This PR also removes the use/dependency on `lipo-target` for all non-MachO platforms.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
