### PR TITLE
[Distributed] Survive generics with Sendable requirement in executeDistributedTarget

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2120,7 +2120,8 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
       },
       [&substFn](const Metadata *type, unsigned index) {
         return substFn.getWitnessTable(type, index);
-      }, /*skipUnknownKinds=*/true);
+      },
+      /*skipUnknownKinds=*/true);
   // The reason we skip unknown kinds is to avoid reporting missing
   // conformances to Sendable, which cannot be checked at runtime, where we're
   // calling this from 'executeDistributedTarget'.

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2120,7 +2120,10 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
       },
       [&substFn](const Metadata *type, unsigned index) {
         return substFn.getWitnessTable(type, index);
-      });
+      }, /*skipUnknownKinds=*/true);
+  // The reason we skip unknown kinds is to avoid reporting missing
+  // conformances to Sendable, which cannot be checked at runtime, where we're
+  // calling this from 'executeDistributedTarget'.
 
   if (error) {
     return {/*ptr=*/nullptr, -1};

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -462,13 +462,17 @@ public:
   /// \param extraArguments The extra arguments determined while checking
   /// generic requirements (e.g., those that need to be
   /// passed to an instantiation function) will be added to this vector.
+  /// \param skipUnknownKinds If true, unknown requirement kinds will not be
+  /// reported as errors. This should used with care, and e.g. only to ignore
+  /// @_marker protocols at runtime, which cannot be checked at runtime.
   ///
   /// \returns the error if an error occurred, None otherwise.
   llvm::Optional<TypeLookupError> _checkGenericRequirements(
       llvm::ArrayRef<GenericRequirementDescriptor> requirements,
       llvm::SmallVectorImpl<const void *> &extraArguments,
       SubstGenericParameterFn substGenericParam,
-      SubstDependentWitnessTableFn substWitnessTable);
+      SubstDependentWitnessTableFn substWitnessTable,
+      bool skipUnknownKinds = false);
 
   /// A helper function which avoids performing a store if the destination
   /// address already contains the source value.  This is useful when

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1234,8 +1234,7 @@ llvm::Optional<TypeLookupError> swift::_checkGenericRequirements(
     llvm::ArrayRef<GenericRequirementDescriptor> requirements,
     llvm::SmallVectorImpl<const void *> &extraArguments,
     SubstGenericParameterFn substGenericParam,
-    SubstDependentWitnessTableFn substWitnessTable,
-    bool skipUnknownKinds) {
+    SubstDependentWitnessTableFn substWitnessTable, bool skipUnknownKinds) {
   for (const auto &req : requirements) {
     // Make sure we understand the requirement we're dealing with.
     if (!req.hasKnownKind()) {
@@ -1245,7 +1244,6 @@ llvm::Optional<TypeLookupError> swift::_checkGenericRequirements(
         return TypeLookupError("unknown kind");
       }
     }
-
 
     // Resolve the subject generic parameter.
     auto result = swift_getTypeByMangledName(

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1234,11 +1234,18 @@ llvm::Optional<TypeLookupError> swift::_checkGenericRequirements(
     llvm::ArrayRef<GenericRequirementDescriptor> requirements,
     llvm::SmallVectorImpl<const void *> &extraArguments,
     SubstGenericParameterFn substGenericParam,
-    SubstDependentWitnessTableFn substWitnessTable) {
+    SubstDependentWitnessTableFn substWitnessTable,
+    bool skipUnknownKinds) {
   for (const auto &req : requirements) {
     // Make sure we understand the requirement we're dealing with.
-    if (!req.hasKnownKind())
-      return TypeLookupError("unknown kind");
+    if (!req.hasKnownKind()) {
+      if (skipUnknownKinds) {
+        continue;
+      } else {
+        return TypeLookupError("unknown kind");
+      }
+    }
+
 
     // Resolve the subject generic parameter.
     auto result = swift_getTypeByMangledName(

--- a/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
@@ -19,6 +19,9 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
+protocol SomeProtocol {}
+extension String: SomeProtocol {}
+
 distributed actor Greeter {
   distributed func noParams() {}
   distributed func noParamsThrows() throws {}
@@ -28,9 +31,10 @@ distributed actor Greeter {
   distributed func oneLabel(value: String, _ value2: String, _ value3: String) {}
   distributed func parameterSingle(first: String) {}
   distributed func parameterPair(first: String, second: Int) {}
-  // FIXME(distributed): rdar://90293494 fails to get
-//  distributed func generic<A: Codable & Sendable>(first: A) {}
-//  distributed func genericNoLabel<A: Codable & Sendable>(_ first: A) {}
+
+  distributed func generic<A: Codable & Sendable>(first: A) {}
+  distributed func genericThree<A: Codable & Sendable & SomeProtocol>(first: A) {}
+  distributed func genericThreeTwo<A: Codable & Sendable, B: Codable & SomeProtocol>(first: A, second: B) {}
 }
 extension Greeter {
   distributed func parameterTriple(first: String, second: Int, third: Double) {}
@@ -62,12 +66,14 @@ func test() async throws {
   _ = try await greeter.parameterPair(first: "X", second: 2)
   // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterPair(first:second:)
 
-  _ = try await greeter.parameterTriple(first: "X", second: 2, third: 3.0)
-  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterTriple(first:second:third:)
+  _ = try await greeter.generic(first: "X")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.generic(first:)
 
-  // FIXME: rdar://90293494 seems to fail getting the substitutions?
-//  _ = try await greeter.generic(first: "X")
-//  // TODO: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.parameterTriple(first:second:third:)
+  _ = try await greeter.genericThree(first: "X")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.genericThree(first:)
+
+  _ = try await greeter.genericThreeTwo(first: "X", second: "SecondValue")
+  // CHECK: >> remoteCallVoid: on:main.Greeter, target:main.Greeter.genericThreeTwo(first:second:)
 
   print("done")
   // CHECK: done
@@ -75,6 +81,10 @@ func test() async throws {
 
 @main struct Main {
   static func main() async {
-    try! await test()
+    do {
+      try await test()
+    } catch {
+      print("ERROR: \(error)")
+    }
   }
 }


### PR DESCRIPTION
Since `Sendable` as any other @_marker protocol does not exist at runtime, we're not able (and DON'T HAVE TO) find a witness for it. The function we're to invoke does not expect a witness for those anyway.

I did not find a way to detect "oh, this was a marker protocol" so instead I provide a mode to ignore unknown kinds. We only use it in our code so there should be no risk to other existing code.

resolves rdar://90293494

