### PR TITLE
[RemoteMirror][swift-inspect] Decode locks in priority-escalation concurrency runtime.

### DIFF
--- a/include/swift/Concurrency/Actor.h
+++ b/include/swift/Concurrency/Actor.h
@@ -1,0 +1,71 @@
+//===--- Actor.h - Swift concurrency actor declarations ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Actor-related declarations that are also used by Remote Mirror.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_ACTOR_H
+#define SWIFT_CONCURRENCY_ACTOR_H
+
+#include <stdint.h>
+
+namespace swift {
+namespace concurrency {
+namespace ActorFlagConstants {
+
+enum : uint32_t {
+  // Bits 0-2: Actor state
+  //
+  // Possible state transitions for an actor:
+  //
+  // Idle -> Running
+  // Running -> Idle
+  // Running -> Scheduled
+  // Scheduled -> Running
+  // Idle -> Deallocated
+  // Running -> Zombie_ReadyForDeallocation
+  // Zombie_ReadyForDeallocation -> Deallocated
+  //
+  // It is possible for an actor to be in Running and yet completely released
+  // by clients. However, the actor needs to be kept alive until it is done
+  // executing the task that is running on it and gives it up. It is only
+  // after that that we can safely deallocate it.
+  ActorStateMask = 0x7,
+
+  /// The actor is not currently scheduled.  Completely redundant
+  /// with the job list being empty.
+  Idle = 0x0,
+  /// There actor is scheduled
+  Scheduled = 0x1,
+  /// There is currently a thread running the actor.
+  Running = 0x2,
+  /// The actor is ready for deallocation once it stops running
+  Zombie_ReadyForDeallocation = 0x3,
+
+  // Bit 3
+  DistributedRemote = 0x8,
+  // Bit 4
+  IsPriorityEscalated = 0x10,
+
+  // Bits 8 - 15. We only need 8 bits of the whole size_t to represent Job
+  // Priority
+  PriorityMask = 0xFF00,
+  PriorityAndOverrideMask = PriorityMask | IsPriorityEscalated,
+  PriorityShift = 0x8,
+};
+
+} // namespace ActorFlagConstants
+} // namespace concurrency
+} // namespace swift
+
+#endif // SWIFT_CONCURRENCY_ACTOR_H

--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -174,6 +174,7 @@ struct ActiveActorStatusWithoutEscalation {
 template <typename Runtime, typename ActiveActorStatus>
 struct DefaultActorImpl {
   HeapObject<Runtime> HeapObject;
+  Job<Runtime> JobStorage;
   ActiveActorStatus Status;
 };
 

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorTypes.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_REMOTE_MIRROR_TYPES_H
 #define SWIFT_REMOTE_MIRROR_TYPES_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -235,18 +236,21 @@ typedef struct swift_async_task_info {
 
   unsigned Kind;
   unsigned EnqueuePriority;
-  uint8_t IsChildTask;
-  uint8_t IsFuture;
-  uint8_t IsGroupChildTask;
-  uint8_t IsAsyncLetTask;
+  bool IsChildTask;
+  bool IsFuture;
+  bool IsGroupChildTask;
+  bool IsAsyncLetTask;
 
   unsigned MaxPriority;
-  uint8_t IsCancelled;
-  uint8_t IsStatusRecordLocked;
-  uint8_t IsEscalated;
-  uint8_t HasIsRunning; // If false, the IsRunning flag is not valid.
-  uint8_t IsRunning;
-  uint8_t IsEnqueued;
+  bool IsCancelled;
+  bool IsStatusRecordLocked;
+  bool IsEscalated;
+  bool HasIsRunning; // If false, the IsRunning flag is not valid.
+  bool IsRunning;
+  bool IsEnqueued;
+
+  bool HasThreadPort;
+  uint32_t ThreadPort;
 
   uint64_t Id;
   swift_reflection_ptr_t RunJob;
@@ -265,8 +269,15 @@ typedef struct swift_actor_info {
   /// swift_reflection call on the given context.
   const char *Error;
 
-  uint64_t Flags;
+  uint8_t State;
+  bool IsDistributedRemote;
+  bool IsPriorityEscalated;
+  uint8_t MaxPriority;
+
   swift_reflection_ptr_t FirstJob;
+
+  bool HasThreadPort;
+  uint32_t ThreadPort;
 } swift_actor_info_t;
 
 /// An opaque pointer to a context which maintains state and

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -38,6 +38,7 @@
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Actor.h"
 #include "swift/Basic/ListMerger.h"
+#include "swift/Concurrency/Actor.h"
 #ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
 // All platforms where we care about back deployment have a known
 // configurations.
@@ -608,47 +609,6 @@ public:
 ///     DefaultActorImpl. The additional alignment requirements are
 ///     enforced by static asserts below.
 class alignas(sizeof(void *) * 2) ActiveActorStatus {
-  enum : uint32_t {
-    // Bits 0-2: Actor state
-    //
-    // Possible state transitions for an actor:
-    //
-    // Idle -> Running
-    // Running -> Idle
-    // Running -> Scheduled
-    // Scheduled -> Running
-    // Idle -> Deallocated
-    // Running -> Zombie_ReadyForDeallocation
-    // Zombie_ReadyForDeallocation -> Deallocated
-    //
-    // It is possible for an actor to be in Running and yet completely released
-    // by clients. However, the actor needs to be kept alive until it is done
-    // executing the task that is running on it and gives it up. It is only
-    // after that that we can safely deallocate it.
-    ActorStateMask = 0x7,
-
-    /// The actor is not currently scheduled.  Completely redundant
-    /// with the job list being empty.
-    Idle = 0x0,
-    /// There actor is scheduled
-    Scheduled = 0x1,
-    /// There is currently a thread running the actor.
-    Running = 0x2,
-    /// The actor is ready for deallocation once it stops running
-    Zombie_ReadyForDeallocation = 0x3,
-
-    // Bit 3
-    DistributedRemote = 0x8,
-    // Bit 4
-    isPriorityEscalated = 0x10,
-
-    // Bits 8 - 15. We only need 8 bits of the whole size_t to represent Job
-    // Priority
-    PriorityMask = 0xFF00,
-    PriorityAndOverrideMask = PriorityMask | isPriorityEscalated,
-    PriorityShift = 0x8,
-  };
-
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
   uint32_t Flags;
   dispatch_lock_t DrainLock;
@@ -673,10 +633,10 @@ class alignas(sizeof(void *) * 2) ActiveActorStatus {
 #endif
 
   uint32_t getActorState() const {
-    return Flags & ActorStateMask;
+    return Flags & concurrency::ActorFlagConstants::ActorStateMask;
   }
   uint32_t setActorState(uint32_t state) const {
-    return (Flags & ~ActorStateMask) | state;
+    return (Flags & ~concurrency::ActorFlagConstants::ActorStateMask) | state;
   }
 
 public:
@@ -689,17 +649,22 @@ public:
       : Flags(), FirstJob(JobRef()) {}
 #endif
 
-  bool isDistributedRemote() const { return Flags & DistributedRemote; }
+  bool isDistributedRemote() const {
+    return Flags & concurrency::ActorFlagConstants::DistributedRemote;
+  }
   ActiveActorStatus withDistributedRemote() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveActorStatus(Flags | DistributedRemote, DrainLock, FirstJob);
+    return ActiveActorStatus(
+        Flags | concurrency::ActorFlagConstants::DistributedRemote, DrainLock,
+        FirstJob);
 #else
-    return ActiveActorStatus(Flags | DistributedRemote, FirstJob);
+    return ActiveActorStatus(
+        Flags | concurrency::ActorFlagConstants::DistributedRemote, FirstJob);
 #endif
   }
 
   bool isIdle() const {
-    bool isIdle = (getActorState() == Idle);
+    bool isIdle = (getActorState() == concurrency::ActorFlagConstants::Idle);
     if (isIdle) {
       assert(!FirstJob);
     }
@@ -707,57 +672,79 @@ public:
   }
   ActiveActorStatus withIdle() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveActorStatus(setActorState(Idle), DLOCK_OWNER_NULL, FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Idle), DLOCK_OWNER_NULL,
+        FirstJob);
 #else
-    return ActiveActorStatus(setActorState(Idle), FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Idle), FirstJob);
 #endif
   }
 
   bool isAnyRunning() const {
     uint32_t state = getActorState();
-    return (state == Running) || (state == Zombie_ReadyForDeallocation);
+    return (state == concurrency::ActorFlagConstants::Running) ||
+           (state ==
+            concurrency::ActorFlagConstants::Zombie_ReadyForDeallocation);
   }
   bool isRunning() const {
-    return getActorState() == Running;
+    return getActorState() == concurrency::ActorFlagConstants::Running;
   }
   ActiveActorStatus withRunning() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveActorStatus(setActorState(Running), dispatch_lock_value_for_self(), FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Running),
+        dispatch_lock_value_for_self(), FirstJob);
 #else
-    return ActiveActorStatus(setActorState(Running), FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Running), FirstJob);
 #endif
   }
 
   bool isScheduled() const {
-    return getActorState() == Scheduled;
+    return getActorState() == concurrency::ActorFlagConstants::Scheduled;
   }
 
   ActiveActorStatus withScheduled() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveActorStatus(setActorState(Scheduled), DLOCK_OWNER_NULL, FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Scheduled),
+        DLOCK_OWNER_NULL, FirstJob);
 #else
-    return ActiveActorStatus(setActorState(Scheduled), FirstJob);
+    return ActiveActorStatus(
+        setActorState(concurrency::ActorFlagConstants::Scheduled), FirstJob);
 #endif
   }
 
   bool isZombie_ReadyForDeallocation() const {
-    return getActorState() == Zombie_ReadyForDeallocation;
+    return getActorState() ==
+           concurrency::ActorFlagConstants::Zombie_ReadyForDeallocation;
   }
   ActiveActorStatus withZombie_ReadyForDeallocation() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
     assert(dispatch_lock_owner(DrainLock) != DLOCK_OWNER_NULL);
-    return ActiveActorStatus(setActorState(Zombie_ReadyForDeallocation), DrainLock, FirstJob);
+    return ActiveActorStatus(
+        setActorState(
+            concurrency::ActorFlagConstants::Zombie_ReadyForDeallocation),
+        DrainLock, FirstJob);
 #else
-    return ActiveActorStatus(setActorState(Zombie_ReadyForDeallocation), FirstJob);
+    return ActiveActorStatus(
+        setActorState(
+            concurrency::ActorFlagConstants::Zombie_ReadyForDeallocation),
+        FirstJob);
 #endif
   }
 
   JobPriority getMaxPriority() const {
-    return (JobPriority) ((Flags & PriorityMask) >> PriorityShift);
+    return (
+        JobPriority)((Flags & concurrency::ActorFlagConstants::PriorityMask) >>
+                     concurrency::ActorFlagConstants::PriorityShift);
   }
   ActiveActorStatus withNewPriority(JobPriority priority) const {
-    uint32_t flags = Flags & ~PriorityAndOverrideMask;
-    flags |= (uint32_t(priority) << PriorityShift);
+    uint32_t flags =
+        Flags & ~concurrency::ActorFlagConstants::PriorityAndOverrideMask;
+    flags |=
+        (uint32_t(priority) << concurrency::ActorFlagConstants::PriorityShift);
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
     return ActiveActorStatus(flags, DrainLock, FirstJob);
 #else
@@ -768,13 +755,19 @@ public:
     return withNewPriority(JobPriority::Unspecified);
   }
 
-  bool isMaxPriorityEscalated() const { return Flags & isPriorityEscalated; }
+  bool isMaxPriorityEscalated() const {
+    return Flags & concurrency::ActorFlagConstants::IsPriorityEscalated;
+  }
   ActiveActorStatus withEscalatedPriority(JobPriority priority) const {
-    JobPriority currentPriority = JobPriority((Flags & PriorityMask) >> PriorityShift);
+    JobPriority currentPriority =
+        JobPriority((Flags & concurrency::ActorFlagConstants::PriorityMask) >>
+                    concurrency::ActorFlagConstants::PriorityShift);
     assert(priority > currentPriority);
 
-    uint32_t flags = (Flags & ~PriorityMask) | (uint32_t(priority) << PriorityShift);
-    flags |= isPriorityEscalated;
+    uint32_t flags =
+        (Flags & ~concurrency::ActorFlagConstants::PriorityMask) |
+        (uint32_t(priority) << concurrency::ActorFlagConstants::PriorityShift);
+    flags |= concurrency::ActorFlagConstants::IsPriorityEscalated;
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
     return ActiveActorStatus(flags, DrainLock, FirstJob);
 #else
@@ -783,9 +776,13 @@ public:
   }
   ActiveActorStatus withoutEscalatedPriority() const {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
-    return ActiveActorStatus(Flags & ~isPriorityEscalated, DrainLock, FirstJob);
+    return ActiveActorStatus(
+        Flags & ~concurrency::ActorFlagConstants::IsPriorityEscalated,
+        DrainLock, FirstJob);
 #else
-    return ActiveActorStatus(Flags & ~isPriorityEscalated, FirstJob);
+    return ActiveActorStatus(
+        Flags & ~concurrency::ActorFlagConstants::IsPriorityEscalated,
+        FirstJob);
 #endif
   }
 
@@ -823,16 +820,16 @@ public:
     // the enum values, but this explicit conversion provides room for change.
     uint8_t traceState = 255;
     switch (getActorState()) {
-    case ActiveActorStatus::Idle:
+    case concurrency::ActorFlagConstants::Idle:
       traceState = 0;
       break;
-    case ActiveActorStatus::Scheduled:
+    case concurrency::ActorFlagConstants::Scheduled:
       traceState = 1;
       break;
-    case ActiveActorStatus::Running:
+    case concurrency::ActorFlagConstants::Running:
       traceState = 2;
       break;
-    case ActiveActorStatus::Zombie_ReadyForDeallocation:
+    case concurrency::ActorFlagConstants::Zombie_ReadyForDeallocation:
       traceState = 3;
       break;
     }

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -892,6 +892,9 @@ swift_reflection_asyncTaskInfo(SwiftReflectionContextRef ContextRef,
   Result.IsEnqueued = TaskInfo.IsEnqueued;
   Result.Id = TaskInfo.Id;
 
+  Result.HasThreadPort = TaskInfo.HasThreadPort;
+  Result.ThreadPort = TaskInfo.ThreadPort;
+
   Result.RunJob = TaskInfo.RunJob;
   Result.AllocatorSlabPtr = TaskInfo.AllocatorSlabPtr;
 
@@ -919,13 +922,19 @@ swift_reflection_actorInfo(SwiftReflectionContextRef ContextRef,
                            swift_reflection_ptr_t ActorPtr) {
   auto Context = ContextRef->nativeContext;
   llvm::Optional<std::string> Error;
-  NativeReflectionContext::ActorInfo TaskInfo;
-  std::tie(Error, TaskInfo) = Context->actorInfo(ActorPtr);
+  NativeReflectionContext::ActorInfo ActorInfo;
+  std::tie(Error, ActorInfo) = Context->actorInfo(ActorPtr);
 
   swift_actor_info_t Result = {};
   Result.Error = returnableCString(ContextRef, Error);
-  Result.Flags = TaskInfo.Flags;
-  Result.FirstJob = TaskInfo.FirstJob;
+  Result.State = ActorInfo.State;
+  Result.IsDistributedRemote = ActorInfo.IsDistributedRemote;
+  Result.IsPriorityEscalated = ActorInfo.IsPriorityEscalated;
+  Result.MaxPriority = ActorInfo.MaxPriority;
+  Result.FirstJob = ActorInfo.FirstJob;
+
+  Result.HasThreadPort = ActorInfo.HasThreadPort;
+  Result.ThreadPort = ActorInfo.ThreadPort;
 
   return Result;
 }

--- a/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/DarwinRemoteProcess.swift
@@ -28,6 +28,8 @@ internal final class DarwinRemoteProcess: RemoteProcess {
   private var swiftCore: CSTypeRef
   private let swiftConcurrency: CSTypeRef
 
+  private lazy var threadInfos = getThreadInfos()
+
   static var QueryDataLayout: QueryDataLayoutFunction {
     return { (context, type, _, output) in
       guard let output = output else { return 0 }
@@ -178,59 +180,115 @@ internal final class DarwinRemoteProcess: RemoteProcess {
 }
 
 extension DarwinRemoteProcess {
-  internal var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
-    var threadList: UnsafeMutablePointer<thread_t>?
-    var threadCount: mach_msg_type_number_t = 0
+  private class PortList: Sequence {
+    let buffer: UnsafeBufferPointer<mach_port_t>
 
-    let result = task_threads(self.task, &threadList, &threadCount)
-    guard result == KERN_SUCCESS else {
-      print("unable to gather threads for process: \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
-      return []
+    init?(task: task_t) {
+      var threadList: UnsafeMutablePointer<mach_port_t>?
+      var threadCount: mach_msg_type_number_t = 0
+
+      let result = task_threads(task, &threadList, &threadCount)
+      guard result == KERN_SUCCESS else {
+        print("unable to gather threads for process: \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
+        return nil
+      }
+
+      buffer = UnsafeBufferPointer(start: threadList, count: Int(threadCount))
     }
 
-    defer {
+    deinit {
       // Deallocate the port rights for the threads.
-      for i in 0 ..< Int(threadCount) {
-        mach_port_deallocate(mach_task_self_, threadList![i])
+      for thread in self {
+        mach_port_deallocate(mach_task_self_, thread)
       }
 
       // Deallocate the thread list.
-      let pointer = vm_address_t(truncatingIfNeeded: Int(bitPattern: threadList))
-      let size = vm_size_t(MemoryLayout<thread_t>.size) * vm_size_t(threadCount)
+      let pointer = vm_address_t(truncatingIfNeeded: Int(bitPattern: buffer.baseAddress))
+      let size = vm_size_t(MemoryLayout<mach_port_t>.size) * vm_size_t(buffer.count)
 
       vm_deallocate(mach_task_self_, pointer, size)
     }
 
-    var results: [(threadID: UInt64, currentTask: swift_addr_t)] = []
-    for i in 0 ..< Int(threadCount) {
-      let THREAD_IDENTIFIER_INFO_COUNT =
-          MemoryLayout<thread_identifier_info_data_t>.size / MemoryLayout<natural_t>.size
-      var info = thread_identifier_info_data_t()
-      var infoCount = mach_msg_type_number_t(THREAD_IDENTIFIER_INFO_COUNT)
+    func makeIterator() -> UnsafeBufferPointer<thread_t>.Iterator {
+      return buffer.makeIterator()
+    }
+  }
 
-      withUnsafeMutablePointer(to: &info) {
-        $0.withMemoryRebound(to: integer_t.self, capacity: THREAD_IDENTIFIER_INFO_COUNT) {
-          let result =
-              thread_info(threadList![i], thread_flavor_t(THREAD_IDENTIFIER_INFO),
-                          $0, &infoCount)
-          guard result == KERN_SUCCESS else {
-            print("unable to get info for thread \(i): \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
-            return
-          }
-        }
+  private struct ThreadInfo {
+    var threadID: UInt64
+    var tlsStart: UInt64
+    var kernelObject: UInt32?
+  }
+
+  private func getThreadInfos() -> [ThreadInfo] {
+    guard let threads = PortList(task: self.task) else {
+      return []
+    }
+    return threads.compactMap {
+      guard let info = getThreadInfo(thread: $0) else {
+        return nil
       }
+      guard let kernelObj = getKernelObject(task: mach_task_self_, port: $0) else {
+        return nil
+      }
+      return ThreadInfo(threadID: info.thread_id,
+                        tlsStart: info.thread_handle,
+                        kernelObject: kernelObj)
+    }
+  }
 
-      let tlsStart = info.thread_handle
-      if tlsStart == 0 { continue }
+  private func getKernelObject(task: task_t, port: mach_port_t) -> UInt32? {
+    var object: UInt32 = 0
+    var type: UInt32 = 0
+    let result = mach_port_kernel_object(task, port, &type, &object)
+    guard result == KERN_SUCCESS else {
+      return nil
+    }
+    return object
+  }
+
+  private func getThreadInfo(thread: thread_t) -> thread_identifier_info_data_t? {
+    let THREAD_IDENTIFIER_INFO_COUNT =
+        MemoryLayout<thread_identifier_info_data_t>.size / MemoryLayout<natural_t>.size
+    var info = thread_identifier_info_data_t()
+    var infoCount = mach_msg_type_number_t(THREAD_IDENTIFIER_INFO_COUNT)
+    var result: kern_return_t = 0
+
+    withUnsafeMutablePointer(to: &info) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: THREAD_IDENTIFIER_INFO_COUNT) {
+        result = thread_info(thread, thread_flavor_t(THREAD_IDENTIFIER_INFO),
+                        $0, &infoCount)
+      }
+    }
+    guard result == KERN_SUCCESS else {
+      print("unable to get info for thread port \(thread): \(String(cString: mach_error_string(result))) (0x\(String(result, radix: 16)))")
+      return nil
+    }
+    return info
+  }
+}
+
+extension DarwinRemoteProcess {
+  internal var currentTasks: [(threadID: UInt64, currentTask: swift_addr_t)] {
+    return threadInfos.compactMap {
+      let tlsStart = $0.tlsStart
+      if tlsStart == 0 { return nil }
 
       let SWIFT_CONCURRENCY_TASK_KEY = 103
       let currentTaskPointer = tlsStart + UInt64(SWIFT_CONCURRENCY_TASK_KEY * MemoryLayout<UnsafeRawPointer>.size)
-      if let pointer = read(address: currentTaskPointer, size: MemoryLayout<UnsafeRawPointer>.size) {
-        let currentTask = pointer.load(as: UInt.self)
-        results.append((threadID: info.thread_id, currentTask: swift_addr_t(currentTask)))
+      guard let pointer = read(address: currentTaskPointer, size: MemoryLayout<UnsafeRawPointer>.size) else {
+        return nil
       }
+      let currentTask = pointer.load(as: UInt.self)
+      return (threadID: $0.threadID, currentTask: swift_addr_t(currentTask))
     }
-    return results
+  }
+
+  internal func getThreadID(remotePort: thread_t) -> UInt64? {
+    guard let remoteThreadObj = getKernelObject(task: self.task, port: remotePort) else {
+      return nil
+    }
+    return threadInfos.first{ $0.kernelObject == remoteThreadObj }?.threadID
   }
 }
 

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -54,6 +54,7 @@ fileprivate class ConcurrencyDumper {
     var hasIsRunning: Bool
     var isRunning: Bool
     var isEnqueued: Bool
+    var threadPort: UInt32?
     var id: UInt64
     var runJob: swift_reflection_ptr_t
     var allocatorSlabPtr: swift_reflection_ptr_t
@@ -100,7 +101,7 @@ fileprivate class ConcurrencyDumper {
 
   func gatherHeapInfo() -> HeapInfo {
     var result = HeapInfo()
-    
+
     process.iterateHeap { (pointer, size) in
       let metadata = swift_reflection_ptr_t(swift_reflection_metadataForObject(context, UInt(pointer)))
       if metadata == jobMetadata {
@@ -198,17 +199,20 @@ fileprivate class ConcurrencyDumper {
       address: task,
       kind: reflectionInfo.Kind,
       enqueuePriority: reflectionInfo.EnqueuePriority,
-      isChildTask: reflectionInfo.IsChildTask != 0,
-      isFuture: reflectionInfo.IsFuture != 0,
-      isGroupChildTask: reflectionInfo.IsGroupChildTask != 0,
-      isAsyncLetTask: reflectionInfo.IsAsyncLetTask != 0,
+      isChildTask: reflectionInfo.IsChildTask,
+      isFuture: reflectionInfo.IsFuture,
+      isGroupChildTask: reflectionInfo.IsGroupChildTask,
+      isAsyncLetTask: reflectionInfo.IsAsyncLetTask,
       maxPriority: reflectionInfo.MaxPriority,
-      isCancelled: reflectionInfo.IsCancelled != 0,
-      isStatusRecordLocked: reflectionInfo.IsStatusRecordLocked != 0,
-      isEscalated: reflectionInfo.IsEscalated != 0,
-      hasIsRunning: reflectionInfo.HasIsRunning != 0,
-      isRunning: reflectionInfo.IsRunning != 0,
-      isEnqueued: reflectionInfo.IsEnqueued != 0,
+      isCancelled: reflectionInfo.IsCancelled,
+      isStatusRecordLocked: reflectionInfo.IsStatusRecordLocked,
+      isEscalated: reflectionInfo.IsEscalated,
+      hasIsRunning: reflectionInfo.HasIsRunning,
+      isRunning: reflectionInfo.IsRunning,
+      isEnqueued: reflectionInfo.IsEnqueued,
+      threadPort: reflectionInfo.HasThreadPort
+                ? reflectionInfo.ThreadPort
+                : nil,
       id: reflectionInfo.Id,
       runJob: reflectionInfo.RunJob,
       allocatorSlabPtr: reflectionInfo.AllocatorSlabPtr,
@@ -257,22 +261,6 @@ fileprivate class ConcurrencyDumper {
     return remove(from: name, upTo: " resume partial function for ")
   }
 
-  func flagsStrings<T: BinaryInteger>(flags: T, strings: [T: String]) -> [String] {
-    return strings.sorted{ $0.key < $1.key }
-                  .filter({ ($0.key & flags) != 0})
-                  .map{ $0.value }
-  }
-
-  func flagsString<T: BinaryInteger>(flags: T, strings: [T: String]) -> String {
-    let flagStrs = flagsStrings(flags: flags, strings: strings)
-    if flagStrs.isEmpty {
-      return "0"
-    }
-
-    let flagsStr = flagStrs.joined(separator: "|")
-    return flagsStr
-  }
-
   func decodeTaskFlags(_ info: TaskInfo) -> String {
     var flags: [String] = []
     if info.isChildTask { flags.append("childTask") }
@@ -289,29 +277,28 @@ fileprivate class ConcurrencyDumper {
     return flagsStr
   }
 
-  func decodeActorFlags(_ flags: UInt64) -> (
-    status: String,
+  func decodeActorFlags(_ info: swift_actor_info_t) -> (
+    state: String,
     flags: String,
-    maxPriority: UInt64
+    maxPriority: UInt8
   ) {
-    let statuses: [UInt64: String] = [
+    let states: [UInt8: String] = [
       0: "idle",
       1: "scheduled",
       2: "running",
       3: "zombie-latching",
       4: "zombie-ready-for-deallocation"
     ]
-    let flagsString = flagsString(flags: flags, strings: [
-      1 << 3: "hasActiveInlineJob",
-      1 << 4: "isDistributedRemote"
-    ])
 
-    let status = flags & 0x7
-    let maxPriority = (flags >> 8) & 0xff
+    var flags: [String] = []
+    if info.IsPriorityEscalated { flags.append("priorityEscalated") }
+    if info.IsDistributedRemote { flags.append("distributedRemote") }
+    let flagsStr = flags.isEmpty ? "0" : flags.joined(separator: "|")
+
     return (
-      status: statuses[status] ?? "unknown(\(status))",
-      flags: flagsString,
-      maxPriority: maxPriority
+      state: states[info.State] ?? "unknown(\(info.State))",
+      flags: flagsStr,
+      maxPriority: info.MaxPriority
     )
   }
 
@@ -323,7 +310,7 @@ fileprivate class ConcurrencyDumper {
       print("warning: unable to decode is-running state of target tasks, running state and async backtraces will not be printed")
     }
 
-    let taskToThread: [swift_addr_t: swift_reflection_ptr_t] =
+    let taskToThread: [swift_addr_t: UInt64] =
         Dictionary(threadCurrentTasks.map{ ($1, $0) }, uniquingKeysWith: { $1 })
 
     var lastChilds: [Bool] = []
@@ -364,11 +351,16 @@ fileprivate class ConcurrencyDumper {
       let flags = decodeTaskFlags(task)
 
       output("Task \(hex: task.id) - flags=\(flags) enqueuePriority=\(hex: task.enqueuePriority) maxPriority=\(hex: task.maxPriority) address=\(hex: task.address)")
-      if let thread = taskToThread[task.address] {
+      if let thread = taskToThread[swift_addr_t(task.address)] {
         output("current task on thread \(hex: thread)")
       }
       if let parent = task.parent {
         output("parent: \(hex: parent)")
+      }
+      if let threadPort = task.threadPort, threadPort != 0 {
+        if let threadID = process.getThreadID(remotePort: threadPort) {
+          output("waiting on thread: port=\(hex: threadPort) id=\(hex: threadID)")
+        }
       }
 
       if let first = symbolicatedBacktrace.first {
@@ -400,11 +392,22 @@ fileprivate class ConcurrencyDumper {
     for actor in actors {
       let metadata = swift_reflection_metadataForObject(context, UInt(actor))
       let metadataName = name(metadata: swift_reflection_ptr_t(metadata)) ?? "<unknown class name>"
-      let info = swift_reflection_actorInfo(context, actor);
+      let info = swift_reflection_actorInfo(context, actor)
+      if let error = info.Error {
+        print(String(utf8String: error) ?? "<unknown error>")
+        continue
+      }
 
-      let flags = decodeActorFlags(info.Flags)
+      let flags = decodeActorFlags(info)
 
-      print("  \(hex: actor) \(metadataName) status=\(flags.status) flags=\(flags.flags) maxPriority=\(hex: flags.maxPriority)")
+      print("  \(hex: actor) \(metadataName) state=\(flags.state) flags=\(flags.flags) maxPriority=\(hex: flags.maxPriority)")
+      if info.HasThreadPort && info.ThreadPort != 0 {
+        if let threadID = process.getThreadID(remotePort: info.ThreadPort) {
+          print("    waiting on thread: port=\(hex: info.ThreadPort) id=\(hex: threadID)")
+        } else {
+          print("    waiting on thread: port=\(hex: info.ThreadPort) (unknown thread ID)")
+        }
+      }
 
       func jobStr(_ job: swift_reflection_ptr_t) -> String {
         if let task = tasks[job] {
@@ -425,7 +428,7 @@ fileprivate class ConcurrencyDumper {
           }
         }
       }
-        print("")
+      print("")
     }
   }
 


### PR DESCRIPTION
When possible, decode the DrainLock/ExecutionLock fields of tasks and actors in concurrency runtimes built with priority escalation, and show the corresponding thread info in swift-inspect output.

We weren't properly decoding actor flags previously, so fix that up as well and have Remote Mirror split them out into separate fields so clients don't have to. We were missing the Job Storage field from the definition of DefaultActorImpl in RuntimeInternals.h, fix that so we actually read the right data.

rdar://88598003