### PR TITLE
[build-presets] Disable SourceKit-LSP tests on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -876,6 +876,8 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
+# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
+skip-test-sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
 


### PR DESCRIPTION
SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause.

Resolves rdar://89359439