### PR TITLE
[CSGen] Use correct locator for member references in enum element pat…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2584,8 +2584,7 @@ namespace {
               parentMetaType, enumPattern->getName(), memberType, CurDC,
               functionRefKind, {},
               CS.getConstraintLocator(locator,
-                                      {LocatorPathElt::PatternMatch(pattern),
-                                       ConstraintLocator::Member}));
+                                      LocatorPathElt::PatternMatch(pattern)));
 
           // Parent type needs to be convertible to the pattern type; this
           // accounts for cases where the pattern type is existential.

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -249,3 +249,26 @@ func test_taps_type_checked_with_correct_decl_context() {
     return false
   }
 }
+
+// rdar://90347159 - in pattern matching context `case` should be preferred over static declarations
+func test_pattern_matches_only_cases() {
+  enum ParsingError : Error {
+    case ok(Int)
+    case failed([Error], Int)
+
+    static var ok: Int { 42 }
+    static func failed(_: [Error], at: Any) -> Self { fatalError() }
+  }
+
+  let _: (ParsingError) -> Void = {
+    switch $0 {
+    case let ParsingError.failed(errors, _): print(errors) // Ok
+    default: break
+    }
+
+    switch $0 {
+    case let ParsingError.ok(result): print(result) // Ok
+    default: break
+    }
+  }
+}


### PR DESCRIPTION
…terns

Referencing a member in pattern context is not a regular member reference,
it should use only enum element declarations, just like leading-dot syntax
does, so both locators should end with `pattern matching` element to indicate
that to the member lookup.

Resolves: rdar://90347159

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
