### PR TITLE
[TypeChecker] NFC: Restrict multi-statement closure + simd test-case …

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
+++ b/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: objc_interop,no_asan
+// REQUIRES: OS=macosx
 
 import simd
 


### PR DESCRIPTION
…to macOS

Resolves: rdar://90445018


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
