### PR TITLE
[Serialization] Abort if serializing CustomAttr with no type

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2703,10 +2703,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Custom: {
       auto abbrCode = S.DeclTypeAbbrCodes[CustomDeclAttrLayout::Code];
       auto theAttr = cast<CustomAttr>(DA);
+      auto typeID = S.addTypeRef(theAttr->getType());
+      if (!typeID && !S.allowCompilerErrors()) {
+        llvm::PrettyStackTraceString message("CustomAttr has no type");
+        abort();
+      }
       CustomDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                        theAttr->isImplicit(),
-                                       S.addTypeRef(theAttr->getType()),
-                                       theAttr->isArgUnsafe());
+                                       typeID, theAttr->isArgUnsafe());
       return;
     }
 


### PR DESCRIPTION
Rather than crash when deserializing a CustomAttr with no type, crash
when serializing it instead (which is usually easier to diagnose).