### PR TITLE
[Demangling] Disable ShowAsyncResumePartial in SimplifiedUI

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -90,6 +90,7 @@ struct DemangleOptions {
     Opt.ShortenArchetype = true;
     Opt.ShowPrivateDiscriminators = false;
     Opt.ShowFunctionArgumentTypes = false;
+    Opt.ShowAsyncResumePartial = false;
     return Opt;
   };
 };

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -215,9 +215,9 @@ void ClosureGraph::finalize() {
 
 #ifndef NDEBUG
 static void dumpFunctionName(SILFunction *function) {
-  llvm::dbgs() << Demangle::demangleSymbolAsString(
-    function->getName(),
-    Demangle::DemangleOptions::SimplifiedUIDemangleOptions())
+  auto opts = Demangle::DemangleOptions::SimplifiedUIDemangleOptions();
+  opts.ShowAsyncResumePartial = true;
+  llvm::dbgs() << Demangle::demangleSymbolAsString(function->getName(), opts)
                << " '" << function->getName() << "'\n";
 }
 

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -211,5 +211,5 @@ _TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> specialized _Legac
 _TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
 _TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
 _TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
-_$s4main1fSiyYaFTQ0_ ---> f() async -> Int
-_$s4main1fSiyYaFTY0_ ---> f() async -> Int
+_$s4main1fSiyYaFTQ0_ ---> f()
+_$s4main1fSiyYaFTY0_ ---> f()

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -211,3 +211,5 @@ _TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> specialized _Legac
 _TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
 _TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
 _TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> specialized _LegacyStringCore.init(_:)
+_$s4main1fSiyYaFTQ0_ ---> f() async -> Int
+_$s4main1fSiyYaFTY0_ ---> f() async -> Int


### PR DESCRIPTION
Change `SimplifiedUIDemangleOptions` to remove "partial function" prefixes when demangling async coroutine symbols.

This removes the prefixes "await resume partial function" and "suspend resume partial function" from demangled names, in doing so hides the effect of async/coroutine function splitting from stack traces and other symbolication. This output will produce the source level function name.

For example, a symbol that previously would have demangled to:

```
(1) await resume partial function for static Main.main()
```

will, with this change, demangle to:

```
static Main.main()
```

See https://github.com/apple/swift/pull/36978 where `ShowAsyncResumePartial` was introduced for lldb.

rdar://90455541