### PR TITLE
[Distributed] Strip marker protocols from distributed thunks and accessible functions

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -186,6 +186,8 @@ public:
                                              Type GlobalActorBound,
                                              ModuleDecl *Module);
 
+  std::string mangleDistributedThunk(const FuncDecl *thunk);
+
   /// Mangle a completion handler block implementation function, used for importing ObjC
   /// APIs as async.
   ///

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -122,6 +122,10 @@ public:
                               ArrayRef<Requirement> requirements,
                               bool isKnownCanonical = false);
 
+  /// Produce a new generic signature which drops all of the marker
+  /// protocol conformance requirements associated with this one.
+  GenericSignature withoutMarkerProtocols() const;
+
 public:
   static ASTContext &getASTContext(TypeArrayView<GenericTypeParamType> params,
                                    ArrayRef<Requirement> requirements);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3457,3 +3457,11 @@ ASTMangler::mangleOpaqueTypeDescriptorRecord(const OpaqueTypeDecl *decl) {
   appendOperator("Ho");
   return finalize();
 }
+
+std::string ASTMangler::mangleDistributedThunk(const FuncDecl *thunk) {
+  // Marker protocols cannot be checked at runtime, so there is no point
+  // in recording them for distributed thunks.
+  llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,
+                                                       false);
+  return mangleEntity(thunk, SymbolKind::DistributedThunk);
+}

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4172,7 +4172,10 @@ void IRGenModule::emitAccessibleFunctions() {
 
     GenericSignature signature;
     if (auto *env = func->getGenericEnvironment()) {
-      signature = env->getGenericSignature();
+      // Drop all of the marker protocols because they are effect-less
+      // at runtime.
+      signature = env->getGenericSignature().withoutMarkerProtocols();
+
       genericEnvironment =
           getAddrOfGenericEnvironment(signature.getCanonicalSignature());
     }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -914,6 +914,10 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
         return CDeclA->Name.str();
       }
 
+    if (SKind == ASTMangler::SymbolKind::DistributedThunk) {
+      return mangler.mangleDistributedThunk(cast<FuncDecl>(getDecl()));
+    }
+
     // Otherwise, fall through into the 'other decl' case.
     LLVM_FALLTHROUGH;
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -375,11 +375,10 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   {
     // --- Mangle the thunk name
     Mangle::ASTMangler mangler;
-    auto symbolKind = swift::Mangle::ASTMangler::SymbolKind::DistributedThunk;
-    auto mangled = C.AllocateCopy(mangler.mangleEntity(thunk, symbolKind));
-    StringRef mangledTargetStringRef = StringRef(mangled);
-    auto mangledTargetStringLiteral = new (C)
-        StringLiteralExpr(mangledTargetStringRef, SourceRange(), implicit);
+    auto mangled =
+        C.AllocateCopy(mangler.mangleDistributedThunk(cast<FuncDecl>(thunk)));
+    auto mangledTargetStringLiteral =
+        new (C) StringLiteralExpr(mangled, SourceRange(), implicit);
 
     // --- let target = RemoteCallTarget(<mangled name>)
     targetVar->setInterfaceType(remoteCallTargetTy);

--- a/test/Distributed/distributed_actor_accessor_section_coff.swift
+++ b/test/Distributed/distributed_actor_accessor_section_coff.swift
@@ -76,6 +76,10 @@ public distributed actor MyActor {
   distributed func complex(_: [Int], _: Obj, _: String?, _: LargeStruct) -> LargeStruct {
     fatalError()
   }
+
+  // Make sure that Sendable doesn't show up in the mangled name
+  distributed func generic<T: Codable & Sendable>(_: T) {
+  }
 }
 
 @available(SwiftStdlib 5.7, *)
@@ -121,6 +125,12 @@ public distributed actor MyOtherActor {
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
 // CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
+// CHECK-SAME: , section ".sw5acfn$B", {{.*}}
+
+/// -> `MyActor.generic`
+// CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section ".sw5acfn$B", {{.*}}
 
 /// -> `MyOtherActor.empty`

--- a/test/Distributed/distributed_actor_accessor_section_elf.swift
+++ b/test/Distributed/distributed_actor_accessor_section_elf.swift
@@ -74,6 +74,10 @@ public distributed actor MyActor {
   distributed func complex(_: [Int], _: Obj, _: String?, _: LargeStruct) -> LargeStruct {
     fatalError()
   }
+
+  // Make sure that Sendable doesn't show up in the mangled name
+  distributed func generic<T: Codable & Sendable>(_: T) {
+  }
 }
 
 @available(SwiftStdlib 5.7, *)
@@ -119,6 +123,12 @@ public distributed actor MyOtherActor {
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
 // CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
+// CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
+
+/// -> `MyActor.generic`
+// CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section "swift5_accessible_functions", {{.*}}
 
 /// -> `MyOtherActor.empty`

--- a/test/Distributed/distributed_actor_accessor_section_macho.swift
+++ b/test/Distributed/distributed_actor_accessor_section_macho.swift
@@ -74,6 +74,10 @@ public distributed actor MyActor {
   distributed func complex(_: [Int], _: Obj, _: String?, _: LargeStruct) -> LargeStruct {
     fatalError()
   }
+
+  // Make sure that Sendable doesn't show up in the mangled name
+  distributed func generic<T: Codable & Sendable>(_: T) {
+  }
 }
 
 @available(SwiftStdlib 5.7, *)
@@ -119,6 +123,12 @@ public distributed actor MyOtherActor {
 // CHECK:      @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTEHF" = private constant
 // CHECK-SAME: @"symbolic SaySiG_____SSSg__________AD______pIetMHgggngrzo_ 27distributed_actor_accessors3ObjC AA11LargeStructV AA7MyActorC s5ErrorP"
 // CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETFTu" to i{{32|64}})
+// CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
+
+/// -> `MyActor.generic`
+// CHECK:      @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTEHF" = private constant
+// CHECK-SAME: @"symbolic x___________pSeRzSERzlIetMHngzo_ 27distributed_actor_accessors7MyActorC s5ErrorP"
+// CHECK-SAME: (%swift.async_func_pointer* @"$s27distributed_actor_accessors7MyActorC7genericyyxYaKSeRzSERzlFTETFTu" to i{{32|64}})
 // CHECK-SAME: , section {{"swift5_accessible_functions"|".sw5acfn$B"|"__TEXT, __swift5_acfuncs, regular"}}
 
 /// -> `MyOtherActor.empty`


### PR DESCRIPTION
Since marker protocols do not exist at runtime, let's strip them from mangling of distributed thunks
and generic environments associated with accessible functions.

Resolves: rdar://90293494

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
