### PR TITLE
Remove invalid install_swiftsyntax_parser preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2354,17 +2354,6 @@ swift-include-tests=0
 darwin-deployment-version-ios=10.0
 darwin-crash-reporter-client=1
 
-[preset: install_swiftsyntax_parser]
-release
-lto
-no-assertions
-build-libparser-only
-verbose-build
-darwin-install-extract-symbols
-install-llvm
-install-swift
-
-
 #===------------------------------------------------------------------------===#
 # Linux corelibs foundation preset
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
It seems that build-libparser-only hasn't existed since 2019 and this
change https://github.com/apple/swift/pull/27871