### PR TITLE
[cxx-interop] Make sure to use TUScope when looking up clang decls.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3071,7 +3071,7 @@ Decl *ClangImporter::Implementation::importDeclByName(StringRef name) {
   clang::LookupResult lookupResult(sema, clangName, clang::SourceLocation(),
                                    clang::Sema::LookupOrdinaryName);
   lookupResult.setAllowHidden(true);
-  if (!sema.LookupName(lookupResult, /*Scope=*/nullptr)) {
+  if (!sema.LookupName(lookupResult, /*Scope=*/sema.TUScope)) {
     return nullptr;
   }
 

--- a/test/Interop/Cxx/class/Inputs/dictionary-of-nsstrings.h
+++ b/test/Interop/Cxx/class/Inputs/dictionary-of-nsstrings.h
@@ -1,0 +1,8 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H
+
+#import <Foundation/Foundation.h>
+
+void takesDictionaryOfStrings(NSDictionary<NSString*, NSString*>*_Nonnull a) { }
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -92,3 +92,8 @@ module ClassProtocolNameClash {
   header "class-protocol-name-clash.h"
   requires cplusplus
 }
+
+module DictionaryOfNSStrings {
+  header "dictionary-of-nsstrings.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/dictionary-of-nsstrings-module-interface.swift
+++ b/test/Interop/Cxx/class/dictionary-of-nsstrings-module-interface.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=DictionaryOfNSStrings -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK: func takesDictionaryOfStrings(_ a: [String : String])


### PR DESCRIPTION
When we look up a name directly, make sure we provide a scope, this is required when C++ interop is enabled.

This issue was exposed when we look up if an NSString is hashable. There is a special case for classes that inherit from NSObject, but we didn't see that, because we couldn't find NSObject (because lookup failed).
