### PR TITLE
Capture properties on closures fix-it

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3826,6 +3826,9 @@ ERROR(method_call_in_closure_without_explicit_self,none,
       " capture semantics explicit", (Identifier))
 NOTE(note_capture_self_explicitly,none,
       "capture 'self' explicitly to enable implicit 'self' in this closure", ())
+NOTE(note_capture_name_explicitly,none,
+      "explicitly capture %0 to %select{call method|use value}1 in this closure", (Identifier, bool))
+
 NOTE(note_reference_self_explicitly,none,
       "reference 'self.' explicitly", ())
 NOTE(note_other_self_capture,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3827,7 +3827,7 @@ ERROR(method_call_in_closure_without_explicit_self,none,
 NOTE(note_capture_self_explicitly,none,
       "capture 'self' explicitly to enable implicit 'self' in this closure", ())
 NOTE(note_capture_name_explicitly,none,
-      "explicitly capture %0 to %select{call method|use value}1 in this closure", (Identifier, bool))
+      "explicitly capture %0 to %select{call method|capture value|capture reference}1 in this closure", (Identifier, unsigned))
 
 NOTE(note_reference_self_explicitly,none,
       "reference 'self.' explicitly", ())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1578,35 +1578,39 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         return !cast<VarDecl>(cast<DeclRefExpr>(selfRef)->getDecl())
                   ->isSelfParameter();
       };
-      
+
       SourceLoc memberLoc = SourceLoc();
+      Identifier memberName;
       if (auto *MRE = dyn_cast<MemberRefExpr>(E))
         if (isImplicitSelfParamUseLikelyToCauseCycle(MRE->getBase(), ACE)) {
           auto baseName = MRE->getMember().getDecl()->getBaseName();
           memberLoc = MRE->getLoc();
-          Diags.diagnose(memberLoc,
-                         diag::property_use_in_closure_without_explicit_self,
-                         baseName.getIdentifier())
-               .warnUntilSwiftVersionIf(shouldOnlyWarn(MRE->getBase()), 6);
+          memberName = baseName.getIdentifier();
+          Diags
+              .diagnose(memberLoc,
+                        diag::property_use_in_closure_without_explicit_self,
+                        memberName)
+              .warnUntilSwiftVersionIf(shouldOnlyWarn(MRE->getBase()), 6);
+          emitFixIts(Diags, memberName, memberLoc, /*isProperty*/ true, ACE);
+          return {false, E};
         }
 
       // Handle method calls with a specific diagnostic + fixit.
       if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(E))
         if (isImplicitSelfParamUseLikelyToCauseCycle(DSCE->getBase(), ACE) &&
             isa<DeclRefExpr>(DSCE->getFn())) {
-          auto MethodExpr = cast<DeclRefExpr>(DSCE->getFn());
+          auto methodExpr = cast<DeclRefExpr>(DSCE->getFn());
           memberLoc = DSCE->getLoc();
-          Diags.diagnose(DSCE->getLoc(),
-                         diag::method_call_in_closure_without_explicit_self,
-                         MethodExpr->getDecl()->getBaseIdentifier())
-               .warnUntilSwiftVersionIf(shouldOnlyWarn(DSCE->getBase()), 6);
+          memberName = methodExpr->getDecl()->getBaseIdentifier();
+          Diags
+              .diagnose(memberLoc,
+                        diag::method_call_in_closure_without_explicit_self,
+                        memberName)
+              .warnUntilSwiftVersionIf(shouldOnlyWarn(DSCE->getBase()), 6);
+          emitFixIts(Diags, memberName, memberLoc, /*isProperty*/ false, ACE);
+          return {false, E};
         }
 
-      if (memberLoc.isValid()) {
-        emitFixIts(Diags, memberLoc, ACE);
-        return { false, E };
-      }
-      
       // Catch any other implicit uses of self with a generic diagnostic.
       if (isImplicitSelfParamUseLikelyToCauseCycle(E, ACE))
         Diags.diagnose(E->getLoc(), diag::implicit_use_of_self_in_closure)
@@ -1614,7 +1618,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       return { true, E };
     }
-    
+
     Expr *walkToExprPost(Expr *E) override {
       if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
         if (isClosureRequiringSelfQualification(CE)) {
@@ -1622,13 +1626,13 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
           Closures.pop_back();
         }
       }
-      
+
       return E;
     }
 
     /// Emit any fix-its for this error.
-    void emitFixIts(DiagnosticEngine &Diags,
-                    SourceLoc memberLoc,
+    void emitFixIts(DiagnosticEngine &Diags, Identifier memberName,
+                    SourceLoc memberLoc, bool isProperty,
                     const AbstractClosureExpr *ACE) {
       // This error can be fixed by either capturing self explicitly (if in an
       // explicit closure), or referencing self explicitly.
@@ -1642,6 +1646,8 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
           return;
         }
         emitFixItsForExplicitClosure(Diags, memberLoc, CE);
+        emitFixItsForExplicitCaptures(Diags, memberName, memberLoc, isProperty,
+                                      CE);
       } else {
         // If this wasn't an explicit closure, just offer the fix-it to
         // reference self explicitly.
@@ -1649,7 +1655,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
           .fixItInsert(memberLoc, "self.");
       }
     }
-    
+
     /// Diagnose any captures which might have been an attempt to capture
     /// \c self strongly, but do not actually enable implicit \c self. Returns
     /// whether there were any such captures to diagnose.
@@ -1666,10 +1672,38 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         } else {
           Diags.diagnose(VD->getLoc(), diag::note_other_self_capture);
         }
-        
+
         return true;
       }
       return false;
+    }
+
+    /// Emit fix-its to explicitly capture members
+    void emitFixItsForExplicitCaptures(DiagnosticEngine &Diags,
+                                       Identifier memberName,
+                                       SourceLoc memberLoc, bool isProperty,
+                                       const ClosureExpr *closureExpr) {
+      auto diag = Diags.diagnose(closureExpr->getLoc(),
+                                 diag::note_capture_name_explicitly, memberName,
+                                 isProperty);
+      // There are four different potential fix-its to offer based on the
+      // closure signature:
+      //   1. There is an existing capture list which already has some
+      //      entries. We need to insert 'self' into the capture list along
+      //      with a separating comma.
+      //   2. There is an existing capture list, but it is empty (just '[]').
+      //      We can just insert 'self'.
+      //   3. Arguments or types are already specified in the signature,
+      //      but there is no existing capture list. We will need to insert
+      //      the capture list, but 'in' will already be present.
+      //   4. The signature empty so far. We must insert the full capture
+      //      list as well as 'in'.
+      const auto brackets = closureExpr->getBracketRange();
+      if (brackets.isValid()) {
+        emitInsertNameIntoCaptureListFixIt(brackets, diag, memberName.str());
+      } else {
+        emitInsertNewCaptureListFixIt(closureExpr, diag, memberName.str());
+      }
     }
 
     /// Emit fix-its for invalid use of implicit \c self in an explicit closure.
@@ -1696,18 +1730,19 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       //      list as well as 'in'.
       const auto brackets = closureExpr->getBracketRange();
       if (brackets.isValid()) {
-        emitInsertSelfIntoCaptureListFixIt(brackets, diag);
+        emitInsertNameIntoCaptureListFixIt(brackets, diag, "self");
       }
       else {
-        emitInsertNewCaptureListFixIt(closureExpr, diag);
+        emitInsertNewCaptureListFixIt(closureExpr, diag, "self");
       }
     }
 
     /// Emit a fix-it for inserting \c self into in existing capture list, along
     /// with a trailing comma if needed. The fix-it will be attached to the
     /// provided diagnostic \c diag.
-    void emitInsertSelfIntoCaptureListFixIt(SourceRange brackets,
-                                            InFlightDiagnostic &diag) {
+    void emitInsertNameIntoCaptureListFixIt(SourceRange brackets,
+                                            InFlightDiagnostic &diag,
+                                            StringRef name) {
       // Look for any non-comment token. If there's anything before the
       // closing bracket, we assume that it is a valid capture list entry and
       // insert 'self,'. If it wasn't a valid entry, then we will at least not
@@ -1716,19 +1751,20 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       const auto nextAfterBracket =
           Lexer::getTokenAtLocation(Ctx.SourceMgr, locAfterBracket,
                                     CommentRetentionMode::None);
+      std::string formatted = name.str();
       if (nextAfterBracket.getLoc() != brackets.End)
-        diag.fixItInsertAfter(brackets.Start, "self, ");
-      else
-        diag.fixItInsertAfter(brackets.Start, "self");
+        formatted += ", ";
+      diag.fixItInsertAfter(brackets.Start, formatted);
     }
 
     /// Emit a fix-it for inserting a capture list into a closure that does not
     /// already have one, along with a trailing \c in if necessary. The fix-it
     /// will be attached to the provided diagnostic \c diag.
     void emitInsertNewCaptureListFixIt(const ClosureExpr *closureExpr,
-                                       InFlightDiagnostic &diag) {
+                                       InFlightDiagnostic &diag,
+                                       StringRef name) {
       if (closureExpr->getInLoc().isValid()) {
-        diag.fixItInsertAfter(closureExpr->getLoc(), " [self]");
+        diag.fixItInsertAfter(closureExpr->getLoc(), (" [" + name + "]").str());
         return;
       }
 
@@ -1739,9 +1775,9 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       const auto next =
       Lexer::getTokenAtLocation(Ctx.SourceMgr, nextLoc,
                                 CommentRetentionMode::None);
-      std::string trailing = next.getLoc() == nextLoc ? " " : "";
-
-      diag.fixItInsertAfter(closureExpr->getLoc(), " [self] in" + trailing);
+      std::string formatted =
+          (" [" + name + "] in" + (next.getLoc() == nextLoc ? " " : "")).str();
+      diag.fixItInsertAfter(closureExpr->getLoc(), formatted);
     }
   };
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -443,6 +443,7 @@ class C_SR_2505 : P_SR_2505 {
     // Note: the diagnostic about capturing 'self', indicates that we have
     // selected test(_) rather than test(it:)
     return c.test { o in test(o) } // expected-error{{call to method 'test' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} expected-note{{reference 'self.' explicitly}}
+    //expected-note@-1{{explicitly capture 'test' to call method in this closure}}{{20-20= [test]}}
   }
 }
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -371,6 +371,7 @@ func checkImplicitSelfInClosure() {
       }
 
       Element.escapingClosure { // expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+        // expected-note@-1{{explicitly capture 'identifier' to capture value in this closure}}{{32-32= [identifier] in}}
         identifier // expected-error {{reference to property 'identifier' in closure requires explicit use of 'self' to make capture semantics explicit}}
         // expected-note@-1 {{reference 'self.' explicitly}}
       }

--- a/test/attr/attr_implicitselfcapture.swift
+++ b/test/attr/attr_implicitselfcapture.swift
@@ -15,6 +15,9 @@ class C {
     }
 
     takeEscapingFn { // expected-note 2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+        // expected-note@-1{{explicitly capture 'property' to capture value in this closure}}{{21-21= [property] in}}
+        // expected-note@-2{{explicitly capture 'method' to call method in this closure}}{{21-21= [method] in}}
+
       method() // expected-error{{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       // expected-note@-1{{reference 'self.' explicitly}}
       return property // expected-error{{reference to property 'property' in closure requires explicit use of 'self' to make capture semantics explicit}}

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -53,6 +53,7 @@ class SomeClass {
   func test() {
     // This should require "self."
     doesEscape { x }  // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{reference 'self.' explicitly}} {{18-18=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{17-17= [x] in}}
 
     // Since 'takesNoEscapeClosure' doesn't escape its closure, it doesn't
     // require "self." qualification of member references.
@@ -65,66 +66,89 @@ class SomeClass {
 
     func plain() { foo() }
     let plain2 = { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
     _ = plain2
 
     func multi() -> Int { foo(); return 0 }
     let multi2: () -> Int = { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{30-30= [self] in}} expected-note{{reference 'self.' explicitly}} {{31-31=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{30-30= [foo] in}}
     _ = multi2
 
     doesEscape { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}}  expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{reference 'self.' explicitly}} {{18-18=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{17-17= [foo] in}}
     takesNoEscapeClosure { foo() } // okay
 
     doesEscape { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{reference 'self.' explicitly}} {{18-18=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{17-17= [foo] in}}
     takesNoEscapeClosure { foo(); return 0 } // okay
 
     func outer() {
       func inner() { foo() }
       let inner2 = { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{21-21= [self] in}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{21-21= [foo] in}}
       _ = inner2
       func multi() -> Int { foo(); return 0 }
       let _: () -> Int = { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{27-27= [self] in}} expected-note{{reference 'self.' explicitly}} {{28-28=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{27-27= [foo] in}}
       doesEscape { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo() }
       doesEscape { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}}  expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo(); return 0 }
     }
 
-    let _: () -> Void = {  // expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{26-26= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{26-26= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{26-26= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{26-26= [self] in}}
+    let _: () -> Void = {
+        // expected-note@-1 4 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{26-26= [self] in}}
+        // expected-note@-2 4 {{explicitly capture 'foo' to call method in this closure}}{{26-26= [foo] in}}
       func inner() { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
       let inner2 = { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{21-21= [self] in}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{21-21= [foo] in}}
       let _ = inner2
       func multi() -> Int { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
       let multi2: () -> Int = { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{32-32= [self] in}} expected-note{{reference 'self.' explicitly}} {{33-33=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{32-32= [foo] in}}
       let _ = multi2
       doesEscape { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{30-30=self.}}
       doesEscape { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+    // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{30-30=self.}}
     }
 
-    doesEscape {  //expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{17-17= [self] in}}
+    doesEscape {  //expected-note 4 {{capture 'self' explicitly to enable implicit 'self' in this closure}}{{17-17= [self] in}}
+      // expected-note@-1 4 {{explicitly capture 'foo' to call method in this closure}}{{17-17= [foo] in}}
       func inner() { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
       let inner2 = { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{21-21= [self] in}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{21-21= [foo] in}}
       _ = inner2
       func multi() -> Int { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
       let multi2: () -> Int = { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{32-32= [self] in}} expected-note{{reference 'self.' explicitly}} {{33-33=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{32-32= [foo] in}}
       _ = multi2
       doesEscape { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{30-30=self.}}
       doesEscape { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{30-30=self.}}
       return 0
     }
     takesNoEscapeClosure {
       func inner() { foo() }
       let inner2 = { foo() }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{21-21= [self] in}} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{21-21= [foo] in}}
       _ = inner2
       func multi() -> Int { foo(); return 0 }
       let multi2: () -> Int = { foo(); return 0 }  // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{32-32= [self] in}} expected-note{{reference 'self.' explicitly}} {{33-33=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{32-32= [foo] in}}
       _ = multi2
       doesEscape { foo() } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo() } // okay
       doesEscape { foo(); return 0 } // expected-error {{call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{19-19= [self] in}} expected-note{{reference 'self.' explicitly}} {{20-20=self.}}
+      // expected-note@-1{{explicitly capture 'foo' to call method in this closure}}{{19-19= [foo] in}}
       takesNoEscapeClosure { foo(); return 0 } // okay
       return 0
     }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -171,11 +171,17 @@ class ExplicitSelfRequiredTest {
     doStuff({ [unowned(unsafe) self] in x+1 })
     doStuff({ [unowned self = self] in x+1 })
     doStuff({ x+1 })    // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}} expected-note{{reference 'self.' explicitly}} {{15-15=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{14-14= [x] in}}
     doVoidStuff({ doStuff({ x+1 })}) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{28-28= [self] in}} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{28-28= [x] in}}
     doVoidStuff({ x += 1 })    // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}} expected-note{{reference 'self.' explicitly}} {{19-19=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{18-18= [x] in}}
     doVoidStuff({ _ = "\(x)"}) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}} expected-note{{reference 'self.' explicitly}} {{26-26=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{18-18= [x] in}}
     doVoidStuff({ [y = self] in x += 1 }) // expected-warning {{capture 'y' was never used}} expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{20-20=self, }} expected-note{{reference 'self.' explicitly}} {{33-33=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{20-20=x, }}
     doStuff({ [y = self] in x+1 }) // expected-warning {{capture 'y' was never used}} expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
+    // expected-note@-1{{explicitly capture 'x' to capture value in this closure}}{{16-16=x, }}
     doVoidStuff({ [weak self] in x += 1 }) // expected-note {{weak capture of 'self' here does not enable implicit 'self'}} expected-warning {{variable 'self' was written to, but never read}} expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
     doStuff({ [weak self] in x+1 }) // expected-note {{weak capture of 'self' here does not enable implicit 'self'}} expected-warning {{variable 'self' was written to, but never read}} expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
     doVoidStuff({ [self = self.x] in x += 1 }) // expected-note {{variable other than 'self' captured here under the name 'self' does not enable implicit 'self'}} expected-warning {{capture 'self' was never used}} expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
@@ -183,11 +189,17 @@ class ExplicitSelfRequiredTest {
 
     // Methods follow the same rules as properties, uses of 'self' without capturing must be marked with "self."
     doStuff { method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}} expected-note{{reference 'self.' explicitly}} {{15-15=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in}}
     doVoidStuff { _ = method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}} expected-note{{reference 'self.' explicitly}} {{23-23=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{18-18= [method] in}}
     doVoidStuff { _ = "\(method())" } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}} expected-note{{reference 'self.' explicitly}} {{26-26=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{18-18= [method] in}}
     doVoidStuff { () -> () in _ = method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self]}} expected-note{{reference 'self.' explicitly}} {{35-35=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{18-18= [method]}}
     doVoidStuff { [y = self] in _ = method() } // expected-warning {{capture 'y' was never used}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{20-20=self, }} expected-note{{reference 'self.' explicitly}} {{37-37=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{20-20=method, }}
     doStuff({ [y = self] in method() }) // expected-warning {{capture 'y' was never used}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{16-16=method, }}
     doVoidStuff({ [weak self] in _ = method() }) // expected-note {{weak capture of 'self' here does not enable implicit 'self'}} expected-warning {{variable 'self' was written to, but never read}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     doStuff({ [weak self] in method() }) // expected-note {{weak capture of 'self' here does not enable implicit 'self'}} expected-warning {{variable 'self' was written to, but never read}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     doVoidStuff({ [self = self.x] in _ = method() }) // expected-note {{variable other than 'self' captured here under the name 'self' does not enable implicit 'self'}} expected-warning {{capture 'self' was never used}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
@@ -208,12 +220,22 @@ class ExplicitSelfRequiredTest {
     
     // When there's no space between the opening brace and the first expression, insert it
     doStuff {method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in }} expected-note{{reference 'self.' explicitly}} {{14-14=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in }}
     doVoidStuff {_ = method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in }} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{18-18= [method] in }}
     doVoidStuff {() -> () in _ = method() }  // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self]}} expected-note{{reference 'self.' explicitly}} {{34-34=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{18-18= [method]}}
     // With an empty capture list, insertion should be suggested without a comma
     doStuff { [] in method() } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self}} expected-note{{reference 'self.' explicitly}} {{21-21=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{16-16=method}}
     doStuff { [  ] in method() } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self}} expected-note{{reference 'self.' explicitly}} {{23-23=self.}}
-    doStuff { [ /* This space intentionally left blank. */ ] in method() } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self}} expected-note{{reference 'self.' explicitly}} {{65-65=self.}}
+    // expected-note@-1{{explicitly capture 'method' to call method in this closure}}{{16-16=method}}
+    doStuff { [ /* This space intentionally left blank. */ ] in method() } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-note@-1{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self}}
+    // expected-note@-2{{reference 'self.' explicitly}} {{65-65=self.}}
+    // expected-note@-3{{explicitly capture 'method' to call method in this closure}}{{16-16=method}}
+
+    // expected-note@+2{{explicitly capture 'method' to call method in this closure}}{{16-16=method}}
     // expected-note@+1 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self}}
     doStuff { [ // Nothing in this capture list!
         ]
@@ -221,32 +243,45 @@ class ExplicitSelfRequiredTest {
         method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{9-9=self.}}
     }
     // An inserted capture list should be on the same line as the opening brace, immediately following it.
+    // expected-note@+2{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in}}
     // expected-note@+1 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}}
     doStuff {
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{7-7=self.}}
     }
+    // expected-note@+3{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in}}
     // expected-note@+2 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}}
     // Note: Trailing whitespace on the following line is intentional and should not be removed!
     doStuff {             
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{7-7=self.}}
     }
+    // expected-note@+2{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in}}
     // expected-note@+1 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}}
     doStuff {   // We have stuff to do.
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{7-7=self.}}
     }
+    // expected-note@+2{{explicitly capture 'method' to call method in this closure}}{{14-14= [method] in}}
     // expected-note@+1 {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}}
     doStuff {// We have stuff to do.
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{7-7=self.}}
     }
 
     // String interpolation should offer the diagnosis and fix-its at the expected locations
-    doVoidStuff { _ = "\(method())" } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{26-26=self.}} expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}}
-    doVoidStuff { _ = "\(x+1)" } // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{reference 'self.' explicitly}} {{26-26=self.}} expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}}
-    
+    doVoidStuff { _ = "\(method())" } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    //expected-note@-1{{reference 'self.' explicitly}} {{26-26=self.}}
+    //expected-note@-2{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}}
+    //expected-note@-3{{explicitly capture 'method' to call method in this closure}}{{18-18= [method] in}}
+    doVoidStuff { _ = "\(x+1)" } // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    //expected-note@-1{{reference 'self.' explicitly}} {{26-26=self.}}
+    //expected-note@-2{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{18-18= [self] in}}
+    //expected-note@-3{{explicitly capture 'x' to capture value in this closure}}{{18-18= [x] in}}
+
     // If we already have a capture list, self should be added to the list
     let y = 1
-    doStuff { [y] in method() } // expected-warning {{capture 'y' was never used}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }} expected-note{{reference 'self.' explicitly}} {{22-22=self.}}
-    doStuff { [ // expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }}
+    doStuff { [y] in method() } // expected-warning {{capture 'y' was never used}} expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    //expected-note@-1{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }}
+    //expected-note@-2{{reference 'self.' explicitly}} {{22-22=self.}}
+    //expected-note@-3{{explicitly capture 'method' to call method in this closure}}{{16-16=method, }}
+    doStuff { [ // expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }} expected-note {{explicitly capture 'method' to call method in this closure}}{{16-16=method, }}
         y // expected-warning {{capture 'y' was never used}}
         ] in method() } // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}  expected-note{{reference 'self.' explicitly}} {{14-14=self.}}
 
@@ -255,8 +290,11 @@ class ExplicitSelfRequiredTest {
     doStuff({ [myX = x] in myX })
 
     // This should produce an error, since x is used within the inner closure.
-    doStuff({ [myX = {x}] in 4 })    // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{23-23= [self] in }} expected-note{{reference 'self.' explicitly}} {{23-23=self.}}
-    // expected-warning @-1 {{capture 'myX' was never used}}
+    doStuff({ [myX = {x}] in 4 })    // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-note@-1{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{23-23= [self] in }}
+    // expected-note@-2{{reference 'self.' explicitly}} {{23-23=self.}}
+    // expected-note@-3:22{{explicitly capture 'x' to capture value in this closure}}{{23-23= [x] in }}
+    // expected-warning @-4 {{capture 'myX' was never used}}
 
     return 42
   }
@@ -343,17 +381,20 @@ extension SomeClass {
     doStuff { [weak xyz = self.field] in xyz!.foo() }
 
     // rdar://16889886 - Assert when trying to weak capture a property of self in a lazy closure
+
     doStuff { [weak self.field] in field!.foo() }
     // expected-error@-1{{fields may only be captured by assigning to a specific name}}{{21-21=field = }}
     // expected-error@-2{{reference to property 'field' in closure requires explicit use of 'self' to make capture semantics explicit}}
     // expected-note@-3{{reference 'self.' explicitly}} {{36-36=self.}}
     // expected-note@-4{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }}
+    // expected-note@-5{{explicitly capture 'field' to capture value in this closure}}{{16-16=field, }}
 
     doStuff { [self.field] in field!.foo() }
     // expected-error@-1{{fields may only be captured by assigning to a specific name}}{{16-16=field = }}
     // expected-error@-2{{reference to property 'field' in closure requires explicit use of 'self' to make capture semantics explicit}}
     // expected-note@-3{{reference 'self.' explicitly}} {{31-31=self.}}
     // expected-note@-4{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{16-16=self, }}
+    // expected-note@-5{{explicitly capture 'field' to capture value in this closure}}{{16-16=field, }}
 
     doStuff { [self.field!.foo()] in 32 }
     //expected-error@-1{{fields may only be captured by assigning to a specific name}}
@@ -366,12 +407,10 @@ extension SomeClass {
     //expected-error@-2{{fields may only be captured by assigning to a specific name}}{{16-16=`in` = }}
     //expected-error@-3{{reference to property 'in' in closure requires explicit use of 'self' to make capture semantics explicit}}
     //expected-note@-4{{reference 'self.' explicitly}}
+    // expected-note@-5{{explicitly capture 'in' to capture value in this closure}}{{16-16=in, }}
 
     // expected-warning @+1 {{variable 'self' was written to, but never read}}
     doStuff { [weak self&field] in 42 }  // expected-error {{expected ']' at end of capture list}}
-
-  }
-
   func strong_in_capture_list() {
     // <rdar://problem/18819742> QOI: "[strong self]" in capture list generates unhelpful error message
     _ = {[strong self] () -> () in return }  // expected-error {{expected 'weak', 'unowned', or no specifier in capture list}}
@@ -567,8 +606,9 @@ class SR14120 {
   func test2() {
     doVoidStuff { [self] in
       doVoidStuff {
-        // expected-warning@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
+        // expected-warning@+4 {{call to method 'operation' in closure requires explicit use of 'self'}}
         // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+        // expected-note@-3 {{explicitly capture 'operation' to call method in this closure}}{{20-20= [operation] in}}
         // expected-note@+1 {{reference 'self.' explicitly}}
         operation()
       }
@@ -603,8 +643,9 @@ class SR14120 {
     doVoidStuff { [self] in
       doVoidStuff { [self] in
         doVoidStuff {
-          // expected-warning@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
+          // expected-warning@+4 {{call to method 'operation' in closure requires explicit use of 'self'}}
           // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+          // expected-note@-3 {{explicitly capture 'operation' to call method in this closure}}{{22-22= [operation] in}}
           // expected-note@+1 {{reference 'self.' explicitly}}
           operation()
         }
@@ -726,6 +767,7 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
         doVoidStuff { [unowned self] in
             doVoidStuff {}
             doVoidStuff { // expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+                //expected-note@-1{{explicitly capture 'property' to capture value in this closure}}{{26-26= [property] in}}
                 doVoidStuff {}
                 property = false // expected-warning {{reference to property 'property' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note {{reference 'self.' explicitly}}
             }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -341,6 +341,7 @@ class SomeClass {
   var field : SomeClass?
   var `class` : SomeClass?
   var `in`: Int = 0
+  var classRef: SomeClass = SomeClass()
   func foo() -> Int {}
 }
 
@@ -411,6 +412,13 @@ extension SomeClass {
 
     // expected-warning @+1 {{variable 'self' was written to, but never read}}
     doStuff { [weak self&field] in 42 }  // expected-error {{expected ']' at end of capture list}}
+
+    doStuff { classRef.foo() } // expected-error {{reference to property 'classRef' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-note@-1{{reference 'self.' explicitly}} {{15-15=self.}}
+    // expected-note@-2{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{14-14= [self] in}}
+    // expected-note@-3{{explicitly capture 'classRef' to capture reference in this closure}}{{14-14= [classRef] in}}
+  }
+
   func strong_in_capture_list() {
     // <rdar://problem/18819742> QOI: "[strong self]" in capture list generates unhelpful error message
     _ = {[strong self] () -> () in return }  // expected-error {{expected 'weak', 'unowned', or no specifier in capture list}}

--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -9,6 +9,7 @@ class ExplicitSelfRequiredTest {
   var x = 42
   func method() {
     doVoidStuff({ doStuff({ x+1 })}) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note{{capture 'self' explicitly to enable implicit 'self' in this closure}} {{28-28= [self] in}} expected-note{{reference 'self.' explicitly}} {{29-29=self.}}
+  // expected-note@-1 {{explicitly capture 'x' to capture value in this closure}}
   }
 }
 
@@ -24,8 +25,9 @@ class SR14120 {
   func test2() {
     doVoidStuff { [self] in
       doVoidStuff {
-        // expected-error@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
+        // expected-error@+4 {{call to method 'operation' in closure requires explicit use of 'self'}}
         // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+        // expected-note@-3 {{explicitly capture 'operation' to call method in this closure}}
         // expected-note@+1 {{reference 'self.' explicitly}}
         operation()
       }
@@ -60,8 +62,9 @@ class SR14120 {
     doVoidStuff { [self] in
       doVoidStuff { [self] in
         doVoidStuff {
-          // expected-error@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
+          // expected-error@+4 {{call to method 'operation' in closure requires explicit use of 'self'}}
           // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+          // expected-note@-3 {{explicitly capture 'operation' to call method in this closure}}
           // expected-note@+1 {{reference 'self.' explicitly}}
           operation()
         }


### PR DESCRIPTION
Add a fix-it to suggest capturing the property or method instead of only suggesting `self`. In order to format this reasonably, I needed to drill info about how the value was being used and information about the decl down into the fix-it emitter so that we could detect if it was a call, or if the thing being captured was a value or a reference.

This also seems to fix part of https://github.com/apple/swift/issues/54045. The other part of that bug suggests adding an additional fix-it for the case where the programmer captured `self.field`, recommending a fix-it that would make the capture `[ field = self.field ]`. The part of the compiler that detects the malfeasant capturing of the field is in the parser though, so I think that should be split into its own PR.

rdar://78550389