### PR TITLE
Use python3 explicitly in shabangs

### DIFF
--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_DTrace.in ---------------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- Benchmark_Driver ------------------------------------------------===//

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_GuardMalloc.in ----------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_QuickCheck.in
+++ b/benchmark/scripts/Benchmark_QuickCheck.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_QuickCheck.in -----------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_RuntimeLeaksRunner.in ---------------------------------===//
 #

--- a/benchmark/scripts/build_linux.py
+++ b/benchmark/scripts/build_linux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/benchmark/scripts/build_script_helper.py
+++ b/benchmark/scripts/build_script_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- compare_perf_tests.py -------------------------------------------===//

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- generate_harness.py ---------------------------------------------===//
 #

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- perf_test_driver.py ---------------------------------------------===//
 #

--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- run_smoke_bench -------------------------------------------------===//

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_Benchmark_Driver.py ----------------------------------------===//

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_compare_perf_tests.py --------------------------------------===//

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_utils.py ---------------------------------------------------===//

--- a/benchmark/utils/convertToJSON.py
+++ b/benchmark/utils/convertToJSON.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- convertToJSON.py ------------------------------------------------===//
 #

--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import re

--- a/test/CrossImport/Inputs/rewrite-module-triples.py
+++ b/test/CrossImport/Inputs/rewrite-module-triples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Renames files or directories with "module-triple-here" in their names to use
 the indicated module triples instead.

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-build-for-bitcode.py - Fake build with -embed-bitcode -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-build-for-whole-module.py - Optimized fake build -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # modify-non-primary-files.py - Fake build while modifying files -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # touch.py - /bin/touch that writes the LLVM epoch -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # update-dependencies-bad.py - Fails on bad.swift -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # update-dependencies.py - Fake build for dependency analysis -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/crash-after-generating-pch.py
+++ b/test/Driver/Inputs/crash-after-generating-pch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # crash.py - Sends SIGKILL to self. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/crash.py
+++ b/test/Driver/Inputs/crash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # crash.py - Sends SIGKILL to self. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/fail.py
+++ b/test/Driver/Inputs/fail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fail.py - Just exits with an error code -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/fake-toolchain/clang
+++ b/test/Driver/Inputs/fake-toolchain/clang
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # clang++ - Fake Clang to test finding clang++ in the toolchain path
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/fake-toolchain/ld
+++ b/test/Driver/Inputs/fake-toolchain/ld
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ld - Fake ld to test finding the Darwin linker in the toolchain path
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/filelists/check-filelist-abc.py
+++ b/test/Driver/Inputs/filelists/check-filelist-abc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # check-filelist-abc.py - Fake build to test driver-produced -filelists.
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/filelists/fake-ld.py
+++ b/test/Driver/Inputs/filelists/fake-ld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-ld.py - Fake Darwin linker to test driver-produced -filelists.
 #
 # This source file is part of the Swift.org open source project

--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test/Inputs/getmtime.py
+++ b/test/Inputs/getmtime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test/Inputs/symlink.py
+++ b/test/Inputs/symlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import sys

--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -1,4 +1,4 @@
-#!/uar/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 import sys

--- a/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
+++ b/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- python -*-
 # RUN: %{python} %s '%swift_src_root'
 

--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-new.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-new.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # check-is-new.py - a more-legible way to read a timestamp test than test(1)
 #

--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-old.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-old.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # check-is-old.py - a more-legible way to read a timestamp test than test(1)
 #

--- a/test/ModuleInterface/ModuleCache/Inputs/make-old.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/make-old.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # make-old.py - /bin/touch that writes a constant "old" timestamp.
 #

--- a/test/RemoteMirror/Inputs/interop.py
+++ b/test/RemoteMirror/Inputs/interop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Exercise the SwiftRemoteMirrorLegacyInterop API. This works with
 # multiple versions of Swift. It builds Swift code using all versions,

--- a/test/ScanDependencies/Inputs/CommandRunner.py
+++ b/test/ScanDependencies/Inputs/CommandRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 import sys

--- a/test/Serialization/Inputs/binary_sub.py
+++ b/test/Serialization/Inputs/binary_sub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
+++ b/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # sourcekitd_path_sanitize.py - Cleans up paths from sourcekitd-test output
 #
 # This source file is part of the Swift.org open source project

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf8
 
 """

--- a/tools/swift-inspect/build_script_helper.py
+++ b/tools/swift-inspect/build_script_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/80+-check
+++ b/utils/80+-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 from __future__ import print_function, unicode_literals

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/PathSanitizingFileCheck -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/analyze_code_size.py
+++ b/utils/analyze_code_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import re

--- a/utils/android/adb_clean.py
+++ b/utils/android/adb_clean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_reboot.py - Reboots and cleans an Android device. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/android/adb_push_built_products.py
+++ b/utils/android/adb_push_built_products.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_push_build_products.py - Push libraries to Android device -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/android/adb_test_runner.py
+++ b/utils/android/adb_test_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_test_runner.py - Calls adb_test_runner.main -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/apply-fixit-edits.py - Apply edits from .remap files -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 """

--- a/utils/bug_reducer/bug_reducer/bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/bug_reducer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #

--- a/utils/build-tooling-libs
+++ b/utils/build-tooling-libs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/build-tooling-libs - Helper tool for building the SwiftSyntax paresr
 # and SwiftStaticMirror libraries -*- python -*-
 #

--- a/utils/build_swift/run_tests.py
+++ b/utils/build_swift/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #

--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/check_freestanding_size.py
+++ b/utils/check_freestanding_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/chex.py
+++ b/utils/chex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Check HEX -- a stupid filter that allows hexadecimal literals to be checked
 # for in LLVM IR FileCheck tests. It works by replacing occurrences of
 # strings matching the regex /< (i[0-9]+) \s+ (0x[0-9A-Fa-f]+) >/x with the

--- a/utils/cmpcodesize/cmpcodesize.py
+++ b/utils/cmpcodesize/cmpcodesize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # cmpcodesize.py - Compare sizes of built products -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # cmpcodesize/main.py - Command-line entry point for cmpcodesize -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/coverage/coverage-build-db
+++ b/utils/coverage/coverage-build-db
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-build-db - Build sqlite3 database from profdata
 #
 # This source file is part of the Swift.org open source project

--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-generate-data - Generate, parse test run profdata
 #
 # This source file is part of the Swift.org open source project

--- a/utils/coverage/coverage-query-db
+++ b/utils/coverage/coverage-query-db
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-query-db - Find covering tests using coverage
 # database
 #

--- a/utils/coverage/coverage-touch-tests
+++ b/utils/coverage/coverage-touch-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-touch-tests - Touch tests covering git changes
 #
 # This source file is part of the Swift.org open source project

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The following script takes as input a SIL fragment and changes all
 # SSA variables into FileCheck variables. This significantly reduces

--- a/utils/dev-scripts/blockifyasm
+++ b/utils/dev-scripts/blockifyasm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # blockifyasm ----- Split disassembly into basic blocks ---------*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/dev-scripts/csvcolumn_to_scurve.py
+++ b/utils/dev-scripts/csvcolumn_to_scurve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a simple script that reads in a csv file, selects a column, and then
 # forms an "s-curve" graph of that column.

--- a/utils/dev-scripts/scurve_printer.py
+++ b/utils/dev-scripts/scurve_printer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a simple script that takes in an scurve file produced by
 # csvcolumn_to_scurve and produces a png graph of the scurve.

--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # split-cmdline - Split swift compiler command lines ------------*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/generate_confusables.py
+++ b/utils/generate_confusables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 # utils/update_confusables.py - Utility to update definitions of unicode
 # confusables

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 

--- a/utils/incrparse/incr_transfer_round_trip.py
+++ b/utils/incrparse/incr_transfer_round_trip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/incrparse/validate_parse.py
+++ b/utils/incrparse/validate_parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/jobstats/__init__.py
+++ b/utils/jobstats/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # line-directive.py - Transform line numbers in error messages -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/optimizer_counters_to_sql.py
+++ b/utils/optimizer_counters_to_sql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # optimizer_counters_to_sql.py - Store CSV counters into SQLite  -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- process-stats-dir - summarize one or more Swift -stats-output-dirs --==#
 #

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import argparse

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # remote-run - Runs a command on another machine, for testing -----*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # A small utility to take the output of a Swift validation test run
 # where some compiler crashers have been fixed, and move them into the

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function, unicode_literals
 

--- a/utils/rth
+++ b/utils/rth
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/rth - Resilience test helper
 #
 # This source file is part of the Swift.org open source project

--- a/utils/rusage.py
+++ b/utils/rusage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/rusage.py - Utility to measure resource usage -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # -*- python -*-
 #

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/sil-opt-verify-all-modules.py - Verifies Swift modules -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/split_file.py
+++ b/utils/split_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Utility script for submitting benchmark results to an LNT server."""
 

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This tool dumps imported Swift APIs to help validate changes in the
 # projection of (Objective-)C APIs into Swift, which is a function of the

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===--- swift-bench.py ------------------------------*- coding: utf-8 -*-===//
 #
 # This source file is part of the Swift.org open source project

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # On Darwin, dynamic libraries have an install name.  At link time, the
 # linker can work with a dylib anywhere in the filesystem, but it will

--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/utils/swift_build_support/run_tests.py
+++ b/utils/swift_build_support/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #

--- a/utils/swift_build_support/tests/mock-distcc
+++ b/utils/swift_build_support/tests/mock-distcc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # mock-distcc - discc mock used from tests ----------------------*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # symbolicate-linux-fatal - Symbolicate Linux stack traces -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/type-layout-fuzzer.py
+++ b/utils/type-layout-fuzzer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script outputs a Swift source with randomly-generated type definitions,
 # which can be used for ABI or layout algorithm fuzzing.

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # viewcfg - A script for viewing the CFG of SIL and LLVM IR -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Note that this test should still "pass" when no swiftinterfaces have been
 # generated.


### PR DESCRIPTION
This project has been built on Python 3 for a while so this shouldn't be
disruptive. More importantly, it's actually kind of hard to install
a `python` executable on a new Mac computer as Homebrew and Apple
toolchains no longer include Python 2.