### PR TITLE
[build-presets] Disable SourceKit-LSP tests for SwiftPM Linux CI jobs

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1705,6 +1705,8 @@ mixin-preset=mixin_swiftpm_linux_platform
 
 skip-test-llbuild
 skip-test-swiftpm
+# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
+skip-test-sourcekit-lsp
 
 
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause.

Resolves rdar://89359439