### PR TITLE
[CodeCompletion] Migrate ForEachSequence and PostfixExprBeginning to solver-based

### DIFF
--- a/include/swift/IDE/ExprCompletion.h
+++ b/include/swift/IDE/ExprCompletion.h
@@ -23,9 +23,6 @@ namespace ide {
 class ExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
 public:
   struct Result {
-    /// The contextual type that the code completion expression should produce.
-    Type ExpectedType;
-
     /// If the code completion expression is an implicit return in a
     /// single-expression closure.
     bool IsImplicitSingleExpressionReturn;
@@ -38,13 +35,36 @@ public:
     /// this result. This in particular includes parameters of closures that
     /// were type-checked with the code completion expression.
     llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+
+    bool operator==(const Result &Other) const;
   };
 
 private:
   CodeCompletionExpr *CompletionExpr;
   DeclContext *DC;
 
+  /// The contextual types to which the code completion results should be
+  /// convertible.
+  /// Technically, each result should have its own expected type because some
+  /// expected types may only be available e.g. for certain
+  /// \c SolutionSpecificVarTypes. But that means that we need to do a separate
+  /// completion lookup for each expected type and de-duplicate the results,
+  /// which can have huge performance implications (>5mins instead of <2secs).
+  /// In practice sharing ExpectedTypes between results yields identical results
+  /// in almost all cases and acceptable results in the other cases.
+  SmallVector<Type, 4> ExpectedTypes;
+
   SmallVector<Result, 4> Results;
+
+  /// Adds the given type to \c ExpectedTypes unless \c ExpectedTypes already
+  /// contains the type.
+  void addExpectedType(Type ExpectedType);
+
+  /// Adds the result with the given parameters to \c Results unless \c Results
+  /// already contains an entry with exactly the same values.
+  void addResult(
+      bool IsImplicitSingleExpressionReturn, bool IsInAsyncContext,
+      llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes);
 
   void sawSolutionImpl(const constraints::Solution &solution) override;
 

--- a/include/swift/IDE/TypeCheckCompletionCallback.h
+++ b/include/swift/IDE/TypeCheckCompletionCallback.h
@@ -90,6 +90,9 @@ bool isImplicitSingleExpressionReturn(constraints::ConstraintSystem &CS,
 /// Returns \c true iff the decl context \p DC allows calling async functions.
 bool isContextAsync(const constraints::Solution &S, DeclContext *DC);
 
+/// Returns true if both types are null or if they are equal.
+bool nullableTypesEqual(Type LHS, Type RHS);
+
 } // namespace ide
 } // namespace swift
 

--- a/include/swift/IDE/TypeCheckCompletionCallback.h
+++ b/include/swift/IDE/TypeCheckCompletionCallback.h
@@ -67,7 +67,13 @@ public:
 
 // MARK: - Utility functions for subclasses of TypeCheckCompletionCallback
 
-Type getTypeForCompletion(const constraints::Solution &S, Expr *E);
+Type getTypeForCompletion(const constraints::Solution &S, ASTNode Node);
+
+/// If \p E occurs in a pattern matching position, returns the type that it is
+/// being pattern-matched against.
+/// If that type is an enum, it allows us to suggest the enum cases for the code
+/// completion expression \p E.
+Type getPatternMatchType(const constraints::Solution &S, Expr *E);
 
 /// Whether the given completion expression is the only expression in its
 /// containing closure or function body and its value is implicitly returned.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4308,11 +4308,11 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
-  assert((conformingReplacementType->is<ErrorType>()
-          || conformingReplacementType->is<SubstitutableType>()
-          || conformingReplacementType->is<DependentMemberType>()
-          || conformingReplacementType->is<TypeVariableType>())
-         && "replacement requires looking up a concrete conformance");
+  assert((conformingReplacementType->is<ErrorType>() ||
+          conformingReplacementType->is<SubstitutableType>() ||
+          conformingReplacementType->is<DependentMemberType>() ||
+          conformingReplacementType->hasTypeVariable()) &&
+         "replacement requires looking up a concrete conformance");
   // A class-constrained archetype might conform to the protocol
   // concretely.
   if (auto *archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -20,18 +20,6 @@ using namespace swift;
 using namespace swift::ide;
 using namespace swift::constraints;
 
-/// Returns true if both types are null or if they are equal.
-static bool nullableTypesEqual(Type LHS, Type RHS) {
-  if (LHS.isNull() && RHS.isNull()) {
-    return true;
-  } else if (LHS.isNull() || RHS.isNull()) {
-    // One type is null but the other is not.
-    return false;
-  } else {
-    return LHS->isEqual(RHS);
-  }
-}
-
 bool ArgumentTypeCheckCompletionCallback::addPossibleParams(
     const ArgumentTypeCheckCompletionCallback::Result &Res,
     SmallVectorImpl<PossibleParamInfo> &Params, SmallVectorImpl<Type> &Types) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1396,7 +1396,9 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
                           CurDeclContext, CompletionContext, Consumer);
     return true;
   }
-  case CompletionKind::StmtOrExpr: {
+  case CompletionKind::StmtOrExpr:
+  case CompletionKind::ForEachSequence:
+  case CompletionKind::PostfixExprBeginning: {
     assert(CodeCompleteTokenExpr);
     assert(CurDeclContext);
 
@@ -1539,17 +1541,10 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::KeyPathExprSwift:
   case CompletionKind::CallArg:
   case CompletionKind::StmtOrExpr:
+  case CompletionKind::ForEachSequence:
+  case CompletionKind::PostfixExprBeginning:
     llvm_unreachable("should be already handled");
     return;
-
-  case CompletionKind::ForEachSequence:
-  case CompletionKind::PostfixExprBeginning: {
-    ExprContextInfo ContextInfo(CurDeclContext, CodeCompleteTokenExpr);
-    Lookup.setExpectedTypes(ContextInfo.getPossibleTypes(),
-                            ContextInfo.isImplicitSingleExpressionReturn());
-    DoPostfixExprBeginning();
-    break;
-  }
 
   case CompletionKind::PostfixExpr: {
     Lookup.setHaveLeadingSpace(HasSpace);

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -19,6 +19,54 @@ using namespace swift;
 using namespace swift::ide;
 using namespace swift::constraints;
 
+static bool solutionSpecificVarTypesEqual(
+    const llvm::SmallDenseMap<const VarDecl *, Type> &LHS,
+    const llvm::SmallDenseMap<const VarDecl *, Type> &RHS) {
+  if (LHS.size() != RHS.size()) {
+    return false;
+  }
+  for (auto LHSEntry : LHS) {
+    auto RHSEntry = RHS.find(LHSEntry.first);
+    if (RHSEntry == RHS.end()) {
+      // Entry of the LHS doesn't exist in RHS
+      return false;
+    } else if (!nullableTypesEqual(LHSEntry.second, RHSEntry->second)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ExprTypeCheckCompletionCallback::Result::operator==(
+    const Result &Other) const {
+  return IsImplicitSingleExpressionReturn ==
+             Other.IsImplicitSingleExpressionReturn &&
+         IsInAsyncContext == Other.IsInAsyncContext &&
+         solutionSpecificVarTypesEqual(SolutionSpecificVarTypes,
+                                       Other.SolutionSpecificVarTypes);
+}
+
+void ExprTypeCheckCompletionCallback::addExpectedType(Type ExpectedType) {
+  auto IsEqual = [&ExpectedType](Type Other) {
+    return nullableTypesEqual(ExpectedType, Other);
+  };
+  if (llvm::any_of(ExpectedTypes, IsEqual)) {
+    return;
+  }
+  ExpectedTypes.push_back(ExpectedType);
+}
+
+void ExprTypeCheckCompletionCallback::addResult(
+    bool IsImplicitSingleExpressionReturn, bool IsInAsyncContext,
+    llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes) {
+  Result NewResult = {IsImplicitSingleExpressionReturn, IsInAsyncContext,
+                      SolutionSpecificVarTypes};
+  if (llvm::is_contained(Results, NewResult)) {
+    return;
+  }
+  Results.push_back(NewResult);
+}
+
 void ExprTypeCheckCompletionCallback::sawSolutionImpl(
     const constraints::Solution &S) {
   auto &CS = S.getConstraintSystem();
@@ -36,12 +84,11 @@ void ExprTypeCheckCompletionCallback::sawSolutionImpl(
     }
   }
 
-  Results.push_back(
-      {ExpectedTy, ImplicitReturn, IsAsync, SolutionSpecificVarTypes});
+  addResult(ImplicitReturn, IsAsync, SolutionSpecificVarTypes);
+  addExpectedType(ExpectedTy);
 
   if (auto PatternMatchType = getPatternMatchType(S, CompletionExpr)) {
-    Results.push_back(
-        {PatternMatchType, ImplicitReturn, IsAsync, SolutionSpecificVarTypes});
+    addExpectedType(PatternMatchType);
   }
 }
 
@@ -53,10 +100,6 @@ void ExprTypeCheckCompletionCallback::deliverResults(
                           &CompletionCtx);
   Lookup.shouldCheckForDuplicates(Results.size() > 1);
 
-  SmallVector<Type, 2> ExpectedTypes;
-  for (auto &Result : Results) {
-    ExpectedTypes.push_back(Result.ExpectedType);
-  }
   for (auto &Result : Results) {
     Lookup.setExpectedTypes(ExpectedTypes,
                             Result.IsImplicitSingleExpressionReturn);

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -107,6 +107,10 @@ void swift::ide::typeCheckContextAt(DeclContext *DC, SourceLoc Loc) {
         auto *Param = AFD->getParameters()->get(defaultArg->getIndex());
         (void)Param->getTypeCheckedDefaultExpr();
       }
+      if (auto *SD = dyn_cast<SubscriptDecl>(defaultArg->getParent())) {
+        auto *Param = SD->getIndices()->get(defaultArg->getIndex());
+        (void)Param->getTypeCheckedDefaultExpr();
+      }
     }
     break;
 

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -208,3 +208,14 @@ bool swift::ide::isContextAsync(const constraints::Solution &S,
   //    async.
   return canDeclContextHandleAsync(DC);
 }
+
+bool swift::ide::nullableTypesEqual(Type LHS, Type RHS) {
+  if (LHS.isNull() && RHS.isNull()) {
+    return true;
+  } else if (LHS.isNull() || RHS.isNull()) {
+    // One type is null but the other is not.
+    return false;
+  } else {
+    return LHS->isEqual(RHS);
+  }
+}

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -40,8 +40,9 @@ void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
 
 // MARK: - Utility functions for subclasses of TypeCheckCompletionCallback
 
-Type swift::ide::getTypeForCompletion(const constraints::Solution &S, Expr *E) {
-  if (!S.hasType(E)) {
+Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
+                                      ASTNode Node) {
+  if (!S.hasType(Node)) {
     assert(false && "Expression wasn't type checked?");
     return nullptr;
   }
@@ -66,8 +67,8 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S, Expr *E) {
   // expression should still have a type of `[T]` instead of `[<<hole>>]`
   // because it helps to produce correct contextual member list based on
   // a conformance requirement associated with generic parameter `T`.
-  if (isa<CodeCompletionExpr>(E)) {
-    auto completionTy = S.getType(E).transform([&](Type type) -> Type {
+  if (isExpr<CodeCompletionExpr>(Node)) {
+    auto completionTy = S.getType(Node).transform([&](Type type) -> Type {
       if (auto *typeVar = type->getAs<TypeVariableType>())
         return S.getFixedType(typeVar);
       return type;
@@ -92,16 +93,75 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S, Expr *E) {
       return type;
     }));
   } else {
-    Result = S.getResolvedType(E);
+    Result = S.getResolvedType(Node);
   }
 
   if (!Result || Result->is<UnresolvedType>()) {
-    Result = CS.getContextualType(E, /*forConstraint=*/false);
+    Result = CS.getContextualType(Node, /*forConstraint=*/false);
   }
   if (Result && Result->is<UnresolvedType>()) {
     Result = Type();
   }
   return Result;
+}
+
+/// If the code completion expression \p E occurs in a pattern matching
+/// position, we have an AST that looks like this.
+/// \code
+/// (binary_expr implicit type='$T3'
+///   (overloaded_decl_ref_expr function_ref=compound decls=[
+///     Swift.(file).~=,
+///     Swift.(file).Optional extension.~=])
+///   (argument_list implicit
+///     (argument
+///       (code_completion_expr implicit type='$T1'))
+///     (argument
+///       (declref_expr implicit decl=swift_ide_test.(file).foo(x:).$match))))
+/// \endcode
+/// If the code completion expression occurs in such an AST, return the
+/// declaration of the \c $match variable, otherwise return \c nullptr.
+static VarDecl *getMatchVarIfInPatternMatch(Expr *E, ConstraintSystem &CS) {
+  auto &Context = CS.getASTContext();
+
+  auto *Binary = dyn_cast_or_null<BinaryExpr>(CS.getParentExpr(E));
+  if (!Binary || !Binary->isImplicit() || Binary->getLHS() != E) {
+    return nullptr;
+  }
+
+  auto CalledOperator = Binary->getFn();
+  if (!isPatternMatchingOperator(CalledOperator)) {
+    return nullptr;
+  }
+
+  auto MatchArg = dyn_cast_or_null<DeclRefExpr>(Binary->getRHS());
+  if (!MatchArg || !MatchArg->isImplicit()) {
+    return nullptr;
+  }
+
+  auto MatchVar = MatchArg->getDecl();
+  if (MatchVar && MatchVar->isImplicit() &&
+      MatchVar->getBaseName() == Context.Id_PatternMatchVar) {
+    return dyn_cast<VarDecl>(MatchVar);
+  } else {
+    return nullptr;
+  }
+}
+
+Type swift::ide::getPatternMatchType(const constraints::Solution &S, Expr *E) {
+  if (auto MatchVar = getMatchVarIfInPatternMatch(E, S.getConstraintSystem())) {
+    Type MatchVarType;
+    // If the MatchVar has an explicit type, it's not part of the solution. But
+    // we can look it up in the constraint system directly.
+    if (auto T = S.getConstraintSystem().getVarType(MatchVar)) {
+      MatchVarType = T;
+    } else {
+      MatchVarType = getTypeForCompletion(S, MatchVar);
+    }
+    if (MatchVarType) {
+      return MatchVarType;
+    }
+  }
+  return nullptr;
 }
 
 bool swift::ide::isImplicitSingleExpressionReturn(ConstraintSystem &CS,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1760,6 +1760,11 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       }
     }
     consumeToken(tok::code_complete);
+    if (canParseAsGenericArgumentList()) {
+      SmallVector<TypeRepr*, 8> args;
+      SourceLoc LAngleLoc, RAngleLoc;
+      parseGenericArguments(args, LAngleLoc, RAngleLoc);
+    }
     return Result;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -433,7 +433,11 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
 Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
                                             DeclContext *DC, Type paramType,
                                             bool isAutoClosure) {
-  assert(paramType && !paramType->hasError());
+  // During normal type checking we don't type check the parameter default if
+  // the param has an error type. For code completion, we also type check the
+  // parameter default because it might contain the code completion token.
+  assert(paramType &&
+         (!paramType->hasError() || DC->getASTContext().CompletionCallback));
 
   auto &ctx = DC->getASTContext();
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1039,7 +1039,10 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
   auto *initExpr = param->getStructuralDefaultExpr();
   assert(initExpr);
 
-  if (paramTy->hasError())
+  // If the param has an error type, there's no point type checking the default
+  // expression, unless we are type checking for code completion, in which case
+  // the default expression might contain the code completion token.
+  if (paramTy->hasError() && !ctx.CompletionCallback)
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), ErrorType::get(ctx));
 
   auto *dc = param->getDefaultArgumentInitContext();

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -341,9 +341,7 @@ struct A<T>: MyProto {
     }
 }
 // BROKEN_CONFORMANCE_UNASSIGNABLE: Begin completions
-// BROKEN_CONFORMANCE_UNASSIGNABLE-NOT: TypeRelation
 // BROKEN_CONFORMANCE_UNASSIGNABLE: Decl[InstanceMethod]/Super:         first()[#MyProto.Element#]; name=first()
-// BROKEN_CONFORMANCE_UNASSIGNABLE-NOT: TypeRelation
 // BROKEN_CONFORMANCE_UNASSIGNABLE: End completions
 
 // BROKEN_CONFORMANCE_ASSIGNABLE: Begin completions

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -361,3 +361,19 @@ func testInitWithUnresolved() {
 // INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg2: _#}[')'][#InitWithUnresolved<_>#];
 // INIT_WITH_UNRESOLVEDTYPE_1: End completions
 }
+
+func testIgnoreGenericArgsAfterCompletionToken() {
+  struct IPv4 {}
+
+  public struct HostRecord<IPType> {
+    init(position: inout Int) throws {}
+  }
+
+  func deserializeRecord() throws -> HostRecord<IPv4> {
+    var position = 42
+    return try #^IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN^#HostRecord<IPv4>(position: &position)
+// IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN: Begin completions
+// IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN-DAG: Decl[Struct]/Local: HostRecord[#HostRecord#];
+// IGNORE_GENERIC_ARGS_AFTER_COMPLETION_TOKEN: End completions
+  }
+}

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -88,21 +88,21 @@ func test002() {
   throw #^THROW1^#
 
 // THROW1:      Begin completions
-// THROW1-DAG:  Decl[Enum]/CurrModule:              Error4[#Error4#]; name=Error4{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule:             Error3[#Error3#]; name=Error3{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule:             Error2[#Error2#]; name=Error2{{$}}
-// THROW1-DAG:  Decl[Class]/CurrModule:             Error1[#Error1#]; name=Error1{{$}}
-// THROW1-DAG:  Decl[Protocol]/CurrModule/Flair[RareType]: ErrorPro1[#ErrorPro1#]; name=ErrorPro1{{$}}
-// THROW1-DAG:  Decl[FreeFunction]/CurrModule:      getError1()[#Error1#]{{; name=.+$}}
-// THROW1-DAG:  Decl[FreeFunction]/CurrModule:      getNSError()[#NSError#]{{; name=.+$}}
+// THROW1-DAG:  Decl[Enum]/CurrModule/TypeRelation[Convertible]:              Error4[#Error4#]; name=Error4{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error3[#Error3#]; name=Error3{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error2[#Error2#]; name=Error2{{$}}
+// THROW1-DAG:  Decl[Class]/CurrModule/TypeRelation[Convertible]:             Error1[#Error1#]; name=Error1{{$}}
+// THROW1-DAG:  Decl[Protocol]/CurrModule/Flair[RareType]/TypeRelation[Convertible]: ErrorPro1[#ErrorPro1#]; name=ErrorPro1{{$}}
+// THROW1-DAG:  Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]:      getError1()[#Error1#]{{; name=.+$}}
+// THROW1-DAG:  Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]:      getNSError()[#NSError#]{{; name=.+$}}
 
 // If we could prove that there is no way to get to an Error value by
 // starting from these, we could remove them.  But that may be infeasible in
 // the presence of overloaded operators.
 // THROW1-DAG: Decl[Class]/CurrModule:             NoneError1[#NoneError1#]; name=NoneError1{{$}}
 // THROW1-LOCAL: Decl[LocalVar]/Local:               text[#String#]; name=text{{$}}
-// THROW1-LOCAL: Decl[LocalVar]/Local:               e1[#Error1#]; name=e1{{$}}
-// THROW1-LOCAL: Decl[LocalVar]/Local:               e2[#Error2#]; name=e2{{$}}
+// THROW1-LOCAL: Decl[LocalVar]/Local/TypeRelation[Convertible]:               e1[#Error1#]; name=e1{{$}}
+// THROW1-LOCAL: Decl[LocalVar]/Local/TypeRelation[Convertible]:               e2[#Error2#]; name=e2{{$}}
 }
 
 func test003() {

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -435,9 +435,14 @@ func testInForEach9(arg: Int) {
 }
 func testInForEach10(arg: Int) {
   let local = 2
-  for index in [1:2, #^IN_FOR_EACH_10?check=IN_FOR_EACH_1^#] {}
+  for index in [1:2, #^IN_FOR_EACH_10^#] {}
   let after = 4
 }
+// IN_FOR_EACH_10-NOT: Decl[LocalVar]
+// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Identical]:               local[#Int#];
+// IN_FOR_EACH_10-NOT: after
+// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Identical]:               arg[#Int#];
+// IN_FOR_EACH_10-NOT: Decl[LocalVar]
 func testInForEach11(arg: Int) {
   let local = 2
   for index in [1:2, #^IN_FOR_EACH_11?check=IN_FOR_EACH_2^#:] {}

--- a/test/IDE/complete_operator_operand.swift
+++ b/test/IDE/complete_operator_operand.swift
@@ -15,7 +15,9 @@ func test_binary1(c1: C1, c2: C2) {
 // BINARY_RHS_1: Begin completion
 // BINARY_RHS_1-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
 // BINARY_RHS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+}
 
+func test_binary2(c1: C1, c2: C2) {
   _ = c2 <--> #^BINARY_RHS_2^#
 // BINARY_RHS_2: Begin completion
 // BINARY_RHS_2-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -338,7 +338,7 @@ func testSwitchCaseWhereExpr1(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_1?check=COND_COMMON^#
+    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_1?check=COND_WHERE_COMMON^#
   }
 }
 
@@ -346,7 +346,7 @@ func testSwitchCaseWhereExpr2(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_2?check=COND_COMMON^#:
+    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_2?check=COND_WHERE_COMMON^#:
   }
 }
 
@@ -354,7 +354,7 @@ func testSwitchCaseWhereExpr3(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_3?check=COND_COMMON^# :
+    case (0, 0) where #^SWITCH_CASE_WHERE_EXPR_3?check=COND_WHERE_COMMON^# :
   }
 }
 
@@ -362,7 +362,7 @@ func testSwitchCaseWhereExprI1(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (var i, 0) where #^SWITCH_CASE_WHERE_EXPR_I_1?check=COND_COMMON;check=WITH_I_INT_LOCAL^#
+    case (var i, 0) where #^SWITCH_CASE_WHERE_EXPR_I_1?check=COND_WHERE_COMMON;check=WITH_I_INT_LOCAL^#
   }
 }
 
@@ -370,7 +370,7 @@ func testSwitchCaseWhereExprI2(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (0, var i) where #^SWITCH_CASE_WHERE_EXPR_I_2?check=COND_COMMON;check=WITH_I_INT_LOCAL^#
+    case (0, var i) where #^SWITCH_CASE_WHERE_EXPR_I_2?check=COND_WHERE_COMMON;check=WITH_I_INT_LOCAL^#
   }
 }
 
@@ -378,7 +378,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
   var localInt = 42
   var localFooObject = FooStruct(localInt)
   switch (0, 42) {
-    case (var i, var j) where #^SWITCH_CASE_WHERE_EXPR_I_J_1?check=COND_COMMON;check=WITH_I_INT_LOCAL;check=WITH_J_INT^#
+    case (var i, var j) where #^SWITCH_CASE_WHERE_EXPR_I_J_1?check=COND_WHERE_COMMON;check=WITH_I_INT_LOCAL;check=WITH_J_INT^#
   }
 }
 
@@ -393,6 +393,16 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 // COND_COMMON-DAG: Decl[LocalVar]/Local:        localFooObject[#FooStruct#]{{; name=.+$}}
 // COND_COMMON-DAG: Decl[Struct]/CurrModule:     FooStruct[#FooStruct#]{{; name=.+$}}
 // COND_COMMON: End completions
+
+// COND_WHERE_COMMON: Begin completions
+// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Identical]: true[#Bool#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Identical]: false[#Bool#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        fooObject[#FooStruct#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        localInt[#Int#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        localFooObject[#FooStruct#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Decl[Struct]/CurrModule:     FooStruct[#FooStruct#]{{; name=.+$}}
+// COND_WHERE_COMMON: End completions
+
 
 // COND-WITH-RELATION: Begin completions
 // COND-WITH-RELATION-DAG: Literal[Boolean]/None/TypeRelation[Identical]: true[#Bool#]{{; name=.+$}}


### PR DESCRIPTION
Migrate two more completion kinds (ForEachSequence and PostfixExprBeginning) to the solver-based implementation.