### PR TITLE
Reuse `_DictionaryStorage<Key, AnyObject>` metadata for any `_DictionaryStorage<Key, SomeClass>` where `SomeClass is AnyObject`

### DIFF
--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -40,6 +40,12 @@ extension _NativeDictionary { // Bridging
       nsDictionary = __RawDictionaryStorage.empty
     } else if _isBridgedVerbatimToObjectiveC(Key.self),
       _isBridgedVerbatimToObjectiveC(Value.self) {
+      // Set proper metadata for _storage. We need it for the zero-cost
+      // bridge back case.
+      if #available(SwiftStdlib 5.7, *) {
+        _swift_setClassMetadata(_DictionaryStorage<Key, Value>.self,
+                                onObject: _storage)
+      }
       nsDictionary = unsafeDowncast(
         _storage,
         to: _DictionaryStorage<Key, Value>.self)

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -434,6 +434,17 @@ extension _DictionaryStorage {
   }
 #endif
 
+  @inline(never)
+  static internal func getDictionaryStorageType(
+  ) -> _DictionaryStorage<Key, Value>.Type {
+    if Value.self is AnyObject.Type {
+      return _uncheckedUnsafeBitCast(
+        _DictionaryStorage<Key, AnyObject>.self,
+        to: _DictionaryStorage<Key, Value>.Type.self)
+    }
+    return _DictionaryStorage<Key, Value>.self
+  }
+
   static internal func allocate(
     scale: Int8,
     age: Int32?,
@@ -446,7 +457,7 @@ extension _DictionaryStorage {
     let bucketCount = (1 as Int) &<< scale
     let wordCount = _UnsafeBitset.wordCount(forCapacity: bucketCount)
     let storage = Builtin.allocWithTailElems_3(
-      _DictionaryStorage<Key, Value>.self,
+      getDictionaryStorageType(),
       wordCount._builtinWordValue, _HashTable.Word.self,
       bucketCount._builtinWordValue, Key.self,
       bucketCount._builtinWordValue, Value.self)


### PR DESCRIPTION
Like #41338 this reduces the number of dynamic _DictionaryStorage metadata at
runtime.

rdar://90487188