### PR TITLE
[CSClosure] Remove last remaining uses of one-way constraints

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -363,7 +363,7 @@ private:
     // Generate constraints to initialize the pattern.
     auto initType =
         cs.generateConstraints(pattern, contextualLocator,
-                               /*shouldBindPatternOneWay=*/true,
+                               /*shouldBindPatternOneWay=*/false,
                                /*patternBinding=*/nullptr, /*patternIndex=*/0);
 
     if (!initType) {
@@ -434,7 +434,7 @@ private:
     {
       auto target = SolutionApplicationTarget::forForEachStmt(
           forEachStmt, sequenceProto, closure,
-          /*bindTypeVarsOneWay=*/true,
+          /*bindTypeVarsOneWay=*/false,
           /*contextualPurpose=*/CTP_ForEachSequence);
 
       auto &targetInfo = target.getForEachStmtInfo();
@@ -451,9 +451,9 @@ private:
   }
 
   void visitCaseItemPattern(Pattern *pattern, ContextualTypeInfo context) {
-    Type patternType =
-        cs.generateConstraints(pattern, locator, /*bindPatternVarsOneWay=*/true,
-                               /*patternBinding=*/nullptr, /*patternIndex=*/0);
+    Type patternType = cs.generateConstraints(
+        pattern, locator, /*bindPatternVarsOneWay=*/false,
+        /*patternBinding=*/nullptr, /*patternIndex=*/0);
 
     if (!patternType) {
       hadError = true;


### PR DESCRIPTION
Removes uses of one-way constraint from for-in conditions and
case patterns which are solved via conjunctions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
