### PR TITLE
Parse: Require a "before: " label in @_backDeploy attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -39,14 +39,19 @@ Most notably, default argument expressions are implicitly
 `@_alwaysEmitIntoClient`, which means that adding a default argument to a
 function which did not have one previously does not break ABI.
 
-## `@_backDeploy(availabilitySpec ...)`
+## `@_backDeploy(before: ...)`
 
 Causes the body of a function to be emitted into the module interface to be
-available for inlining in clients with deployment targets lower than the formal
-availability of the function. When inlined, the body of the function is
-transformed such that it calls the library's copy of the function if it is
-available at runtime. Otherwise, the copy of the original function body is
-executed.
+available for emission into clients with deployment targets lower than the
+ABI availability of the function. When the client's deployment target is
+before the function's ABI availability, the compiler replaces calls to that
+function with a call to a thunk that checks at runtime whether the original
+library function is available. If the the original is available then it is
+called. Otherwise, the fallback copy of the function that was emitted into the
+client is called instead.
+
+For more details, see the [pitch thread](https://forums.swift.org/t/pitch-function-back-deployment/55769/)
+in the forums.
 
 ## `@_assemblyVision`
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1572,6 +1572,10 @@ ERROR(originally_defined_in_need_nonempty_module_name,none,
       "original module name cannot be empty in @_originallyDefinedIn", ())
 
 // backDeploy
+ERROR(attr_back_deploy_expected_before_label,none,
+      "expected 'before:' in '@_backDeploy' attribute", ())
+ERROR(attr_back_deploy_expected_colon_after_before,none,
+      "expected ':' after 'before' in '@_backDeploy' attribute", ())
 ERROR(attr_back_deploy_missing_rparen,none,
       "expected ')' in '@_backDeploy' argument list", ())
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -895,6 +895,22 @@ public:
   /// close brace.
   SourceLoc getErrorOrMissingLoc() const;
 
+  enum class ParseListItemResult {
+    /// There are more list items to parse.
+    Continue,
+    /// The list ended inside a string literal interpolation context.
+    FinishedInStringInterpolation,
+    /// The list ended for another reason.
+    Finished,
+  };
+
+  /// Parses a single item from a comma separated list and updates `Status`.
+  ParseListItemResult
+  parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
+                SourceLoc &RightLoc, bool AllowSepAfterLast,
+                SyntaxKind ElementKind,
+                llvm::function_ref<ParserStatus()> callback);
+
   /// Parse a comma separated list of some elements.
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
                          bool AllowSepAfterLast, Diag<> ErrorDiag,
@@ -1069,6 +1085,10 @@ public:
   /// Parse the @transpose attribute.
   ParserResult<TransposeAttr> parseTransposeAttribute(SourceLoc AtLoc,
                                                       SourceLoc Loc);
+
+  /// Parse the @_backDeploy attribute.
+  bool parseBackDeployAttribute(DeclAttributes &Attributes, StringRef AttrName,
+                                SourceLoc AtLoc, SourceLoc Loc);
 
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1215,7 +1215,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_BackDeploy: {
     Printer.printAttrName("@_backDeploy");
-    Printer << "(";
+    Printer << "(before: ";
     auto Attr = cast<BackDeployAttr>(this);
     Printer << platformString(Attr->Platform) << " " <<
       Attr->Version.getAsString();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1848,9 +1848,11 @@ bool Parser::parseBackDeployAttribute(DeclAttributes &Attributes,
     if (Tok.is(tok::identifier) && Tok.getText() == "before") {
       consumeToken();
       if (!consumeIf(tok::colon))
-        diagnose(Tok, diag::attr_back_deploy_expected_colon_after_before);
+        diagnose(Tok, diag::attr_back_deploy_expected_colon_after_before)
+            .fixItInsertAfter(PreviousLoc, ":");
     } else {
-      diagnose(Tok, diag::attr_back_deploy_expected_before_label);
+      diagnose(Tok, diag::attr_back_deploy_expected_before_label)
+          .fixItInsertAfter(PreviousLoc, "before:");
     }
 
     // Parse the version list.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1824,6 +1824,76 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
   return makeParserSuccess();
 }
 
+bool Parser::parseBackDeployAttribute(DeclAttributes &Attributes,
+                                      StringRef AttrName, SourceLoc AtLoc,
+                                      SourceLoc Loc) {
+  std::string AtAttrName = (llvm::Twine("@") + AttrName).str();
+  auto LeftLoc = Tok.getLoc();
+  if (!consumeIf(tok::l_paren)) {
+    diagnose(Loc, diag::attr_expected_lparen, AtAttrName,
+             DeclAttribute::isDeclModifier(DAK_BackDeploy));
+    return false;
+  }
+
+  SourceLoc RightLoc;
+  ParserStatus Status;
+  bool SuppressLaterDiags = false;
+  llvm::SmallVector<PlatformAndVersion, 4> PlatformAndVersions;
+
+  {
+    SyntaxParsingContext SpecListListContext(
+        SyntaxContext, SyntaxKind::BackDeployAttributeSpecList);
+
+    // Parse 'before' ':'.
+    if (Tok.is(tok::identifier) && Tok.getText() == "before") {
+      consumeToken();
+      if (!consumeIf(tok::colon))
+        diagnose(Tok, diag::attr_back_deploy_expected_colon_after_before);
+    } else {
+      diagnose(Tok, diag::attr_back_deploy_expected_before_label);
+    }
+
+    // Parse the version list.
+    if (!Tok.is(tok::r_paren)) {
+      SyntaxParsingContext VersionListContext(
+          SyntaxContext, SyntaxKind::BackDeployVersionList);
+
+      ParseListItemResult Result;
+      do {
+        Result = parseListItem(Status, tok::r_paren, LeftLoc, RightLoc,
+                               /*AllowSepAfterLast=*/false,
+                               SyntaxKind::BackDeployVersionArgument,
+                               [&]() -> ParserStatus {
+                                 return parsePlatformVersionInList(
+                                     AtAttrName, PlatformAndVersions);
+                               });
+      } while (Result == ParseListItemResult::Continue);
+    }
+  }
+
+  if (parseMatchingToken(tok::r_paren, RightLoc,
+                         diag::attr_back_deploy_missing_rparen, LeftLoc))
+    return false;
+
+  if (Status.isErrorOrHasCompletion() || SuppressLaterDiags) {
+    return false;
+  }
+
+  if (PlatformAndVersions.empty()) {
+    diagnose(Loc, diag::attr_availability_need_platform_version, AtAttrName);
+    return false;
+  }
+
+  assert(!PlatformAndVersions.empty());
+  auto AttrRange = SourceRange(Loc, Tok.getLoc());
+  for (auto &Item : PlatformAndVersions) {
+    Attributes.add(new (Context)
+                       BackDeployAttr(AtLoc, AttrRange, Item.first, Item.second,
+                                      /*IsImplicit*/ false));
+  }
+  return true;
+}
+
 /// Processes a parsed option name by attempting to match it to a list of
 /// alternative name/value pairs provided by a chain of \c when() calls, ending
 /// in either \c whenOmitted() if omitting the option is allowed, or
@@ -2858,45 +2928,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
   case DAK_BackDeploy: {
-    auto LeftLoc = Tok.getLoc();
-    if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
+    if (!parseBackDeployAttribute(Attributes, AttrName, AtLoc, Loc))
       return false;
-    }
-
-    bool SuppressLaterDiags = false;
-    SourceLoc RightLoc;
-    llvm::SmallVector<PlatformAndVersion, 4> PlatformAndVersions;
-    StringRef AttrName = "@_backDeploy";
-    ParserStatus Status = parseList(tok::r_paren, LeftLoc, RightLoc, false,
-                                    diag::attr_back_deploy_missing_rparen,
-                                    SyntaxKind::AvailabilitySpecList,
-                                    [&]() -> ParserStatus {
-      ParserStatus ListItemStatus =
-          parsePlatformVersionInList(AttrName, PlatformAndVersions);
-      if (ListItemStatus.isErrorOrHasCompletion())
-        SuppressLaterDiags = true;
-      return ListItemStatus;
-    });
-
-    if (Status.isErrorOrHasCompletion() || SuppressLaterDiags) {
-      return false;
-    }
-
-    if (PlatformAndVersions.empty()) {
-      diagnose(Loc, diag::attr_availability_need_platform_version, AttrName);
-      return false;
-    }
-    
-    assert(!PlatformAndVersions.empty());
-    AttrRange = SourceRange(Loc, Tok.getLoc());
-    for (auto &Item: PlatformAndVersions) {
-      Attributes.add(new (Context) BackDeployAttr(AtLoc, AttrRange,
-                                                  Item.first,
-                                                  Item.second,
-                                                  /*IsImplicit*/false));
-    }
     break;
   }
   }

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -18,73 +18,73 @@
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
 public struct TopLevelStruct {
-  // CHECK: @_backDeploy(macOS 12.0)
+  // CHECK: @_backDeploy(before: macOS 12.0)
   // FROMSOURCE: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 42 }
   // FROMMODULE: public func backDeployedFunc_SinglePlatform() -> Swift.Int
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedFunc_SinglePlatform() -> Int { return 42 }
   
-  // CHECK: @_backDeploy(macOS 12.0)
-  // CHECK: @_backDeploy(iOS 15.0)
+  // CHECK: @_backDeploy(before: macOS 12.0)
+  // CHECK: @_backDeploy(before: iOS 15.0)
   // FROMSOURCE: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
   // FROMMODULE: public func backDeployedFunc_MultiPlatform() -> Swift.Int
   @available(macOS 11.0, iOS 14.0, *)
-  @_backDeploy(macOS 12.0, iOS 15.0)
+  @_backDeploy(before: macOS 12.0, iOS 15.0)
   public func backDeployedFunc_MultiPlatform() -> Int { return 43 }
 
-  // CHECK: @_backDeploy(macOS 12.0)
+  // CHECK: @_backDeploy(before: macOS 12.0)
   // FROMSOURCE: public var backDeployedComputedProperty: Swift.Int {
   // FROMSOURCE:   get { 44 }
   // FROMSOURCE: }
   // FROMMODULE: public var backDeployedComputedProperty: Swift.Int
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 44 }
 
-  // CHECK: @_backDeploy(macOS 12.0)
+  // CHECK: @_backDeploy(before: macOS 12.0)
   // FROMSOURCE: public var backDeployedPropertyWithAccessors: Swift.Int {
   // FROMSOURCE:   get { 45 }
   // FROMSOURCE: }
   // FROMMODULE: public var backDeployedPropertyWithAccessors: Swift.Int
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public var backDeployedPropertyWithAccessors: Int {
     get { 45 }
   }
 
-  // CHECK: @_backDeploy(macOS 12.0)
+  // CHECK: @_backDeploy(before: macOS 12.0)
   // FROMSOURCE: public subscript(index: Swift.Int) -> Swift.Int {
   // FROMSOURCE:   get { 46 }
   // FROMSOURCE: }
   // FROMMODULE: public subscript(index: Swift.Int) -> Swift.Int
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public subscript(index: Int) -> Int {
     get { 46 }
   }
 }
 
-// CHECK: @_backDeploy(macOS 12.0)
+// CHECK: @_backDeploy(before: macOS 12.0)
 // FROMSOURCE: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
 // FROMMODULE: public func backDeployTopLevelFunc1() -> Swift.Int
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 public func backDeployTopLevelFunc1() -> Int { return 47 }
 
 // MARK: - Availability macros
 
-// CHECK: @_backDeploy(macOS 12.1)
+// CHECK: @_backDeploy(before: macOS 12.1)
 // FROMSOURCE: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
 // FROMMODULE: public func backDeployTopLevelFunc2() -> Swift.Int
 @available(macOS 11.0, *)
-@_backDeploy(_macOS12_1)
+@_backDeploy(before: _macOS12_1)
 public func backDeployTopLevelFunc2() -> Int { return 48 }
 
-// CHECK: @_backDeploy(macOS 12.1)
-// CHECK: @_backDeploy(iOS 15.1)
+// CHECK: @_backDeploy(before: macOS 12.1)
+// CHECK: @_backDeploy(before: iOS 15.1)
 // FROMSOURCE: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
 // FROMMODULE: public func backDeployTopLevelFunc3() -> Swift.Int
 @available(macOS 11.0, iOS 14.0, *)
-@_backDeploy(_myProject 1.0)
+@_backDeploy(before: _myProject 1.0)
 public func backDeployTopLevelFunc3() -> Int { return 49 }

--- a/test/SILGen/back_deploy_attribute_accessor.swift
+++ b/test/SILGen/back_deploy_attribute_accessor.swift
@@ -38,7 +38,7 @@ public struct TopLevelStruct {
   // -- Original definition of TopLevelStruct.property.getter
   // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   @available(macOS 10.51, *)
-  @_backDeploy(macOS 10.52)
+  @_backDeploy(before: macOS 10.52)
   public var property: TopLevelStruct { self }
 }
 

--- a/test/SILGen/back_deploy_attribute_func.swift
+++ b/test/SILGen/back_deploy_attribute_func.swift
@@ -38,7 +38,7 @@
 // -- Original definition of trivialFunc()
 // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
 @available(macOS 10.51, *)
-@_backDeploy(macOS 10.52)
+@_backDeploy(before: macOS 10.52)
 public func trivialFunc() {}
 
 // -- Fallback definition of isNumber(_:)
@@ -73,7 +73,7 @@ public func trivialFunc() {}
 // -- Original definition of isNumber(_:)
 // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
 @available(macOS 10.51, *)
-@_backDeploy(macOS 10.52)
+@_backDeploy(before: macOS 10.52)
 public func isNumber(_ x: Int) -> Bool {
   return true
 }

--- a/test/SILGen/back_deploy_attribute_generic_func.swift
+++ b/test/SILGen/back_deploy_attribute_generic_func.swift
@@ -39,7 +39,7 @@
 // -- Original definition of genericFunc()
 // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 @available(macOS 10.51, *)
-@_backDeploy(macOS 10.52)
+@_backDeploy(before: macOS 10.52)
 public func genericFunc<T>(_ t: T) -> T {
   return t
 }

--- a/test/SILGen/back_deploy_attribute_struct_method.swift
+++ b/test/SILGen/back_deploy_attribute_struct_method.swift
@@ -40,7 +40,7 @@ public struct TopLevelStruct {
   // -- Original definition of TopLevelStruct.trivialMethod()
   // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
   @available(macOS 10.51, *)
-  @_backDeploy(macOS 10.52)
+  @_backDeploy(before: macOS 10.52)
   public func trivialMethod() {}
 }
 

--- a/test/SILGen/back_deploy_attribute_throwing_func.swift
+++ b/test/SILGen/back_deploy_attribute_throwing_func.swift
@@ -51,7 +51,7 @@
 // -- Original definition of throwingFunc()
 // CHECK-LABEL: sil [serialized] [available 10.51] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error Error
 @available(macOS 10.51, *)
-@_backDeploy(macOS 10.52)
+@_backDeploy(before: macOS 10.52)
 public func throwingFunc() throws {}
 
 // CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyKF : $@convention(thin) () -> @error Error

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -87,7 +87,7 @@ public func forbidMacrosInInlinableCode1() {
 }
 
 @available(_iOS8Aligned, *)
-@_backDeploy(_iOS9Aligned)
+@_backDeploy(before: _iOS9Aligned)
 public func forbidMacrosInInlinableCode2() {
   if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
   if #available(_iOS9, _macOS10_11, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}

--- a/test/attr/Inputs/BackDeployHelper.swift
+++ b/test/attr/Inputs/BackDeployHelper.swift
@@ -95,20 +95,20 @@ extension Int {
 #if !STRIP_V2_APIS
 
 @available(BackDeploy 1.0, *)
-@_backDeploy(BackDeploy 2.0)
+@_backDeploy(before: BackDeploy 2.0)
 public func trivial() {
   testPrint(handle: #dsohandle, "trivial")
 }
 
 @available(BackDeploy 1.0, *)
-@_backDeploy(BackDeploy 2.0)
+@_backDeploy(before: BackDeploy 2.0)
 public func pleaseThrow(_ shouldThrow: Bool) throws -> Bool {
   if shouldThrow { throw BadError.bad }
   return !shouldThrow
 }
 
 @available(BackDeploy 1.0, *)
-@_backDeploy(BackDeploy 2.0)
+@_backDeploy(before: BackDeploy 2.0)
 public func genericIncrement<T: Incrementable>(
   _ x: inout T,
   by amount: T.Operand
@@ -117,78 +117,78 @@ public func genericIncrement<T: Incrementable>(
 }
 
 @available(BackDeploy 1.0, *)
-@_backDeploy(BackDeploy 2.0)
+@_backDeploy(before: BackDeploy 2.0)
 public func existentialIncrementByOne(_ x: inout any Incrementable) {
   testPrint(handle: #dsohandle, x.incrementByOne())
 }
 
 extension MutableInt {
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public var value: Int { _value }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public func print() {
     // Tests recursive @_backDeploy since `value` is also @_backDeploy
     testPrint(handle: #dsohandle, String(value))
   }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public static var zero: Self { MutableInt(0) }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public mutating func decrement(by amount: Int) -> Int {
     _value -= amount
     return _value
   }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public func toIncrementable() -> any Incrementable { self }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public subscript(byteAt index: Int) -> UInt8 { _value.byte(at: index) }
 }
 
 extension ReferenceInt {
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final var value: Int { _value }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final func print() {
     // Tests recursive use of back deployed APIs, since `value` is also
     testPrint(handle: #dsohandle, String(value))
   }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final func copy() -> ReferenceInt {
     return ReferenceInt(value)
   }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final class var zero: ReferenceInt { ReferenceInt(0) }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final func decrement(by amount: Int) -> Int {
     _value -= amount
     return _value
   }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final func toIncrementable() -> any Incrementable { self }
 
   @available(BackDeploy 1.0, *)
-  @_backDeploy(BackDeploy 2.0)
+  @_backDeploy(before: BackDeploy 2.0)
   public final subscript(byteAt index: Int) -> UInt8 { _value.byte(at: index) }
 }
 

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -304,10 +304,34 @@ public func unknownMacroVersionned() {}
 @_backDeploy(before: _unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
 public func knownAndUnknownMacroVersionned() {}
 
-@_backDeploy() // expected-error {{expected at least one platform version in '@_backDeploy' attribute}}
+@_backDeploy() // expected-error {{expected 'before:' in '@_backDeploy' attribute}}
+// expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
+public func emptyAttributeFunc() {}
+
+@available(macOS 11.0, *)
+@_backDeploy(macOS 12.0) // expected-error {{expected 'before:' in '@_backDeploy' attribute}}
+public func missingBeforeFunc() {}
+
+@_backDeploy(before) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}}
+// expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
+public func missingColonAfterBeforeFunc() {}
+
+@available(macOS 11.0, *)
+@_backDeploy(before macOS 12.0) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}}
+public func missingColonBetweenBeforeAndPlatformFunc() {}
+
+@available(macOS 11.0, *)
+@_backDeploy(before: macOS 12.0,) // expected-error {{unexpected ',' separator}}
+public func unexpectedTrailingCommaFunc() {}
+
+@available(macOS 11.0, iOS 14.0, *)
+@_backDeploy(before: macOS 12.0,, iOS 15.0) // expected-error {{unexpected ',' separator}}
+public func extraCommaFunc() {}
+
+@_backDeploy(before:) // expected-error {{expected at least one platform version in '@_backDeploy' attribute}}
 public func emptyPlatformVersionsFunc() {}
 
-@_backDeploy // expected-error {{expected '(' in '_backDeploy' attribute}}
+@_backDeploy // expected-error {{expected '(' in '@_backDeploy' attribute}}
 public func expectedLeftParenFunc() {}
 
 @_backDeploy(before: macOS 12.0 // expected-note {{to match this opening '('}}

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -5,57 +5,57 @@
 
 // OK: top level functions
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 public func backDeployedTopLevelFunc() {}
 
 // OK: internal decls may be back deployed when @usableFromInline
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 @usableFromInline
 internal func backDeployedUsableFromInlineTopLevelFunc() {}
 
 // OK: function/property/subscript decls in a struct
 public struct TopLevelStruct {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {}
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 98 }
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public subscript(_ index: Int) -> Int { index }
 }
 
 // OK: final function decls in a non-final class
 public class TopLevelClass {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   final public func backDeployedFinalMethod() {}
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   final public var backDeployedFinalComputedProperty: Int { 98 }
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public static func backDeployedStaticMethod() {}
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public final class func backDeployedClassMethod() {}
 }
 
 // OK: function decls in a final class
 final public class FinalTopLevelClass {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {}
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 98 }
 }
 
@@ -63,31 +63,31 @@ final public class FinalTopLevelClass {
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 public actor TopLevelActor {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   final public func finalActorMethod() {}
 
   // OK: actor methods are effectively final
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func actorMethod() {}
 }
 
 // OK: function decls in extension on public types
 extension TopLevelStruct {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
 
 extension TopLevelClass {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   final public func backDeployedExtensionMethod() {}
 }
 
 extension FinalTopLevelClass {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
 
@@ -95,54 +95,54 @@ public protocol TopLevelProtocol {}
 
 extension TopLevelProtocol {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
 
 // MARK: - Unsupported declaration types
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public class CannotBackDeployClass {}
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public struct CannotBackDeployStruct {
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
   public var cannotBackDeployStoredProperty: Int = 83
 
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
   public lazy var cannotBackDeployLazyStoredProperty: Int = 15
 }
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public enum CannotBackDeployEnum {
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
   case cannotBackDeployEnumCase
 }
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}
 public var cannotBackDeployTopLevelVar = 79
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 extension TopLevelStruct {}
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 protocol CannotBackDeployProtocol {}
 
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
 
 // FIXME(backDeploy): support coroutines rdar://90111169
 public struct CannotBackDeployCoroutines {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
   public var readWriteProperty: Int {
     get { 42 }
     set(newValue) {}
   }
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
   public subscript(at index: Int) -> Int {
     get { 42 }
     set(newValue) {}
@@ -150,11 +150,11 @@ public struct CannotBackDeployCoroutines {
 
   public var explicitReadAndModify: Int {
     @available(macOS 11.0, *)
-    @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _read accessor}}
+    @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _read accessor}}
     _read { yield 42 }
 
     @available(macOS 11.0, *)
-    @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
+    @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
     _modify {}
   }
 }
@@ -169,7 +169,7 @@ public struct FunctionBodyDiagnostics {
   private func privateFunc() {} // expected-note {{instance method 'privateFunc()' is not '@usableFromInline' or public}}
 
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {
     struct Nested {} // expected-error {{type 'Nested' cannot be nested inside a '@_backDeploy' function}}
 
@@ -183,125 +183,125 @@ public struct FunctionBodyDiagnostics {
 
 // MARK: - Incompatible declarations
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' may not be used on fileprivate declarations}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' may not be used on fileprivate declarations}}
 fileprivate func filePrivateFunc() {}
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' may not be used on private declarations}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' may not be used on private declarations}}
 private func privateFunc() {}
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' may not be used on internal declarations}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' may not be used on internal declarations}}
 internal func internalFunc() {}
 
 private struct PrivateTopLevelStruct {
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' may not be used on private declarations}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' may not be used on private declarations}}
   public func effectivelyPrivateFunc() {}
 }
 
 public class TopLevelClass2 {
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' cannot be applied to a non-final instance method}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' cannot be applied to a non-final instance method}}
   public func nonFinalMethod() {}
 
-  @_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' cannot be applied to a non-final class method}}
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' cannot be applied to a non-final class method}}
   public class func nonFinalClassMethod() {}
 }
 
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' requires that 'missingAllAvailabilityFunc()' have explicit availability for macOS}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' requires that 'missingAllAvailabilityFunc()' have explicit availability for macOS}}
 public func missingAllAvailabilityFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0, iOS 15.0) // expected-error {{'@_backDeploy' requires that 'missingiOSAvailabilityFunc()' have explicit availability for iOS}}
+@_backDeploy(before: macOS 12.0, iOS 15.0) // expected-error {{'@_backDeploy' requires that 'missingiOSAvailabilityFunc()' have explicit availability for iOS}}
 public func missingiOSAvailabilityFunc() {}
 
 @available(macOS 12.0, *)
-@_backDeploy(macOS 12.0) // expected-error {{'@_backDeploy' has no effect because 'availableSameVersionAsBackDeployment()' is not available before macOS 12.0}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' has no effect because 'availableSameVersionAsBackDeployment()' is not available before macOS 12.0}}
 public func availableSameVersionAsBackDeployment() {}
 
 @available(macOS 12.1, *)
-@_backDeploy(macOS 12.0) // expected-error {{'availableAfterBackDeployment()' is not available before macOS 12.0}}
+@_backDeploy(before: macOS 12.0) // expected-error {{'availableAfterBackDeployment()' is not available before macOS 12.0}}
 public func availableAfterBackDeployment() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0, macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
+@_backDeploy(before: macOS 12.0, macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
 public func duplicatePlatformsFunc1() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
-@_backDeploy(macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
+@_backDeploy(before: macOS 12.0)
+@_backDeploy(before: macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
 public func duplicatePlatformsFunc2() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 @_alwaysEmitIntoClient // expected-error {{'@_alwaysEmitIntoClient' cannot be applied to a back deployed global function}}
 public func alwaysEmitIntoClientFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 @inlinable // expected-error {{'@inlinable' cannot be applied to a back deployed global function}}
 public func inlinableFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0)
+@_backDeploy(before: macOS 12.0)
 @_transparent // expected-error {{'@_transparent' cannot be applied to a back deployed global function}}
 public func transparentFunc() {}
 
 // MARK: - Attribute parsing
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
+@_backDeploy(before: macOS 12.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
 public func unknownOSFunc() {}
 
-@_backDeploy(@) // expected-error {{expected platform in '@_backDeploy' attribute}}
+@_backDeploy(before: @) // expected-error {{expected platform in '@_backDeploy' attribute}}
 public func badPlatformFunc1() {}
 
-@_backDeploy(@ 12.0) // expected-error {{expected platform in '@_backDeploy' attribute}}
+@_backDeploy(before: @ 12.0) // expected-error {{expected platform in '@_backDeploy' attribute}}
 public func badPlatformFunc2() {}
 
-@_backDeploy(macOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
 public func missingVersionFunc1() {}
 
-@_backDeploy(macOS 12.0, iOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS 12.0, iOS) // expected-error {{expected version number in '@_backDeploy' attribute}}
 public func missingVersionFunc2() {}
 
-@_backDeploy(macOS, iOS) // expected-error 2{{expected version number in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS, iOS) // expected-error 2{{expected version number in '@_backDeploy' attribute}}
 public func missingVersionFunc3() {}
 
 @available(macOS 11.0, iOS 14.0, *)
-@_backDeploy(macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}}
+@_backDeploy(before: macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}}
 public func unexpectedSeparatorFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0.1) // expected-warning {{'@_backDeploy' only uses major and minor version number}}
+@_backDeploy(before: macOS 12.0.1) // expected-warning {{'@_backDeploy' only uses major and minor version number}}
 public func patchVersionFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0, * 9.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS 12.0, * 9.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func wildcardWithVersionFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0, *) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS 12.0, *) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func trailingWildcardFunc() {}
 
 @available(macOS 11.0, iOS 14.0, *)
-@_backDeploy(macOS 12.0, *, iOS 15.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
+@_backDeploy(before: macOS 12.0, *, iOS 15.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func embeddedWildcardFunc() {}
 
-@_backDeploy(_myProject 3.0) // expected-error {{reference to undefined version '3.0' for availability macro '_myProject'}}
+@_backDeploy(before: _myProject 3.0) // expected-error {{reference to undefined version '3.0' for availability macro '_myProject'}}
 public func macroVersionned() {}
 
-@_backDeploy(_myProject) // expected-error {{reference to undefined version '0' for availability macro '_myProject'}}
+@_backDeploy(before: _myProject) // expected-error {{reference to undefined version '0' for availability macro '_myProject'}}
 public func missingMacroVersion() {}
 
 // Fall back to the default diagnostic when the macro is unknown.
-@_backDeploy(_unknownMacro) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
+@_backDeploy(before: _unknownMacro) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
 // expected-error@-1 {{expected version number in '@_backDeploy' attribute}}
 public func unknownMacroMissingVersion() {}
 
-@_backDeploy(_unknownMacro 1.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
+@_backDeploy(before: _unknownMacro 1.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
 // expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
 public func unknownMacroVersionned() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(_unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
+@_backDeploy(before: _unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
 public func knownAndUnknownMacroVersionned() {}
 
 @_backDeploy() // expected-error {{expected at least one platform version in '@_backDeploy' attribute}}
@@ -310,5 +310,5 @@ public func emptyPlatformVersionsFunc() {}
 @_backDeploy // expected-error {{expected '(' in '_backDeploy' attribute}}
 public func expectedLeftParenFunc() {}
 
-@_backDeploy(macOS 12.0 // expected-note {{to match this opening '('}}
+@_backDeploy(before: macOS 12.0 // expected-note {{to match this opening '('}}
 public func expectedRightParenFunc() {} // expected-error {{expected ')' in '@_backDeploy' argument list}}

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -309,23 +309,23 @@ public func knownAndUnknownMacroVersionned() {}
 public func emptyAttributeFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(macOS 12.0) // expected-error {{expected 'before:' in '@_backDeploy' attribute}}
+@_backDeploy(macOS 12.0) // expected-error {{expected 'before:' in '@_backDeploy' attribute}} {{14-14=before:}}
 public func missingBeforeFunc() {}
 
-@_backDeploy(before) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}}
+@_backDeploy(before) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}} {{20-20=:}}
 // expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
 public func missingColonAfterBeforeFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(before macOS 12.0) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}}
+@_backDeploy(before macOS 12.0) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}} {{20-20=:}}
 public func missingColonBetweenBeforeAndPlatformFunc() {}
 
 @available(macOS 11.0, *)
-@_backDeploy(before: macOS 12.0,) // expected-error {{unexpected ',' separator}}
+@_backDeploy(before: macOS 12.0,) // expected-error {{unexpected ',' separator}} {{32-33=}}
 public func unexpectedTrailingCommaFunc() {}
 
 @available(macOS 11.0, iOS 14.0, *)
-@_backDeploy(before: macOS 12.0,, iOS 15.0) // expected-error {{unexpected ',' separator}}
+@_backDeploy(before: macOS 12.0,, iOS 15.0) // expected-error {{unexpected ',' separator}} {{33-34=}}
 public func extraCommaFunc() {}
 
 @_backDeploy(before:) // expected-error {{expected at least one platform version in '@_backDeploy' attribute}}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -428,7 +428,7 @@ internal func fn() {
 // @_backDeploy acts like @inlinable.
 
 @available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
-@_backDeploy(macOS 999.0, iOS 999.0, tvOS 999.0, watchOS 999.0)
+@_backDeploy(before: macOS 999.0, iOS 999.0, tvOS 999.0, watchOS 999.0)
 public func backDeployedToInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2660,7 +2660,7 @@ class SR12801 {
 
 public class BackDeployClass {
   @available(macOS 11.0, *)
-  @_backDeploy(macOS 12.0)
+  @_backDeploy(before: macOS 12.0)
   @objc // expected-error {{'@objc' cannot be applied to a back deployed instance method}}
   final public func objcMethod() {}
 }

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -35,6 +35,7 @@ ATTRIBUTE_NODES = [
     #                | specialize-attr-spec-list
     #                | implements-attr-arguments
     #                | named-attribute-string-argument
+    #                | back-deploy-attr-spec-list
     #              )? ')'?
     Node('Attribute', kind='Syntax',
          description='''
@@ -66,6 +67,8 @@ ATTRIBUTE_NODES = [
                              kind='DerivativeRegistrationAttributeArguments'),
                        Child('NamedAttributeString',
                              kind='NamedAttributeStringArgument'),
+                       Child('BackDeployArguments',
+                             kind='BackDeployAttributeSpecList'),
                        # TokenList for custom effects which are parsed by
                        # `FunctionEffects.parse()` in swift.
                        Child('TokenList', kind='TokenList',
@@ -416,4 +419,45 @@ ATTRIBUTE_NODES = [
                    specified.
                    '''),
          ]),
+
+    # The arguments of '@_backDeploy(...)'
+    # back-deploy-attr-spec-list -> 'before' ':' back-deploy-version-list
+    Node('BackDeployAttributeSpecList', kind='Syntax',
+         description='''
+         A collection of arguments for the `@_backDeploy` attribute
+         ''',
+         children=[
+             Child('BeforeLabel', kind='IdentifierToken',
+                   text_choices=['before'], description='The "before" label.'),
+             Child('Colon', kind='ColonToken', description='''
+                   The colon separating "before" and the parameter list.
+                   '''),
+             Child('VersionList', kind='BackDeployVersionList',
+                   collection_element_name='Availability', description='''
+                   The list of OS versions in which the declaration became ABI
+                   stable.
+                   '''),
+         ]),
+
+    # back-deploy-version-list ->
+    #   back-deploy-version-entry back-deploy-version-list?
+    Node('BackDeployVersionList', kind='SyntaxCollection',
+         element='BackDeployVersionArgument'),
+
+    # back-deploy-version-entry -> availability-version-restriction ','?
+    Node('BackDeployVersionArgument', kind='Syntax',
+         description='''
+         A single platform/version pair in a `@_backDeploy` attribute,
+         e.g. `iOS 10.1`.
+         ''',
+         children=[
+             Child('AvailabilityVersionRestriction',
+                   kind='AvailabilityVersionRestriction'),
+             Child('TrailingComma', kind='CommaToken', is_optional=True,
+                   description='''
+                   A trailing comma if the argument is followed by another
+                   argument
+                   '''),
+         ]),
+
 ]

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -258,6 +258,9 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'PrimaryAssociatedTypeList' : 254,
     'PrimaryAssociatedType' : 255,
     'PrimaryAssociatedTypeClause' : 256,
+    'BackDeployAttributeSpecList' : 257,
+    'BackDeployVersionList' : 258,
+    'BackDeployVersionArgument' : 259,
 }
 
 


### PR DESCRIPTION
Require a "before: " label in the first item of the list in the `@_backDeploy` attribute in order to match the pitched syntax for the attribute:

```
@available(macOS 11.0, *)
@_backDeploy(before: macOS 12.0)
public func foo() {}
```

The previous implementation of parsing the `@_backDeploy` attribute body used the `parseList()` utility. With the addition of the "before:" label, it was no longer possible to use that utility unchanged because the necessary syntax node creation could not be nested properly to match the following grammar:

```
back-deploy-attr-spec-list -> 'before' ':' back-deploy-version-list
back-deploy-version-list   -> back-deploy-version-entry back-deploy-version-list?
back-deploy-version-entry  -> availability-version-restriction ','?
```

I refactored the loop body out of `parseList()` into a separate `parseListItem()` function that could be used by the attribute parsing implementation, avoiding duplication of much of the list parsing logic while also allowing more control over syntax node creation.

Resolves rdar://90374640