### PR TITLE
[cxx-interop] Avoid crashing when importing functions that take pointers to dependent types

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -454,6 +454,9 @@ namespace {
                 ImportHint::OtherPointer};
       }
 
+      if (pointeeQualType->isDependentType())
+        return Type();
+
       // All other C pointers to concrete types map to
       // UnsafeMutablePointer<T> or OpaquePointer.
 

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -44,6 +44,22 @@ decltype(auto) testAuto(T arg) {
   return arg;
 }
 
+template <typename T>
+struct ClassTemplate {
+  T t;
+};
+
+template <typename T>
+void takesPointerToDependent(ClassTemplate<T> *ct) {
+  ct->t++;
+}
+
+template <typename T>
+T usedInDeclType(T) {}
+
+template <typename T>
+void takesDeclTypePointer(decltype(usedInDeclType<T>()) *) {}
+
 // TODO: Add tests for Decltype, UnaryTransform, and TemplateSpecialization with
 // a dependent type once those are supported.
 

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -17,6 +17,7 @@
 // CHECK: func defaultedTemplateReferenceTypeParam<T>(_ t: inout T)
 // The following types aren't imported correctly, but that does not have to do
 // with the fact that the template type paramaters are defaulted.
-// CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: UnsafeMutablePointer<T>)
-// CHECK: func defaultedTemplatePointerReferenceTypeParam<T>(_ t: inout OpaquePointer!)
-// CHECK: func defaultedTemplatePointerPointerTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>!)
+// TODO: reenable the following checks: (rdar://90587703)
+// TODO-CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: UnsafeMutablePointer<T>)
+// TODO-CHECK: func defaultedTemplatePointerReferenceTypeParam<T>(_ t: inout OpaquePointer!)
+// TODO-CHECK: func defaultedTemplatePointerPointerTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>!)

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -14,6 +14,10 @@
 // CHECK:   mutating func test2(_: Int32, _ varargs: Any...)
 // CHECK: }
 
+// TODO: import functions that take a pointer to a dependent type (rdar://90587703).
+// CHECK-NOT: func takesPointerToDependent
+// CHECK-NOT: func takesDeclTypePointer
+
 // CHECK: func lvalueReference<T>(_ ref: inout T)
 // CHECK: func constLvalueReference<T>(_: T)
 // CHECK: func forwardingReference<T>(_: inout T)


### PR DESCRIPTION
Importing `type_traits` from libstdc++ currently causes a crash on Linux:
```
swift-ide-test: tools/clang/include/clang/AST/TypeNodes.inc:33: clang::TypeInfo clang::ASTContext::getTypeInfoImpl(const clang::Type *) const: Assertion `!T->isDependentType() && "should not see dependent types here"' failed.
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.	Program arguments: /home/egorzh/Builds/swift/swift/bin/swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-cxx-interop
1.	/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:1110:10: importing 'std::__do_is_implicitly_default_constructible_impl'
2.	/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:1116:22: importing 'std::__do_is_implicitly_default_constructible_impl::__test'
```

This change fixes the crash by bailing on such functions.