### PR TITLE
[Diagnostics] Ignore type mismatches related to synthesized arguments

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4826,6 +4826,27 @@ bool ConstraintSystem::repairFailures(
   case ConstraintLocator::ApplyArgToParam: {
     auto loc = getConstraintLocator(locator);
 
+    // If this type mismatch is associated with a synthesized argument,
+    // let's just ignore it because the main problem is the absence of
+    // the argument.
+    if (auto applyLoc = elt.getAs<LocatorPathElt::ApplyArgToParam>()) {
+      if (auto *argumentList = getArgumentList(loc)) {
+        // This is either synthesized argument or a default value.
+        if (applyLoc->getArgIdx() >= argumentList->size()) {
+          auto *calleeLoc = getCalleeLocator(loc);
+          auto overload = findSelectedOverloadFor(calleeLoc);
+          // If this cannot be a default value matching, let's ignore.
+          if (!(overload && overload->choice.isDecl()))
+            return true;
+
+          if (!getParameterList(overload->choice.getDecl())
+                   ->get(applyLoc->getParamIdx())
+                   ->getTypeOfDefaultExpr())
+            return true;
+        }
+      }
+    }
+
     // Don't attempt to fix an argument being passed to a
     // _OptionalNilComparisonType parameter. Such an overload should only take
     // effect when a nil literal is used in valid code, and doesn't offer any

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar90419017.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar90419017.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift
+
+public enum APIError {
+case unknown
+case message
+}
+
+struct NewItemResponse {}
+
+protocol Publisher {
+  associatedtype Output // expected-note {{protocol requires nested type 'Output'; do you want to add it?}}
+}
+
+extension Publisher {
+  func sink(receiveCompletion: @escaping ((Int) -> Void), receiveValue: @escaping ((Self.Output) -> Void)) { fatalError() }
+  // expected-note@-1 {{'sink(receiveCompletion:receiveValue:)' declared here}}
+}
+
+func fetchFile<T>(name: String) -> MyPublisher<T, APIError> {
+  fatalError()
+}
+
+struct ReplaceError<Upstream> : Publisher { // expected-error {{type 'ReplaceError<Upstream>' does not conform to protocol 'Publisher'}}
+  typealias Output = Upstream.Output // expected-error {{'Output' is not a member type of type 'Upstream'}}
+  typealias Failure = Never
+}
+
+struct MyPublisher<Output, Failure> : Publisher {
+  init<P>(_ publisher: P) { fatalError() }
+
+  func replaceError(with output: Self.Output) -> ReplaceError<Self> { fatalError() }
+}
+
+public class Items {
+  func test() {
+    _ = fetchFile(name: "abc")
+          .replaceError(with: NewItemResponse())
+          .sink { [weak self] items in } // expected-error {{missing argument for parameter 'receiveValue' in call}}
+  }
+}


### PR DESCRIPTION
The main issue is the absence of the argument itself.

Resolves: rdar://90419017

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
