### PR TITLE
Make sure functions defined in a header are inline.

### DIFF
--- a/include/swift/Runtime/DispatchShims.h
+++ b/include/swift/Runtime/DispatchShims.h
@@ -20,7 +20,7 @@
 
 // Provide wrappers with runtime checks to make sure that the dispatch functions
 // are only called on OS-es where they are supported
-dispatch_thread_override_info_s
+static inline dispatch_thread_override_info_s
 swift_dispatch_thread_get_current_override_qos_floor()
 {
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
@@ -30,7 +30,7 @@ swift_dispatch_thread_get_current_override_qos_floor()
   return (dispatch_thread_override_info_s) {0};
 }
 
-int
+static inline int
 swift_dispatch_thread_override_self(qos_class_t override_qos) {
 
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
@@ -40,7 +40,7 @@ swift_dispatch_thread_override_self(qos_class_t override_qos) {
   return 0;
 }
 
-int
+static inline int
 swift_dispatch_lock_override_start_with_debounce(dispatch_lock_t *lock_addr,
    dispatch_tid_t expected_thread, qos_class_t override_to_apply) {
 
@@ -51,7 +51,7 @@ swift_dispatch_lock_override_start_with_debounce(dispatch_lock_t *lock_addr,
   return 0;
 }
 
-int
+static inline int
 swift_dispatch_lock_override_end(qos_class_t override_to_end) {
   if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
     return dispatch_lock_override_end(override_to_end);


### PR DESCRIPTION
Fixes rdar://89976658.
