### PR TITLE
[utils] Remove Python 2

### DIFF
--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -355,9 +355,6 @@ class UnicodeTrieGenerator(object):
                 else:
                     return idx
 
-            # NOTE: Python 2's `map` function returns a list. Where Python 3's
-            # `map` function returns an iterator. To work around this the
-            # result of the `map` is explicitly converted to a `list`.
             return list(map(map_index, indexes))
 
         # If self.bmp_data contains identical data blocks, keep the first one,

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -72,10 +72,6 @@ def main():
     found_stack_trace_start = False
     found_stack_trace_entry = False
     for line in lines:
-        # In Python 2, string objects can contain Unicode characters.
-        if sys.version_info.major == 2:
-            line = line.decode('utf-8', 'replace')
-
         line = line.rstrip('\n')
 
         # First see if we found the start of our stack trace start. If so, set

--- a/utils/build-script
+++ b/utils/build-script
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -31,8 +31,6 @@ from build_swift.build_swift.constants import BUILD_SCRIPT_IMPL_PATH
 from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
-
-import six
 
 from swift_build_support.swift_build_support import build_script_invocation
 from swift_build_support.swift_build_support import shell
@@ -120,7 +118,7 @@ class JSONDumper(json.JSONEncoder):
     def default(self, o):
         if hasattr(o, '__dict__'):
             return vars(o)
-        return six.text_type(o)
+        return str(o)
 
 
 def print_xcodebuild_versions(file=sys.stdout):
@@ -499,7 +497,7 @@ def main_preset():
     try:
         preset_parser.read_files(args.preset_file_names)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     if args.show_presets:
         for name in sorted(preset_parser.preset_names,
@@ -520,7 +518,7 @@ def main_preset():
             args.preset,
             vars=args.preset_substitutions)
     except presets.PresetError as e:
-        fatal_error(six.text_type(e))
+        fatal_error(str(e))
 
     preset_args = migration.migrate_swift_sdks(preset.args)
 

--- a/utils/build_swift/build_swift/argparse/actions.py
+++ b/utils/build_swift/build_swift/argparse/actions.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import, unicode_literals
 import argparse
 import copy
 
-import six
-
 from .types import BoolType, PathType
 
 
@@ -81,7 +79,7 @@ class Action(argparse.Action):
         if dests == argparse.SUPPRESS:
             dests = []
             metavar = metavar or ''
-        elif isinstance(dests, six.string_types):
+        elif isinstance(dests, (str,)):
             dests = [dests]
             metavar = metavar or dests[0].upper()
 
@@ -138,7 +136,7 @@ class AppendAction(Action):
             **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        if isinstance(values, six.string_types):
+        if isinstance(values, (str,)):
             values = [values]
 
         for dest in self.dests:
@@ -343,5 +341,5 @@ class UnsupportedAction(Action):
         if self.message is not None:
             parser.error(self.message)
 
-        arg = option_string or six.text_type(values)
+        arg = option_string or str(values)
         parser.error('unsupported argument: {}'.format(arg))

--- a/utils/build_swift/build_swift/argparse/parser.py
+++ b/utils/build_swift/build_swift/argparse/parser.py
@@ -19,8 +19,6 @@ from __future__ import absolute_import, unicode_literals
 import argparse
 from contextlib import contextmanager
 
-import six
-
 from . import Namespace, SUPPRESS, actions
 from .actions import Action
 
@@ -133,7 +131,7 @@ class _Builder(object):
             *names, action=action, **kwargs)
 
     def add_positional(self, dests, action=None, **kwargs):
-        if isinstance(dests, six.string_types):
+        if isinstance(dests, (str,)):
             dests = [dests]
 
         if any(dest.startswith('-') for dest in dests):
@@ -145,7 +143,7 @@ class _Builder(object):
         return self._add_argument(dests, action, **kwargs)
 
     def add_option(self, option_strings, *actions, **kwargs):
-        if isinstance(option_strings, six.string_types):
+        if isinstance(option_strings, (str,)):
             option_strings = [option_strings]
 
         if not all(opt.startswith('-') for opt in option_strings):

--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -19,8 +19,6 @@ import os.path
 import re
 import shlex
 
-import six
-
 from . import ArgumentTypeError
 from ..versions import Version
 
@@ -42,7 +40,7 @@ def _repr(cls, args):
     """
 
     _args = []
-    for key, value in six.iteritems(args):
+    for key, value in args.items():
         _args.append('{}={}'.format(key, repr(value)))
 
     return '{}({})'.format(type(cls).__name__, ', '.join(_args))

--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -17,9 +17,6 @@ from __future__ import absolute_import, unicode_literals
 import itertools
 import subprocess
 
-import six
-from six.moves import map
-
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
 
@@ -137,4 +134,4 @@ def check_impl_args(build_script_impl, args):
     _, err = pipe.communicate()
 
     if pipe.returncode != 0:
-        raise ValueError(six.text_type(err.splitlines()[0].decode()))
+        raise ValueError(str(err.splitlines()[0].decode()))

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -14,12 +14,10 @@ Swift preset parsing and handling functionality.
 
 from __future__ import absolute_import, unicode_literals
 
+import configparser
 import functools
 import io
 from collections import OrderedDict, namedtuple
-
-from six import StringIO
-from six.moves import configparser
 
 from . import class_utils
 
@@ -313,14 +311,9 @@ class PresetParser(object):
         """Reads and parses a string containing preset definintions.
         """
 
-        fp = StringIO(string)
+        fp = io.StringIO(string)
 
-        # ConfigParser changes drastically from Python 2 to 3
-        if hasattr(self._parser, 'read_file'):
-            self._parser.read_file(fp)
-        else:
-            self._parser.readfp(fp)
-
+        self._parser.read_file(fp)
         self._parse_raw_presets()
 
     # -------------------------------------------------------------------------

--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -24,25 +24,10 @@ import shutil
 import subprocess
 import sys
 from copy import copy as _copy
+from pathlib import Path
+from pipes import quote as _quote
 from shlex import split
 from subprocess import CalledProcessError
-
-import six
-from six.moves import map
-
-
-try:
-    # Python 2
-    from pipes import quote as _quote
-except ImportError:
-    from shutil import quote as _quote
-
-
-try:
-    # Python 3.4
-    from pathlib import Path
-except ImportError:
-    Path = None
 
 
 __all__ = [
@@ -111,7 +96,7 @@ def _convert_pathlib_path(path):
         return path
 
     if isinstance(path, Path):
-        return six.text_type(path)
+        return str(path)
 
     return path
 
@@ -150,14 +135,14 @@ def _normalize_args(args):
     CommandWrapper instances into a one-dimensional list of strings.
     """
 
-    if isinstance(args, six.string_types):
+    if isinstance(args, (str,)):
         return shlex.split(args)
 
     def normalize_arg(arg):
         arg = _convert_pathlib_path(arg)
 
-        if isinstance(arg, six.string_types):
-            return [six.text_type(arg)]
+        if isinstance(arg, (str,)):
+            return [str(arg)]
         if isinstance(arg, AbstractWrapper):
             return list(map(_convert_pathlib_path, arg.command))
 
@@ -173,34 +158,6 @@ def _normalize_args(args):
 # -----------------------------------------------------------------------------
 # Decorators
 
-def _backport_devnull(func):
-    """Decorator used to backport the subprocess.DEVNULL functionality from
-    Python 3 to Python 2.
-    """
-
-    # DEVNULL was introduced in Python 3.3
-    if _PY_VERSION >= (3, 3):
-        return func
-
-    @functools.wraps(func)
-    def wrapper(command, **kwargs):
-        stdout = kwargs.get('stdout', sys.stdout)
-        stderr = kwargs.get('stderr', sys.stderr)
-
-        if stdout != DEVNULL and stderr != DEVNULL:
-            return func(command, **kwargs)
-
-        with open(os.devnull, 'w') as devnull:
-            if stdout == DEVNULL:
-                kwargs['stdout'] = devnull
-            if stderr == DEVNULL:
-                kwargs['stderr'] = devnull
-
-            return func(command, **kwargs)
-
-    return wrapper
-
-
 def _normalize_command(func):
     """Decorator used to uniformly normalize the input command of the
     subprocess wrappers.
@@ -208,7 +165,7 @@ def _normalize_command(func):
 
     @functools.wraps(func)
     def wrapper(command, **kwargs):
-        if not isinstance(command, six.string_types):
+        if not isinstance(command, (str,)):
             command = _normalize_args(command)
 
         return func(command, **kwargs)
@@ -237,10 +194,9 @@ def _add_echo_kwarg(func):
 # Public Functions
 
 def quote(command):
-    """Extension of the standard pipes.quote (Python 2) or shutil.quote
-    (Python 3) that handles both strings and lists of strings. This mirrors
-    how the subprocess package can handle commands as both a standalone string
-    or list of strings.
+    """Extension of the standard shutil.quote that handles both strings and
+    lists of strings. This mirrors how the subprocess package can handle
+    commands as both a standalone string or list of strings.
 
     >>> quote('/Applications/App Store.app')
     "'/Applications/App Store.app'"
@@ -249,7 +205,7 @@ def quote(command):
     "rm -rf '~/Documents/My Homework'"
     """
 
-    if isinstance(command, six.string_types):
+    if isinstance(command, (str,)):
         return _quote(command)
 
     if isinstance(command, collections.Iterable):
@@ -288,7 +244,6 @@ class Popen(subprocess.Popen):
         solution to this problem in the form of their `method_decorator`.
         """
 
-        @_backport_devnull
         @_normalize_command
         @_add_echo_kwarg
         def closure(command, **kwargs):
@@ -305,7 +260,6 @@ class Popen(subprocess.Popen):
             self.wait()
 
 
-@_backport_devnull
 @_normalize_command
 @_add_echo_kwarg
 def call(command, **kwargs):
@@ -316,7 +270,6 @@ def call(command, **kwargs):
     return subprocess.call(command, **kwargs)
 
 
-@_backport_devnull
 @_normalize_command
 @_add_echo_kwarg
 def check_call(command, **kwargs):
@@ -327,7 +280,6 @@ def check_call(command, **kwargs):
     return subprocess.check_call(command, **kwargs)
 
 
-@_backport_devnull
 @_normalize_command
 @_add_echo_kwarg
 def check_output(command, **kwargs):
@@ -337,16 +289,11 @@ def check_output(command, **kwargs):
     Output is returned as a unicode string.
     """
 
-    if six.PY3:
-        kwargs['encoding'] = 'utf-8'
+    kwargs['encoding'] = 'utf-8'
 
     output = subprocess.check_output(command, **kwargs)
 
-    if six.PY3:
-        return output
-
-    # Return unicode string rather than bytes in Python 2.
-    return six.text_type(output, errors='ignore')
+    return output
 
 
 # -----------------------------------------------------------------------------
@@ -484,8 +431,7 @@ def wraps(command):
     return CommandWrapper(command)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AbstractWrapper(object):
+class AbstractWrapper(object, metaclass=abc.ABCMeta):
     """Abstract base class for implementing wrappers around command line
     utilities and executables. Subclasses must implement the `command` method
     which returns a command list suitable for use with executor instances.
@@ -555,7 +501,7 @@ class ExecutableWrapper(AbstractWrapper):
 
         self.EXECUTABLE = _convert_pathlib_path(self.EXECUTABLE)
 
-        if not isinstance(self.EXECUTABLE, six.string_types):
+        if not isinstance(self.EXECUTABLE, (str,)):
             raise AttributeError(
                 '{}.EXECUTABLE must be an executable name or path'.format(
                     type(self).__name__))

--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -16,8 +16,6 @@ from __future__ import absolute_import, unicode_literals
 
 import functools
 
-import six
-
 
 __all__ = [
     'InvalidVersionError',
@@ -175,7 +173,7 @@ class Version(object):
     __slots__ = ('components', '_str')
 
     def __init__(self, version):
-        version = six.text_type(version)
+        version = str(version)
 
         # Save the version string since it's impossible to reconstruct it from
         # just the parsed components
@@ -189,10 +187,6 @@ class Version(object):
             return NotImplemented
 
         return self.components == other.components
-
-    # NOTE: Python 2 compatibility.
-    def __ne__(self, other):
-        return not self == other
 
     def __lt__(self, other):
         if not isinstance(other, Version):

--- a/utils/build_swift/build_swift/wrappers/xcrun.py
+++ b/utils/build_swift/build_swift/wrappers/xcrun.py
@@ -18,8 +18,6 @@ import functools
 import re
 import shlex
 
-import six
-
 from .. import shell
 from ..versions import Version
 
@@ -61,7 +59,7 @@ def _prepend_sdk_and_toolchain(func):
 
     @functools.wraps(func)
     def wrapper(self, args, sdk=None, toolchain=None, **kwargs):
-        if isinstance(args, six.string_types):
+        if isinstance(args, (str,)):
             args = shlex.split(args)
         if toolchain:
             args = ['--toolchain', toolchain] + args

--- a/utils/build_swift/tests/build_swift/argparse/test_actions.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_actions.py
@@ -14,8 +14,6 @@ import unittest
 from build_swift.argparse import (
     ArgumentParser, BoolType, Nargs, PathType, SUPPRESS, actions)
 
-import six
-
 from ... import utils
 
 
@@ -186,7 +184,7 @@ class TestStoreIntAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.StoreIntAction)
 
         for i in [0, 1, 42, -64]:
-            args = parser.parse_args(['--foo', six.text_type(i)])
+            args = parser.parse_args(['--foo', str(i)])
             self.assertEqual(args.foo, i)
 
     def test_invalid_int(self):
@@ -195,7 +193,7 @@ class TestStoreIntAction(unittest.TestCase):
 
         for i in [0.0, True, 'bar']:
             with utils.quiet_output(), self.assertRaises(SystemExit):
-                parser.parse_args(['--foo', six.text_type(i)])
+                parser.parse_args(['--foo', str(i)])
 
 
 class TestStoreTrueAction(unittest.TestCase):
@@ -301,7 +299,7 @@ class TestToggleTrueAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
         for value in BoolType.TRUE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -312,7 +310,7 @@ class TestToggleTrueAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleTrueAction)
 
         for value in BoolType.FALSE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -363,7 +361,7 @@ class TestToggleFalseAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
         for value in BoolType.TRUE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertFalse(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])
@@ -374,7 +372,7 @@ class TestToggleFalseAction(unittest.TestCase):
         parser.add_argument('--foo', action=actions.ToggleFalseAction)
 
         for value in BoolType.FALSE_VALUES:
-            args = parser.parse_args(['--foo', six.text_type(value)])
+            args = parser.parse_args(['--foo', str(value)])
             self.assertTrue(args.foo)
 
             args = parser.parse_args(['--foo={}'.format(value)])

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -20,8 +20,6 @@ from build_swift import driver_arguments
 from build_swift import migration
 from build_swift.presets import PresetParser
 
-import six
-
 from .test_presets import PRESET_DEFAULTS
 from .. import expected_options as eo
 from .. import utils
@@ -80,9 +78,6 @@ class TestDriverArgumentParserMeta(type):
             test_name = 'test_preset_{}'.format(name)
             attrs[test_name] = cls.generate_preset_test(name, args)
 
-        if six.PY2:
-            name = str(name)
-
         return super(TestDriverArgumentParserMeta, cls).__new__(
             cls, name, bases, attrs)
 
@@ -92,8 +87,8 @@ class TestDriverArgumentParserMeta(type):
             parsed_values = self.parse_default_args([])
 
             parsed_value = getattr(parsed_values, dest)
-            if default_value.__class__ in six.string_types:
-                parsed_value = six.text_type(parsed_value)
+            if default_value.__class__ in (str,):
+                parsed_value = str(parsed_value)
 
             self.assertEqual(default_value, parsed_value,
                              'Invalid default value for "{}": {} != {}'
@@ -215,7 +210,7 @@ class TestDriverArgumentParserMeta(type):
         def test(self):
             for choice in option.choices:
                 namespace = self.parse_args(
-                    [option.option_string, six.text_type(choice)])
+                    [option.option_string, str(choice)])
                 self.assertEqual(getattr(namespace, option.dest), choice)
 
             with self.assertRaises(ParserError):
@@ -228,13 +223,13 @@ class TestDriverArgumentParserMeta(type):
         def test(self):
             for i in [0, 1, 42]:
                 namespace = self.parse_args(
-                    [option.option_string, six.text_type(i)])
+                    [option.option_string, str(i)])
                 self.assertEqual(int(getattr(namespace, option.dest)), i)
 
             # FIXME: int-type options should not accept non-int strings
-            # self.parse_args([option.option_string, six.text_type(0.0)])
-            # self.parse_args([option.option_string, six.text_type(1.0)])
-            # self.parse_args([option.option_string, six.text_type(3.14)])
+            # self.parse_args([option.option_string, str(0.0)])
+            # self.parse_args([option.option_string, str(1.0)])
+            # self.parse_args([option.option_string, str(3.14)])
             # self.parse_args([option.option_string, 'NaN'])
 
         return test
@@ -335,15 +330,15 @@ class TestDriverArgumentParserMeta(type):
         return test
 
 
-@six.add_metaclass(TestDriverArgumentParserMeta)
-class TestDriverArgumentParser(unittest.TestCase):
+class TestDriverArgumentParser(
+        unittest.TestCase, metaclass=TestDriverArgumentParserMeta):
 
     def _parse_args(self, args):
         try:
             return migration.parse_args(self.parser, args)
         except (SystemExit, ValueError) as e:
             raise ParserError('failed to parse arguments: {} {}'.format(
-                six.text_type(args), e))
+                str(args), e))
 
     def _check_impl_args(self, namespace):
         assert hasattr(namespace, 'build_script_impl_args')
@@ -354,7 +349,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                 namespace.build_script_impl_args)
         except (SystemExit, ValueError) as e:
             raise ParserError('failed to parse impl arguments: {} {}'.format(
-                six.text_type(namespace.build_script_impl_args), e))
+                str(namespace.build_script_impl_args), e))
 
     def parse_args_and_unknown_args(self, args, namespace=None):
         if namespace is None:
@@ -370,7 +365,7 @@ class TestDriverArgumentParser(unittest.TestCase):
                         namespace, unknown_args))
             except (SystemExit, argparse.ArgumentError) as e:
                 raise ParserError('failed to parse arguments: {} {}'.format(
-                    six.text_type(args), e))
+                    str(args), e))
 
         return namespace, unknown_args
 
@@ -380,7 +375,7 @@ class TestDriverArgumentParser(unittest.TestCase):
 
         if unknown_args:
             raise ParserError('unknown arguments: {}'.format(
-                six.text_type(unknown_args)))
+                str(unknown_args)))
 
         return namespace
 

--- a/utils/build_swift/tests/build_swift/test_migration.py
+++ b/utils/build_swift/tests/build_swift/test_migration.py
@@ -16,8 +16,6 @@ from build_swift import argparse
 from build_swift import migration
 from build_swift.constants import BUILD_SCRIPT_IMPL_PATH
 
-import six
-
 from swift_build_support.swift_build_support.targets import StdlibDeploymentTarget
 
 
@@ -66,8 +64,7 @@ class TestMigrateSwiftSDKsMeta(type):
         return test
 
 
-@six.add_metaclass(TestMigrateSwiftSDKsMeta)
-class TestMigrateSwiftSDKs(unittest.TestCase):
+class TestMigrateSwiftSDKs(unittest.TestCase, metaclass=TestMigrateSwiftSDKsMeta):
 
     def test_empty_swift_sdks(self):
         args = migration.migrate_swift_sdks(['--swift-sdks='])

--- a/utils/build_swift/tests/build_swift/test_presets.py
+++ b/utils/build_swift/tests/build_swift/test_presets.py
@@ -9,15 +9,13 @@
 
 from __future__ import unicode_literals
 
+import configparser
 import os
 import unittest
 
 from build_swift import constants
 from build_swift import presets
 from build_swift.presets import Preset, PresetParser
-
-import six
-from six.moves import configparser
 
 from .. import utils
 
@@ -158,8 +156,7 @@ class TestPresetParserMeta(type):
         return test
 
 
-@six.add_metaclass(TestPresetParserMeta)
-class TestPresetParser(unittest.TestCase):
+class TestPresetParser(unittest.TestCase, metaclass=TestPresetParserMeta):
 
     def test_read_files(self):
         parser = PresetParser()

--- a/utils/build_swift/tests/build_swift/test_shell.py
+++ b/utils/build_swift/tests/build_swift/test_shell.py
@@ -9,14 +9,13 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import builtins
 import collections
 import sys
 import unittest
+from io import StringIO
 
 from build_swift import shell
-
-import six
-from six import StringIO
 
 from .. import utils
 
@@ -48,7 +47,7 @@ except ImportError:
 # -----------------------------------------------------------------------------
 # Constants
 
-_OPEN_NAME = '{}.open'.format(six.moves.builtins.__name__)
+_OPEN_NAME = '{}.open'.format(builtins.__name__)
 
 
 # -----------------------------------------------------------------------------
@@ -90,7 +89,7 @@ class TestHelpers(unittest.TestCase):
 
         self.assertEqual(
             shell._convert_pathlib_path(path),
-            six.text_type(path))
+            str(path))
 
     # -------------------------------------------------------------------------
     # _get_stream_file
@@ -192,59 +191,6 @@ class TestDecorators(unittest.TestCase):
     """Unit tests for the decorators defined in the build_swift.shell module
     used to backport or add functionality to the subprocess wrappers.
     """
-
-    # -------------------------------------------------------------------------
-    # _backport_devnull
-
-    @utils.requires_module('unittest.mock')
-    @patch(_OPEN_NAME, new_callable=mock_open)
-    @patch('build_swift.shell._PY_VERSION', (3, 2))
-    def test_backport_devnull_stdout_kwarg(self, mock_open):
-        mock_file = MagicMock()
-        mock_open.return_value.__enter__.return_value = mock_file
-
-        @shell._backport_devnull
-        def func(command, **kwargs):
-            self.assertEqual(kwargs['stdout'], mock_file)
-
-        func('', stdout=shell.DEVNULL)
-        assert(mock_open.return_value.__enter__.called)
-        assert(mock_open.return_value.__exit__.called)
-
-    @utils.requires_module('unittest.mock')
-    @patch(_OPEN_NAME, new_callable=mock_open)
-    @patch('build_swift.shell._PY_VERSION', (3, 2))
-    def test_backport_devnull_stderr_kwarg(self, mock_open):
-        mock_file = MagicMock()
-        mock_open.return_value.__enter__.return_value = mock_file
-
-        @shell._backport_devnull
-        def func(command, **kwargs):
-            self.assertEqual(kwargs['stderr'], mock_file)
-
-        func('', stderr=shell.DEVNULL)
-        assert(mock_open.return_value.__enter__.called)
-        assert(mock_open.return_value.__exit__.called)
-
-    @utils.requires_module('unittest.mock')
-    @patch(_OPEN_NAME, new_callable=mock_open)
-    def test_backport_devnull_does_not_open(self, mock_open):
-        @shell._backport_devnull
-        def func(command):
-            pass
-
-        func('')
-        mock_open.return_value.__enter__.assert_not_called()
-        mock_open.return_value.__exit__.assert_not_called()
-
-    @utils.requires_module('unittest.mock')
-    @patch('build_swift.shell._PY_VERSION', (3, 3))
-    def test_backport_devnull_noop_starting_with_python_3_3(self):
-        def func():
-            pass
-
-        self.assertEqual(shell._backport_devnull(func), func)
-
     # -------------------------------------------------------------------------
     # _normalize_command
 
@@ -368,20 +314,14 @@ class TestSubprocessWrappers(unittest.TestCase):
     @patch('subprocess.check_output')
     def test_check_output(self, mock_check_output):
         # Before Python 3 the subprocess.check_output function returned bytes.
-        if six.PY3:
-            mock_check_output.return_value = ''
-        else:
-            mock_check_output.return_value = b''
+        mock_check_output.return_value = ''
 
         output = shell.check_output('ls')
 
         # We always expect str (utf-8) output
-        self.assertIsInstance(output, six.text_type)
+        self.assertIsInstance(output, str)
 
-        if six.PY3:
-            mock_check_output.assert_called_with('ls', encoding='utf-8')
-        else:
-            mock_check_output.assert_called_with('ls')
+        mock_check_output.assert_called_with('ls', encoding='utf-8')
 
 
 class TestShellUtilities(unittest.TestCase):
@@ -468,7 +408,7 @@ class TestShellUtilities(unittest.TestCase):
     @patch('build_swift.shell._convert_pathlib_path')
     def test_pushd_converts_pathlib_path(self, mock_convert):
         path = Path('/other/path')
-        mock_convert.return_value = six.text_type(path)
+        mock_convert.return_value = str(path)
 
         shell.pushd(path)
 

--- a/utils/build_swift/tests/build_swift/test_versions.py
+++ b/utils/build_swift/tests/build_swift/test_versions.py
@@ -13,8 +13,6 @@ import unittest
 
 from build_swift.versions import Version
 
-import six
-
 
 class TestVersion(unittest.TestCase):
     """Unit tests for the Version class.
@@ -59,7 +57,7 @@ class TestVersion(unittest.TestCase):
     # -------------------------------------------------------------------------
 
     def test_parse(self):
-        for string, components in six.iteritems(self.VERSION_COMPONENTS):
+        for string, components in self.VERSION_COMPONENTS.items():
             # Version parses
             version = Version(string)
 
@@ -90,7 +88,7 @@ class TestVersion(unittest.TestCase):
         self.assertVersionLess('a0b', 'a1')
 
     def test_str(self):
-        for string in six.iterkeys(self.VERSION_COMPONENTS):
+        for string in self.VERSION_COMPONENTS.keys():
             version = Version(string)
 
-            self.assertEqual(six.text_type(version), string)
+            self.assertEqual(str(version), string)

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -14,13 +14,10 @@ import os
 import platform
 import sys
 import unittest
+from io import StringIO
 
 from build_swift import cache_utils
 from build_swift.versions import Version
-
-import six
-from six import StringIO
-
 
 __all__ = [
     'quiet_output',
@@ -161,7 +158,7 @@ def requires_python(version):
     greater or equal to the required version.
     """
 
-    if isinstance(version, six.string_types):
+    if isinstance(version, str):
         version = Version(version)
 
     if _PYTHON_VERSION >= version:

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -62,10 +62,7 @@ line_pattern = re.compile(
 
 def _make_line_map(target_filename, stream=None):
     """
-    >>> try:
-    ...     from StringIO import StringIO # py2
-    ... except ImportError:
-    ...     from io import StringIO # py3
+    >>> from io import StringIO
     >>> _make_line_map('box',
     ... StringIO('''// ###sourceLocation(file: "foo.bar", line: 3)
     ... line 2

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -14,21 +14,12 @@ from functools import reduce
 logging.basicConfig(format='%(message)s', level=logging.INFO)
 
 
-# Python 2 `unicode` was renamed `str` in Python 3.  To consistently support
-# both, define `unicode` to be `str` when using Python 3.  Once we can drop
-# Python 2 support, delete this and change all uses of `unicode` to `str`.
-# (Currently, this is only here to avoid a python_lint failure from unicode
-# references below.)
-if sys.version_info[0] >= 3:
-    unicode = str
-
-
 class RoundTripTask(object):
     def __init__(self, input_filename, action, swift_syntax_test,
                  skip_bad_syntax):
         assert action == '-round-trip-parse' or action == '-round-trip-lex'
         if sys.version_info[0] < 3:
-            assert type(input_filename) == unicode
+            assert type(input_filename) == str
         assert type(swift_syntax_test) == str
 
         assert os.path.isfile(input_filename), \

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -20,8 +20,6 @@ from build_swift.build_swift.constants import SWIFT_BUILD_ROOT
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 from build_swift.build_swift.constants import SWIFT_SOURCE_ROOT
 
-import six
-
 from swift_build_support.swift_build_support import products
 from swift_build_support.swift_build_support import shell
 from swift_build_support.swift_build_support import targets
@@ -495,7 +493,7 @@ class BuildScriptInvocation(object):
             try:
                 config = HostSpecificConfiguration(host_target, args)
             except argparse.ArgumentError as e:
-                exit_rejecting_arguments(six.text_type(e))
+                exit_rejecting_arguments(str(e))
 
             # Convert into `build-script-impl` style variables.
             options[host_target] = {
@@ -696,7 +694,7 @@ class BuildScriptInvocation(object):
             try:
                 config = HostSpecificConfiguration(host_target.name, self.args)
             except argparse.ArgumentError as e:
-                exit_rejecting_arguments(six.text_type(e))
+                exit_rejecting_arguments(str(e))
             print("Building the standard library for: {}".format(
                 " ".join(config.swift_stdlib_build_targets)))
             if config.swift_test_run_targets and (

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -22,8 +22,6 @@ import platform
 import re
 from numbers import Number
 
-import six
-
 from . import shell
 
 
@@ -46,7 +44,7 @@ class CMakeOptions(object):
             value = self.true_false(value)
         if value is None:
             value = ""
-        elif not isinstance(value, six.string_types + (Number,)):
+        elif not isinstance(value, (str, Number)):
             raise ValueError('define: invalid value for key %s: %s (%s)' %
                              (var, value, type(value)))
         self._options.append('-D%s=%s' % (var, value))
@@ -202,7 +200,7 @@ class CMake(object):
 
         elif args.cmake_generator == 'Xcode':
             build_args += ['-parallelizeTargets',
-                           '-jobs', six.text_type(jobs)]
+                           '-jobs', str(jobs)]
 
         return build_args
 

--- a/utils/swift_build_support/tests/products/test_cmark.py
+++ b/utils/swift_build_support/tests/products/test_cmark.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 # from swift_build_support import cmake
 from swift_build_support import shell

--- a/utils/swift_build_support/tests/products/test_earlyswiftdriver.py
+++ b/utils/swift_build_support/tests/products/test_earlyswiftdriver.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import EarlySwiftDriver

--- a/utils/swift_build_support/tests/products/test_llvm.py
+++ b/utils/swift_build_support/tests/products/test_llvm.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import LLVM

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -16,12 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from build_swift.build_swift.wrappers import xcrun
 

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -15,12 +15,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 from swift_build_support.products import Swift

--- a/utils/swift_build_support/tests/test_shell.py
+++ b/utils/swift_build_support/tests/test_shell.py
@@ -16,12 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-try:
-    # py2
-    from StringIO import StringIO
-except ImportError:
-    # py3
-    from io import StringIO
+from io import StringIO
 
 from swift_build_support import shell
 


### PR DESCRIPTION
The library `six` provides compatibility between Python 2, and 3. It's no
longer necessary once we migrate off Python 2 completely.

Also remove any custom logic for Python 2 (the ones referenced by
a comment anyways).

https://bugs.swift.org/browse/SR-16025

[six's doc](https://six.readthedocs.io)
[amazing explanation wrt `__ne__`](https://stackoverflow.com/a/30676267/243798)