### PR TITLE
[cxx-interop] Add snake_case to CXXMethodBridging

### DIFF
--- a/test/Interop/Cxx/ergonomics/Inputs/implicit-computed-properties.h
+++ b/test/Interop/Cxx/ergonomics/Inputs/implicit-computed-properties.h
@@ -191,4 +191,22 @@ public:
   void setValue(int i);
 };
 
+struct SnakeCaseGetterSetter {
+  int value = 42;
+  int get_foo() const { return value; };
+  void set_foo(int v) { value = v; };
+};
+
+struct SnakeCaseUTF8Str {
+  int value = 42;
+  int get_utf8_string() const { return value; };
+  void set_utf8_string(int v) { value = v; };
+};
+
+struct SnakeCaseTrailing {
+  int value = 42;
+  int get_x_() const { return value; };
+  void set_x_(int v) { value = v; } ;
+};
+
 #endif // SWIFT_IMPLICIT_COMPUTED_PROPERTIES_H

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
@@ -111,6 +111,7 @@
 // CHECK:      struct IntGetterSetterSnakeCase {
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
+// CHECK-NEXT:    var x: Int32
 // CHECK-NEXT:    func get_x() -> Int32
 // CHECK-NEXT:    mutating func set_x(_ v: Int32)
 // CHECK-NEXT:    var val: Int32
@@ -265,4 +266,31 @@
 // CHECK-NEXT:    var value: Int32
 // CHECK-NEXT:    func getValue() -> Int32
 // CHECK-NEXT:    mutating func setValue(_ i: Int32)
+// CHECK-NEXT: }
+
+// CHECK:      struct SnakeCaseGetterSetter {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    init(value: Int32)
+// CHECK-NEXT:    var foo: Int32
+// CHECK-NEXT:    func get_foo() -> Int32
+// CHECK-NEXT:    mutating func set_foo(_ v: Int32)
+// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT: }
+
+// CHECK:      struct SnakeCaseUTF8Str {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    init(value: Int32)
+// CHECK-NEXT:    var utf8String: Int32
+// CHECK-NEXT:    func get_utf8_string() -> Int32
+// CHECK-NEXT:    mutating func set_utf8_string(_ v: Int32)
+// CHECK-NEXT:    var value: Int32
+// CHECK-NEXT: }
+
+// CHECK:      struct SnakeCaseTrailing {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    init(value: Int32)
+// CHECK-NEXT:    var x: Int32
+// CHECK-NEXT:    func get_x_() -> Int32
+// CHECK-NEXT:    mutating func set_x_(_ v: Int32)
+// CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties.swift
@@ -32,7 +32,7 @@ ImplicitComputedPropertiesTestSuite.test("UpperCaseMix") {
 }
 
 ImplicitComputedPropertiesTestSuite.test("GetterOnly") {
-    var d = GetterOnly()
+    let d = GetterOnly()
     expectEqual(d.foo, 42)
 }
 
@@ -77,6 +77,20 @@ ImplicitComputedPropertiesTestSuite.test("non trivial") {
     expectEqual(Object.x.value, 42)
     Object.x = NonTrivial(value: 20)
     expectEqual(Object.x.value, 20)
+}
+
+ImplicitComputedPropertiesTestSuite.test("SnakeCaseGetterSetter") {
+    var object = SnakeCaseGetterSetter()
+    expectEqual(object.foo, 42)
+    object.foo = 32
+    expectEqual(object.foo, 32)
+}
+
+ImplicitComputedPropertiesTestSuite.test("SnakeCaseUTF8Str") {
+    var object = SnakeCaseUTF8Str()
+    expectEqual(object.utf8String, 42)
+    object.utf8String = 32
+    expectEqual(object.utf8String, 32)
 }
 
 runAllTests()

--- a/test/SILOptimizer/array_element_propagation_ossa_nontrivial.sil
+++ b/test/SILOptimizer/array_element_propagation_ossa_nontrivial.sil
@@ -204,7 +204,7 @@ bb0(%arg0 : @owned $MyKlass, %arg1 : @owned $MyKlass, %arg2 : @owned $MyKlass):
   return %52 : $()
 }
 
-sil [ossa] @unkown_use : $@convention(thin) (@owned MyKlass) -> () {
+sil [ossa] @unknown_use : $@convention(thin) (@owned MyKlass) -> () {
 bb0(%arg0 : @owned $MyKlass):
   %0 = function_ref @swift_bufferAllocate : $@convention(thin) () -> @owned _ContiguousArrayStorage<MyKlass>
   %1 = integer_literal $Builtin.Word, 1

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -278,7 +278,7 @@ class TestDriverArgumentParserMeta(type):
                 [option.option_string])
             # The argument should never show up in the namespace
             self.assertFalse(hasattr(namespace, option.dest))
-            # It should instead be forwareded to unkown_args
+            # It should instead be forwareded to unknown_args
             self.assertEqual(unknown_args, [option.option_string])
 
         return test


### PR DESCRIPTION
Update CxxMethodBridging to transform snake_case names.
Also fixed some typos `unkown` -> `unknown`

related: #40842


@bro4all