### PR TITLE
Sema: Fix structural resolution of protocol typealiases with UnboundGenericType

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -433,7 +433,8 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
       if (typeDecl->getDeclContext()->getSelfProtocolDecl()) {
         if (isa<AssociatedTypeDecl>(typeDecl) ||
             (isa<TypeAliasDecl>(typeDecl) &&
-             !cast<TypeAliasDecl>(typeDecl)->isGeneric())) {
+             !cast<TypeAliasDecl>(typeDecl)->isGeneric() &&
+             !isSpecialized)) {
           if (getStage() == TypeResolutionStage::Structural) {
             return DependentMemberType::get(selfType, typeDecl->getName());
           } else if (auto assocType = dyn_cast<AssociatedTypeDecl>(typeDecl)) {

--- a/test/Generics/protocol_typealias_cycle_4.swift
+++ b/test/Generics/protocol_typealias_cycle_4.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: .P@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P]X == _A<Int>>
+protocol P {
+  typealias A = _A
+  typealias B = A<Int>
+
+  associatedtype X where X == B
+}
+
+struct _A<T> {}


### PR DESCRIPTION
We want to resolve them to their real underlying type here instead of
returning a DependentMemberType.