### PR TITLE
Tests: Temporarily disable attr_backDeploy_evolution during swift_test_mode_optimize builds

### DIFF
--- a/test/attr/attr_backDeploy_evolution.swift
+++ b/test/attr/attr_backDeploy_evolution.swift
@@ -32,6 +32,9 @@
 // REQUIRES: executable_test
 // REQUIRES: VENDOR=apple
 
+// rdar://90525337
+// UNSUPPORTED: swift_test_mode_optimize
+
 // ---- (0) Prepare SDK
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/SDK_ABI)


### PR DESCRIPTION
Fixes the [https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator/](https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator/43/console) bot.