### PR TITLE
RequirementMachine: Don't consider protocol typealiases with UnboundGenericType

### DIFF
--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -78,6 +78,7 @@ struct Symbol::Storage final
   Storage(Symbol::Kind kind, CanType type, ArrayRef<Term> substitutions) {
     assert(kind == Symbol::Kind::Superclass ||
            kind == Symbol::Kind::ConcreteType);
+    assert(!type->hasUnboundGenericType());
     assert(!type->hasTypeVariable());
     assert(type->hasTypeParameter() != substitutions.empty());
 

--- a/test/Generics/protocol_typealias_unbound_generic.swift
+++ b/test/Generics/protocol_typealias_unbound_generic.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  typealias A = Array
+
+  associatedtype X where X == A // expected-error {{reference to generic type 'Self.A' (aka 'Array') requires arguments in <...>}}
+}


### PR DESCRIPTION
These are stealth generic typealiases and should not participate in the rewrite system.