### PR TITLE
[SE-0338] Contexts with the same actor isolation never execute concurrently

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -112,6 +112,7 @@ public:
   bool isActorIsolated() const {
     switch (getKind()) {
     case ActorInstance:
+    case DistributedActorInstance:
     case GlobalActor:
     case GlobalActorUnsafe:
       return true;

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -109,6 +109,19 @@ public:
   
   bool isIndependent() const { return kind == Independent; }
 
+  bool isActorIsolated() const {
+    switch (getKind()) {
+    case ActorInstance:
+    case GlobalActor:
+    case GlobalActorUnsafe:
+      return true;
+
+    case Unspecified:
+    case Independent:
+      return false;
+    }
+  }
+
   NominalTypeDecl *getActor() const {
     assert(getKind() == ActorInstance || getKind() == DistributedActorInstance);
     return actor;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2860,6 +2860,21 @@ namespace {
 
 bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
     const DeclContext *useContext, const DeclContext *defContext) {
+  // Fast path for when the use and definition contexts are the same.
+  if (useContext == defContext)
+    return false;
+
+  // If both contexts are isolated to the same actor, then they will not
+  // execute concurrently.
+  auto useIsolation = getActorIsolationOfContext(
+      const_cast<DeclContext *>(useContext));
+  if (useIsolation.isActorIsolated()) {
+    auto defIsolation = getActorIsolationOfContext(
+        const_cast<DeclContext *>(defContext));
+    if (useIsolation == defIsolation)
+      return false;
+  }
+
   // Walk the context chain from the use to the definition.
   while (useContext != defContext) {
     // If we find a concurrent closure... it can be run concurrently.

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -979,28 +979,56 @@ actor MyServer : Server {
 // ----------------------------------------------------------------------
 // @_inheritActorContext
 // ----------------------------------------------------------------------
+@available(SwiftStdlib 5.1, *)
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
+@available(SwiftStdlib 5.1, *)
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
 
 @available(SwiftStdlib 5.1, *)
 extension MyActor {
   func testSendableAndInheriting() {
+    var counter = 0
+
     acceptAsyncSendableClosure {
-      synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}
+      _ = synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}
       // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+
+      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosure {
-      await synchronous() // ok
+      _ = await synchronous() // ok
+      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosureInheriting {
-      synchronous() // okay
+      _ = synchronous() // okay
+      counter += 1 // okay
     }
 
     acceptAsyncSendableClosureInheriting {
-      await synchronous() // expected-warning{{no 'async' operations occur within 'await' expression}}
+      _ = await synchronous() // expected-warning{{no 'async' operations occur within 'await' expression}}
+      counter += 1 // okay
     }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@SomeGlobalActor
+func testGlobalActorInheritance() {
+  var counter = 0
+
+  acceptAsyncSendableClosure {
+    counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+  }
+
+  acceptAsyncSendableClosure { @SomeGlobalActor in
+    counter += 1 // ok
+  }
+
+
+  acceptAsyncSendableClosureInheriting {
+    counter += 1 // ok
   }
 }
 


### PR DESCRIPTION
With the clarification in SE-0338, revise the definition of "may
execute concurrently with" to always be false when we're accessing a
value from a same-actor-isolated inner context.

Fixes rdar://82004833.
