### PR TITLE
GSB: Relax verify check some more in RequirementSignatureRequest

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8664,20 +8664,31 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
                      ArrayRef<Requirement> gsbResult) {
     if (rqmResult.size() > gsbResult.size())
       return false;
+
+    SmallVector<Requirement, 2> rqmNonSameType;
+    SmallVector<Requirement, 2> gsbNonSameType;
+
+    for (auto req : rqmResult) {
+      if (req.getKind() != RequirementKind::SameType)
+        rqmNonSameType.push_back(req);
+    }
+
+    for (auto req : gsbResult) {
+      if (req.getKind() != RequirementKind::SameType)
+        gsbNonSameType.push_back(req);
+    }
+
+    if (rqmNonSameType.size() != gsbNonSameType.size())
+      return false;
     
-    if (!std::equal(rqmResult.begin(),
-                    rqmResult.end(),
-                    gsbResult.begin(),
+    if (!std::equal(rqmNonSameType.begin(),
+                    rqmNonSameType.end(),
+                    gsbNonSameType.begin(),
                     [](const Requirement &lhs,
                        const Requirement &rhs) {
                       return lhs.getCanonical() == rhs.getCanonical();
                     }))
       return false;
-
-    for (auto req : gsbResult.slice(rqmResult.size())) {
-      if (req.getKind() != RequirementKind::SameType)
-        return false;
-    }
 
     return true;
   };


### PR DESCRIPTION
The GSB sometimes emits redundant same-type requirements here. Only
checking for a prefix would still trigger false positives, so relax
it all the way to only consider conformance requirements, which
are the important ones from an ABI standpoint.