### PR TITLE
[SourceKit] Make sure to use overlays when reading files

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -16,7 +16,9 @@
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/PathRemapper.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
 #include <string>
@@ -356,6 +358,14 @@ public:
                                   llvm::vfs::FileSystem *FS, bool IsOSDarwin) {
     return Lookup.searchPathsContainingFile(this, Filenames, FS, IsOSDarwin);
   }
+
+  /// Creates a filesystem taking into account any overlays specified in
+  /// \c VFSOverlayFiles. Returns \p BaseFS if there were no overlays and
+  /// \c FileError(s) if any error occurred while attempting to parse the
+  /// overlay files.
+  llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+  makeOverlayFileSystem(
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS) const;
 
 private:
   static StringRef

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -109,6 +109,7 @@ class CompletionInstance {
   bool performCachedOperationIfPossible(
       llvm::hash_code ArgsHash,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      const SearchPathOptions &SearchPathOpts,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
       DiagnosticConsumer *DiagC,
       std::shared_ptr<std::atomic<bool>> CancellationFlag,

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/AST/SearchPathOptions.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/Errc.h"
 
 using namespace swift;
 
@@ -113,4 +114,48 @@ ModuleSearchPathLookup::searchPathsContainingFile(
   llvm::sort(Result, [](const ModuleSearchPath *Lhs,
                         const ModuleSearchPath *Rhs) { return *Lhs < *Rhs; });
   return Result;
+}
+
+/// Loads a VFS YAML file located at \p File using \p BaseFS and adds it to
+/// \p OverlayFS. Returns an error if either loading the \p File failed or it
+/// is invalid.
+static llvm::Error loadAndValidateVFSOverlay(
+    const std::string &File,
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> &BaseFS,
+    const llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> &OverlayFS) {
+  auto Buffer = BaseFS->getBufferForFile(File);
+  if (!Buffer)
+    return llvm::createFileError(File, Buffer.getError());
+
+  auto VFS = llvm::vfs::getVFSFromYAML(std::move(Buffer.get()), nullptr, File);
+  if (!VFS)
+    return llvm::createFileError(File, llvm::errc::invalid_argument);
+
+  OverlayFS->pushOverlay(std::move(VFS));
+  return llvm::Error::success();
+}
+
+llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+SearchPathOptions::makeOverlayFileSystem(
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS) const {
+  // TODO: This implementation is different to how Clang reads overlays in.
+  // Expose a helper in Clang rather than doing this ourselves.
+
+  auto OverlayFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
+
+  llvm::Error AllErrors = llvm::Error::success();
+  bool hasOverlays = false;
+  for (const auto &File : VFSOverlayFiles) {
+    hasOverlays = true;
+    if (auto Err = loadAndValidateVFSOverlay(File, BaseFS, OverlayFS))
+      AllErrors = llvm::joinErrors(std::move(AllErrors), std::move(Err));
+  }
+
+  if (AllErrors)
+    return std::move(AllErrors);
+
+  if (hasOverlays)
+    return OverlayFS;
+  return BaseFS;
 }

--- a/test/SourceKit/CodeComplete/complete_swift_overlay.swift
+++ b/test/SourceKit/CodeComplete/complete_swift_overlay.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: sed -e "s@NAME_DIR@%{/t:regex_replacement}/A@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/B@g" %t/base.yaml > %t/overlay.yaml
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=global-config -req-opts=completion_check_dependency_interval=0 == \
+// RUN:   -req=complete -pos=2:5 %t/A/a.swift -- -vfsoverlay %t/overlay.yaml %t/A/a.swift %t/A/b.swift == \
+// RUN:   -req=complete -pos=2:5 %t/A/a.swift -- -vfsoverlay %t/overlay.yaml %t/A/a.swift %t/A/b.swift \
+// RUN:   | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.name: "method()"
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.name: "method()"
+// CHECK: ]
+// CHECK: key.reusingastcontext: 1
+
+
+//--- A/a.swift
+func a(b: B) {
+  b.
+}
+
+//--- B/b.swift
+struct B {
+  func method() {}
+}
+
+//--- base.yaml
+{
+  version: 0,
+  redirecting-with: "fallback",
+  use-external-names: true,
+  roots: [
+    {
+      type: "directory-remap",
+      name: "NAME_DIR",
+      external-contents: "EXTERNAL_DIR"
+    }
+  ]
+}

--- a/test/SourceKit/CursorInfo/cursor_swift_overlay.swift
+++ b/test/SourceKit/CursorInfo/cursor_swift_overlay.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// RUN: sed -e "s@NAME_DIR@%{/t:regex_replacement}/A@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/B@g" %t/base.yaml > %t/overlay.yaml
+
+//--- A/a.swift
+func a() {
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):3 %t/A/a.swift -- -vfsoverlay %t/overlay.yaml %t/A/a.swift %t/A/b.swift | %FileCheck %s
+  b()
+}
+
+//--- B/b.swift
+// TODO: This should be B/b.swift, but there's currently a bug with multiple overlays.
+//       See rdar://90578880 or https://github.com/llvm/llvm-project/issues/53306.
+//       Replace with CHECK-FIXED when that's fixed.
+// CHECK: source.lang.swift.ref.function.free ({{.*}}{{/|\\}}A{{/|\\}}b.swift:*missing file*)
+// CHECK-FIXED: source.lang.swift.ref.function.free ({{.*}}{{/|\\}}B{{/|\\}}b.swift:[[@LINE+1]]:6-[[@LINE+1]]:9)
+func b() {}
+
+//--- base.yaml
+{
+  version: 0,
+  redirecting-with: "fallback",
+  use-external-names: true,
+  roots: [
+    {
+      type: "directory-remap",
+      name: "NAME_DIR",
+      external-contents: "EXTERNAL_DIR"
+    }
+  ]
+}

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -105,14 +105,17 @@ static unsigned resolveFromLineCol(unsigned Line, unsigned Col,
                                    llvm::MemoryBuffer *InputBuf);
 static std::pair<unsigned, unsigned>
 resolveToLineCol(unsigned Offset, StringRef Filename,
-                 const llvm::StringMap<TestOptions::VFSFile> &VFSFiles);
-static std::pair<unsigned, unsigned> resolveToLineCol(unsigned Offset,
-                                                  llvm::MemoryBuffer *InputBuf);
+                 const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
+                 bool ExitOnError = true);
+static std::pair<unsigned, unsigned>
+resolveToLineCol(unsigned Offset, llvm::MemoryBuffer *InputBuf,
+                 bool ExitOnError = true);
 static std::pair<unsigned, unsigned> resolveToLineColFromBuf(unsigned Offset,
                                                       const char *Buf);
 static llvm::MemoryBuffer *
 getBufferForFilename(StringRef Filename,
-                     const llvm::StringMap<TestOptions::VFSFile> &VFSFiles);
+                     const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
+                     bool ExitOnError = true);
 
 static void notification_receiver(sourcekitd_response_t resp);
 
@@ -1842,8 +1845,11 @@ struct ResponseSymbolInfo {
       if (CurrentFilename != StringRef(FilePath))
         OS << FilePath << ':';
 
-      auto LineCol = resolveToLineCol(Offset, FilePath, VFSFiles);
-      if (LineCol.first != Line || LineCol.second != Column) {
+      auto LineCol =
+          resolveToLineCol(Offset, FilePath, VFSFiles, /*ExitOnError=*/false);
+      if (LineCol.first == 0 && LineCol.second == 0) {
+        OS << "*missing file*";
+      } else if (LineCol.first != Line || LineCol.second != Column) {
         OS << "*offset does not match line/column in response*";
       } else {
         OS << LineCol.first << ':' << LineCol.second;
@@ -2579,13 +2585,23 @@ static void expandPlaceholders(llvm::MemoryBuffer *SourceBuf,
 
 static std::pair<unsigned, unsigned>
 resolveToLineCol(unsigned Offset, StringRef Filename,
-                 const llvm::StringMap<TestOptions::VFSFile> &VFSFiles) {
-  return resolveToLineCol(Offset, getBufferForFilename(Filename, VFSFiles));
+                 const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
+                 bool ExitOnError) {
+  return resolveToLineCol(Offset,
+                          getBufferForFilename(Filename, VFSFiles, ExitOnError),
+                          ExitOnError);
 }
 
+/// Maps \p Offset to the {Line, Col} position in \p InputBuf. If it could not
+/// be resolved and \p ExitOnError is \c true, the process exits with an error
+/// message. Otherwise, {0, 0} is returned.
 static std::pair<unsigned, unsigned>
-resolveToLineCol(unsigned Offset, llvm::MemoryBuffer *InputBuf) {
+resolveToLineCol(unsigned Offset, llvm::MemoryBuffer *InputBuf,
+                 bool ExitOnError) {
   if (Offset >= InputBuf->getBufferSize()) {
+    if (!ExitOnError)
+      return {0, 0};
+
     llvm::errs() << "offset " << Offset << " for filename '"
         << InputBuf->getBufferIdentifier() << "' is too large\n";
     exit(1);
@@ -2653,9 +2669,14 @@ static unsigned resolveFromLineCol(unsigned Line, unsigned Col,
 
 static llvm::StringMap<llvm::MemoryBuffer*> Buffers;
 
+/// Opens \p Filename, first checking \p VFSFiles and then falling back to the
+/// filesystem otherwise. If the file could not be opened and \p ExitOnError is
+/// true, the process exits with an error message. Otherwise a buffer
+/// containing "<missing file>" is returned.
 static llvm::MemoryBuffer *
 getBufferForFilename(StringRef Filename,
-                     const llvm::StringMap<TestOptions::VFSFile> &VFSFiles) {
+                     const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
+                     bool ExitOnError) {
   auto VFSFileIt = VFSFiles.find(Filename);
   auto MappedFilename =
       VFSFileIt == VFSFiles.end() ? Filename : StringRef(VFSFileIt->second.path);
@@ -2665,11 +2686,18 @@ getBufferForFilename(StringRef Filename,
     return It->second;
 
   auto FileBufOrErr = llvm::MemoryBuffer::getFile(MappedFilename);
+  std::unique_ptr<llvm::MemoryBuffer> Buffer;
   if (!FileBufOrErr) {
-    llvm::errs() << "error opening input file '" << MappedFilename << "' ("
-                 << FileBufOrErr.getError().message() << ")\n";
-    exit(1);
+    if (ExitOnError) {
+      llvm::errs() << "error opening input file '" << MappedFilename << "' ("
+                   << FileBufOrErr.getError().message() << ")\n";
+      exit(1);
+    }
+
+    Buffer = llvm::MemoryBuffer::getMemBuffer("<missing file>");
+  } else {
+    Buffer = std::move(FileBufOrErr.get());
   }
 
-  return Buffers[MappedFilename] = FileBufOrErr.get().release();
+  return Buffers[MappedFilename] = Buffer.release();
 }


### PR DESCRIPTION
Two paths missed setting up overlays:
  - `CompletionInstance` when checking files from dependencies
  - `SwiftASTManager` when reading in files that it would later replace
    all inputs with

(1) would cause the AST context not to be re-used, even though nothing
had changed. (2) caused all non-completion functionality to fail for any
symbols within files only specified by the overlay.

Resolves rdar://85508213.