### PR TITLE
[SIL-opaque] Handled forward captures.

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -270,10 +270,13 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         capturedArgs.push_back(emitUndef(getLoweredType(type)));
         break;
       case CaptureKind::Immutable:
-      case CaptureKind::StorageAddress:
-        // FIXME_addrlower: only call getAddressType for M.useLoweredAddresses()
-        capturedArgs.push_back(emitUndef(getLoweredType(type).getAddressType()));
+      case CaptureKind::StorageAddress: {
+        auto ty = getLoweredType(type);
+        if (SGM.M.useLoweredAddresses())
+          ty = ty.getAddressType();
+        capturedArgs.push_back(emitUndef(ty));
         break;
+      }
       case CaptureKind::Box: {
         auto boxTy = SGM.Types.getContextBoxTypeForCapture(
             vd,

--- a/test/SILGen/opaque_values_invalid.swift
+++ b/test/SILGen/opaque_values_invalid.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen -verify -enable-sil-opaque-values -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+
+func take<T>(_ t: T) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21opaque_values_invalid27forward_capture_generic_let4withSayxGx_tlF : {{.*}} {
+// CHECK:         [[F:%[^,]+]] = function_ref @$s21opaque_values_invalid27forward_capture_generic_let4withSayxGx_tlF1fL_yylF {{.*}}
+// CHECK:         [[F]]<U>(undef)
+// CHECK-LABEL: } // end sil function '$s21opaque_values_invalid27forward_capture_generic_let4withSayxGx_tlF'
+func forward_capture_generic_let<U>(with u: U) -> [U] {
+  func f() { g() } // expected-error {{closure captures 'x' before it is declared}}
+  f()
+  let x = u // expected-note{{captured value declared here}}
+  func g() { 
+    take(x) // expected-note {{captured here}}
+  }
+}
+


### PR DESCRIPTION
A let that isn't defined yet can be captured by a local function to which a closure is formed.  Don't use an address type unless we're using lowered addresses.
