### PR TITLE
Cleaning up _runAsyncMain

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -834,7 +834,9 @@ internal func _asyncMainDrainQueue() -> Never
 internal func _getMainExecutor() -> Builtin.Executor
 
 @available(SwiftStdlib 5.1, *)
-public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
+@usableFromInline
+@preconcurrency
+internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> ()) {
   Task.detached {
     do {
 #if !os(Windows)

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -58,6 +58,7 @@ Func AsyncSequence.map(_:) is now with @preconcurrency
 Func AsyncSequence.prefix(while:) is now with @preconcurrency
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
+Func _runAsyncMain(_:) is now with @preconcurrency
 Protocol Actor has added inherited protocol AnyActor
 Protocol Actor has generic signature change from <Self : AnyObject, Self : Swift.Sendable> to <Self : _Concurrency.AnyActor>
 Struct CheckedContinuation has removed conformance to UnsafeSendable


### PR DESCRIPTION
Relanding; https://github.com/apple/swift/pull/40661 (but not making `@preconcurrency` ABI stable to add).

I'm making two cleanups here. First, the closure going into
_runAsyncMain needs to be @Sendable or passing it to the task is not
safe. This will also result in a warning being emitted.
Second, I'm making the function `@usableFromInline` and internal. The
function is part of ABI, so it can't be pulled out entirely, but we don't
want people using it directly.

rdar://74942340