### PR TITLE
[Option] Add feature flag for empty ABI descriptors

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -17,6 +17,9 @@
     },
     {
       "name": "no-warn-superfluous-index-unit-path"
+    },
+    {
+      "name": "empty-abi-descriptor"
     }
   ]
 }


### PR DESCRIPTION
Allow clients to check whether they can force empty ABI descriptors to
be output.