### PR TITLE
RequirementMachine: Try harder to preserve sugar

### DIFF
--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -419,9 +419,8 @@ class TypeMatcher {
 
     bool visitBoundGenericType(CanBoundGenericType firstBGT,
                                Type secondType, Type sugaredFirstType) {
-      auto _secondBGT = secondType->getCanonicalType();
-      if (firstBGT->getKind() == _secondBGT->getKind()) {
-        auto secondBGT = cast<BoundGenericType>(_secondBGT);
+      if (firstBGT->getKind() == secondType->getDesugaredType()->getKind()) {
+        auto secondBGT = secondType->castTo<BoundGenericType>();
         if (firstBGT->getDecl() != secondBGT->getDecl())
           return mismatch(firstBGT.getPointer(), secondBGT, sugaredFirstType);
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -73,13 +73,13 @@ static void desugarSameTypeRequirement(Type lhs, Type rhs, SourceLoc loc,
 
       if (secondType->isTypeParameter()) {
         result.emplace_back(RequirementKind::SameType,
-                            secondType, firstType);
+                            secondType, sugaredFirstType);
         recordedRequirements = true;
         return true;
       }
 
       errors.push_back(
-          RequirementError::forConcreteTypeMismatch(firstType,
+          RequirementError::forConcreteTypeMismatch(sugaredFirstType,
                                                     secondType,
                                                     loc));
       recordedErrors = true;

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -194,3 +194,7 @@ func inferred3<T : P11>(_: T) where T.X : Hashable, T.Z == Set<T.Y>, T.X == T.Y 
 func inferred4<T : P11>(_: T) where T.Z == Set<T.Y>, T.X : Hashable, T.X == T.Y {}
 func inferred5<T : P11>(_: T) where T.Z == Set<T.X>, T.Y : Hashable, T.X == T.Y {}
 func inferred6<T : P11>(_: T) where T.Y : Hashable, T.Z == Set<T.X>, T.X == T.Y {}
+
+func typeMatcherSugar<T>(_: T) where Array<Int> == Array<T>, Array<Int> == Array<T> {}
+// expected-warning@-1 2{{redundant same-type constraint 'Array<Int>' == 'Array<T>'}}
+// expected-warning@-2{{redundant same-type constraint 'T' == 'Int'}}

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -19,7 +19,7 @@ typealias NotAnInt = Double
 
 protocol X {}
 
-// expected-error@+1{{generic signature requires types 'Double' and 'Int' to be the same}}
+// expected-error@+1{{generic signature requires types 'NotAnInt' (aka 'Double') and 'Int' to be the same}}
 extension X where NotAnInt == Int {}
 
 protocol EqualComparable {


### PR DESCRIPTION
Something else I was working on caused us to introduce redundant requirements erroneously, but this unearthed a minor bug.