### PR TITLE
[Diagnostics] Fix out-of-bounds index while fixing argument mismatch

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4258,6 +4258,12 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
 
   auto currArgIdx =
       locator->castLastElementTo<LocatorPathElt::ApplyArgToParam>().getArgIdx();
+
+  // Argument is extraneous and has been re-ordered to match one
+  // of two parameter types.
+  if (currArgIdx >= 2)
+    return false;
+
   auto otherArgIdx = currArgIdx == 0 ? 1 : 0;
 
   auto argType = cs.getType(argument);

--- a/validation-test/Sema/SwiftUI/rdar87407899.swift
+++ b/validation-test/Sema/SwiftUI/rdar87407899.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct AStruct {
+  let aField: MyEnum = .aCase // expected-note {{change 'let' to 'var' to make it mutable}}
+}
+
+enum MyEnum {
+case aCase
+}
+
+extension EmptyView {
+  func doImport(showImport: Binding<Bool>, anEnum: MyEnum) -> some View {
+    EmptyView()
+  }
+}
+
+struct SegFaultingView: View {
+  @Binding var aStruct: AStruct
+  @Binding var showImport: Bool
+  @State var importMessage: String = "none"
+
+  var body: some View {
+    EmptyView()
+      .doImport(showImport: showImport, // expected-error {{cannot convert value 'showImport' of type 'Bool' to expected type 'Binding<Bool>', use wrapper instead}}
+                importMessage: importMessage, // expected-error {{extra argument 'importMessage' in call}}
+                anEnum: $aStruct.aField) // expected-error {{cannot convert value of type 'Binding<MyEnum>' to expected argument type 'MyEnum'}}
+                // expected-error@-1 {{cannot assign to property: 'aField' is a 'let' constant}}
+  }
+}


### PR DESCRIPTION
Although the overload choice has two parameters, it doesn't
mean that there are exactly two arguments passed to it.

Resolves: rdar://87407899

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
