### PR TITLE
Assume `-target-min-inlining-version min` for `-library-level api` modules

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -805,17 +805,15 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // First, set up default minimum inlining target versions.
   auto getDefaultMinimumInliningTargetVersion =
       [&](const llvm::Triple &triple) -> llvm::VersionTuple {
-#if SWIFT_DEFAULT_TARGET_MIN_INLINING_VERSION_TO_MIN
-    // In ABI-stable modules, default to the version when Swift first became
-    // available.
-    if (FrontendOpts.EnableLibraryEvolution)
+    // In API modules, default to the version when Swift first became available.
+    if (Opts.LibraryLevel == LibraryLevel::API)
       if (auto minTriple = minimumAvailableOSVersionForTriple(triple))
-        return minTriple;
-#endif
+        return *minTriple;
 
-    // In ABI-unstable modules, we will never have to interoperate with
-    // older versions of the module, so we should default to the minimum
-    // deployment target.
+    // In other modules, assume that availability is used less consistently
+    // and that library clients will generally raise deployment targets as the
+    // library evolves so the min inlining version should be the deployment
+    // target by default.
     unsigned major, minor, patch;
     if (triple.isMacOSX())
       triple.getMacOSXVersion(major, minor, patch);

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -16,16 +16,28 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version min
 
 
+// Check that `-library-level api` implies `-target-min-inlining-version min`
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -library-level api
+
+
 // Check that these rules are only applied when requested and that at least some
 // diagnostics are not present without it.
-// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple 2>&1 | %FileCheck --check-prefix NON_ABI %s
-// NON_ABI: error: expected error not produced
-// NON_ABI: {'BetweenTargets' is only available in}
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple 2>&1 | %FileCheck --check-prefix NON_MIN %s
+
+
+// Check that -target-min-inlining-version overrides -library-level, allowing
+// library owners to disable this behavior for API libraries if needed.
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api 2>&1 | %FileCheck --check-prefix NON_MIN %s
 
 
 // Check that we respect -target-min-inlining-version by cranking it up high
 // enough to suppress any possible errors.
 // RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module %s -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version 42.0
+
+
+// NON_MIN: error: expected error not produced
+// NON_MIN: {'BetweenTargets' is only available in}
+
 
 /// Declaration with no availability annotation. Should be inferred as minimum
 /// inlining target.


### PR DESCRIPTION
By default, assume `-target-min-inlining-version min` for modules compiled with `-library-level api` since API modules generally cannot expect their clients to have the same deployment target that the library is built with.

Resolves rdar://90575987
