### PR TITLE
[cmake] Include StdlibOptions when only building toolchain extras.

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Toolchain-only build products
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../cmake/modules)
+include(StdlibOptions)
 include(AddSwiftStdlib)
 
 set(CXX_COMPILE_FLAGS)


### PR DESCRIPTION
In #40610 some options were moved into `StdlibOptions.cmake`, but that
file is only included from `stdlib/CMakeLists.txt` and
`cmake/modules/StandaloneOverlay.cmake`. However, if one does not build
neither the dynamic nor the static standard library, but enables
building the "toolchain extras" with
`SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT` `stdlib/CMakeLists.txt`
will not be included, but `stdlib/toolchain/CMakeLists.txt` will, which
uses a value from `StandardOverlay.cmake` that will not be provided the
correct default value and will skip building most of what
`SWIFT_BUILD_STDLIB_EXTRA_TOOLCHAIN_CONTENT` used to do.
