### PR TITLE
[move-function] Add initial support for moved lets over async funclet edges

### DIFF
--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/raw_ostream.h"
@@ -108,6 +109,12 @@ public:
     return DIOp;
   }
 };
+
+/// Returns the hashcode for the di expr element.
+inline llvm::hash_code hash_value(const SILDIExprElement &elt) {
+  return llvm::hash_combine(elt.getKind(), elt.getAsDecl(), elt.getAsDecl(),
+                            elt.getAsConstInt());
+}
 
 /// For a given SILDIExprOperator, provides information
 /// like its textual name and operand types.
@@ -273,5 +280,11 @@ public:
             SILDIExprOperator::Fragment;
   }
 };
+
+/// Returns the hashcode for the di expr element.
+inline llvm::hash_code hash_value(const SILDebugInfoExpression &elt) {
+  return llvm::hash_combine_range(elt.element_begin(), elt.element_end());
+}
+
 } // end namespace swift
 #endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -9863,6 +9863,19 @@ private:
   void createNode(const SILInstruction &);
 };
 
+template <>
+struct DenseMapInfo<swift::SILDebugVariable> {
+  using KeyTy = swift::SILDebugVariable;
+  static inline KeyTy getEmptyKey() {
+    return KeyTy(KeyTy::IsDenseMapSingleton::IsEmpty);
+  }
+  static inline KeyTy getTombstoneKey() {
+    return KeyTy(KeyTy::IsDenseMapSingleton::IsTombstone);
+  }
+  static unsigned getHashValue(const KeyTy &Val) { return hash_value(Val); }
+  static bool isEqual(const KeyTy &LHS, const KeyTy &RHS) { return LHS == RHS; }
+};
+
 } // end llvm namespace
 
 #endif

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -72,8 +72,10 @@ public:
       return line == rhs.line && column == rhs.column &&
              filename.equals(rhs.filename);
     }
+
     void dump() const;
     void print(raw_ostream &OS) const;
+    friend llvm::hash_code hash_value(const FilenameAndLocation &);
   };
 
 protected:
@@ -431,7 +433,18 @@ public:
   }
 
   inline bool operator!=(const SILLocation &R) const { return !(*this == R); }
+
+  friend llvm::hash_code hash_value(const SILLocation &);
 };
+
+inline llvm::hash_code hash_value(const SILLocation &R) {
+  return llvm::hash_combine(R.kindAndFlags.packedKindAndFlags,
+                            *R.storage.filePositionLoc);
+}
+
+inline llvm::hash_code hash_value(const SILLocation::FilenameAndLocation &R) {
+  return llvm::hash_combine(R.line, R.column, R.filename);
+}
 
 /// Allowed on any instruction.
 class RegularLocation : public SILLocation {

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -436,6 +436,8 @@ PASS(MoveKillsCopyableAddressesChecker, "sil-move-kills-copyable-addresses-check
 PASS(MoveFunctionCanonicalization, "sil-move-function-canon",
      "Pass that canonicalizes certain parts of the IR before we perform move "
      "function checking.")
+PASS(DebugInfoCanonicalizer, "sil-onone-debuginfo-canonicalizer",
+     "Canonicalize debug info at -Onone by propagating debug info into coroutine funclets")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(swiftSILOptimizer PRIVATE
   CapturePromotion.cpp
   ClosureLifetimeFixup.cpp
   ConstantPropagation.cpp
+  DebugInfoCanonicalizer.cpp
   DefiniteInitialization.cpp
   DIMemoryUseCollector.cpp
   DataflowDiagnostics.cpp

--- a/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
+++ b/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
@@ -1,0 +1,343 @@
+//===--- DebugInfoCanonicalizer.cpp ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file contains transformations that propagate debug info at the SIL
+/// level to make IRGen's job easier. The specific transformations that we
+/// perform is that we clone dominating debug_value for a specific
+/// SILDebugVariable after all coroutine-func-let boundary instructions. This in
+/// practice this as an algorithm works as follows:
+///
+/// 1. We walk the CFG along successors. By doing this we guarantee that we
+/// visit
+///    blocks after their dominators.
+///
+/// 2. When we visit a block, we walk the block from start->end. During this
+/// walk:
+///
+///    a. We grab a new block state from the centralized block->blockState map.
+///    This
+///       state is a [SILDebugVariable : DebugValueInst].
+///
+///    b. If we see a debug_value, we map blockState[debug_value.getDbgVar()] =
+///       debug_value. This ensures that when we get to the bottom of the block,
+///       we have pairs of SILDebugVariable + last debug_value on it.
+///
+///    c. If we see any coroutine funclet boundaries, we clone the current
+///    tracked
+///       set of our block state and then walk up the dom tree dumping in each
+///       block any debug_value with a SILDebugVariable that we have not already
+///       dumped. This is maintained by using a visited set of SILDebugVariable
+///       for each funclet boundary.
+///
+/// The end result is that at the beginning of each funclet we will basically
+/// declare the debug info for an addr.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-onone-debuginfo-canonicalizer"
+
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/FrozenMultiMap.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILUndef.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallSet.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                                  Utility
+//===----------------------------------------------------------------------===//
+
+static SILInstruction *cloneDebugValue(DebugValueInst *original,
+                                       SILInstruction *insertPt) {
+  SILBuilderWithScope builder(std::next(insertPt->getIterator()));
+  builder.setCurrentDebugScope(original->getDebugScope());
+  return builder.createDebugValue(original->getLoc(), original->getOperand(),
+                                  *original->getVarInfo(), false,
+                                  true /*was moved*/);
+}
+
+static SILInstruction *cloneDebugValue(DebugValueInst *original,
+                                       SILBasicBlock *block) {
+  SILBuilderWithScope builder(&block->front());
+  builder.setCurrentDebugScope(original->getDebugScope());
+  return builder.createDebugValue(original->getLoc(), original->getOperand(),
+                                  *original->getVarInfo(), false,
+                                  true /*was moved*/);
+}
+
+//===----------------------------------------------------------------------===//
+//                               Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct BlockState {
+  llvm::SmallMapVector<SILDebugVariable, DebugValueInst *, 4> debugValues;
+};
+
+struct DebugInfoCanonicalizer {
+  SILFunction *fn;
+  DominanceAnalysis *da;
+  DominanceInfo *dt;
+  llvm::MapVector<SILBasicBlock *, BlockState> blockToBlockState;
+
+  DebugInfoCanonicalizer(SILFunction *fn, DominanceAnalysis *da)
+      : fn(fn), da(da), dt(nullptr) {}
+
+  // We only need the dominance info if we actually see a funclet boundary. So
+  // make this lazy so we only create the dom tree in functions that actually
+  // use coroutines.
+  DominanceInfo *getDominance() {
+    if (!dt)
+      dt = da->get(fn);
+    return dt;
+  }
+
+  bool process();
+
+  /// NOTE: insertPt->getParent() may not equal startBlock! This is b/c if we
+  /// are propagating from a yield, we want to begin in the yields block, not
+  /// the yield's insertion point successor block.
+  bool propagateDebugValuesFromDominators(
+      PointerUnion<SILInstruction *, SILBasicBlock *> insertPt,
+      SILBasicBlock *startBlock,
+      llvm::SmallDenseSet<SILDebugVariable, 8> &seenDebugVars) {
+    LLVM_DEBUG(llvm::dbgs() << "==> PROPAGATING VALUE\n");
+    if (insertPt.is<SILInstruction *>()) {
+      LLVM_DEBUG(llvm::dbgs() << "Inst: " << *insertPt.get<SILInstruction *>());
+    }
+
+    auto *dt = getDominance();
+    auto *domTreeNode = dt->getNode(startBlock);
+    auto *rootNode = dt->getRootNode();
+    if (domTreeNode == rootNode) {
+      LLVM_DEBUG(llvm::dbgs() << "Root node! Nothing to propagate!\n");
+      return false;
+    }
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Root Node: " << rootNode->getBlock()->getDebugID() << '\n');
+
+    // We already emitted in our caller all debug_value needed from the block we
+    // were processing. We just need to walk up the dominator tree until we
+    // process the root node.
+    bool madeChange = false;
+    do {
+      domTreeNode = domTreeNode->getIDom();
+      LLVM_DEBUG(llvm::dbgs() << "Visiting idom: "
+                              << domTreeNode->getBlock()->getDebugID() << '\n');
+      auto &domBlockState = blockToBlockState[domTreeNode->getBlock()];
+      for (auto &pred : domBlockState.debugValues) {
+        // If we see a nullptr, we had a SILUndef. Do not clone, but mark this
+        // as a debug var we have seen so if it is again defined in previous
+        // blocks, we don't clone.
+        if (!pred.second) {
+          seenDebugVars.insert(pred.first);
+          continue;
+        }
+
+        LLVM_DEBUG(llvm::dbgs() << "Has DebugValue: " << *pred.second);
+
+        // If we have already inserted something for this debug_value,
+        // continue.
+        if (!seenDebugVars.insert(pred.first).second) {
+          LLVM_DEBUG(llvm::dbgs() << "Already seen this one... skipping!\n");
+          continue;
+        }
+
+        // Otherwise do the clone.
+        LLVM_DEBUG(llvm::dbgs() << "Haven't seen this one... cloning!\n");
+        if (auto *inst = insertPt.dyn_cast<SILInstruction *>()) {
+          cloneDebugValue(pred.second, inst);
+        } else {
+          cloneDebugValue(pred.second, insertPt.get<SILBasicBlock *>());
+        }
+
+        madeChange = true;
+      }
+    } while (domTreeNode != rootNode);
+
+    return madeChange;
+  }
+};
+
+} // namespace
+
+bool DebugInfoCanonicalizer::process() {
+  bool madeChange = false;
+
+  // We walk along successor edges depth first. This guarantees that we will
+  // visit any dominator of a specific block before we visit that block since
+  // any path to the block along successors by definition of dominators we must
+  // go through all such dominators.
+  BasicBlockWorklist worklist(&*fn->begin());
+  llvm::SmallDenseSet<SILDebugVariable, 8> seenDebugVars;
+
+  while (auto *block = worklist.pop()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "BB: Visiting. bb" << block->getDebugID() << '\n');
+    auto &state = blockToBlockState[block];
+
+    // Then for each inst in the block...
+    for (auto &inst : *block) {
+      LLVM_DEBUG(llvm::dbgs() << "    Inst: " << inst);
+      // If we have a debug_value that was moved, store state for it.
+      if (auto *dvi = dyn_cast<DebugValueInst>(&inst)) {
+        if (!dvi->getWasMoved())
+          continue;
+
+        LLVM_DEBUG(llvm::dbgs() << "        Found DebugValueInst!\n");
+        auto debugInfo = dvi->getVarInfo();
+        if (!debugInfo) {
+          LLVM_DEBUG(llvm::dbgs() << "        Has no var info?! Skipping!\n");
+          continue;
+        }
+
+        // If we have a SILUndef, mark this debug info as being mapped to
+        // nullptr.
+        if (isa<SILUndef>(dvi->getOperand())) {
+          LLVM_DEBUG(llvm::dbgs() << "        SILUndef.\n");
+          auto iter = state.debugValues.insert({*debugInfo, nullptr});
+          if (!iter.second)
+            iter.first->second = nullptr;
+          continue;
+        }
+
+        // Otherwise, we may have a new debug_value to track. Try to begin
+        // tracking it...
+        auto iter = state.debugValues.insert({*debugInfo, dvi});
+
+        // If we already have one, we failed to insert... So update the iter
+        // by hand. We track the last instance always.
+        if (!iter.second) {
+          iter.first->second = dvi;
+        }
+        LLVM_DEBUG(llvm::dbgs() << "        ==> Updated Map.\n");
+        continue;
+      }
+
+      // Otherwise, check if we have a coroutine boundary non-terminator
+      // instruction. If we do, we just dump the relevant debug_value right
+      // afterwards.
+      auto shouldHandleNonTermInst = [](SILInstruction *inst) -> bool {
+        // This handles begin_apply.
+        if (auto fas = FullApplySite::isa(inst)) {
+          if (fas.beginsCoroutineEvaluation() || fas.isAsync())
+            return true;
+        }
+        if (isa<HopToExecutorInst>(inst))
+          return true;
+        if (isa<EndApplyInst>(inst) || isa<AbortApplyInst>(inst))
+          return true;
+        return false;
+      };
+      if (shouldHandleNonTermInst(&inst)) {
+        LLVM_DEBUG(llvm::dbgs() << "        Found apply edge!.\n");
+        // Clone all of the debug_values that we are currently tracking both
+        // after the begin_apply,
+        SWIFT_DEFER { seenDebugVars.clear(); };
+
+        for (auto &pred : state.debugValues) {
+          // If we found a SILUndef, mark this debug var as seen but do not
+          // clone.
+          if (!pred.second) {
+            seenDebugVars.insert(pred.first);
+            continue;
+          }
+
+          cloneDebugValue(pred.second, &inst);
+          // Inside our block, we know that we do not have any repeats since we
+          // always track the last debug var.
+          seenDebugVars.insert(pred.first);
+          madeChange = true;
+        }
+
+        // Then walk up the idoms until we reach the entry searching for
+        // seenDebugVars.
+        madeChange |= propagateDebugValuesFromDominators(
+            &inst, inst.getParent(), seenDebugVars);
+        continue;
+      }
+
+      // Otherwise, we have a yield. We handle this separately since we need to
+      // insert the debug_value into its successor blocks.
+      if (auto *yi = dyn_cast<YieldInst>(&inst)) {
+        LLVM_DEBUG(llvm::dbgs() << "    Found Yield: " << *yi);
+
+        SWIFT_DEFER { seenDebugVars.clear(); };
+
+        // Duplicate all of our tracked debug values into our successor
+        // blocks.
+        for (auto *succBlock : yi->getSuccessorBlocks()) {
+          LLVM_DEBUG(llvm::dbgs() << "        Visiting Succ: bb"
+                                  << succBlock->getDebugID() << '\n');
+          for (auto &pred : state.debugValues) {
+            if (!pred.second)
+              continue;
+            LLVM_DEBUG(llvm::dbgs() << "            Cloning: " << *pred.second);
+            cloneDebugValue(pred.second, succBlock);
+            madeChange = true;
+          }
+
+          // We start out dataflow in yi, not in inst, even though we use inst
+          // as the insert pt. This is b/c inst is in the successor block we
+          // haven't processed yet so we would emit any debug_value in the
+          // yields own block twice.
+          madeChange |= propagateDebugValuesFromDominators(
+              succBlock, yi->getParent(), seenDebugVars);
+        }
+      }
+    }
+
+    // Now add the block's successor to the worklist if we haven't visited them
+    // yet.
+    for (auto *succBlock : block->getSuccessorBlocks())
+      worklist.pushIfNotVisited(succBlock);
+  }
+
+  return madeChange;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class DebugInfoCanonicalizerTransform : public SILFunctionTransform {
+  void run() override {
+    DebugInfoCanonicalizer canonicalizer(getFunction(),
+                                         getAnalysis<DominanceAnalysis>());
+    if (canonicalizer.process()) {
+      invalidateAnalysis(
+          SILAnalysis::InvalidationKind::BranchesAndInstructions);
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createDebugInfoCanonicalizer() {
+  return new DebugInfoCanonicalizerTransform();
+}

--- a/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
+++ b/lib/SILOptimizer/Mandatory/DebugInfoCanonicalizer.cpp
@@ -214,16 +214,6 @@ bool DebugInfoCanonicalizer::process() {
           continue;
         }
 
-        // If we have a SILUndef, mark this debug info as being mapped to
-        // nullptr.
-        if (isa<SILUndef>(dvi->getOperand())) {
-          LLVM_DEBUG(llvm::dbgs() << "        SILUndef.\n");
-          auto iter = state.debugValues.insert({*debugInfo, nullptr});
-          if (!iter.second)
-            iter.first->second = nullptr;
-          continue;
-        }
-
         // Otherwise, we may have a new debug_value to track. Try to begin
         // tracking it...
         auto iter = state.debugValues.insert({*debugInfo, dvi});

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -19,11 +19,12 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/SILOptions.h"
 #define DEBUG_TYPE "sil-passpipeline-plan"
+
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -924,6 +925,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // First serialize the SIL if we are asked to.
   P.startPipeline("Serialization");
   P.addSerializeSILPass();
+
+  // Fix up debug info by propagating dbg_values.
+  P.addDebugInfoCanonicalizer();
 
   // Now strip any transparent functions that still have ownership.
   P.addOwnershipModelEliminator();

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -41,7 +41,7 @@ public func forceSplit() async {}
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalF"(%swift.context* swiftasync %0, %swift.opaque* noalias %1, %swift.type* %T)
 // CHECK: entry:
-// CHECK:   call void @llvm.dbg.addr(metadata %swift.opaque** %msg.debug, metadata ![[SIMPLE_TEST_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   call void @llvm.dbg.addr(metadata %swift.context* %0, metadata ![[SIMPLE_TEST_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
 // CHECK:   musttail call swifttailcc void
 // CHECK-NEXT: ret void
 
@@ -60,10 +60,8 @@ public func forceSplit() async {}
 
 // DWARF:  DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalF")
 // DWARF:  DW_TAG_formal_parameter
-// Disable this part of the test due to a different codegen bug.
-// XWARF-NEXT:  DW_AT_location         (0x{{[a-f0-9]+}}:
-// XWARF-NEXT:     [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg0 RAX+0, DW_OP_deref)
-// XWARF-NEXT:  DW_AT_name ("msg")
+// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT:  DW_AT_name ("msg")
 //
 // DWARF:  DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalFTQ0_")
 // DWARF:  DW_AT_name	("letSimpleTest")
@@ -83,7 +81,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 }
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(%swift.context* swiftasync %0, %swift.opaque* %1, %swift.opaque* noalias %2, %swift.type* %T)
-// CHECK:   call void @llvm.dbg.addr(metadata %swift.opaque** %msg.debug, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref))
+// CHECK:   call void @llvm.dbg.addr(metadata %swift.context* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref))
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(%swift.context* swiftasync %{{[0-9]+}})
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -118,10 +116,8 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalF")
 // DWARF: DW_AT_name	("varSimpleTest")
 // DWARF: DW_TAG_formal_parameter
-// Disable this part of the test due to an additional error.
-// XWARF-NEXT:  DW_AT_location (0x{{[a-f0-9]+}}:
-// XWARF-NEXT:     [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg2 RCX+0, DW_OP_deref)
-// XWARF-NEXT:  DW_AT_name ("msg")
+// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name ("msg")
 //
 // DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTQ0_")
 // DWARF: DW_AT_name	("varSimpleTest")
@@ -162,8 +158,10 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTY5_")
 // DWARF: DW_AT_name	("varSimpleTest")
 // DWARF: DW_TAG_formal_parameter
-// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
-// DWARF-NEXT: DW_AT_name	("msg")
+// DWARF: DW_AT_location	(0x{{[a-f0-9]+}}:
+// DWARF:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref
+// DWARF:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg6 RBP-88, DW_OP_deref, DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF: DW_AT_name	("msg")
 
 public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
     await forceSplit()

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -1,0 +1,171 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -Xllvm -sil-disable-pass=alloc-stack-hoisting -g -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -Xllvm -sil-disable-pass=alloc-stack-hoisting -g -c %s -o %t/out.o
+// RUN: %llvm-dwarfdump --show-children %t/out.o | %FileCheck -check-prefix=DWARF %s
+
+// This test checks that:
+//
+// 1. At the IR level, we insert the appropriate llvm.dbg.addr, llvm.dbg.value.
+//
+// 2. At the Dwarf that we have proper locations with PC validity ranges where
+//    the value isn't valid.
+
+// We only run this on macOS right now since we would need to pattern match
+// slightly differently on other platforms.
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
+// REQUIRES: optimized_stdlib
+
+//////////////////
+// Declarations //
+//////////////////
+
+public class Klass {
+    public func doSomething() {}
+}
+
+public protocol P {
+    static var value: P { get }
+    func doSomething()
+}
+
+public var trueValue: Bool { true }
+public var falseValue: Bool { false }
+
+public func use<T>(_ t: T) {}
+public func forceSplit() async {}
+
+///////////
+// Tests //
+///////////
+
+// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalF"(%swift.context* swiftasync %0, %swift.opaque* noalias %1, %swift.type* %T)
+// CHECK: entry:
+// CHECK:   call void @llvm.dbg.addr(metadata %swift.opaque** %msg.debug, metadata ![[SIMPLE_TEST_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   musttail call swifttailcc void
+// CHECK-NEXT: ret void
+
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalFTQ0_"(i8* swiftasync %0)
+// CHECK: entryresume.0:
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_2:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)),
+// CHECK:   musttail call swifttailcc void
+// CHECK-NEXT: ret void
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalFTY1_"(i8* swiftasync %0)
+// CHECK: entryresume.1:
+// CHECK:     call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_3:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:     call void @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[SIMPLE_TEST_METADATA_3]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK:   musttail call swifttailcc void
+// CHECK-NEXT: ret void
+
+// DWARF:  DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalF")
+// DWARF:  DW_TAG_formal_parameter
+// Disable this part of the test due to a different codegen bug.
+// XWARF-NEXT:  DW_AT_location         (0x{{[a-f0-9]+}}:
+// XWARF-NEXT:     [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg0 RAX+0, DW_OP_deref)
+// XWARF-NEXT:  DW_AT_name ("msg")
+//
+// DWARF:  DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalFTQ0_")
+// DWARF:  DW_AT_name	("letSimpleTest")
+// DWARF:  DW_TAG_formal_parameter
+// DWARF-NEXT:  DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC:[a-f0-9]+]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT:  DW_AT_name	("msg")
+//
+// DWARF: DW_AT_linkage_name	("$s3out13letSimpleTestyyxnYalFTY1_")
+// DWARF: DW_AT_name	("letSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF: DW_AT_location	(0x{{[a-f0-9]+}}:
+// DWARF-NEXT:            [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT:            DW_AT_name	("msg")
+public func letSimpleTest<T>(_ msg: __owned T) async {
+    await forceSplit()
+    use(_move(msg))
+}
+
+// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(%swift.context* swiftasync %0, %swift.opaque* %1, %swift.opaque* noalias %2, %swift.type* %T)
+// CHECK:   call void @llvm.dbg.addr(metadata %swift.opaque** %msg.debug, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref))
+// CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(%swift.context* swiftasync %{{[0-9]+}})
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTQ0_"(i8* swiftasync %0)
+// CHECK: entryresume.0:
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref))
+// CHECK: musttail call swifttailcc void @swift_task_switch(%swift.context* swiftasync %9, i8* bitcast (void (i8*)* @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_" to i8*), i64 0, i64 0)
+// CHECK-NEXT: ret void
+// CHECK-NEXT: }
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_"(i8* swiftasync %0)
+// CHECK: entryresume.1:
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   call void @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(%swift.context* swiftasync %34)
+// CHECK-NEXT: ret void
+// CHECK-NEXT: }
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTQ2_"(i8* swiftasync %0)
+// CHECK: entryresume.2:
+
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY3_"(i8* swiftasync %0)
+// CHECK: entryresume.3:
+// CHECK:    call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref))
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalF")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// Disable this part of the test due to an additional error.
+// XWARF-NEXT:  DW_AT_location (0x{{[a-f0-9]+}}:
+// XWARF-NEXT:     [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg2 RCX+0, DW_OP_deref)
+// XWARF-NEXT:  DW_AT_name ("msg")
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTQ0_")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC:[a-f0-9]+]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name	("msg")
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTY1_")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(0x{{[a-f0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name	("msg")
+//
+// TODO: Missing debug info in s3out13varSimpleTestyyxz_xtYalFTQ2_
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTQ2_")
+// DWARF: DW_AT_name	("varSimpleTest")
+//
+// We perform moves in this funclet so we at first have an entry_value value
+// that is moved and then we use a normal register.
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTY3_")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF: DW_AT_location	(0x{{[a-f0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}):
+// DWARF-SAME:        DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref
+// DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}})
+// DWARF-SAME:        DW_OP_breg{{.*}}, DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name	("msg")
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTQ4_")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name	("msg")
+//
+// DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTY5_")
+// DWARF: DW_AT_name	("varSimpleTest")
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
+// DWARF-NEXT: DW_AT_name	("msg")
+public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
+    await forceSplit()
+    use(_move(msg))
+    await forceSplit()
+    msg = msg2
+    let msg3 = _move(msg)
+    let _ = msg3
+    msg = msg2
+    await forceSplit()
+}

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -146,6 +146,8 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}):
 // DWARF-SAME:        DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref
 // DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}})
+// DWARF-SAME:        DW_OP_breg{{.*}}, DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref
+// DWARF-NEXT:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}})
 // DWARF-SAME:        DW_OP_breg{{.*}}, DW_OP_deref, DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
 // DWARF-NEXT: DW_AT_name	("msg")
 //

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -47,13 +47,13 @@ public func forceSplit() async {}
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalFTQ0_"(i8* swiftasync %0)
 // CHECK: entryresume.0:
-// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_2:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)),
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_2:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)),
 // CHECK:   musttail call swifttailcc void
 // CHECK-NEXT: ret void
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13letSimpleTestyyxnYalFTY1_"(i8* swiftasync %0)
 // CHECK: entryresume.1:
-// CHECK:     call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_3:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:     call void @llvm.dbg.addr(metadata i8* %0, metadata ![[SIMPLE_TEST_METADATA_3:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
 // CHECK:     call void @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[SIMPLE_TEST_METADATA_3]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
 // CHECK:   musttail call swifttailcc void
 // CHECK-NEXT: ret void
@@ -90,14 +90,14 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTQ0_"(i8* swiftasync %0)
 // CHECK: entryresume.0:
-// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref))
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref))
 // CHECK: musttail call swifttailcc void @swift_task_switch(%swift.context* swiftasync %9, i8* bitcast (void (i8*)* @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_" to i8*), i64 0, i64 0)
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 //
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_"(i8* swiftasync %0)
 // CHECK: entryresume.1:
-// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
 // CHECK:   call void @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
 // CHECK:   musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(%swift.context* swiftasync %34)
 // CHECK-NEXT: ret void
@@ -108,7 +108,12 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY3_"(i8* swiftasync %0)
 // CHECK: entryresume.3:
-// CHECK:    call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 24, DW_OP_plus_uconst, 8, DW_OP_deref))
+// CHECK:    call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK:   call void @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK: musttail call swifttailcc void @"$s27move_function_dbginfo_async10forceSplityyYaF"(
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 //
 // DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalF")
 // DWARF: DW_AT_name	("varSimpleTest")
@@ -159,6 +164,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF: DW_TAG_formal_parameter
 // DWARF-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg14 R14), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref)
 // DWARF-NEXT: DW_AT_name	("msg")
+
 public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
     await forceSplit()
     use(_move(msg))

--- a/test/SILOptimizer/debuginfo_canonicalizer.sil
+++ b/test/SILOptimizer/debuginfo_canonicalizer.sil
@@ -113,6 +113,7 @@ bb3:
 // CHECK: [[BB_RHS]]:
 // CHECK-NEXT:   debug_value [moved] undef
 // CHECK-NEXT:   abort_apply
+// CHECK-NEXT:   debug_value [moved] undef
 // CHECK-NEXT:   br [[BB_CONT]]
 // CHECK: } // end sil function 'testUndefDiamond'
 sil @testUndefDiamond : $@convention(thin) (@guaranteed Klass) -> () {

--- a/test/SILOptimizer/debuginfo_canonicalizer.sil
+++ b/test/SILOptimizer/debuginfo_canonicalizer.sil
@@ -1,0 +1,137 @@
+// RUN: %target-sil-opt -sil-onone-debuginfo-canonicalizer -enable-sil-verify-all %s 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+struct Int64 {
+  var value: Builtin.Int64
+}
+
+class Klass {
+  var value: Int64
+}
+
+// Since we only take the last debug_value associated with a SILDebugVariable,
+// we only should see someVar for debug_value %2.
+//
+// CHECK-LABEL: sil @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64 {
+// CHECK: bb0([[ARG:%.*]] : $Klass):
+// CHECK-NEXT: debug_value [moved] [[ARG]] : $Klass, let, name "someVar"
+// CHECK-NEXT: [[ADDR:%.*]] = ref_element_addr [[ARG]] : $Klass
+// CHECK-NEXT: yield [[ADDR]] : $*Int64, resume bb1, unwind bb2
+//
+// CHECK: bb1:
+// CHECK-NEXT: debug_value [moved] [[ARG]] : $Klass, let, name "someVar"
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+//
+// CHECK: bb2:
+// CHECK-NEXT: debug_value [moved] [[ARG]] : $Klass, let, name "someVar"
+// CHECK-NEXT: unwind
+// CHECK: } // end sil function 'yieldOnceCoroutine'
+sil @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64 {
+bb0(%0 : $Klass):
+  debug_value [moved] %0 : $Klass, let, name "someVar"
+  %1 = ref_element_addr %0 : $Klass, #Klass.value
+  yield %1 : $*Int64, resume bb1, unwind bb2
+
+bb1:
+  %9999 = tuple()
+  return %9999 : $()
+
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: sil @testSimple : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [moved] [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT:   debug_value [moved] [[ARG]]
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [moved] [[ARG]]
+// CHECK: } // end sil function 'testSimple'
+sil @testSimple : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value [moved] %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %4) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  %9999 = tuple()
+  end_apply %4
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @testDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [moved] [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT: debug_value [moved] [[ARG]]
+// CHECK-NEXT:   cond_br undef, [[BB_LHS:bb[0-9]+]], [[BB_RHS:bb[0-9]+]]
+//
+// CHECK: [[BB_LHS]]:
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [moved] [[ARG]]
+// CHECK-NEXT:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_RHS]]:
+// CHECK:   abort_apply
+// CHECK-NEXT:   debug_value [moved] [[ARG]]
+// CHECK: } // end sil function 'testDiamond'
+sil @testDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value [moved] %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %token) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_apply %token
+  br bb3
+
+bb2:
+  abort_apply %token
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @testUndefDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   debug_value [moved] [[ARG]]
+// CHECK:   begin_apply
+// CHECK-NEXT: debug_value [moved] [[ARG]]
+// CHECK-NEXT:   cond_br undef, [[BB_LHS:bb[0-9]+]], [[BB_RHS:bb[0-9]+]]
+//
+// CHECK: [[BB_LHS]]:
+// CHECK:   end_apply
+// CHECK-NEXT:   debug_value [moved] [[ARG]]
+// CHECK-NEXT:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_RHS]]:
+// CHECK-NEXT:   debug_value [moved] undef
+// CHECK-NEXT:   abort_apply
+// CHECK-NEXT:   br [[BB_CONT]]
+// CHECK: } // end sil function 'testUndefDiamond'
+sil @testUndefDiamond : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  debug_value [moved] %0 : $Klass, let, name "arg"
+  %f = function_ref @yieldOnceCoroutine : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  (%3, %token) = begin_apply %f(%0) : $@yield_once @convention(method) (@guaranteed Klass) -> @yields @inout Int64
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_apply %token
+  br bb3
+
+bb2:
+  debug_value [moved] undef : $Klass, let, name "arg"
+  abort_apply %token
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -6,7 +6,8 @@
 // CHECK: "mandatory-arc-opts" ]
 // CHECK: ---
 // CHECK: name:            Serialization
-// CHECK: passes:          [ "serialize-sil", "ownership-model-eliminator" ]
+// CHECK: passes:          [ "serialize-sil", "sil-onone-debuginfo-canonicalizer",
+// CHECK-NEXT:               "ownership-model-eliminator" ]
 // CHECK: ---
 // CHECK: name:            Rest of Onone
 // CHECK: passes:          [ "use-prespecialized", "onone-prespecializer", "sil-debuginfo-gen" ]


### PR DESCRIPTION
In this PR, I introduce a new SIL pass that propagates debug_values over funclet edges and then use that to implement the necessary behavior at the SIL/IRGen level so that combined with an additional change I am going to make to LLVM, we can properly debug straight line async code with moves.

Some things to keep in mind:

1. I have another PR after this to add support for vars. I am just trying to split it up.
2. I am going to need to make at least one more change to LLVM (more likely 2, one to selection dag builder and one to live debug variables) to handle code that has conditional control flow.
3. Once I have a working straight line implementation, I am going to change this to use the same sort of data flow algorithm as live debug variables when I am propagating here so that we can handle moves that are conditional (i.e. in a branch of an if-else).