### PR TITLE
RequirementMachine: Improve the 'split concrete equivalence classes' hack a bit

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -525,6 +525,10 @@ namespace swift {
     /// algorithm.
     unsigned RequirementMachineMaxConcreteNesting = 30;
 
+    /// Maximum number of attempts to make when splitting concrete equivalence
+    /// classes.
+    unsigned RequirementMachineMaxSplitConcreteEquivClassAttempts = 2;
+
     /// Enable the new experimental protocol requirement signature minimization
     /// algorithm.
     RequirementMachineMode RequirementMachineProtocolSignatures =

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -355,6 +355,12 @@ def requirement_machine_max_concrete_nesting : Joined<["-"], "requirement-machin
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Set the maximum concrete type nesting depth before giving up">;
 
+def requirement_machine_max_split_concrete_equiv_class_attempts : Joined<["-"], "requirement-machine-max-split-concrete-equiv-class-attempts=">,
+  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Set the maximum concrete number of attempts at splitting "
+           "concrete equivalence classes before giving up. There should "
+           "never be a reason to change this">;
+
 def disable_requirement_machine_concrete_contraction : Flag<["-"], "disable-requirement-machine-concrete-contraction">,
   HelpText<"Disable preprocessing pass to eliminate conformance requirements "
            "on generic parameters which are made concrete">;

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -156,9 +156,14 @@ getSuperclassBound(Type depType,
   return props->getSuperclassBound(genericParams, term, Map);
 }
 
-bool RequirementMachine::isConcreteType(Type depType) const {
+/// Unlike the other queries, we have occasion to call this on a requirement
+/// machine for a protocol connected component as well as a top-level
+/// generic signature, so plumb through the protocol to use for the root
+/// `Self` generic parameter here.
+bool RequirementMachine::isConcreteType(Type depType,
+                                        const ProtocolDecl *proto) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
-                                            /*proto=*/nullptr);
+                                            proto);
   System.simplify(term);
   verify(term);
 
@@ -169,11 +174,16 @@ bool RequirementMachine::isConcreteType(Type depType) const {
   return props->isConcreteType();
 }
 
+/// Unlike the other queries, we have occasion to call this on a requirement
+/// machine for a protocol connected component as well as a top-level
+/// generic signature, so plumb through the protocol to use for the root
+/// `Self` generic parameter here.
 Type RequirementMachine::
 getConcreteType(Type depType,
-                TypeArrayView<GenericTypeParamType> genericParams) const {
+                TypeArrayView<GenericTypeParamType> genericParams,
+                const ProtocolDecl *proto) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
-                                            /*proto=*/nullptr);
+                                            proto);
   System.simplify(term);
   verify(term);
 

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -683,9 +683,11 @@ void RequirementMachine::verify(const MutableTerm &term) const {
   if (term.begin()->getKind() == Symbol::Kind::GenericParam) {
     auto *genericParam = term.begin()->getGenericParam();
     TypeArrayView<GenericTypeParamType> genericParams = getGenericParams();
-    auto found = std::find(genericParams.begin(),
-                           genericParams.end(),
-                           genericParam);
+    auto found = std::find_if(genericParams.begin(),
+                              genericParams.end(),
+                              [&](GenericTypeParamType *otherType) {
+                                return genericParam->isEqual(otherType);
+                              });
     if (found == genericParams.end()) {
       llvm::errs() << "Bad generic parameter in " << term << "\n";
       dump(llvm::errs());

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -172,6 +172,10 @@ RequirementMachine::initWithProtocolWrittenRequirements(
                          SmallVector<StructuralRequirement, 4>> protos) {
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 
+  // For RequirementMachine::verify() when called by generic signature queries;
+  // We have a single valid generic parameter at depth 0, index 0.
+  Params.push_back(component[0]->getSelfInterfaceType()->getCanonicalType());
+
   if (Dump) {
     llvm::dbgs() << "Adding protocols";
     for (auto *proto : component) {

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -167,22 +167,24 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
 /// Returns failure if completion fails within the configured number of steps.
 std::pair<CompletionResult, unsigned>
 RequirementMachine::initWithProtocolWrittenRequirements(
-    ArrayRef<const ProtocolDecl *> protos) {
+    ArrayRef<const ProtocolDecl *> component,
+    const llvm::DenseMap<const ProtocolDecl *,
+                         SmallVector<StructuralRequirement, 4>> protos) {
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 
   if (Dump) {
     llvm::dbgs() << "Adding protocols";
-    for (auto *proto : protos) {
+    for (auto *proto : component) {
       llvm::dbgs() << " " << proto->getName();
     }
     llvm::dbgs() << " {\n";
   }
 
   RuleBuilder builder(Context, System.getReferencedProtocols());
-  builder.initWithProtocolWrittenRequirements(protos);
+  builder.initWithProtocolWrittenRequirements(component, protos);
 
   // Add the initial set of rewrite rules to the rewrite system.
-  System.initialize(/*recordLoops=*/true, protos,
+  System.initialize(/*recordLoops=*/true, component,
                     std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -142,9 +142,11 @@ public:
   GenericSignature::RequiredProtocols getRequiredProtocols(Type depType) const;
   Type getSuperclassBound(Type depType,
                           TypeArrayView<GenericTypeParamType> genericParams) const;
-  bool isConcreteType(Type depType) const;
+  bool isConcreteType(Type depType,
+                      const ProtocolDecl *proto=nullptr) const;
   Type getConcreteType(Type depType,
-                       TypeArrayView<GenericTypeParamType> genericParams) const;
+                       TypeArrayView<GenericTypeParamType> genericParams,
+                       const ProtocolDecl *proto=nullptr) const;
   bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
   bool isCanonicalTypeInContext(Type type) const;
   Type getCanonicalTypeInContext(Type type,

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -99,7 +99,9 @@ class RequirementMachine final {
 
   std::pair<CompletionResult, unsigned>
   initWithProtocolWrittenRequirements(
-      ArrayRef<const ProtocolDecl *> protos);
+      ArrayRef<const ProtocolDecl *> component,
+      const llvm::DenseMap<const ProtocolDecl *,
+                           SmallVector<StructuralRequirement, 4>> protos);
 
   std::pair<CompletionResult, unsigned>
   initWithWrittenRequirements(

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -119,8 +119,6 @@ RequirementMachine::computeMinimalProtocolRequirements() {
 
   assert(protos.size() > 0 &&
          "Not a protocol connected component rewrite system");
-  assert(Params.empty() &&
-         "Not a protocol connected component rewrite system");
 
   System.minimizeRewriteSystem();
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -85,14 +85,12 @@ static void splitConcreteEquivalenceClasses(
 
   for (auto req : sig.getRequirements()) {
     if (shouldSplitConcreteEquivalenceClass(req, sig)) {
-      auto canType = sig->getSugaredType(
-        sig.getCanonicalTypeInContext(
-          req.getSecondType()));
+      auto concreteType = sig->getConcreteType(req.getSecondType());
 
       Requirement firstReq(RequirementKind::SameType,
-                           req.getFirstType(), canType);
+                           req.getFirstType(), concreteType);
       Requirement secondReq(RequirementKind::SameType,
-                            req.getSecondType(), canType);
+                            req.getSecondType(), concreteType);
       requirements.push_back({firstReq, SourceLoc(), /*inferred=*/false});
       requirements.push_back({secondReq, SourceLoc(), /*inferred=*/false});
       continue;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -42,10 +42,11 @@ using namespace rewriting;
 /// concrete type requirements.
 static bool shouldSplitConcreteEquivalenceClass(
     Requirement req,
+    const ProtocolDecl *proto,
     const RequirementMachine *machine) {
   return (req.getKind() == RequirementKind::SameType &&
           req.getSecondType()->isTypeParameter() &&
-          machine->isConcreteType(req.getSecondType()));
+          machine->isConcreteType(req.getSecondType(), proto));
 }
 
 /// Returns true if this generic signature contains abstract same-type
@@ -54,9 +55,24 @@ static bool shouldSplitConcreteEquivalenceClass(
 /// requirements, and minimize the signature again.
 static bool shouldSplitConcreteEquivalenceClasses(
     ArrayRef<Requirement> requirements,
+    const ProtocolDecl *proto,
     const RequirementMachine *machine) {
   for (auto req : requirements) {
-    if (shouldSplitConcreteEquivalenceClass(req, machine))
+    if (shouldSplitConcreteEquivalenceClass(req, proto, machine))
+      return true;
+  }
+
+  return false;
+}
+
+/// Same as the above, but with the requirements of a protocol connected
+/// component.
+static bool shouldSplitConcreteEquivalenceClasses(
+    const llvm::DenseMap<const ProtocolDecl *, RequirementSignature> &protos,
+    const RequirementMachine *machine) {
+  for (const auto &pair : protos) {
+    if (shouldSplitConcreteEquivalenceClasses(pair.second.getRequirements(),
+                                              pair.first, machine))
       return true;
   }
 
@@ -71,6 +87,7 @@ static bool shouldSplitConcreteEquivalenceClasses(
 static void splitConcreteEquivalenceClasses(
     ASTContext &ctx,
     ArrayRef<Requirement> requirements,
+    const ProtocolDecl *proto,
     const RequirementMachine *machine,
     TypeArrayView<GenericTypeParamType> genericParams,
     SmallVectorImpl<StructuralRequirement> &splitRequirements,
@@ -78,7 +95,6 @@ static void splitConcreteEquivalenceClasses(
   unsigned maxAttempts =
       ctx.LangOpts.RequirementMachineMaxSplitConcreteEquivClassAttempts;
 
-  ++attempt;
   if (attempt >= maxAttempts) {
     llvm::errs() << "Splitting concrete equivalence classes did not "
                  << "reach fixed point after " << attempt << " attempts.\n";
@@ -94,9 +110,9 @@ static void splitConcreteEquivalenceClasses(
   splitRequirements.clear();
 
   for (auto req : requirements) {
-    if (shouldSplitConcreteEquivalenceClass(req, machine)) {
+    if (shouldSplitConcreteEquivalenceClass(req, proto, machine)) {
       auto concreteType = machine->getConcreteType(
-          req.getSecondType(), genericParams);
+          req.getSecondType(), genericParams, proto);
 
       Requirement firstReq(RequirementKind::SameType,
                            req.getFirstType(), concreteType);
@@ -108,6 +124,25 @@ static void splitConcreteEquivalenceClasses(
     }
 
     splitRequirements.push_back({req, SourceLoc(), /*inferred=*/false});
+  }
+}
+
+/// Same as the above, but with the requirements of a protocol connected
+/// component.
+static void splitConcreteEquivalenceClasses(
+    ASTContext &ctx,
+    const llvm::DenseMap<const ProtocolDecl *, RequirementSignature> &protos,
+    const RequirementMachine *machine,
+    llvm::DenseMap<const ProtocolDecl *,
+                   SmallVector<StructuralRequirement, 4>> &splitProtos,
+    unsigned &attempt) {
+  for (const auto &pair : protos) {
+    const auto *proto = pair.first;
+    auto genericParams = proto->getGenericSignature().getGenericParams();
+    splitConcreteEquivalenceClasses(ctx, pair.second.getRequirements(),
+                                    proto, machine, genericParams,
+                                    splitProtos[proto],
+                                    attempt);
   }
 }
 
@@ -195,87 +230,99 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
       requirements.push_back({req, SourceLoc(), /*inferred=*/false});
   }
 
-  // Heap-allocate the requirement machine to save stack space.
-  std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
-      ctx.getRewriteContext()));
+  unsigned attempt = 0;
+  for (;;) {
+    // Heap-allocate the requirement machine to save stack space.
+    std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
+        ctx.getRewriteContext()));
 
-  auto status = machine->initWithProtocolWrittenRequirements(component, protos);
-  if (status.first != CompletionResult::Success) {
-    // All we can do at this point is diagnose and give each protocol an empty
-    // requirement signature.
-    for (const auto *otherProto : component) {
-      ctx.Diags.diagnose(otherProto->getLoc(),
-                         diag::requirement_machine_completion_failed,
-                         /*protocol=*/1,
-                         unsigned(status.first));
+    auto status = machine->initWithProtocolWrittenRequirements(component, protos);
+    if (status.first != CompletionResult::Success) {
+      // All we can do at this point is diagnose and give each protocol an empty
+      // requirement signature.
+      for (const auto *otherProto : component) {
+        ctx.Diags.diagnose(otherProto->getLoc(),
+                           diag::requirement_machine_completion_failed,
+                           /*protocol=*/1,
+                           unsigned(status.first));
 
-      auto rule = machine->getRuleAsStringForDiagnostics(status.second);
-      ctx.Diags.diagnose(otherProto->getLoc(),
-                         diag::requirement_machine_completion_rule,
-                         rule);
+        auto rule = machine->getRuleAsStringForDiagnostics(status.second);
+        ctx.Diags.diagnose(otherProto->getLoc(),
+                           diag::requirement_machine_completion_rule,
+                           rule);
 
-      if (otherProto != proto) {
-        ctx.evaluator.cacheOutput(
-          RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(otherProto)},
-          RequirementSignature(GenericSignatureErrorFlags::CompletionFailed));
+        if (otherProto != proto) {
+          ctx.evaluator.cacheOutput(
+            RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(otherProto)},
+            RequirementSignature(GenericSignatureErrorFlags::CompletionFailed));
+        }
+      }
+
+      return RequirementSignature(GenericSignatureErrorFlags::CompletionFailed);
+    }
+
+    auto minimalRequirements = machine->computeMinimalProtocolRequirements();
+
+    if (!machine->getErrors()) {
+      if (shouldSplitConcreteEquivalenceClasses(minimalRequirements, machine.get())) {
+        ++attempt;
+        splitConcreteEquivalenceClasses(ctx, minimalRequirements,
+                                        machine.get(), protos, attempt);
+        continue;
       }
     }
 
-    return RequirementSignature(GenericSignatureErrorFlags::CompletionFailed);
-  }
+    bool debug = machine->getDebugOptions().contains(DebugFlags::Minimization);
 
-  auto minimalRequirements = machine->computeMinimalProtocolRequirements();
+    // The requirement signature for the actual protocol that the result
+    // was kicked off with.
+    Optional<RequirementSignature> result;
 
-  bool debug = machine->getDebugOptions().contains(DebugFlags::Minimization);
-
-  // The requirement signature for the actual protocol that the result
-  // was kicked off with.
-  Optional<RequirementSignature> result;
-
-  if (debug) {
-    llvm::dbgs() << "\nRequirement signatures:\n";
-  }
-
-  for (const auto &pair : minimalRequirements) {
-    auto *otherProto = pair.first;
-    const auto &reqs = pair.second;
-
-    // Dump the result if requested.
     if (debug) {
-      llvm::dbgs() << "- Protocol " << otherProto->getName() << ": ";
-
-      auto sig = GenericSignature::get(
-          otherProto->getGenericSignature().getGenericParams(),
-          reqs.getRequirements());
-
-      PrintOptions opts;
-      opts.ProtocolQualifiedDependentMemberTypes = true;
-      sig.print(llvm::dbgs(), opts);
-      llvm::dbgs() << "\n";
+      llvm::dbgs() << "\nRequirement signatures:\n";
     }
 
-    // Don't call setRequirementSignature() on the original proto; the
-    // request evaluator will do it for us.
-    if (otherProto == proto)
-      result = reqs;
-    else {
-      auto temp = reqs;
-      ctx.evaluator.cacheOutput(
-        RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(otherProto)},
-        std::move(temp));
+    for (const auto &pair : minimalRequirements) {
+      auto *otherProto = pair.first;
+      const auto &reqs = pair.second;
+
+      // Dump the result if requested.
+      if (debug) {
+        llvm::dbgs() << "- Protocol " << otherProto->getName() << ": ";
+
+        auto sig = GenericSignature::get(
+            otherProto->getGenericSignature().getGenericParams(),
+            reqs.getRequirements());
+
+        PrintOptions opts;
+        opts.ProtocolQualifiedDependentMemberTypes = true;
+        sig.print(llvm::dbgs(), opts);
+        llvm::dbgs() << "\n";
+      }
+
+      // Don't call setRequirementSignature() on the original proto; the
+      // request evaluator will do it for us.
+      if (otherProto == proto)
+        result = reqs;
+      else {
+        auto temp = reqs;
+        ctx.evaluator.cacheOutput(
+          RequirementSignatureRequestRQM{const_cast<ProtocolDecl *>(otherProto)},
+          std::move(temp));
+      }
     }
-  }
 
-  if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
-      RequirementMachineMode::Enabled) {
-    SmallVector<RequirementError, 4> errors;
-    machine->System.computeRedundantRequirementDiagnostics(errors);
-    diagnoseRequirementErrors(ctx, errors,
-                              /*allowConcreteGenericParams=*/false);
-  }
+    if (ctx.LangOpts.RequirementMachineProtocolSignatures ==
+        RequirementMachineMode::Enabled) {
+      SmallVector<RequirementError, 4> errors;
+      machine->System.computeRedundantRequirementDiagnostics(errors);
+      diagnoseRequirementErrors(ctx, errors,
+                                /*allowConcreteGenericParams=*/false);
+    }
 
-  // Return the result for the specific protocol this request was kicked off on.
-  return *result;
+    // Return the result for the specific protocol this request was kicked off on.
+    return *result;
+  }
 }
 
 /// Builds the top-level generic signature requirements for this rewrite system.
@@ -479,9 +526,12 @@ AbstractGenericSignatureRequestRQM::evaluate(
 
     if (!errorFlags) {
       if (shouldSplitConcreteEquivalenceClasses(result.getRequirements(),
+                                                /*proto=*/nullptr,
                                                 machine.get())) {
+        ++attempt;
         splitConcreteEquivalenceClasses(ctx, result.getRequirements(),
-                                        machine.get(), result.getGenericParams(),
+                                        /*proto=*/nullptr, machine.get(),
+                                        result.getGenericParams(),
                                         requirements, attempt);
         continue;
       }
@@ -646,9 +696,12 @@ InferredGenericSignatureRequestRQM::evaluate(
     if (!errorFlags) {
       // Check if we need to rebuild the signature.
       if (shouldSplitConcreteEquivalenceClasses(result.getRequirements(),
+                                                /*proto=*/nullptr,
                                                 machine.get())) {
+        ++attempt;
         splitConcreteEquivalenceClasses(ctx, result.getRequirements(),
-                                        machine.get(), result.getGenericParams(),
+                                        /*proto=*/nullptr, machine.get(),
+                                        result.getGenericParams(),
                                         requirements, attempt);
         continue;
       }

--- a/lib/AST/RequirementMachine/RuleBuilder.h
+++ b/lib/AST/RequirementMachine/RuleBuilder.h
@@ -98,7 +98,10 @@ struct RuleBuilder {
   void initWithGenericSignatureRequirements(ArrayRef<Requirement> requirements);
   void initWithWrittenRequirements(ArrayRef<StructuralRequirement> requirements);
   void initWithProtocolSignatureRequirements(ArrayRef<const ProtocolDecl *> proto);
-  void initWithProtocolWrittenRequirements(ArrayRef<const ProtocolDecl *> proto);
+  void initWithProtocolWrittenRequirements(
+      ArrayRef<const ProtocolDecl *> component,
+      const llvm::DenseMap<const ProtocolDecl *,
+                           SmallVector<StructuralRequirement, 4>> protos);
   void initWithConditionalRequirements(ArrayRef<Requirement> requirements,
                                        ArrayRef<Term> substitutions);
   void addReferencedProtocol(const ProtocolDecl *proto);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -998,6 +998,17 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_requirement_machine_max_split_concrete_equiv_class_attempts)) {
+    unsigned limit;
+    if (StringRef(A->getValue()).getAsInteger(10, limit)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      HadError = true;
+    } else {
+      Opts.RequirementMachineMaxSplitConcreteEquivClassAttempts = limit;
+    }
+  }
+
   if (Args.hasArg(OPT_disable_requirement_machine_concrete_contraction))
     Opts.EnableRequirementMachineConcreteContraction = false;
 

--- a/test/Generics/reconstitute_sugar.swift
+++ b/test/Generics/reconstitute_sugar.swift
@@ -45,3 +45,17 @@ extension G where X : C<Dictionary<Y, Z>> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=G
 // CHECK-NEXT: Generic signature: <X, Y, Z where X : C<()>>
 extension G where X : C<()> {}
+
+// Make sure we reconstitute sugar when splitting concrete
+// equivalence classes too.
+
+protocol P {
+  associatedtype T where T == [U]
+  associatedtype U
+}
+
+struct G2<T1 : P, T2 : P> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G2
+// CHECK-NEXT: Generic signature: <T1, T2 where T1 : P, T2 : P, T1.[P]U == [Int], T2.[P]U == [Int]>
+extension G2 where T2.U == [Int], T1.T == T2.T {}

--- a/test/Generics/split_concrete_equivalence_class_in_protocol.swift
+++ b/test/Generics/split_concrete_equivalence_class_in_protocol.swift
@@ -1,0 +1,51 @@
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: .P1@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P1]T : P1, Self.[P1]U == Int, Self.[P1]V == Int>
+protocol P1 {
+  associatedtype T : P1
+  associatedtype U where U == Int
+  associatedtype V where V == T.U
+}
+
+struct G<X> {}
+
+// CHECK-LABEL: .P2@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P2]T : P2, Self.[P2]U == G<Self.[P2]X>, Self.[P2]V == G<Self.[P2]T.[P2]X>>
+protocol P2 {
+  associatedtype T : P2
+  associatedtype U where U == G<X>
+  associatedtype V where V == T.U
+  associatedtype X
+}
+
+// CHECK-LABEL: .P3@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P3]T : P3, Self.[P3]U == G<Self.[P3]X>, Self.[P3]V == G<Self.[P3]X>, Self.[P3]X == Self.[P3]T.[P3]X>
+protocol P3 {
+  associatedtype T : P3
+  associatedtype U where U == G<X>
+  associatedtype V where V == T.U, V == G<X>
+  associatedtype X
+}
+
+// CHECK-LABEL: .P4@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P4]T : P4, Self.[P4]U == G<Self.[P4]X>, Self.[P4]V == G<Self.[P4]X>, Self.[P4]X == Self.[P4]T.[P4]X>
+protocol P4 {
+  associatedtype T : P4
+  associatedtype U where U == G<X>
+  associatedtype V where V == T.U
+  associatedtype X where X == T.X
+}
+
+// We don't split concrete equivalence classes if the signature had an error,
+// but we also shouldn't crash in verify() because of an unsplit concrete
+// equivalence class.
+
+// CHECK-LABEL: .P4Bad@
+// CHECK-NEXT: Requirement signature: <Self where Self.[P4Bad]T : P4Bad, Self.[P4Bad]U == G<Self.[P4Bad]X>, Self.[P4Bad]V == Self.[P4Bad]T.[P4Bad]U>
+protocol P4Bad {
+  associatedtype T : P4Bad
+  associatedtype U where U == G<X>
+  associatedtype V where V == T.U
+  associatedtype X where X == U.X
+}

--- a/test/SILGen/class_conforms_with_default_concrete_self.swift
+++ b/test/SILGen/class_conforms_with_default_concrete_self.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-silgen %s -requirement-machine-abstract-signatures=on | %FileCheck %s
-// RUN: %target-swift-emit-silgen %s -requirement-machine-abstract-signatures=on -disable-requirement-machine-concrete-contraction | %FileCheck %s
 
 public protocol P {
   associatedtype A : Q where A.B == Self

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -requirement-machine-protocol-signatures=off -requirement-machine-abstract-signatures=on
-
-// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -requirement-machine-abstract-signatures=on
 
 //===----------------------------------------------------------------------===//
 // Use of protocols with Self or associated type requirements

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -1,7 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
-// RUN: not %target-swift-frontend -typecheck -dump-type-witness-systems %s -requirement-machine-protocol-signatures=off 2>&1 | %FileCheck %s
-
-// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck -dump-type-witness-systems %s 2>&1 | %FileCheck %s
 
 protocol P1 where A == Never {
   associatedtype A
@@ -572,7 +570,7 @@ protocol P32e where A == B {
 }
 protocol Q32: P32e, P32a, P32b, P32c, P32d {}
 // expected-error@-1 {{'Self.B' cannot be equal to both 'Never' and 'Int'}}
-// expected-error@-2 {{'Self.B' cannot be equal to both 'Void' and 'Int'}}
+// expected-error@-2 {{'Self.B' cannot be equal to both '()' and 'Int'}}
 // expected-error@-3 {{'Self.A' cannot be equal to both 'Bool' and 'Int'}}
 // expected-note@-4 3 {{same-type constraint 'Self.A' == 'Int' implied here}}
 do {


### PR DESCRIPTION
- Catch and assert on runaway recursion
- Preserve type sugar
- Generalize it to protocol requirement signatures