### PR TITLE
Ensure that we don't emit references to marker protocols in existential type metadata.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1670,8 +1670,12 @@ namespace {
       }
 
       auto layout = type.getExistentialLayout();
-      
-      auto protocols = layout.getProtocols();
+
+      SmallVector<ProtocolType *, 4> protocols;
+      for (auto proto : layout.getProtocols()) {
+        if (!proto->getDecl()->isMarkerProtocol())
+          protocols.push_back(proto);
+      }
 
       // Collect references to the protocol descriptors.
       auto descriptorArrayTy

--- a/test/IRGen/marker_protocol_backdeploy.swift
+++ b/test/IRGen/marker_protocol_backdeploy.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -primary-file %s -target %target-cpu-apple-macosx10.15 -emit-ir -o - | %FileCheck %s
+
+// Marker protocols should have no ABI impact at all, so this source file checks
+// for the absence of symbols related to marker protocols.
+
+// CHECK-NOT: $s26marker_protocol_backdeploy1PP
+// CHECK-NOT: $s26marker_protocol_backdeploy1PMp
+
+// REQUIRES: PTRSIZE=64
+// REQUIRES: OS=macosx
+
+@_marker public protocol P { }
+public protocol Q: P { }
+protocol R { }
+
+
+// Suppress marker protocols when forming existentials at runtime
+public func takeAnyType<T>(_: T.Type) { }
+
+// CHECK-LABEL: define {{.*}}@"$ss8Sendable_26marker_protocol_backdeploy1QAB1RpMa"
+// CHECK: ss8Sendable_26marker_protocol_backdeploy1QAB1RpML
+// CHECK-NOT: Sendable
+// CHECK: s26marker_protocol_backdeploy1QMp
+// CHECK-NOT: Sendable
+// CHECK: s26marker_protocol_backdeploy1RMp
+// CHECK-NOT: SENDABLE
+// CHECK: swift_getExistentialTypeMetadata
+public func passExistentialType() {
+  typealias Fn = (Sendable & P & Q & R) async -> Void
+  takeAnyType(Fn.self)
+}

--- a/test/IRGen/marker_protocol_backdeploy.swift
+++ b/test/IRGen/marker_protocol_backdeploy.swift
@@ -9,6 +9,9 @@
 // REQUIRES: PTRSIZE=64
 // REQUIRES: OS=macosx
 
+// Temporarily disable on arm (rdar://89910199)
+// UNSUPPORTED: CPU=arm64, CPU=arm64e
+
 @_marker public protocol P { }
 public protocol Q: P { }
 protocol R { }


### PR DESCRIPTION
Fixes rdar://88922030.