### PR TITLE
Ensure that emit unnamed isolated parameters

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -314,7 +314,7 @@ struct ArgumentInitHelper {
     assert(type->isMaterializable());
 
     ++ArgNo;
-    if (PD->hasName()) {
+    if (PD->hasName() || PD->isIsolated()) {
       makeArgumentIntoBinding(type, &*f.begin(), PD);
       return;
     }

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -10,3 +10,17 @@ public actor A {
 // CHECK: sil{{.*}} [ossa] @$s4test13takesIsolatedyyAA1ACYiF
 @available(SwiftStdlib 5.1, *)
 public func takesIsolated(_: isolated A) { }
+
+@available(SwiftStdlib 5.1, *)
+public func takeClosureWithIsolatedParam(body: (isolated A) async -> Void) { }
+
+// Emit the unnamed parameter when it's isolated, so that we can hop to it.
+// CHECK-LABEL: sil private [ossa] @$s4test0A24ClosureWithIsolatedParamyyFyAA1ACYiYaXEfU_ : $@convention(thin) @async (@guaranteed A)
+// CHECK: bb0(%0 : @guaranteed $A):
+// CHECK: [[COPY:%.*]] = copy_value %0 : $A
+// CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [[COPY]] : $A
+// CHECK-NEXT:  hop_to_executor [[BORROW]] : $A
+@available(SwiftStdlib 5.1, *)
+public func testClosureWithIsolatedParam() {
+  takeClosureWithIsolatedParam { _ in }
+}


### PR DESCRIPTION
... because we need to be able to hop to their actors.
Fixes rdar://86753732.
