### PR TITLE
Add doesCastPreserveOwnershipForType() to SIL/Utils/DynamicCasts.cpp

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1246,6 +1246,10 @@ public:
   /// Whether this is the AnyObject type.
   bool isAnyObject();
 
+  /// Return true if this type is potentially an AnyObject existential after
+  /// substitution.
+  bool isPotentiallyAnyObject();
+
   /// Whether this is an existential composition containing
   /// Error.
   bool isExistentialWithError();

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -35,6 +35,11 @@ class SILType;
 enum class CastConsumptionKind : uint8_t;
 struct SILDynamicCastInst;
 
+/// Returns true if the ownership of all references in this type are preserved
+/// (without unbalanced retains or releases) during dynamic casting.
+bool doesCastPreserveOwnershipForTypes(SILModule &module, CanType sourceType,
+                                       CanType targetType);
+
 enum class DynamicCastFeasibility {
   /// The cast will always succeed.
   WillSucceed,
@@ -82,10 +87,17 @@ bool emitSuccessfulIndirectUnconditionalCast(
 bool emitSuccessfulIndirectUnconditionalCast(SILBuilder &B, SILLocation loc,
                                              SILDynamicCastInst dynamicCast);
 
+/// Can the given cast be performed by the scalar checked-cast instructions in
+/// the current SIL stage, or do we need to use the indirect instructions?
+bool canSILUseScalarCheckedCastInstructions(SILModule &M,
+                                            CanType sourceType,
+                                            CanType targetType);
+
 /// Can the given cast be performed by the scalar checked-cast
-/// instructions, or does we need to use the indirect instructions?
-bool canUseScalarCheckedCastInstructions(SILModule &M,
-                                         CanType sourceType,CanType targetType);
+/// instructions at IRGen, or do we need to use the indirect instructions?
+bool canIRGenUseScalarCheckedCastInstructions(SILModule &M,
+                                              CanType sourceType,
+                                              CanType targetType);
 
 /// Carry out the operations required for an indirect conditional cast
 /// using a scalar cast operation.
@@ -435,8 +447,8 @@ public:
     llvm_unreachable("covered switch");
   }
 
-  bool canUseScalarCheckedCastInstructions() const {
-    return swift::canUseScalarCheckedCastInstructions(
+  bool canSILUseScalarCheckedCastInstructions() const {
+    return swift::canSILUseScalarCheckedCastInstructions(
         getModule(), getSourceFormalType(), getTargetFormalType());
   }
 };

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -269,8 +269,8 @@ protected:
     auto FalseCount = inst->getFalseBBCount();
 
     // Try to use the scalar cast instruction.
-    if (canUseScalarCheckedCastInstructions(B.getModule(),
-                                            sourceType, targetType)) {
+    if (canSILUseScalarCheckedCastInstructions(B.getModule(),
+                                               sourceType, targetType)) {
       emitIndirectConditionalCastWithScalar(
           B, SwiftMod, loc, inst->getConsumptionKind(), src, sourceType, dest,
           targetType, succBB, failBB, TrueCount, FalseCount);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -976,6 +976,20 @@ bool TypeBase::isAnyObject() {
   return canTy.getExistentialLayout().isAnyObject();
 }
 
+// Distinguish between class-bound types that might be AnyObject vs other
+// class-bound types. Only types that are potentially AnyObject might have a
+// transparent runtime type wrapper like __SwiftValue. This must look through
+// all optional types because dynamic casting sees through them.
+bool TypeBase::isPotentiallyAnyObject() {
+  Type unwrappedTy = lookThroughAllOptionalTypes();
+  if (auto archetype = unwrappedTy->getAs<ArchetypeType>()) {
+    // Does archetype have any requirements that contradict AnyObject?
+    // 'T : AnyObject' requires a layout constraint, not a conformance.
+    return archetype->getConformsTo().empty() && !archetype->getSuperclass();
+  }
+  return unwrappedTy->isAnyObject();
+}
+
 bool ExistentialLayout::isErrorExistential() const {
   auto protocols = getProtocols();
   return (!hasExplicitAnyObject &&

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -225,14 +225,103 @@ static CanType getHashableExistentialType(ModuleDecl *M) {
   return hashable->getDeclaredInterfaceType()->getCanonicalType();
 }
 
-static bool canBeExistential(CanType ty) {
-  // If ty is an archetype, conservatively assume it's an existential.
-  return ty.isAnyExistentialType() || ty->is<ArchetypeType>();
-}
+// Returns true if casting \p sourceFormalType to \p targetFormalType preserves
+// ownership.
+//
+// Casting preserves ownership when all references from the source value are
+// forwarded into the result value (without unbalanced retains or releases).
+//
+// When both the source and target types of checked-cast preserve ownership,
+// then the cast is compatible with guaranteed ownership. A guaranteed
+// compatible cast cannot release any references within its operand's value
+// and cannot retain any references owned by its result.
+//
+// A type's ownership might not be preserved by a dynamic cast if it is either
+//   (A) a potentially bridged value
+// or
+//   (B) potentially wrapped in a transparent type, which is equivalent to
+//       isPotentiallyAnyObject()
+//
+// Given:
+//   let source: sourceType
+//   let dest = source as! targetType
+//
+// Ownership conversion happens when
+//
+//   (A) one type is a bridged value and the other is an object:
+//
+//      (A1) Boxing: <trivial> as! Object instantiates references in Object
+//           Presumably, Object's type must be class-bound, but this is not
+//           currently checked.
+//
+//      (A2) Unboxing: Object as! <trivial> destroys references in Object
+//           Object may be any type that can hold an object, including
+//           non-class-bound archetypes and existentials.
+//
+//   (B) one type is transparently wrapped in __SwiftValue, while the other is
+//       unwrapped. Given:
+//
+//     class C : Hashable {}
+//     let a = AnyHashable(C())
+//
+//     (B1) When the substituted source type is AnyHashable and the
+//          substituted destination type is AnyObject, the cast
+//          instantiates an owned __SwiftValue:
+//
+//          // instantiates __SwiftValue
+//          let b = a as! AnyObject
+//        or
+//          let b = a as! T where T.self == AnyObject.self
+//
+//     (B2) When the substituted source type is Any or AnyObject, and the
+//          substituted destination type is not Any or AnyObject, the cast
+//          releases the owned __SwiftValue:
+//
+//          let c = b as! C // releases __SwiftValue
+//
+// After unwrapping Optional, the type may fall into one one of
+// the following categories that are relevant for cast ownership:
+//
+// Class-bound types (hasReferenceSemantics() && !isPotentiallyAnyObject())
+// - includes classes, class-bound existentials other than AnyObject,
+//   class-bound archetypes with a superclass or protocol constraint,
+//   objc types, blocks, Builtin.NativeObject, etc.
+// - excludes any type that are potentially AnyObject after substitution
+// - the value is a single reference
+// - the single reference is "known unwrapped". It never transparently wraps the
+//   underlying dynamically typed value in another type, such as __SwiftValue
+// - casting directly forwards the reference
+//
+// Potentially bridged values:
+// - includes struct, enum, non-class archetype, non-class existential,
+//   and non-objc-metatype
+// - these types are potentially trivial after subsitution. If so, then they
+//   convert to a reference when casting to AnyObject or certain classes
+//
+// Any and AnyObject existentials:
+// - although called existentials, their type is a protocol composition
+// - these do not include existentials with constraints
+// - these are very special types, unlike normal existentials...
+// - the immediately erased value may itself be an existential
+//   (an AnyObject existential can be wrapped within an Any existential!)
+// - the underlying dynamically typed value may be transparently wrapped in
+//   __SwiftValue
+//
+// These type categories are disjoint, except that a non-class archetype is both
+// potentially bridged and potentially Any or AnyObject after substitution.
+//
+// TODO: In the future, when the runtime stops wrapping nontrivial types inside
+// __SwiftValue, cases (B1) and (B2) above will no longer apply. At that time,
+// expand ownership preserving cast types to AnyObject. Then remove the
+// isPotentiallyAnyObject() check.
+bool swift::doesCastPreserveOwnershipForTypes(SILModule &module,
+                                              CanType sourceType,
+                                              CanType targetType) {
+  if (!canIRGenUseScalarCheckedCastInstructions(module, sourceType, targetType))
+    return false;
 
-static bool canBeClass(CanType ty) {
-  // If ty is an archetype, conservatively assume it's an existential.
-  return ty.getClassOrBoundGenericClass() || ty->is<ArchetypeType>();
+  return !sourceType->isPotentiallyAnyObject()
+    && !targetType->isPotentiallyAnyObject();
 }
 
 bool SILDynamicCastInst::isRCIdentityPreserving() const {
@@ -247,26 +336,12 @@ bool SILDynamicCastInst::isRCIdentityPreserving() const {
   // would get confused and might eliminate a retain of such an object
   // completely.
   SILFunction &f = *getFunction();
-  if (getSourceLoweredType().isTrivial(f) != getTargetLoweredType().isTrivial(f))
-    return false;
-
-  CanType source = getSourceFormalType();
-  CanType target = getTargetFormalType();
-
-  // An existential may be holding a reference to a bridgeable struct.
-  // In this case, ARC on the existential affects the refcount of the container
-  // holding the struct, not the class to which the struct is bridged.
-  // Therefore, don't assume RC identity when casting between existentials and
-  // classes (and also between two existentials).
-  if (canBeExistential(source) &&
-      (canBeClass(target) || canBeExistential(target)))
-    return false;
-
-  // And vice versa.
-  if (canBeClass(source) && canBeExistential(target))
-    return false;
-
-  return true;
+  if (getSourceLoweredType().isTrivial(f)
+      && getTargetLoweredType().isTrivial(f)) {
+    return true;
+  }
+  return doesCastPreserveOwnershipForTypes(f.getModule(), getSourceFormalType(),
+                                           getTargetFormalType());
 }
 
 /// Check if a given type conforms to _BridgedToObjectiveC protocol.
@@ -1204,15 +1279,29 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
 }
 
 /// Can the given cast be performed by the scalar checked-cast
-/// instructions?
+/// instructions at the current SIL stage?
 ///
-/// TODO: in OSSA-with-opaque-values SIL, all casts could be modeled using
-/// scalar casts by setting 'OwnershipForwardingMixin::directlyForwards =
-/// false'. This would simplify SIL analysis. Temporaries would be emitted
-/// during address lowering.
-bool swift::canUseScalarCheckedCastInstructions(SILModule &M,
-                                                CanType sourceFormalType,
-                                                CanType targetFormalType) {
+/// FIXME: Always return true for !useLoweredAddresses: Scalar casts are always
+/// valid for owned values. If the operand is +1, the case will always destroy
+/// or forward it. The result is always either +1 or trivial. The cast never
+/// hides a copy. doesCastPreserveOwnershipForTypes determines whether the
+/// scalar cast is also compatible with guaranteed values.
+bool swift::canSILUseScalarCheckedCastInstructions(SILModule &M,
+                                                   CanType sourceFormalType,
+                                                   CanType targetFormalType) {
+  if (M.useLoweredAddresses())
+    return canIRGenUseScalarCheckedCastInstructions(M, sourceFormalType,
+                                                    targetFormalType);
+
+  return
+    doesCastPreserveOwnershipForTypes(M, sourceFormalType, targetFormalType);
+}
+
+/// Can the given cast be performed by the scalar checked-cast
+/// instructions?
+bool swift::canIRGenUseScalarCheckedCastInstructions(SILModule &M,
+                                                     CanType sourceFormalType,
+                                                     CanType targetFormalType) {
   // Look through one level of optionality on the source.
   auto objectType = sourceFormalType;
   if (auto type = objectType.getOptionalObjectType())
@@ -1278,8 +1367,9 @@ void swift::emitIndirectConditionalCastWithScalar(
     SILValue destAddr, CanType targetFormalType,
     SILBasicBlock *indirectSuccBB, SILBasicBlock *indirectFailBB,
     ProfileCounter TrueCount, ProfileCounter FalseCount) {
-  assert(canUseScalarCheckedCastInstructions(B.getModule(),
-                                             sourceFormalType, targetFormalType));
+  assert(canSILUseScalarCheckedCastInstructions(B.getModule(),
+                                                sourceFormalType,
+                                                targetFormalType));
 
   // Create our successor and fail blocks.
   SILBasicBlock *scalarFailBB = B.splitBlockForFallthrough();

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -1281,7 +1281,7 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
 /// Can the given cast be performed by the scalar checked-cast
 /// instructions at the current SIL stage?
 ///
-/// FIXME: Always return true for !useLoweredAddresses: Scalar casts are always
+/// Always returns true for !useLoweredAddresses. Scalar casts are always
 /// valid for owned values. If the operand is +1, the case will always destroy
 /// or forward it. The result is always either +1 or trivial. The cast never
 /// hides a copy. doesCastPreserveOwnershipForTypes determines whether the
@@ -1289,12 +1289,11 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
 bool swift::canSILUseScalarCheckedCastInstructions(SILModule &M,
                                                    CanType sourceFormalType,
                                                    CanType targetFormalType) {
-  if (M.useLoweredAddresses())
-    return canIRGenUseScalarCheckedCastInstructions(M, sourceFormalType,
-                                                    targetFormalType);
+  if (!M.useLoweredAddresses())
+    return true;
 
-  return
-    doesCastPreserveOwnershipForTypes(M, sourceFormalType, targetFormalType);
+  return canIRGenUseScalarCheckedCastInstructions(M, sourceFormalType,
+                                                  targetFormalType);
 }
 
 /// Can the given cast be performed by the scalar checked-cast

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3994,8 +3994,7 @@ public:
     }
   }
 
-  void verifyCheckedCast(bool isExact, SILType fromTy, SILType toTy,
-                         bool isOpaque = false) {
+  void verifyCheckedCast(bool isExact, SILType fromTy, SILType toTy) {
     // Verify common invariants.
     require(fromTy.isObject() && toTy.isObject(),
             "value checked cast src and dest must be objects");
@@ -4003,8 +4002,8 @@ public:
     auto fromCanTy = fromTy.getASTType();
     auto toCanTy = toTy.getASTType();
 
-    require(isOpaque || canUseScalarCheckedCastInstructions(F.getModule(),
-                                                            fromCanTy, toCanTy),
+    require(canUseScalarCheckedCastInstructions(F.getModule(),
+                                                fromCanTy, toCanTy),
             "invalid value checked cast src or dest types");
 
     // Peel off metatypes. If two types are checked-cast-able, so are their

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4002,8 +4002,8 @@ public:
     auto fromCanTy = fromTy.getASTType();
     auto toCanTy = toTy.getASTType();
 
-    require(canUseScalarCheckedCastInstructions(F.getModule(),
-                                                fromCanTy, toCanTy),
+    require(canSILUseScalarCheckedCastInstructions(F.getModule(),
+                                                   fromCanTy, toCanTy),
             "invalid value checked cast src or dest types");
 
     // Peel off metatypes. If two types are checked-cast-able, so are their

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -287,8 +287,8 @@ namespace {
 
   private:
     CastStrategy computeStrategy() const {
-      if (canUseScalarCheckedCastInstructions(SGF.SGM.M, SourceType,
-                                              TargetType))
+      if (canSILUseScalarCheckedCastInstructions(SGF.SGM.M, SourceType,
+                                                 TargetType))
         return CastStrategy::Scalar;
       return CastStrategy::Address;
     }
@@ -361,7 +361,7 @@ adjustForConditionalCheckedCastOperand(SILLocation loc, ManagedValue src,
   
   // Figure out if we need the value to be in a temporary.
   bool requiresAddress =
-    !canUseScalarCheckedCastInstructions(SGF.SGM.M, sourceType, targetType);
+    !canSILUseScalarCheckedCastInstructions(SGF.SGM.M, sourceType, targetType);
   
   AbstractionPattern abstraction = SGF.SGM.M.Types.getMostGeneralAbstraction();
   auto &srcAbstractTL = SGF.getTypeLowering(abstraction, sourceType);

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1638,8 +1638,8 @@ emitCastOperand(SILGenFunction &SGF, SILLocation loc,
   // temporary if necessary.
 
   // Figure out if we need the value to be in a temporary.
-  bool requiresAddress = !canUseScalarCheckedCastInstructions(SGF.SGM.M,
-                                                        sourceType, targetType);
+  bool requiresAddress =
+    !canSILUseScalarCheckedCastInstructions(SGF.SGM.M, sourceType, targetType);
 
   AbstractionPattern abstraction = SGF.SGM.M.Types.getMostGeneralAbstraction();
   auto &srcAbstractTL = SGF.getTypeLowering(abstraction, sourceType);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1048,7 +1048,7 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
       // The unconditional_cast can be skipped, if the result of a cast
       // is not used afterwards.
       if (!ResultNotUsed) {
-        if (!dynamicCast.canUseScalarCheckedCastInstructions())
+        if (!dynamicCast.canSILUseScalarCheckedCastInstructions())
           return nullptr;
 
         CastedValue =
@@ -1143,7 +1143,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
 
       if (MI) {
         if (SuccessBB->getSinglePredecessorBlock() &&
-            canUseScalarCheckedCastInstructions(
+            canSILUseScalarCheckedCastInstructions(
                 Inst->getModule(), MI->getType().getASTType(),
                 Inst->getTargetFormalType())) {
           SILBuilderWithScope B(Inst, builderContext);

--- a/test/SILOptimizer/rcidentity.sil
+++ b/test/SILOptimizer/rcidentity.sil
@@ -8,7 +8,7 @@ import Builtin
 
 typealias AnyObject = Builtin.AnyObject
 
-protocol FakeAnyObject : class {}
+protocol FakeAnyObject : AnyObject {}
 
 class C : FakeAnyObject {
   init()
@@ -58,7 +58,8 @@ enum E1 {
 // Tests //
 ///////////
 
-// Make sure that we see all the way through the chain of casts that %9 has an RCIdentity of %0 and that %12 is really the partial apply.
+// Make sure that we see all the way through the chain of casts that %9 has
+// an RCIdentity of %0 and that %12 is really the partial apply.
 // CHECK-LABEL: @test_rcid_preserving_casts@
 // CHECK: RESULT #9: 9 = 0
 // CHECK: RESULT #12: 12 = 11

--- a/test/SILOptimizer/rcidentity_opaque.sil
+++ b/test/SILOptimizer/rcidentity_opaque.sil
@@ -1,0 +1,404 @@
+// RUN: %target-sil-opt -rc-id-dumper -enable-sil-opaque-values -module-name Swift %s -o /dev/null | %FileCheck %s
+
+import Builtin
+
+typealias AnyObject = Builtin.AnyObject
+
+struct STrivial {}
+
+class Base {}
+
+class Sub : Base {}
+
+protocol P {}
+
+protocol PClass : AnyObject {}
+
+protocol PBase : Base {}
+
+// Test dynamic casts that preserve ownership. See DynamicCasts.cpp
+// swift::doesCastPreserveOwnershipForTypes.
+//
+// Non-ownership-preserving casts fall into these categories:
+//
+//   (A) one type is a bridged value and the other is an object:
+//      (A1) Boxing: <trivial> as! Object
+//      (A2) Unboxing: Object as! <trivial>
+//
+//   (B) one type is transparently wrapped in __SwiftValue, while the other is
+//       unwrapped. Given:
+//
+//     class C : Hashable {}
+//     let a = AnyHashable(C())
+//
+//     (B1) The substituted source type is AnyHashable and the
+//          substituted destination type is AnyObject
+//
+//          // instantiates __SwiftValue
+//          let b = a as! AnyObject
+//        or
+//          let b = a as! T where T.self == AnyObject.self
+//
+//     (B2) The substituted source type is Any or AnyObject, and the
+//          substituted destination type is not Any or AnyObject
+//
+//          let c = b as! C // releases __SwiftValue
+//
+// With opaque values, ownership preserving casts are emitted as
+// scalar casts. Non-ownership preserving casts are emitted as indirect casts.
+
+// =============================================================================
+// (A1) Potential boxing.
+
+// CHECK-LABEL: @testStructToAnyObjectIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testStructToAnyObjectIsBridged : $@convention(thin) (STrivial) -> @owned AnyObject {
+bb0(%0 : $STrivial):
+  %1 = unconditional_checked_cast %0 : $STrivial to AnyObject
+  return %1 : $AnyObject
+}
+
+// CHECK-LABEL: @testStructToClassIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testStructToClassIsBridged : $@convention(thin) (STrivial) -> @owned Sub {
+bb0(%0 : $STrivial):
+  %1 = unconditional_checked_cast %0 : $STrivial to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testStructToClassExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testStructToClassExistentialIsBridged : $@convention(thin) (STrivial) -> @owned PClass {
+bb0(%0 : $STrivial):
+  %1 = unconditional_checked_cast %0 : $STrivial to PClass
+  return %1 : $PClass
+}
+
+// CHECK-LABEL: @testStructToClassArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testStructToClassArchetypeIsBridged : $@convention(thin) <T : AnyObject>(STrivial) -> @owned T {
+bb0(%0 : $STrivial):
+  %1 = unconditional_checked_cast %0 : $STrivial to T
+  return %1 : $T
+}
+
+// CHECK-LABEL: @testArchetypeToAnyObjectIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testArchetypeToAnyObjectIsBridged : $@convention(thin) <T>(@owned T) -> @owned AnyObject {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to AnyObject
+  return %1 : $AnyObject
+}
+
+// CHECK-LABEL: @testArchetypeToClassIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testArchetypeToClassIsBridged : $@convention(thin) <T>(@owned T) -> @owned Sub {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testArchetypeToClassExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testArchetypeToClassExistentialIsBridged : $@convention(thin) <T>(@owned T) -> @owned PClass {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to PClass
+  return %1 : $PClass
+}
+
+// CHECK-LABEL: @testArchetypeToClassArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testArchetypeToClassArchetypeIsBridged : $@convention(thin) <T, U : AnyObject>(@owned T) -> @owned U {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testExistentialToAnyObjectIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testExistentialToAnyObjectIsBridged : $@convention(thin) (@owned P) -> @owned AnyObject {
+bb0(%0 : @owned $P):
+  %1 = unconditional_checked_cast %0 : $P to AnyObject
+  return %1 : $AnyObject
+}
+
+// CHECK-LABEL: @testExistentialToClassIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testExistentialToClassIsBridged : $@convention(thin) (@owned P) -> @owned Sub {
+bb0(%0 : @owned $P):
+  %1 = unconditional_checked_cast %0 : $P to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testExistentialToClassExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testExistentialToClassExistentialIsBridged : $@convention(thin) (@owned P) -> @owned PClass {
+bb0(%0 : @owned $P):
+  %1 = unconditional_checked_cast %0 : $P to PClass
+  return %1 : $PClass
+}
+
+// CHECK-LABEL: @testExistentialToClassArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testExistentialToClassArchetypeIsBridged : $@convention(thin) <U : AnyObject>(@owned P) -> @owned U {
+bb0(%0 : @owned $P):
+  %1 = unconditional_checked_cast %0 : $P to U
+  return %1 : $U
+}
+
+// =============================================================================
+// (A2) Potential unboxing.
+
+// CHECK-LABEL: @testAnyObjectToStructIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testAnyObjectToStructIsBridged : $@convention(thin) (@owned AnyObject) -> @owned STrivial {
+bb0(%0 : @owned $AnyObject):
+  %1 = unconditional_checked_cast %0 : $AnyObject to STrivial
+  return %1 : $STrivial
+}
+
+// CHECK-LABEL: @testClassToStructIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassToStructIsBridged : $@convention(thin) (@owned Sub) -> @owned STrivial {
+bb0(%0 : @owned $Sub):
+  %1 = unconditional_checked_cast %0 : $Sub to STrivial
+  return %1 : $STrivial
+}
+
+// CHECK-LABEL: @testClassExistentialToStructIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassExistentialToStructIsBridged : $@convention(thin) (@owned PClass) -> @owned STrivial {
+bb0(%0 : @owned $PClass):
+  %1 = unconditional_checked_cast %0 : $PClass to STrivial
+  return %1 : $STrivial
+}
+
+// CHECK-LABEL: @testClassArchetypeToStructIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassArchetypeToStructIsBridged : $@convention(thin) <T : AnyObject>(@owned T) -> @owned STrivial {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to STrivial
+  return %1 : $STrivial
+}
+
+// CHECK-LABEL: @testAnyObjectToExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testAnyObjectToExistentialIsBridged : $@convention(thin) (@owned AnyObject) -> @owned P {
+bb0(%0 : @owned $AnyObject):
+  %1 = unconditional_checked_cast %0 : $AnyObject to P
+  return %1 : $P
+}
+
+// CHECK-LABEL: @testClassToExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassToExistentialIsBridged : $@convention(thin) (@owned Sub) -> @owned P {
+bb0(%0 : @owned $Sub):
+  %1 = unconditional_checked_cast %0 : $Sub to P
+  return %1 : $P
+}
+
+// CHECK-LABEL: @testClassExistentialToExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassExistentialToExistentialIsBridged : $@convention(thin) (@owned PClass) -> @owned P {
+bb0(%0 : @owned $PClass):
+  %1 = unconditional_checked_cast %0 : $PClass to P
+  return %1 : $P
+}
+
+// CHECK-LABEL: @testClassArchetypeToExistentialIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassArchetypeToExistentialIsBridged : $@convention(thin) <T : AnyObject>(@owned T) -> @owned P {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to P
+  return %1 : $P
+}
+
+// CHECK-LABEL: @testAnyObjectToArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testAnyObjectToArchetypeIsBridged : $@convention(thin) <U>(@owned AnyObject) -> @owned U {
+bb0(%0 : @owned $AnyObject):
+  %1 = unconditional_checked_cast %0 : $AnyObject to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testClassToArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassToArchetypeIsBridged : $@convention(thin) <U>(@owned Sub) -> @owned U {
+bb0(%0 : @owned $Sub):
+  %1 = unconditional_checked_cast %0 : $Sub to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testClassExistentialToArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassExistentialToArchetypeIsBridged : $@convention(thin) <U>(@owned PClass) -> @owned U {
+bb0(%0 : @owned $PClass):
+  %1 = unconditional_checked_cast %0 : $PClass to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testClassArchetypeToArchetypeIsBridged
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassArchetypeToArchetypeIsBridged : $@convention(thin) <T : AnyObject, U>(@owned T) -> @owned U {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to U
+  return %1 : $U
+}
+
+// =============================================================================
+// (B1) Wrapped casts - may forward through a wrapper object
+//
+// Note: the AnyHashable-to-AnyObject cases are currently covered
+// by the potentially bridged casts.
+
+// TODO: The compiler could recognize this case as forwarded. Casting
+// *from* a class to AnyObject will not wrap the class.
+//
+// CHECK-LABEL: @testClassToClassArchetypeIsWrapped
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassToClassArchetypeIsWrapped : $@convention(thin) <U : AnyObject>(@owned Base) -> @owned U {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to U
+  return %1 : $U
+}
+
+// =============================================================================
+// (B2) Wrapped casts - may forward through a wrapper object
+//
+// Note: (B1) the AnyHashable-to-AnyObject cases are currently covered
+// by the potentially bridged casts.
+//
+// TODO: In the future, when the runtime stops wrapping nontrivial types inside
+// __SwiftValue, cases (B1) and (B2) above will no longer apply. At that time,
+// expand ownership preserving cast types to AnyObject. Then remove the
+// isPotentiallyAnyObject() check.
+
+// CHECK-LABEL: @testAnyObjectToClassIsWrapped
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testAnyObjectToClassIsWrapped : $@convention(thin) (@owned AnyObject) -> @owned Sub {
+bb0(%0 : @owned $AnyObject):
+  %1 = unconditional_checked_cast %0 : $AnyObject to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassArchetypeToClassIsWrapped
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testClassArchetypeToClassIsWrapped : $@convention(thin) <U : AnyObject>(@owned U) -> @owned Sub {
+bb0(%0 : @owned $U):
+  %1 = unconditional_checked_cast %0 : $U to Sub
+  return %1 : $Sub
+}
+
+// =============================================================================
+// Constrained exisentials and generics are not wrapped
+
+// CHECK-LABEL: @testClassExistentialToClassIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassExistentialToClassIsForwarded : $@convention(thin) (@owned PClass) -> @owned Sub {
+bb0(%0 : @owned $PClass):
+  %1 = unconditional_checked_cast %0 : $PClass to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassToClassExistentialIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToClassExistentialIsForwarded : $@convention(thin) (@owned Base) -> @owned PClass {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to PClass
+  return %1 : $PClass
+}
+
+// CHECK-LABEL: @testConstrainedExistentialToClassIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testConstrainedExistentialToClassIsForwarded : $@convention(thin) (@owned PBase) -> @owned Sub {
+bb0(%0 : @owned $PBase):
+  %1 = unconditional_checked_cast %0 : $PBase to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassToConstrainedExistentialIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToConstrainedExistentialIsForwarded : $@convention(thin) <U : Base>(@owned Base) -> @owned U {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testClassConstrainedArchetypeToClassIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassConstrainedArchetypeToClassIsForwarded : $@convention(thin) <T : Base>(@owned T) -> @owned Sub {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassToClassConstrainedArchetypeIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToClassConstrainedArchetypeIsForwarded : $@convention(thin) <U : Sub>(@owned Base) -> @owned U {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to U
+  return %1 : $U
+}
+
+// CHECK-LABEL: @testProtocolConstrainedArchetypeToClassIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testProtocolConstrainedArchetypeToClassIsForwarded : $@convention(thin) <T : Base>(@owned T) -> @owned Sub {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to Sub
+  return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassToProtocolConstrainedArchetypeIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToProtocolConstrainedArchetypeIsForwarded : $@convention(thin) <U : Sub>(@owned Base) -> @owned U {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to U
+  return %1 : $U
+}
+
+// =============================================================================
+// Directly Forwarding casts
+
+// CHECK-LABEL: @testClassToClassIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToClassIsForwarded : $@convention(thin) (@owned Base) -> @owned Sub {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to Sub
+  return %1 : $Sub
+}

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -842,11 +842,13 @@ bb3(%24 : $Optional<fuzz>):
   return %24 : $Optional<fuzz>
 }
 
-// CHECK-LABEL: sil @dontMoveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P>
-// CHECK:    strong_retain %0
+// CHECK-LABEL: sil @moveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P>
 // CHECK:    checked_cast_br %0
-// CHECK:  } // end sil function 'dontMoveOverClassToExistentialCast'
-sil @dontMoveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P> {
+// CHECK:    enum $Optional<P>, #Optional.some!enumelt
+// CHECK:    strong_retain %0
+// CHECK-NOT: release
+// CHECK:  } // end sil function 'moveOverClassToExistentialCast'
+sil @moveOverClassToExistentialCast : $@convention(thin) (@guaranteed fuzz) -> Optional<P> {
 bb0(%0 : $fuzz):
   strong_retain %0 : $fuzz
   checked_cast_br %0 : $fuzz to P, bb1, bb2


### PR DESCRIPTION
Add doesCastPreserveOwnershipForType() to SIL/Utils/DynamicCasts.cpp

Added helpers in the AST Types.h

- isNotPotentiallyAnyObject()

- isPotentiallyBridgedValueOrExistentialType()

This formalizes logic for when cast operations forward
ownership. Various OSSA optimization rely on this for
correctness. This may fixes latent bugs throughout the optimizer.

I was compelled to fix this now because we want to make OSSA
optimizations across dynamic casts more aggressive. For example, we
want to optimize retain/release across enum formation.