### PR TITLE
[Concurrency] Have StackAllocator gracefully fail when passed a small firstSlabBuffer

### DIFF
--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -259,7 +259,10 @@ public:
   StackAllocator() : firstSlab(nullptr), firstSlabIsPreallocated(false) { }
 
   /// Construct a StackAllocator with a pre-allocated first slab.
-  StackAllocator(void *firstSlabBuffer, size_t bufferCapacity) {
+  StackAllocator(void *firstSlabBuffer, size_t bufferCapacity) : StackAllocator() {
+    // If the pre-allocated buffer can't hold a slab header, ignore it.
+    if (bufferCapacity <= Slab::headerSize())
+      return;
     char *start = (char *)llvm::alignAddr(firstSlabBuffer,
                                           llvm::Align(alignment));
     char *end = (char *)firstSlabBuffer + bufferCapacity;


### PR DESCRIPTION
Creating a task for an async let will attempt to allocate the task in the async let's preallocated space, and if there's any space left over then it will use the extra for the new tasks's allocator. However, StackAllocator requires the preallocated buffer to be large enough to hold a slab header, but the task creation code doesn't check for that. As a result, the task creation code can end up passing a buffer that's too small to hold the slab header. When asserts are enabled, this is caught by an assert. When asserts are not enabled, disaster strikes. We end up computing a negative number for the remaining slab capacity, which underflows to a large positive number, causing the slab to overflow the async let's preallocated space. This results in weird memory corruption.

SR-15996
rdar://90357994
