### PR TITLE
Fix a minor (1 per process) leak in AccessEnforcementSelection

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -614,7 +614,7 @@ void AccessEnforcementSelection::run() {
   closureOrder.compute();
 
   dynamicCaptures = std::make_unique<DynamicCaptures>(closureOrder);
-  SWIFT_DEFER { dynamicCaptures.release(); };
+  SWIFT_DEFER { dynamicCaptures.reset(); };
 
   for (SILFunction *function : closureOrder.getTopDownFunctions()) {
     this->processFunction(function);


### PR DESCRIPTION
This fixes a commit from a few days ago where I meant to call
unique_ptr::reset() instead of unique_ptr::release() and
apparently didn't notice the compiler warning.