### PR TITLE
[swift-inspect] Support forking corpses and self-inspection of the swift-inspect process on Darwin.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpArray.swift
@@ -21,7 +21,7 @@ internal struct DumpArrays: ParsableCommand {
   var options: UniversalOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       print("Address", "Size", "Count", "Is Class", separator: "\t")
       process.iterateHeap { (allocation, size) in
         let metadata: UInt =

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpCacheNodes.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpCacheNodes.swift
@@ -21,7 +21,7 @@ internal struct DumpCacheNodes: ParsableCommand {
   var options: UniversalOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       print("Address", "Tag", "Tag Name", "Size", "Left", "Right", separator: "\t")
       try process.context.allocations.forEach {
         var node: swift_metadata_cache_node_t = swift_metadata_cache_node_t()

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConcurrency.swift
@@ -23,7 +23,7 @@ struct DumpConcurrency: ParsableCommand {
   var options: UniversalOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       let dumper = ConcurrencyDumper(context: process.context,
                                      process: process as! DarwinRemoteProcess)
       dumper.dumpTasks()

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConformanceCache.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpConformanceCache.swift
@@ -20,7 +20,7 @@ internal struct DumpConformanceCache: ParsableCommand {
   var options: UniversalOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       try process.context.iterateConformanceCache { type, proto in
         let type: String = process.context.name(type: type) ?? "<unknown>"
         let conformance: String = process.context.name(protocol: proto) ?? "<unknown>"

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpGenericMetadata.swift
@@ -34,7 +34,7 @@ internal struct DumpGenericMetadata: ParsableCommand {
   var backtraceOptions: BacktraceOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       let allocations: [swift_metadata_allocation_t] =
           try process.context.allocations.sorted()
 

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
@@ -24,7 +24,7 @@ internal struct DumpRawMetadata: ParsableCommand {
   var backtraceOptions: BacktraceOptions
 
   func run() throws {
-    try inspect(process: options.nameOrPid) { process in
+    try inspect(options: options) { process in
       let stacks: [swift_reflection_ptr_t:[swift_reflection_ptr_t]]? =
           backtraceOptions.style == nil
               ? nil

--- a/tools/swift-inspect/Sources/swift-inspect/Process.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Process.swift
@@ -16,7 +16,32 @@ import Darwin
 internal typealias ProcessIdentifier = DarwinRemoteProcess.ProcessIdentifier
 
 internal func process(matching: String) -> ProcessIdentifier? {
-  return pidFromHint(matching)
+  if refersToSelf(matching) {
+    return getpid()
+  } else {
+    return pidFromHint(matching)
+  }
+}
+
+private func refersToSelf(_ str: String) -> Bool {
+  guard let myPath = CommandLine.arguments.first else {
+    return false
+  }
+
+  // If string matches the full path, success.
+  if myPath == str {
+    return true
+  }
+
+  // If there's a slash in the string, compare with the component following the
+  // slash.
+  if let slashIndex = myPath.lastIndex(of: "/") {
+    let myName = myPath[slashIndex...].dropFirst()
+    return myName == str
+  }
+
+  // No match.
+  return false
 }
 #elseif os(Windows)
 import WinSDK

--- a/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/RemoteProcess.swift
@@ -19,8 +19,6 @@ internal protocol RemoteProcess: AnyObject {
   var process: ProcessHandle { get }
   var context: SwiftReflectionContextRef! { get }
 
-  init?(processId: ProcessIdentifier)
-
   typealias QueryDataLayoutFunction =
       @convention(c) (UnsafeMutableRawPointer?, DataLayoutQueryType,
                       UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> CInt

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -17,6 +17,15 @@ import SwiftRemoteMirror
 internal struct UniversalOptions: ParsableArguments {
   @Argument(help: "The pid or partial name of the target process")
   var nameOrPid: String
+
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+  @Flag(help: ArgumentHelp(
+      "Fork a corpse of the target process",
+      discussion: "Creates a low-level copy of the target process, allowing " +
+                  "the target to immediately resume execution before " +
+                  "swift-inspect has completed its work."))
+  var forkCorpse: Bool = false
+#endif
 }
 
 internal struct BacktraceOptions: ParsableArguments {
@@ -34,15 +43,16 @@ internal struct BacktraceOptions: ParsableArguments {
 }
 
 
-internal func inspect(process pattern: String,
+internal func inspect(options: UniversalOptions,
                       _ body: (any RemoteProcess) throws -> Void) throws {
-  guard let processId = process(matching: pattern) else {
-    print("No process found matching \(pattern)")
+  guard let processId = process(matching: options.nameOrPid) else {
+    print("No process found matching \(options.nameOrPid)")
     return
   }
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  guard let process = DarwinRemoteProcess(processId: processId) else {
+  guard let process = DarwinRemoteProcess(processId: processId,
+                                          forkCorpse: options.forkCorpse) else {
     print("Failed to create inspector for process id \(processId)")
     return
   }


### PR DESCRIPTION
Support inspecting the swift-inspect process itself. `pidFromHint` skips the process it's in, so we manually check the requested name against `argv[0]` as a special case.

Add a `--fork-corpse` flag which uses `task_generate_corpse` on the target task before inspecting it. This allows the target to keep running while we inspect it, and also works around a bug when self-inspecting.