### PR TITLE
[move-function] Add support for propagating from vars

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -341,6 +341,39 @@ struct DebugVarCarryingInst {
     }
   }
 
+  /// Returns true if this DebugVarCarryingInst was moved.
+  bool getWasMoved() const {
+    switch (kind) {
+    case Kind::Invalid:
+      llvm_unreachable("Invalid?!");
+    case Kind::DebugValue:
+      return cast<DebugValueInst>(inst)->getWasMoved();
+    case Kind::AllocStack:
+      return cast<AllocStackInst>(inst)->getWasMoved();
+    case Kind::AllocBox:
+      llvm_unreachable("Not implemented");
+    }
+  }
+
+  /// If we are attempting to create a "debug_value" clone of this debug var
+  /// carrying inst, return the appropriate SILValue to use as the operand of
+  /// that debug value.
+  ///
+  /// For a debug_value, we just return the actual operand, otherwise we return
+  /// the pointer address.
+  SILValue getOperandForDebugValueClone() const {
+    switch (kind) {
+    case Kind::Invalid:
+      llvm_unreachable("Invalid?!");
+    case Kind::DebugValue:
+      return cast<DebugValueInst>(inst)->getOperand();
+    case Kind::AllocStack:
+      return cast<AllocStackInst>(inst);
+    case Kind::AllocBox:
+      llvm_unreachable("Not implemented");
+    }
+  }
+
   /// If \p value is an alloc_stack, alloc_box use that. Otherwise, see if \p
   /// value has a single debug user, return that. Otherwise return the invalid
   /// DebugVarCarryingInst.

--- a/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
+++ b/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
@@ -39,6 +39,8 @@ struct SwiftDbgAddrBlockSplitter : FunctionPass {
 bool SwiftDbgAddrBlockSplitter::runOnFunction(Function &fn) {
   SmallVector<Instruction *, 32> breakBlockPoints;
 
+  // If we are in the first block,
+
   for (auto &block : fn) {
     for (auto &inst : block) {
       if (isa<DbgAddrIntrinsic>(&inst)) {

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -165,6 +165,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF:    [0x{{[a-f0-9]+}}, 0x{{[a-f0-9]+}}): DW_OP_breg6 RBP-88, DW_OP_deref, DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x8, DW_OP_deref)
 // DWARF: DW_AT_name	("msg")
 
+// Change name to varSimpleTestArg
 public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
     await forceSplit()
     use(_move(msg))
@@ -174,4 +175,44 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
     let _ = msg3
     msg = msg2
     await forceSplit()
+}
+
+// We don't have an argument here, so we shouldn't have an llvm.dbg.addr in the
+// initial function.
+//
+// CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaF"(%swift.context* swiftasync %0)
+// CHECK-NOT: llvm.dbg.addr
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTY0_"(i8* swiftasync %0)
+// CHECK: call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8))
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTQ1_"(i8* swiftasync %0)
+// CHECK: call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8))
+
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTY2_"(i8* swiftasync %0)
+// CHECK: call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8)), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK: call void @llvm.dbg.value(metadata %T27move_function_dbginfo_async5KlassC** undef, metadata ![[METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTQ3_"(i8* swiftasync %0)
+// We should only see an llvm.dbg.value here.
+// CHECK-NOT: llvm.dbg.addr
+// CHECK: call void @llvm.dbg.value(metadata %T27move_function_dbginfo_async5KlassC** undef,
+// CHECK-NOT: llvm.dbg.addr
+//
+// We should see first a llvm.dbg.value to undef the value until we reinit. Then
+// we should see a llvm.dbg.addr to reinit.
+//
+// CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async16varSimpleTestVaryyYaFTY4_"(i8* swiftasync %0)
+// CHECK: call void @llvm.dbg.value(metadata %T27move_function_dbginfo_async5KlassC** undef, metadata ![[METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK: call void @llvm.dbg.addr(metadata i8* %0, metadata ![[METADATA]], metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8)), !dbg ![[ADDR_LOC]]
+public func varSimpleTestVar() async {
+    var k = Klass()
+    k.doSomething()
+    await forceSplit()
+    let m = _move(k)
+    m.doSomething()
+    await forceSplit()
+    k = Klass()
+    k.doSomething()
+    print("stop here")
 }


### PR DESCRIPTION
This PR does two different things:

1. The first commit adds support for debug info in async contexts for vars. This involved propagating debug_value from alloc_stack.
2. The 2nd commit fixes an issue where in very small async functions do not have vars show up. Example: the coroutine in between an async function and a hop to executor call. We are careful and only hoist the first initial llvm.dbg.addr on a specific debug var in the entry block. We don't hoist if we see a llvm.dbg.value (undef). This ensures that the dbg.addr is early enough that it shows up at the beginning of the frame.