### PR TITLE
[CSGen/CSApply] Don't expect implicit casts to have type reprs

### DIFF
--- a/unittests/Sema/CMakeLists.txt
+++ b/unittests/Sema/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_swift_unittest(swiftSemaTests
   SemaFixture.cpp
   BindingInferenceTests.cpp
+  ConstraintGenerationTests.cpp
   ConstraintSimplificationTests.cpp
   UnresolvedMemberLookupTests.cpp
   PlaceholderTypeInferenceTests.cpp

--- a/unittests/Sema/ConstraintGenerationTests.cpp
+++ b/unittests/Sema/ConstraintGenerationTests.cpp
@@ -1,0 +1,88 @@
+//===--- ConstraintGenerationTests.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SemaFixture.h"
+#include "swift/AST/Expr.h"
+
+using namespace swift;
+using namespace swift::unittest;
+using namespace swift::constraints;
+
+TEST_F(SemaTest, TestImplicitForceCastConstraintGeneration) {
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+
+  auto *literal = IntegerLiteralExpr::createFromUnsigned(Context, 42);
+
+  auto *cast = ForcedCheckedCastExpr::createImplicit(Context, literal,
+                                                     getStdlibType("Double"));
+
+  auto *expr = cs.generateConstraints(cast, DC, /*isInputExpression=*/true);
+
+  ASSERT_NE(expr, nullptr);
+
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  ASSERT_EQ(solutions.size(), (unsigned)1);
+
+  auto &solution = solutions.front();
+
+  ASSERT_TRUE(solution.getResolvedType(literal)->isEqual(getStdlibType("Int")));
+  ASSERT_TRUE(solution.getResolvedType(cast)->isEqual(getStdlibType("Double")));
+}
+
+TEST_F(SemaTest, TestImplicitCoercionConstraintGeneration) {
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+
+  auto *literal = IntegerLiteralExpr::createFromUnsigned(Context, 42);
+
+  auto *cast = CoerceExpr::createImplicit(Context, literal,
+                                          getStdlibType("Double"));
+
+  auto *expr = cs.generateConstraints(cast, DC, /*isInputExpression=*/true);
+
+  ASSERT_NE(expr, nullptr);
+
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  ASSERT_EQ(solutions.size(), (unsigned)1);
+
+  auto &solution = solutions.front();
+
+  ASSERT_TRUE(solution.getResolvedType(literal)->isEqual(getStdlibType("Double")));
+  ASSERT_TRUE(solution.getResolvedType(cast)->isEqual(getStdlibType("Double")));
+}
+
+TEST_F(SemaTest, TestImplicitConditionalCastConstraintGeneration) {
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+
+  auto *literal = IntegerLiteralExpr::createFromUnsigned(Context, 42);
+
+  auto *cast = ConditionalCheckedCastExpr::createImplicit(
+      Context, literal, getStdlibType("Double"));
+
+  auto *expr = cs.generateConstraints(cast, DC, /*isInputExpression=*/true);
+
+  ASSERT_NE(expr, nullptr);
+
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  ASSERT_EQ(solutions.size(), (unsigned)1);
+
+  auto &solution = solutions.front();
+
+  ASSERT_TRUE(solution.getResolvedType(literal)->isEqual(getStdlibType("Int")));
+  ASSERT_TRUE(solution.getResolvedType(cast)->isEqual(
+      OptionalType::get(getStdlibType("Double"))));
+}


### PR DESCRIPTION
Implicit casts are allowed to be constructed with a type, instead
of a type repr. Constraint generation should honor that, and fallback
to using cast type when repr is was not given.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
