### PR TITLE
Augment Test for Confusing ExpressibleByNilLiteral Case

### DIFF
--- a/test/stmt/switch_nil.swift
+++ b/test/stmt/switch_nil.swift
@@ -12,3 +12,19 @@ func test() {
     break
   }
 }
+
+struct Nilable: ExpressibleByNilLiteral {
+  init(nilLiteral: ()) {}
+}
+
+func testNil() {
+  // N.B. A deeply confusing case as no conversion is performed on the `nil`
+  // literal. Instead, the match subject is converted to `Nilable?` and compared
+  // using ~=.
+  switch Nilable(nilLiteral: ()) {
+  case nil: // expected-warning {{type 'Nilable' is not optional, value can never be nil}}
+    break
+  default:
+    break
+  }
+}


### PR DESCRIPTION
Add a test for an extremely confusing behavior of switches for
ExpressibleByNilLiteral-conforming types. From the looks of the expression
tree, one would hope that `case nil` would match such types. Instead, the
subject value is up-converted to an optional and compared to `nil` directly
with ~=.