### PR TITLE
[MiscDiagnostics] Produce warnings about confusable `self` iff its ex…

### DIFF
--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -126,3 +126,8 @@ enum EnumCaseNamedSelf {
         self = EnumCaseNamedSelf.`self` // OK
     }
 }
+
+// rdar://90624344 - warning about `self` which cannot be fixed because it's located in implicitly generated code.
+struct TestImplicitSelfUse : Codable {
+  let `self`: Int // Ok
+}


### PR DESCRIPTION
…plicit

Restrict the warning to diagnose only explicit instances of `self` reference
that do not mention the parent type via dot syntax e.g. `MyStruct.self`.

Resolves: SR-15897
Resolves: SR-15691
Resolves: rdar://90624344

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
