### PR TITLE
RequirementMachine: Better tests for concrete type requirements with opaque archetypes

### DIFF
--- a/lib/AST/RequirementMachine/NameLookup.cpp
+++ b/lib/AST/RequirementMachine/NameLookup.cpp
@@ -34,8 +34,10 @@ swift::rewriting::lookupConcreteNestedType(
     auto *genericEnv = archetype->getGenericEnvironment();
     auto genericSig = genericEnv->getGenericSignature();
 
-    concreteDecls.push_back(
-        genericSig->lookupNestedType(archetype->getInterfaceType(), name));
+    auto *typeDecl =
+        genericSig->lookupNestedType(archetype->getInterfaceType(), name);
+    if (typeDecl != nullptr)
+      concreteDecls.push_back(typeDecl);
   }
 }
 

--- a/test/Generics/opaque_archetype_concrete_requirement.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -debug-generic-signatures -requirement-machine-inferred-signatures=on -enable-requirement-machine-opaque-archetypes 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking -requirement-machine-inferred-signatures=on -enable-requirement-machine-opaque-archetypes
 
 protocol P1 {
   associatedtype T : P2
@@ -51,31 +52,3 @@ extension HasP where T == DefinesOpaqueP1.T, U == G<T.T> {
   func checkSameType1(_ t: T.T) -> DefinesOpaqueP1.T.T { return t }
   func checkSameType2(_ u: T.U) -> DefinesOpaqueP1.T.U { return u }
 }
-
-// FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
-// See opaque_archetype_concrete_requirement_recursive.swift for a demonstration
-// that it works without the flag (but more involved examples like the above
-// won't work).
-
-protocol RecursiveP {
-  associatedtype T : RecursiveP
-}
-
-struct S_RecursiveP : RecursiveP {
-  typealias T = S_RecursiveP
-}
-
-struct DefinesRecursiveP : P {
-  var t: some RecursiveP {
-    return S_RecursiveP()
-  }
-}
-
-protocol HasRecursiveP {
-  associatedtype T : RecursiveP
-}
-
-extension HasRecursiveP where T == DefinesRecursiveP.T {}
-// expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is τ_0_0.[HasRecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[concrete: (((((((((@_opaqueReturnTypeOf("$s37opaque_archetype_concrete_requirement17DefinesRecursivePV1tQrvp", 0) __.T).T).T).T).T).T).T).T).T).T] => τ_0_0.[HasRecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T]}}
-

--- a/test/Generics/opaque_archetype_concrete_requirement_invalid.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_invalid.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -requirement-machine-inferred-signatures=on -enable-requirement-machine-opaque-archetypes
+
+protocol P1 {}
+
+struct S_P1 : P1 {}
+
+protocol P {
+  associatedtype T
+
+  var t: T { get }
+}
+
+struct DefinesOpaqueP1 : P {
+  var t: some P1 {
+    return S_P1()
+  }
+}
+
+protocol HasP {
+  associatedtype T : P1
+  associatedtype U
+}
+
+extension HasP where T == DefinesOpaqueP1.T, U == T.DoesNotExist {}
+// expected-error@-1 {{'DoesNotExist' is not a member type of type 'Self.T'}}

--- a/test/Generics/opaque_archetype_concrete_requirement_recursive.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_recursive.swift
@@ -1,14 +1,15 @@
 // RUN: %target-swift-frontend -typecheck -verify %s -disable-availability-checking -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking -requirement-machine-inferred-signatures=on
+
+// FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
+// See opaque_archetype_concrete_requirement_rejected.swift for a demonstration
+// that it fails with the flag.
 
 protocol P {
   associatedtype T
 
   var t: T { get }
 }
-
-// FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
-// See opaque_archetype_concrete_requirement.swift for a demonstration that it
-// fails with the flag.
 
 protocol RecursiveP {
   associatedtype T : RecursiveP
@@ -31,6 +32,5 @@ protocol HasRecursiveP {
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=HasRecursiveP
 // CHECK-NEXT: Generic signature: <Self where Self : HasRecursiveP, Self.[HasRecursiveP]T == some RecursiveP>
 extension HasRecursiveP where T == DefinesRecursiveP.T {
-  func checkSameType1(_ t: T) -> DefinesRecursiveP.T { return t }
-  func checkSameType2(_ t: T.T) -> DefinesRecursiveP.T.T { return t }
+  func checkSameType(_ t: T) -> DefinesRecursiveP.T { return t }
 }

--- a/test/Generics/opaque_archetype_concrete_requirement_recursive_rejected.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement_recursive_rejected.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -requirement-machine-inferred-signatures=on -enable-requirement-machine-opaque-archetypes
+
+// FIXME: This does not work with -enable-requirement-machine-opaque-archetypes.
+// See opaque_archetype_concrete_requirement_recursive.swift for a demonstration
+// that it works without the flag (but more involved examples like the above
+// won't work).
+
+protocol P {
+  associatedtype T
+
+  var t: T { get }
+}
+
+protocol RecursiveP {
+  associatedtype T : RecursiveP
+}
+
+struct S_RecursiveP : RecursiveP {
+  typealias T = S_RecursiveP
+}
+
+struct DefinesRecursiveP : P {
+  var t: some RecursiveP {
+    return S_RecursiveP()
+  }
+}
+
+protocol HasRecursiveP {
+  associatedtype T : RecursiveP
+}
+
+extension HasRecursiveP where T == DefinesRecursiveP.T {}
+// expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is τ_0_0.[HasRecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[concrete: (((((((((@_opaqueReturnTypeOf("$s56opaque_archetype_concrete_requirement_recursive_rejected17DefinesRecursivePV1tQrvp", 0) __.T).T).T).T).T).T).T).T).T).T] => τ_0_0.[HasRecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T].[RecursiveP:T]}}
+


### PR DESCRIPTION
Also fix a weird latent bug. In lookupConcreteNestedType(), we would
push nullptr onto the concreteDecls vector if the opaque archetype
did not have a nested type with this name. However, this did not
turn out to be a problem, since in this code path we would only
have a single element in this vector, and the later call to
std::min_element() did not end up dereferencing the null pointer.

However this is very dodgy, so tweak the code to prevent this from
happening and add a test case (which already passed anyway).