### PR TITLE
[5.6][MiscDiagnostics] Produce warnings about confusable `self` iff its explicit

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4717,30 +4717,42 @@ static void diagUnqualifiedAccessToMethodNamedSelf(const Expr *E,
       if (!E || isa<ErrorExpr>(E) || !E->getType())
         return {false, E};
 
-      if (auto *declRefExpr = dyn_cast<DeclRefExpr>(E)) {
-        if (declRefExpr->getDecl()->getBaseName() == Ctx.Id_self &&
-            declRefExpr->getType()->is<AnyFunctionType>()) {
-          if (auto typeContext = DC->getInnermostTypeContext()) {
-            // self() is not easily confusable
-            if (!isa<CallExpr>(Parent.getAsExpr())) {
-              auto baseType = typeContext->getDeclaredInterfaceType();
-              if (!baseType->getEnumOrBoundGenericEnum()) {
-                auto baseTypeString = baseType.getString();
+      auto *DRE = dyn_cast<DeclRefExpr>(E);
+      // If this is not an explicit 'self' reference, let's keep searching.
+      if (!DRE || DRE->isImplicit())
+        return {true, E};
 
-                Ctx.Diags.diagnose(E->getLoc(), diag::self_refers_to_method,
-                    baseTypeString);
+      // If this not 'self' or it's not a function reference, it's unrelated.
+      if (!(DRE->getDecl()->getBaseName() == Ctx.Id_self &&
+            DRE->getType()->is<AnyFunctionType>()))
+        return {true, E};
 
-                Ctx.Diags
-                  .diagnose(E->getLoc(),
-                      diag::fix_unqualified_access_member_named_self,
-                      baseTypeString)
-                  .fixItInsert(E->getLoc(), diag::insert_type_qualification,
-                      baseType);
-              }
-            }
-          }
-        }
+      auto typeContext = DC->getInnermostTypeContext();
+      // Use of 'self' in enums is not confusable.
+      if (!typeContext || typeContext->getSelfEnumDecl())
+        return {true, E};
+
+      // self(...) is not easily confusable.
+      if (auto *parentExpr = Parent.getAsExpr()) {
+        if (isa<CallExpr>(parentExpr))
+          return {true, E};
+
+        // Explicit call to a static method 'self' of some type is not
+        // confusable.
+        if (isa<DotSyntaxCallExpr>(parentExpr) && !parentExpr->isImplicit())
+          return {true, E};
       }
+
+      auto baseType = typeContext->getDeclaredInterfaceType();
+      auto baseTypeString = baseType.getString();
+
+      Ctx.Diags.diagnose(E->getLoc(), diag::self_refers_to_method,
+                         baseTypeString);
+
+      Ctx.Diags
+          .diagnose(E->getLoc(), diag::fix_unqualified_access_member_named_self,
+                    baseTypeString)
+          .fixItInsert(E->getLoc(), diag::insert_type_qualification, baseType);
 
       return {true, E};
     }

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -126,3 +126,8 @@ enum EnumCaseNamedSelf {
         self = EnumCaseNamedSelf.`self` // OK
     }
 }
+
+// rdar://90624344 - warning about `self` which cannot be fixed because it's located in implicitly generated code.
+struct TestImplicitSelfUse : Codable {
+  let `self`: Int // Ok
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/41969

---

- Explanation:

Fixes an issue where invalid warning couldn't be suppressed because it refers to implicitly generated code.

Restrict the warning to diagnose only explicit instances of `self` reference
that do not mention the parent type via dot syntax e.g. `MyStruct.self`.

- Scope: Property initializers. 

- Main Branch PR: https://github.com/apple/swift/pull/41969

- Resolves: rdar://90666315

- Risk: Very low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

Resolves: SR-15897
Resolves: SR-15691
Resolves: rdar://90624344
Resolves: rdar://90666315
(cherry picked from commit e52c3a0548ea4ce2e30bdd9bb35ea1d91e53aa16)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
