### PR TITLE
[SIL-opaque] Don't override arg value category.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -78,8 +78,9 @@ public:
         SGF.SGM.Types.getLoweredType(t, TypeExpansionContext::minimal());
     argType = argType.getCategoryType(argTypeConv.getCategory());
 
-    if (isInOut
-        || orig.getParameterConvention(SGF.SGM.Types) == AbstractionPattern::Indirect)
+    if (isInOut || (orig.getParameterConvention(SGF.SGM.Types) ==
+                        AbstractionPattern::Indirect &&
+                    SGF.SGM.M.useLoweredAddresses()))
       argType = argType.getCategoryType(SILValueCategory::Address);
 
     // Pop the next parameter info.

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -350,3 +350,20 @@ public struct EnumSeq<Base : Seq> : Seq {
     return EnumIter(_base: _base.makeIterator())
   }
 }
+
+extension Collection {
+  func transformEachElement<U>(_ cl: (Element) -> U) -> [U] {
+    return map(cl)
+  }
+}
+
+extension Array where Element == Int {
+  // CHECK-LABEL: sil private [ossa] @$sSa20opaque_values_silgenSiRszlE20incrementEachElementSaySiGyFS2iXEfU_ : {{.*}} {
+  // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $Int):
+  // CHECK-LABEL: } // end sil function '$sSa20opaque_values_silgenSiRszlE20incrementEachElementSaySiGyFS2iXEfU_'
+  func incrementEachElement() -> [Int] {
+    return transformEachElement { element in
+      return element + 1
+    }
+  }
+}


### PR DESCRIPTION
Previously, when emitting block arguments, the value category of the SILType was overridden to be address for indirect arguments.  With opaque types, that distinction is made later during AddressLowering.  So only do that when opaque types are disabled.
