### PR TITLE
[Serialization] Ignore the exported module name for XRefs

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 679; // NoAsync
+const uint16_t SWIFTMODULE_VERSION_MINOR = 680; // Ignore export_as in XRef
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -203,7 +203,8 @@ namespace {
     int32_t getNameDataForBase(const NominalTypeDecl *nominal,
                                StringRef *dataToWrite = nullptr) {
       if (nominal->getDeclContext()->isModuleScopeContext())
-        return -Serializer.addContainingModuleRef(nominal->getDeclContext());
+        return -Serializer.addContainingModuleRef(nominal->getDeclContext(),
+                                                  /*ignoreExport=*/false);
 
       auto &mangledName = MangledNameCache[nominal];
       if (mangledName.empty())
@@ -727,7 +728,8 @@ IdentifierID Serializer::addFilename(StringRef filename) {
   return addUniquedString(filename).second;
 }
 
-IdentifierID Serializer::addContainingModuleRef(const DeclContext *DC) {
+IdentifierID Serializer::addContainingModuleRef(const DeclContext *DC,
+                                                bool ignoreExport) {
   assert(!isa<ModuleDecl>(DC) &&
          "References should be to things within modules");
   const FileUnit *file = cast<FileUnit>(DC->getModuleScopeContext());
@@ -746,8 +748,19 @@ IdentifierID Serializer::addContainingModuleRef(const DeclContext *DC) {
 
   auto exportedModuleName = file->getExportedModuleName();
   assert(!exportedModuleName.empty());
-  auto exportedModuleID = M->getASTContext().getIdentifier(exportedModuleName);
-  return addDeclBaseNameRef(exportedModuleID);
+  auto moduleID = M->getASTContext().getIdentifier(exportedModuleName);
+  if (ignoreExport) {
+    auto realModuleName = M->getRealName().str();
+    assert(!realModuleName.empty());
+    if (realModuleName != exportedModuleName) {
+      // Still register the exported name as it can be referenced
+      // from the lookup tables.
+      addDeclBaseNameRef(moduleID);
+
+      moduleID = M->getASTContext().getIdentifier(realModuleName);
+    }
+  }
+  return addDeclBaseNameRef(moduleID);
 }
 
 IdentifierID Serializer::addModuleRef(const ModuleDecl *module) {
@@ -1632,7 +1645,8 @@ Serializer::writeASTBlockEntity(ProtocolConformance *conformance) {
         abbrCode,
         addDeclRef(normal->getProtocol()),
         addDeclRef(normal->getType()->getAnyNominal()),
-        addContainingModuleRef(normal->getDeclContext()));
+        addContainingModuleRef(normal->getDeclContext(),
+                               /*ignoreExport=*/true));
     }
     break;
   }
@@ -1831,7 +1845,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
   case DeclContextKind::FileUnit:
     abbrCode = DeclTypeAbbrCodes[XRefLayout::Code];
     XRefLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                           addContainingModuleRef(DC), pathLen);
+                           addContainingModuleRef(DC, /*ignoreExport=*/true),
+                           pathLen);
     break;
 
   case DeclContextKind::GenericTypeDecl: {
@@ -1883,7 +1898,8 @@ void Serializer::writeCrossReference(const DeclContext *DC, uint32_t pathLen) {
       genericSig = ext->getGenericSignature().getCanonicalSignature();
     }
     XRefExtensionPathPieceLayout::emitRecord(
-        Out, ScratchRecord, abbrCode, addContainingModuleRef(DC),
+        Out, ScratchRecord, abbrCode,
+        addContainingModuleRef(DC, /*ignoreExport=*/true),
         addGenericSignatureRef(genericSig));
     break;
   }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -518,10 +518,13 @@ public:
   /// may not be exactly the same as the name of the module containing DC;
   /// instead, it will match the containing file's "exported module name".
   ///
+  /// \param ignoreExport When true, register the real module name,
+  /// ignoring exported_as definitions.
   /// \returns The ID for the identifier for the module's name, or one of the
   /// special module codes defined above.
   /// \see FileUnit::getExportedModuleName
-  IdentifierID addContainingModuleRef(const DeclContext *DC);
+  IdentifierID addContainingModuleRef(const DeclContext *DC,
+                                      bool ignoreExport);
 
   /// Records the module \m.
   IdentifierID addModuleRef(const ModuleDecl *m);

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -6,19 +6,23 @@
 // FIXME: END -enable-source-import hackaround
 
 // Build the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift -enable-library-evolution -emit-module-interface-path %t/SomeKit.swiftinterface
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h
 
-// Use the overlay without private frameworks.
+// Using the binary overlay without private frameworks should fail.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h %s -verify
+
+// Using an overlay rebuilt from the swiftinterface without private frameworks should work.
+// RUN: rm %t/SomeKit.swiftmodule
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h %s
 
 // Build the overlay with public frameworks.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withoutprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h
 
 // Use the overlay without private frameworks.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h 
@@ -27,12 +31,12 @@
 // RUN: echo 'import private_frameworks; testErrorConformance()' > %t/main.swift
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t -F %S/Inputs/privateframeworks/withoutprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %t/main.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate %t/main.swift
 
 // REQUIRES: objc_interop
 
@@ -42,18 +46,18 @@ func testWidget(widget: SKWidget) {
   widget.someObjCMethod()
   widget.someObjCExtensionMethod()
 
-  let ext = widget.extensionMethod()
+  let ext = widget.extensionMethod() // expected-error {{value of type 'SKWidget' has no member 'extensionMethod'}}
   ext.foo()
 
-  widget.doSomethingElse(widget)
-  inlineWidgetOperations(widget)
+  widget.doSomethingElse(widget) // expected-error {{value of type 'SKWidget' has no member 'doSomethingElse'; did you mean 'doSomething'?}}
+  inlineWidgetOperations(widget) // expected-error {{cannot find 'inlineWidgetOperations' in scope}}
 
   let _ = widget.name
 }
 
 func testError(widget: SKWidget) {
-  let c: SKWidget.Error.Code = SKWidget.Error(.boom).getCode(from: widget)
-  if c.isBoom { }
+  let c: SKWidget.Error.Code = SKWidget.Error(.boom).getCode(from: widget) // expected-error {{value of type 'SKWidget.Error' has no member 'getCode'}}
+  if c.isBoom { } // expected-error {{value of type 'SKWidget.Error.Code' has no member 'isBoom'}}
 }
 
 func testGlobals() {

--- a/test/Serialization/Inputs/exported-modules/ExportedCore.h
+++ b/test/Serialization/Inputs/exported-modules/ExportedCore.h
@@ -1,0 +1,1 @@
+struct ExportedType {};

--- a/test/Serialization/Inputs/exported-modules/module.modulemap
+++ b/test/Serialization/Inputs/exported-modules/module.modulemap
@@ -1,0 +1,9 @@
+module ExportedCore [system] [extern_c] {
+  header "ExportedCore.h"
+
+  export_as Exported
+}
+
+module Exported [system] [extern_c] {
+  header "Exported.h"
+}

--- a/test/Serialization/export_as_xrefs.swift
+++ b/test/Serialization/export_as_xrefs.swift
@@ -1,0 +1,19 @@
+/// Ensure that export_as decls don't cause a deserialization failure (even one if recovered from)
+/// rdar://90272035
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DLIB_A %s -module-name A -emit-module-path %t/A.swiftmodule -I %t -I %S/Inputs/exported-modules
+// RUN: %target-swift-frontend -emit-module -DLIB_B %s -module-name B -emit-module-path %t/B.swiftmodule -I %t -I %S/Inputs/exported-modules -disable-deserialization-recovery
+
+#if LIB_A
+import ExportedCore
+
+public func foo() -> ExportedType { fatalError() }
+
+#elseif LIB_B
+
+import A
+
+let a = foo()
+
+#endif


### PR DESCRIPTION
Write the real module name for XRefs in swiftmodule files instead of the exported module name, which is taken from `export_as` declarations in module maps. Swiftmodule files are internal details now, they should represent the
truth. Swiftinterface files still display the export as name, so distributed modules will take care of hiding the private module with the `export_as` declaration.

We keep using the exported module name for the extensions lookup table as clients should still expect the exported name. However, we may need to write both alternatives in the lookup table in the future if extensions can't be found from clients not importing the exported as module.

rdar://90272035