### PR TITLE
[SymbolGraph] don't emit symbols for implicit inherited initializers

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -679,8 +679,12 @@ bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
   if (D->getModuleContext()->getName() != M.getName() && !Walker.isFromExportedImportedModule(D)) {
     return false;
   }
-  
-  if (!isa<ValueDecl>(D)) {
+
+  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
+    if (VD->getOverriddenDecl() && D->isImplicit()) {
+      return false;
+    }
+  } else {
     return false;
   }
   return !isImplicitlyPrivate(cast<ValueDecl>(D)) 

--- a/test/SymbolGraph/ClangImporter/ObjcProperty.swift
+++ b/test/SymbolGraph/ClangImporter/ObjcProperty.swift
@@ -3,12 +3,15 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/ObjcProperty.framework/Modules/ObjcProperty.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ObjcProperty -disable-objc-attr-requires-foundation-module %s
 // RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ObjcProperty -F %t -output-dir %t -pretty-print -v
 // RUN: %FileCheck %s --input-file %t/ObjcProperty.symbols.json
+// RUN: %FileCheck %s --input-file %t/ObjcProperty.symbols.json --check-prefix XLANG
 
 // REQUIRES: objc_interop
 
 import Foundation
 
 public enum SwiftEnum {}
+
+public class SwiftClass : Foo {}
 
 // ensure that synthesized inherited objc symbols do not appear in the symbol graph
 
@@ -17,3 +20,8 @@ public enum SwiftEnum {}
 // ensure that children of clang nodes appear in the symbol graph
 
 // CHECK: "precise": "c:objc(cs)Foo(py)today"
+
+// ensure that a swift class that inherits from an objc class still doesn't generate inherited
+// symbols
+
+// XLANG-COUNT-2: selectDate:

--- a/test/SymbolGraph/ClangImporter/ObjcProperty.swift
+++ b/test/SymbolGraph/ClangImporter/ObjcProperty.swift
@@ -10,4 +10,10 @@ import Foundation
 
 public enum SwiftEnum {}
 
+// ensure that synthesized inherited objc symbols do not appear in the symbol graph
+
+// CHECK-NOT:       "c:objc(cs)NSObject(im)init"
+
+// ensure that children of clang nodes appear in the symbol graph
+
 // CHECK: "precise": "c:objc(cs)Foo(py)today"

--- a/test/SymbolGraph/Relationships/Synthesized/SuperclassImplementation.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/SuperclassImplementation.swift
@@ -19,8 +19,14 @@ public class Base {
 
 public class Derived: Base {
   // CHECK-NOT: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation7DerivedC"
+
+  // Also skip synthesized constructors
+  // CHECK-NOT: "precise": "s:24SuperclassImplementation7DerivedCACycfc"
 }
 
 public class DerivedDerived: Derived {
   // CHECK-NOT: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation07DerivedC0C"
+
+  // Also skip synthesized constructors
+  // CHECK-NOT: "precise": "s:24SuperclassImplementation07DerivedC0CACycfc"
 }


### PR DESCRIPTION
Currently, we only create synthesied USRs for symbols that appear in an extension block. This can fail to catch implicitly-inherited symbols in other situations. Now that we emit implicit constructor decls (see #41141), this can create situations where different symbols get the same USR. This PR ensures that these implicit constructors are given synthesized USRs, so that they don't clash with their upstream symbol.

Resolves rdar://90401347
