### PR TITLE
[CSApply] Use declaration context associated with rewriter

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -513,7 +513,7 @@ namespace {
 
       return SubstitutionMap::get(sig,
                                   QueryTypeSubstitutionMap{subs},
-                                  LookUpConformanceInModule(cs.DC->getParentModule()));
+                                  LookUpConformanceInModule(dc->getParentModule()));
     }
 
     /// Determine whether the given reference is to a method on
@@ -532,7 +532,7 @@ namespace {
       // Determine the declaration selected for this overloaded reference.
       auto &ctx = cs.getASTContext();
       
-      auto semantics = decl->getAccessSemanticsFromContext(cs.DC,
+      auto semantics = decl->getAccessSemanticsFromContext(dc,
                                                            /*isAccessOnSelf*/false);
 
       // If this is a member of a nominal type, build a reference to the
@@ -552,7 +552,7 @@ namespace {
           // the protocol requirement with Self == the concrete type, and SILGen
           // (or later) can devirtualize as appropriate.
           auto conformance =
-            TypeChecker::conformsToProtocol(baseTy, proto, cs.DC->getParentModule());
+            TypeChecker::conformsToProtocol(baseTy, proto, dc->getParentModule());
           if (conformance.isConcrete()) {
             if (auto witness = conformance.getConcrete()->getWitnessDecl(decl)) {
               bool isMemberOperator = witness->getDeclContext()->isTypeContext();
@@ -859,7 +859,7 @@ namespace {
       resultTy = cs.getType(result);
       if (resultTy->hasOpenedExistentialWithRoot(record.Archetype)) {
         Type erasedTy = resultTy->typeEraseOpenedArchetypesWithRoot(
-            record.Archetype, cs.DC);
+            record.Archetype, dc);
         auto range = result->getSourceRange();
         result = coerceToType(result, erasedTy, locator);
         // FIXME: Implement missing tuple-to-tuple conversion
@@ -1288,7 +1288,7 @@ namespace {
       // reference.
       if (auto *TD = dyn_cast<TypeDecl>(member)) {
         Type refType = simplifyType(openedType);
-        auto ref = TypeExpr::createForDecl(memberLoc, TD, cs.DC);
+        auto ref = TypeExpr::createForDecl(memberLoc, TD, dc);
         cs.setType(ref, refType);
         auto *result = new (context) DotSyntaxBaseIgnoredExpr(
             base, dotLoc, ref, refType);
@@ -1354,7 +1354,7 @@ namespace {
           // Erase opened existentials from the type of the thunk; we're
           // going to open the existential inside the thunk's body.
           containerTy = containerTy->typeEraseOpenedArchetypesWithRoot(
-              knownOpened->second, cs.DC);
+              knownOpened->second, dc);
           selfTy = containerTy;
         }
       }
@@ -1414,7 +1414,7 @@ namespace {
         // existential.
         if (openedExistential) {
           refType = refType->typeEraseOpenedArchetypesWithRoot(
-              baseTy->castTo<OpenedArchetypeType>(), cs.DC);
+              baseTy->castTo<OpenedArchetypeType>(), dc);
         }
 
         cs.setType(ref, refType);
@@ -1555,7 +1555,7 @@ namespace {
         if (knownOpened != solution.OpenedExistentialTypes.end()) {
           curryThunkTy = curryThunkTy
                              ->typeEraseOpenedArchetypesWithRoot(
-                                 knownOpened->second, cs.DC)
+                                 knownOpened->second, dc)
                              ->castTo<FunctionType>();
         }
 
@@ -1569,7 +1569,7 @@ namespace {
             SourceLoc(),
             /*argument label*/ SourceLoc(), Identifier(),
             /*parameter name*/ SourceLoc(), context.Id_self,
-            cs.DC);
+            dc);
 
         auto selfParamTy = selfParam.getPlainType();
         bool isLValue = selfParam.isInOut();
@@ -2212,7 +2212,7 @@ namespace {
       auto bridgedToObjectiveCConformance
         = TypeChecker::conformsToProtocol(valueType,
                                           bridgedProto,
-                                          cs.DC->getParentModule());
+                                          dc->getParentModule());
 
       FuncDecl *fn = nullptr;
 
@@ -2473,7 +2473,7 @@ namespace {
       ProtocolDecl *protocol = TypeChecker::getProtocol(
           ctx, expr->getLoc(), KnownProtocolKind::ExpressibleByStringLiteral);
 
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC->getParentModule())) {
+      if (!TypeChecker::conformsToProtocol(type, protocol, dc->getParentModule())) {
         // If the type does not conform to ExpressibleByStringLiteral, it should
         // be ExpressibleByExtendedGraphemeClusterLiteral.
         protocol = TypeChecker::getProtocol(
@@ -2482,7 +2482,7 @@ namespace {
         isStringLiteral = false;
         isGraphemeClusterLiteral = true;
       }
-      if (!TypeChecker::conformsToProtocol(type, protocol, cs.DC->getParentModule())) {
+      if (!TypeChecker::conformsToProtocol(type, protocol, dc->getParentModule())) {
         // ... or it should be ExpressibleByUnicodeScalarLiteral.
         protocol = TypeChecker::getProtocol(
             cs.getASTContext(), expr->getLoc(),
@@ -2597,7 +2597,7 @@ namespace {
         assert(proto && "Missing string interpolation protocol?");
 
         auto conformance =
-          TypeChecker::conformsToProtocol(type, proto, cs.DC->getParentModule());
+          TypeChecker::conformsToProtocol(type, proto, dc->getParentModule());
         assert(conformance && "string interpolation type conforms to protocol");
 
         DeclName constrName(ctx, DeclBaseName::createConstructor(), argLabels);
@@ -2711,7 +2711,7 @@ namespace {
       assert(proto && "Missing object literal protocol?");
       auto conformance =
         TypeChecker::conformsToProtocol(conformingType, proto,
-                                        cs.DC->getParentModule());
+                                        dc->getParentModule());
       assert(conformance && "object literal type conforms to protocol");
 
       auto constrName = TypeChecker::getObjectLiteralConstructorName(ctx, expr);
@@ -2931,7 +2931,7 @@ namespace {
             diagnoseBadInitRef = false;
             // Make sure the reference to 'self' occurs within an initializer.
             if (!dyn_cast_or_null<ConstructorDecl>(
-                   cs.DC->getInnermostMethodContext())) {
+                   dc->getInnermostMethodContext())) {
               if (!SuppressDiagnostics)
                 de.diagnose(dotLoc, diag::init_delegation_outside_initializer);
               return nullptr;
@@ -2944,7 +2944,7 @@ namespace {
         if (diagnoseBadInitRef) {
           // Determine whether 'super' would have made sense as a base.
           bool hasSuper = false;
-          if (auto func = cs.DC->getInnermostMethodContext()) {
+          if (auto func = dc->getInnermostMethodContext()) {
             if (auto classDecl = func->getDeclContext()->getSelfClassDecl()) {
               hasSuper = classDecl->hasSuperclass();
             }
@@ -2984,7 +2984,7 @@ namespace {
       };
 
       auto result =
-          TypeChecker::lookupUnqualified(cs.DC, UDE->getName(), UDE->getLoc());
+          TypeChecker::lookupUnqualified(dc, UDE->getName(), UDE->getLoc());
       assert(result && "names can't just disappear");
       // These should all come from the same place.
       auto exampleInner = result.front();
@@ -3066,7 +3066,7 @@ namespace {
         auto &ctx = cs.getASTContext();
         auto baseMetaTy = baseTy->getAs<MetatypeType>();
         auto baseInstTy = (baseMetaTy ? baseMetaTy->getInstanceType() : baseTy);
-        auto classTy = ctx.getBridgedToObjC(cs.DC, baseInstTy);
+        auto classTy = ctx.getBridgedToObjC(dc, baseInstTy);
 
         if (baseMetaTy) {
           // FIXME: We're dropping side effects in the base here!
@@ -3328,7 +3328,7 @@ namespace {
 
       auto conformance =
         TypeChecker::conformsToProtocol(arrayTy, arrayProto,
-                                        cs.DC->getParentModule());
+                                        dc->getParentModule());
       assert(conformance && "Type does not conform to protocol?");
 
       DeclName name(ctx, DeclBaseName::createConstructor(),
@@ -3373,7 +3373,7 @@ namespace {
 
       auto conformance =
         TypeChecker::conformsToProtocol(dictionaryTy, dictionaryProto,
-                                        cs.DC->getParentModule());
+                                        dc->getParentModule());
       if (conformance.isInvalid())
         return nullptr;
 
@@ -3498,7 +3498,7 @@ namespace {
       // initializer.
       Expr *unwrappedSubExpr = expr->getSubExpr()->getSemanticsProvidingExpr();
       Type valueTy = cs.getType(unwrappedSubExpr)->getOptionalObjectType();
-      auto inCtor = cast<ConstructorDecl>(cs.DC->getInnermostMethodContext());
+      auto inCtor = cast<ConstructorDecl>(dc->getInnermostMethodContext());
       if (valueTy && !inCtor->isFailable()) {
         bool isChaining;
         auto *otherCtorRef = expr->getCalledConstructor(isChaining);
@@ -3588,7 +3588,7 @@ namespace {
           SuppressDiagnostics ? CheckedCastContextKind::None
                               : CheckedCastContextKind::IsExpr;
       auto castKind = TypeChecker::typeCheckCheckedCast(
-          fromType, toType, castContextKind, cs.DC, expr->getLoc(), sub,
+          fromType, toType, castContextKind, dc, expr->getLoc(), sub,
           castTypeRepr->getSourceRange());
 
       switch (castKind) {
@@ -4302,7 +4302,7 @@ namespace {
       Expr *callExpr = CallExpr::createImplicit(ctx, fnRef, argList);
 
       auto resultTy = TypeChecker::typeCheckExpression(
-          callExpr, cs.DC, /*contextualInfo=*/{valueType, CTP_CannotFail});
+          callExpr, dc, /*contextualInfo=*/{valueType, CTP_CannotFail});
       assert(resultTy && "Conversion cannot fail!");
       (void)resultTy;
 
@@ -4470,8 +4470,8 @@ namespace {
         // Check that we requested a property getter or setter.
         switch (E->getSelectorKind()) {
         case ObjCSelectorExpr::Method: {
-          bool isSettable = var->isSettable(cs.DC) &&
-            var->isSetterAccessibleFrom(cs.DC);
+          bool isSettable = var->isSettable(dc) &&
+            var->isSetterAccessibleFrom(dc);
           auto primaryDiag =
               de.diagnose(E->getLoc(), diag::expr_selector_expected_method,
                           isSettable, var->getName());
@@ -4512,7 +4512,7 @@ namespace {
 
         case ObjCSelectorExpr::Setter:
           // Make sure we actually have a setter.
-          if (!var->isSettable(cs.DC)) {
+          if (!var->isSettable(dc)) {
             de.diagnose(E->getLoc(), diag::expr_selector_property_not_settable,
                         var->getDescriptiveKind(), var->getName());
             de.diagnose(var, diag::decl_declared_here, var->getName());
@@ -4520,7 +4520,7 @@ namespace {
           }
 
           // Make sure the setter is accessible.
-          if (!var->isSetterAccessibleFrom(cs.DC)) {
+          if (!var->isSetterAccessibleFrom(dc)) {
             de.diagnose(E->getLoc(),
                         diag::expr_selector_property_setter_inaccessible,
                         var->getDescriptiveKind(), var->getName());
@@ -4802,7 +4802,7 @@ namespace {
           FunctionType::get({FunctionType::Param(baseTy)}, leafTy, closureInfo);
       auto closure = new (ctx)
           AutoClosureExpr(/*set body later*/nullptr, leafTy,
-                          discriminator, cs.DC);
+                          discriminator, dc);
       auto param = new (ctx) ParamDecl(
           SourceLoc(),
           /*argument label*/ SourceLoc(), Identifier(),
@@ -4821,7 +4821,7 @@ namespace {
                                               closureTy, outerClosureInfo);
       auto outerClosure = new (ctx)
           AutoClosureExpr(/*set body later*/nullptr, closureTy,
-                          discriminator, cs.DC);
+                          discriminator, dc);
       auto outerParam =
           new (ctx) ParamDecl(SourceLoc(),
                               /*argument label*/ SourceLoc(), Identifier(),
@@ -4989,7 +4989,7 @@ namespace {
         // with all of the generic parameters resolved.
         auto hashableConformance =
           TypeChecker::conformsToProtocol(indexType, hashable,
-                                          cs.DC->getParentModule());
+                                          dc->getParentModule());
         assert(hashableConformance);
 
         conformances.push_back(hashableConformance);
@@ -5270,7 +5270,7 @@ Expr *ExprRewriter::coerceSuperclass(Expr *expr, Type toType) {
     // concrete superclass.
     auto fromArchetype =
         OpenedArchetypeType::getAny(fromType->getCanonicalType(),
-                                    cs.DC->getGenericSignatureOfContext());
+                                    dc->getGenericSignatureOfContext());
 
     auto *archetypeVal = cs.cacheType(new (ctx) OpaqueValueExpr(
         expr->getSourceRange(), fromArchetype));
@@ -6023,7 +6023,8 @@ static Expr *buildElementConversion(ExprRewriter &rewriter,
   auto &cs = rewriter.getConstraintSystem();
   if (bridged &&
       TypeChecker::typeCheckCheckedCast(srcType, destType,
-                                        CheckedCastContextKind::None, cs.DC,
+                                        CheckedCastContextKind::None,
+                                        rewriter.dc,
                                         SourceLoc(), nullptr, SourceRange())
         != CheckedCastKind::Coercion) {
     if (auto conversion =
@@ -6279,7 +6280,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
 
   auto conformances =
     collectExistentialConformances(fromInstanceType, toInstanceType,
-                                   cs.DC->getParentModule());
+                                   dc->getParentModule());
 
   // Use the requirements of any parameterized protocols to build out fake
   // argument conversions that can be used to infer opaque types.
@@ -6336,7 +6337,7 @@ Expr *ExprRewriter::coerceExistential(Expr *expr, Type toType,
   // For existential-to-existential coercions, open the source existential.
   if (fromType->isAnyExistentialType()) {
     fromType = OpenedArchetypeType::getAny(fromType->getCanonicalType(),
-                                           cs.DC->getGenericSignatureOfContext());
+                                           dc->getGenericSignatureOfContext());
 
     auto *archetypeVal = cs.cacheType(
         new (ctx) OpaqueValueExpr(expr->getSourceRange(), fromType));
@@ -6500,7 +6501,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       auto hashable = ctx.getProtocol(KnownProtocolKind::Hashable);
       auto conformance =
         TypeChecker::conformsToProtocol(
-                        cs.getType(expr), hashable, cs.DC->getParentModule());
+                        cs.getType(expr), hashable, dc->getParentModule());
       assert(conformance && "must conform to Hashable");
 
       return cs.cacheType(
@@ -6759,7 +6760,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     // leave an explicit escape to noescape cast here such that SILGen can skip
     // the cast and emit a code for the escaping function.
     bool isInDefaultArgumentContext = false;
-    if (auto initalizerCtx = dyn_cast<Initializer>(cs.DC))
+    if (auto initalizerCtx = dyn_cast<Initializer>(dc))
       isInDefaultArgumentContext = (initalizerCtx->getInitializerKind() ==
                                     InitializerKind::DefaultArgument);
     auto toEI = toFunc->getExtInfo();
@@ -7209,7 +7210,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
   // initialize via the builtin protocol.
   if (builtinProtocol) {
     auto builtinConformance = TypeChecker::conformsToProtocol(
-        type, builtinProtocol, cs.DC->getParentModule());
+        type, builtinProtocol, dc->getParentModule());
     if (builtinConformance) {
       // Find the witness that we'll use to initialize the type via a builtin
       // literal.
@@ -7233,7 +7234,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
   // This literal type must conform to the (non-builtin) protocol.
   assert(protocol && "requirements should have stopped recursion");
   auto conformance = TypeChecker::conformsToProtocol(type, protocol,
-                                                     cs.DC->getParentModule());
+                                                     dc->getParentModule());
   assert(conformance && "must conform to literal protocol");
 
   // Dig out the literal type and perform a builtin literal conversion to it.
@@ -7358,7 +7359,7 @@ std::pair<Expr *, ArgumentList *> ExprRewriter::buildDynamicCallable(
         ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     auto conformance =
         TypeChecker::conformsToProtocol(argumentType, dictLitProto,
-                                        cs.DC->getParentModule());
+                                        dc->getParentModule());
     auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
     auto valueType =
         conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);
@@ -8478,6 +8479,8 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
 
   resultTarget.setExpr(sequence);
 
+  auto *dc = target.getDeclContext();
+
   // Get the conformance of the sequence type to the Sequence protocol.
   auto stmt = forEachStmtInfo.stmt;
   auto sequenceProto = TypeChecker::getProtocol(
@@ -8485,7 +8488,7 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
       stmt->getAwaitLoc().isValid() ? 
         KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
   auto sequenceConformance = TypeChecker::conformsToProtocol(
-      forEachStmtInfo.sequenceType, sequenceProto, cs.DC->getParentModule());
+      forEachStmtInfo.sequenceType, sequenceProto, dc->getParentModule());
   assert(!sequenceConformance.isInvalid() &&
          "Couldn't find sequence conformance");
 
@@ -8503,7 +8506,6 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
   }
 
   // Apply the solution to the filtering condition, if there is one.
-  auto dc = target.getDeclContext();
   if (forEachStmtInfo.whereExpr) {
     auto *boolDecl = dc->getASTContext().getBoolDecl();
     assert(boolDecl);


### PR DESCRIPTION
`ExprRewriter` could be created for a solution application target,
which could have its own declaration context if it's e.g. an inner
statement or a pattern binding.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
