### PR TITLE
Implicitly open existential call arguments and its effect on other parameters

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5113,6 +5113,10 @@ private:
                                   SourceLoc referenceLoc);
 
 public:
+  /// If the given argument, specified by its type and expression, a reference
+  /// to a generic function?
+  bool isArgumentGenericFunction(Type argType, Expr *argExpr);
+
   // Given a type variable, attempt to find the disjunction of
   // bind overloads associated with it. This may return null in cases where
   // the disjunction has either not been created or binds the type variable
@@ -5643,7 +5647,8 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
-                                         const DeclContext *useDC);
+                                         const DeclContext *useDC,
+                                         TypePosition outermostPosition);
 
 /// Returns true if a reference to a member on a given base type will apply
 /// its curried self parameter, assuming it has one.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4048,9 +4048,16 @@ GenericParameterReferenceInfo swift::findGenericParameterReferences(
             sig, genericParam, param.getPlainType(), TypePosition::Invariant);
         continue;
       }
+
+      // Parameters are contravariant, but if we're prior to the skipped
+      // parameter treat them as invariant because we're not allowed to
+      // reference the parameter at all.
+      TypePosition position = TypePosition::Contravariant;
+      if (skipParamIndex && paramIdx < *skipParamIndex)
+        position = TypePosition::Invariant;
+
       inputInfo |= ::findGenericParameterReferences(
-          sig, genericParam, param.getParameterType(),
-          TypePosition::Contravariant);
+          sig, genericParam, param.getParameterType(), position);
     }
 
     // A covariant Self result inside a parameter will not be bona fide.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1432,12 +1432,13 @@ namespace {
 /// \param argTy The type of the argument.
 ///
 /// \returns If the argument type is existential and opening it can bind a
-/// generic parameter in the callee, returns the type variable (from the
-/// opened parameter type) the existential type that needs to be opened
-/// (from the argument type), and the adjustements that need to be applied to
-/// the existential type after it is opened.
+/// generic parameter in the callee, returns the generic parameter, type
+/// variable (from the opened parameter type) the existential type that needs
+/// to be opened (from the argument type), and the adjustements that need to be
+/// applied to the existential type after it is opened.
 static Optional<
-    std::tuple<TypeVariableType *, Type, OpenedExistentialAdjustments>>
+    std::tuple<GenericTypeParamType *, TypeVariableType *, Type,
+               OpenedExistentialAdjustments>>
 shouldOpenExistentialCallArgument(
     ValueDecl *callee, unsigned paramIdx, Type paramTy, Type argTy,
     Expr *argExpr, ConstraintSystem &cs) {
@@ -1551,7 +1552,7 @@ shouldOpenExistentialCallArgument(
       referenceInfo.assocTypeRef > TypePosition::Covariant)
     return None;
 
-  return std::make_tuple(paramTypeVar, argTy, adjustments);
+  return std::make_tuple(genericParam, paramTypeVar, argTy, adjustments);
 }
 
 // Match the argument of a call to the parameter.
@@ -1831,15 +1832,29 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
             cs, cs.getConstraintLocator(loc)));
       }
 
+      // Type-erase any opened existentials from subsequent parameter types
+      // unless the argument itself is a generic function, which could handle
+      // the opened existentials.
+      if (!openedExistentials.empty() && paramTy->hasTypeVariable() &&
+          !cs.isArgumentGenericFunction(argTy, argExpr)) {
+        for (const auto &opened : openedExistentials) {
+          paramTy = typeEraseOpenedExistentialReference(
+              paramTy, opened.second->getExistentialType(), opened.first,
+              /*FIXME*/cs.DC, TypePosition::Contravariant);
+        }
+      }
+
       // If the argument is an existential type and the parameter is generic,
       // consider opening the existential type.
       if (auto existentialArg = shouldOpenExistentialCallArgument(
               callee, paramIdx, paramTy, argTy, argExpr, cs)) {
         // My kingdom for a decent "if let" in C++.
+        GenericTypeParamType *openedGenericParam;
         TypeVariableType *openedTypeVar;
         Type existentialType;
         OpenedExistentialAdjustments adjustments;
-        std::tie(openedTypeVar, existentialType, adjustments) = *existentialArg;
+        std::tie(openedGenericParam, openedTypeVar, existentialType,
+                 adjustments) = *existentialArg;
 
         OpenedArchetypeType *opened;
         std::tie(argTy, opened) = cs.openExistentialType(
@@ -11314,7 +11329,8 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (result2->hasTypeVariable() && !openedExistentials.empty()) {
       for (const auto &opened : openedExistentials) {
         result2 = typeEraseOpenedExistentialReference(
-            result2, opened.second->getExistentialType(), opened.first, DC);
+            result2, opened.second->getExistentialType(), opened.first, DC,
+            TypePosition::Covariant);
       }
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1794,8 +1794,9 @@ static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
 /// \note If a 'Self'-rooted type parameter is bound to a concrete type, this
 /// routine will recurse into the concrete type.
 static Type
-typeEraseCovariantExistentialSelfReferences(Type refTy, Type baseTy,
-                                            const DeclContext *useDC) {
+typeEraseExistentialSelfReferences(
+    Type refTy, Type baseTy, const DeclContext *useDC,
+    TypePosition outermostPosition) {
   assert(baseTy->isExistentialType());
   if (!refTy->hasTypeParameter()) {
     return refTy;
@@ -1910,12 +1911,12 @@ typeEraseCovariantExistentialSelfReferences(Type refTy, Type baseTy,
     });
   };
 
-  return transformFn(refTy, TypePosition::Covariant);
+  return transformFn(refTy, outermostPosition);
 }
 
 Type constraints::typeEraseOpenedExistentialReference(
     Type type, Type existentialBaseType, TypeVariableType *openedTypeVar,
-    const DeclContext *useDC) {
+    const DeclContext *useDC, TypePosition outermostPosition) {
   Type selfGP = GenericTypeParamType::get(false, 0, 0, type->getASTContext());
 
   // First, temporarily reconstitute the 'Self' generic parameter.
@@ -1932,8 +1933,8 @@ Type constraints::typeEraseOpenedExistentialReference(
   });
 
   // Then, type-erase occurrences of covariant 'Self'-rooted type parameters.
-  type = typeEraseCovariantExistentialSelfReferences(type, existentialBaseType,
-                                                     useDC);
+  type = typeEraseExistentialSelfReferences(
+      type, existentialBaseType, useDC, outermostPosition);
 
   // Finally, swap the 'Self'-corresponding type variable back in.
   return type.transformRec([&](TypeBase *t) -> Optional<Type> {
@@ -2260,7 +2261,8 @@ ConstraintSystem::getTypeOfMemberReference(
         outerDC->getSelfInterfaceType()->getCanonicalType());
     auto openedTypeVar = replacements.lookup(selfGP);
     type =
-        typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar, DC);
+        typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar, DC,
+                                            TypePosition::Covariant);
   }
 
   // Construct an idealized parameter type of the initializer associated
@@ -6431,6 +6433,51 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
     if (maybeUnavail.hasValue()) {
       return true;
     }
+  }
+
+  return false;
+}
+
+bool ConstraintSystem::isArgumentGenericFunction(Type argType, Expr *argExpr) {
+  // Only makes sense if the argument type involves type variables somehow.
+  if (!argType->hasTypeVariable())
+    return false;
+
+  // Have we bound an overload for the argument already?
+  if (argExpr) {
+    auto locator = getConstraintLocator(argExpr);
+    auto knownOverloadBinding = ResolvedOverloads.find(locator);
+    if (knownOverloadBinding != ResolvedOverloads.end()) {
+      // If the overload choice is a generic function, then we have a generic
+      // function reference.
+      auto choice = knownOverloadBinding->second;
+      if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(
+              choice.choice.getDeclOrNull())) {
+        if (func->isGeneric())
+          return true;
+      }
+
+      return false;
+    }
+  }
+
+  // We might have a type variable referring to an overload set.
+  auto argTypeVar = argType->getAs<TypeVariableType>();
+  if (!argTypeVar)
+    return false;
+
+  auto disjunction = getUnboundBindOverloadDisjunction(argTypeVar);
+  if (!disjunction)
+    return false;
+
+  for (auto constraint : disjunction->getNestedConstraints()) {
+    auto *decl = constraint->getOverloadChoice().getDeclOrNull();
+    if (!decl)
+      continue;
+
+    if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
+      if (func->isGeneric())
+        return true;
   }
 
   return false;

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -178,3 +178,25 @@ func testReturningOpaqueTypes(p: any P) {
   _ = createX(p) // expected-error{{type 'any P' cannot conform to 'P'}}
   // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
 }
+
+// Type-erasing vs. opening for parameters after the opened one.
+func takeValueAndClosure<T: P>(_ value: T, body: (T) -> Void) { }
+
+func genericFunctionTakingP<T: P>(_: T) { }
+func genericFunctionTakingPQ<T: P & Q>(_: T) { }
+
+func overloadedGenericFunctionTakingP<T: P>(_: T) -> Int { 0 }
+func overloadedGenericFunctionTakingP<T: P>(_: T) { }
+
+func testTakeValueAndClosure(p: any P) {
+  // Type-erase when not provided with a generic function.
+  takeValueAndClosure(p) { x in
+    print(x)
+    let _: Int = x // expected-error{{cannot convert value of type 'any P' to specified type 'Int'}}
+  }
+
+  // Do not erase when referring to a generic function.
+  takeValueAndClosure(p, body: genericFunctionTakingP)
+  takeValueAndClosure(p, body: overloadedGenericFunctionTakingP)
+  takeValueAndClosure(p, body: genericFunctionTakingPQ) // expected-error{{global function 'genericFunctionTakingPQ' requires that 'T' conform to 'Q'}}
+}

--- a/test/SILGen/opened_existentials.swift
+++ b/test/SILGen/opened_existentials.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-opened-existential-types %s | %FileCheck %s
+
+public protocol P { }
+
+func f() -> String {
+  print("f()")
+  return "Hello"
+}
+
+func g<T: P> (_ value: String, _: T) -> String {
+  print("g()")
+  return value + ", world"
+}
+
+extension Int: P { }
+
+func getP() -> any P {
+  return 17
+}
+
+// CHECK: sil [ossa] @$s19opened_existentials4testSSyF : $@convention(thin) () -> @owned String
+public func test() -> String {
+  // FIXME: This demonstrates that we are opening the existential out of
+  // order. This test will break when we properly update the existential-opening
+  // logic to wait until the argument is evaluated.
+
+  // CHECK: [[PSTACK:%.*]] = alloc_stack $P
+  // CHECK: [[GETP:%.*]] = function_ref @$s19opened_existentials4getPAA1P_pyF : $@convention(thin) () -> @out P // user: %2
+  // CHECK: [[P:%.*]] = apply [[GETP]]([[PSTACK]]) : $@convention(thin) () -> @out P
+  // CHECK: [[OPENEDP:%.*]] = open_existential_addr immutable_access [[PSTACK]] : $*P to $*@opened
+  // CHECK: [[F:%.*]] = function_ref @$s19opened_existentials1fSSyF : $@convention(thin) () -> @owned String
+  // CHECK: [[F_RESULT:%.*]] = apply [[F]]() : $@convention(thin) () -> @owned String
+  g(f(), getP())
+}
+


### PR DESCRIPTION
When we want to implicitly open an existential call argument, consider its effect on other parameters that use the corresponding generic type parameter. 
* For parameters prior to one corresponding to the argument we are trying to implicitly open, any reference to the type parameter that would bind to the opened existential type. When such parameters exist, don't open the existential because it would require the existential argument to be evaluated out-of-order.
* For parameters following the one corresponding to the argument we are trying to implicitly open, type-erase any contravariant uses of the type parameter *unless* the corresponding arguments are generic functions. This ensures that opened types don't escape into the user model, because they're always immediately bound to a generic parameter (and therefore hidden). 
