### PR TITLE
[CSRanking] Fix a bug in archetype vs. concrete type ranking

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1331,7 +1331,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
       continue;
     } else if (type2->is<ArchetypeType>() && !type1->is<ArchetypeType>() &&
                !type1->is<PlaceholderType>()) {
-      ++score2;
+      ++score1;
       continue;
     }
 


### PR DESCRIPTION
Code completion related changes introduced a bug which increased
`score2` regardless which type was an archetype, which surfaced
as a source compatibility regression in ReactiveKit.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
