### PR TITLE
IRGen: Use indirect relative func-ptr for harvard archs

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -320,6 +320,10 @@ public:
   unsigned LazyInitializeProtocolConformances : 1;
   unsigned IndirectAsyncFunctionPointer : 1;
 
+  /// Force relative function pointer to be indirect
+  /// Used on harvard architectures like WebAssembly
+  unsigned IndirectRelativeFunctionPointer : 1;
+
   /// Normally if the -read-legacy-type-info flag is not specified, we look for
   /// a file named "legacy-<arch>.yaml" in SearchPathOpts.RuntimeLibraryPath.
   /// Passing this flag completely disables this behavior.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2161,6 +2161,12 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // AsyncFunctionPointer access.
   Opts.IndirectAsyncFunctionPointer = Triple.isOSBinFormatCOFF();
 
+  // Harvard architectures cannot make direct relative function pointer
+  // because the referent function and the metadata are in different
+  // address spaces, and the relative offset between them is not representable.
+  // So we always use indirect relative function pointer for those.
+  Opts.IndirectRelativeFunctionPointer = Triple.isOSBinFormatWasm();
+
   if (Args.hasArg(OPT_disable_legacy_type_info)) {
     Opts.DisableLegacyTypeInfo = true;
   }

--- a/lib/IRGen/ConformanceDescription.h
+++ b/lib/IRGen/ConformanceDescription.h
@@ -53,7 +53,7 @@ public:
 
   /// The instantiation function, to be run at the end of witness table
   /// instantiation.
-  llvm::Constant *instantiationFn = nullptr;
+  llvm::Function *instantiationFn = nullptr;
 
   /// The resilient witnesses, if any.
   SmallVector<llvm::Constant *, 4> resilientWitnesses;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2086,7 +2086,7 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
       llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(
           getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
           getAFPPtr(), 0);
-      fn = IGF.emitLoadOfRelativePointer(
+      fn = IGF.emitLoadOfRelativeFunctionPointer(
           Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
           /*expectedType*/ functionPointer.getFunctionType()->getPointerTo());
     }
@@ -4952,7 +4952,7 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
     auto *addrPtr = IGF.Builder.CreateStructGEP(
         descriptorPtr->getType()->getScalarType()->getPointerElementType(),
         descriptorPtr, 0);
-    auto *result = IGF.emitLoadOfRelativePointer(
+    auto *result = IGF.emitLoadOfRelativeFunctionPointer(
         Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
         /*expectedType*/ getFunctionType()->getPointerTo());
     if (auto codeAuthInfo = AuthInfo.getCorrespondingCodeAuthInfo()) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2063,7 +2063,7 @@ void IRGenerator::emitEntryPointInfo() {
   auto &IGM = *getGenModule(entrypoint);
   ConstantInitBuilder builder(IGM);
   auto entrypointInfo = builder.beginStruct();
-  entrypointInfo.addRelativeAddress(
+  entrypointInfo.addRelativeFunctionAddress(
       IGM.getAddrOfSILFunction(entrypoint, NotForDefinition));
   auto var = entrypointInfo.finishAndCreateGlobal(
       "\x01l_entry_point", Alignment(4),

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1472,7 +1472,7 @@ public:
 
     /// Build the instantiation function that runs at the end of witness
     /// table specialization.
-    llvm::Constant *buildInstantiationFunction();
+    llvm::Function *buildInstantiationFunction();
   };
 
   /// A resilient witness table consists of a list of descriptor/witness pairs,
@@ -1741,7 +1741,7 @@ void ResilientWitnessTableBuilder::collectResilientWitnesses(
   }
 }
 
-llvm::Constant *FragileWitnessTableBuilder::buildInstantiationFunction() {
+llvm::Function *FragileWitnessTableBuilder::buildInstantiationFunction() {
   // We need an instantiation function if any base conformance
   // is non-dependent.
   if (SpecializedBaseConformances.empty())
@@ -1962,7 +1962,12 @@ namespace {
         }
 
         // Add the witness.
-        B.addRelativeAddress(witnesses.front());
+        llvm::Constant *witness = witnesses.front();
+        if (auto *fn = llvm::dyn_cast<llvm::Function>(witness)) {
+          B.addRelativeFunctionAddress(fn);
+        } else {
+          B.addRelativeAddress(witness);
+        }
         witnesses = witnesses.drop_front();
       }
       assert(witnesses.empty() && "Wrong # of resilient witnesses");
@@ -1979,7 +1984,7 @@ namespace {
                (Description.witnessTablePrivateSize << 1) |
                 Description.requiresSpecialization);
       // Instantiation function
-      B.addRelativeAddressOrNull(Description.instantiationFn);
+      B.addRelativeFunctionAddressOrNull(Description.instantiationFn);
 
       // Private data
       if (IGM.IRGen.Opts.NoPreallocatedInstantiationCaches) {
@@ -2255,7 +2260,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
 
   unsigned tableSize = 0;
   llvm::GlobalVariable *global = nullptr;
-  llvm::Constant *instantiationFunction = nullptr;
+  llvm::Function *instantiationFunction = nullptr;
   bool isDependent = isDependentConformance(conf);
   SmallVector<llvm::Constant *, 4> resilientWitnesses;
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -281,7 +281,7 @@ getTypeRefByFunction(IRGenModule &IGM,
       S.setPacked(true);
       S.add(llvm::ConstantInt::get(IGM.Int8Ty, 255));
       S.add(llvm::ConstantInt::get(IGM.Int8Ty, 9));
-      S.addRelativeAddress(accessor);
+      S.addRelativeFunctionAddress(accessor);
 
       // And a null terminator!
       S.addInt(IGM.Int8Ty, 0);
@@ -438,7 +438,7 @@ IRGenModule::emitWitnessTableRefString(CanType type,
         S.setPacked(true);
         S.add(llvm::ConstantInt::get(Int8Ty, 255));
         S.add(llvm::ConstantInt::get(Int8Ty, 9));
-        S.addRelativeAddress(accessorThunk);
+        S.addRelativeFunctionAddress(accessorThunk);
 
         // And a null terminator!
         S.addInt(Int8Ty, 0);
@@ -482,7 +482,7 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   S.setPacked(true);
   S.add(llvm::ConstantInt::get(Int8Ty, 255));
   S.add(llvm::ConstantInt::get(Int8Ty, kind));
-  S.addRelativeAddress(accessor);
+  S.addRelativeFunctionAddress(accessor);
 
   // And a null terminator!
   S.addInt(Int8Ty, 0);

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -337,6 +337,19 @@ IRGenFunction::emitLoadOfRelativePointer(Address addr, bool isFar,
   return pointer.getAddress();
 }
 
+llvm::Value *IRGenFunction::emitLoadOfRelativeFunctionPointer(
+    Address addr, bool isFar, llvm::PointerType *expectedType,
+    const llvm::Twine &name) {
+  if (IGM.getOptions().IndirectRelativeFunctionPointer) {
+    llvm::Value *value = emitLoadOfRelativePointer(
+        Address(addr.getAddress(), IGM.getPointerAlignment()), isFar,
+        expectedType->getPointerTo(), name);
+    return Builder.CreateLoad(value, addr.getAlignment());
+  } else {
+    return emitLoadOfRelativePointer(addr, isFar, expectedType, name);
+  }
+}
+
 llvm::Value *
 IRGenFunction::emitLoadOfRelativeIndirectablePointer(Address addr,
                                                 bool isFar,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -266,6 +266,10 @@ public:
   llvm::Value *emitLoadOfRelativePointer(Address addr, bool isFar,
                                          llvm::PointerType *expectedType,
                                          const llvm::Twine &name = "");
+  llvm::Value *
+  emitLoadOfRelativeFunctionPointer(Address addr, bool isFar,
+                                    llvm::PointerType *expectedType,
+                                    const llvm::Twine &name = "");
 
   llvm::Value *emitAllocObjectCall(llvm::Value *metadata, llvm::Value *size,
                                    llvm::Value *alignMask,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1118,6 +1118,7 @@ private:
   llvm::DenseMap<LinkEntity, llvm::Constant*> IndirectAsyncFunctionPointers;
   llvm::DenseMap<LinkEntity, llvm::Constant*> GlobalGOTEquivalents;
   llvm::DenseMap<LinkEntity, llvm::Function*> GlobalFuncs;
+  llvm::DenseMap<llvm::Function *, llvm::Constant *> IndirectRelativeFunctionPointers;
   llvm::DenseSet<const clang::Decl *> GlobalClangDecls;
   llvm::StringMap<std::pair<llvm::GlobalVariable*, llvm::Constant*>>
     GlobalStrings;
@@ -1293,6 +1294,8 @@ public:
   /// Produce an associated type witness that refers to the given type.
   llvm::Constant *getAssociatedTypeWitness(Type type, GenericSignature sig,
                                            bool inProtocolContext);
+
+  llvm::Constant *getAddrOfIndirectFunctionPointer(llvm::Function *fn);
 
   void emitAssociatedTypeMetadataRecord(const RootProtocolConformance *C);
   void emitFieldDescriptor(const NominalTypeDecl *Decl);

--- a/test/IRGen/harvard-arch-relative-func-ptr.swift
+++ b/test/IRGen/harvard-arch-relative-func-ptr.swift
@@ -1,0 +1,13 @@
+// RUN: %swift -target wasm32-unknown-wasi -parse-stdlib -emit-ir -o - %s | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+// Ensure that relative function pointer in entry_point is indirect on harvard archs
+//
+// CHECK:      @indirect.main = private unnamed_addr constant i32 (i32, i8*)* @main
+// CHECK:      @"\01l_entry_point" = private constant { i32 } {
+// CHECK-SAME:   i32 sub (
+// CHECK-SAME:     i32 ptrtoint (i32 (i32, i8*)** @indirect.main to i32),
+// CHECK-SAME:     i32 ptrtoint ({ i32 }* @"\01l_entry_point" to i32)
+// CHECK-SAME:   )
+// CHECK-SAME: }, section "swift5_entry", align 4


### PR DESCRIPTION
Harvard architectures like WebAssembly cannot make direct relative function pointer because the referent function and the metadata are in different address spaces and the relative offset between them is not representable.
So we need to force such relative function pointers to always be indirect for those archs.

This change shouldn't affect other than WebAssembly, and Runtime changes will come in another PR

See also: https://forums.swift.org/t/wasm-support/16087/39