### PR TITLE
[c++-interop] APINotes test for ObjCMethods

### DIFF
--- a/test/Interop/Cxx/apinotes/Inputs/SomeModule.apinotes
+++ b/test/Interop/Cxx/apinotes/Inputs/SomeModule.apinotes
@@ -3,3 +3,7 @@ Name: SomeModule
 Classes:
 - Name: NSSomeClass
   SwiftName: SomeClass
+  Methods:
+  - Selector: 'didMoveToParentViewController:'
+    SwiftName: didMove(toParent:)
+    MethodKind: Instance

--- a/test/Interop/Cxx/apinotes/Inputs/SomeModule.h
+++ b/test/Interop/Cxx/apinotes/Inputs/SomeModule.h
@@ -2,3 +2,9 @@
   -(instancetype)init;
 @end
 
+// Extension, inspired by UIKit UIViewController.h
+@interface NSSomeClass (UIContainerViewControllerCallbacks)
+
+- (void)didMoveToParentViewController:(NSSomeClass *)parent;
+
+@end

--- a/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
+++ b/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
@@ -7,3 +7,16 @@ import SomeModule
 // CHECK-IDE-TEST: typealias NSSomeClass = SomeClass
 // CHECK-IDE-TEST-NEXT: class SomeClass
 class MyClass : SomeClass { }
+
+// CHECK-IDE-TEST: extension SomeClass {
+// CHECK-IDE-TEST-NEXT: class func didMove(toParent parent
+// CHECK-IDE-TEST-NEXT: func didMove(toParent parent:
+// CHECK-IDE-TEST-NEXT: @available
+// CHECK-IDE-TEST-NEXT: class func didMoveToParentViewController(_ parent
+// CHECK-IDE-TEST-NEXT: @available
+// CHECK-IDE-TEST-NEXT: func didMoveToParentViewController(_ parent
+
+// CHECK: didMove
+let a = SomeClass()
+let b = MyClass()
+let c = b!.didMove(toParent: a!)


### PR DESCRIPTION
This is swift test to go with https://github.com/apple/llvm-project/pull/4118

The test is verifying that a ObjCMethod that is annotated by an APINote
is in fact getting the APINote applied. These types of APINotes are
heavily used by UIKit for instance in didMoveToParentViewController in
UIViewController.
