### PR TITLE
Disable String breadcrumbs tests for freestanding stdlib

### DIFF
--- a/validation-test/stdlib/StringBreadcrumbs.swift
+++ b/validation-test/stdlib/StringBreadcrumbs.swift
@@ -1,8 +1,8 @@
-
 // RUN: %target-run-stdlib-swift
 // REQUIRES: executable_test,optimized_stdlib
+// UNSUPPORTED: freestanding
 
-// Some targetted tests for the breadcrumbs path. There is some overlap with
+// Some targeted tests for the breadcrumbs path. There is some overlap with
 // UTF16View tests for huge strings, but we want a simpler suite that targets
 // some corner cases specifically.
 


### PR DESCRIPTION
Should address failure in https://ci.swift.org/job/oss-swift-test-stdlib-with-toolchain-minimaln//379/console