### PR TITLE
[build-presets] Disabled SourceKit-LSP tests for all SwiftPM Linux jobs

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1686,6 +1686,9 @@ skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
 
+# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
+skip-test-sourcekit-lsp
+
 # Builds enough of the the toolchain to build a swift pacakge on macOS.
 [preset: mixin_swiftpm_package_macos_platform]
 mixin-preset=mixin_swiftpm_macos_platform
@@ -1707,8 +1710,6 @@ mixin-preset=mixin_swiftpm_linux_platform
 
 skip-test-llbuild
 skip-test-swiftpm
-# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
-skip-test-sourcekit-lsp
 
 
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
Disable SourceKit-LSP testing for everything that uses `mixin_swiftpm_linux_platform` instead of `mixin_swiftpm_package_linux_platform`.