### PR TITLE
[stdlib] prevent preventable buffer overflows when constructing Strings from C strings.

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2182,9 +2182,10 @@ func _getSystemVersionPlistProperty(_ propertyName: String) -> String? {
 func _getSystemVersionPlistProperty(_ propertyName: String) -> String? {
   var count = 0
   sysctlbyname("kern.osproductversion", nil, &count, nil, 0)
-  var s = [CChar](repeating: 0, count: count)
-  sysctlbyname("kern.osproductversion", &s, &count, nil, 0)
-  return String(cString: &s)
+  return withUnsafeTemporaryAllocation(of: CChar.self, capacity: count) {
+    sysctlbyname("kern.osproductversion", $0.baseAddress, &count, nil, 0)
+    return String(cString: $0.baseAddress!)
+  }
 }
 #endif
 #endif

--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -373,25 +373,25 @@ internal func reflect(instanceAddress: UInt,
                       shouldUnwrapClassExistential: Bool = false) {
   while let command = readLine(strippingNewline: true) {
     switch command {
-    case String(validatingUTF8: RequestInstanceKind)!:
+    case RequestInstanceKind:
       sendValue(kind.rawValue)
-    case String(validatingUTF8: RequestShouldUnwrapClassExistential)!:
+    case RequestShouldUnwrapClassExistential:
       sendValue(shouldUnwrapClassExistential)
-    case String(validatingUTF8: RequestInstanceAddress)!:
+    case RequestInstanceAddress:
       sendValue(instanceAddress)
-    case String(validatingUTF8: RequestReflectionInfos)!:
+    case RequestReflectionInfos:
       sendReflectionInfos()
-    case String(validatingUTF8: RequestImages)!:
+    case RequestImages:
       sendImages()
-    case String(validatingUTF8: RequestReadBytes)!:
+    case RequestReadBytes:
       sendBytes()
-    case String(validatingUTF8: RequestSymbolAddress)!:
+    case RequestSymbolAddress:
       sendSymbolAddress()
-    case String(validatingUTF8: RequestStringLength)!:
+    case RequestStringLength:
       sendStringLength()
-    case String(validatingUTF8: RequestPointerSize)!:
+    case RequestPointerSize:
       sendPointerSize()
-    case String(validatingUTF8: RequestDone)!:
+    case RequestDone:
       return
     default:
       fatalError("Unknown request received: '\(Array(command.utf8))'!")

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -74,7 +74,7 @@ extension String {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated)
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init(cString nullTerminatedUTF8: inout CChar) {
     guard nullTerminatedUTF8 == 0 else {
       _preconditionFailure(
@@ -105,14 +105,14 @@ extension String {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Operate directly on the String")
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public init(cString nullTerminatedUTF8: String) {
     self = nullTerminatedUTF8.withCString(String.init(cString:))
   }
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated)
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init(cString nullTerminatedUTF8: inout UInt8) {
     guard nullTerminatedUTF8 == 0 else {
       _preconditionFailure(
@@ -174,14 +174,14 @@ extension String {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Operate directly on the String")
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public init?(validatingUTF8 cString: String) {
     self = cString.withCString(String.init(cString:))
   }
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated)
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init?(validatingUTF8 cString: inout CChar) {
     guard cString == 0 else {
       _preconditionFailure(
@@ -302,7 +302,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Operate directly on the String")
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: String,
     as encoding: Encoding.Type,
@@ -319,7 +319,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated)
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public static func decodeCString<Encoding: _UnicodeEncoding>(
     _ cString: inout Encoding.CodeUnit,
     as encoding: Encoding.Type,
@@ -367,7 +367,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, message: "Operate directly on the String")
+  @available(*, deprecated, message: "Use a copy of the String argument")
   public init<Encoding: _UnicodeEncoding>(
     decodingCString nullTerminatedCodeUnits: String,
     as sourceEncoding: Encoding.Type
@@ -381,7 +381,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable // Fold away specializations
   @_alwaysEmitIntoClient
-  @available(*, deprecated)
+  @available(*, deprecated, message: "Use String(_ scalar: Unicode.Scalar)")
   public init<Encoding: Unicode.Encoding>(
     decodingCString nullTerminatedCodeUnits: inout Encoding.CodeUnit,
     as sourceEncoding: Encoding.Type

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -381,6 +381,7 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable // Fold away specializations
   @_alwaysEmitIntoClient
+  @available(*, deprecated)
   public init<Encoding: Unicode.Encoding>(
     decodingCString nullTerminatedCodeUnits: inout Encoding.CodeUnit,
     as sourceEncoding: Encoding.Type

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -49,6 +49,29 @@ extension String {
       UnsafeBufferPointer(start: nullTerminatedUTF8._asUInt8, count: len)).0
   }
 
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(cString nullTerminatedUTF8: [CChar]) {
+    self = nullTerminatedUTF8.withUnsafeBytes {
+      String(_checkingCString: $0.assumingMemoryBound(to: UInt8.self))
+    }
+  }
+
+  @_alwaysEmitIntoClient
+  private init(_checkingCString bytes: UnsafeBufferPointer<UInt8>) {
+    guard let length = bytes.firstIndex(of: 0) else {
+      _preconditionFailure(
+        "input of String.init(cString:) must be null-terminated"
+      )
+    }
+    self = String._fromUTF8Repairing(
+      UnsafeBufferPointer(
+        start: bytes.baseAddress._unsafelyUnwrappedUnchecked,
+        count: length
+      )
+    ).0
+  }
+
   /// Creates a new string by copying the null-terminated UTF-8 data referenced
   /// by the given pointer.
   ///
@@ -58,6 +81,14 @@ extension String {
     let len = UTF8._nullCodeUnitOffset(in: nullTerminatedUTF8)
     self = String._fromUTF8Repairing(
       UnsafeBufferPointer(start: nullTerminatedUTF8, count: len)).0
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init(cString nullTerminatedUTF8: [UInt8]) {
+    self = nullTerminatedUTF8.withUnsafeBufferPointer {
+      String(_checkingCString: $0)
+    }
   }
 
   /// Creates a new string by copying and validating the null-terminated UTF-8

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -126,6 +126,21 @@ extension String {
     self = str
   }
 
+  @inlinable
+  @_alwaysEmitIntoClient
+  public init?(validatingUTF8 cString: [CChar]) {
+    guard let length = cString.firstIndex(of: 0) else {
+      _preconditionFailure(
+        "input of String.init(validatingUTF8:) must be null-terminated"
+      )
+    }
+    guard let string = cString.prefix(length).withUnsafeBytes({
+      String._tryFromUTF8($0.assumingMemoryBound(to: UInt8.self))
+    }) else { return nil }
+
+    self = string
+  }
+
   /// Creates a new string by copying the null-terminated data referenced by
   /// the given pointer using the specified encoding.
   ///

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -91,6 +91,13 @@ extension String {
     }
   }
 
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Operate directly on the String")
+  public init(cString nullTerminatedUTF8: String) {
+    self = nullTerminatedUTF8.withCString(String.init(cString:))
+  }
+
   /// Creates a new string by copying and validating the null-terminated UTF-8
   /// data referenced by the given pointer.
   ///
@@ -139,6 +146,13 @@ extension String {
     }) else { return nil }
 
     self = string
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Operate directly on the String")
+  public init?(validatingUTF8 cString: String) {
+    self = cString.withCString(String.init(cString:))
   }
 
   /// Creates a new string by copying the null-terminated data referenced by
@@ -248,6 +262,23 @@ extension String {
     }
   }
 
+  @_specialize(where Encoding == Unicode.UTF8)
+  @_specialize(where Encoding == Unicode.UTF16)
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Operate directly on the String")
+  public static func decodeCString<Encoding: _UnicodeEncoding>(
+    _ cString: String,
+    as encoding: Encoding.Type,
+    repairingInvalidCodeUnits isRepairing: Bool = true
+  ) -> (result: String, repairsMade: Bool)? {
+    return cString.withCString(encodedAs: encoding) {
+      String.decodeCString(
+        $0, as: encoding, repairingInvalidCodeUnits: isRepairing
+      )
+    }
+  }
+
   /// Creates a string from the null-terminated sequence of bytes at the given
   /// pointer.
   ///
@@ -276,6 +307,20 @@ extension String {
     as sourceEncoding: Encoding.Type
   ) {
     self = String.decodeCString(nullTerminatedCodeUnits, as: sourceEncoding)!.0
+  }
+
+  @_specialize(where Encoding == Unicode.UTF8)
+  @_specialize(where Encoding == Unicode.UTF16)
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "Operate directly on the String")
+  public init<Encoding: _UnicodeEncoding>(
+    decodingCString nullTerminatedCodeUnits: String,
+    as sourceEncoding: Encoding.Type
+  ) {
+    self = nullTerminatedCodeUnits.withCString(encodedAs: sourceEncoding) {
+      String(decodingCString: $0, as: sourceEncoding.self)
+    }
   }
 }
 

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -72,6 +72,18 @@ extension String {
     ).0
   }
 
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated)
+  public init(cString nullTerminatedUTF8: inout CChar) {
+    guard nullTerminatedUTF8 == 0 else {
+      _preconditionFailure(
+        "input of String.init(cString:) must be null-terminated"
+      )
+    }
+    self = ""
+  }
+
   /// Creates a new string by copying the null-terminated UTF-8 data referenced
   /// by the given pointer.
   ///
@@ -96,6 +108,18 @@ extension String {
   @available(*, deprecated, message: "Operate directly on the String")
   public init(cString nullTerminatedUTF8: String) {
     self = nullTerminatedUTF8.withCString(String.init(cString:))
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated)
+  public init(cString nullTerminatedUTF8: inout UInt8) {
+    guard nullTerminatedUTF8 == 0 else {
+      _preconditionFailure(
+        "input of String.init(cString:) must be null-terminated"
+      )
+    }
+    self = ""
   }
 
   /// Creates a new string by copying and validating the null-terminated UTF-8
@@ -153,6 +177,18 @@ extension String {
   @available(*, deprecated, message: "Operate directly on the String")
   public init?(validatingUTF8 cString: String) {
     self = cString.withCString(String.init(cString:))
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated)
+  public init?(validatingUTF8 cString: inout CChar) {
+    guard cString == 0 else {
+      _preconditionFailure(
+        "input of String.init(validatingUTF8:) must be null-terminated"
+      )
+    }
+    self = ""
   }
 
   /// Creates a new string by copying the null-terminated data referenced by
@@ -279,6 +315,24 @@ extension String {
     }
   }
 
+  @_specialize(where Encoding == Unicode.UTF8)
+  @_specialize(where Encoding == Unicode.UTF16)
+  @inlinable
+  @_alwaysEmitIntoClient
+  @available(*, deprecated)
+  public static func decodeCString<Encoding: _UnicodeEncoding>(
+    _ cString: inout Encoding.CodeUnit,
+    as encoding: Encoding.Type,
+    repairingInvalidCodeUnits isRepairing: Bool = true
+  ) -> (result: String, repairsMade: Bool)? {
+    guard cString == 0 else {
+      _preconditionFailure(
+        "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
+      )
+    }
+    return ("", false)
+  }
+
   /// Creates a string from the null-terminated sequence of bytes at the given
   /// pointer.
   ///
@@ -321,6 +375,22 @@ extension String {
     self = nullTerminatedCodeUnits.withCString(encodedAs: sourceEncoding) {
       String(decodingCString: $0, as: sourceEncoding.self)
     }
+  }
+
+  @_specialize(where Encoding == Unicode.UTF8)
+  @_specialize(where Encoding == Unicode.UTF16)
+  @inlinable // Fold away specializations
+  @_alwaysEmitIntoClient
+  public init<Encoding: Unicode.Encoding>(
+    decodingCString nullTerminatedCodeUnits: inout Encoding.CodeUnit,
+    as sourceEncoding: Encoding.Type
+  ) {
+    guard nullTerminatedCodeUnits == 0 else {
+      _preconditionFailure(
+        "input of String.init(decodingCString:as:) must be null-terminated"
+      )
+    }
+    self = ""
   }
 }
 

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -42,11 +42,11 @@ extension String {
   ///     }
   ///     // Prints "Caf�"
   ///
-  /// - Parameter cString: A pointer to a null-terminated UTF-8 code sequence.
-  public init(cString: UnsafePointer<CChar>) {
-    let len = UTF8._nullCodeUnitOffset(in: cString)
+  /// - Parameter nullTerminatedUTF8: A pointer to a null-terminated UTF-8 code sequence.
+  public init(cString nullTerminatedUTF8: UnsafePointer<CChar>) {
+    let len = UTF8._nullCodeUnitOffset(in: nullTerminatedUTF8)
     self = String._fromUTF8Repairing(
-      UnsafeBufferPointer(start: cString._asUInt8, count: len)).0
+      UnsafeBufferPointer(start: nullTerminatedUTF8._asUInt8, count: len)).0
   }
 
   /// Creates a new string by copying the null-terminated UTF-8 data referenced
@@ -54,10 +54,10 @@ extension String {
   ///
   /// This is identical to `init(cString: UnsafePointer<CChar>)` but operates on
   /// an unsigned sequence of bytes.
-  public init(cString: UnsafePointer<UInt8>) {
-    let len = UTF8._nullCodeUnitOffset(in: cString)
+  public init(cString nullTerminatedUTF8: UnsafePointer<UInt8>) {
+    let len = UTF8._nullCodeUnitOffset(in: nullTerminatedUTF8)
     self = String._fromUTF8Repairing(
-      UnsafeBufferPointer(start: cString, count: len)).0
+      UnsafeBufferPointer(start: nullTerminatedUTF8, count: len)).0
   }
 
   /// Creates a new string by copying and validating the null-terminated UTF-8
@@ -179,10 +179,10 @@ extension String {
   @_specialize(where Encoding == Unicode.UTF16)
   @inlinable // Fold away specializations
   public init<Encoding: Unicode.Encoding>(
-    decodingCString ptr: UnsafePointer<Encoding.CodeUnit>,
+    decodingCString nullTerminatedCodeUnits: UnsafePointer<Encoding.CodeUnit>,
     as sourceEncoding: Encoding.Type
   ) {
-    self = String.decodeCString(ptr, as: sourceEncoding)!.0
+    self = String.decodeCString(nullTerminatedCodeUnits, as: sourceEncoding)!.0
   }
 }
 

--- a/test/Prototypes/PatternMatching.swift
+++ b/test/Prototypes/PatternMatching.swift
@@ -302,7 +302,9 @@ extension Collection where Iterator.Element == UTF8.CodeUnit {
     a.reserveCapacity(count + 1)
     a.append(contentsOf: self)
     a.append(0)
-    return String(reflecting: String(cString: a))
+    return a.withUnsafeBufferPointer {
+      String(reflecting: String(cString: $0.baseAddress!))
+    }
   }
 }
 

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -280,6 +280,30 @@ CStringTests.test("String.cString.with.String.input") {
   expectTrue(str.isEmpty)
 }
 
+CStringTests.test("String.cString.with.inout.UInt8.conversion") {
+  var c = UInt8.zero
+  var str = String(cString: &c)
+  expectTrue(str.isEmpty)
+  c = 100
+  expectCrashLater(
+    withMessage: "input of String.init(cString:) must be null-terminated"
+  )
+  str = String(cString: &c)
+  expectUnreachable()
+}
+
+CStringTests.test("String.cString.with.inout.CChar.conversion") {
+  var c = CChar.zero
+  var str = String(cString: &c)
+  expectTrue(str.isEmpty)
+  c = 100
+  expectCrashLater(
+    withMessage: "input of String.init(cString:) must be null-terminated"
+  )
+  str = String(cString: &c)
+  expectUnreachable()
+}
+
 CStringTests.test("String.validatingUTF8.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
@@ -315,6 +339,19 @@ CStringTests.test("String.validatingUTF8.with.String.input") {
   str = String(validatingUTF8: "")
   expectNotNil(str)
   expectEqual(str?.isEmpty, true)
+}
+
+CStringTests.test("String.validatingUTF8.with.inout.conversion") {
+  var c = CChar.zero
+  var str = String(validatingUTF8: &c)
+  expectNotNil(str)
+  expectEqual(str?.isEmpty, true)
+  c = 100
+  expectCrashLater(
+    withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
+  )
+  str = String(validatingUTF8: &c)
+  expectUnreachable()
 }
 
 CStringTests.test("String.decodeCString.with.Array.input") {
@@ -359,7 +396,23 @@ CStringTests.test("String.decodeCString.with.String.input") {
   expectEqual(result?.result.isEmpty, true)
 }
 
-CStringTests.test("String.decodingCString.with.Array.input") {
+CStringTests.test("String.decodeCString.with.inout.conversion") {
+  var c = Unicode.UTF8.CodeUnit.zero
+  var result = String.decodeCString(
+    &c, as: Unicode.UTF8.self, repairingInvalidCodeUnits: true
+  )
+  expectNotNil(result)
+  expectEqual(result?.result.isEmpty, true)
+  expectEqual(result?.repairsMade, false)
+  c = 100
+  expectCrashLater(
+    withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
+  )
+  result = String.decodeCString(&c, as: Unicode.UTF8.self)
+  expectUnreachable()
+}
+
+CStringTests.test("String.init.decodingCString.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
     defer { dealloc() }
@@ -391,6 +444,18 @@ CStringTests.test("String.init.decodingCString.with.String.input") {
   }
   str = String(decodingCString: "", as: Unicode.UTF8.self)
   expectTrue(str.isEmpty)
+}
+
+CStringTests.test("String.init.decodingCString.with.inout.conversion") {
+  var c = Unicode.UTF8.CodeUnit.zero
+  var str = String(decodingCString: &c, as: Unicode.UTF8.self)
+  expectEqual(str.isEmpty, true)
+  c = 100
+  expectCrashLater(
+    withMessage: "input of String.init(decodingCString:as:) must be null-terminated"
+  )
+  str = String(decodingCString: &c, as: Unicode.UTF8.self)
+  expectUnreachable()
 }
 
 runAllTests()

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -267,6 +267,19 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
   expectUnreachable()
 }
 
+CStringTests.test("String.cString.with.String.input") {
+  let (u8p, dealloc) = getASCIIUTF8()
+  defer { dealloc() }
+  var str = String(cString: "ab")
+  str.withCString {
+    $0.withMemoryRebound(to: UInt8.self, capacity: getUTF8Length(u8p)+1) {
+      expectEqualCString(u8p, $0)
+    }
+  }
+  str = String(cString: "")
+  expectTrue(str.isEmpty)
+}
+
 CStringTests.test("String.validatingUTF8.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
@@ -287,6 +300,21 @@ CStringTests.test("String.validatingUTF8.with.Array.input") {
   )
   _ = String(validatingUTF8: [])
   expectUnreachable()
+}
+
+CStringTests.test("String.validatingUTF8.with.String.input") {
+  let (u8p, dealloc) = getASCIIUTF8()
+  defer { dealloc() }
+  var str = String(validatingUTF8: "ab")
+  expectNotNil(str)
+  str?.withCString {
+    $0.withMemoryRebound(to: UInt8.self, capacity: getUTF8Length(u8p)+1) {
+      expectEqualCString(u8p, $0)
+    }
+  }
+  str = String(validatingUTF8: "")
+  expectNotNil(str)
+  expectEqual(str?.isEmpty, true)
 }
 
 CStringTests.test("String.decodeCString.with.Array.input") {
@@ -312,6 +340,25 @@ CStringTests.test("String.decodeCString.with.Array.input") {
   expectUnreachable()
 }
 
+CStringTests.test("String.decodeCString.with.String.input") {
+  let (u8p, dealloc) = getASCIIUTF8()
+  defer { dealloc() }
+  var result = String.decodeCString(
+    "ab", as: Unicode.UTF8.self, repairingInvalidCodeUnits: true
+  )
+  expectNotNil(result)
+  expectEqual(result?.repairsMade, false)
+  result?.result.withCString {
+    $0.withMemoryRebound(to: UInt8.self, capacity: getUTF8Length(u8p)+1) {
+      expectEqualCString(u8p, $0)
+    }
+  }
+  result = String.decodeCString("", as: Unicode.UTF8.self)
+  expectNotNil(result)
+  expectEqual(result?.repairsMade, false)
+  expectEqual(result?.result.isEmpty, true)
+}
+
 CStringTests.test("String.decodingCString.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
@@ -331,6 +378,19 @@ CStringTests.test("String.decodingCString.with.Array.input") {
   )
   _ = String(decodingCString: [], as: Unicode.UTF8.self)
   expectUnreachable()
+}
+
+CStringTests.test("String.init.decodingCString.with.String.input") {
+  let (u8p, dealloc) = getASCIIUTF8()
+  defer { dealloc() }
+  var str = String(decodingCString: "ab", as: Unicode.UTF8.self)
+  str.withCString {
+    $0.withMemoryRebound(to: UInt8.self, capacity: getUTF8Length(u8p)+1) {
+      expectEqualCString(u8p, $0)
+    }
+  }
+  str = String(decodingCString: "", as: Unicode.UTF8.self)
+  expectTrue(str.isEmpty)
 }
 
 runAllTests()

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -239,9 +239,13 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
     }
   }
   // no need to test every case; that is covered in other tests
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(cString:) must be null-terminated"
   )
+  #endif
   _ = String(cString: [] as [UInt8])
   expectUnreachable()
 }
@@ -260,9 +264,13 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
     }
   }
   // no need to test every case; that is covered in other tests
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(cString:) must be null-terminated"
   )
+  #endif
   _ = String(cString: [] as [CChar])
   expectUnreachable()
 }
@@ -285,9 +293,13 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(cString:) must be null-terminated"
   )
+  #endif
   str = String(cString: &c)
   expectUnreachable()
 }
@@ -297,9 +309,13 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(cString:) must be null-terminated"
   )
+  #endif
   str = String(cString: &c)
   expectUnreachable()
 }
@@ -319,9 +335,13 @@ CStringTests.test("String.validatingUTF8.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
   )
+  #endif
   _ = String(validatingUTF8: [])
   expectUnreachable()
 }
@@ -347,9 +367,13 @@ CStringTests.test("String.validatingUTF8.with.inout.conversion") {
   expectNotNil(str)
   expectEqual(str?.isEmpty, true)
   c = 100
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
   )
+  #endif
   str = String(validatingUTF8: &c)
   expectUnreachable()
 }
@@ -370,9 +394,13 @@ CStringTests.test("String.decodeCString.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
+  #endif
   _ = String.decodeCString([], as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -405,9 +433,13 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
   expectEqual(result?.result.isEmpty, true)
   expectEqual(result?.repairsMade, false)
   c = 100
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
+  #endif
   result = String.decodeCString(&c, as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -426,9 +458,13 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
+  #endif
   _ = String(decodingCString: [], as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -451,9 +487,13 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
   var str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectEqual(str.isEmpty, true)
   c = 100
+  #if os(Linux)
+  expectCrashLater()
+  #else
   expectCrashLater(
     withMessage: "input of String.init(decodingCString:as:) must be null-terminated"
   )
+  #endif
   str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectUnreachable()
 }

--- a/test/stdlib/StringAPICStringDiagnostics.swift
+++ b/test/stdlib/StringAPICStringDiagnostics.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+import StdlibUnittest
+
+func checkStringOverloadCompilationDiagnostics() {
+
+  _ = String(cString: "string") // expected-warning {{'init(cString:)' is deprecated: Operate directly on the String}}
+
+  _ = String(validatingUTF8: "string") // expected-warning {{init(validatingUTF8:)' is deprecated: Operate directly on the String}}
+
+  _ = String.decodeCString("string", as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Operate directly on the String}}
+
+  _ = String(decodingCString: "string", as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Operate directly on the String}}
+}
+
+func checkInoutConversionOverloadCompilationDiagnostics() {
+
+  var i = UInt8.zero
+
+  _ = String(cString: &i) // expected-warning {{'init(cString:)' is deprecated}}
+
+  var c = CChar.zero
+
+  _ = String(cString: &c) // expected-warning {{'init(cString:)' is deprecated}}
+
+  _ = String(validatingUTF8: &c) // expected-warning {{init(validatingUTF8:)' is deprecated}}
+
+  var u = Unicode.UTF8.CodeUnit.zero
+
+  _ = String.decodeCString(&u, as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated}}
+
+  _ = String(decodingCString: &u, as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated}}
+}

--- a/test/stdlib/StringAPICStringDiagnostics.swift
+++ b/test/stdlib/StringAPICStringDiagnostics.swift
@@ -4,30 +4,30 @@ import StdlibUnittest
 
 func checkStringOverloadCompilationDiagnostics() {
 
-  _ = String(cString: "string") // expected-warning {{'init(cString:)' is deprecated: Operate directly on the String}}
+  _ = String(cString: "string") // expected-warning {{'init(cString:)' is deprecated: Use a copy of the String argument}}
 
-  _ = String(validatingUTF8: "string") // expected-warning {{init(validatingUTF8:)' is deprecated: Operate directly on the String}}
+  _ = String(validatingUTF8: "string") // expected-warning {{init(validatingUTF8:)' is deprecated: Use a copy of the String argument}}
 
-  _ = String.decodeCString("string", as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Operate directly on the String}}
+  _ = String.decodeCString("string", as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use a copy of the String argument}}
 
-  _ = String(decodingCString: "string", as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Operate directly on the String}}
+  _ = String(decodingCString: "string", as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use a copy of the String argument}}
 }
 
 func checkInoutConversionOverloadCompilationDiagnostics() {
 
   var i = UInt8.zero
 
-  _ = String(cString: &i) // expected-warning {{'init(cString:)' is deprecated}}
+  _ = String(cString: &i) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
 
   var c = CChar.zero
 
-  _ = String(cString: &c) // expected-warning {{'init(cString:)' is deprecated}}
+  _ = String(cString: &c) // expected-warning {{'init(cString:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
 
-  _ = String(validatingUTF8: &c) // expected-warning {{init(validatingUTF8:)' is deprecated}}
+  _ = String(validatingUTF8: &c) // expected-warning {{init(validatingUTF8:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
 
   var u = Unicode.UTF8.CodeUnit.zero
 
-  _ = String.decodeCString(&u, as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated}}
+  _ = String.decodeCString(&u, as: Unicode.UTF8.self) // expected-warning {{'decodeCString(_:as:repairingInvalidCodeUnits:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
 
-  _ = String(decodingCString: &u, as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated}}
+  _ = String(decodingCString: &u, as: Unicode.UTF8.self) // expected-warning {{'init(decodingCString:as:)' is deprecated: Use String(_ scalar: Unicode.Scalar)}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The family of `String` initializers that convert from C strings (null-terminated byte buffers) could until now be called with Swift arrays. When the array passed in to them violates the C string precondition of containing a zero byte, this would result in a buffer overflow. This is unexpected when the entirety of the code is pure Swift. This patch adds overloads to capture arguments that would become array-to-pointer conversions and inout-to-pointer conversions. The new overloads prevent reading past the end of these allocations. Note that the `String` conversion is not susceptible to this overflow bug, since it always appends a trailing null.

The `String` construction methods affected are:
- `String.init(cString: UnsafePointer<UInt>)` and `String.init(cString: UnsafePointer<CChar>)`
- `String.init?(validatingCString: UnsafePointer<CChar>)`
- `String.decodeCString<Encoding>(_ cString: UnsafePointer<Encoding.CodeUnit>?, as: Encoding.Type, repairingInvalidCodeUnits: Bool = true)`
- `String.init<Encoding>(decodingCString: UnsafePointer<Encoding.CodeUnit>, as: Encoding.Type)`

All of these have been overloaded to capture misuses of array conversion and inout conversion. In both cases, if there is no zero-valued code unit within the allocation, a precondition is considered violated and the function traps. In the case of the inout conversion, the only valid code unit value is zero, so we also added a deprecation warning.

The construction methods above were also overloaded to capture `String` conversions. The `String` conversions are safe but wasteful, so we added a deprecation warning to those as well, pointing out that using the `String` argument directly is more straightforward.

Note that we considered adding the `@_nonEphemeral` attribute to the affected `UnsafePointer` parameters, and concluded that it is not an appropriate solution, because it only adds a warning without fixing the buffer overflow issue.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://90336023.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
