### PR TITLE
[cxx-interop] Import `size_t` as Int instead of UInt on Linux

### DIFF
--- a/benchmark/cxx-source/ReadAccessor.swift
+++ b/benchmark/cxx-source/ReadAccessor.swift
@@ -34,17 +34,9 @@ public let benchmarks = [
 public func run_ReadAccessor(_ N: Int) {
   for i in 0...N {
     for j in 0..<100 {
-#if os(Linux)
-      let row = vec![UInt(j)];
-#else
       let row = vec![j];
-#endif
       for k in 0..<1_000 {
-#if os(Linux)
-        let element = row[UInt(k)];
-#else
         let element = row[k];
-#endif
         blackHole(element)
       }
     }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2718,7 +2718,8 @@ namespace {
                                             *correctSwiftName);
 
       Type SwiftType;
-      if (Decl->getDeclContext()->getRedeclContext()->isTranslationUnit()) {
+      auto clangDC = Decl->getDeclContext()->getRedeclContext();
+      if (clangDC->isTranslationUnit() || clangDC->isStdNamespace()) {
         bool IsError;
         StringRef StdlibTypeName;
         MappedTypeNameKind NameMapping;

--- a/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/fake-toolchain.h
+++ b/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/fake-toolchain.h
@@ -7,4 +7,8 @@ void foo(int x) {}
 
 }; // namespace FakeNamespace
 
+namespace std {
+typedef unsigned long size_t;
+} // namespace std
+
 #endif

--- a/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
@@ -9,3 +9,7 @@
 // CHECK: enum FakeNamespace {
 // CHECK:   static func foo(_ x: Int32)
 // CHECK: }
+// CHECK: enum std {
+// CHECK:   typealias size_t = Int
+// CHECK: }
+


### PR DESCRIPTION
When using libc++, Swift imports `size_t` as Int despite `size_t` being an unsigned type. This is intentional & is specified in `lib/ClangImporter/MappedTypes.def`. Previously, MappedTypes were only honored for C/C++ types declared on the file level.

In libstdc++, `size_t` is declared within `namespace std` and not on the file level, so the mapping to Int was not applied.

This change ensures that MappedTypes are also applied to types declared in `namespace std`.