### PR TITLE
TypeWitnessSystem: Disable by default

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -352,6 +352,10 @@ namespace swift {
     /// Enable variadic generics.
     bool EnableExperimentalVariadicGenerics = false;
 
+    /// Enable experimental associated type inference using type witness
+    /// systems.
+    bool EnableExperimentalAssociatedTypeInference = false;
+
     /// Disable the implicit import of the _Concurrency module.
     bool DisableImplicitConcurrencyModuleImport =
         !SWIFT_IMPLICIT_CONCURRENCY_IMPORT;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -556,6 +556,10 @@ def enable_experimental_variadic_generics :
   Flag<["-"], "enable-experimental-variadic-generics">,
   HelpText<"Enable experimental support for variadic generic types">;
 
+def enable_experimental_associated_type_inference :
+  Flag<["-"], "enable-experimental-associated-type-inference">,
+  HelpText<"Enable experimental associated type inference via type witness systems">;
+
 def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -459,6 +459,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalVariadicGenerics |=
     Args.hasArg(OPT_enable_experimental_variadic_generics);
 
+  Opts.EnableExperimentalAssociatedTypeInference |=
+      Args.hasArg(OPT_enable_experimental_associated_type_inference);
+
   Opts.EnableExperimentalMoveOnly |=
     Args.hasArg(OPT_enable_experimental_move_only);
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -945,7 +945,7 @@ class TypeWitnessSystem final {
   struct TypeWitnessCandidate final {
     /// The defaulted associated type declaration correlating with this
     /// candidate, if present.
-    const AssociatedTypeDecl *DefaultedAssocType;
+    AssociatedTypeDecl *DefaultedAssocType;
 
     /// The equivalence class of this candidate.
     EquivalenceClass *EquivClass;
@@ -973,7 +973,7 @@ public:
 
   /// Get the defaulted associated type relating to the resolved type witness
   /// for the associated type with the given name, if present.
-  const AssociatedTypeDecl *getDefaultedAssocType(Identifier name) const;
+  AssociatedTypeDecl *getDefaultedAssocType(Identifier name) const;
 
   /// Record a type witness for the given associated type name.
   ///
@@ -987,8 +987,7 @@ public:
   /// defines the given default type.
   ///
   /// \note This need not lead to the resolution of a type witness.
-  void addDefaultTypeWitness(Type type,
-                             const AssociatedTypeDecl *defaultedAssocType);
+  void addDefaultTypeWitness(Type type, AssociatedTypeDecl *defaultedAssocType);
 
   /// Record the given same-type requirement, if regarded of interest to
   /// the system.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -100,51 +100,25 @@ CheckTypeWitnessResult checkTypeWitness(Type type,
                                         const NormalProtocolConformance *Conf,
                                         SubstOptions options = None);
 
-/// Describes the means of inferring an abstract type witness.
-enum class AbstractTypeWitnessKind : uint8_t {
-  /// The type witness was inferred via a same-type-to-concrete constraint
-  /// in a protocol requirement signature.
-  Fixed,
-
-  /// The type witness was inferred via a defaulted associated type.
-  Default,
-
-  /// The type witness was inferred to a generic parameter of the
-  /// conforming type.
-  GenericParam,
-};
-
 /// A type witness inferred without the aid of a specific potential
 /// value witness.
 class AbstractTypeWitness {
-  AbstractTypeWitnessKind Kind;
   AssociatedTypeDecl *AssocType;
   Type TheType;
 
-  /// When this is a default type witness, the declaration responsible for it.
-  /// May not necessarilly match \c AssocType.
+  /// The defaulted associated type that was used to infer this type witness.
+  /// Need not necessarilly match \c AssocType, but their names must.
   AssociatedTypeDecl *DefaultedAssocType;
 
-  AbstractTypeWitness(AbstractTypeWitnessKind Kind,
-                      AssociatedTypeDecl *AssocType, Type TheType,
-                      AssociatedTypeDecl *DefaultedAssocType)
-      : Kind(Kind), AssocType(AssocType), TheType(TheType),
+public:
+  AbstractTypeWitness(AssociatedTypeDecl *AssocType, Type TheType,
+                      AssociatedTypeDecl *DefaultedAssocType = nullptr)
+      : AssocType(AssocType), TheType(TheType),
         DefaultedAssocType(DefaultedAssocType) {
     assert(AssocType && TheType);
+    assert(!DefaultedAssocType ||
+           (AssocType->getName() == DefaultedAssocType->getName()));
   }
-
-public:
-  static AbstractTypeWitness forFixed(AssociatedTypeDecl *assocType, Type type);
-
-  static AbstractTypeWitness forDefault(AssociatedTypeDecl *assocType,
-                                        Type type,
-                                        AssociatedTypeDecl *defaultedAssocType);
-
-  static AbstractTypeWitness forGenericParam(AssociatedTypeDecl *assocType,
-                                             Type type);
-
-public:
-  AbstractTypeWitnessKind getKind() const { return Kind; }
 
   AssociatedTypeDecl *getAssocType() const { return AssocType; }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -100,6 +100,61 @@ CheckTypeWitnessResult checkTypeWitness(Type type,
                                         const NormalProtocolConformance *Conf,
                                         SubstOptions options = None);
 
+/// Describes the means of inferring an abstract type witness.
+enum class AbstractTypeWitnessKind : uint8_t {
+  /// The type witness was inferred via a same-type-to-concrete constraint
+  /// in a protocol requirement signature.
+  Fixed,
+
+  /// The type witness was inferred via a defaulted associated type.
+  Default,
+
+  /// The type witness was inferred to a generic parameter of the
+  /// conforming type.
+  GenericParam,
+};
+
+/// A type witness inferred without the aid of a specific potential
+/// value witness.
+class AbstractTypeWitness {
+  AbstractTypeWitnessKind Kind;
+  AssociatedTypeDecl *AssocType;
+  Type TheType;
+
+  /// When this is a default type witness, the declaration responsible for it.
+  /// May not necessarilly match \c AssocType.
+  AssociatedTypeDecl *DefaultedAssocType;
+
+  AbstractTypeWitness(AbstractTypeWitnessKind Kind,
+                      AssociatedTypeDecl *AssocType, Type TheType,
+                      AssociatedTypeDecl *DefaultedAssocType)
+      : Kind(Kind), AssocType(AssocType), TheType(TheType),
+        DefaultedAssocType(DefaultedAssocType) {
+    assert(AssocType && TheType);
+  }
+
+public:
+  static AbstractTypeWitness forFixed(AssociatedTypeDecl *assocType, Type type);
+
+  static AbstractTypeWitness forDefault(AssociatedTypeDecl *assocType,
+                                        Type type,
+                                        AssociatedTypeDecl *defaultedAssocType);
+
+  static AbstractTypeWitness forGenericParam(AssociatedTypeDecl *assocType,
+                                             Type type);
+
+public:
+  AbstractTypeWitnessKind getKind() const { return Kind; }
+
+  AssociatedTypeDecl *getAssocType() const { return AssocType; }
+
+  Type getType() const { return TheType; }
+
+  AssociatedTypeDecl *getDefaultedAssocType() const {
+    return DefaultedAssocType;
+  }
+};
+
 /// The set of associated types that have been inferred by matching
 /// the given value witness to its corresponding requirement.
 struct InferredAssociatedTypesByWitness {
@@ -1076,15 +1131,23 @@ private:
     ConformanceChecker &checker,
     const llvm::SetVector<AssociatedTypeDecl *> &assocTypes);
 
+  /// Compute a "fixed" type witness for an associated type, e.g.,
+  /// if the refined protocol requires it to be equivalent to some other type.
+  Type computeFixedTypeWitness(AssociatedTypeDecl *assocType);
+
   /// Compute the default type witness from an associated type default,
   /// if there is one.
-  Optional<std::pair<AssociatedTypeDecl *, Type>>
+  Optional<AbstractTypeWitness>
   computeDefaultTypeWitness(AssociatedTypeDecl *assocType) const;
 
   /// Compute the "derived" type witness for an associated type that is
   /// known to the compiler.
   std::pair<Type, TypeDecl *>
   computeDerivedTypeWitness(AssociatedTypeDecl *assocType);
+
+  /// Compute a type witness without using a specific potential witness.
+  Optional<AbstractTypeWitness>
+  computeAbstractTypeWitness(AssociatedTypeDecl *assocType);
 
   /// Collect abstract type witnesses and feed them to the given system.
   void collectAbstractTypeWitnesses(

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -627,3 +627,10 @@ do {
     struct Inner: P47 {}
   }
 }
+
+protocol P48a { associatedtype A = Int }
+protocol P48b { associatedtype B }
+protocol P48c: P48a, P48b where A == B {}
+do {
+  struct Conformer: P48c {}
+}

--- a/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
@@ -871,3 +871,24 @@ do {
     struct Inner: P47 {}
   }
 }
+
+protocol P48a { associatedtype A = Int } // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+protocol P48b { associatedtype B } // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
+protocol P48c: P48a, P48b where A == B {}
+do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P48a: {
+  // CHECK-NEXT: A => Self.B,
+  // CHECK-NEXT: }
+
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P48b: {
+  // CHECK-NEXT: B => Self.A,
+  // CHECK-NEXT: }
+
+  // CHECK-NOT: Abstract type witness system for conformance of Conformer to P48c
+
+  // FIXME: Should compile
+  struct Conformer: P48c {}
+  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P48a'}}
+  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P48b'}}
+  // expected-error@-3 {{type 'Conformer' does not conform to protocol 'P48c'}}
+}

--- a/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
@@ -1,8 +1,12 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-associated-type-inference -dump-type-witness-systems %s 2>&1 | %FileCheck %s
 
 protocol P1 where A == Never {
   associatedtype A
 }
+// CHECK-LABEL: Abstract type witness system for conformance of S1 to P1: {
+// CHECK-NEXT: A => Never,
+// CHECK-NEXT: }
 struct S1: P1 {}
 
 protocol P2a {
@@ -10,7 +14,13 @@ protocol P2a {
 }
 protocol P2b: P2a where A == Never {}
 protocol P2c: P2b {}
+// CHECK-LABEL: Abstract type witness system for conformance of S2a to P2a: {
+// CHECK-NEXT: A => Never,
+// CHECK-NEXT: }
 struct S2a: P2b {}
+// CHECK-LABEL: Abstract type witness system for conformance of S2b to P2a: {
+// CHECK-NEXT: A => Never,
+// CHECK-NEXT: }
 struct S2b: P2c {}
 
 // Fixed type witnesses can reference dependent members.
@@ -19,6 +29,9 @@ protocol P3a {
   associatedtype B
 }
 protocol P3b: P3a where A == [B] {}
+// CHECK-LABEL: Abstract type witness system for conformance of S3 to P3a: {
+// CHECK-NEXT: A => [Self.B],
+// CHECK-NEXT: }
 struct S3: P3b {
   typealias B = Never
 }
@@ -31,6 +44,9 @@ protocol P4b {}
 extension P4b {
   typealias B = Self
 }
+// CHECK-LABEL: Abstract type witness system for conformance of S4 to P4a: {
+// CHECK-NEXT: A => [Self.B],
+// CHECK-NEXT: }
 struct S4: P4a, P4b {}
 
 // Self is a valid fixed type witness.
@@ -38,6 +54,9 @@ protocol P5a {
   associatedtype A
 }
 protocol P5b: P5a where A == Self {}
+// CHECK-LABEL: Abstract type witness system for conformance of S5<X> to P5a: {
+// CHECK-NEXT: A => Self,
+// CHECK-NEXT: }
 struct S5<X>: P5b {} // OK, A := S5<X>
 
 
@@ -46,6 +65,9 @@ protocol P6 where A == Never { // expected-error {{same-type constraint type 'Ne
   // expected-note@+1 {{protocol requires nested type 'A}}
   associatedtype A: P6
 }
+// CHECK-LABEL: Abstract type witness system for conformance of S6 to P6: {
+// CHECK-NEXT: A => (unresolved){{$}}
+// CHECK-NEXT: }
 struct S6: P6 {} // expected-error {{type 'S6' does not conform to protocol 'P6'}}
 
 protocol P7a where A == Never {
@@ -54,18 +76,24 @@ protocol P7a where A == Never {
 // expected-error@+2 {{'Self.A' cannot be equal to both 'Bool' and 'Never'}}
 // expected-note@+1 {{same-type constraint 'Self.A' == 'Never' implied here}}
 protocol P7b: P7a where A == Bool {}
+// CHECK-LABEL: Abstract type witness system for conformance of S7 to P7a: {
+// CHECK-NEXT: A => Never,
+// CHECK-NEXT: }
 struct S7: P7b {}
 
 protocol P8a where A == Never {
-  associatedtype A
+  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
 }
 protocol P8b where A == Bool {
   associatedtype A
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P8a: {
+  // CHECK-NEXT: A => (ambiguous),
+  // CHECK-NEXT: }
   struct Conformer: P8a, P8b {}
-  // expected-error@-1 {{'P8b' requires the types 'Conformer.A' (aka 'Never') and 'Bool' be equivalent}}
-  // expected-note@-2 {{requirement specified as 'Self.A' == 'Bool' [with Self = Conformer]}}
+  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P8a'}}
+  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P8b'}}
 }
 
 protocol P9a where A == Never {
@@ -74,6 +102,9 @@ protocol P9a where A == Never {
 protocol P9b: P9a {
   associatedtype A
 }
+// CHECK-LABEL: Abstract type witness system for conformance of S9a to P9b: {
+// CHECK-NEXT: A => Never,
+// CHECK-NEXT: }
 struct S9a: P9b {}
 // expected-error@+2 {{'P9a' requires the types 'S9b.A' (aka 'Bool') and 'Never' be equivalent}}
 // expected-note@+1 {{requirement specified as 'Self.A' == 'Never' [with Self = S9b]}}
@@ -103,13 +134,13 @@ protocol P11a {
 }
 protocol P11b: P11a where A == Never {}
 protocol Q11 {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  associatedtype A
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to Q11: {
+  // CHECK-NEXT: A => Never,
+  // CHECK-NEXT: }
   struct Conformer: Q11, P11b {}
-  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P11b'}}
-  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P11a'}}
-  // expected-error@-3 {{type 'Conformer' does not conform to protocol 'Q11'}}
 }
 
 protocol P12 where A == B {
@@ -117,6 +148,9 @@ protocol P12 where A == B {
   associatedtype B
   func foo(arg: A)
 }
+// CHECK-LABEL: Abstract type witness system for conformance of S12 to P12: {
+// CHECK-NEXT: B => Self.A,
+// CHECK-NEXT: }
 struct S12: P12 {
   func foo(arg: Never) {}
 }
@@ -129,6 +163,9 @@ protocol P13b {
   associatedtype B
 }
 protocol P13c: P13a, P13b where A == B {}
+// CHECK-LABEL: Abstract type witness system for conformance of S13 to P13b: {
+// CHECK-NEXT: B => Self.A,
+// CHECK-NEXT: }
 struct S13: P13c {
   func foo(arg: Never) {}
 }
@@ -137,30 +174,38 @@ protocol P14 {
   associatedtype A = Array<Self>
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Outer<Element>.Conformer to P14: {
+  // CHECK-NEXT: A => Array<Self>,
+  // CHECK-NEXT: }
   struct Outer<Element> {
     struct Conformer: P14 {}
   }
 }
 
 protocol P15a {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
-  associatedtype B = Never // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
+  associatedtype A
+  associatedtype B = Never
 }
 protocol P15b: P15a where A == B {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P15a: {
+  // CHECK-NEXT: A => Never, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Never, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer: P15b {}
-  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P15a'}}
-  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P15b'}}
 }
 
 protocol P16a where A == B {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
-  associatedtype B = Never // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
+  associatedtype A
+  associatedtype B = Never
 }
 protocol P16b: P16a {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P16a: {
+  // CHECK-NEXT: A => Never, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Never, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer: P16b {}
-  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P16a'}}
 }
 
 protocol P17a where A == Never {
@@ -180,9 +225,25 @@ protocol P17d {
   associatedtype B = Int
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1 to P17a: {
+  // CHECK-NEXT: A => Never,
+  // CHECK-NEXT: B => (unresolved){{$}}
+  // CHECK-NEXT: }
   struct Conformer1: P17a {} // expected-error {{type 'Conformer1' does not conform to protocol 'P17a'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<A> to P17b: {
+  // CHECK-NEXT: A => (unresolved), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (unresolved), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer2<A>: P17b {} // expected-error {{type 'Conformer2<A>' does not conform to protocol 'P17b'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer3 to P17c: {
+  // CHECK-NEXT: A => Never, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Never, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer3: P17c {}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer4<A> to P17d: {
+  // CHECK-NEXT: A => Int, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Int, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer4<A>: P17d {}
 }
 
@@ -193,6 +254,12 @@ protocol P18 {
   associatedtype D
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<D> to P18: {
+  // CHECK-NEXT: A => (Self.D) -> Self.D, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (Self.D) -> Self.D, [[EQUIV_CLASS]]
+  // CHECK-NEXT: C => (Self.D) -> Self.D, [[EQUIV_CLASS]]
+  // CHECK-NEXT: D => D,
+  // CHECK-NEXT: }
   struct Conformer<D>: P18 {}
 }
 
@@ -201,27 +268,40 @@ protocol P19 where Self == A {
   associatedtype B = (A, A)
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P19: {
+  // CHECK-NEXT: A => Self,
+  // CHECK-NEXT: B => (Self.A, Self.A),
+  // CHECK-NEXT: }
   struct Conformer: P19 {}
 }
 
 protocol P20 where A == B.Element, B == B.SubSequence, C.Element == B.Element {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  associatedtype A
   associatedtype B: Collection
-  associatedtype C: Collection = Array<Character> // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype C: Collection = Array<Character>
 }
 do {
-  struct Conformer: P20 { // expected-error {{type 'Conformer' does not conform to protocol 'P20'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P20: {
+  // CHECK-NEXT: A => Self.B.Element,
+  // CHECK-NEXT: C => Array<Character>,
+  // CHECK-NEXT: }
+  struct Conformer: P20 {
     typealias B = Substring
   }
 }
 
 protocol P21 where A == B {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
-  associatedtype B = C // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
-  associatedtype C // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype A
+  associatedtype B = C
+  associatedtype C
 }
 do {
-  struct Conformer<C>: P21 {} // expected-error {{type 'Conformer<C>' does not conform to protocol 'P21'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<C> to P21: {
+  // CHECK-NEXT: A => C, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => C, [[EQUIV_CLASS]]
+  // CHECK-NEXT: C => C, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
+  struct Conformer<C>: P21 {}
 }
 
 protocol P22 where A == B, C == D {
@@ -231,6 +311,12 @@ protocol P22 where A == B, C == D {
   associatedtype D
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<A> to P22: {
+  // CHECK-NEXT: A => A, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => A, [[EQUIV_CLASS]]
+  // CHECK-NEXT: C => A, [[EQUIV_CLASS]]
+  // CHECK-NEXT: D => A, [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer<A>: P22 {}
 }
 
@@ -239,7 +325,15 @@ protocol P23 {
   associatedtype B: P23 = A.B // expected-note 2 {{protocol requires nested type 'B'; do you want to add it?}}
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P23: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: B => Self.A.B,
+  // CHECK-NEXT: }
   struct Conformer: P23 {} // expected-error {{type 'Conformer' does not conform to protocol 'P23'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of ConformerGeneric<T> to P23: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: B => Self.A.B,
+  // CHECK-NEXT: }
   struct ConformerGeneric<T>: P23 {} // expected-error {{type 'ConformerGeneric<T>' does not conform to protocol 'P23'}}
 }
 
@@ -248,7 +342,15 @@ protocol P24 where A == B.A {
   associatedtype B: P24 = A.B // expected-note 2 {{protocol requires nested type 'B'; do you want to add it?}}
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P24: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: B => Self.A.B,
+  // CHECK-NEXT: }
   struct Conformer: P24 {} // expected-error {{type 'Conformer' does not conform to protocol 'P24'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of ConformerGeneric<T> to P24: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: B => Self.A.B,
+  // CHECK-NEXT: }
   struct ConformerGeneric<T>: P24 {} // expected-error {{type 'ConformerGeneric<T>' does not conform to protocol 'P24'}}
 }
 
@@ -269,23 +371,42 @@ protocol P25b where A == B {
 protocol P25c_1: P25a_1, P25b {}
 protocol P25c_2: P25a_2, P25b {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<C> to P25a_1: {
+  // CHECK-NEXT: A => Int, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Int, [[EQUIV_CLASS]]
+  // CHECK-NEXT: C => C,
+  // CHECK-NEXT: }
   struct Conformer1<C: Sequence>: P25c_1 where C.Element == Int {}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<C> to P25a_2: {
+  // CHECK-NEXT: A => Int, [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Int, [[EQUIV_CLASS]]
+  // CHECK-NEXT: C => C,
+  // CHECK-NEXT: }
   struct Conformer2<C: Sequence>: P25c_2 where C.Element == Int {}
 }
 
 protocol P26 where C == B, F == G {
-  associatedtype A = Int // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
-  associatedtype B = A // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
-  associatedtype C // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype A = Int
+  associatedtype B = A
+  associatedtype C
 
-  associatedtype D // expected-note {{protocol requires nested type 'D'; do you want to add it?}}
-  associatedtype E = D // expected-note {{protocol requires nested type 'E'; do you want to add it?}}
+  associatedtype D
+  associatedtype E = D
 
-  associatedtype F // expected-note {{protocol requires nested type 'F'; do you want to add it?}}
-  associatedtype G = [B] // expected-note {{protocol requires nested type 'G'; do you want to add it?}}
+  associatedtype F
+  associatedtype G = [B]
 }
 do {
-  struct Conformer<D>: P26 {} // expected-error {{type 'Conformer<D>' does not conform to protocol 'P26'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<D> to P26: {
+  // CHECK-NEXT: A => Int, [[EQUIV_CLASS_1:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => Int, [[EQUIV_CLASS_1]]
+  // CHECK-NEXT: C => Int, [[EQUIV_CLASS_1]]
+  // CHECK-NEXT: D => D, [[EQUIV_CLASS_2:0x[0-9a-f]+]]
+  // CHECK-NEXT: E => D, [[EQUIV_CLASS_2]]
+  // CHECK-NEXT: F => [Self.B], [[EQUIV_CLASS_3:0x[0-9a-f]+]]
+  // CHECK-NEXT: G => [Self.B], [[EQUIV_CLASS_3]]
+  // CHECK-NEXT: }
+  struct Conformer<D>: P26 {}
 }
 
 protocol P27a where A == Int {
@@ -298,12 +419,22 @@ protocol P27b where A == B.Element {
 protocol P27c_1: P27a, P27b {}
 protocol P27c_2: P27b, P27a {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<B> to P27a: {
+  // CHECK-NEXT: A => Int,
+  // CHECK-NEXT: }
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<B> to P27b: {
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: }
   struct Conformer1<B: Sequence>: P27c_1 where B.Element == Int {}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<B> to P27b: {
+  // CHECK-NEXT: A => Int,
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: }
   struct Conformer2<B: Sequence>: P27c_2 where B.Element == Int {}
 }
 
 protocol P28a where A == Int {
-  associatedtype A
+  associatedtype A // expected-note 2 {{protocol requires nested type 'A'; do you want to add it?}}
 }
 protocol P28b where A == Bool {
   associatedtype A
@@ -320,21 +451,25 @@ protocol Q28b: P28a, P28b, P28c {}
 // expected-note@-3 {{same-type constraint 'Self.A' == 'Int' implied here}}
 // expected-note@-4 {{same-type constraint 'Self.A' == 'Int' implied here}}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1 to P28a: {
+  // CHECK-NEXT: A => (ambiguous),
+  // CHECK-NEXT: }
   struct Conformer1: Q28a {}
-  // expected-error@-1 {{'P28b' requires the types 'Conformer1.A' (aka 'Int') and 'Bool' be equivalent}}
-  // expected-note@-2 {{requirement specified as 'Self.A' == 'Bool' [with Self = Conformer1]}}
+  // expected-error@-1 {{type 'Conformer1' does not conform to protocol 'P28a'}}
+  // expected-error@-2 {{type 'Conformer1' does not conform to protocol 'P28b'}}
 
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2 to P28a: {
+  // CHECK-NEXT: A => (ambiguous),
+  // CHECK-NEXT: }
   struct Conformer2: Q28b {}
-  // expected-error@-1 {{'P28c' requires the types 'Conformer2.A' (aka 'Int') and 'Never' be equivalent}}
-  // expected-error@-2 {{'P28b' requires the types 'Conformer2.A' (aka 'Int') and 'Bool' be equivalent}}
-  // expected-note@-3 {{requirement specified as 'Self.A' == 'Never' [with Self = Conformer2]}}
-  // expected-note@-4 {{requirement specified as 'Self.A' == 'Bool' [with Self = Conformer2]}}
-
+  // expected-error@-1 {{type 'Conformer2' does not conform to protocol 'P28a'}}
+  // expected-error@-2 {{type 'Conformer2' does not conform to protocol 'P28b'}}
+  // expected-error@-3 {{type 'Conformer2' does not conform to protocol 'P28c'}}
 }
 
 protocol P29a where A == Int {
-  associatedtype A
-  associatedtype B
+  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+  associatedtype B // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
 }
 protocol P29b where B == Never {
   associatedtype B
@@ -350,11 +485,19 @@ protocol Q29b: P29c, P29a, P29b {}
 // expected-error@-1 {{'Self.B' cannot be equal to both 'Never' and 'Int'}}
 // expected-note@-2 {{same-type constraint 'Self.A' == 'Int' implied here}}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1 to P29a: {
+  // CHECK-NEXT: A => (ambiguous), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (ambiguous), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer1: Q29a {}
-  // expected-error@-1 {{'P29b' requires the types 'Conformer1.B' (aka 'Int') and 'Never' be equivalent}}
-  // expected-note@-2 {{requirement specified as 'Self.B' == 'Never' [with Self = Conformer1]}}
+  // expected-error@-1 {{type 'Conformer1' does not conform to protocol 'P29a'}}
+  // expected-error@-2 {{type 'Conformer1' does not conform to protocol 'P29b'}}
+  // expected-error@-3 {{type 'Conformer1' does not conform to protocol 'P29c'}}
 
-
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2 to P29c: {
+  // CHECK-NEXT: A => (ambiguous), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (ambiguous), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer2: Q29b {}
   // expected-error@-1 {{type 'Conformer2' does not conform to protocol 'P29a'}}
   // expected-error@-2 {{type 'Conformer2' does not conform to protocol 'P29b'}}
@@ -375,6 +518,10 @@ protocol Q30: P30c, P30a, P30b {}
 // expected-error@-1 {{'Self.A' cannot be equal to both 'Never' and 'Int'}}
 // expected-note@-2 {{same-type constraint 'Self.A' == 'Int' implied here}}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P30c: {
+  // CHECK-NEXT: A => (ambiguous), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (ambiguous), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer: Q30 {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P30a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P30b'}}
@@ -395,6 +542,10 @@ protocol Q31: P31c, P31a, P31b {}
 // expected-error@-1 {{'Self.B' cannot be equal to both 'Never' and 'Int'}}
 // expected-note@-2 {{same-type constraint 'Self.B' == 'Int' implied here}}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P31c: {
+  // CHECK-NEXT: A => (ambiguous), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (ambiguous), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer: Q31 {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P31a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P31b'}}
@@ -423,6 +574,10 @@ protocol Q32: P32e, P32a, P32b, P32c, P32d {}
 // expected-error@-3 {{'Self.A' cannot be equal to both 'Bool' and 'Int'}}
 // expected-note@-4 3 {{same-type constraint 'Self.A' == 'Int' implied here}}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P32e: {
+  // CHECK-NEXT: A => (ambiguous), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: B => (ambiguous), [[EQUIV_CLASS]]
+  // CHECK-NEXT: }
   struct Conformer: Q32 {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P32a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P32b'}}
@@ -439,6 +594,9 @@ protocol P33b where A == Int {
 }
 protocol Q33: P33a, P33b {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P33a: {
+  // CHECK-NEXT: A => Int,
+  // CHECK-NEXT: }
   struct Conformer: Q33 {}
 }
 
@@ -454,8 +612,21 @@ protocol Q34c: P34a, P34b {
   associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
 }
 do {
+  // FIXME: should really be ambiguous (source-breaking)?
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1 to P34a: {
+  // CHECK-NEXT: A => Void,
+  // CHECK-NEXT: }
   struct Conformer1: Q34a {}
+
+  // FIXME: should really be ambiguous (source-breaking)?
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2 to P34b: {
+  // CHECK-NEXT: A => Never,
+  // CHECK-NEXT: }
   struct Conformer2: Q34b {}
+
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer3 to Q34c: {
+  // CHECK-NEXT: A => (unresolved){{$}}
+  // CHECK-NEXT: }
   struct Conformer3: Q34c {} // expected-error {{type 'Conformer3' does not conform to protocol 'Q34c'}}
 }
 
@@ -466,9 +637,20 @@ protocol P35 {
   associatedtype D = Array<A>
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P35: {
+  // CHECK-NEXT: B => Array<Self.C>,
+  // CHECK-NEXT: C => Array<Self.D>,
+  // CHECK-NEXT: D => Array<Self.A>,
+  // CHECK-NEXT: }
   struct Conformer: P35 {
     typealias A = Never
   }
+  // CHECK-LABEL: Abstract type witness system for conformance of ConformerGeneric<A> to P35: {
+  // CHECK-NEXT: A => A,
+  // CHECK-NEXT: B => Array<Self.C>,
+  // CHECK-NEXT: C => Array<Self.D>,
+  // CHECK-NEXT: D => Array<Self.A>,
+  // CHECK-NEXT: }
   struct ConformerGeneric<A>: P35 {}
 }
 
@@ -481,6 +663,10 @@ protocol P36 {
   associatedtype B: P36 = Never
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P36: {
+  // CHECK-NEXT: A => G36<Self.B>,
+  // CHECK-NEXT: B => Never,
+  // CHECK-NEXT: }
   struct Conformer: P36 {} // expected-error {{type 'Conformer' does not conform to protocol 'P36'}}
 }
 
@@ -489,16 +675,22 @@ protocol P37a {
 }
 protocol P37b {
   associatedtype B : P37a
-  associatedtype C where C == B.A // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype C where C == B.A
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<C> to P37b: {
+  // CHECK-NEXT: C => Self.B.A,
+  // CHECK-NEXT: }
   struct Conformer1<C>: P37b {
     struct Inner: P37a { typealias A = C }
 
     typealias B = Inner
   }
 
-  struct Conformer2<T>: P37b { // expected-error {{type 'Conformer2<T>' does not conform to protocol 'P37b'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<T> to P37b: {
+  // CHECK-NEXT: C => Self.B.A,
+  // CHECK-NEXT: }
+  struct Conformer2<T>: P37b {
     struct Inner: P37a { typealias A = T }
 
     typealias B = Inner
@@ -513,6 +705,9 @@ protocol P38b {
 }
 protocol P38c: P38a, P38b where A == B {}
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<T> to P38b: {
+  // CHECK-NEXT: B => Self.A,
+  // CHECK-NEXT: }
   struct Conformer<T>: P38c {
     typealias A = Self
   }
@@ -524,6 +719,10 @@ protocol P39 {
   associatedtype C = Never
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P39: {
+  // CHECK-NEXT: B => Self.A.C,
+  // CHECK-NEXT: C => Never,
+  // CHECK-NEXT: }
   struct Conformer: P39 {
     typealias A = Self
   }
@@ -541,6 +740,10 @@ protocol P40c: P40b {
   override associatedtype B
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P40c: {
+  // CHECK-NEXT: A => Int,
+  // CHECK-NEXT: B => (Self.A, Self.A),
+  // CHECK-NEXT: }
   struct Conformer: P40c {}
 }
 
@@ -549,6 +752,10 @@ protocol P41 {
   associatedtype B: P41 = Self // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer to P41: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: B => Self,
+  // CHECK-NEXT: }
   struct Conformer: P41 {} // expected-error{{type 'Conformer' does not conform to protocol 'P41'}}
 }
 
@@ -559,6 +766,13 @@ protocol P42b: P42a {
   associatedtype A = B.A
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<B> to P42b: {
+  // CHECK-NEXT: A => Self.B.A,
+  // CHECK-NEXT: }
+
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<B> to P42a: {
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: }
   struct Conformer<B: P42b>: P42b {}
 }
 
@@ -567,51 +781,78 @@ protocol P43a {
   associatedtype B
 }
 protocol P43b: P43a {
-  associatedtype C where C == A.B // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype C where C == A.B
 }
 do {
-  struct Conformer<B: P43a>: P43b { // expected-error {{type 'Conformer<B>' does not conform to protocol 'P43b'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<B> to P43b: {
+  // CHECK-NEXT: C => Self.A.B,
+  // CHECK-NEXT: }
+
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<B> to P43a: {
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: }
+  struct Conformer<B: P43a>: P43b {
     typealias A = Conformer<B.A>
   }
 }
 
 protocol P44 {
   associatedtype A: P44
-  associatedtype B // expected-note 2{{protocol requires nested type 'B'; do you want to add it?}}
-  associatedtype C where C == A.B // expected-note 3{{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype B
+  associatedtype C where C == A.B
 }
 do {
-  struct Conformer1<T: P44>: P44 { // expected-error {{type 'Conformer1<T>' does not conform to protocol 'P44'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<T> to P44: {
+  // CHECK-NEXT: C => Self.A.B,
+  // CHECK-NEXT: }
+  struct Conformer1<T: P44>: P44 {
     typealias B = T.A
     typealias A = Conformer1<T.A>
   }
 
-  struct Conformer2<B: P44>: P44 { // expected-error {{type 'Conformer2<B>' does not conform to protocol 'P44'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<B> to P44: {
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: C => Self.A.B,
+  // CHECK-NEXT: }
+  struct Conformer2<B: P44>: P44 {
     typealias A = Conformer2<B.A>
   }
 
-  struct Conformer3<B>: P44 { // expected-error {{type 'Conformer3<B>' does not conform to protocol 'P44'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer3<B> to P44: {
+  // CHECK-NEXT: B => B,
+  // CHECK-NEXT: C => Self.A.B,
+  // CHECK-NEXT: }
+  struct Conformer3<B>: P44 {
     typealias A = Conformer3<Int>
   }
 }
 
 protocol P45 {
-  associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
-  associatedtype B: P45 = Conformer45<D> // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
-  associatedtype C where C == B.A // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
-  associatedtype D = Never // expected-note {{protocol requires nested type 'D'; do you want to add it?}}
+  associatedtype A
+  associatedtype B: P45 = Conformer45<D>
+  associatedtype C where C == B.A
+  associatedtype D = Never
 }
-struct Conformer45<A>: P45 {} // expected-error {{type 'Conformer45<A>' does not conform to protocol 'P45'}}
+// CHECK-LABEL: Abstract type witness system for conformance of Conformer45<A> to P45: {
+// CHECK-NEXT: A => A,
+// CHECK-NEXT: B => Conformer45<Self.D>,
+// CHECK-NEXT: C => Self.B.A,
+// CHECK-NEXT: D => Never,
+// CHECK-NEXT: }
+struct Conformer45<A>: P45 {}
 
 protocol P46 {
   associatedtype A: P46
-  associatedtype B // expected-note {{protocol requires nested type 'B'; do you want to add it?}}
-  associatedtype C where C == A.B // expected-note {{protocol requires nested type 'C'; do you want to add it?}}
+  associatedtype B
+  associatedtype C where C == A.B
 
   func method(_: B)
 }
 do {
-  struct Conformer<T: P46>: P46 { // expected-error {{type 'Conformer<T>' does not conform to protocol 'P46'}}
+  // CHECK-LABEL: Abstract type witness system for conformance of Conformer<T> to P46: {
+  // CHECK-NEXT: C => Self.A.B,
+  // CHECK-NEXT: }
+  struct Conformer<T: P46>: P46 {
     typealias A = Conformer<T.A>
 
     func method(_: T) {}
@@ -623,6 +864,9 @@ protocol P47 {
   associatedtype A
 }
 do {
+  // CHECK-LABEL: Abstract type witness system for conformance of Outer<A>.Inner to P47: {
+  // CHECK-NEXT: A => A,
+  // CHECK-NEXT: }
   struct Outer<A> {
     struct Inner: P47 {}
   }

--- a/validation-test/compiler_crashers_2_fixed/sr11392.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11392.swift
@@ -1,7 +1,11 @@
 // RUN: %target-swift-frontend -verify -emit-ir %s
 
+// Works with experimental associated type inference.
+// RUN: %target-swift-frontend -enable-experimental-associated-type-inference -emit-ir %s
+
 protocol P1 {
     associatedtype X
+    // expected-note@-1 {{protocol requires nested type 'X'; do you want to add it?}}
     associatedtype A: P2 where A.X == X
 }
 
@@ -19,5 +23,6 @@ extension S {
 
 
 extension S: P1 {}
+// expected-error@-1 {{type 'S' does not conform to protocol 'P1'}}
 
 print(S.X.self)


### PR DESCRIPTION
Disables experimental associated type inference via type witness systems by default for source compatibility. 

Note: The added test file is for the flag and has identical test cases.
