### PR TITLE
[CodeCompletion][Sema] Multiple improvements to prepare for migration of PostfixExprParen to solver-based

### DIFF
--- a/include/swift/IDE/ArgumentCompletion.h
+++ b/include/swift/IDE/ArgumentCompletion.h
@@ -48,6 +48,11 @@ class ArgumentTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
     /// Whether the surrounding context is async and thus calling async
     /// functions is supported.
     bool IsInAsyncContext;
+
+    /// Types of variables that were determined in the solution that produced
+    /// this result. This in particular includes parameters of closures that
+    /// were type-checked with the code completion expression.
+    llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
   };
 
   CodeCompletionExpr *CompletionExpr;

--- a/include/swift/IDE/TypeCheckCompletionCallback.h
+++ b/include/swift/IDE/TypeCheckCompletionCallback.h
@@ -75,6 +75,13 @@ Type getTypeForCompletion(const constraints::Solution &S, ASTNode Node);
 /// completion expression \p E.
 Type getPatternMatchType(const constraints::Solution &S, Expr *E);
 
+/// Populate \p Result with types of variables that were determined in the
+/// solution \p S. This in particular includes parameters of closures that
+/// were type-checked with the code completion expression.
+void getSolutionSpecificVarTypes(
+    const constraints::Solution &S,
+    llvm::SmallDenseMap<const VarDecl *, Type> &Result);
+
 /// Whether the given completion expression is the only expression in its
 /// containing closure or function body and its value is implicitly returned.
 ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1288,6 +1288,24 @@ public:
   /// type variables for their fixed types.
   Type simplifyType(Type type) const;
 
+  // To aid code completion, we need to attempt to convert type placeholders
+  // back into underlying generic parameters if possible, since type
+  // of the code completion expression is used as "expected" (or contextual)
+  // type so it's helpful to know what requirements it has to filter
+  // the list of possible member candidates e.g.
+  //
+  // \code
+  // func test<T: P>(_: [T]) {}
+  //
+  // test(42.#^MEMBERS^#)
+  // \code
+  //
+  // It's impossible to resolve `T` in this case but code completion
+  // expression should still have a type of `[T]` instead of `[<<hole>>]`
+  // because it helps to produce correct contextual member list based on
+  // a conformance requirement associated with generic parameter `T`.
+  Type simplifyTypeForCodeCompletion(Type type) const;
+
   /// Coerce the given expression to the given type.
   ///
   /// This operation cannot fail.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3825,17 +3825,20 @@ namespace {
     void printAnyFunctionTypeCommon(AnyFunctionType *T, StringRef label,
                                     StringRef name) {
       printCommon(label, name);
-      SILFunctionType::Representation representation =
-        T->getExtInfo().getSILRepresentation();
 
-      if (representation != SILFunctionType::Representation::Thick)
-        printField("representation",
-                   getSILFunctionTypeRepresentationString(representation));
+      if (T->hasExtInfo()) {
+        SILFunctionType::Representation representation =
+            T->getExtInfo().getSILRepresentation();
 
-      printFlag(!T->isNoEscape(), "escaping");
-      printFlag(T->isSendable(), "Sendable");
-      printFlag(T->isAsync(), "async");
-      printFlag(T->isThrowing(), "throws");
+        if (representation != SILFunctionType::Representation::Thick) {
+          printField("representation",
+                     getSILFunctionTypeRepresentationString(representation));
+        }
+        printFlag(!T->isNoEscape(), "escaping");
+        printFlag(T->isSendable(), "Sendable");
+        printFlag(T->isAsync(), "async");
+        printFlag(T->isThrowing(), "throws");
+      }
 
       if (Type globalActor = T->getGlobalActor()) {
         printField("global_actor", globalActor.getString());

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -193,9 +193,13 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
     return;
   }
 
+  llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+  getSolutionSpecificVarTypes(S, SolutionSpecificVarTypes);
+
   Results.push_back({ExpectedTy, isa<SubscriptExpr>(ParentCall), FuncD, FuncTy,
                      ArgIdx, ParamIdx, std::move(ClaimedParams),
-                     IsNoninitialVariadic, CallBaseTy, HasLabel, IsAsync});
+                     IsNoninitialVariadic, CallBaseTy, HasLabel, IsAsync,
+                     SolutionSpecificVarTypes});
 }
 
 void ArgumentTypeCheckCompletionCallback::deliverResults(
@@ -267,6 +271,7 @@ void ArgumentTypeCheckCompletionCallback::deliverResults(
   if (shouldPerformGlobalCompletion) {
     for (auto &Result : Results) {
       ExpectedTypes.push_back(Result.ExpectedType);
+      Lookup.setSolutionSpecificVarTypes(Result.SolutionSpecificVarTypes);
     }
     Lookup.setExpectedTypes(ExpectedTypes, false);
     bool IsInAsyncContext = llvm::any_of(

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -231,6 +231,15 @@ void ArgumentTypeCheckCompletionCallback::deliverResults(
           SemanticContext = SemanticContextKind::CurrentNominal;
         }
       }
+      if (SemanticContext == SemanticContextKind::None && Result.FuncD) {
+        if (Result.FuncD->getDeclContext()->isTypeContext()) {
+          SemanticContext = SemanticContextKind::CurrentNominal;
+        } else if (Result.FuncD->getDeclContext()->isLocalContext()) {
+          SemanticContext = SemanticContextKind::Local;
+        } else if (Result.FuncD->getModuleContext() == DC->getParentModule()) {
+          SemanticContext = SemanticContextKind::CurrentModule;
+        }
+      }
       if (Result.IsSubscript) {
         assert(SemanticContext != SemanticContextKind::None);
         auto *SD = dyn_cast_or_null<SubscriptDecl>(Result.FuncD);

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -250,15 +250,16 @@ void ArgumentTypeCheckCompletionCallback::deliverResults(
         }
       }
       if (Result.FuncTy) {
-        if (Result.IsSubscript) {
-          assert(SemanticContext != SemanticContextKind::None);
-          auto *SD = dyn_cast_or_null<SubscriptDecl>(Result.FuncD);
-          Lookup.addSubscriptCallPattern(
-              Result.FuncTy->getAs<AnyFunctionType>(), SD, SemanticContext);
-        } else {
-          auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(Result.FuncD);
-          Lookup.addFunctionCallPattern(Result.FuncTy->getAs<AnyFunctionType>(),
-                                        FD, SemanticContext);
+        if (auto FuncTy = Result.FuncTy->lookThroughAllOptionalTypes()
+                              ->getAs<AnyFunctionType>()) {
+          if (Result.IsSubscript) {
+            assert(SemanticContext != SemanticContextKind::None);
+            auto *SD = dyn_cast_or_null<SubscriptDecl>(Result.FuncD);
+            Lookup.addSubscriptCallPattern(FuncTy, SD, SemanticContext);
+          } else {
+            auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(Result.FuncD);
+            Lookup.addFunctionCallPattern(FuncTy, FD, SemanticContext);
+          }
         }
       }
     }

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -115,7 +115,7 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
   }
 
   ValueDecl *FuncD = SelectedOverload->choice.getDeclOrNull();
-  Type FuncTy = S.simplifyType(SelectedOverload->openedType)->getRValueType();
+  Type FuncTy = S.simplifyTypeForCodeCompletion(SelectedOverload->openedType);
 
   // For completion as the arg in a call to the implicit [keypath: _] subscript
   // the solver can't know what kind of keypath is expected without an actual

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -977,13 +977,14 @@ void CompletionLookup::addEffectsSpecifiers(
   assert(AFT != nullptr);
 
   // 'async'.
-  if (forceAsync || (AFD && AFD->hasAsync()) || AFT->isAsync())
+  if (forceAsync || (AFD && AFD->hasAsync()) ||
+      (AFT->hasExtInfo() && AFT->isAsync()))
     Builder.addAnnotatedAsync();
 
   // 'throws' or 'rethrows'.
   if (AFD && AFD->getAttrs().hasAttribute<RethrowsAttr>())
     Builder.addAnnotatedRethrows();
-  else if (AFT->isThrowing())
+  else if (AFT->hasExtInfo() && AFT->isThrowing())
     Builder.addAnnotatedThrows();
 }
 
@@ -1146,7 +1147,8 @@ void CompletionLookup::addFunctionCallPattern(
     else
       addTypeAnnotation(Builder, AFT->getResult(), genericSig);
 
-    if (!isForCaching() && AFT->isAsync() && !CanCurrDeclContextHandleAsync) {
+    if (!isForCaching() && AFT->hasExtInfo() && AFT->isAsync() &&
+        !CanCurrDeclContextHandleAsync) {
       Builder.setContextualNotRecommended(
           ContextualNotRecommendedReason::InvalidAsyncContext);
     }

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -78,11 +78,7 @@ void ExprTypeCheckCompletionCallback::sawSolutionImpl(
   bool IsAsync = isContextAsync(S, DC);
 
   llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
-  for (auto NT : S.nodeTypes) {
-    if (auto VD = dyn_cast_or_null<VarDecl>(NT.first.dyn_cast<Decl *>())) {
-      SolutionSpecificVarTypes[VD] = S.simplifyType(NT.second);
-    }
-  }
+  getSolutionSpecificVarTypes(S, SolutionSpecificVarTypes);
 
   addResult(ImplicitReturn, IsAsync, SolutionSpecificVarTypes);
   addExpectedType(ExpectedTy);

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -51,47 +51,8 @@ Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
 
   Type Result;
 
-  // To aid code completion, we need to attempt to convert type placeholders
-  // back into underlying generic parameters if possible, since type
-  // of the code completion expression is used as "expected" (or contextual)
-  // type so it's helpful to know what requirements it has to filter
-  // the list of possible member candidates e.g.
-  //
-  // \code
-  // func test<T: P>(_: [T]) {}
-  //
-  // test(42.#^MEMBERS^#)
-  // \code
-  //
-  // It's impossible to resolve `T` in this case but code completion
-  // expression should still have a type of `[T]` instead of `[<<hole>>]`
-  // because it helps to produce correct contextual member list based on
-  // a conformance requirement associated with generic parameter `T`.
   if (isExpr<CodeCompletionExpr>(Node)) {
-    auto completionTy = S.getType(Node).transform([&](Type type) -> Type {
-      if (auto *typeVar = type->getAs<TypeVariableType>())
-        return S.getFixedType(typeVar);
-      return type;
-    });
-
-    Result = S.simplifyType(completionTy.transform([&](Type type) {
-      if (auto *placeholder = type->getAs<PlaceholderType>()) {
-        if (auto *typeVar =
-                placeholder->getOriginator().dyn_cast<TypeVariableType *>()) {
-          if (auto *GP = typeVar->getImpl().getGenericParameter()) {
-            // Code completion depends on generic parameter type being
-            // represented in terms of `ArchetypeType` since it's easy
-            // to extract protocol requirements from it.
-            if (auto *GPD = GP->getDecl())
-              return GPD->getInnermostDeclContext()->mapTypeIntoContext(GP);
-          }
-        }
-
-        return Type(CS.getASTContext().TheUnresolvedType);
-      }
-
-      return type;
-    }));
+    Result = S.simplifyTypeForCodeCompletion(S.getType(Node));
   } else {
     Result = S.getResolvedType(Node);
   }

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -125,6 +125,17 @@ Type swift::ide::getPatternMatchType(const constraints::Solution &S, Expr *E) {
   return nullptr;
 }
 
+void swift::ide::getSolutionSpecificVarTypes(
+    const constraints::Solution &S,
+    llvm::SmallDenseMap<const VarDecl *, Type> &Result) {
+  assert(Result.empty());
+  for (auto NT : S.nodeTypes) {
+    if (auto VD = dyn_cast_or_null<VarDecl>(NT.first.dyn_cast<Decl *>())) {
+      Result[VD] = S.simplifyType(NT.second);
+    }
+  }
+}
+
 bool swift::ide::isImplicitSingleExpressionReturn(ConstraintSystem &CS,
                                                   Expr *CompletionExpr) {
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1815,7 +1815,6 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       auto *argExpr = getArgumentExpr(locator.getAnchor(), argIdx);
       if (param.isAutoClosure() && !isSynthesizedArgument(argument)) {
         auto &ctx = cs.getASTContext();
-        auto *fnType = paramTy->castTo<FunctionType>();
 
         // If this is a call to a function with a closure argument and the
         // parameter is an autoclosure, let's just increment the score here
@@ -1835,7 +1834,9 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         if (ctx.isSwiftVersionAtLeast(5) || !isAutoClosureArgument(argExpr)) {
           // In Swift >= 5 mode there is no @autoclosure forwarding,
           // so let's match result types.
-          paramTy = fnType->getResult();
+          if (auto *fnType = paramTy->getAs<FunctionType>()) {
+            paramTy = fnType->getResult();
+          }
         } else {
           // Matching @autoclosure argument to @autoclosure parameter
           // directly would mean introducting a function conversion

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1275,6 +1275,9 @@ public:
     if (ArgInfo.isBefore(argIdx)) {
       return false;
     }
+    if (argIdx == 0 && ArgInfo.completionIdx == 0) {
+      return false;
+    }
     return ArgumentFailureTracker::extraArgument(argIdx);
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3496,6 +3496,48 @@ Type Solution::simplifyType(Type type) const {
   return resolvedType;
 }
 
+Type Solution::simplifyTypeForCodeCompletion(Type Ty) const {
+  auto &CS = getConstraintSystem();
+
+  // First, instantiate all type variables that we know, but don't replace
+  // placeholders by unresolved types.
+  Ty = CS.simplifyTypeImpl(Ty, [this](TypeVariableType *typeVar) -> Type {
+    return getFixedType(typeVar);
+  });
+
+  // Next, replace all placeholders by type variables. We know that all type
+  // variables now in the type originate from placeholders.
+  Ty = Ty.transform([](Type type) -> Type {
+    if (auto *placeholder = type->getAs<PlaceholderType>()) {
+      if (auto *typeVar =
+              placeholder->getOriginator().dyn_cast<TypeVariableType *>()) {
+        return typeVar;
+      }
+    }
+
+    return type;
+  });
+
+  // Replace all type variables (which must come from placeholders) by their
+  // generic parameters. Because we call into simplifyTypeImpl
+  Ty = CS.simplifyTypeImpl(Ty, [](TypeVariableType *typeVar) -> Type {
+    if (auto *GP = typeVar->getImpl().getGenericParameter()) {
+      // Code completion depends on generic parameter type being
+      // represented in terms of `ArchetypeType` since it's easy
+      // to extract protocol requirements from it.
+      if (auto *GPD = GP->getDecl()) {
+        return GPD->getInnermostDeclContext()->mapTypeIntoContext(GP);
+      }
+    }
+    return typeVar;
+  });
+
+  // Remove any remaining type variables and placeholders
+  Ty = simplifyType(Ty);
+
+  return Ty->getRValueType();
+}
+
 size_t Solution::getTotalMemory() const {
   return sizeof(*this) + typeBindings.getMemorySize() +
          overloadChoices.getMemorySize() +

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1317,7 +1317,7 @@ func testPlaceholderNoBetterThanArchetype() {
   }
 // PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1:     Begin completions, 2 items
 // PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1-DAG: Pattern/Local/Flair[ArgLabels]:     {#footer: String#}[#String#];
-// PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1-DAG: Pattern/Local/Flair[ArgLabels]:     {#content: () -> _##() -> _#}[#() -> _#];
+// PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1-DAG: Pattern/Local/Flair[ArgLabels]:     {#content: () -> Content##() -> Content#}[#() -> Content#];
 // PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1:     End completions
 
   Section(header: TectionHeaderView(text: "abc"), #^PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_2?check=PLACEHOLDER_NO_BETTER_THAN_ARCHETYPE_1^#)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1623,6 +1623,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
   llvm::errs() << "----\n";
   if (!FailedTokens.empty()) {
     llvm::errs() << "Unexpected failures: ";
+    llvm::sort(FailedTokens);
     llvm::interleave(
         FailedTokens, [&](StringRef name) { llvm::errs() << name; },
         [&]() { llvm::errs() << ", "; });
@@ -1630,6 +1631,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
   }
   if (!UPassTokens.empty()) {
     llvm::errs() << "Unexpected passes: ";
+    llvm::sort(UPassTokens);
     llvm::interleave(
         UPassTokens, [&](StringRef name) { llvm::errs() << name; },
         [&]() { llvm::errs() << ", "; });


### PR DESCRIPTION
This is a collection of multiple changes, which I hope aren’t too controversial, that are needed to migrate PostfixExprParen to solver-based. It might make sense to look at the commits individually for review to see the scope of each change.