### PR TITLE
[build-script] Drop Python2.7 from swift_cmake_options.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -574,7 +574,6 @@ function set_build_options_for_host() {
         watchos-*           | \
         watchsimulator-*)
             swift_cmake_options+=(
-              -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
               -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
             case ${host} in


### PR DESCRIPTION
Since Swift is dropping Python2 support, and since this xcrun line causes
spurious errors during a build-script build on systems without Python2,
I am proposing we drop this xcrun -find line from build-script-impl.

@gottesmm 