### PR TITLE
Don't open an existential argument that's completely self-conforming. 

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -538,7 +538,7 @@ def enable_experimental_opened_existential_types :
   HelpText<"Enable experimental support for implicitly opened existentials">;
 
 def disable_experimental_opened_existential_types :
-  Flag<["-"], "disble-experimental-opened-existential-types">,
+  Flag<["-"], "disable-experimental-opened-existential-types">,
   HelpText<"Disable experimental support for implicitly opened existentials">;
 
 def enable_deserialization_recovery :

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -459,11 +459,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalVariadicGenerics |=
     Args.hasArg(OPT_enable_experimental_variadic_generics);
 
-  // SwiftOnoneSupport produces different symbols when opening existentials,
-  // so disable it.
-  if (FrontendOpts.ModuleName == SWIFT_ONONE_SUPPORT)
-    Opts.EnableOpenedExistentialTypes = false;
-
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1501,6 +1501,25 @@ shouldOpenExistentialCallArgument(
   if (!argTy->isAnyExistentialType())
     return None;
 
+  if (argTy->isExistentialType()) {
+    // If the existential argument type conforms to all of its protocol
+    // requirements, don't open the existential.
+    auto layout = argTy->getExistentialLayout();
+    auto module = cs.DC->getParentModule();
+    bool containsNonSelfConformance = false;
+    for (auto proto : layout.getProtocols()) {
+      auto protoDecl = proto->getDecl();
+      auto conformance = module->lookupExistentialConformance(argTy, protoDecl);
+      if (conformance.isInvalid()) {
+        containsNonSelfConformance = true;
+        break;
+      }
+    }
+
+    if (!containsNonSelfConformance)
+      return None;
+  }
+
   auto param = getParameterAt(callee, paramIdx);
   if (!param)
     return None;

--- a/test/Constraints/opened_existentials_suppression.swift
+++ b/test/Constraints/opened_existentials_suppression.swift
@@ -6,6 +6,8 @@ func acceptsBox<T>(_ value: T) { }
 
 // CHECK: passBox
 // CHECK-NOT: open_existential_expr
-func passBox(p: P) {
+func passBox(p: P, obj: AnyObject, err: Error) {
   acceptsBox(p as P)
+  acceptsBox(obj)
+  acceptsBox(err)
 }


### PR DESCRIPTION
Such existential arguments will already meet the requirements of a
generic function they are passed to, but would change runtime
semantics. Therefore, don't open the existential in such cases.