### PR TITLE
[cxx interop]Add tests for iterator, std::next, and std::prev

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -7,3 +7,8 @@ module StdString {
   header "std-string.h"
   requires cplusplus
 }
+
+module StdIterator {
+  header "std-iterator.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-iterator.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-iterator.h
@@ -1,0 +1,11 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_ITERATOR_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_ITERATOR_H
+
+#include <iterator>
+#include <vector>
+
+using Iterator = std::vector<int>::iterator;
+
+inline Iterator initIterator() { return {}; }
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_ITERATOR_H

--- a/test/Interop/Cxx/stdlib/use-std-iterator.swift
+++ b/test/Interop/Cxx/stdlib/use-std-iterator.swift
@@ -1,0 +1,48 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
+// REQUIRES: OS=macosx
+
+import StdlibUnittest
+import StdIterator
+import std.iterator
+import StdVector
+import std.vector
+
+var StdIteratorTestSuite = TestSuite("StdIterator")
+
+StdIteratorTestSuite.test("init") {
+    var vector = Vector()
+    var _1: CInt = 1
+    vector.push_back(&_1)
+    //ideally we should call vector.begin(), however we need to prevent a copy of self before vector.begin() is invoked
+    //current workaround is to use beginMutating()
+    let it = vector.beginMutating()
+    expectEqual(it[0], 1)
+}
+
+StdIteratorTestSuite.test("next") {
+    var vector = Vector()
+    var _1: CInt = 1, _2: CInt = 2, _3: CInt = 3
+    vector.push_back(&_1)
+    vector.push_back(&_2)
+    vector.push_back(&_3)
+    let it = vector.beginMutating()
+    let n1 = next(it, 2)
+    expectEqual(n1[0], 3)
+}
+
+StdIteratorTestSuite.test("prev") {
+    var vector = Vector()
+    var _1: CInt = 1, _2: CInt = 2, _3: CInt = 3
+    vector.push_back(&_1)
+    vector.push_back(&_2)
+    vector.push_back(&_3)
+    let e = vector.endMutating()
+    let n1 = prev(e, 2)
+    expectEqual(n1[0], 2)
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is to add test cases for iterator std::next and std:prev

@zoecarver @hyp 