### PR TITLE
SILGen: Handle coroutines with the @_backDeploy attribute

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6313,9 +6313,5 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
-ERROR(back_deploy_not_on_coroutine,none,
-      "'%0' is not supported on coroutine %1",
-      (DeclAttribute, DescriptiveDeclKind))
-
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3562,21 +3562,6 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
       }
     }
 
-    // FIXME(backDeploy): support coroutines rdar://90111169
-    auto diagnoseCoroutineIfNecessary = [&](AccessorDecl *AD) {
-      if (AD->isCoroutine())
-        diagnose(Attr->getLocation(), diag::back_deploy_not_on_coroutine,
-                 Attr, AD->getDescriptiveKind());
-    };
-    if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
-      ASD->visitEmittedAccessors([&](AccessorDecl *AD) {
-        diagnoseCoroutineIfNecessary(AD);
-      });
-    }
-    if (auto *AD = dyn_cast<AccessorDecl>(D)) {
-      diagnoseCoroutineIfNecessary(AD);
-    }
-
     auto AtLoc = Attr->AtLoc;
     auto Platform = Attr->Platform;
 

--- a/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
+++ b/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
@@ -1,0 +1,79 @@
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+@available(macOS 10.50, *)
+public struct TopLevelStruct {
+  // -- Fallback definition for TopLevelStruct.property.read
+  // CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
+  // CHECK:   yield [[BB0_ARG]] : $TopLevelStruct, resume [[RESUME_BB:bb[0-9]+]], unwind [[UNWIND_BB:bb[0-9]+]]
+  //
+  // CHECK: [[RESUME_BB]]:
+  // CHECK:   [[RESULT:%.*]] = tuple ()
+  // CHECK:   return [[RESULT]] : $()
+  //
+  // CHECK: [[UNWIND_BB]]:
+  // CHECK:   unwind
+
+  // -- Back deployment thunk for TopLevelStruct.property.read
+  // CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
+  // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+  // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+  // CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+  // CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+  // CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+  //
+  // CHECK: [[UNAVAIL_BB]]:
+  // CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK:   ([[YIELD_RES:%.*]], [[YIELD_TOK:%.*]]) = begin_apply [[FALLBACKFN]]([[BB0_ARG]]) : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK:   end_apply [[YIELD_TOK]]
+  // CHECK:   yield [[YIELD_RES]] : $TopLevelStruct, resume [[UNAVAIL_RESUME_BB:bb[0-9]+]], unwind [[UNAVAIL_UNWIND_BB:bb[0-9]+]]
+  //
+  // CHECK: [[UNAVAIL_UNWIND_BB]]:
+  // CHECK:   br [[UNWIND_BB:bb[0-9]+]]
+  //
+  // CHECK: [[UNAVAIL_RESUME_BB]]:
+  // CHECK:   br [[RETURN_BB:bb[0-9]+]]
+  //
+  // CHECK: [[AVAIL_BB]]:
+  // CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK:   ([[YIELD_RES:%.*]], [[YIELD_TOK:%.*]]) = begin_apply [[ORIGFN]]([[BB0_ARG]]) : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK:   end_apply [[YIELD_TOK]]
+  // CHECK:   yield [[YIELD_RES]] : $TopLevelStruct, resume [[AVAIL_RESUME_BB:bb[0-9]+]], unwind [[UAVAIL_UNWIND_BB:bb[0-9]+]]
+  //
+  // CHECK: [[UAVAIL_UNWIND_BB]]:
+  // CHECK:   br [[UNWIND_BB]]
+  //
+  // CHECK: [[AVAIL_RESUME_BB]]:
+  // CHECK:   br [[RETURN_BB]]
+  //
+  // CHECK: [[RETURN_BB]]:
+  // CHECK:   [[RESULT:%.*]] = tuple ()
+  // CHECK:   return [[RESULT]] : $()
+  //
+  // CHECK: [[UNWIND_BB]]:
+  // CHECK:   unwind
+
+  // -- Original definition of TopLevelStruct.property.read
+  // CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  @available(macOS 10.51, *)
+  @_backDeploy(before: macOS 10.52)
+  public var property: TopLevelStruct {
+    _read { yield self }
+  }
+}
+
+// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK: bb0([[STRUCT_ARG:%.*]] : $TopLevelStruct):
+@available(macOS 10.51, *)
+func caller(_ s: TopLevelStruct) {
+  // -- Verify the thunk is called
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  _ = s.property
+}

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -27,6 +27,30 @@ public struct TopLevelStruct {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public subscript(_ index: Int) -> Int { index }
+
+  @available(macOS 11.0, *)
+  @_backDeploy(before: macOS 12.0)
+  public var readWriteProperty: Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  @available(macOS 11.0, *)
+  @_backDeploy(before: macOS 12.0)
+  public subscript(at index: Int) -> Int {
+    get { 42 }
+    set(newValue) {}
+  }
+
+  public var explicitReadAndModify: Int {
+    @available(macOS 11.0, *)
+    @_backDeploy(before: macOS 12.0)
+    _read { yield 42 }
+
+    @available(macOS 11.0, *)
+    @_backDeploy(before: macOS 12.0)
+    _modify {}
+  }
 }
 
 // OK: final function decls in a non-final class
@@ -131,33 +155,6 @@ protocol CannotBackDeployProtocol {}
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
-
-// FIXME(backDeploy): support coroutines rdar://90111169
-public struct CannotBackDeployCoroutines {
-  @available(macOS 11.0, *)
-  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
-  public var readWriteProperty: Int {
-    get { 42 }
-    set(newValue) {}
-  }
-
-  @available(macOS 11.0, *)
-  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
-  public subscript(at index: Int) -> Int {
-    get { 42 }
-    set(newValue) {}
-  }
-
-  public var explicitReadAndModify: Int {
-    @available(macOS 11.0, *)
-    @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _read accessor}}
-    _read { yield 42 }
-
-    @available(macOS 11.0, *)
-    @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' is not supported on coroutine _modify accessor}}
-    _modify {}
-  }
-}
 
 // MARK: - Function body diagnostics
 

--- a/test/attr/attr_backDeploy_evolution.swift
+++ b/test/attr/attr_backDeploy_evolution.swift
@@ -132,59 +132,51 @@ do {
 }
 
 do {
-  let zero = MutableInt.zero
-  precondition(zero.value == 0)
+  let empty = IntArray.empty
+  precondition(empty.values == [])
 
-  var int = MutableInt(5)
+  var array = IntArray([5])
 
-  // CHECK-ABI: library: 5
-  // CHECK-BD: client: 5
-  int.print()
+  // CHECK-ABI: library: [5]
+  // CHECK-BD: client: [5]
+  array.print()
 
-  precondition(int.increment(by: 2) == 7)
-  precondition(genericIncrement(&int, by: 3) == 10)
-  precondition(int.decrement(by: 1) == 9)
+  array.append(42)
+  genericAppend(&array, 3)
+  let countable = array.toCountable()
+  precondition(existentialCount(countable) == 3)
+  array[1] += 1
+  precondition(array[1] == 43)
 
-  var incrementable: any Incrementable = int.toIncrementable()
-
-  // CHECK-ABI: library: 10
-  // CHECK-BD: client: 10
-  existentialIncrementByOne(&incrementable)
-
-  let int2 = MutableInt(0x7BB7914B)
-  for (i, expectedByte) in [0x4B, 0x91, 0xB7, 0x7B].enumerated() {
-    precondition(int2[byteAt: i] == expectedByte)
-  }
+  // CHECK-ABI: library: [5, 43, 3]
+  // CHECK-BD: client: [5, 43, 3]
+  array.print()
 }
 
 do {
-  let zero = ReferenceInt.zero
-  precondition(zero.value == 0)
+  let empty = ReferenceIntArray.empty
+  precondition(empty.values == [])
 
-  var int = ReferenceInt(42)
+  var array = ReferenceIntArray([7])
 
-  // CHECK-ABI: library: 42
-  // CHECK-BD: client: 42
-  int.print()
+  // CHECK-ABI: library: [7]
+  // CHECK-BD: client: [7]
+  array.print()
 
   do {
-    let copy = int.copy()
-    precondition(int !== copy)
-    precondition(copy.value == 42)
+    let copy = array.copy()
+    precondition(array !== copy)
+    precondition(copy.values == [7])
   }
 
-  precondition(int.increment(by: 2) == 44)
-  precondition(genericIncrement(&int, by: 3) == 47)
-  precondition(int.decrement(by: 46) == 1)
+  array.append(39)
+  genericAppend(&array, 1)
+  let countable = array.toCountable()
+  precondition(existentialCount(countable) == 3)
+  array[1] += 1
+  precondition(array[1] == 40)
 
-  var incrementable: any Incrementable = int.toIncrementable()
-
-  // CHECK-ABI: library: 2
-  // CHECK-BD: client: 2
-  existentialIncrementByOne(&incrementable)
-
-  let int2 = MutableInt(0x08AFAB76)
-  for (i, expectedByte) in [0x76, 0xAB, 0xAF, 0x08].enumerated() {
-    precondition(int2[byteAt: i] == expectedByte)
-  }
+  // CHECK-ABI: library: [7, 40, 1]
+  // CHECK-BD: client: [7, 40, 1]
+  array.print()
 }


### PR DESCRIPTION
Generate appropriate SIL for `@_backDeploy` thunks that wrap coroutine functions (e.g. `_read` and `_modify` accessors). Remove the temporary diagnostics that rejected use of `@_backDeploy` on decls that would result in coroutines.

Resolves rdar://90111169