### PR TITLE
[Concurrency] Improve diagnostic for inout params with Sendable closures.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4576,6 +4576,10 @@ ERROR(concurrent_access_of_local_capture,none,
       "%select{mutation of|reference to}0 captured %1 %2 in "
       "concurrently-executing code",
       (bool, DescriptiveDeclKind, DeclName))
+ERROR(concurrent_access_of_inout_param,none,
+      "mutable capture of 'inout' parameter %0 is not allowed in "
+      "concurrently-executing code",
+      (DeclName))
 ERROR(non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in a `@Sendable` closure",
       (Type, DeclName))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2567,6 +2567,13 @@ namespace {
           return false;
         }
 
+        if (auto param =  dyn_cast<ParamDecl>(value)){
+          if(param->isInOut()){
+              ctx.Diags.diagnose(loc, diag::concurrent_access_of_inout_param, param->getName());
+          }
+          return true;
+        }
+
         // Otherwise, we have concurrent access. Complain.
         ctx.Diags.diagnose(
             loc, diag::concurrent_access_of_local_capture,

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -128,3 +128,12 @@ func test_detached_throwing() async -> String {
     print("caught: \(error)")
   }
 }
+
+// ==== Detached Tasks with inout Params---------------------------------------
+@available(SwiftStdlib 5.1, *)
+func printOrderNumber(n: inout Int) async {
+  Task.detached {
+      n+=1 //expected-error {{mutable capture of 'inout' parameter 'n' is not allowed in concurrently-executing code}}
+      print(n) //expected-error {{mutable capture of 'inout' parameter 'n' is not allowed in concurrently-executing code}}
+  }
+}


### PR DESCRIPTION
Error should point out any operation with mutable params is not permitted in a Sendable closure
