### PR TITLE
[ConstraintSystem] Only attempt to infer a type from a default argument if there is a non-null callee.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1748,7 +1748,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     // If type inference from default arguments is enabled, let's
     // add a constraint from the parameter if necessary, otherwise
     // there is nothing to do but move to the next parameter.
-    if (parameterBindings[paramIdx].empty()) {
+    if (parameterBindings[paramIdx].empty() && callee) {
       auto &ctx = cs.getASTContext();
 
       if (ctx.TypeCheckerOpts.EnableTypeInferenceFromDefaultArguments) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1753,10 +1753,12 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
 
       if (ctx.TypeCheckerOpts.EnableTypeInferenceFromDefaultArguments) {
         auto *paramList = getParameterList(callee);
-        auto *PD = paramList->get(paramIdx);
+        if (!paramList)
+          continue;
 
         // There is nothing to infer if parameter doesn't have any
         // generic parameters in its type.
+        auto *PD = paramList->get(paramIdx);
         if (!PD->getInterfaceType()->hasTypeParameter())
           continue;
 

--- a/test/decl/func/vararg.swift
+++ b/test/decl/func/vararg.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-type-inference-from-defaults
 
 var t1a: (Int...) = (1)
 // expected-error@-1 {{cannot create a variadic tuple}}

--- a/test/expr/closure/basic.swift
+++ b/test/expr/closure/basic.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-type-inference-from-defaults
 
 func takeIntToInt(_ f: (Int) -> Int) { }
 func takeIntIntToInt(_ f: (Int, Int) -> Int) { }


### PR DESCRIPTION
Otherwise, `getParameterList(callee)` will crash if the callee is a closure. Closures can't have default arguments anyway, so there's no need to attempt this new inference.
