### PR TITLE
Add @available attributes on the implicit "extension" for @_nonSendable types

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -291,6 +291,10 @@ public:
     OnAnyClangDecl = 1ull << (unsigned(DeclKindIndex::Last_Decl) + 17),
   };
 
+  static_assert(
+      (unsigned(DeclKindIndex::Last_Decl) + 17) < 64,
+      "Overflow decl attr options bitfields");
+
   LLVM_READNONE
   static uint64_t getOptions(DeclAttrKind DK);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4413,6 +4413,43 @@ bool swift::checkSendableConformance(
   return checkSendableInstanceStorage(nominal, conformanceDC, check);
 }
 
+/// Add "unavailable" attributes to the given extension.
+static void addUnavailableAttrs(ExtensionDecl *ext, NominalTypeDecl *nominal) {
+  ASTContext &ctx = nominal->getASTContext();
+  llvm::VersionTuple noVersion;
+
+  // Add platform-version-specific @available attributes.
+  for (auto available : nominal->getAttrs().getAttributes<AvailableAttr>()) {
+    if (available->Platform == PlatformKind::none)
+      continue;
+
+    auto attr = new (ctx) AvailableAttr(
+        SourceLoc(), SourceRange(),
+        available->Platform,
+        available->Message,
+        "", nullptr,
+        available->Introduced.getValueOr(noVersion), SourceRange(),
+        available->Deprecated.getValueOr(noVersion), SourceRange(),
+        available->Obsoleted.getValueOr(noVersion), SourceRange(),
+        PlatformAgnosticAvailabilityKind::Unavailable,
+        /*implicit=*/true,
+        available->IsSPI);
+    ext->getAttrs().add(attr);
+  }
+
+  // Add the blanket "unavailable".
+
+  auto attr = new (ctx) AvailableAttr(SourceLoc(), SourceRange(),
+                                      PlatformKind::none, "", "", nullptr,
+                                      noVersion, SourceRange(),
+                                      noVersion, SourceRange(),
+                                      noVersion, SourceRange(),
+                                      PlatformAgnosticAvailabilityKind::Unavailable,
+                                      false,
+                                      false);
+  ext->getAttrs().add(attr);
+}
+
 ProtocolConformance *GetImplicitSendableRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *nominal) const {
   // Protocols never get implicit Sendable conformances.
@@ -4468,16 +4505,6 @@ ProtocolConformance *GetImplicitSendableRequest::evaluate(
         -> NormalProtocolConformance * {
     DeclContext *conformanceDC = nominal;
     if (attrMakingUnavailable) {
-      llvm::VersionTuple NoVersion;
-      auto attr = new (ctx) AvailableAttr(SourceLoc(), SourceRange(),
-                                          PlatformKind::none, "", "", nullptr,
-                                          NoVersion, SourceRange(),
-                                          NoVersion, SourceRange(),
-                                          NoVersion, SourceRange(),
-                                          PlatformAgnosticAvailabilityKind::Unavailable,
-                                          false,
-                                          false);
-
       // Conformance availability is currently tied to the declaring extension.
       // FIXME: This is a hack--we should give conformances real availability.
       auto inherits = ctx.AllocateCopy(makeArrayRef(
@@ -4490,7 +4517,7 @@ ProtocolConformance *GetImplicitSendableRequest::evaluate(
                                              nominal->getModuleScopeContext(),
                                              nullptr);
       extension->setImplicit();
-      extension->getAttrs().add(attr);
+      addUnavailableAttrs(extension, nominal);
 
       ctx.evaluator.cacheOutput(ExtendedTypeRequest{extension},
                                 nominal->getDeclaredType());

--- a/test/ModuleInterface/sendable_availability.swift
+++ b/test/ModuleInterface/sendable_availability.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -target %target-cpu-apple-macosx12.0 -emit-module-interface-path %t/Library.swiftinterface -module-name Library %s
+
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+@available(macOS 11.0, *)
+@_nonSendable
+public struct X { }
+
+@_nonSendable
+public struct Y { }
+
+// RUN: %FileCheck %s <%t/Library.swiftinterface
+// CHECK: @available(macOS 11.0, *)
+// CHECK-NEXT: public struct X
+
+// CHECK: @available(macOS, unavailable, introduced: 11.0)
+// CHECK-NEXT: @available(*, unavailable)
+// CHECK-NEXT: extension Library.X{{( )?}}: @unchecked Swift.Sendable {
+
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension Library.Y{{( )?}}: @unchecked Swift.Sendable {
+
+// RUN: %target-swift-frontend -typecheck -enable-library-evolution -target %target-cpu-apple-macosx12.0 -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s -module-interface-preserve-types-as-written
+// RUN: %FileCheck %s <%t/Library.swiftinterface


### PR DESCRIPTION
`@_nonSendable` on a type effectively desugars to an unavailable
extension that provides (`@unchecked`) conformance to the `Sendable`
protocol. Make sure we copy over platform availability so that the
extension does not promise greater availability than the type it extends.

Fixes rdar://90330588.