### PR TITLE
Make sure we evaluate the a global actor annotation on an extension.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3281,8 +3281,18 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   // retrieval request perform checking for us.
   if (nominal->isGlobalActor()) {
     (void)D->getGlobalActorAttr();
-    if (auto value = dyn_cast<ValueDecl>(D))
+    if (auto value = dyn_cast<ValueDecl>(D)) {
       (void)getActorIsolation(value);
+    } else {
+      // Make sure we evaluate the global actor type.
+      auto dc = D->getInnermostDeclContext();
+      (void)evaluateOrDefault(
+          Ctx.evaluator,
+          CustomAttrTypeRequest{
+            attr, dc, CustomAttrTypeKind::GlobalActor},
+          Type());
+    }
+
     return;
   }
 

--- a/test/Serialization/Inputs/actor_bar.swift
+++ b/test/Serialization/Inputs/actor_bar.swift
@@ -1,1 +1,6 @@
 public actor Bar {}
+
+public class SomewhatOnMainActor { }
+
+@MainActor
+extension SomewhatOnMainActor { }


### PR DESCRIPTION
Without doing this, we crash during serialization. Fixes rdar://90170284.
