### PR TITLE
Ensure that lookup of Sendable always considers superclass Sendable.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4516,27 +4516,27 @@ ProtocolConformance *GetImplicitSendableRequest::evaluate(
     return conformance;
   };
 
-  // A non-protocol type with a global actor is implicitly Sendable.
-  if (nominal->getGlobalActorAttr()) {
-    // If this is a class, check the superclass. If it's already Sendable,
-    // form an inherited conformance.
-    if (classDecl) {
-      if (Type superclass = classDecl->getSuperclass()) {
-        auto classModule = classDecl->getParentModule();
-        if (auto inheritedConformance = TypeChecker::conformsToProtocol(
-                classDecl->mapTypeIntoContext(superclass),
-                proto, classModule, /*allowMissing=*/false)) {
-          inheritedConformance = inheritedConformance
-              .mapConformanceOutOfContext();
-          if (inheritedConformance.isConcrete()) {
-            return ctx.getInheritedConformance(
-                nominal->getDeclaredInterfaceType(),
-                inheritedConformance.getConcrete());
-          }
+  // If this is a class, check the superclass. If it's already Sendable,
+  // form an inherited conformance.
+  if (classDecl) {
+    if (Type superclass = classDecl->getSuperclass()) {
+      auto classModule = classDecl->getParentModule();
+      if (auto inheritedConformance = TypeChecker::conformsToProtocol(
+              classDecl->mapTypeIntoContext(superclass),
+              proto, classModule, /*allowMissing=*/false)) {
+        inheritedConformance = inheritedConformance
+            .mapConformanceOutOfContext();
+        if (inheritedConformance.isConcrete()) {
+          return ctx.getInheritedConformance(
+              nominal->getDeclaredInterfaceType(),
+              inheritedConformance.getConcrete());
         }
       }
     }
+  }
 
+  // A non-protocol type with a global actor is implicitly Sendable.
+  if (nominal->getGlobalActorAttr()) {
     // Form the implicit conformance to Sendable.
     return formConformance(nullptr);
   }

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -parse-as-library -require-explicit-sendable
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+import Foundation
+import ObjCConcurrency
+
+open class X: NXView { }
+open class Y: X { }
+
+
+open class Z: NSObject { } // expected-warning{{public class 'Z' does not specify whether it is 'Sendable' or not}}
+// expected-note@-1{{add '@unchecked Sendable' conformance to class 'Z' if this type manually implements concurrency safety}}
+// expected-note@-2{{make class 'Z' explicitly non-Sendable to suppress this warning}}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -99,3 +99,12 @@ struct S11: Sendable {
 }
 
 @_nonSendable public struct S12 { }
+
+// Don't complain about global-actor-qualified classes or their subclasses.
+@MainActor
+open class TestThing {}
+open class TestSubThing : TestThing {}
+
+@MainActor(unsafe)
+open class TestThing2 {}
+open class TestSubThing2 : TestThing2 {}


### PR DESCRIPTION
Fixes rdar://90617628.
