### PR TITLE
IRGen: Artificially pad async let entry point contexts.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -328,10 +328,10 @@ private:
 
   /// The queue of IRGenModules for multi-threaded compilation.
   SmallVector<IRGenModule *, 8> Queue;
-
+  
   std::atomic<int> QueueIndex;
   
-  friend class CurrentIGMPtr;  
+  friend class CurrentIGMPtr;
 public:
   explicit IRGenerator(const IRGenOptions &opts, SILModule &module);
 
@@ -892,6 +892,10 @@ public:
 
   std::string GetObjCSectionName(StringRef Section, StringRef MachOAttributes);
   void SetCStringLiteralSection(llvm::GlobalVariable *GV, ObjCLabelType Type);
+
+  // Mapping of AsyncFunctionPointer records to their corresponding
+  // `@llvm.coro.id.async` intrinsic tag in the function implementation.
+  llvm::DenseMap<llvm::GlobalVariable*, llvm::CallInst*> AsyncCoroIDs;
 
 private:
   Size PtrSize;

--- a/test/IRGen/async_let_back_deploy_workaround.swift
+++ b/test/IRGen/async_let_back_deploy_workaround.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -emit-ir -target x86_64-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-sans-workaround %s
+// RUN: %target-swift-frontend -emit-ir -target x86_64-apple-macos12.3 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-with-workaround %s
+
+// REQUIRES: OS=macosx
+ 
+// rdar://90506708: Prior to Swift 5.7, the Swift concurrency runtime had a bug
+// that led to memory corruption in cases when an `async let` child task
+// would try to use the last 16 bytes of the preallocated slab from the parent
+// to seed its own task allocator. When targeting older Apple OSes that shipped
+// with this bug in their runtime, we work around the bug by inflating the
+// initial context sizes of any async functions used as `async let` entry points
+// to ensure that the preallocated space is never used for the initial context.
+
+// CHECK: [[ASYNC_LET_ENTRY:@"\$sSiIeghHd_Sis5Error_pIegHrzo_TRTATu"]]
+// CHECK-with-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 6{{[0-9][0-9]}} }>
+// CHECK-sans-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 {{[0-9][0-9]}} }>
+
+// CHECK: swift_asyncLet_begin{{.*}}[[ASYNC_LET_ENTRY]]
+public func foo(x: Int, y: Int) async -> Int {
+    async let z = x + y
+    return await z
+}


### PR DESCRIPTION
We fixed a bug in the concurrency runtime (rdar://problem/90357994) that would
lead to memory corruption when a new `async let` child task tried to use the
last 16 bytes of the preallocated slab from its parent to seed its own task
allocator. To work around this bug in older OSes that shipped with the bug,
artificially pad the async coroutine context size for any async functions
used as an `async let` entry point, which will prevent the runtime from
going down the path of trying to use the preallocated storage at all.
rdar://90506708