### PR TITLE
[MiscDiagnostics] Fix a crash in `OpaqueUnderlyingTypeChecker`

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2646,15 +2646,19 @@ public:
     // TODO [OPAQUE SUPPORT]: diagnose multiple opaque types
     SubstitutionMap underlyingSubs = Candidates.front().second;
     if (Candidates.size() > 1) {
-      unsigned mismatchIndex = OpaqueDecl->getOpaqueGenericParams().size();
-      for (auto genericParam : OpaqueDecl->getOpaqueGenericParams()) {
-        unsigned index = genericParam->getIndex();
-        Type underlyingType = Candidates[0].second.getReplacementTypes()[index];
+      Optional<std::pair<unsigned, GenericTypeParamType *>> mismatch;
+
+      auto opaqueParams = OpaqueDecl->getOpaqueGenericParams();
+      for (auto index : indices(opaqueParams)) {
+        auto *genericParam = opaqueParams[index];
+
+        Type underlyingType = Type(genericParam).subst(underlyingSubs);
         bool found = false;
         for (const auto &candidate : Candidates) {
-          Type otherType = candidate.second.getReplacementTypes()[index];
+          Type otherType = Type(genericParam).subst(candidate.second);
+
           if (!underlyingType->isEqual(otherType)) {
-            mismatchIndex = index;
+            mismatch.emplace(index, genericParam);
             found = true;
             break;
           }
@@ -2663,17 +2667,17 @@ public:
         if (found)
           break;
       }
-      assert(mismatchIndex < OpaqueDecl->getOpaqueGenericParams().size());
+      assert(mismatch.hasValue());
 
       if (auto genericParam =
-              OpaqueDecl->getExplicitGenericParam(mismatchIndex)) {
+              OpaqueDecl->getExplicitGenericParam(mismatch->first)) {
         Implementation->diagnose(
             diag::opaque_type_mismatched_underlying_type_candidates_named,
             genericParam->getName())
           .highlight(genericParam->getLoc());
       } else {
         TypeRepr *opaqueRepr =
-            OpaqueDecl->getOpaqueReturnTypeReprs()[mismatchIndex];
+            OpaqueDecl->getOpaqueReturnTypeReprs()[mismatch->first];
         Implementation->diagnose(
             diag::opaque_type_mismatched_underlying_type_candidates,
             opaqueRepr)
@@ -2681,10 +2685,9 @@ public:
       }
 
       for (auto candidate : Candidates) {
-        Ctx.Diags.diagnose(
-           candidate.first->getLoc(),
-           diag::opaque_type_underlying_type_candidate_here,
-           candidate.second.getReplacementTypes()[mismatchIndex]);
+        Ctx.Diags.diagnose(candidate.first->getLoc(),
+                           diag::opaque_type_underlying_type_candidate_here,
+                           Type(mismatch->second).subst(candidate.second));
       }
       return;
     }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -519,3 +519,17 @@ func takesOpaqueProtocol<T : OpaqueProtocol>(generic: T) {
 
 func opaquePlaceholderFunc() -> some _ { 1 } // expected-error {{type placeholder not allowed here}}
 var opaquePlaceholderVar: some _ = 1 // expected-error {{type placeholder not allowed here}}
+
+// rdar://90456579 - crash in `OpaqueUnderlyingTypeChecker`
+func test_diagnostic_with_contextual_generic_params() {
+  struct S {
+    func test<T: Q>(t: T) -> some Q {
+    // expected-error@-1 {{function declares an opaque return type 'some Q', but the return statements in its body do not have matching underlying types}}
+      if true {
+        return t // expected-note {{return statement has underlying type 'T'}}
+      }
+      return "" // String conforms to `Q`
+      // expected-note@-1 {{return statement has underlying type 'String'}}
+    }
+  }
+}


### PR DESCRIPTION
Since opaque result type can reference generic parameters of context,
it cannot reply purely on "index" of the opaque generic parameter
while diagnosing a problem, it needs to perform a type substitution
using a substitution map of a particular candidate to determine the
underlying type.

Resolves: rdar://90456579

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
