### PR TITLE
Fix case of filenames to match files on disk

### DIFF
--- a/test/Generics/generic-nested-in-extension-on-objc-class.swift
+++ b/test/Generics/generic-nested-in-extension-on-objc-class.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-build-swift -module-name test %t/main.swift %S/inputs/generic-nested-in-extension-on-objc-class.swift -o %t/a.out
+// RUN: %target-build-swift -module-name test %t/main.swift %S/Inputs/generic-nested-in-extension-on-objc-class.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/attr/attr_originally_definedin_backward_compatibility.swift
+++ b/test/attr/attr_originally_definedin_backward_compatibility.swift
@@ -17,7 +17,7 @@
 // RUN: mkdir -p %t/SDK/Frameworks/HighLevel.framework/Modules/HighLevel.swiftmodule
 // RUN: %target-build-swift-dylib(%t/SDK/Frameworks/HighLevel.framework/HighLevel) -module-name HighLevel -emit-module \
 // RUN:		-emit-module-path %t/SDK/Frameworks/HighLevel.framework/Modules/HighLevel.swiftmodule/%module-target-triple.swiftmodule \
-// RUN:     %S/Inputs/SymbolMove/HighLevelOriginal.swift -Xlinker -install_name -Xlinker @rpath/HighLevel.framework/HighLevel -enable-library-evolution
+// RUN:     %S/Inputs/SymbolMove/HighlevelOriginal.swift -Xlinker -install_name -Xlinker @rpath/HighLevel.framework/HighLevel -enable-library-evolution
 
 // --- Build an executable using the original high level framework
 // RUN: %target-build-swift -emit-executable %s -g -o %t/HighlevelRunner -F %t/SDK/Frameworks/ -framework HighLevel \


### PR DESCRIPTION
Two tests fail on case-sensitive filesystems because the files on disk have different case than the test expects.

This changes two tests to match the case of the files on disk.