### PR TITLE
Derive nonisolated members for protocol conformances

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -331,6 +331,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
 
   if (ICK == ImplicitConstructorKind::Memberwise) {
     ctor->setIsMemberwiseInitializer();
+    addNonIsolatedToSynthesized(decl, ctor);
   }
 
   // If we are defining a default initializer for a class that has a superclass,
@@ -1525,4 +1526,13 @@ void swift::addFixedLayoutAttr(NominalTypeDecl *nominal) {
   }
   // Add `@_fixed_layout` to the nominal.
   nominal->getAttrs().add(new (C) FixedLayoutAttr(/*Implicit*/ true));
+}
+
+void swift::addNonIsolatedToSynthesized(
+    NominalTypeDecl *nominal, ValueDecl *value) {
+  if (!getActorIsolation(nominal).isActorIsolated())
+    return;
+
+  ASTContext &ctx = nominal->getASTContext();
+  value->getAttrs().add(new (ctx) NonisolatedAttr(/*isImplicit=*/true));
 }

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -77,6 +77,9 @@ bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal);
 /// Add `@_fixed_layout` attribute to the nominal type, if possible.
 void addFixedLayoutAttr(NominalTypeDecl *nominal);
 
+/// Add 'nonisolated' to the synthesized declaration when needed.
+void addNonIsolatedToSynthesized(NominalTypeDecl *nominal, ValueDecl *value);
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CodeSynthesis.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
@@ -274,6 +275,8 @@ deriveComparable_lt(
     derived.ConformanceDecl->diagnose(diag::no_less_than_overload_for_int);
     return nullptr;
   }
+
+  addNonIsolatedToSynthesized(derived.Nominal, comparableDecl);
 
   comparableDecl->setBodySynthesizer(bodySynthesizer);
 

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CodeSynthesis.h"
 #include "TypeChecker.h"
 #include "DerivedConformances.h"
 #include "swift/AST/Decl.h"
@@ -100,6 +101,7 @@ deriveBridgedNSError_enum_nsErrorDomain(
       DerivedConformance::SynthesizedIntroducer::Var,
       derived.Context.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
       /*isFinal=*/true);
+  addNonIsolatedToSynthesized(derived.Nominal, propDecl);
 
   // Define the getter.
   auto getterDecl = derived.addGetterToReadOnlyDerivedProperty(

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CodeSynthesis.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Stmt.h"
@@ -168,6 +169,7 @@ static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
       DerivedConformance::SynthesizedIntroducer::Var, C.Id_rawValue,
       rawInterfaceType, rawType, /*isStatic=*/false,
       /*isFinal=*/false);
+  addNonIsolatedToSynthesized(enumDecl, propDecl);
 
   // Define the getter.
   auto getterDecl = DerivedConformance::addGetterToReadOnlyDerivedProperty(
@@ -432,7 +434,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
   
   initDecl->setImplicit();
   initDecl->setBodySynthesizer(&deriveBodyRawRepresentable_init);
-
+  addNonIsolatedToSynthesized(enumDecl, initDecl);
   initDecl->copyFormalAccessFrom(enumDecl, /*sourceIsParentContext*/true);
 
   // If the containing module is not resilient, make sure clients can construct

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -502,7 +502,6 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
     property->getInterfaceType(), parentDC);
   getterDecl->setImplicit();
   getterDecl->setIsTransparent(false);
-
   getterDecl->copyFormalAccessFrom(property);
 
 
@@ -886,4 +885,19 @@ VarDecl *DerivedConformance::indexedVarDecl(char prefixChar, int index, Type typ
                                  varContext);
   varDecl->setInterfaceType(type);
   return varDecl;
+}
+
+bool swift::memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal) {
+  if (!getActorIsolation(nominal).isActorIsolated())
+    return false;
+
+  for (auto property : nominal->getStoredProperties()) {
+    if (!property->isUserAccessible())
+      continue;
+
+    if (!property->isLet())
+      return true;
+  }
+
+  return false;
 }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -442,6 +442,12 @@ public:
   static VarDecl *indexedVarDecl(char prefixChar, int index, Type type,
                                  DeclContext *varContext);
 };
+
+/// Determine whether any "memberwise" accessors, which walk through the
+/// stored properties of the given nominal type, require actor isolation
+/// because they involve mutable state.
+bool memberwiseAccessorsRequireActorIsolation(NominalTypeDecl *nominal);
+
 } // namespace swift
 
 #endif

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3554,11 +3554,11 @@ static Optional<MemberIsolationPropagation> getMemberIsolationPropagation(
   case DeclKind::Param:
   case DeclKind::Module:
   case DeclKind::Destructor:
+  case DeclKind::EnumCase:
+  case DeclKind::EnumElement:
     return None;
 
   case DeclKind::PatternBinding:
-  case DeclKind::EnumCase:
-  case DeclKind::EnumElement:
     return MemberIsolationPropagation::GlobalActor;
 
   case DeclKind::Constructor:

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency -parse-as-library
+// REQUIRES: concurrency
+
+@MainActor
+struct X1: Equatable, Hashable, Codable {
+  let x: Int
+  let y: String
+}
+
+// expected-error@+5{{type 'X2' does not conform to protocol 'Encodable'}}
+// expected-error@+4{{type 'X2' does not conform to protocol 'Decodable'}}
+// expected-error@+3{{type 'X2' does not conform to protocol 'Equatable'}}
+// expected-error@+2{{type 'X2' does not conform to protocol 'Hashable'}}
+@MainActor
+struct X2: Equatable, Hashable, Codable {
+  let x: Int
+  var y: String
+}
+
+@MainActor
+enum X3: Hashable, Comparable, Codable {
+  case a
+  case b(Int)
+}


### PR DESCRIPTION
When deriving witnesses for protocol conformances within an
actor-isolated type, make those members 'nonisolated'. In the case
where this would work, for example because some of the state is
mutable, don't allow derivation of those witnesses.

Fixes rdar://90233250.
