### PR TITLE
RequirementMachine: Re-use requirement machines constructed by minimization for queries

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -535,13 +535,16 @@ GenericSignature buildGenericSignature(
 
 /// Summary of error conditions detected by the Requirement Machine.
 enum class GenericSignatureErrorFlags {
-  /// The original requirements referenced a non-existent type parameter.
-  HasUnresolvedType = (1<<0),
-
-  /// The original requirements were in conflict with each other, meaning
+  /// The original requirements referenced a non-existent type parameter,
+  /// or the original requirements were in conflict with each other, meaning
   /// there are no possible concrete substitutions which statisfy the
   /// generic signature.
-  HasConflict = (1<<1),
+  HasInvalidRequirements = (1<<0),
+
+  /// The generic signature had non-redundant concrete conformance
+  /// requirements, which means the rewrite system used for minimization
+  /// must be discarded and a new one built for queries.
+  HasConcreteConformances = (1<<1),
 
   /// The Knuth-Bendix completion procedure failed to construct a confluent
   /// rewrite system.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1067,7 +1067,9 @@ void swift::validateGenericSignature(ASTContext &context,
         GenericSignatureWithError());
 
     // If there were any errors, the signature was invalid.
-    if (newSigWithError.getInt()) {
+    auto errorFlags = newSigWithError.getInt();
+    if (errorFlags.contains(GenericSignatureErrorFlags::HasInvalidRequirements) ||
+        errorFlags.contains(GenericSignatureErrorFlags::CompletionFailed)) {
       context.Diags.diagnose(SourceLoc(), diag::generic_signature_not_valid,
                              sig->getAsString());
     }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8275,7 +8275,7 @@ AbstractGenericSignatureRequest::evaluate(
     if (!rqmResult.getPointer() && !gsbResult.getPointer())
       return rqmResult;
 
-    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasInvalidRequirements) &&
         !rqmResult.getInt().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
@@ -8427,7 +8427,7 @@ AbstractGenericSignatureRequestGSB::evaluate(
 
   GenericSignatureErrors errorFlags;
   if (builder.hadAnyError())
-    errorFlags |= GenericSignatureErrorFlags::HasUnresolvedType;
+    errorFlags |= GenericSignatureErrorFlags::HasInvalidRequirements;
   auto result = std::move(builder).computeGenericSignature(
       /*allowConcreteGenericParams=*/true);
   return GenericSignatureWithError(result, errorFlags);
@@ -8489,7 +8489,7 @@ InferredGenericSignatureRequest::evaluate(
     if (!rqmResult.getPointer() && !gsbResult.getPointer())
       return rqmResult;
 
-    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasConflict) &&
+    if (!rqmResult.getInt().contains(GenericSignatureErrorFlags::HasInvalidRequirements) &&
         !rqmResult.getInt().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !rqmResult.getPointer()->isEqual(gsbResult.getPointer())) {
       PrintOptions opts;
@@ -8635,7 +8635,7 @@ InferredGenericSignatureRequestGSB::evaluate(
 
   GenericSignatureErrors errorFlags;
   if (builder.hadAnyError())
-    errorFlags |= GenericSignatureErrorFlags::HasUnresolvedType;
+    errorFlags |= GenericSignatureErrorFlags::HasInvalidRequirements;
   auto result = std::move(builder).computeGenericSignature(
       allowConcreteGenericParams);
   return GenericSignatureWithError(result, errorFlags);
@@ -8705,7 +8705,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     auto rqmResult = buildViaRQM();
     auto gsbResult = buildViaGSB();
 
-    if (!rqmResult.getErrors().contains(GenericSignatureErrorFlags::HasConflict) &&
+    if (!rqmResult.getErrors().contains(GenericSignatureErrorFlags::HasInvalidRequirements) &&
         !rqmResult.getErrors().contains(GenericSignatureErrorFlags::CompletionFailed) &&
         !compare(rqmResult.getRequirements(),
                  gsbResult.getRequirements())) {

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -69,6 +69,9 @@ enum class DebugFlags : unsigned {
   /// Print debug output from propagating explicit requirement
   /// IDs from redundant rules.
   PropagateRequirementIDs = (1<<15),
+
+  /// Print a trace of requirement machines constructed and how long each took.
+  Timers = (1<<16),
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/KnuthBendix.cpp
+++ b/lib/AST/RequirementMachine/KnuthBendix.cpp
@@ -287,6 +287,7 @@ RewriteSystem::computeConfluentCompletion(unsigned maxRuleCount,
                                           unsigned maxRuleLength) {
   assert(Initialized);
   assert(!Minimized);
+  assert(!Frozen);
 
   // Complete might already be set, if we're re-running completion after
   // adding new rules in the property map's concrete type unification procedure.

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -332,6 +332,10 @@ RequirementMachine::computeCompletion(RewriteSystem::ValidityPolicy policy) {
   return std::make_pair(CompletionResult::Success, 0);
 }
 
+void RequirementMachine::freeze() {
+  System.freeze();
+}
+
 std::string RequirementMachine::getRuleAsStringForDiagnostics(
     unsigned ruleID) const {
   const auto &rule = System.getRule(ruleID);

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -90,7 +90,7 @@ RequirementMachine::initWithProtocolSignatureRequirements(
   builder.initWithProtocolSignatureRequirements(protos);
 
   // Add the initial set of rewrite rules to the rewrite system.
-  System.initialize(/*recordLoops=*/true, protos,
+  System.initialize(/*recordLoops=*/false, protos,
                     std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -359,19 +359,18 @@ void RequirementMachine::dump(llvm::raw_ostream &out) const {
   out << "Requirement machine for ";
   if (Sig)
     out << Sig;
-  else if (!Params.empty()) {
-    out << "fresh signature <";
-    for (auto paramTy : Params)
-      out << " " << Type(paramTy);
-    out << " >";
-  } else {
+  else if (!System.getProtocols().empty()) {
     auto protos = System.getProtocols();
-    assert(!protos.empty());
     out << "protocols [";
     for (auto *proto : protos) {
       out << " " << proto->getName();
     }
     out << " ]";
+  } else {
+    out << "fresh signature <";
+    for (auto paramTy : Params)
+      out << " " << Type(paramTy);
+    out << " >";
   }
   out << "\n";
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -98,6 +98,8 @@ RequirementMachine::initWithProtocolSignatureRequirements(
 
   auto result = computeCompletion(RewriteSystem::DisallowInvalidRequirements);
 
+  freeze();
+
   if (Dump) {
     llvm::dbgs() << "}\n";
   }
@@ -144,6 +146,8 @@ RequirementMachine::initWithGenericSignature(CanGenericSignature sig) {
                     std::move(builder.RequirementRules));
 
   auto result = computeCompletion(RewriteSystem::DisallowInvalidRequirements);
+
+  freeze();
 
   if (Dump) {
     llvm::dbgs() << "}\n";

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -113,6 +113,8 @@ class RequirementMachine final {
   std::pair<CompletionResult, unsigned>
   computeCompletion(RewriteSystem::ValidityPolicy policy);
 
+  void freeze();
+
   MutableTerm getLongestValidPrefix(const MutableTerm &term) const;
 
   void buildRequirementsFromRules(
@@ -159,8 +161,8 @@ public:
   llvm::DenseMap<const ProtocolDecl *, RequirementSignature>
   computeMinimalProtocolRequirements();
 
-  std::vector<Requirement>
-  computeMinimalGenericSignatureRequirements(bool reconstituteSugar);
+  GenericSignature
+  computeMinimalGenericSignature(bool reconstituteSugar);
 
   ArrayRef<Rule> getLocalRules() const;
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -237,6 +237,24 @@ RequirementSignatureRequestRQM::evaluate(Evaluator &evaluator,
       requirements.push_back({req, SourceLoc(), /*inferred=*/false});
   }
 
+  if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+    rewriteCtx.beginTimer("RequirementSignatureRequest");
+    llvm::dbgs() << "[";
+    for (auto *proto : component)
+      llvm::dbgs() << " " << proto->getName();
+    llvm::dbgs() << " ]\n";
+  }
+
+  SWIFT_DEFER {
+    if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+      rewriteCtx.endTimer("RequirementSignatureRequest");
+      llvm::dbgs() << "[";
+      for (auto *proto : component)
+        llvm::dbgs() << " " << proto->getName();
+      llvm::dbgs() << " ]\n";
+    }
+  };
+
   unsigned attempt = 0;
   for (;;) {
     // Heap-allocate the requirement machine to save stack space.
@@ -501,12 +519,19 @@ AbstractGenericSignatureRequestRQM::evaluate(
       requirements.push_back({req, SourceLoc(), /*wasInferred=*/false});
   }
 
+  auto &rewriteCtx = ctx.getRewriteContext();
+
+  if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+    rewriteCtx.beginTimer("AbstractGenericSignatureRequest");
+    llvm::dbgs() << "\n";
+  }
+
   // Preprocess requirements to eliminate conformances on generic parameters
   // which are made concrete.
   if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
     SmallVector<StructuralRequirement, 4> contractedRequirements;
     if (performConcreteContraction(requirements, contractedRequirements,
-                                   ctx.getRewriteContext().getDebugOptions()
+                                   rewriteCtx.getDebugOptions()
                                       .contains(DebugFlags::ConcreteContraction))) {
       std::swap(contractedRequirements, requirements);
     }
@@ -516,7 +541,7 @@ AbstractGenericSignatureRequestRQM::evaluate(
   for (;;) {
     // Heap-allocate the requirement machine to save stack space.
     std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
-        ctx.getRewriteContext()));
+        rewriteCtx));
 
     auto status =
         machine->initWithWrittenRequirements(genericParams, requirements);
@@ -545,6 +570,11 @@ AbstractGenericSignatureRequestRQM::evaluate(
 
       // Check invariants.
       result.verify();
+    }
+
+    if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+      rewriteCtx.endTimer("AbstractGenericSignatureRequest");
+      llvm::dbgs() << result << "\n";
     }
 
     return GenericSignatureWithError(result, errorFlags);
@@ -648,12 +678,23 @@ InferredGenericSignatureRequestRQM::evaluate(
   for (const auto &req : addedRequirements)
     requirements.push_back({req, SourceLoc(), /*wasInferred=*/true});
 
+  auto &rewriteCtx = ctx.getRewriteContext();
+
+  if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+    rewriteCtx.beginTimer("InferredGenericSignatureRequest");
+
+    llvm::dbgs() << "@ ";
+    auto &sourceMgr = ctx.SourceMgr;
+    loc.print(llvm::dbgs(), sourceMgr);
+    llvm::dbgs() << "\n";
+  }
+
   // Preprocess requirements to eliminate conformances on generic parameters
   // which are made concrete.
   if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
     SmallVector<StructuralRequirement, 4> contractedRequirements;
     if (performConcreteContraction(requirements, contractedRequirements,
-                                   ctx.getRewriteContext().getDebugOptions()
+                                   rewriteCtx.getDebugOptions()
                                       .contains(DebugFlags::ConcreteContraction))) {
       std::swap(contractedRequirements, requirements);
     }
@@ -663,7 +704,7 @@ InferredGenericSignatureRequestRQM::evaluate(
   for (;;) {
     // Heap-allocate the requirement machine to save stack space.
     std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
-        ctx.getRewriteContext()));
+        rewriteCtx));
 
     auto status =
         machine->initWithWrittenRequirements(genericParams, requirements);
@@ -680,6 +721,12 @@ InferredGenericSignatureRequestRQM::evaluate(
 
       auto result = GenericSignature::get(genericParams,
                                           parentSig.getRequirements());
+
+      if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+        rewriteCtx.endTimer("InferredGenericSignatureRequest");
+        llvm::dbgs() << result << "\n";
+      }
+
       return GenericSignatureWithError(
           result, GenericSignatureErrorFlags::CompletionFailed);
     }
@@ -715,6 +762,11 @@ InferredGenericSignatureRequestRQM::evaluate(
 
       // Check invariants.
       result.verify();
+    }
+
+    if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
+      rewriteCtx.endTimer("InferredGenericSignatureRequest");
+      llvm::dbgs() << result << "\n";
     }
 
     return GenericSignatureWithError(result, errorFlags);

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -206,6 +206,9 @@ public:
   RequirementMachine *getRequirementMachine(CanGenericSignature sig);
   bool isRecursivelyConstructingRequirementMachine(CanGenericSignature sig);
 
+  void installRequirementMachine(CanGenericSignature sig,
+                                 std::unique_ptr<RequirementMachine> machine);
+
   ArrayRef<const ProtocolDecl *>
   startComputingRequirementSignatures(const ProtocolDecl *proto);
 
@@ -213,6 +216,9 @@ public:
 
   RequirementMachine *getRequirementMachine(const ProtocolDecl *proto);
   bool isRecursivelyConstructingRequirementMachine(const ProtocolDecl *proto);
+
+  void installRequirementMachine(const ProtocolDecl *proto,
+                                 std::unique_ptr<RequirementMachine> machine);
 
   ~RewriteContext();
 };

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -116,6 +116,10 @@ class RewriteContext final {
   /// ProtocolNode.
   llvm::DenseMap<unsigned, ProtocolComponent> Components;
 
+  /// The stack of timers for performance analysis. See beginTimer() and
+  /// endTimer().
+  llvm::SmallVector<uint64_t, 2> Timers;
+
   ASTContext &Context;
 
   DebugOptions Debug;
@@ -148,6 +152,10 @@ public:
   DebugOptions getDebugOptions() const { return Debug; }
 
   ASTContext &getASTContext() const { return Context; }
+
+  void beginTimer(StringRef name);
+
+  void endTimer(StringRef name);
 
   //////////////////////////////////////////////////////////////////////////////
   ///

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -29,6 +29,7 @@ RewriteSystem::RewriteSystem(RewriteContext &ctx)
   Initialized = 0;
   Complete = 0;
   Minimized = 0;
+  Frozen = 0;
   RecordLoops = 0;
   LongestInitialRule = 0;
 }
@@ -170,9 +171,7 @@ bool RewriteSystem::simplify(MutableTerm &term, RewritePath *path) const {
 /// \p lhs to \p rhs.
 bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
                             const RewritePath *path) {
-  // FIXME:
-  // assert(!Complete || path != nullptr &&
-  //        "Rules added by completion must have a path");
+  assert(!Frozen);
 
   assert(!lhs.empty());
   assert(!rhs.empty());
@@ -494,6 +493,8 @@ bool RewriteSystem::isInMinimizationDomain(const ProtocolDecl *proto) const {
 
 void RewriteSystem::recordRewriteLoop(MutableTerm basepoint,
                                       RewritePath path) {
+  assert(!Frozen);
+
   RewriteLoop loop(basepoint, path);
   loop.verify(*this);
 
@@ -725,6 +726,30 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
                                                     requirement.loc));
     }
   }
+}
+
+/// Free up memory by purging unused data structures after completion
+/// (for a rewrite system built from a generic signature) or minimization
+/// (for a rewrite system built from user-written requirements).
+void RewriteSystem::freeze() {
+  assert(Complete);
+  assert(!Frozen);
+
+  for (unsigned ruleID = FirstLocalRule, e = Rules.size();
+       ruleID < e; ++ruleID) {
+    getRule(ruleID).freeze();
+  }
+
+  WrittenRequirements.clear();
+  CheckedOverlaps.clear();
+  RelationMap.clear();
+  Relations.clear();
+  DifferenceMap.clear();
+  Differences.clear();
+  CheckedDifferences.clear();
+  Loops.clear();
+  RedundantRules.clear();
+  ConflictingRules.clear();
 }
 
 void RewriteSystem::dump(llvm::raw_ostream &out) const {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -332,10 +332,10 @@ void RewriteSystem::addRules(
     const auto &newRule = Rules[newRuleID];
     // Skip simplified rules. At the very least we need to skip RHS-simplified
     // rules since their left hand sides might duplicate existing rules; the
-    // others are skipped purely as an optimization.
+    // others are skipped purely as an optimization. We can't skip subst-
+    // simplified rules, since property map construction considers them.
     if (newRule.isLHSSimplified() ||
-        newRule.isRHSSimplified() ||
-        newRule.isSubstitutionSimplified())
+        newRule.isRHSSimplified())
       continue;
 
     auto oldRuleID = Trie.insert(newRule.getLHS().begin(),

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -102,6 +102,10 @@ class RewriteSystem final {
   /// Whether we've minimized the rewrite system.
   unsigned Minimized : 1;
 
+  /// Whether the rewrite system is finalized, immutable, and ready for
+  /// generic signature queries.
+  unsigned Frozen : 1;
+
   /// If set, the completion procedure records rewrite loops describing the
   /// identities among rewrite rules discovered while resolving critical pairs.
   unsigned RecordLoops : 1;
@@ -403,6 +407,8 @@ private:
       const llvm::DenseSet<unsigned> &redundantConformances) const;
 
 public:
+  void freeze();
+
   void dump(llvm::raw_ostream &out) const;
 };
 

--- a/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
+++ b/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
@@ -259,8 +259,15 @@ void RewriteSystem::processTypeDifference(const TypeDifference &difference,
   // the same rewrite loop in concretelySimplifyLeftHandSideSubstitutions().
   auto &lhsRule = getRule(lhsRuleID);
   if (lhsRule.getRHS() == difference.BaseTerm &&
-      !lhsRule.isSubstitutionSimplified())
+      !lhsRule.isSubstitutionSimplified()) {
+    if (lhsRule.isFrozen()) {
+      llvm::errs() << "Frozen rule should already be subst-simplified: "
+                   << lhsRule << "\n\n";
+      dump(llvm::errs());
+      abort();
+    }
     lhsRule.markSubstitutionSimplified();
+  }
 }
 
 /// Simplify terms appearing in the substitutions of the last symbol of \p term,

--- a/test/Generics/generic_objc_superclass.swift
+++ b/test/Generics/generic_objc_superclass.swift
@@ -11,7 +11,7 @@ func foo<T : Generic<U>, U>(_: T, _: U) {
   _ = U.self
 }
 
-// CHECK-LABEL: Requirement machine for <τ_0_0, τ_0_1 where τ_0_0 : Generic<τ_0_1>>
+// CHECK: Requirement machine for fresh signature < T U >
 // CHECK-NEXT: Rewrite system: {
 // CHECK-NEXT: - τ_0_0.[superclass: Generic<τ_0_1>] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[layout: AnyObject] => τ_0_0

--- a/test/Generics/rdar79564324.swift
+++ b/test/Generics/rdar79564324.swift
@@ -21,19 +21,19 @@ public func test<T : P>(_ t: T) where T == T.A {
 //
 // The rewrite system handles this correctly though:
 
-// CHECK-LABEL: Requirement machine for <τ_0_0, τ_0_1 where τ_0_0 == τ_0_0.A, τ_0_1 : P, τ_0_0.A == τ_0_1.A>
+// CHECK-LABEL: Requirement machine for fresh signature < T U >
 // CHECK-NEXT: Rewrite system: {
 // CHECK-NEXT: - [P].[P] => [P] [permanent]
 // CHECK-NEXT: - [P].A => [P:A] [permanent]
 // CHECK-NEXT: - [P:A].[P] => [P:A]
 // CHECK-NEXT: - [P].[P:A] => [P:A]
 // CHECK-NEXT: - [P:A].A => [P:A].[P:A]
-// CHECK-NEXT: - τ_0_0.[P:A] => τ_0_0
+// CHECK-NEXT: - τ_0_0.A => τ_0_0
 // CHECK-NEXT: - τ_0_1.[P] => τ_0_1
+// CHECK-NEXT: - τ_0_1.A => τ_0_0
 // CHECK-NEXT: - τ_0_1.[P:A] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[P] => τ_0_0
-// CHECK-NEXT: - τ_0_0.A => τ_0_0
-// CHECK-NEXT: - τ_0_1.A => τ_0_0
+// CHECK-NEXT: - τ_0_0.[P:A] => τ_0_0
 // CHECK-NEXT: }
 // CHECK: Property map: {
 // CHECK-NEXT:   [P] => { conforms_to: [P] }

--- a/test/Generics/rdar90219229.swift
+++ b/test/Generics/rdar90219229.swift
@@ -26,11 +26,11 @@ protocol PBad {
 // FIXME: Terrible diagnostics.
 
 protocol PWorse {
-// expected-error@-1 4{{circular reference}}
-// expected-note@-2 6{{through reference here}}
+// expected-error@-1 5{{circular reference}}
+// expected-note@-2 9{{through reference here}}
   typealias A = C
 
   associatedtype T : Self.A
-// expected-note@-1 4{{while resolving type 'Self.A'}}
-// expected-note@-2 4{{through reference here}}
+// expected-note@-1 5{{while resolving type 'Self.A'}}
+// expected-note@-2 5{{through reference here}}
 }

--- a/test/Generics/unify_associated_types.swift
+++ b/test/Generics/unify_associated_types.swift
@@ -20,7 +20,7 @@ protocol P2a {
 
 struct MergeTest<G : P1a & P2a> {}
 
-// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1a, τ_0_0 : P2a> {
+// CHECK-LABEL: Requirement machine for fresh signature < G >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P2a:T] => τ_0_0.[P1a:T]
 // CHECK: - τ_0_0.[P1a:T].[P2] => τ_0_0.[P1a:T]
@@ -30,5 +30,3 @@ struct MergeTest<G : P1a & P2a> {}
 // CHECK:   τ_0_0 => { conforms_to: [P1a P2a] }
 // CHECK:   τ_0_0.[P1a:T] => { conforms_to: [P1 P2] }
 // CHECK: }
-// CHECK: }
-

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -19,7 +19,7 @@ struct MergeTest<G : P1 & P2> {
   func foo2(x: G.Z1) -> G.Z2 { return x }
 }
 
-// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Requirement machine for fresh signature < G >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P2:Y2] => τ_0_0.[P1:Y1]
 // CHECK: - τ_0_0.[P2:Z2] => τ_0_0.[P1:Z1]

--- a/test/Generics/unify_concrete_types_2.swift
+++ b/test/Generics/unify_concrete_types_2.swift
@@ -27,10 +27,9 @@ struct MergeTest<G : P1a & P2a> {
   func foo2(x: G.T.Z1) -> G.T.Z2 { return x }
 }
 
-// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1a, τ_0_0 : P2a> {
+// CHECK-LABEL: Requirement machine for fresh signature < G >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P2a:T] => τ_0_0.[P1a:T]
 // CHECK: - τ_0_0.[P1a:T].[P2:Y2] => τ_0_0.[P1a:T].[P1:Y1]
 // CHECK: - τ_0_0.[P1a:T].[P2:Z2] => τ_0_0.[P1a:T].[P1:Z1]
-// CHECK: }
 // CHECK: }

--- a/test/Generics/unify_nested_types_1.swift
+++ b/test/Generics/unify_nested_types_1.swift
@@ -17,10 +17,9 @@ struct G<T : P1 & P2> {}
 // Since G.T.T == G.T.T.T == G.T.T.T.T = ... = Int, we tie off the
 // recursion by introducing a same-type requirement G.T.T => G.T.
 
-// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Requirement machine for fresh signature < T >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - [P1:T].T => [P1:T].[P1:T]
 // CHECK: - τ_0_0.[P1:T].[concrete: Int] => τ_0_0.[P1:T]
 // CHECK: - τ_0_0.[P1:T].[P1:T] => τ_0_0.[P1:T]
-// CHECK: }
 // CHECK: }

--- a/test/Generics/unify_nested_types_2.swift
+++ b/test/Generics/unify_nested_types_2.swift
@@ -22,10 +22,9 @@ struct G<T : P1 & P2> {}
 // Since G.T.T == G.T.T.T == G.T.T.T.T = ... = X<T.U>, we tie off the
 // recursion by introducing a same-type requirement G.T.T => G.T.
 
-// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Requirement machine for fresh signature < T >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - [P1:T].T => [P1:T].[P1:T]
 // CHECK: - τ_0_0.[P1:T].[concrete: X<τ_0_0.[P2:U]>] => τ_0_0.[P1:T]
 // CHECK: - τ_0_0.[P1:T].[P1:T] => τ_0_0.[P1:T]
-// CHECK: }
 // CHECK: }

--- a/test/Generics/unify_nested_types_3.swift
+++ b/test/Generics/unify_nested_types_3.swift
@@ -26,7 +26,7 @@ struct G<T : P2a & P3a> {}
 // X.T has a DependentMemberType in it; make sure that we build the
 // correct substitution schema.
 
-// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P2a, τ_0_0 : P3a>
+// CHECK-LABEL: Requirement machine for fresh signature < T >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P2a:T].[concrete: X<τ_0_0.[P3a:U]>] => τ_0_0.[P2a:T]
 // CHECK: - τ_0_0.[P2a:T].[P2:T].[concrete: X<τ_0_0.[P3a:U].[P1:T]>] => τ_0_0.[P2a:T].[P2:T]
@@ -34,5 +34,4 @@ struct G<T : P2a & P3a> {}
 // CHECK-LABEL: Property map: {
 // CHECK: τ_0_0.[P2a:T] => { conforms_to: [P2] concrete_type: [concrete: X<τ_0_0.[P3a:U]>] }
 // CHECK: τ_0_0.[P2a:T].[P2:T] => { concrete_type: [concrete: X<τ_0_0.[P3a:U].[P1:T]>] }
-// CHECK: }
 // CHECK: }

--- a/test/Generics/unify_nested_types_4.swift
+++ b/test/Generics/unify_nested_types_4.swift
@@ -40,7 +40,7 @@ struct G<T : P1 & P2> {}
 // T.B.A => T.B
 // ...
 
-// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
+// CHECK-LABEL: Requirement machine for fresh signature < T >
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P1:A].[concrete: S1 : P1] => τ_0_0.[P1:A]
 // CHECK: - τ_0_0.[P1:A].[P1:A] => τ_0_0.[P1:A]
@@ -60,5 +60,4 @@ struct G<T : P1 & P2> {}
 // CHECK: τ_0_0.[P1:B] => { conforms_to: [P1] concrete_type: [concrete: S2] }
 // CHECK: τ_0_0.[P1:A].[P1:B] => { conforms_to: [P1] concrete_type: [concrete: S2] }
 // CHECK: τ_0_0.[P1:B].[P1:B] => { conforms_to: [P1] concrete_type: [concrete: S1] }
-// CHECK: }
 // CHECK: }

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -13,13 +13,13 @@ extension P where Self : Derived {
   func passesDerived() { derivedMethod() }
 }
 
-// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : Derived, τ_0_0 : P>
+// CHECK-LABEL: Requirement machine for fresh signature < Self >
 // CHECK-NEXT: Rewrite system: {
 // CHECK-NEXT: - [P].[P] => [P] [permanent]
 // CHECK-NEXT: - [P].[superclass: Base] => [P]
 // CHECK-NEXT: - [P].[layout: _NativeClass] => [P]
-// CHECK-NEXT: - τ_0_0.[superclass: Derived] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[P] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[superclass: Derived] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[superclass: Base] => τ_0_0
 // CHECK-NEXT: - τ_0_0.[layout: _NativeClass] => τ_0_0
 // CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -38,10 +38,10 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-RULE-NEXT: Rewrite system: {
 // CHECK-RULE:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<τ_0_0.[P2:A2], String, τ_0_0.[P2:B2]>] => τ_0_0.[P1:X]
-// CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
-// CHECK-RULE:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
 // CHECK-RULE:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK-RULE:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
+// CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.B2 => τ_0_0.[P1:B1]
 // CHECK-RULE:      }
 // CHECK-RULE: Property map: {

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -42,10 +42,10 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-RULE:      - [P2:X].[layout: _NativeClass] => [P2:X]
 // CHECK-RULE:      - τ_0_0.[P2:X] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<Int, τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
-// CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
-// CHECK-RULE:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
 // CHECK-RULE:      - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
+// CHECK-RULE:      - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK-RULE:      - τ_0_0.[P1:X].[superclass: Generic<Int, String, τ_0_0.[P1:B1]>] => τ_0_0.[P1:X]
 // CHECK-RULE:      - τ_0_0.B2 => τ_0_0.[P1:B1]
 // CHECK-RULE:      }
 // CHECK-RULE: Property map: {

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -33,7 +33,7 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
   takesDerived(T.X.self, T.A2.self)
 }
 
-// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
+// CHECK-LABEL: Requirement machine for fresh signature < T >
 // CHECK-NEXT: Rewrite system: {
 // CHECK:      - [P1:X].[superclass: Base<[P1:A1]>] => [P1:X] [explicit]
 // CHECK:      - [P1:X].[layout: _NativeClass] => [P1:X]
@@ -48,8 +48,8 @@ func unifySuperclassTest<T : P1 & P2>(_: T) {
 // CHECK-NEXT:   [P1] => { conforms_to: [P1] }
 // CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<[P1:A1]>] }
 // CHECK-NEXT:   [P2] => { conforms_to: [P2] }
-// CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
 // CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<[P2:A2]>] }
+// CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
 // CHECK-NEXT:   [Q] => { conforms_to: [Q] }
 // CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
 // CHECK-NEXT:   τ_0_0.[P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0.[P2:A2]>] }


### PR DESCRIPTION
Based on https://github.com/apple/swift/pull/42035.

This is the Requirement Machine equivalent of an old GSB optimization: after we minimize a generic signature, we install the requirement machine instance that was used for minimization as the canonical requirement machine for this generic signature.

This avoids building a new requirement machine the first time a query is performed against a freshly-minimized signature.

The requirement machine also takes this a step further than the GSB: after building protocol requirement signatures from a protocol connected component, we install this as the canonical requirement machine for the component as well.

This is a complementary optimization to the rule sharing optimization from https://github.com/apple/swift/pull/41817, which eliminates duplicated work when multiple generic signatures reference the same set of protocols by storing and re-using a requirement machine for each protocol connected component.

Resolves rdar://problem/88135641.