### PR TITLE
RequirementMachine: Fix request evaluator cycle if a typealias requirement becomes redundant

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -480,7 +480,7 @@ static bool isInterestingTypealias(Type type) {
   else
     return false;
 
-  if (aliasDecl->getUnderlyingType()->isVoid())
+  if (type->isVoid())
     return false;
 
   // The 'Swift.AnyObject' typealias is not 'interesting'.

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -712,7 +712,13 @@ StructuralRequirementsRequest::evaluate(Evaluator &evaluator,
         if (assocTypes.contains(typeAliasDecl->getName()))
           continue;
 
+        // The structural type of a typealias will always be a TypeAliasType,
+        // so unwrap it to avoid a requirement that prints as 'Self.T == Self.T'
+        // in diagnostics.
         auto underlyingType = typeAliasDecl->getStructuralType();
+        if (auto *aliasType = dyn_cast<TypeAliasType>(underlyingType.getPointer()))
+          underlyingType = aliasType->getSinglyDesugaredType();
+
         if (underlyingType->is<UnboundGenericType>())
           continue;
 

--- a/test/Generics/protocol_typealias_cycle_5.swift
+++ b/test/Generics/protocol_typealias_cycle_5.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+
+protocol P : Sequence {
+  typealias Element = Iterator.Element
+  // expected-warning@-1 {{typealias overriding associated type 'Element' from protocol 'Sequence' is better expressed as same-type constraint on the protocol}}
+  // expected-warning@-2 {{redundant same-type constraint 'Self.Element' == 'Self.Iterator.Element'}}
+}


### PR DESCRIPTION
If a typealias introduces a same-type requirement that is redundant (see the test case), we would produce a diagnostic with a sugared TypeAliasType. The diagnostic engine would call getUnderlyingType() on this typealias, which triggers computing the requirement signature of the protocol we're currently diagnosing redundancies for.

This sort of thing is a fundamental problem with our diagnostics engine, but we can re-arrange things a little to avoid this scenario in this test case at least, by unwrapping the TypeAliasType when introducing implied same-type requirements from protocol typealiases.