### PR TITLE
[gyb] Remove Python 2

### DIFF
--- a/utils/gyb
+++ b/utils/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 import gyb
 gyb.main()

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 
@@ -11,18 +11,7 @@ import sys
 import textwrap
 import tokenize
 from bisect import bisect
-
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
-
-try:
-    basestring
-except NameError:
-    basestring = str
+from io import StringIO
 
 
 def get_line_starts(s):
@@ -732,7 +721,7 @@ class Code(ASTNode):
         # If we got a result, the code was an expression, so append
         # its value
         if result is not None \
-                or (isinstance(result, basestring) and result != ''):
+                or (isinstance(result, str) and result != ''):
             from numbers import Number, Integral
             result_string = None
             if isinstance(result, Number) and not isinstance(result, Integral):
@@ -740,7 +729,7 @@ class Code(ASTNode):
             elif isinstance(result, Integral) or isinstance(result, list):
                 result_string = str(result)
             else:
-                result_string = StringIO(result).read()
+                result_string = result
             context.append_text(
                 result_string, self.filename, self.start_line_number)
 


### PR DESCRIPTION
Delete some logic related to Python 2. Remove the explicit python 2 reference from shebang

https://bugs.swift.org/browse/SR-13304