### PR TITLE
Add type metadata for extended existential types

### DIFF
--- a/include/swift/ABI/GenericContext.h
+++ b/include/swift/ABI/GenericContext.h
@@ -184,6 +184,13 @@ public:
 using GenericRequirementDescriptor =
   TargetGenericRequirementDescriptor<InProcess>;
 
+/// An array of generic parameter descriptors, all
+/// GenericParamDescriptor::implicit(), which is by far
+/// the most common case.  Some generic context storage can
+/// avoid storing descriptors when they all match this pattern.
+extern const GenericParamDescriptor
+ImplicitGenericParamDescriptors[MaxNumImplicitGenericParamDescriptors];
+
 /// A runtime description of a generic signature.
 class RuntimeGenericSignature {
   GenericContextDescriptorHeader Header;

--- a/include/swift/ABI/MetadataKind.def
+++ b/include/swift/ABI/MetadataKind.def
@@ -74,6 +74,9 @@ METADATAKIND(ObjCClassWrapper, 5 | MetadataKindIsRuntimePrivate | MetadataKindIs
 /// An existential metatype.
 METADATAKIND(ExistentialMetatype, 6 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
 
+/// An extended existential type.
+METADATAKIND(ExtendedExistential, 7 | MetadataKindIsRuntimePrivate | MetadataKindIsNonHeap)
+
 /// A heap-allocated local variable using statically-generated metadata.
 METADATAKIND(HeapLocalVariable, 0 | MetadataKindIsNonType)
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -57,6 +57,9 @@ enum {
   /// The number of words in an AsyncLet (flags + child task context & allocation)
   NumWords_AsyncLet = 80, // 640 bytes ought to be enough for anyone
 
+  /// The size of a unique hash.
+  NumBytes_UniqueHash = 16,
+
   /// The maximum number of generic parameters that can be
   /// implicitly declared, for generic signatures that support that.
   MaxNumImplicitGenericParamDescriptors = 64,
@@ -791,6 +794,140 @@ public:
   }
 };
 
+/// Flags in an extended existential shape.
+class ExtendedExistentialTypeShapeFlags {
+public:
+  typedef uint32_t int_type;
+
+  /// Special cases for the representation.
+  enum class SpecialKind {
+    None = 0,
+
+    /// The existential has a class constraint.
+    /// The inline storage is sizeof(void*) / alignof(void*),
+    /// the value is always stored inline, the value is reference-
+    /// counted (using unknown reference counting), and the
+    /// type metadata for the requirement generic parameters are
+    /// not stored in the existential container because they can
+    /// be recovered from the instance type of the class.
+    Class = 1,
+
+    /// The existential has a metatype constraint.
+    /// The inline storage is sizeof(void*) / alignof(void*),
+    /// the value is always stored inline, the value is a Metadata*,
+    /// and the type metadata for the requirement generic parameters
+    /// are not stored in the existential container because they can
+    /// be recovered from the stored metatype.
+    Metatype = 2,
+
+    /// The inline value storage has a non-storage layout.  The shape
+    /// must include a value witness table.  Type metadata for the
+    /// requirement generic parameters are still stored in the existential
+    /// container.
+    ExplicitLayout = 3,
+
+    // 255 is the maximum
+  };
+
+private:
+  enum : int_type {
+    SpecialKindMask             = 0x000000FFU,
+    SpecialKindShift            = 0,
+    HasGeneralizationSignature  = 0x00000100U,
+    HasTypeExpression           = 0x00000200U,
+    HasSuggestedValueWitnesses  = 0x00000400U,
+    HasImplicitReqSigParams     = 0x00000800U,
+    HasImplicitGenSigParams     = 0x00001000U,
+  };
+  int_type Data;
+
+public:
+  constexpr ExtendedExistentialTypeShapeFlags() : Data(0) {}
+  constexpr ExtendedExistentialTypeShapeFlags(int_type Data) : Data(Data) {}
+  constexpr ExtendedExistentialTypeShapeFlags
+  withSpecialKind(SpecialKind kind) const {
+    return ExtendedExistentialTypeShapeFlags(
+      (Data & ~SpecialKindMask) | (int_type(kind) << SpecialKindShift));
+  }
+  constexpr ExtendedExistentialTypeShapeFlags
+  withHasTypeExpresssion(bool hasTypeExpression) const {
+    return ExtendedExistentialTypeShapeFlags(
+      hasTypeExpression ? (Data | HasTypeExpression)
+                        : (Data & ~HasTypeExpression));
+  }
+  constexpr ExtendedExistentialTypeShapeFlags
+  withGeneralizationSignature(bool hasGeneralization) const {
+    return ExtendedExistentialTypeShapeFlags(
+      hasGeneralization ? (Data | HasGeneralizationSignature)
+                        : (Data & ~HasGeneralizationSignature));
+  }
+  constexpr ExtendedExistentialTypeShapeFlags
+  withSuggestedValueWitnesses(bool hasSuggestedVWT) const {
+    return ExtendedExistentialTypeShapeFlags(
+      hasSuggestedVWT ? (Data | HasSuggestedValueWitnesses)
+                      : (Data & ~HasSuggestedValueWitnesses));
+  }
+  constexpr ExtendedExistentialTypeShapeFlags
+  withImplicitReqSigParams(bool implicit) const {
+    return ExtendedExistentialTypeShapeFlags(
+      implicit ? (Data | HasImplicitReqSigParams)
+               : (Data & ~HasImplicitReqSigParams));
+  }
+  constexpr ExtendedExistentialTypeShapeFlags
+  withImplicitGenSigParams(bool implicit) const {
+    return ExtendedExistentialTypeShapeFlags(
+      implicit ? (Data | HasImplicitGenSigParams)
+               : (Data & ~HasImplicitGenSigParams));
+  }
+
+  /// Is this a special kind of existential?
+  SpecialKind getSpecialKind() const {
+    return SpecialKind((Data & SpecialKindMask) >> SpecialKindShift);
+  }
+  bool isClassConstrained() const {
+    return getSpecialKind() == SpecialKind::Class;
+  }
+  bool isMetatypeConstrained() const {
+    return getSpecialKind() == SpecialKind::Metatype;
+  }
+
+  bool hasGeneralizationSignature() const {
+    return Data & HasGeneralizationSignature;
+  }
+
+  bool hasTypeExpression() const {
+    return Data & HasTypeExpression;
+  }
+
+  bool hasSuggestedValueWitnesses() const {
+    return Data & HasSuggestedValueWitnesses;
+  }
+
+  /// The parameters of the requirement signature are not stored
+  /// explicitly in the shape.
+  ///
+  /// In order to enable this, there must be no more than
+  /// MaxNumImplicitGenericParamDescriptors generic parameters, and
+  /// they must match GenericParamDescriptor::implicit().
+  bool hasImplicitReqSigParams() const {
+    return Data & HasImplicitReqSigParams;
+  }
+
+  /// The parameters of the generalization signature are not stored
+  /// explicitly in the shape.
+  ///
+  /// In order to enable this, there must be no more than
+  /// MaxNumImplicitGenericParamDescriptors generic parameters, and
+  /// they must match GenericParamDescriptor::implicit().
+  bool hasImplicitGenSigParams() const {
+    return Data & HasImplicitGenSigParams;
+  }
+
+  int_type getIntValue() const {
+    return Data;
+  }
+};
+
 /// Convention values for function type metadata.
 enum class FunctionMetadataConvention: uint8_t {
   Swift = 0,
@@ -1195,6 +1332,10 @@ namespace SpecialPointerAuthDiscriminators {
 
   /// Protocol conformance descriptors.
   const uint16_t ProtocolConformanceDescriptor = 0xc6eb;
+
+  /// Extended existential type shapes.
+  const uint16_t ExtendedExistentialTypeShape = 0x5a3d; // = 23101
+  const uint16_t NonUniqueExtendedExistentialTypeShape = 0xe798; // = 59288
 
   /// Value witness functions.
   const uint16_t InitializeBufferWithCopyOfBuffer = 0xda4a;

--- a/include/swift/ABI/TargetLayout.h
+++ b/include/swift/ABI/TargetLayout.h
@@ -100,6 +100,11 @@ struct InProcess {
 
   template <typename T, bool Nullable = true>
   using RelativeDirectPointer = RelativeDirectPointer<T, Nullable>;
+
+  template<typename T>
+  T *getStrippedSignedPointer(const T *pointer) const {
+    return swift_ptrauth_strip(pointer);
+  }
 };
 
 /// Represents a pointer in another address space.
@@ -157,6 +162,10 @@ struct External {
 
   template <typename T, bool Nullable = true>
   using RelativeDirectPointer = int32_t;
+
+  StoredPointer getStrippedSignedPointer(const StoredSignedPointer pointer) const {
+    return swift_ptrauth_strip(pointer);
+  }
 };
 
 template <typename Runtime, typename T>

--- a/include/swift/Basic/ExternalUnion.h
+++ b/include/swift/Basic/ExternalUnion.h
@@ -70,6 +70,17 @@ struct ExternalUnionMembers {
   // (private to the implementation)
   using Info = ExternalUnionImpl::MembersHelper<Members...>;
 
+  enum : bool {
+    is_copy_constructible = Info::is_copy_constructible,
+    is_nothrow_copy_constructible = Info::is_nothrow_copy_constructible,
+    is_move_constructible = Info::is_move_constructible,
+    is_nothrow_move_constructible = Info::is_nothrow_move_constructible,
+    is_copy_assignable = Info::is_copy_assignable,
+    is_nothrow_copy_assignable = Info::is_nothrow_copy_assignable,
+    is_move_assignable = Info::is_move_assignable,
+    is_nothrow_move_assignable = Info::is_nothrow_move_assignable,
+  };
+
   /// The type of indices into the union member type list.
   enum Index : unsigned {};
 
@@ -429,7 +440,15 @@ namespace ExternalUnionImpl {
 template <>
 struct MembersHelper<> {
   enum : bool {
-    is_trivially_copyable = true
+    is_trivially_copyable = true,
+    is_copy_constructible = true,
+    is_nothrow_copy_constructible = true,
+    is_move_constructible = true,
+    is_nothrow_move_constructible = true,
+    is_copy_assignable = true,
+    is_nothrow_copy_assignable = true,
+    is_move_assignable = true,
+    is_nothrow_move_assignable = true,
   };
 
   enum : size_t {
@@ -476,7 +495,32 @@ private:
 public:
   enum : bool {
     is_trivially_copyable =
-      Member::is_trivially_copyable && Others::is_trivially_copyable
+      Member::is_trivially_copyable &&
+      Others::is_trivially_copyable,
+    is_copy_constructible =
+      Member::is_copy_constructible &&
+      Others::is_copy_constructible,
+    is_nothrow_copy_constructible =
+      Member::is_nothrow_copy_constructible &&
+      Others::is_nothrow_copy_constructible,
+    is_move_constructible =
+      Member::is_move_constructible &&
+      Others::is_move_constructible,
+    is_nothrow_move_constructible =
+      Member::is_nothrow_move_constructible &&
+      Others::is_nothrow_move_constructible,
+    is_copy_assignable =
+      Member::is_copy_assignable &&
+      Others::is_copy_assignable,
+    is_nothrow_copy_assignable =
+      Member::is_nothrow_copy_assignable &&
+      Others::is_nothrow_copy_assignable,
+    is_move_assignable = 
+      Member::is_move_assignable &&
+      Others::is_move_assignable,
+    is_nothrow_move_assignable =
+      Member::is_nothrow_move_assignable &&
+      Others::is_nothrow_move_assignable,
   };
 
   enum : size_t {
@@ -536,7 +580,19 @@ public:
 template <class T>
 struct UnionMemberInfo {
   enum : bool {
-    is_trivially_copyable = IsTriviallyCopyable<T>::value
+    is_trivially_copyable = IsTriviallyCopyable<T>::value,
+    is_copy_constructible = std::is_copy_constructible<T>::value,
+    is_nothrow_copy_constructible =
+      std::is_nothrow_copy_constructible<T>::value,
+    is_move_constructible = std::is_move_constructible<T>::value,
+    is_nothrow_move_constructible =
+      std::is_nothrow_move_constructible<T>::value,
+    is_copy_assignable = std::is_copy_assignable<T>::value,
+    is_nothrow_copy_assignable =
+      std::is_nothrow_copy_assignable<T>::value,
+    is_move_assignable = std::is_move_assignable<T>::value,
+    is_nothrow_move_assignable =
+      std::is_nothrow_move_assignable<T>::value,
   };
 
   enum : size_t {
@@ -575,7 +631,15 @@ struct UnionMemberInfo {
 template <>
 struct UnionMemberInfo<void> {
   enum : bool {
-    is_trivially_copyable = true
+    is_trivially_copyable = true,
+    is_copy_constructible = true,
+    is_nothrow_copy_constructible = true,
+    is_move_constructible = true,
+    is_nothrow_move_constructible = true,
+    is_copy_assignable = true,
+    is_nothrow_copy_assignable = true,
+    is_move_assignable = true,
+    is_nothrow_move_assignable = true,
   };
 
   enum : size_t {

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -769,6 +769,20 @@ erase_if(std::unordered_set<Key, Hash, KeyEqual, Alloc> &c, Pred pred) {
   return startingSize - c.size();
 }
 
+/// Call \c vector.emplace_back with each of the other arguments
+/// to this function, in order.  Constructing an intermediate
+/// \c std::initializer_list can be inefficient; more problematically,
+/// types such as \c std::vector copy out of the \c initializer_list
+/// instead of move.
+template <class VectorType, class ValueType, class... ValueTypes>
+void emplace_back_all(VectorType &vector, ValueType &&value,
+                      ValueTypes &&...values) {
+  vector.emplace_back(std::forward<ValueType>(value));
+  emplace_back_all(vector, std::forward<ValueTypes>(values)...);
+}
+template <class VectorType>
+void emplace_back_all(VectorType &vector) {}
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_INTERLEAVE_H

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -1306,6 +1306,8 @@ public:
     case ExistentialMetatypeValueWitnessTablesTag:
     case ExistentialMetatypesTag:
     case ExistentialTypesTag:
+    case ExtendedExistentialTypesTag:
+    case ExtendedExistentialTypeShapesTag:
     case OpaqueExistentialValueWitnessTablesTag:
     case ClassExistentialValueWitnessTablesTag:
     case ForeignWitnessTablesTag:

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -295,6 +295,9 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_objc_superclass                                        \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             swift::SpecialPointerAuthDiscriminators::ObjCSuperclass)
+#define __ptrauth_swift_nonunique_extended_existential_type_shape                        \
+  __ptrauth(ptrauth_key_process_independent_data, 1,                           \
+            SpecialPointerAuthDiscriminators::NonUniqueExtendedExistentialTypeShape)
 #define swift_ptrauth_sign_opaque_read_resume_function(__fn, __buffer)         \
   ptrauth_auth_and_resign(__fn, ptrauth_key_function_pointer, 0,               \
                           ptrauth_key_process_independent_code,                \
@@ -327,6 +330,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_runtime_function_entry_strip(__fn) (__fn)
 #define __ptrauth_swift_heap_object_destructor
 #define __ptrauth_swift_type_descriptor
+#define __ptrauth_swift_nonunique_extended_existential_type_shape
 #define __ptrauth_swift_dynamic_replacement_key
 #define swift_ptrauth_sign_opaque_read_resume_function(__fn, __buffer) (__fn)
 #define swift_ptrauth_sign_opaque_modify_resume_function(__fn, __buffer) (__fn)

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -670,14 +670,43 @@ SWIFT_RUNTIME_EXPORT
 const ExistentialMetatypeMetadata *
 swift_getExistentialMetatypeMetadata(const Metadata *instanceType);
 
-/// Fetch a uniqued metadata for an existential type. The array
-/// referenced by \c protocols will be sorted in-place.
+/// Fetch a uniqued metadata for an existential type.
+///
+/// The array referenced by \c protocols will be sorted in-place.
 SWIFT_RUNTIME_EXPORT
 const ExistentialTypeMetadata *
 swift_getExistentialTypeMetadata(ProtocolClassConstraint classConstraint,
                                  const Metadata *superclassConstraint,
                                  size_t numProtocols,
                                  const ProtocolDescriptorRef *protocols);
+
+/// Fetch unique metadata for an extended existential type.
+///
+/// The shape must not correspond to an existential that could be
+/// represented with ExistentialTypeMetadata.  Its uniquing cache
+/// pointer is guaranteed to be filled after this call.
+SWIFT_RUNTIME_EXPORT
+const ExtendedExistentialTypeMetadata *
+swift_getExtendedExistentialTypeMetadata(
+            const NonUniqueExtendedExistentialTypeShape *shape,
+            const void * const *generalizationArguments);
+
+/// Fetch unique metadata for an extended existential type, given its
+/// known-unique existential shape.  The shape must not correspond to
+/// an existential that could be represented with ExistentialTypeMetadata.
+SWIFT_RUNTIME_EXPORT
+const ExtendedExistentialTypeMetadata *
+swift_getExtendedExistentialTypeMetadata_unique(
+            const ExtendedExistentialTypeShape *shape,
+            const void * const *generalizationArguments);
+
+/// Fetch the unique existential shape for the given non-unique shape.
+/// The shape's uniquing cache pointer is guaranteed to be filled after
+/// this call.
+SWIFT_RUNTIME_EXPORT
+const ExtendedExistentialTypeShape *
+swift_getExtendedExistentialTypeShape(
+            const NonUniqueExtendedExistentialTypeShape *shape);
 
 /// Perform a copy-assignment from one existential container to another.
 /// Both containers must be of the same existential type representable with the

--- a/stdlib/public/runtime/MetadataAllocatorTags.def
+++ b/stdlib/public/runtime/MetadataAllocatorTags.def
@@ -44,5 +44,7 @@ TAG(GenericValueMetadata, 18)
 TAG(SingletonGenericWitnessTableCache, 19)
 TAG(GlobalMetadataCache, 20)
 TAG(GlobalWitnessTableCache, 21)
+TAG(ExtendedExistentialTypes, 22)
+TAG(ExtendedExistentialTypeShapes, 23)
 
 #undef TAG

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -112,6 +112,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     Concurrent.cpp
     Metadata.cpp
     Enum.cpp
+    ExtendedExistential.cpp
     Refcounting.cpp
     Stdlib.cpp
     StackAllocator.cpp

--- a/unittests/runtime/ExtendedExistential.cpp
+++ b/unittests/runtime/ExtendedExistential.cpp
@@ -1,0 +1,506 @@
+//===--- ExtendedExiential.cpp - Extended existential metadata unit tests -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "MetadataObjectBuilder.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/Runtime/Metadata.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+static const ModuleContextDescriptor *module() {
+  return buildGlobalModuleContextDescriptor([] {
+    return "ExtendedExistential";
+  });
+}
+
+template <unsigned N>
+static ProtocolSpecifier globalProtocol() {
+  return protocol(buildGlobalProtocolDescriptor(module(), [] {
+    std::ostringstream str;
+    str << "Anonymous" << N;
+    return str.str();
+  }));
+}
+
+/// Construct the type () -> ... -> (), just so we have different
+/// metadata.
+static const Metadata *metadata(unsigned n) {
+  auto result = swift_getTupleTypeMetadata(MetadataState::Abstract,
+                                           TupleTypeFlags().withNumElements(0),
+                                           nullptr, nullptr, nullptr).Value;
+  while (n--) {
+    result = swift_getFunctionTypeMetadata(FunctionTypeFlags().withNumParameters(0),
+                                           nullptr, nullptr, result);
+  }
+  return result;
+}
+
+using SpecialKind = ExtendedExistentialTypeShapeFlags::SpecialKind;
+
+namespace {
+
+struct GenSigShapeSpecifier {
+  GenericSignatureSpecifier sig;
+};
+struct ReqSigShapeSpecifier {
+  GenericSignatureSpecifier sig;
+};
+struct SpecialKindShapeSpecifier {
+  SpecialKind kind;
+};
+struct VWTableShapeSpecifier {
+  const ValueWitnessTable *vwtable;
+};
+
+struct ShapeSpecifier : TaggedUnion<GenSigShapeSpecifier,
+                                    ReqSigShapeSpecifier,
+                                    SpecialKindShapeSpecifier,
+                                    VWTableShapeSpecifier> {
+  using TaggedUnion::TaggedUnion;
+};
+
+} // end anonymous namespace
+
+static TypeSpecifier genParam(unsigned index) {
+  return typeParam(1, index);
+}
+static TypeSpecifier reqParam(unsigned index) {
+ return typeParam(0, index);
+}
+
+template <class... Specs>
+static GenSigShapeSpecifier genSig(Specs &&...specs) {
+  return GenSigShapeSpecifier{signature(std::forward<Specs>(specs)...)};
+}
+template <class... Specs>
+static ReqSigShapeSpecifier reqSig(Specs &&...specs) {
+  return ReqSigShapeSpecifier{signature(std::forward<Specs>(specs)...)};
+}
+static SpecialKindShapeSpecifier special(SpecialKind kind) {
+  return SpecialKindShapeSpecifier{kind};
+}
+static VWTableShapeSpecifier valueWitnesses(const ValueWitnessTable *table) {
+  return VWTableShapeSpecifier{table};
+}
+
+using ShapeSpecifierList = std::vector<ShapeSpecifier>;
+
+template <class... Specs>
+static ShapeSpecifierList shape(Specs &&...specs) {
+  ShapeSpecifierList list;
+  // When we move to C++17, this can become:
+  //   (list.emplace_back(std::forward<Specs>(specs)), ...);
+  emplace_back_all(list, std::forward<Specs>(specs)...);
+  return list;
+}
+
+static void addExistentialShape(AnyObjectBuilder &builder,
+                                const ShapeSpecifierList &specifiers) {
+  ExtendedExistentialTypeShapeFlags flags;
+  const ValueWitnessTable *vwtable = nullptr;
+  const GenericSignatureSpecifier *genSig = nullptr;
+  const GenericSignatureSpecifier *reqSig = nullptr;
+
+  for (auto &spec : specifiers) {
+    if (auto sig = spec.dyn_cast<GenSigShapeSpecifier>()) {
+      assert(genSig == nullptr && "generalization signature specified twice");
+      genSig = &sig->sig;
+    } else if (auto sig = spec.dyn_cast<ReqSigShapeSpecifier>()) {
+      assert(reqSig == nullptr && "requirement signature specified twice");
+      reqSig = &sig->sig;
+    } else if (auto table = spec.dyn_cast<VWTableShapeSpecifier>()) {
+      assert(vwtable == nullptr && "vwtable override specified twice");
+      vwtable = table->vwtable;
+      flags = flags.withSuggestedValueWitnesses(true);
+    } else if (auto special = spec.dyn_cast<SpecialKindShapeSpecifier>()) {
+      assert(flags.getSpecialKind() == SpecialKind::None &&
+             "special kind specified twice");
+      flags = flags.withSpecialKind(special->kind);
+    } else {
+      swift_unreachable("bad shape specifier");
+    }
+  }
+
+  assert(reqSig && "requirement signature wasn't specified");
+  flags = flags.withImplicitReqSigParams(
+                                canGenericParamsBeImplicit(reqSig->params));
+  if (genSig) {
+    flags = flags.withGeneralizationSignature(true)
+                 .withImplicitGenSigParams(
+                                canGenericParamsBeImplicit(genSig->params));
+  }
+
+  // Flags
+  builder.add32(flags.getIntValue());
+
+  // ReqSigHeader
+  addGenericContextDescriptorHeader(builder, *reqSig);
+
+  // Optional GenSigHeader
+  if (flags.hasGeneralizationSignature())
+    addGenericContextDescriptorHeader(builder, *genSig);
+
+  // TODO: optional type expression
+
+  // Optional suggested value witnesses
+  if (flags.hasSuggestedValueWitnesses())
+    builder.addRelativeIndirectReference(vwtable, /*addend*/ 1);
+
+  // Generic parameter descriptors
+  if (!flags.hasImplicitReqSigParams())
+    addGenericParams(builder, *reqSig);
+  if (flags.hasGeneralizationSignature() &&
+      !flags.hasImplicitGenSigParams())
+    addGenericParams(builder, *genSig);
+
+  // Generic requirement descriptors
+  builder.padToAlignment(alignof(GenericRequirementDescriptor));
+  addGenericRequirements(builder, *reqSig);
+  if (flags.hasGeneralizationSignature())
+    addGenericRequirements(builder, *genSig);
+}
+
+static void addNonUniqueExistentialShape(AnyObjectBuilder &builder,
+                                         size_t hashValue,
+                                   const ShapeSpecifierList &specifiers) {
+  // cache
+  builder.addRelativeIndirectReference(nullptr);
+
+  // hash
+  {
+    UniqueHash hash = {};
+    hash.Data[0] = hashValue;
+    builder.addBytes(&hash, sizeof(hash));
+  }
+
+  addExistentialShape(builder, specifiers);
+}
+
+template <class Fn>
+static const NonUniqueExtendedExistentialTypeShape *
+buildGlobalNonUniqueShape(size_t hashValue, Fn &&fn) {
+  return buildGlobalObject<NonUniqueExtendedExistentialTypeShape>(
+      [&](AnyObjectBuilder &builder) {
+    addNonUniqueExistentialShape(builder, hashValue, std::forward<Fn>(fn)());
+  });
+}
+
+template <class Fn>
+static const ExtendedExistentialTypeShape *
+buildGlobalShape(Fn &&fn) {
+  return buildGlobalObject<ExtendedExistentialTypeShape>(
+      [&](AnyObjectBuilder &builder) {
+    addExistentialShape(builder, std::forward<Fn>(fn)());
+  });
+}
+
+TEST(TestExtendedExistential, shapeUniquing) {
+  auto shape0 = buildGlobalNonUniqueShape(567, []{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()),
+             sameType(member(reqParam(0), "Element"), genParam(0)))
+    );
+  });
+  auto shape1 = buildGlobalNonUniqueShape(567, []{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()),
+             sameType(member(reqParam(0), "Element"), genParam(0)))
+    );
+  });
+  auto shape2 = buildGlobalNonUniqueShape(1123, []{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<1>()),
+             sameType(member(reqParam(0), "Element"), genParam(0)))
+    );
+  });
+  auto shape3 = buildGlobalNonUniqueShape(1123, []{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<1>()),
+             sameType(member(reqParam(0), "Element"), genParam(0)))
+    );
+  });
+
+  auto result0 = swift_getExtendedExistentialTypeShape(shape0);
+  EXPECT_EQ(result0, &shape0->LocalCopy);
+
+  auto result1 = shape0->UniqueCache.get()->load(std::memory_order_acquire);
+  EXPECT_EQ(result1, result0);
+
+  auto result2 = swift_getExtendedExistentialTypeShape(shape0);
+  EXPECT_EQ(result2, result0);
+
+  auto result3 = swift_getExtendedExistentialTypeShape(shape1);
+  EXPECT_EQ(result3, result0);
+
+  auto result4 = shape1->UniqueCache.get()->load(std::memory_order_acquire);
+  EXPECT_EQ(result4, result0);
+
+  auto result5 = swift_getExtendedExistentialTypeShape(shape2);
+  EXPECT_EQ(result5, &shape2->LocalCopy);
+  EXPECT_NE(result5, result0);
+
+  auto result6 = swift_getExtendedExistentialTypeShape(shape3);
+  EXPECT_EQ(result6, result5);
+}
+
+TEST(TestExtendedExistential, nullaryMetadata) {
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
+  EXPECT_EQ(metadata1->Shape, shape1);
+
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
+  EXPECT_EQ(metadata2->Shape, shape1);
+  EXPECT_EQ(metadata2, metadata1);
+}
+
+TEST(TestExtendedExistential, unaryMetadata) {
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+  auto shape2 = buildGlobalShape([]{
+    return shape(
+      genSig(param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<1>()))
+    );
+  });
+
+  const void *args1[] = { metadata(0) };
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args1);
+  EXPECT_EQ(metadata1->Shape, shape1);
+  EXPECT_EQ(metadata1->getGeneralizationArguments()[0], args1[0]);
+
+  const void *args2[] = { metadata(0) };
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args2);
+  EXPECT_EQ(metadata2->Shape, shape1);
+  EXPECT_EQ(metadata2->getGeneralizationArguments()[0], args2[0]);
+  EXPECT_EQ(metadata2, metadata1);
+
+  const void *args3[] = { metadata(1) };
+  auto metadata3 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args3);
+  EXPECT_EQ(metadata3->Shape, shape1);
+  EXPECT_EQ(metadata3->getGeneralizationArguments()[0], args3[0]);
+  EXPECT_NE(metadata3, metadata1);
+
+  const void *args4[] = { metadata(1) };
+  auto metadata4 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args4);
+  EXPECT_EQ(metadata4->Shape, shape1);
+  EXPECT_EQ(metadata4->getGeneralizationArguments()[0], args4[0]);
+  EXPECT_NE(metadata4, metadata1);
+  EXPECT_EQ(metadata4, metadata3);
+
+  const void *args5[] = { metadata(0) };
+  auto metadata5 = swift_getExtendedExistentialTypeMetadata_unique(shape2, args5);
+  EXPECT_EQ(metadata5->Shape, shape2);
+  EXPECT_EQ(metadata5->getGeneralizationArguments()[0], args5[0]);
+  EXPECT_NE(metadata5, metadata1);
+}
+
+TEST(TestExtendedExistential, binaryMetadata) {
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      genSig(param(), param()),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+
+  const void *args1[] = { metadata(0), metadata(0) };
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args1);
+  EXPECT_EQ(metadata1->Shape, shape1);
+  EXPECT_EQ(metadata1->getGeneralizationArguments()[0], args1[0]);
+  EXPECT_EQ(metadata1->getGeneralizationArguments()[1], args1[1]);
+
+  const void *args2[] = { metadata(0), metadata(0) };
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args2);
+  EXPECT_EQ(metadata2->Shape, shape1);
+  EXPECT_EQ(metadata2->getGeneralizationArguments()[0], args2[0]);
+  EXPECT_EQ(metadata2->getGeneralizationArguments()[1], args2[1]);
+  EXPECT_EQ(metadata2, metadata1);
+
+  const void *args3[] = { metadata(1), metadata(0) };
+  auto metadata3 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args3);
+  EXPECT_EQ(metadata3->Shape, shape1);
+  EXPECT_EQ(metadata3->getGeneralizationArguments()[0], args3[0]);
+  EXPECT_EQ(metadata3->getGeneralizationArguments()[1], args3[1]);
+  EXPECT_NE(metadata3, metadata1);
+
+  const void *args4[] = { metadata(0), metadata(1) };
+  auto metadata4 = swift_getExtendedExistentialTypeMetadata_unique(shape1, args4);
+  EXPECT_EQ(metadata4->Shape, shape1);
+  EXPECT_EQ(metadata4->getGeneralizationArguments()[0], args4[0]);
+  EXPECT_EQ(metadata4->getGeneralizationArguments()[1], args4[1]);
+  EXPECT_NE(metadata4, metadata1);
+  EXPECT_NE(metadata4, metadata3);
+}
+
+TEST(TestExtendedExistential, overrideValueWitnesses) {
+  static ValueWitnessTable table = {};
+  auto shape0 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::ExplicitLayout),
+      valueWitnesses(&table),
+      reqSig(param())
+    );
+  });
+  auto metadata0 = swift_getExtendedExistentialTypeMetadata_unique(shape0, nullptr);
+  EXPECT_EQ(metadata0->Shape, shape0);
+  EXPECT_EQ(metadata0->Shape->Flags.getSpecialKind(),
+            SpecialKind::ExplicitLayout);
+
+  auto vwtable0 = metadata0->getValueWitnesses();
+  EXPECT_EQ(vwtable0, &table);
+}
+
+TEST(TestExtendedExistential, defaultOpaqueValueWitnessses) {
+  auto shape0 = buildGlobalShape([]{
+    return shape(
+      reqSig(param())
+    );
+  });
+  EXPECT_EQ(shape0->Flags.getSpecialKind(), SpecialKind::None);
+
+  auto metadata0 = swift_getExtendedExistentialTypeMetadata_unique(shape0, nullptr);
+  auto vwtable0 = metadata0->getValueWitnesses();
+  EXPECT_NE(vwtable0, nullptr);
+  EXPECT_EQ(vwtable0->size, sizeof(ValueBuffer) + 1 * sizeof(void*));
+  EXPECT_FALSE(vwtable0->isPOD());
+
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
+  auto vwtable1 = metadata1->getValueWitnesses();
+  EXPECT_NE(vwtable1, nullptr);
+  EXPECT_EQ(vwtable1->size, sizeof(ValueBuffer) + 2 * sizeof(void*));
+  EXPECT_FALSE(vwtable1->isPOD());
+
+  auto shape2 = buildGlobalShape([]{
+    return shape(
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()),
+             conforms(reqParam(0), globalProtocol<1>()))
+    );
+  });
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);
+  auto vwtable2 = metadata2->getValueWitnesses();
+  EXPECT_NE(vwtable2, nullptr);
+  EXPECT_EQ(vwtable2->size, sizeof(ValueBuffer) + 3 * sizeof(void*));
+  EXPECT_FALSE(vwtable2->isPOD());
+}
+
+TEST(TestExtendedExistential, defaultClassValueWitnessses) {
+  auto shape0 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Class),
+      reqSig(param())
+    );
+  });
+  EXPECT_EQ(shape0->Flags.getSpecialKind(), SpecialKind::Class);
+
+  auto metadata0 = swift_getExtendedExistentialTypeMetadata_unique(shape0, nullptr);
+  auto vwtable0 = metadata0->getValueWitnesses();
+  EXPECT_NE(vwtable0, nullptr);
+  EXPECT_EQ(vwtable0->size, sizeof(void*) + 0 * sizeof(void*));
+  EXPECT_FALSE(vwtable0->isPOD());
+
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Class),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
+  auto vwtable1 = metadata1->getValueWitnesses();
+  EXPECT_NE(vwtable1, nullptr);
+  EXPECT_EQ(vwtable1->size, sizeof(void*) + 1 * sizeof(void*));
+  EXPECT_FALSE(vwtable1->isPOD());
+
+  auto shape2 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Class),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()),
+             conforms(reqParam(0), globalProtocol<1>()))
+    );
+  });
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);
+  auto vwtable2 = metadata2->getValueWitnesses();
+  EXPECT_NE(vwtable2, nullptr);
+  EXPECT_EQ(vwtable2->size, sizeof(void*) + 2 * sizeof(void*));
+  EXPECT_FALSE(vwtable2->isPOD());
+}
+
+TEST(TestExtendedExistential, defaultMetatypeValueWitnessses) {
+  auto shape0 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Metatype),
+      reqSig(param())
+    );
+  });
+  EXPECT_EQ(shape0->Flags.getSpecialKind(), SpecialKind::Metatype);
+
+  auto metadata0 = swift_getExtendedExistentialTypeMetadata_unique(shape0, nullptr);
+  auto vwtable0 = metadata0->getValueWitnesses();
+  EXPECT_NE(vwtable0, nullptr);
+  EXPECT_EQ(vwtable0->size, sizeof(void*) + 0 * sizeof(void*));
+  EXPECT_TRUE(vwtable0->isPOD());
+
+  auto shape1 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Metatype),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()))
+    );
+  });
+  auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
+  auto vwtable1 = metadata1->getValueWitnesses();
+  EXPECT_NE(vwtable1, nullptr);
+  EXPECT_EQ(vwtable1->size, sizeof(void*) + 1 * sizeof(void*));
+  EXPECT_TRUE(vwtable1->isPOD());
+
+  auto shape2 = buildGlobalShape([]{
+    return shape(
+      special(SpecialKind::Metatype),
+      reqSig(param(),
+             conforms(reqParam(0), globalProtocol<0>()),
+             conforms(reqParam(0), globalProtocol<1>()))
+    );
+  });
+  auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);
+  auto vwtable2 = metadata2->getValueWitnesses();
+  EXPECT_NE(vwtable2, nullptr);
+  EXPECT_EQ(vwtable2->size, sizeof(void*) + 2 * sizeof(void*));
+  EXPECT_TRUE(vwtable2->isPOD());
+}

--- a/unittests/runtime/MetadataObjectBuilder.h
+++ b/unittests/runtime/MetadataObjectBuilder.h
@@ -1,0 +1,163 @@
+//===--- MetadataObjectBuilder.h -------------------------------*- C++ -*--===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines routines for use with ObjectBuilder that are specifically
+// useful for building metadata objects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef METADATA_OBJECT_BUILDER_H
+#define METADATA_OBJECT_BUILDER_H
+
+#include "ObjectBuilder.h"
+#include "SpecifierDSL.h"
+#include "swift/ABI/Metadata.h"
+#include <sstream>
+#include <type_traits>
+
+namespace swift {
+using namespace specifierDSL;
+
+/// Add a simple ModuleContextDescriptor with the given name.
+inline void addModuleContextDescriptor(AnyObjectBuilder &builder,
+                                       StringRef moduleName) {
+  // Context descriptor flags
+  auto contextFlags = ContextDescriptorFlags(ContextDescriptorKind::Module,
+                                             /*generic*/ false,
+                                             /*unique*/ true,
+                                             /*version*/ 0,
+                                             /*kindSpecific*/ 0);
+  builder.add32(contextFlags.getIntValue());
+
+  // Parent
+  builder.add32(0);
+
+  // Name
+  builder.addRelativeReferenceToString(moduleName);
+}
+
+/// Add a simple ProtocolDescriptor with the given base protocols
+/// but no other requirements.
+inline void addProtocolDescriptor(AnyObjectBuilder &builder,
+                                  const ModuleContextDescriptor *module,
+                                  StringRef protocolName,
+                            llvm::ArrayRef<ProtocolSpecifier> baseProtocols) {
+  // Context descriptor flags
+  auto contextFlags = ContextDescriptorFlags(ContextDescriptorKind::Protocol,
+                                             /*generic*/ false,
+                                             /*unique*/ true,
+                                             /*version*/ 0,
+                                             /*kindSpecific*/ 0);
+  builder.add32(contextFlags.getIntValue());
+
+  // Parent
+  builder.addRelativeIndirectReference(module, /*addend*/ 1);
+
+  // Name
+  builder.addRelativeReferenceToString(protocolName);
+
+  // NumRequirementsInSignature
+  builder.add32(baseProtocols.size());
+
+  // NumRequirements
+  builder.add32(baseProtocols.size());
+
+  // Associated type names
+  builder.add32(0);
+
+  ObjectRef<const char> selfType;
+  if (!baseProtocols.empty()) {
+    auto subbuilder = builder.createSubobject<const char>(/*align*/ 2);
+    mangleGenericParamType(subbuilder, 0, 0);
+    selfType = subbuilder.ref();
+  }
+
+  // Requirement signature requirement descriptors
+  for (auto &baseProtocol : baseProtocols) {
+    addConformanceRequirement(builder, selfType, baseProtocol);
+  }
+
+  // Protocol requirement descriptors
+  for (auto baseProtocol : baseProtocols) {
+    (void) baseProtocol; // Requirements don't actually collect specifics here
+
+    // Flags
+    auto flags = ProtocolRequirementFlags(
+                              ProtocolRequirementFlags::Kind::BaseProtocol);
+    builder.add32(flags.getIntValue());
+
+    // Default implementation
+    builder.add32(0);
+  }
+}
+
+template <class T>
+class GlobalObjectBuilder {
+  ObjectBuilder<T> builder;
+public:
+  template <class Fn>
+  GlobalObjectBuilder(Fn &&fn) {
+    std::forward<Fn>(fn)(builder);
+    (void) builder.finish();
+  }
+  const T *get() const { return builder.get(); }
+};
+
+/// Build a global object with the given lambda.
+///
+/// This uses a static local to magically cache and preserve the
+/// global object.  This global caching is uniqued by the template
+/// arguments to this function, so callers should not re-use lambdas
+/// for different calls.
+template <class T, class Fn>
+inline const T *buildGlobalObject(Fn &&fn) {
+  static const GlobalObjectBuilder<T> builder(std::forward<Fn>(fn));
+  return builder.get();
+}
+
+/// Build a global ModuleContextDescriptor with the name returned by the
+/// given lambda.
+///
+/// This uses a static local to magically cache and preserve the
+/// global object.  This global caching is uniqued by the template
+/// arguments to this function, so callers should not re-use lambdas
+/// for different calls.
+template <class Fn>
+inline const ModuleContextDescriptor *
+buildGlobalModuleContextDescriptor(Fn &&fn) {
+  static const GlobalObjectBuilder<ModuleContextDescriptor> builder(
+      [&](AnyObjectBuilder &builder) {
+    addModuleContextDescriptor(builder, std::forward<Fn>(fn)());
+  });
+  return builder.get();
+}
+
+/// Build a global protocol descriptor for an empty protocol with
+/// the name returned by the given lambda.
+///
+/// This uses a static local to magically cache and preserve the
+/// global object.  This global caching is uniqued by the template
+/// arguments to this function, so callers should not re-use lambdas
+/// for different calls.
+template <class Fn>
+inline const ProtocolDescriptor *
+buildGlobalProtocolDescriptor(const ModuleContextDescriptor *module, Fn &&fn) {
+  static const GlobalObjectBuilder<ProtocolDescriptor> builder(
+      [&](AnyObjectBuilder &builder) {
+    addProtocolDescriptor(builder, module, std::forward<Fn>(fn)(), {});
+  });
+  return builder.get();
+}
+
+} // end namespace swift
+
+#endif

--- a/unittests/runtime/ObjectBuilder.h
+++ b/unittests/runtime/ObjectBuilder.h
@@ -1,0 +1,413 @@
+//===--- ObjectBuilder.h ---------------------------------------*- C++ -*--===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines ObjectBuilder, a class that's useful for building objects
+// with relative references to other objects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef OBJECT_BUILDER_H
+#define OBJECT_BUILDER_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MathExtras.h"
+#include <vector>
+
+namespace swift {
+
+class RootObjectBuilder;
+
+template <class T>
+class SubobjectBuilder;
+
+template <class T>
+class ObjectRef;
+
+class AnyObjectBuilder {
+protected:
+  struct Object;
+  template <class T> friend class ObjectRef;
+
+  using RelativeReferenceType = int32_t;
+
+  struct Reference {
+    /// The offset at which the reference is stored in the data.
+    size_t offset;
+
+    /// The target of the reference.
+    Object *referent;
+
+    /// A value to add to the value of the reference.  Generally used for
+    /// things like storing small integers in alignment bits.
+    size_t addend;
+
+    /// Return a copy of this reference for a containing object in
+    /// which the referring object has been placed at the given offset.
+    Reference atOffset(size_t offsetInContainer) const {
+      return { offsetInContainer + offset, referent, addend };
+    }
+  };
+
+  struct Object {
+    static constexpr size_t invalidOffset = -1;
+    std::vector<char> data;
+    std::vector<Reference> refs;
+    size_t requiredAlignment;
+    size_t assignedOffset = invalidOffset;
+
+    Object(size_t requiredAlignment) : requiredAlignment(requiredAlignment) {
+      assert(llvm::isPowerOf2_64(requiredAlignment));
+    }
+    Object(const Object &) = delete;
+    Object &operator=(const Object &) = delete;
+
+    bool hasAssignedOffset() const {
+      return assignedOffset != invalidOffset;
+    }
+
+    /// Given that this object has been merged into the topmost object,
+    /// free any memory associated with it.
+    void clearMemory() {
+      assert(hasAssignedOffset());
+      data = std::vector<char>();
+      if (!refs.empty())
+        refs = std::vector<Reference>();
+    }
+  };
+
+  RootObjectBuilder *root;
+  Object *self;
+
+  AnyObjectBuilder(RootObjectBuilder *root, Object *self)
+    : root(root), self(self) {}
+
+public:
+  AnyObjectBuilder(const AnyObjectBuilder &) = delete;
+  AnyObjectBuilder &operator=(const AnyObjectBuilder &) = delete;
+  AnyObjectBuilder &operator=(AnyObjectBuilder &&) = delete;
+
+  AnyObjectBuilder(AnyObjectBuilder &&other)
+      : root(other.root), self(other.self) {
+    // Flag that the other builder has been moved from.
+    other.root = nullptr;
+  }
+
+  /// Round the current offset up to a particular alignment.
+  void padToAlignment(size_t alignment);
+
+  /// Add a fixed-size value (in native byte ordering).
+  void add8(uint8_t value);
+  void add16(uint16_t value);
+  void add32(uint32_t value);
+  void add64(uint64_t value);
+
+  /// Add a sequence of bytes.
+  void addBytes(llvm::StringRef value);
+  void addBytes(const void *data, size_t length);
+
+  /// Add a string of ('\0'-terminated) bytes.
+  void addString(llvm::StringRef value);
+
+  /// Add an indirect reference to a string of '\0'-terminated bytes.
+  void addRelativeReferenceToString(llvm::StringRef value,
+                                    size_t alignment = alignof(char),
+                                    size_t addend = 0);
+
+  /// Create a object which will be laid out somewhere near this
+  /// object.  A relative reference can be built to the object,
+  /// but this method doesn't itself do so; it must be added later
+  /// with `addRelativeReference(subBuilder.ref())`.
+  template <class T>
+  SubobjectBuilder<T> createSubobject(size_t alignment = alignof(T));
+
+  /// Add a relative reference to the given subobject.
+  template <class T>
+  void addRelativeReference(ObjectRef<T> object, size_t addend = 0);
+
+  /// Add a relative reference to a variable that holds the
+  /// given pointer.
+  void addRelativeIndirectReference(const void *value, size_t addend = 0);
+
+  /// Add an absolute pointer.
+  void addPointer(const void *value);
+};
+
+class RootObjectBuilder : public AnyObjectBuilder {
+  friend class AnyObjectBuilder;
+  std::vector<std::unique_ptr<Object>> subobjects;
+
+  void fillReference(const Reference &ref);
+
+protected:
+  char *finishedPointer = nullptr;
+  void *finishImpl();
+
+public:
+  RootObjectBuilder(size_t alignment)
+    : AnyObjectBuilder(this, new Object(alignment)) {
+    // We directly retain ownership of self instead of adding it to
+    // subobjects.
+  }
+
+  // We can't copy/move a root builder because subbuilders will have
+  // unsafe pointers to it.
+  RootObjectBuilder(const RootObjectBuilder &other) = delete;
+  RootObjectBuilder &operator=(const RootObjectBuilder &other) = delete;
+
+  ~RootObjectBuilder() {
+    delete self;
+  }
+
+  bool isFinished() const {
+    return finishedPointer != nullptr;
+  }
+
+  template <class T>
+  T *findObject(ObjectRef<T> object) {
+    assert(isFinished() && "finding object in unfinished builder");
+    assert(object.object->hasAssignedOffset());
+    return reinterpret_cast<T*>(
+                      finishedPointer + object.object->assignedOffset);
+  }
+
+  template <class T>
+  const T *findObject(ObjectRef<T> object) const {
+    assert(isFinished() && "finding object in unfinished builder");
+    assert(object.object->hasAssignedOffset());
+    return reinterpret_cast<const T *>(
+                      finishedPointer + object.object->assignedOffset);
+  }
+};
+
+/// The main type to interact with.
+template <class T>
+class ObjectBuilder : public RootObjectBuilder {
+public:
+  ObjectBuilder(size_t alignment = alignof(T))
+    : RootObjectBuilder(alignment) {}
+
+  ObjectRef<T> ref() const {
+    return ObjectRef<T>(root, self);
+  }
+
+  T *finish() {
+    return static_cast<T*>(finishImpl());
+  }
+
+  T *get() {
+    assert(isFinished());
+    return reinterpret_cast<T*>(finishedPointer);
+  }
+
+  const T *get() const {
+    assert(isFinished());
+    return reinterpret_cast<const T*>(finishedPointer);
+  }
+};
+
+template <class T>
+class SubobjectBuilder : public AnyObjectBuilder {
+  friend class AnyObjectBuilder;
+
+  SubobjectBuilder(RootObjectBuilder *root, Object *self)
+    : AnyObjectBuilder(root, self) {}
+
+public:
+  ObjectRef<T> ref() const {
+    return ObjectRef<T>(root, self);
+  }
+};
+
+template <class T>
+class ObjectRef {
+  friend class AnyObjectBuilder;
+
+  RootObjectBuilder *root;
+  AnyObjectBuilder::Object *object;
+
+public:
+  // Only really callable from builder subclasses.
+  ObjectRef(RootObjectBuilder *root, AnyObjectBuilder::Object *object)
+    : root(root), object(object) {
+    assert(root && object);
+  }
+
+  constexpr ObjectRef() : root(nullptr), object(nullptr) {}
+
+  T *get() const {
+    return root->findObject(*this);
+  }
+};
+
+inline void AnyObjectBuilder::padToAlignment(size_t alignment) {
+  assert(root && "builder was moved from");
+  assert(!root->isFinished());
+  assert(llvm::isPowerOf2_64(alignment));
+  size_t rawOffset = self->data.size();
+  size_t offset = (rawOffset + alignment - 1) & ~(alignment - 1);
+  if (offset != rawOffset)
+    self->data.resize(offset);
+}
+
+inline void AnyObjectBuilder::addBytes(const void *data, size_t length) {
+  assert(root && "builder was moved from");
+  assert(!root->isFinished());
+  self->data.insert(self->data.end(),
+                    ((const char *) data),
+                    ((const char *) data) + length);
+}
+
+inline void AnyObjectBuilder::add8(uint8_t value) {
+  assert(root && "builder was moved from");
+  assert(!root->isFinished());
+  self->data.push_back(value);
+}
+
+inline void AnyObjectBuilder::add16(uint16_t value) {
+  addBytes(&value, sizeof(value));
+}
+inline void AnyObjectBuilder::add32(uint32_t value) {
+  addBytes(&value, sizeof(value));
+}
+inline void AnyObjectBuilder::add64(uint64_t value) {
+  addBytes(&value, sizeof(value));
+}
+inline void AnyObjectBuilder::addBytes(llvm::StringRef value) {
+  addBytes(value.begin(), value.size());
+}
+inline void AnyObjectBuilder::addString(llvm::StringRef value) {
+  addBytes(value);
+  add8(0);
+}
+inline void AnyObjectBuilder::addPointer(const void *object) {
+  addBytes(&object, sizeof(object));
+}
+
+template <class T>
+inline void AnyObjectBuilder::addRelativeReference(ObjectRef<T> object,
+                                                   size_t addend) {
+  assert(root && "builder was moved from");
+  assert(root == object.root &&
+         "adding reference to object from different builder");
+
+  // This assertion can be weakened if we ever need to do relative
+  // references to the interior of subobjects.
+  assert(addend < object.object->requiredAlignment &&
+         "addend too large for requested alignment; will be ambiguous");
+
+  auto offset = self->data.size();
+  RelativeReferenceType ref = 0;
+  addBytes(&ref, sizeof(ref));
+  self->refs.push_back({offset, object.object, addend});
+}
+
+inline void AnyObjectBuilder::addRelativeIndirectReference(const void *value,
+                                                           size_t addend) {
+  auto sub = createSubobject<const void *>();
+  sub.addPointer(value);
+  addRelativeReference(sub.ref(), addend);
+}
+
+inline void
+AnyObjectBuilder::addRelativeReferenceToString(llvm::StringRef value,
+                                               size_t alignment,
+                                               size_t addend) {
+  auto sub = createSubobject<const char>(alignment);
+  sub.addString(value);
+  addRelativeReference(sub.ref(), addend);
+}
+
+template <class T>
+inline SubobjectBuilder<T>
+AnyObjectBuilder::createSubobject(size_t alignment) {
+  auto object = new Object(alignment);
+  root->subobjects.emplace_back(object);
+  return SubobjectBuilder<T>(root, object);
+}
+
+inline void *RootObjectBuilder::finishImpl() {
+  assert(!isFinished());
+
+  // Add all the subobjects to the buffer in self.
+  for (auto &ownedObject: subobjects) {
+    auto obj = ownedObject.get();
+
+    // Determine the offset of the object.
+    assert(!obj->hasAssignedOffset());
+    padToAlignment(obj->requiredAlignment);
+    size_t offset = self->data.size();
+    obj->assignedOffset = offset;
+
+    // Add the object data.
+    self->data.insert(self->data.end(), obj->data.begin(), obj->data.end());
+
+    // Handle refs in the object.
+    for (auto &objRef : obj->refs) {
+      auto ref = objRef.atOffset(offset);
+      if (ref.referent->hasAssignedOffset())
+        fillReference(ref);
+      else
+        self->refs.push_back(ref);
+    }
+
+    obj->clearMemory();
+  }
+
+  // Handle all the unresolved references.
+  for (auto &ref : self->refs) {
+    fillReference(ref);
+  }
+
+  auto leadingOffset = [&] {
+    // Dynamically align the start of the buffer to the required alignment.
+    uintptr_t base = reinterpret_cast<uintptr_t>(&self->data[0]);
+    uintptr_t alignedBase = (base + self->requiredAlignment - 1)
+                               & ~uintptr_t(self->requiredAlignment - 1);
+    return alignedBase - base;
+  };
+
+  finishedPointer = &self->data[0];
+
+  // If we need a non-zero leading offset, adjust the buffer.
+  if (auto requiredPadding = leadingOffset()) {
+    // Make sure we have space for the padding.
+    self->data.reserve(self->data.size() + requiredPadding);
+
+    // That might have reallocated the vector, in which case
+    // the required padding may have changed.
+    requiredPadding = leadingOffset();
+    if (requiredPadding)
+      self->data.insert(self->data.begin(), requiredPadding, '\0');
+
+    assert(requiredPadding == leadingOffset() &&
+           "insert() after reserve() changed leading offset");
+
+    finishedPointer = &self->data[requiredPadding];
+  }
+
+  return finishedPointer;
+}
+
+inline void RootObjectBuilder::fillReference(const Reference &ref) {
+  assert(ref.referent->hasAssignedOffset());
+  ptrdiff_t difference = 
+    (ptrdiff_t) (ref.referent->assignedOffset + ref.addend - ref.offset);
+  auto truncated = (RelativeReferenceType) difference;
+  assert(difference == truncated && "built object > 2GB?");
+  assert(ref.offset + sizeof(truncated) <= self->data.size());
+  std::memcpy(&self->data[ref.offset], &truncated, sizeof(truncated));
+}
+
+} // end namespace swift
+
+#endif

--- a/unittests/runtime/SpecifierDSL.h
+++ b/unittests/runtime/SpecifierDSL.h
@@ -1,0 +1,323 @@
+//===--- SpecifierDSL.h ----------------------------------------*- C++ -*--===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines a little DSL for building metadata objects from specifier
+// values.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SPECIFIER_DSL_H
+#define SPECIFIER_DSL_H
+
+#include "ObjectBuilder.h"
+#include "swift/Basic/TaggedUnion.h"
+#include "swift/ABI/Metadata.h"
+#include <sstream>
+
+namespace swift {
+namespace specifierDSL {
+
+struct TypeSpecifier;
+
+struct IndirectTypeSpecifier {
+  std::unique_ptr<TypeSpecifier> ptr;
+
+  template <class T>
+  IndirectTypeSpecifier(T &&specifier);
+};
+struct ParamTypeSpecifier {
+  unsigned depth;
+  unsigned index;
+};
+struct MemberTypeSpecifier {
+  IndirectTypeSpecifier _base;
+  std::string name;
+
+  const TypeSpecifier &base() const { return *_base.ptr.get(); }
+};
+struct TypeSpecifier : TaggedUnion<ParamTypeSpecifier,
+                                   MemberTypeSpecifier> {
+  using TaggedUnion::TaggedUnion;
+};
+
+template <class T>
+inline IndirectTypeSpecifier::IndirectTypeSpecifier(T &&spec)
+  : ptr(new TypeSpecifier(std::forward<T>(spec))) {}
+
+/// Construct a type specifier for a generic type parameter at the
+/// given depth and index.
+inline TypeSpecifier typeParam(unsigned depth, unsigned index) {
+  return ParamTypeSpecifier{depth, index};
+}
+
+/// Construct a type specifier for a dependent member type.
+inline TypeSpecifier member(TypeSpecifier &&base, std::string &&member) {
+  return MemberTypeSpecifier{std::move(base), std::move(member)};
+}
+
+inline void mangleNatural(AnyObjectBuilder &builder, size_t value) {
+  std::ostringstream str;
+  str << value;
+  builder.addBytes(str.str());
+}
+
+inline void mangleIndex(AnyObjectBuilder &builder, unsigned value) {
+  if (value > 0)
+    mangleNatural(builder, value - 1);
+  builder.add8('_');
+}
+
+inline void mangleIdentifier(AnyObjectBuilder &builder, llvm::StringRef value) {
+  mangleNatural(builder, value.size());
+  // assumes no non-ASCII characters, which is fine for testing
+  builder.addBytes(value);
+}
+
+inline void mangleGenericParamIndex(AnyObjectBuilder &builder,
+                                    unsigned depth, unsigned index) {
+
+  if (depth == 0) {
+    assert(index != 0 && "didn't special-case depth=0, index=0 in caller");
+    builder.add8('q');
+    mangleIndex(builder, index - 1);
+  } else {
+    builder.add8('q');
+    builder.add8('d');
+    mangleIndex(builder, depth - 1);
+    mangleIndex(builder, index);
+  }
+}
+
+inline void mangleGenericParamType(AnyObjectBuilder &builder,
+                                   unsigned depth, unsigned index) {
+  if (depth == 0 && index == 0) {
+    builder.add8('x');
+  } else {
+    builder.add8('q');
+    mangleGenericParamIndex(builder, depth, index);
+  }
+}
+
+inline void
+mangleDependentMemberType(AnyObjectBuilder &builder,
+                          const MemberTypeSpecifier &spec) {
+  std::vector<const std::string *> path;
+  path.push_back(&spec.name);
+
+  auto cur = &spec.base();
+  while (auto member = cur->dyn_cast<MemberTypeSpecifier>()) {
+    path.push_back(&member->name);
+    cur = &member->base();
+  }
+  bool first = true;
+  for (auto *memberName : llvm::reverse(path)) {
+    if (!first) builder.add8('_');
+    first = false;
+    mangleIdentifier(builder, *memberName);
+  }
+  auto &param = cur->get<ParamTypeSpecifier>();
+  if (param.depth == 0 && param.index == 0)
+    builder.addBytes(path.size() == 1 ? "Qz" : "QZ");
+  else {
+    builder.addBytes(path.size() == 1 ? "Qy" : "QY");
+    mangleGenericParamIndex(builder, param.depth, param.index);
+  }
+}
+
+inline ObjectRef<const char>
+createMangledTypeString(AnyObjectBuilder &builder, const TypeSpecifier &spec) {
+  auto nameBuilder = builder.createSubobject<const char>(/*align*/ 2);
+  if (auto paramType = spec.dyn_cast<ParamTypeSpecifier>()) {
+    mangleGenericParamType(nameBuilder, paramType->depth, paramType->index);
+  } else if (auto memberType = spec.dyn_cast<MemberTypeSpecifier>()) {
+    mangleDependentMemberType(builder, *memberType);
+  } else {
+    swift_unreachable("unknown type specifier");
+  }
+  return nameBuilder.ref();
+}
+
+struct ProtocolSpecifier {
+  const ProtocolDescriptor *descriptor;
+};
+
+/// Construct a protocol specifier for a protocol descriptor reference.
+inline ProtocolSpecifier protocol(const ProtocolDescriptor *descriptor) {
+  return ProtocolSpecifier{descriptor};
+}
+
+/// Add a ProtocolDescriptorRef.
+inline void addProtocolDescriptorRef(AnyObjectBuilder &builder,
+                                     const ProtocolSpecifier &spec) {
+  builder.addRelativeIndirectReference(spec.descriptor, /*addend*/ 1);
+}
+
+struct SameTypeReqtSpecifier {
+  TypeSpecifier lhs, rhs;
+};
+struct ConformanceReqtSpecifier {
+  TypeSpecifier type;
+  ProtocolSpecifier protocol;
+  bool isKeyArgument;
+};
+struct ReqtSpecifier : TaggedUnion<SameTypeReqtSpecifier,
+                                   ConformanceReqtSpecifier> {
+  using TaggedUnion::TaggedUnion;
+};
+
+inline ReqtSpecifier sameType(TypeSpecifier &&lhs, TypeSpecifier &&rhs) {
+  return SameTypeReqtSpecifier{std::move(lhs), std::move(rhs)};
+}
+
+inline ReqtSpecifier conforms(TypeSpecifier &&type,
+                              ProtocolSpecifier &&protocol,
+                              bool isKeyArgument = true) {
+  return ConformanceReqtSpecifier{std::move(type), std::move(protocol),
+                                  isKeyArgument};
+}
+
+/// Add a GenericRequirementDescriptor that makes the given two
+/// types the same.
+inline void addSameTypeRequirement(AnyObjectBuilder &builder,
+                                   ObjectRef<const char> type1,
+                                   ObjectRef<const char> type2) {
+  auto flags = GenericRequirementFlags(GenericRequirementKind::SameType,
+                                       /*key argument*/ false,
+                                       /*extra argument*/ false);
+  builder.add32(flags.getIntValue());
+  builder.addRelativeReference(type1);
+  builder.addRelativeReference(type2);
+}
+inline void addSameTypeRequirement(AnyObjectBuilder &builder,
+                                   const TypeSpecifier &type1,
+                                   const TypeSpecifier &type2) {
+  auto type1Object = createMangledTypeString(builder, type1);
+  auto type2Object = createMangledTypeString(builder, type2);
+  addSameTypeRequirement(builder, type1Object, type2Object);
+}
+
+/// Add a GenericRequirementDescriptor that marks the first type
+/// as conforming to the given protocol.
+inline void addConformanceRequirement(AnyObjectBuilder &builder,
+                                      ObjectRef<const char> type,
+                                      const ProtocolSpecifier &protocol,
+                                      bool isKeyArgument = true) {
+  auto flags = GenericRequirementFlags(GenericRequirementKind::Protocol,
+                                       isKeyArgument,
+                                       /*extra argument*/ false);
+  builder.add32(flags.getIntValue());
+  builder.addRelativeReference(type);
+  addProtocolDescriptorRef(builder, protocol);
+}
+inline void addConformanceRequirement(AnyObjectBuilder &builder,
+                                      const TypeSpecifier &type,
+                                      const ProtocolSpecifier &protocol,
+                                      bool isKeyArgument = true) {
+  auto typeObject = createMangledTypeString(builder, type);
+  addConformanceRequirement(builder, typeObject, protocol, isKeyArgument);
+}
+
+static void addGenericRequirements(AnyObjectBuilder &builder,
+                                   llvm::ArrayRef<ReqtSpecifier> reqts) {
+  for (auto &reqt : reqts) {
+    if (auto sameType = reqt.dyn_cast<SameTypeReqtSpecifier>()) {
+      addSameTypeRequirement(builder, sameType->lhs, sameType->rhs);
+    } else if (auto conforms = reqt.dyn_cast<ConformanceReqtSpecifier>()) {
+      addConformanceRequirement(builder, conforms->type, conforms->protocol,
+                                conforms->isKeyArgument);
+    } else {
+      swift_unreachable("unknown requirement specifier");
+    }
+  }
+}
+
+struct GenericSignatureSpecifier {
+  std::vector<GenericParamDescriptor> params;
+  std::vector<ReqtSpecifier> reqts;
+
+  void addSpecifiers() {}
+  template <class S, class... T>
+  void addSpecifiers(S &&spec, T &&...rest) {
+    addSpecifier(std::forward<S>(spec));
+    addSpecifiers(std::forward<T>(rest)...);
+  }
+
+  void addSpecifier(GenericParamDescriptor param) {
+    params.push_back(param);
+  }
+  void addSpecifier(ReqtSpecifier &&reqt) {
+    reqts.push_back(std::move(reqt));
+  }
+};
+
+inline GenericParamDescriptor param() {
+  return GenericParamDescriptor::implicit();
+}
+
+template <class... Specs>
+inline GenericSignatureSpecifier signature(Specs &&...specs) {
+  GenericSignatureSpecifier sig;
+  sig.addSpecifiers(std::forward<Specs>(specs)...);
+  return sig;
+}
+
+inline void addGenericParams(AnyObjectBuilder &builder,
+                             llvm::ArrayRef<GenericParamDescriptor> params) {
+  builder.addBytes(params.data(), params.size());
+}
+
+/// Add a GenericContextDescriptorHeader to the given object.
+inline void addGenericContextDescriptorHeader(AnyObjectBuilder &builder,
+                             llvm::ArrayRef<GenericParamDescriptor> params,
+                             llvm::ArrayRef<ReqtSpecifier> reqts) {
+  unsigned argSizeInWords = 0;
+  for (auto param: params) {
+    if (param.hasKeyArgument())
+      argSizeInWords++;
+  }
+  for (auto &reqt : reqts) {
+    if (auto conf = reqt.dyn_cast<ConformanceReqtSpecifier>())
+      if (conf->isKeyArgument)
+        argSizeInWords++;
+  }
+
+  // NumParams
+  builder.add16(params.size());
+
+  // NumReqts
+  builder.add16(reqts.size());
+
+  // NumKeyArguments
+  builder.add16(argSizeInWords);
+
+  // NumExtraArguments
+  builder.add16(0);
+}
+inline void addGenericContextDescriptorHeader(AnyObjectBuilder &builder,
+                                        const GenericSignatureSpecifier &sig) {
+  addGenericContextDescriptorHeader(builder, sig.params, sig.reqts);
+}
+
+inline void addGenericParams(AnyObjectBuilder &builder,
+                             const GenericSignatureSpecifier &sig) {
+  addGenericParams(builder, sig.params);
+}
+
+inline void addGenericRequirements(AnyObjectBuilder &builder,
+                                   const GenericSignatureSpecifier &sig) {
+  addGenericRequirements(builder, sig.reqts);
+}
+
+} // end namespace specifierDSL
+} // end namespace swift
+
+#endif


### PR DESCRIPTION
The immediate use case is only concretely-constrained existential types, which could use a much simpler representation, but I've future-proofed the representation as much as I can; thus, the requirement signature can have arbitrary parameters and requirements, and the type can have an arbitrary type as the sub-expression.  The latter is also necessary for existential metatypes.

The chief implementation complexity here is that we must be able to agree on the identity of an existential type that might be produced by substitution.  Thus, for example, `any P<T>` when `T == Int` must resolve to the same type metadata as `any P<Int>`.  To handle this, we identify the "shape" of the existential type, consisting of those parts which cannot possibly be the result of substitution, and then abstract the substitutable "holes" as an application of a generalization signature.  That algorithm will come in a later patch; this patch just represents it.

Uniquing existential shapes from the requirements would be quite complex because of all the symbolic mangled names they use. This is particularly true because it's not reasonable to require translation units to agree about what portions they mangle vs. reference symbolically.  Instead, we expect the compiler to do a cryptographic hash of a mangling of the shape, then use that as the unique key identifying the shape.