### PR TITLE
[benchmark] Remove Python 2 logic

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -408,12 +408,7 @@ class MarkdownReportHandler(logging.StreamHandler):
         msg = self.format(record)
         stream = self.stream
         try:
-            # In Python 2 Unicode strings have a special type
-            unicode_type = unicode
-        except NameError:
-            unicode_type = str
-        try:
-            if isinstance(msg, unicode_type) and getattr(stream, "encoding", None):
+            if isinstance(msg, str) and getattr(stream, "encoding", None):
                 stream.write(msg.encode(stream.encoding))
             else:
                 stream.write(msg)

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -18,13 +18,7 @@ import os
 import sys
 import time
 import unittest
-
-try:
-    # for Python 2
-    from StringIO import StringIO
-except ImportError:
-    # for Python 3
-    from io import StringIO
+from io import StringIO
 
 from compare_perf_tests import PerformanceTestResult
 

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -24,11 +24,8 @@ common unit testing patterns that is used in this project.
 
 import logging
 import sys
-try:
-    from StringIO import StringIO  # for Python 2
-except ImportError:
-    from io import StringIO  # for Python 3
 from contextlib import contextmanager
+from io import StringIO
 
 
 @contextmanager


### PR DESCRIPTION
Found a few pieces of Python 2 code. Remove them since we are on Python 3 entirely.