### PR TITLE
findGenericParameterReferences: Do better at honoring 'treatNonResultCovarianceAsInvariant' and 'hasCovariantSelfResult'

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -689,7 +689,7 @@ public:
   bool canDynamicallyBeOptionalType(bool includeExistential);
 
   /// Determine whether this type contains a type parameter somewhere in it.
-  bool hasTypeParameter() {
+  bool hasTypeParameter() const {
     return getRecursiveProperties().hasTypeParameter();
   }
 

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -88,8 +88,18 @@ protocol P14 {
 
 // Never inheritable: parameter is a function accepting a function
 // returning 'Self'.
+// Not Inheritable: method returning tuple containing 'Self'.
+// Not Inheritable: method returning array of 'Self'.
+// Not Inheritable: requirement with reference to covariant 'Self', if this
+// reference is not the uncurried type, stripped of any optionality.
 protocol P15 {
   func f15(_ s: (() -> Self) -> ())
+  func f16() -> (Self, Self)
+  func f17() -> Array<Self>
+  func f18() -> (Never, Array<Self>)
+}
+extension P15 {
+  func f18() -> (Never, Array<Self>) {} // expected-note {{'f18()' declared here}}
 }
 
 // Class A conforms to everything that can be conformed to by a
@@ -265,7 +275,9 @@ class A14 : P14 {
   func f14(_ s: ((A14) -> ()) -> ()) {}
 }
 
-class A15 : P15 {
+class A15 : P15 { // expected-error{{protocol 'P15' requirement 'f18()' cannot be satisfied by a non-final class ('A15') because it uses 'Self' in a non-parameter, non-result type position}}
   func f15(_ s: (() -> A15) -> ()) {} // expected-error{{protocol 'P15' requirement 'f15' cannot be satisfied by a non-final class ('A15') because it uses 'Self' in a non-parameter, non-result type position}}
+  func f16() -> (A15, A15) {} // expected-error{{protocol 'P15' requirement 'f16()' cannot be satisfied by a non-final class ('A15') because it uses 'Self' in a non-parameter, non-result type position}}
+  func f17() -> Array<A15> {} // expected-error{{protocol 'P15' requirement 'f17()' cannot be satisfied by a non-final class ('A15') because it uses 'Self' in a non-parameter, non-result type position}}
 }
 


### PR DESCRIPTION
Robustify the computations associated with these flags in structural positions. The added complexity is unfortunate, but it should go away once support of dynamic Self is generalized. As unrelated as it may look, this is also a preliminary cleanup to the final and most involved part of SE-309.
