### PR TITLE
[SR-16058][Sema] Consider wrapping type variable layers of optionality when warning about checked casts

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7467,13 +7467,20 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
   // we need to store the difference as a signed integer.
   int extraOptionals = fromOptionals.size() - toOptionals.size();
 
-  // "from" expression could be a type variable with value-to-optional
-  // restrictions that we have to account for optionality mismatch.
+  // "from" expression could be a type variable wrapped in an optional e.g.
+  // Optional<$T0>. So when that is the case we have to add this additional
+  // optionality levels to from type.
   const auto subExprType = cs.getType(castExpr->getSubExpr());
-  if (cs.hasConversionRestriction(fromType, subExprType,
-                                  ConversionRestrictionKind::ValueToOptional)) {
-    extraOptionals++;
-    origFromType = OptionalType::get(origFromType);
+  if (subExprType->getOptionalObjectType()) {
+    SmallVector<Type, 4> subExprOptionals;
+    const auto unwrappedSubExprType =
+        subExprType->lookThroughAllOptionalTypes(subExprOptionals);
+    if (unwrappedSubExprType->is<TypeVariableType>()) {
+      extraOptionals += subExprOptionals.size();
+      for (size_t i = 0; i != subExprOptionals.size(); ++i) {
+        origFromType = OptionalType::get(origFromType);
+      }
+    }
   }
 
   // Removing the optionality from to type when the force cast expr is an IUO.

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -680,3 +680,16 @@ func test_SR_15562() {
     // expected-error@-1{{left side of mutating operator has immutable type 'Int'}}
   }
 }
+
+// SR-16058
+extension Dictionary {
+  func SR16058(_: Key) -> Value?? { nil }
+}
+func SR_16058_tests() { 
+  let dict: [Int: String?] = [:]
+  let foo: Int? = 1
+  let _: String? = foo.flatMap { dict[$0] } as? String  // OK
+
+  // More than one optionality wrapping
+  let _: String? = foo.flatMap { dict.SR16058(_: $0) } as? String // OK
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In #39648 I have only considered an extra layer of optionality coming from a value-to-optional constraint restriction. 
But that is not the only case where extra optionals need to be added. This can come from overload resolution of a unresolved member producing as result a generic argument that would be bound by context wrapped in layers of optionality. For example the case in the SR:
```swift
  let dict: [Int: String?] = [:]
  let foo: Int? = 1
  let _: String? = foo.flatMap { dict[$0] } as? String  // OK
```
If we look to the constraints debugging we can se that `checked cast` constraint is 
`$T3 checked cast to String`
Where overload being attempted is
` selected overload set choice Int?.flatMap: $T1 == (($T2) throws -> $T3?) throws -> $T3?`
So when recording warning fixes we should consider these extra layer of optionality(`$T3?`) in the "from" checked cast sub-expression. 

This changes the logic to be based on type of checked cast "from" expression when it is a type variable wrapped in optionals to handle this correctly.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-16058.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
