### PR TITLE
[test] Make spi-available-inline test target dynamic

### DIFF
--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -1,5 +1,5 @@
 // REQUIRES: VENDOR=apple
-// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx11.9
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9
 
 @_spi_available(macOS 10.4, *)
 public class MacOSSPIClass { public init() {} }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Same as #39676, test fails locally running on M1 `did not find a prebuilt standard library for target 'x86_64-apple-macos' compatible with this Swift compiler;`. Since it seems not target specific and is already constrained to `VENDOR=apple` should be fine to just make dynamic target.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
