### PR TITLE
[move-function] Add tests for debug info for owned arguments.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -1539,7 +1539,9 @@ bool DataflowState::cleanupAllDestroyAddr(
     // Make sure to create a new debug_value for the reinit value.
     if (addressDebugInst) {
       if (auto varInfo = addressDebugInst.getVarInfo()) {
-        SILBuilderWithScope reinitBuilder(*reinit);
+        // We need to always insert /after/ the reinit since the value will not
+        // be defined before the value.
+        SILBuilderWithScope reinitBuilder((*reinit)->getNextInstruction());
         reinitBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
         reinitBuilder.createDebugValue(
             addressDebugInst.inst->getLoc(), address, *varInfo, false,

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -85,6 +85,52 @@ public func copyableValueTest() {
     m.doSomething()
 }
 
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo15copyableArgTestyyAA5KlassCnF"(%T21move_function_dbginfo5KlassC* %0)
+//
+// In contrast, we should have a dbg.declare for m since we aren't
+// CHECK: call void @llvm.dbg.declare(metadata {{.*}}** %m.debug, metadata ![[M_COPYABLE_VALUE_TEST:[0-9]*]],
+//
+// We should have a llvm.dbg.addr for k since we moved it.
+// CHECK: call void @llvm.dbg.addr(metadata {{.*}}** %k.debug, metadata ![[K_COPYABLE_VALUE_METADATA:[0-9]*]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br
+//
+// Our undef should be an llvm.dbg.value. Counter-intuitively this works for
+// both llvm.dbg.addr /and/ llvm.dbg.value. Importantly though its metadata
+// should be for k since that is the variable that we are telling the debugger
+// is no longer defined.
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_VALUE_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+// CHECK-NOT: br label
+//
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name{{.*}}("$s3out15copyableArgTestyyAA5KlassCnF")
+// DWARF-NEXT: DW_AT_name ("copyableArgTest")
+// DWARF-NEXT: DW_AT_decl_file
+// DWARF-NEXT: DW_AT_decl_line
+// DWARF-NEXT: DW_AT_type
+// DWARF-NEXT: DW_AT_external	(true)
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name	("k")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location	(DW_OP_fbreg
+// DWARF-NEXT: DW_AT_name	("m")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+public func copyableArgTest(_ k: __owned Klass) {
+    k.doSomething()
+    let m = _move(k)
+    m.doSomething()
+}
+
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo15copyableVarTestyyF"()
 // CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** [[VAR:%.*]], metadata ![[K_COPYABLE_VAR_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
@@ -122,6 +168,50 @@ public func copyableValueTest() {
 // DWARF-NEXT: DW_AT_type	(
 public func copyableVarTest() {
     var k = Klass()
+    k.doSomething()
+    let m = _move(k)
+    m.doSomething()
+    k = Klass()
+    k.doSomething()
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18copyableVarArgTestyyAA5KlassCzF"(
+// CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR:%.*]], metadata ![[K_COPYABLE_VAR_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br
+// CHECK: call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// TODO: Should this be a deref like the original?
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR]], metadata ![[K_COPYABLE_VAR_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT: br
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name	("$s3out18copyableVarArgTestyyAA5KlassCzF")
+// DWARF-NEXT: DW_AT_name	("copyableVarArgTest")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+// DWARF-NEXT: DW_AT_external	(
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location	(0x{{[a-z0-9]+}}:
+// We check that we get two separate locations for the different lifetimes of
+// the values.
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// TODO: This is incorrect.
+// XWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name	("k")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location	(DW_OP_fbreg -24)
+// DWARF-NEXT: DW_AT_name	("m")
+// DWARF-NEXT: DW_AT_decl_file	(
+// DWARF-NEXT: DW_AT_decl_line	(
+// DWARF-NEXT: DW_AT_type	(
+public func copyableVarArgTest(_ k: inout Klass) {
     k.doSomething()
     let m = _move(k)
     m.doSomething()
@@ -180,6 +270,48 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
     m.doSomething()
 }
 
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo23addressOnlyValueArgTestyyxnAA1PRzlF"(
+// CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
+// CHECK: @llvm.dbg.declare(metadata i8** %m.debug,
+// CHECK: @llvm.dbg.addr(metadata %swift.opaque** %k.debug, metadata ![[K_ADDR_LET_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDR_LET_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name   ("$s3out23addressOnlyValueArgTestyyxnAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyValueArgTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
+    k.doSomething()
+    let m = _move(k)
+    m.doSomething()
+}
+
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo18addressOnlyVarTestyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T, i8** %T.P)
 // CHECK: @llvm.dbg.declare(metadata %swift.type** %T1,
 // CHECK: @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
@@ -222,6 +354,7 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // DWARF: DW_TAG_variable
 // DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
 // DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// TODO: Missing def in dbg info here.
 // DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
 // DWARF-NEXT: DW_AT_name      ("k")
 // DWARF-NEXT: DW_AT_decl_file (
@@ -229,6 +362,62 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // DWARF-NEXT: DW_AT_type      (
 public func addressOnlyVarTest<T : P>(_ x: T) {
     var k = x
+    k.doSomething()
+    let m = _move(k)
+    m.doSomething()
+    k = x
+    k.doSomething()
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo21addressOnlyVarArgTestyyxz_xtAA1PRzlF"(
+// CHECK: call void @llvm.dbg.declare(metadata %swift.type** %T1,
+// CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %x.debug,
+// CHECK: call void @llvm.dbg.declare(metadata i8** %m.debug,
+// CHECK: call void @llvm.dbg.addr(metadata %swift.opaque** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br
+// CHECK: @llvm.dbg.value(metadata %swift.opaque* undef, metadata ![[K_ADDRONLY_VAR_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK: @llvm.dbg.addr(metadata %swift.opaque** %k.debug, metadata ![[K_ADDRONLY_VAR_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT: br
+// CHECK: ret void
+// CHECK-NEXT: }
+//
+// DWARF: DW_AT_linkage_name   ("$s3out21addressOnlyVarArgTestyyxz_xtAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyVarArgTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// TODO: We are missing a debug_value in codegen.
+// XWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("x")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
     k.doSomething()
     let m = _move(k)
     m.doSomething()
@@ -251,6 +440,23 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 // CHECK:    call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_LET_CCFLOW_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
 public func copyableValueCCFlowTest() {
     let k = Klass()
+    k.doSomething()
+    if trueValue {
+        let m = _move(k)
+        m.doSomething()
+    }
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo26copyableValueArgCCFlowTestyyAA5KlassCnF"(
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC** %k.debug, metadata ![[K_COPYABLE_LET_CCFLOW_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]+]]
+// CHECK-NEXT: br label %[[NEXT_BB:[a-z\.0-9]+]],
+//
+// CHECK: [[NEXT_BB]]:
+// CHECK:    br i1 {{%[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
+//
+// CHECK: [[LHS]]:
+// CHECK:    call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC* undef, metadata ![[K_COPYABLE_LET_CCFLOW_METADATA]], metadata !DIExpression()), !dbg ![[ADDR_LOC]]
+public func copyableValueArgCCFlowTest(_ k: __owned Klass) {
     k.doSomething()
     if trueValue {
         let m = _move(k)
@@ -281,6 +487,36 @@ public func copyableValueCCFlowTest() {
 // CHECK-NEXT: }
 public func copyableVarTestCCFlowReinitOutOfBlockTest() {
     var k = Klass()
+    k.doSomething()
+    if trueValue {
+        let m = _move(k)
+        m.doSomething()
+    }
+    k = Klass()
+    k.doSomething()
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040copyableVarArgTestCCFlowReinitOutOfBlockG0yyAA5KlassCzF"(
+// CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR:%.*]], metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
+//
+// CHECK: [[BB_NEXT]]:
+// CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
+//
+// CHECK: [[LHS]]:
+// CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK:      br label %[[CONT_BB:[0-9]+]],
+//
+// CHECK: [[RHS]]:
+// CHECK:      br label %[[CONT_BB]],
+//
+// CHECK: [[CONT_BB]]:
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR]], metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT: br
+// CHECK: ret void
+// CHECK-NEXT: }
+public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
     k.doSomething()
     if trueValue {
         let m = _move(k)
@@ -325,6 +561,40 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
     k.doSomething()
 }
 
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo037copyableVarArgTestCCFlowReinitInBlockG0yyAA5KlassCzF"(
+// CHECK: entry:
+// CHECK: call void @llvm.dbg.declare(metadata %T21move_function_dbginfo5KlassC** %m.debug,
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR:%.*]], metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
+//
+// CHECK: [[BB_NEXT]]:
+// CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
+//
+// CHECK: [[LHS]]:
+// CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo5KlassC** undef, metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// TODO: Should this be a deref like the original?
+// CHECK:      call void @llvm.dbg.addr(metadata %T21move_function_dbginfo5KlassC*** [[VAR]], metadata ![[K_COPYABLE_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT:      br label %[[BB_NEXT_2:[a-z\.0-9]+]],
+//
+// CHECK: [[BB_NEXT_2]]:
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
+//
+// CHECK: [[RHS]]:
+// CHECK:      br label %[[CONT_BB]],
+//
+// CHECK: [[CONT_BB]]:
+// CHECK: ret void
+// CHECK-NEXT: }
+public func copyableVarArgTestCCFlowReinitInBlockTest(_ k: inout Klass) {
+    k.doSomething()
+    if trueValue {
+        let m = _move(k)
+        m.doSomething()
+        k = Klass()
+    }
+    k.doSomething()
+}
+
 // CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040addressOnlyVarTestCCFlowReinitOutOfBlockG0yyxmAA1PRzlF"(
 // CHECK: entry:
 // CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP* [[VAR:%.*]], metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], metadata !DIExpression()), !dbg ![[ADDR_LOC:[0-9]*]]
@@ -348,6 +618,37 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
 // CHECK-NEXT: }
 public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
     var k = T.value
+    k.doSomething()
+    if trueValue {
+        let m = _move(k)
+        m.doSomething()
+    }
+    k = T.value
+    k.doSomething()
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo043addressOnlyVarArgTestCCFlowReinitOutOfBlockH0yyAA1P_pz_xmtAaCRzlF"(
+// CHECK: entry:
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP** [[VAR:%.*]], metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
+//
+// CHECK: [[BB_NEXT]]:
+// CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
+//
+// CHECK: [[LHS]]:
+// CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo1PP* undef, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
+//
+// CHECK: [[RHS]]:
+// CHECK:      br label %[[CONT_BB]],
+//
+// CHECK: [[CONT_BB]]:
+// TODO: Should this be a deref like the original?
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP** [[VAR]], metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT: br
+// CHECK: ret void
+// CHECK-NEXT: }
+public func addressOnlyVarArgTestCCFlowReinitOutOfBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
     k.doSomething()
     if trueValue {
         let m = _move(k)
@@ -382,6 +683,39 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 // CHECK-NEXT: }
 public func addressOnlyVarTestCCFlowReinitInBlockTest<T : P>(_ x: T.Type) {
     var k = T.value
+    k.doSomething()
+    if trueValue {
+        let m = _move(k)
+        m.doSomething()
+        k = T.value
+    }
+    k.doSomething()
+}
+
+// CHECK-LABEL: define swiftcc void @"$s21move_function_dbginfo040addressOnlyVarArgTestCCFlowReinitInBlockH0yyAA1P_pz_xmtAaCRzlF"(
+// CHECK: entry:
+// CHECK: call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP** [[VAR:%.*]], metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA:[0-9]+]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC:[0-9]*]]
+// CHECK-NEXT: br label %[[BB_NEXT:[a-z0-9\.]+]],
+//
+// CHECK: [[BB_NEXT]]:
+// CHECK:      br i1 %{{[0-9]+}}, label %[[LHS:[0-9]+]], label %[[RHS:[0-9]+]],
+//
+// CHECK: [[LHS]]:
+// CHECK:      call void @llvm.dbg.value(metadata %T21move_function_dbginfo1PP* undef, metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// TODO: Should this be a deref like the original?
+// CHECK:      call void @llvm.dbg.addr(metadata %T21move_function_dbginfo1PP** [[VAR]], metadata ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]], metadata !DIExpression(DW_OP_deref)), !dbg ![[ADDR_LOC]]
+// CHECK-NEXT:      br label %[[BB_NEXT_2:[a-z\.0-9]+]],
+//
+// CHECK: [[BB_NEXT_2]]:
+// CHECK:      br label %[[CONT_BB:[a-z\.0-9]+]],
+//
+// CHECK: [[RHS]]:
+// CHECK:      br label %[[CONT_BB]],
+//
+// CHECK: [[CONT_BB]]:
+// CHECK: ret void
+// CHECK-NEXT: }
+public func addressOnlyVarArgTestCCFlowReinitInBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
     k.doSomething()
     if trueValue {
         let m = _move(k)

--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars_crash.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars_crash.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only %s -parse-stdlib -emit-sil -o /dev/null
+
+// REQUIRES: optimized_stdlib
+
+import Swift
+
+var booleanValue: Bool { true }
+
+public class Klass {
+    func doSomething() { print("something") }
+}
+
+
+// Make sure we put the dbg_info after the reinit, not before it. Otherwise this
+// test case crashes b/c we are using the value before it is reinited.
+public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
+    k.doSomething()
+    if booleanValue {
+        let m = _move(k)
+        m.doSomething()
+    }
+    k = Klass()
+    k.doSomething()
+}
+


### PR DESCRIPTION
The first commit fixes a small issue where I was inserted a debug_info inst before a reinit instead of after. The main commit is the 2nd one.

----
[move-function] Add tests for debug info for owned arguments.

Some notes:

1. I only updated the dwarf dump checks for the cases where the test case I was
   adding already had checks. The rest I am going to add the dwarf checks all at
   once in a subsequent commit.

2. In the dwarf checks that I wrote, there are a few issues that show up due to
   some LLVM fixes that I need to finish upstreaming. Once I upstream them, I will
   be able to enable the specific patterns I have disabled. This ensures I atleast
   will be able to tell if I am changing the current codegen.

3. This is dependent on the previous commit since one of the test cases hit the
   bug fixed by the first commit in the PR.
