### PR TITLE
[LangOptions] Specify PowerPC 32-bit as big endian

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -393,6 +393,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::ArchType::riscv64:
     addPlatformConditionValue(PlatformConditionKind::Endianness, "little");
     break;
+  case llvm::Triple::ArchType::ppc:
   case llvm::Triple::ArchType::ppc64:
   case llvm::Triple::ArchType::systemz:
     addPlatformConditionValue(PlatformConditionKind::Endianness, "big");


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add fixes PowerPC 32-bit support:
- Specify PPC32 as big endian (e.g. `#if _endian(big)`)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-15945](https://github.com/apple/swift/issues/58206)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
