### PR TITLE
[CSApply] NFC: Remove unused `cs` variable

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6020,7 +6020,6 @@ static Expr *buildElementConversion(ExprRewriter &rewriter,
                                     Type destType, bool bridged,
                                     ConstraintLocatorBuilder locator,
                                     Expr *element) {
-  auto &cs = rewriter.getConstraintSystem();
   if (bridged &&
       TypeChecker::typeCheckCheckedCast(srcType, destType,
                                         CheckedCastContextKind::None,


### PR DESCRIPTION
After switching to use a declaration context of rewriter,
variable `cs` became obsolete.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
