### PR TITLE
Handle output file maps that use the key "objc-header".

### DIFF
--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -61,6 +61,7 @@ ID file_types::lookupTypeForName(StringRef Name) {
 #define TYPE(NAME, ID, EXTENSION, FLAGS) \
            .Case(NAME, TY_##ID)
 #include "swift/Basic/FileTypes.def"
+      .Case("objc-header", TY_ClangHeader)
       .Default(TY_INVALID);
 }
 

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -13,6 +13,13 @@
 // RUN: %check-in-clang %t/enums.WMO.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.WMO.h -include ctypes.h -include CoreFoundation.h
 
+// Ensure that providing the output header path via the supplementary output
+// file map also works.
+
+// RUN: echo "{\"%s\": {\"objc-header\": \"%t/enums-supplemental.h\"}}" > %t-output-file-map.json
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %s -enable-source-import -typecheck -supplementary-output-file-map %t-output-file-map.json -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck -check-prefix CHECK-SUPPLEMENTAL %s < %t/enums-supplemental.h
+
 // REQUIRES: objc_interop
 
 import Foundation
@@ -22,6 +29,9 @@ import Foundation
 // CHECK-LABEL: enum FooComments : NSInteger;
 // CHECK-LABEL: enum NegativeValues : int16_t;
 // CHECK-LABEL: enum ObjcEnumNamed : NSInteger;
+
+// CHECK-SUPPLEMENTAL: enum NegativeValues : int16_t;
+// CHECK-SUPPLEMENTAL: enum ObjcEnumNamed : NSInteger;
 
 // CHECK-LABEL: @interface AnEnumMethod
 // CHECK-NEXT: - (enum NegativeValues)takeAndReturnEnum:(enum FooComments)foo SWIFT_WARN_UNUSED_RESULT;


### PR DESCRIPTION
This anachronously-named key is nonetheless still important to accept,
or else we'll fail to emit the generated header.

Fixes rdar://90900115.
