### PR TITLE
Map case variable types out of context.

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1516,7 +1516,8 @@ public:
     for (auto *expected : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
       assert(expected->hasName());
       auto prev = expected->getParentVarDecl();
-      auto type = solution.resolveInterfaceType(solution.getType(prev));
+      auto type = solution.resolveInterfaceType(
+          solution.getType(prev)->mapTypeOutOfContext());
       expected->setInterfaceType(type);
     }
 

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1349,7 +1349,8 @@ private:
     for (auto *expected : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
       assert(expected->hasName());
       auto prev = expected->getParentVarDecl();
-      auto type = solution.resolveInterfaceType(solution.getType(prev));
+      auto type = solution.resolveInterfaceType(
+          solution.getType(prev)->mapTypeOutOfContext());
       expected->setInterfaceType(type);
     }
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1172,3 +1172,15 @@ func test(arr: [[Int]]) {
   arr.map { ($0 as? [Int]).map { A($0) } } // expected-error {{missing argument label 'arg:' in call}} {{36-36=arg: }}
   // expected-warning@-1 {{conditional cast from '[Int]' to '[Int]' always succeeds}}
 }
+
+func closureWithCaseArchetype<T>(_: T.Type) {
+  let _ = { (any: Any) throws -> Any? in
+    switch any {
+    case let type as T:
+      return type
+
+    default:
+      return any
+    }
+  }
+}


### PR DESCRIPTION
Otherwise, we end up recording contextual types here.
