### PR TITLE
IRGen: Fix enable-testing of internal with resilient super class

### DIFF
--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -93,7 +93,7 @@ public:
     asImpl().addIVarDestroyer();
 
     // Class members.
-    addClassMembers(Target);
+    addClassMembers(Target, Target);
   }
 
   /// Notes the beginning of the field offset vector for a particular ancestor
@@ -110,9 +110,11 @@ public:
         
 private:
   /// Add fields associated with the given class and its bases.
-  void addClassMembers(ClassDecl *theClass) {
+  void addClassMembers(ClassDecl *theClass,
+                       ClassDecl *rootClass) {
     // Visit the superclass first.
     if (auto *superclassDecl = theClass->getSuperclassDecl()) {
+
       if (superclassDecl->hasClangNode()) {
         // Nothing to do; Objective-C classes do not add new members to
         // Swift class metadata.
@@ -123,10 +125,9 @@ private:
       //    not publically accessible (e.g private or internal). This would
       //    normally not happen except if we compile theClass's module with
       //    enable-testing.
-      } else if (IGM.hasResilientMetadata(superclassDecl, ResilienceExpansion::Maximal) &&
-                 (theClass->getModuleContext() == IGM.getSwiftModule() ||
-                 theClass->getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublic())) {
+      } else if (IGM.hasResilientMetadata(superclassDecl,
+                                          ResilienceExpansion::Maximal,
+                                          rootClass)) {
         // Runtime metadata instantiation will initialize our field offset
         // vector and vtable entries.
         //
@@ -137,7 +138,8 @@ private:
         // NB: We don't apply superclass substitutions to members because we want
         // consistent metadata layout between generic superclasses and concrete
         // subclasses.
-        addClassMembers(superclassDecl);
+        addClassMembers(superclassDecl,
+                        rootClass);
       }
     }
 
@@ -151,7 +153,8 @@ private:
 
     // If the class has resilient storage, we cannot make any assumptions about
     // its storage layout, so skip the rest of this method.
-    if (IGM.isResilient(theClass, ResilienceExpansion::Maximal))
+    if (IGM.isResilient(theClass, ResilienceExpansion::Maximal,
+                        rootClass))
       return;
 
     // A class only really *needs* a field-offset vector in the
@@ -175,7 +178,8 @@ private:
 
     // If the class has resilient metadata, we cannot make any assumptions
     // about its metadata layout, so skip the rest of this method.
-    if (IGM.hasResilientMetadata(theClass, ResilienceExpansion::Maximal))
+    if (IGM.hasResilientMetadata(theClass, ResilienceExpansion::Maximal,
+                                 rootClass))
       return;
 
     // Add vtable entries.

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -229,11 +229,14 @@ namespace {
         auto superclassDecl = superclassType.getClassOrBoundGenericClass();
         assert(superclassType && superclassDecl);
 
-        if (IGM.hasResilientMetadata(superclassDecl, ResilienceExpansion::Maximal))
+        if (IGM.hasResilientMetadata(superclassDecl,
+                                     ResilienceExpansion::Maximal,
+                                     rootClass))
           Options |= ClassMetadataFlags::ClassHasResilientAncestry;
 
         // If the superclass has resilient storage, don't walk its fields.
-        if (IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal)) {
+        if (IGM.isResilient(superclassDecl, ResilienceExpansion::Maximal,
+                            rootClass)) {
           Options |= ClassMetadataFlags::ClassHasResilientMembers;
 
           // If the superclass is generic, we have to assume that its layout
@@ -263,10 +266,11 @@ namespace {
       if (classHasIncompleteLayout(IGM, theClass))
         Options |= ClassMetadataFlags::ClassHasMissingMembers;
 
-      if (IGM.hasResilientMetadata(theClass, ResilienceExpansion::Maximal))
+      if (IGM.hasResilientMetadata(theClass, ResilienceExpansion::Maximal,
+                                   rootClass))
         Options |= ClassMetadataFlags::ClassHasResilientAncestry;
 
-      if (IGM.isResilient(theClass, ResilienceExpansion::Maximal)) {
+      if (IGM.isResilient(theClass, ResilienceExpansion::Maximal, rootClass)) {
         Options |= ClassMetadataFlags::ClassHasResilientMembers;
         return;
       }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -977,8 +977,10 @@ public:
   substOpaqueTypesWithUnderlyingTypes(CanType type,
                                       ProtocolConformanceRef conformance);
 
-  bool isResilient(NominalTypeDecl *decl, ResilienceExpansion expansion);
-  bool hasResilientMetadata(ClassDecl *decl, ResilienceExpansion expansion);
+  bool isResilient(NominalTypeDecl *decl, ResilienceExpansion expansion,
+                   ClassDecl *asViewedFromRootClass = nullptr);
+  bool hasResilientMetadata(ClassDecl *decl, ResilienceExpansion expansion,
+                            ClassDecl *asViewedFromRootClass = nullptr);
   ResilienceExpansion getResilienceExpansionForAccess(NominalTypeDecl *decl);
   ResilienceExpansion getResilienceExpansionForLayout(NominalTypeDecl *decl);
   ResilienceExpansion getResilienceExpansionForLayout(SILGlobalVariable *var);

--- a/test/IRGen/Inputs/resilient-class.swift
+++ b/test/IRGen/Inputs/resilient-class.swift
@@ -1,7 +1,18 @@
 open class Base {
-    var x = 1
+   var x = 1
+}
+internal struct TypeContainer {
+
+  enum SomeEnum:String {
+    case FirstCase = "first"
+    case SecondCase = "second"
+  }
 }
 
 internal class SubClass : Base {
-    var y = 2
+    var y : TypeContainer.SomeEnum
+
+    override init() {
+        y = .FirstCase
+    }
 }

--- a/test/IRGen/testing-enabled-resilient-super-class.swift
+++ b/test/IRGen/testing-enabled-resilient-super-class.swift
@@ -7,6 +7,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(resilient)) %S/Inputs/resilient-class.swift -module-name resilient -emit-module -emit-module-path %t/resilient.swiftmodule -enable-library-evolution -enable-testing
 // RUN: %target-build-swift -I %t -L %t -lresilient %s -o %t/main %target-rpath(%t)
 // RUN: %target-build-swift -O -I %t -L %t -lresilient %s -o %t/main %target-rpath(%t)
+// RUN: %target-run %t/main %t/%target-library-name(resilient) | %FileCheck --check-prefix=EXEC-CHECK %s
 
 @testable import resilient
 
@@ -14,7 +15,14 @@
 
 // CHECK-NOT: s9resilient8SubClassCMo
 
+public func isEqual<T:Equatable>(_ l: T, _ r: T) -> Bool {
+    return l == r
+}
+
 public func testCase() {
   let t = SubClass()
-  print(t.y)
+  print(t.y)  // EXEC-CHECK: FirstCase
+  print("isEqual \(isEqual(t.y, .FirstCase))") // EXEC-CHECK: isEqual true
 }
+
+testCase()


### PR DESCRIPTION
Enable testing makes `internal` types visible from outside the module.
We can no longer treat super classes as resilient.

Follow-up to #41044.

rdar://90489618