### PR TITLE
Add RegexBuilder module.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -125,6 +125,7 @@ if(SWIFT_BUILD_STDLIB)
   if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
     add_subdirectory(MatchingEngine)
     add_subdirectory(StringProcessing)
+    add_subdirectory(RegexBuilder)
   endif()
 endif()
 

--- a/stdlib/public/RegexBuilder/CMakeLists.txt
+++ b/stdlib/public/RegexBuilder/CMakeLists.txt
@@ -1,0 +1,48 @@
+#===--- CMakeLists.txt - String processing support library -----------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===------------------------------------------------------------------------===#
+
+set(swift_regex_builder_link_libraries
+  swiftCore
+  swift_MatchingEngine
+  swift_StringProcessing)
+
+file(GLOB_RECURSE _REGEX_BUILDER_SOURCES
+  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/RegexBuilder/*.swift")
+set(REGEX_BUILDER_SOURCES)
+foreach(source ${_REGEX_BUILDER_SOURCES})
+  file(TO_CMAKE_PATH "${source}" source)
+  list(APPEND REGEX_BUILDER_SOURCES ${source})
+endforeach()
+message(STATUS "Using Experimental String Processing library for RegexBuilder (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
+
+add_swift_target_library(swiftRegexBuilder ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  "${REGEX_BUILDER_SOURCES}"
+
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_OPENBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
+  SWIFT_MODULE_DEPENDS_WINDOWS CRT
+
+  LINK_LIBRARIES ${swift_regex_builder_link_libraries}
+
+  C_COMPILE_FLAGS
+    -DswiftRegexBuilder_EXPORTS
+  SWIFT_COMPILE_FLAGS
+    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -Xfrontend -enable-experimental-pairwise-build-block
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+
+  SWIFT_MODULE_DEPENDS _StringProcessing
+  INSTALL_IN_COMPONENT stdlib
+)


### PR DESCRIPTION
The [regex builder DSL](https://forums.swift.org/t/pitch-regex-builder-dsl/56007) proposal adds regex builder to a new module named `RegexBuilder`.

Friend PR: apple/swift-experimental-string-processing#231