### PR TITLE
Tests: Use `REQUIRES: maccatalyst_support` instead of `REQUIRES: OS=maccatalyst`

### DIFF
--- a/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/macabiTargetEnv.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -swift-version 4 -typecheck %s -verify -target x86_64-apple-ios12.0-macabi -parse-stdlib
 // RUN: %swift-ide-test -swift-version 4 -test-input-complete -source-filename=%s -target x86_64-apple-ios12.0-macabi
 
-// REQUIRES: OS=maccatalyst
+// REQUIRES: maccatalyst_support
 
 #if targetEnvironment(macabi) // expected-warning {{'macabi' has been renamed to 'macCatalyst'}} {{23-29=macCatalyst}}
 func underMacABI() {

--- a/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module_availability_maccatalyst_is_deprecated.swift
@@ -1,4 +1,5 @@
-// REQUIRES: OS=maccatalyst
+// REQUIRES: maccatalyst_support
+// REQUIRES: rdar90937993
 
 // RUN: %empty-directory(%t.mod)
 // RUN: %swift -emit-module -target x86_64-apple-ios13.1-macabi -o %t.mod/availability.swiftmodule %S/Inputs/availability_maccatalyst_is_deprecated.swift -parse-as-library -emit-module-doc-path %t.mod/availability.swiftdoc

--- a/test/attr/attr_availability_maccatalyst.swift
+++ b/test/attr/attr_availability_maccatalyst.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -typecheck -verify -parse-stdlib -target x86_64-apple-ios51.0-macabi %s
 
-// REQUIRES: OS=maccatalyst
+// REQUIRES: maccatalyst_support
 
 @available(macCatalyst, introduced: 1.0, deprecated: 2.0, obsoleted: 9.0,
            message: "you don't want to do that anyway")


### PR DESCRIPTION
Use `REQUIRES: maccatalyst_support` instead of `REQUIRES: OS=maccatalyst` whereever possible to broaden coverage for MacCatalyst specific tests. These tests did not need the runtime OS to be MacCatalyst; they need the compiler to support `macabi` triples (e.g. `-target x86_64-apple-ios13.1-macabi`).

Also, disable a test that has rotted because it had not been running in CI.

Resolves rdar://90937822
