### PR TITLE
Fix statically linked concurrency on Linux

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -209,10 +209,13 @@ foreach(sdk ${SWIFT_SDKS})
     if(${SWIFT_SDK_${sdk}_OBJECT_FORMAT} STREQUAL ELF)
       string(TOLOWER "${sdk}" lowercase_sdk)
       set(libpthread -lpthread)
+      set(concurrency_libs)
       set(android_libraries)
       if(${sdk} STREQUAL ANDROID)
         set(android_libraries -llog)
         set(libpthread)
+      elseif(SWIFT_CONCURRENCY_USES_DISPATCH)
+        set(concurrency_libs "-ldispatch -lBlocksRuntime")
       endif()
 
       set(linkfile ${lowercase_sdk}/static-stdlib-args.lnk)
@@ -221,6 +224,7 @@ foreach(sdk ${SWIFT_SDKS})
 ${libpthread}
 ${android_libraries}
 -lswiftCore
+${concurrency_libs}
 -lstdc++
 -lm
 -Xlinker -export-dynamic

--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -6,6 +6,8 @@
 -undefined=pthread_once
 -Xlinker
 -undefined=pthread_key_create
+-ldispatch
+-lBlocksRuntime
 -lpthread
 -licui18nswift
 -licuucswift


### PR DESCRIPTION
Generating a statically-linked executable either with
`-static-executable` or `-static-stdlib` that contains concurrency needs
to link the concurrency libraries or the missing symbols will cause link
failures.

This patch adds dispatch and blocks runtime to the list of statically
linked libraries. In the case of the static stdlib, it only adds them if
the concurrency mechanisms use dispatch, otherwise it doesn't.

For the static executable, it always adds them since that doesn't appear
to be very configurable.