### PR TITLE
[TypeChecker] Allow opaque to have multiple underlying types based on availability

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2840,7 +2840,7 @@ private:
   /// expressed as a SubstitutionMap for the opaque interface generic signature.
   /// This maps types in the interface generic signature to the outer generic
   /// signature of the original declaration.
-  Optional<SubstitutionMap> UnderlyingTypeSubstitutions;
+  Optional<SubstitutionMap> UniqueUnderlyingType;
 
   /// A set of substitutions which are used based on the availability
   /// checks performed at runtime. This set of only populated if there
@@ -2922,16 +2922,16 @@ public:
   }
 
   /// The substitutions that map the generic parameters of the opaque type to
-  /// their underlying types, when that information is known.
-  Optional<SubstitutionMap> getUnderlyingTypeSubstitutions() const {
-    return UnderlyingTypeSubstitutions;
+  /// the unique underlying types, when that information is known.
+  Optional<SubstitutionMap> getUniqueUnderlyingTypeSubstitutions() const {
+    return UniqueUnderlyingType;
   }
   
-  void setUnderlyingTypeSubstitutions(SubstitutionMap subs) {
-    assert(!UnderlyingTypeSubstitutions.hasValue() && "resetting underlying type?!");
-    UnderlyingTypeSubstitutions = subs;
+  void setUniqueUnderlyingTypeSubstitutions(SubstitutionMap subs) {
+    assert(!UniqueUnderlyingType.hasValue() && "resetting underlying type?!");
+    UniqueUnderlyingType = subs;
   }
-t
+
   void setConditionallyAvailableSubstitutions(
       ArrayRef<ConditionallyAvailableSubstitutions *> substitutions) {
     assert(!ConditionallyAvailableTypes &&

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -572,7 +572,7 @@ namespace {
         << OTD->getDeclaredInterfaceType().getString();
       OS << " in "
          << OTD->getOpaqueInterfaceGenericSignature()->getAsString();
-      if (auto underlyingSubs = OTD->getUnderlyingTypeSubstitutions()) {
+      if (auto underlyingSubs = OTD->getUniqueUnderlyingTypeSubstitutions()) {
         OS << " underlying:\n";
         SmallPtrSet<const ProtocolConformance *, 4> Dumped;
         dumpSubstitutionMapRec(*underlyingSubs, OS,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8173,6 +8173,26 @@ Identifier OpaqueTypeDecl::getOpaqueReturnTypeIdentifier() const {
   return OpaqueReturnTypeIdentifier;
 }
 
+OpaqueTypeDecl::ConditionalAlternatives *
+OpaqueTypeDecl::ConditionalAlternatives::get(
+    ASTContext &ctx,
+    ArrayRef<ConditionallyAvailableSubstitutions *> underlyingTypes) {
+  auto size = totalSizeToAlloc<ConditionallyAvailableSubstitutions *>(
+      underlyingTypes.size());
+  auto mem = ctx.Allocate(size, alignof(ConditionalAlternatives));
+  return new (mem) ConditionalAlternatives(underlyingTypes);
+}
+
+OpaqueTypeDecl::ConditionallyAvailableSubstitutions *
+OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
+    ASTContext &ctx, ArrayRef<VersionRange> availabilityContext,
+    SubstitutionMap substitutions) {
+  auto size = totalSizeToAlloc<VersionRange>(availabilityContext.size());
+  auto mem = ctx.Allocate(size, alignof(ConditionallyAvailableSubstitutions));
+  return new (mem)
+      ConditionallyAvailableSubstitutions(availabilityContext, substitutions);
+}
+
 bool AbstractFunctionDecl::hasInlinableBodyText() const {
   switch (getBodyKind()) {
   case BodyKind::Deserialized:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8173,14 +8173,11 @@ Identifier OpaqueTypeDecl::getOpaqueReturnTypeIdentifier() const {
   return OpaqueReturnTypeIdentifier;
 }
 
-OpaqueTypeDecl::ConditionalAlternatives *
-OpaqueTypeDecl::ConditionalAlternatives::get(
-    ASTContext &ctx,
-    ArrayRef<ConditionallyAvailableSubstitutions *> underlyingTypes) {
-  auto size = totalSizeToAlloc<ConditionallyAvailableSubstitutions *>(
-      underlyingTypes.size());
-  auto mem = ctx.Allocate(size, alignof(ConditionalAlternatives));
-  return new (mem) ConditionalAlternatives(underlyingTypes);
+void OpaqueTypeDecl::setConditionallyAvailableSubstitutions(
+    ArrayRef<ConditionallyAvailableSubstitutions *> substitutions) {
+  assert(!ConditionallyAvailableTypes &&
+         "resetting conditionally available substitutions?!");
+  ConditionallyAvailableTypes = getASTContext().AllocateCopy(substitutions);
 }
 
 OpaqueTypeDecl::ConditionallyAvailableSubstitutions *

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3638,7 +3638,7 @@ operator()(SubstitutableType *maybeOpaqueType) const {
     return maybeOpaqueType;
   }
 
-  auto subs = opaqueRoot->getDecl()->getUnderlyingTypeSubstitutions();
+  auto subs = opaqueRoot->getDecl()->getUniqueUnderlyingTypeSubstitutions();
   // If the body of the opaque decl providing decl has not been type checked we
   // don't have a underlying subsitution.
   if (!subs.hasValue())
@@ -3749,7 +3749,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
     return abstractRef;
   }
 
-  auto subs = opaqueRoot->getDecl()->getUnderlyingTypeSubstitutions();
+  auto subs = opaqueRoot->getDecl()->getUniqueUnderlyingTypeSubstitutions();
   // If the body of the opaque decl providing decl has not been type checked we
   // don't have a underlying subsitution.
   if (!subs.hasValue())

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2040,7 +2040,7 @@ namespace {
     void addUnderlyingTypeAndConformances() {
       auto sig = O->getOpaqueInterfaceGenericSignature();
       auto contextSig = O->getGenericSignature().getCanonicalSignature();
-      auto subs = *O->getUnderlyingTypeSubstitutions();
+      auto subs = *O->getUniqueUnderlyingTypeSubstitutions();
 
       // Add the underlying types for each generic parameter.
       for (auto genericParam : O->getOpaqueGenericParams()) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8442,7 +8442,7 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
         return expr;
       });
 
-      opaque->setUnderlyingTypeSubstitutions(substitutions);
+      opaque->setUniqueUnderlyingTypeSubstitutions(substitutions);
     }
   }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2603,29 +2603,36 @@ public:
 /// An AST walker that determines the underlying type of an opaque return decl
 /// from its associated function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
-  using Candidate = std::pair<Expr *, SubstitutionMap>;
+  using Candidate = std::tuple<Expr *, SubstitutionMap, /*isUnique=*/bool>;
+  using AvailabilityContext = IfStmt *;
 
   ASTContext &Ctx;
   AbstractFunctionDecl *Implementation;
   OpaqueTypeDecl *OpaqueDecl;
   BraceStmt *Body;
-  SmallVector<Candidate, 4> Candidates;
-  SmallPtrSet<const void *, 4> KnownCandidates;
+
+  /// A set of all candidates with unique signatures.
+  SmallPtrSet<const void *, 4> UniqueSignatures;
+
+  /// Represents a current availability context. `nullptr` means that
+  /// there are no restrictions.
+  AvailabilityContext CurrentAvailability = nullptr;
+
+  /// All of the candidates together with their availability.
+  ///
+  /// If a candidate is found in non-`if #available` context or
+  /// `if #available` has other dynamic conditions, it covers 'all'
+  /// versions and the context is set to `nullptr`.
+  SmallVector<std::pair<AvailabilityContext, Candidate>, 4> Candidates;
 
   bool HasInvalidReturn = false;
 
 public:
   OpaqueUnderlyingTypeChecker(AbstractFunctionDecl *Implementation,
-                              OpaqueTypeDecl *OpaqueDecl,
-                              BraceStmt *Body)
-    : Ctx(Implementation->getASTContext()),
-      Implementation(Implementation),
-      OpaqueDecl(OpaqueDecl),
-      Body(Body)
-  {
-    
-  }
-  
+                              OpaqueTypeDecl *OpaqueDecl, BraceStmt *Body)
+      : Ctx(Implementation->getASTContext()), Implementation(Implementation),
+        OpaqueDecl(OpaqueDecl), Body(Body) {}
+
   void check() {
     Body->walk(*this);
 
@@ -2642,95 +2649,242 @@ public:
       return;
     }
 
-    // Check whether all of the underlying type candidates match up.
-    // TODO [OPAQUE SUPPORT]: diagnose multiple opaque types
-    SubstitutionMap underlyingSubs = Candidates.front().second;
-    if (Candidates.size() > 1) {
-      Optional<std::pair<unsigned, GenericTypeParamType *>> mismatch;
-
-      auto opaqueParams = OpaqueDecl->getOpaqueGenericParams();
-      for (auto index : indices(opaqueParams)) {
-        auto *genericParam = opaqueParams[index];
-
-        Type underlyingType = Type(genericParam).subst(underlyingSubs);
-        bool found = false;
-        for (const auto &candidate : Candidates) {
-          Type otherType = Type(genericParam).subst(candidate.second);
-
-          if (!underlyingType->isEqual(otherType)) {
-            mismatch.emplace(index, genericParam);
-            found = true;
-            break;
-          }
-        }
-
-        if (found)
-          break;
-      }
-      assert(mismatch.hasValue());
-
-      if (auto genericParam =
-              OpaqueDecl->getExplicitGenericParam(mismatch->first)) {
-        Implementation->diagnose(
-            diag::opaque_type_mismatched_underlying_type_candidates_named,
-            genericParam->getName())
-          .highlight(genericParam->getLoc());
-      } else {
-        TypeRepr *opaqueRepr =
-            OpaqueDecl->getOpaqueReturnTypeReprs()[mismatch->first];
-        Implementation->diagnose(
-            diag::opaque_type_mismatched_underlying_type_candidates,
-            opaqueRepr)
-          .highlight(opaqueRepr->getSourceRange());
-      }
-
-      for (auto candidate : Candidates) {
-        Ctx.Diags.diagnose(candidate.first->getLoc(),
-                           diag::opaque_type_underlying_type_candidate_here,
-                           Type(mismatch->second).subst(candidate.second));
-      }
+    if (Candidates.size() == 1) {
+      finalizeUnique(Candidates.front().second);
       return;
     }
-    
+
+    // Check whether all of the underlying type candidates match up.
+    // TODO [OPAQUE SUPPORT]: diagnose multiple opaque types
+
+    // There is a single unique signature, which means that all returns
+    // matched.
+    if (llvm::count_if(Candidates, [](const auto &entry) {
+          const auto &candidate = entry.second;
+          return std::get<2>(candidate); // isUnique field.
+        }) == 1) {
+      finalizeUnique(Candidates.front().second);
+      return;
+    }
+
+    SmallVector<Candidate, 4> universalyUniqueCandidates;
+
+    for (const auto &entry : Candidates) {
+      AvailabilityContext availability = entry.first;
+      const auto &candidate = entry.second;
+
+      // Unique candidate without availability context.
+      if (!availability && std::get<2>(candidate))
+        universalyUniqueCandidates.push_back(candidate);
+    }
+
+    // TODO(diagnostics): Need a tailored diagnostic for this case.
+    if (universalyUniqueCandidates.empty()) {
+      Implementation->diagnose(diag::opaque_type_no_underlying_type_candidates);
+      return;
+    }
+
+    // If there is a single universally available unique candidate
+    // the underlying type would have to be determined at runtime
+    // based on the results of availability checks.
+    if (universalyUniqueCandidates.size() == 1) {
+      finalizeOpaque(universalyUniqueCandidates.front());
+      return;
+    }
+
+    // A list of all mismatches discovered across all candidates.
+    // If there are any mismatches in availability contexts, they
+    // are not diagnosed but propagated to the declaration.
+    Optional<std::pair<unsigned, GenericTypeParamType *>> mismatch;
+
+    auto opaqueParams = OpaqueDecl->getOpaqueGenericParams();
+    SubstitutionMap underlyingSubs = std::get<1>(Candidates.front().second);
+
+    for (auto index : indices(opaqueParams)) {
+      auto *genericParam = opaqueParams[index];
+
+      Type underlyingType = Type(genericParam).subst(underlyingSubs);
+      bool found = false;
+      for (const auto &candidate : universalyUniqueCandidates) {
+        Type otherType = Type(genericParam).subst(std::get<1>(candidate));
+
+        if (!underlyingType->isEqual(otherType)) {
+          mismatch.emplace(index, genericParam);
+          found = true;
+          break;
+        }
+      }
+
+      if (found)
+        break;
+    }
+
+    assert(mismatch.hasValue());
+
+    if (auto genericParam =
+            OpaqueDecl->getExplicitGenericParam(mismatch->first)) {
+      Implementation
+          ->diagnose(
+              diag::opaque_type_mismatched_underlying_type_candidates_named,
+              genericParam->getName())
+          .highlight(genericParam->getLoc());
+    } else {
+      TypeRepr *opaqueRepr =
+          OpaqueDecl->getOpaqueReturnTypeReprs()[mismatch->first];
+      Implementation
+          ->diagnose(diag::opaque_type_mismatched_underlying_type_candidates,
+                     opaqueRepr)
+          .highlight(opaqueRepr->getSourceRange());
+    }
+
+    for (const auto &candidate : universalyUniqueCandidates) {
+      Ctx.Diags.diagnose(std::get<0>(candidate)->getLoc(),
+                         diag::opaque_type_underlying_type_candidate_here,
+                         Type(mismatch->second).subst(std::get<1>(candidate)));
+    }
+  }
+
+  bool isSelfReferencing(const Candidate &candidate) {
+    auto substitutions = std::get<1>(candidate);
+
     // The underlying type can't be defined recursively
     // in terms of the opaque type itself.
     auto opaqueTypeInContext = Implementation->mapTypeIntoContext(
         OpaqueDecl->getDeclaredInterfaceType());
     for (auto genericParam : OpaqueDecl->getOpaqueGenericParams()) {
-      auto underlyingType = Type(genericParam).subst(underlyingSubs);
-      auto isSelfReferencing = underlyingType.findIf([&](Type t) -> bool {
-        return t->isEqual(opaqueTypeInContext);
-      });
+      auto underlyingType = Type(genericParam).subst(substitutions);
+      auto isSelfReferencing = underlyingType.findIf(
+          [&](Type t) -> bool { return t->isEqual(opaqueTypeInContext); });
 
       if (isSelfReferencing) {
-        unsigned index = genericParam->getIndex();
-        Ctx.Diags.diagnose(Candidates.front().first->getLoc(),
+        Ctx.Diags.diagnose(std::get<0>(candidate)->getLoc(),
                            diag::opaque_type_self_referential_underlying_type,
-                           underlyingSubs.getReplacementTypes()[index]);
-        return;
+                           underlyingType);
+        return true;
       }
     }
 
+    return false;
+  }
+
+  // A single unique underlying substitution.
+  void finalizeUnique(const Candidate &candidate) {
     // If we have one successful candidate, then save it as the underlying
     // substitutions of the opaque decl.
     OpaqueDecl->setUniqueUnderlyingTypeSubstitutions(
-        underlyingSubs.mapReplacementTypesOutOfContext());
+        std::get<1>(candidate).mapReplacementTypesOutOfContext());
   }
-  
+
+  // There is no clear winner here since there are candidates within
+  // limited availability contexts.
+  void finalizeOpaque(const Candidate &universallyAvailable) {
+    SmallVector<OpaqueTypeDecl::ConditionallyAvailableSubstitutions *, 4>
+        conditionalSubstitutions;
+
+    for (const auto &entry : Candidates) {
+      auto availabilityContext = entry.first;
+      const auto &candidate = entry.second;
+
+      if (!availabilityContext)
+        continue;
+
+      SmallVector<VersionRange, 4> conditions;
+
+      llvm::transform(availabilityContext->getCond(),
+                      std::back_inserter(conditions),
+                      [&](const StmtConditionElement &elt) {
+                        return elt.getAvailability()->getAvailableRange();
+                      });
+
+      conditionalSubstitutions.push_back(
+          OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
+              Ctx, conditions,
+              std::get<1>(candidate).mapReplacementTypesOutOfContext()));
+    }
+
+    // Add universally available choice as the last one.
+    conditionalSubstitutions.push_back(
+        OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(
+            Ctx, {VersionRange::empty()},
+            std::get<1>(universallyAvailable)
+                .mapReplacementTypesOutOfContext()));
+
+    OpaqueDecl->setConditionallyAvailableSubstitutions(
+        conditionalSubstitutions);
+  }
+
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (auto underlyingToOpaque = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
       auto key =
           underlyingToOpaque->substitutions.getCanonical().getOpaqueValue();
-      if (KnownCandidates.insert(key).second) {
-        Candidates.push_back(std::make_pair(underlyingToOpaque->getSubExpr(),
-                                            underlyingToOpaque->substitutions));
+
+      auto isUnique = UniqueSignatures.insert(key).second;
+
+      auto candidate =
+          std::make_tuple(underlyingToOpaque->getSubExpr(),
+                          underlyingToOpaque->substitutions, isUnique);
+
+      if (isSelfReferencing(candidate)) {
+        HasInvalidReturn = true;
+        return {false, nullptr};
       }
+
+      Candidates.push_back({CurrentAvailability, candidate});
       return {false, E};
     }
+
     return {true, E};
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    if (auto *If = dyn_cast<IfStmt>(S)) {
+      if (Parent.getAsStmt() != Body) {
+        // If this is not a top-level `if`, let's drop
+        // contextual information that has been set previously.
+        CurrentAvailability = nullptr;
+        return {true, S};
+      }
+
+      // If this is `if #available` statement with no other dynamic
+      // conditions, let's check if it returns opaque type directly.
+      if (llvm::all_of(If->getCond(), [&](const auto &condition) {
+            return condition.getKind() == StmtConditionElement::CK_Availability;
+          })) {
+        // Check return statement directly with availability context set.
+        if (auto *Then = dyn_cast<BraceStmt>(If->getThenStmt())) {
+          llvm::SaveAndRestore<ParentTy> parent(Parent, Then);
+
+          for (auto element : Then->getElements()) {
+            auto *Return = getAsStmt<ReturnStmt>(element);
+
+            // If this is not a direct return statement, walk into it
+            // without setting contextual availability because we want
+            // to find all `return`s.
+            if (!(Return && Return->hasResult())) {
+              element.walk(*this);
+              continue;
+            }
+
+            // Note that we are about to walk into a return statement
+            // that is located in a `if #available` without any other
+            // conditions.
+            llvm::SaveAndRestore<AvailabilityContext> context(
+                CurrentAvailability, If);
+
+            Return->getResult()->walk(*this);
+          }
+        }
+
+        // Walk the else branch directly as well.
+        if (auto *Else = If->getElseStmt()) {
+          llvm::SaveAndRestore<ParentTy> parent(Parent, If);
+          Else->walk(*this);
+        }
+
+        return {false, S};
+      }
+    }
+
     if (auto *RS = dyn_cast<ReturnStmt>(S)) {
       if (RS->hasResult()) {
         auto resultTy = RS->getResult()->getType();
@@ -2743,7 +2897,7 @@ public:
 
     return {true, S};
   }
-  
+
   // Don't descend into nested decls.
   bool walkToDeclPre(Decl *D) override {
     return false;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2713,7 +2713,7 @@ public:
 
     // If we have one successful candidate, then save it as the underlying
     // substitutions of the opaque decl.
-    OpaqueDecl->setUnderlyingTypeSubstitutions(
+    OpaqueDecl->setUniqueUnderlyingTypeSubstitutions(
         underlyingSubs.mapReplacementTypesOutOfContext());
   }
   

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3571,7 +3571,7 @@ public:
       auto subMapOrError = MF.getSubstitutionMapChecked(underlyingTypeSubsID);
       if (!subMapOrError)
         return subMapOrError.takeError();
-      opaqueDecl->setUnderlyingTypeSubstitutions(subMapOrError.get());
+      opaqueDecl->setUniqueUnderlyingTypeSubstitutions(subMapOrError.get());
     }
     return opaqueDecl;
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3898,7 +3898,7 @@ public:
     auto genericSigID = S.addGenericSignatureRef(opaqueDecl->getGenericSignature());
 
     SubstitutionMapID underlyingSubsID = 0;
-    if (auto underlying = opaqueDecl->getUnderlyingTypeSubstitutions())
+    if (auto underlying = opaqueDecl->getUniqueUnderlyingTypeSubstitutions())
       underlyingSubsID = S.addSubstitutionMapRef(*underlying);
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(opaqueDecl->getFormalAccess());

--- a/test/type/opaque_with_conditional_availability.swift
+++ b/test/type/opaque_with_conditional_availability.swift
@@ -1,0 +1,108 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -typecheck -verify %s
+// REQUIRES: OS=macosx
+
+protocol P {}
+
+@available(macOS 10.16, *)
+struct X : P {
+}
+
+struct Y : P {
+}
+
+struct Z : P {
+}
+
+// Ok: X is only available on 10.16, Y is universal
+func test1() -> some P {
+  if #available(macOS 10.16, *) {
+    return X()
+  }
+
+  return Y()
+}
+
+func test2() -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if #available(macOS 10.16, *) {
+    return X()
+  } else {
+    return Y() // expected-note {{return statement has underlying type 'Y'}}
+  }
+
+  return Z() // expected-note {{return statement has underlying type 'Z'}}
+}
+
+func test_no_else_if() -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if #available(macOS 10.16, *) {
+    return X()
+  } else if #available(macOS 10.17, *) {
+    return Y() // expected-note {{return statement has underlying type 'Y'}}
+  }
+
+  return Z() // expected-note {{return statement has underlying type 'Z'}}
+}
+
+func test4(cond: Bool) -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if cond {
+    if #available(macOS 10.16, *) {
+      return X() // expected-note {{return statement has underlying type 'X'}}
+    }
+  }
+
+  return Y() // expected-note {{return statement has underlying type 'Y'}}
+}
+
+func test5(cond: Bool) -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if #available(macOS 10.16, *) {
+    if cond {
+      return X() // expected-note {{return statement has underlying type 'X'}}
+    }
+  }
+
+  return Y() // expected-note {{return statement has underlying type 'Y'}}
+}
+
+func test5(v: Int) -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if #available(macOS 10.16, *), v > 42 {
+    return X() // expected-note {{return statement has underlying type 'X'}}
+  }
+
+  return Y() // expected-note {{return statement has underlying type 'Y'}}
+}
+
+// Ok because availability conditions are conjoined.
+func test_multiple_conditions() -> some P {
+  if #available(macOS 10.16, *), #available(iOS 1000, *) {
+    return X()
+  }
+
+  return Y()
+}
+
+func test_no_nested_availability_conditions() -> some P {
+  // expected-error@-1 {{function declares an opaque return type 'some P', but the return statements in its body do not have matching underlying types}}
+  if #available(macOS 10.16, *) {
+    if #available(iOS 10000, *) {
+      return X() // expected-note {{return statement has underlying type 'X'}}
+    }
+  }
+
+  return Y() // expected-note {{return statement has underlying type 'Y'}}
+}
+
+// TODO(diagnostics): Need a tailored diagnostic in this case to point out that there is no unconditional `return`.
+func test_fail_without_universally_available_type() -> some P {
+  // expected-error@-1 {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
+  if #available(macOS 11, *) {
+    return X()
+  }
+
+  if #available(macOS 12, *) {
+    return Y()
+  }
+}


### PR DESCRIPTION
Allow opaque type declarations to have multiple unique underlying
types if all such types are conditional on availability via
`if #available(...)` and there is only one universally available
substitution.  Neither nesting of availability conditions nor other
dynamic conditions are allowed.

For example:

```swift
protocol P {}

@available(iOS 31.337, *)
struct X : P {
}

struct Y : P {
}

func test() -> some P {
  if #available(iOS 31.337, *) {
    // ... some computation ...
    return X()
  }

  return Y()
 }
 ```

 Allows `some P` to refer to `X` instead of `Y` on `iOS 31.337`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
