### PR TITLE
Revert "[test] Make spi-available-inline test target dynamic"

### DIFF
--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -1,5 +1,5 @@
 // REQUIRES: VENDOR=apple
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx11.9
 
 @_spi_available(macOS 10.4, *)
 public class MacOSSPIClass { public init() {} }


### PR DESCRIPTION
Reverts apple/swift#42051