### PR TITLE
[test] Restrict spi-available inline to macosx only

### DIFF
--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -1,4 +1,5 @@
 // REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9
 
 @_spi_available(macOS 10.4, *)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Follow-up to #42051 


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
