### PR TITLE
[stdlib] remove preconditions from compatibility entry point

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -336,7 +336,9 @@ public struct UnsafePointer<Pointee>: _Pointer {
     capacity count: Int,
     _ body: (UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
-    return try withMemoryRebound(to: T.self, capacity: count, body)
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
   }
 
   /// Accesses the pointee at the specified offset from this pointer.
@@ -1040,7 +1042,9 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     capacity count: Int,
     _ body: (UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
-    return try withMemoryRebound(to: T.self, capacity: count, body)
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
   }
 
   /// Accesses the pointee at the specified offset from this pointer.


### PR DESCRIPTION
- The old implementation of `UnsafePointer.withMemoryRebound` had no precondition checking.
- When implementing SE-0333, we forwarded the old entry point to the new implementation, which has a debug
   precondition. (see https://github.com/apple/swift/pull/39529)
- This change removes the debug precondition from the compatibility entry point, reverting its previous behaviour.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://90462471

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
