### PR TITLE
sema: allow unavailable context to refer SPI-available decls

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1546,6 +1546,14 @@ swift::getDisallowedOriginKind(const Decl *decl,
     // Implementation-only imported, cannot be reexported.
     return DisallowedOriginKind::ImplementationOnly;
   } else if ((decl->isSPI() || decl->isAvailableAsSPI()) && !where.isSPI()) {
+    // Allowing unavailable context to use @_spi_available decls.
+    // Decls with @_spi_available aren't hidden entirely from public interfaces,
+    // thus public interfaces may still refer them. Be forgiving here so public
+    // interfaces can compile.
+    if (where.getUnavailablePlatformKind().hasValue() &&
+        decl->isAvailableAsSPI() && !decl->isSPI()) {
+      return DisallowedOriginKind::None;
+    }
     // SPI can only be exported in SPI.
     return where.getDeclContext()->getParentModule() == M ?
       DisallowedOriginKind::SPILocal :

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -16,3 +16,15 @@ public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' 
 public func inlinableUsingSPI() {
   SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from 'SPIContainer'}}
 }
+
+@available(macOS, unavailable)
+public let e: SPIInterface2
+
+@available(iOS, unavailable)
+public let f: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from 'SPIContainer'}}
+
+@inlinable
+@available(macOS, unavailable)
+public func inlinableUnavailableUsingSPI() {
+  SharedInterface.foo()
+}


### PR DESCRIPTION
Decls with @_spi_available aren't hidden entirely from public interfaces,
thus public interfaces may still refer to them. Be forgiving for such cases so public
interfaces can compile.

rdar://90938725
