### PR TITLE
[build-presets] Disable SourceKit-LSP tests on Linux Incremental

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1113,6 +1113,8 @@ swiftsyntax
 swiftsyntax-verify-generated-files
 indexstore-db
 sourcekit-lsp
+# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://89359439
+skip-test-sourcekit-lsp
 install-llvm
 install-swift
 install-llbuild


### PR DESCRIPTION
https://github.com/apple/swift/pull/41856 disabled them for the Linux preset, but it appears they need to be disabled for the incremental Linux preset too.

rdar://89359439