### PR TITLE
Frontend: Separate macCatalyst `-target-min-inlining-version` floor

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -84,6 +84,10 @@ swift::minimumAvailableOSVersionForTriple(const llvm::Triple &triple) {
   if (triple.isMacOSX())
     return llvm::VersionTuple(10, 10, 0);
 
+  // Mac Catalyst was introduced with an iOS deployment target of 13.1.
+  if (tripleIsMacCatalystEnvironment(triple))
+    return llvm::VersionTuple(13, 1);
+  
   // Note: this must come before checking iOS since that returns true for
   // both iOS and tvOS.
   if (triple.isTvOS())
@@ -133,6 +137,7 @@ DarwinPlatformKind swift::getDarwinPlatformKind(const llvm::Triple &triple) {
 
     if (tripleIsiOSSimulator(triple))
       return DarwinPlatformKind::IPhoneOSSimulator;
+
     return DarwinPlatformKind::IPhoneOS;
   }
 


### PR DESCRIPTION
Add a separate inlining version floor for the macCatalyst platform, which was introduced as 13.1. Create a variant of the tests for `-target-min-inlining-version` specifically for macCatalyst (unfortunately, covering the macCatalyst platform in the same test file is prohibitively difficult because the tests never run with macCatalyst as the host OS and therefore the target triple substitutions need to be explicit).

Resolves rdar://90858579