### PR TITLE
Restrict implicit opening of existentials based on the generic function's requirements

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1421,18 +1421,6 @@ namespace {
     OptionSet<OpenedExistentialAdjustmentFlags>;
 }
 
-/// Determine if this function is part of the _isUnique family of functions in
-/// the standard library.
-static bool isStdlibUniqueFunction(ValueDecl *callee) {
-  if (!callee->isStdlibDecl())
-    return false;
-
-  auto baseName = callee->getName().getBaseName().userFacingName();
-  return baseName ==  "_isUnique" || baseName == "_isUnique_native" ||
-         baseName == "_COWBufferForReading" ||
-         baseName == "_unsafeDowncastToAnyObject";
-}
-
 /// Determine whether we should open up the existential argument to the
 /// given parameters.
 ///
@@ -1469,14 +1457,6 @@ shouldOpenExistentialCallArgument(
     return None;
 
   case DeclTypeCheckingSemantics::Normal:
-    // _isUnique and friends are special because opening an existential when
-    // calling them would make them non-unique.
-    // FIXME: Borrowing properly from the existential box would probably
-    // eliminate this.
-    if (isStdlibUniqueFunction(callee))
-      return None;
-    break;
-
   case DeclTypeCheckingSemantics::WithoutActuallyEscaping:
     break;
   }

--- a/test/Constraints/opened_existentials_suppression.swift
+++ b/test/Constraints/opened_existentials_suppression.swift
@@ -9,6 +9,7 @@ func acceptsBoxType<T>(_ value: T.Type) { }
 // CHECK: passBox
 // CHECK-NOT: open_existential_expr
 func passBox(p: P, obj: AnyObject, err: Error) {
+  acceptsBox(p)
   acceptsBox(p as P)
   acceptsBox(p as! P)
   acceptsBox(p as? P)


### PR DESCRIPTION
Rather than looking solely at the existential argument of a generic
function to determine whether it self-conforms, compare the
existential argument against each of the protocols to which the
corresponding generic parameter conforms. This better models when the
existential value itself will successfully meet the requirements of
the generic function, and therefore not require opening.

This provides far better source compatibility by not changing
semantics of existing, well-formed calls, and eliminates the need to
special-case CoW-related operations in the standard library.