### PR TITLE
[SourceKit] Link SwiftCompilerModules to SourceKit

### DIFF
--- a/test/IDE/complete_regex.swift
+++ b/test/IDE/complete_regex.swift
@@ -1,0 +1,12 @@
+// REQUIRES: swift_in_compiler
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -enable-experimental-string-processing -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+func testLiteral() {
+    re'foo'.#^RE_LITERAL_MEMBER^#
+// RE_LITERAL_MEMBER: Begin completions
+// RE_LITERAL_MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Regex<Substring>#];
+// RE_LITERAL_MEMBER: End completions
+}
+

--- a/test/SourceKit/Sema/sema_regex.swift
+++ b/test/SourceKit/Sema/sema_regex.swift
@@ -1,0 +1,24 @@
+public func retRegex() -> Regex<Substring> {
+  re'foo'
+}
+
+// REQUIRES: swift_in_compiler
+// RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-experimental-string-processing | %FileCheck %s
+
+// CHECK: [
+// CHECK:   {
+// CHECK:     key.kind: source.lang.swift.ref.struct
+// CHECK:     key.offset: 26
+// CHECK:     key.length: 5
+// CHECK:     key.is_system: 1
+// CHECK:   },
+// CHECK:   {
+// CHECK:     key.kind: source.lang.swift.ref.struct
+// CHECK:     key.offset: 32
+// CHECK:     key.length: 9
+// CHECK:     key.is_system: 1
+// CHECK:   }
+// CHECK: ]
+
+// Ensure there's no diagnostics
+// CHECK-NOT: key.severity:

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/CMakeLists.txt
@@ -21,6 +21,7 @@ if (SOURCEKIT_INSTALLING_INPROC)
       ${sourcekitdInProc_args}
       MODULEMAP module.modulemap
       INSTALL_IN_COMPONENT sourcekit-inproc
+      HAS_SWIFT_MODULES
     )
     set_property(TARGET sourcekitdInProc APPEND_STRING PROPERTY LINK_FLAGS " -fapplication-extension")
     if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
@@ -35,6 +36,7 @@ if (SOURCEKIT_INSTALLING_INPROC)
         ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
       INSTALL_IN_COMPONENT sourcekit-inproc
       SHARED
+      HAS_SWIFT_MODULES
     )
   endif()
 else()
@@ -44,6 +46,7 @@ else()
       ${SOURCEKITD_SOURCE_DIR}/include/sourcekitd/sourcekitd.h
     INSTALL_IN_COMPONENT sourcekit-inproc
     SHARED
+    HAS_SWIFT_MODULES
   )
 endif()
 target_link_libraries(sourcekitdInProc PRIVATE

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/CMakeLists.txt
@@ -2,6 +2,7 @@ if (BUILD_SOURCEKIT_XPC_SERVICE)
   add_sourcekit_xpc_service(SourceKitService sourcekitd
     XPCService.cpp
     LLVM_LINK_COMPONENTS support coverage
+    HAS_SWIFT_MODULES
   )
   swift_is_installing_component(sourcekit-inproc SOURCEKIT_INSTALLING_INPROC)
   if(SOURCEKIT_INSTALLING_INPROC)

--- a/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/CMakeLists.txt
@@ -18,7 +18,8 @@ add_sourcekit_library(sourcekitdAPI
 target_link_libraries(sourcekitdAPI PRIVATE
   swiftBasic
   SourceKitSupport
-  SourceKitSwiftLang)
+  SourceKitSwiftLang
+  swiftCompilerModules)
 
 if(APPLE AND HAVE_XPC_H)
   target_sources(sourcekitdAPI PRIVATE

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -31,6 +31,7 @@
 
 #include "swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/InitializeSwiftModules.h"
 #include "swift/Basic/Mangler.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/Version.h"
@@ -109,6 +110,7 @@ void sourcekitd::initializeService(
     StringRef runtimeLibPath, StringRef diagnosticDocumentationPath,
     std::function<void(sourcekitd_response_t)> postNotification) {
   INITIALIZE_LLVM();
+  initializeSwiftModules();
   llvm::EnablePrettyStackTrace();
   GlobalCtx =
       new SourceKit::Context(runtimeLibPath, diagnosticDocumentationPath,

--- a/tools/swift-ide-test/CMakeLists.txt
+++ b/tools/swift-ide-test/CMakeLists.txt
@@ -4,13 +4,15 @@ add_swift_host_tool(swift-ide-test
   XMLValidator.cpp
   SWIFT_COMPONENT tools
   THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
+  HAS_SWIFT_MODULES
 )
 target_link_libraries(swift-ide-test
                       PRIVATE
                         swiftAST
                         swiftDriver
                         swiftFrontend
-                        swiftIDE)
+                        swiftIDE
+                        swiftCompilerModules)
 
 # If libxml2 is available, make it available for swift-ide-test.
 if(LLVM_ENABLE_LIBXML2)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -30,6 +30,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/PrimitiveParsing.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/InitializeSwiftModules.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
@@ -803,6 +804,11 @@ static llvm::cl::opt<bool>
 EnableExperimentalDistributed("enable-experimental-distributed",
                               llvm::cl::desc("Enable experimental distributed actors and functions"),
                               llvm::cl::init(false));
+
+static llvm::cl::opt<bool> EnableExperimentalStringProcessing(
+    "enable-experimental-string-processing",
+    llvm::cl::desc("Enable experimental string processing"),
+    llvm::cl::init(false));
 
 static llvm::cl::list<std::string>
 AccessNotesPath("access-notes-path", llvm::cl::desc("Path to access notes file"),
@@ -4116,6 +4122,7 @@ void anchorForGetMainExecutable() {}
 int main(int argc, char *argv[]) {
   PROGRAM_START(argc, argv);
   INITIALIZE_LLVM();
+  initializeSwiftModules();
 
   if (argc > 1) {
     // Handle integrated test tools which do not use
@@ -4269,6 +4276,9 @@ int main(int argc, char *argv[]) {
   }
   if (options::EnableExperimentalNamedOpaqueTypes) {
     InitInvok.getLangOptions().EnableExperimentalNamedOpaqueTypes = true;
+  }
+  if (options::EnableExperimentalStringProcessing) {
+    InitInvok.getLangOptions().EnableExperimentalStringProcessing= true;
   }
 
   if (!options::Triple.empty())


### PR DESCRIPTION
This is required for SourceKit to parse Regex literals

Also link it to `swift-ide-test` too, to test IDE functionalities for regex literals.

rdar://90236990
