### PR TITLE
[TypeChecker] SE-0347: Allow same-type requirements connecting depend…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -621,6 +621,12 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
             !containsTypes(rhsTy, genericParameters))
           continue;
 
+        // If both sides are dependent members, that's okay because types
+        // don't flow from member to the base e.g. `T.Element == U.Element`.
+        if (lhsTy->is<DependentMemberType>() &&
+            rhsTy->is<DependentMemberType>())
+          continue;
+
         // Allow a subset of generic same-type requirements that only mention
         // "in scope" generic parameters e.g. `T.X == Int` or `T == U.Z`
         if (!containsGenericParamsExcluding(lhsTy, genericParameters) &&


### PR DESCRIPTION
…ent members

Since the types don't flow from member to the base, there is no risk
that dependent member type is going to affect other generic parameters
through this kind of requirement.

Resolves: SR-16069

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
