### PR TITLE
[cxx-interop][ClangImporter] Fix protocol renaming issue with objc++ interop enabled

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -999,7 +999,11 @@ bool NameImporter::hasNamingConflict(const clang::NamedDecl *decl,
   lookupResult.setAllowHidden(true);
   lookupResult.suppressDiagnostics();
 
-  if (clangSema.LookupName(lookupResult, /*scope=*/clangSema.TUScope)) {
+  // Only force the Objective-C codepath in LookupName if clangSema.TUScope is
+  // nullptr
+  if (clangSema.LookupName(lookupResult, /*scope=*/clangSema.TUScope,
+                           /*AllowBuiltinCreation=*/false,
+                           /*ForceNoCPlusPlus=*/!clangSema.TUScope)) {
     if (std::any_of(lookupResult.begin(), lookupResult.end(), conflicts))
       return true;
   }

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module ProtocolNamingConflict [extern_c] {
+  header "protocol-naming-conflict.h"
+  requires objc
+}

--- a/test/Interop/Cxx/objc-correctness/Inputs/protocol-naming-conflict.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/protocol-naming-conflict.h
@@ -1,0 +1,4 @@
+@protocol Foo
+@end
+@interface Foo <Foo>
+@end

--- a/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
+++ b/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ProtocolNamingConflict -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
+// RUN: %swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -emit-sil -o - | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import ProtocolNamingConflict
+
+// CHECK: class Thing : FooProtocol
+// CHECK-IDE-TEST: protocol FooProtocol
+// CHECK-IDE-TEST: class Foo : FooProtocol
+class Thing: FooProtocol {
+}


### PR DESCRIPTION
Please note that this depends on https://reviews.llvm.org/D122691 (I have a PR open [here](https://github.com/apple/llvm-project/pull/4139) so we can test on swift-ci)

When constructing SwiftLookupTable at clang module creation time, calls
to `clang::Sema::LookupName` will fail in C++ mode (including ObjC++).
The specific reason is that `clangSema.TUScope` (which we are passing in
as a Scope) is `nullptr` as we have no active Parser. The C++ path in
`clang::Sema::LookupName` is set to fail early and hard when the Scope
passed in is nullptr. In most, if not all, calls to `LookupName`, we
care about ObjC symbols and not C++ names. For example, the motivation
behind this issue is that ObjC protocols are not being renamed when
there is an ObjC class with the same name, leading to compilation
failures.
