### PR TITLE
[Concurrency] Avoid redundant conformance warning on Actor

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -35,7 +35,7 @@ public protocol AnyActor: AnyObject, Sendable {}
 /// The `Actor` protocol generalizes over all `actor` types. Actor types
 /// implicitly conform to this protocol.
 @available(SwiftStdlib 5.1, *)
-public protocol Actor: AnyActor, Sendable {
+public protocol Actor: AnyActor {
 
   /// Retrieve the executor for this actor as an optimized, unowned
   /// reference.


### PR DESCRIPTION
Since the `Actor` type is now `Sendable` via `AnyActor`:

```
/Users/ktoso/code/swift-project/swift/stdlib/public/Concurrency/Actor.swift:38:34: warning: redundant conformance constraint 'Self' : 'Sendable'
public protocol Actor: AnyActor, Sendable {
                                 ^
/Users/ktoso/code/swift-project/swift/stdlib/public/Concurrency/Actor.swift:38:24: note: conformance constraint 'Self' : 'Sendable' implied here
public protocol Actor: AnyActor, Sendable {
                       ^
```


