### PR TITLE
[Wasm][IRGen] Add initial support for unconditional absolute function pointer

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -320,6 +320,11 @@ public:
   unsigned LazyInitializeProtocolConformances : 1;
   unsigned IndirectAsyncFunctionPointer : 1;
 
+  /// Use absolute function references instead of relative ones.
+  /// Mainly used on WebAssembly, that doesn't support relative references
+  /// to code from data.
+  unsigned CompactAbsoluteFunctionPointer : 1;
+
   /// Normally if the -read-legacy-type-info flag is not specified, we look for
   /// a file named "legacy-<arch>.yaml" in SearchPathOpts.RuntimeLibraryPath.
   /// Passing this flag completely disables this behavior.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2153,6 +2153,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   // AsyncFunctionPointer access.
   Opts.IndirectAsyncFunctionPointer = Triple.isOSBinFormatCOFF();
 
+  // On some Harvard architectures that allow sliding code and data address space
+  // offsets independently, it's impossible to make direct relative reference to
+  // code from data because the relative offset between them is not representable.
+  // Use absolute function references instead of relative ones on such targets.
+  // TODO(katei): This is a short-term solution until the WebAssembly target stabilizes
+  // PIC and 64-bit specifications and toolchain support.
+  Opts.CompactAbsoluteFunctionPointer = Triple.isOSBinFormatWasm();
+
   if (Args.hasArg(OPT_disable_legacy_type_info)) {
     Opts.DisableLegacyTypeInfo = true;
   }

--- a/lib/IRGen/ConformanceDescription.h
+++ b/lib/IRGen/ConformanceDescription.h
@@ -53,7 +53,7 @@ public:
 
   /// The instantiation function, to be run at the end of witness table
   /// instantiation.
-  llvm::Constant *instantiationFn = nullptr;
+  llvm::Function *instantiationFn = nullptr;
 
   /// The resilient witnesses, if any.
   SmallVector<llvm::Constant *, 4> resilientWitnesses;

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/IRGenOptions.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/GlobalVariable.h"
@@ -81,6 +82,26 @@ public:
 
   void addSize(Size size) { addInt(IGM().SizeTy, size.getValue()); }
 
+  void addCompactFunctionReferenceOrNull(llvm::Function *function) {
+    if (function) {
+      addCompactFunctionReference(function);
+    } else {
+      addInt(IGM().RelativeAddressTy, 0);
+    }
+  }
+
+  /// Add a 32-bit function reference to the given function. The reference
+  /// is direct relative pointer whenever possible. Otherwise, it is a
+  /// absolute pointer assuming the function address is 32-bit.
+  void addCompactFunctionReference(llvm::Function *function) {
+    if (IGM().getOptions().CompactAbsoluteFunctionPointer) {
+      // Assume that the function address is 32-bit.
+      add(llvm::ConstantExpr::getPtrToInt(function, IGM().RelativeAddressTy));
+    } else {
+      addRelativeOffset(IGM().RelativeAddressTy, function);
+    }
+  }
+
   void addRelativeAddressOrNull(llvm::Constant *target) {
     if (target) {
       addRelativeAddress(target);
@@ -91,6 +112,8 @@ public:
 
   void addRelativeAddress(llvm::Constant *target) {
     assert(!isa<llvm::ConstantPointerNull>(target));
+    assert((!IGM().getOptions().CompactAbsoluteFunctionPointer ||
+           !isa<llvm::Function>(target)) && "use addCompactFunctionReference");
     addRelativeOffset(IGM().RelativeAddressTy, target);
   }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2086,7 +2086,7 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
       llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(
           getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
           getAFPPtr(), 0);
-      fn = IGF.emitLoadOfRelativePointer(
+      fn = IGF.emitLoadOfCompactFunctionPointer(
           Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
           /*expectedType*/ functionPointer.getFunctionType()->getPointerTo());
     }
@@ -4955,7 +4955,7 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
     auto *addrPtr = IGF.Builder.CreateStructGEP(
         descriptorPtr->getType()->getScalarType()->getPointerElementType(),
         descriptorPtr, 0);
-    auto *result = IGF.emitLoadOfRelativePointer(
+    auto *result = IGF.emitLoadOfCompactFunctionPointer(
         Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
         /*expectedType*/ getFunctionType()->getPointerTo());
     if (auto codeAuthInfo = AuthInfo.getCorrespondingCodeAuthInfo()) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2063,7 +2063,7 @@ void IRGenerator::emitEntryPointInfo() {
   auto &IGM = *getGenModule(entrypoint);
   ConstantInitBuilder builder(IGM);
   auto entrypointInfo = builder.beginStruct();
-  entrypointInfo.addRelativeAddress(
+  entrypointInfo.addCompactFunctionReference(
       IGM.getAddrOfSILFunction(entrypoint, NotForDefinition));
   auto var = entrypointInfo.finishAndCreateGlobal(
       "\x01l_entry_point", Alignment(4),

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -268,7 +268,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
   return accessorThunk;
 }
 
-static llvm::Constant *
+static llvm::Function *
 getLayoutFunctionForComputedComponent(IRGenModule &IGM,
                                     const KeyPathPatternComponent &component,
                                     GenericEnvironment *genericEnv,
@@ -548,7 +548,7 @@ struct KeyPathIndexOperand {
   const KeyPathPatternComponent *LastUser;
 };
 
-static llvm::Constant *
+static llvm::Function *
 getInitializerForComputedComponent(IRGenModule &IGM,
            const KeyPathPatternComponent &component,
            ArrayRef<KeyPathIndexOperand> operands,
@@ -1101,12 +1101,12 @@ emitKeyPathComponent(IRGenModule &IGM,
     }
 
     // Push the accessors, possibly thunked to marshal generic environment.
-    fields.addRelativeAddress(
+    fields.addCompactFunctionReference(
       getAccessorForComputedComponent(IGM, component, Getter,
                                       genericEnv, requirements,
                                       hasSubscriptIndices));
     if (settable)
-      fields.addRelativeAddress(
+      fields.addCompactFunctionReference(
         getAccessorForComputedComponent(IGM, component, Setter,
                                         genericEnv, requirements,
                                         hasSubscriptIndices));
@@ -1116,7 +1116,7 @@ emitKeyPathComponent(IRGenModule &IGM,
       // arguments in the component. Thunk the SIL-level accessors to give the
       // runtime implementation a polymorphically-callable interface.
 
-      fields.addRelativeAddress(
+      fields.addCompactFunctionReference(
         getLayoutFunctionForComputedComponent(IGM, component,
                                               genericEnv, requirements));
       
@@ -1136,7 +1136,7 @@ emitKeyPathComponent(IRGenModule &IGM,
       
       // Add an initializer function that copies generic arguments out of the
       // pattern argument buffer into the instantiated object.
-      fields.addRelativeAddress(
+      fields.addCompactFunctionReference(
         getInitializerForComputedComponent(IGM, component, operands,
                                            genericEnv, requirements));
     }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -281,7 +281,7 @@ getTypeRefByFunction(IRGenModule &IGM,
       S.setPacked(true);
       S.add(llvm::ConstantInt::get(IGM.Int8Ty, 255));
       S.add(llvm::ConstantInt::get(IGM.Int8Ty, 9));
-      S.addRelativeAddress(accessor);
+      S.addCompactFunctionReference(accessor);
 
       // And a null terminator!
       S.addInt(IGM.Int8Ty, 0);
@@ -438,7 +438,7 @@ IRGenModule::emitWitnessTableRefString(CanType type,
         S.setPacked(true);
         S.add(llvm::ConstantInt::get(Int8Ty, 255));
         S.add(llvm::ConstantInt::get(Int8Ty, 9));
-        S.addRelativeAddress(accessorThunk);
+        S.addCompactFunctionReference(accessorThunk);
 
         // And a null terminator!
         S.addInt(Int8Ty, 0);
@@ -482,7 +482,7 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   S.setPacked(true);
   S.add(llvm::ConstantInt::get(Int8Ty, 255));
   S.add(llvm::ConstantInt::get(Int8Ty, kind));
-  S.addRelativeAddress(accessor);
+  S.addCompactFunctionReference(accessor);
 
   // And a null terminator!
   S.addInt(Int8Ty, 0);

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -338,6 +338,20 @@ IRGenFunction::emitLoadOfRelativePointer(Address addr, bool isFar,
 }
 
 llvm::Value *
+IRGenFunction::emitLoadOfCompactFunctionPointer(Address addr, bool isFar,
+                                                 llvm::PointerType *expectedType,
+                                                 const llvm::Twine &name) {
+  if (IGM.getOptions().CompactAbsoluteFunctionPointer) {
+    llvm::Value *value = Builder.CreateLoad(addr);
+    auto *uncastPointer = Builder.CreateIntToPtr(value, IGM.Int8PtrTy);
+    auto pointer = Builder.CreateBitCast(Address(uncastPointer, IGM.getPointerAlignment()), expectedType);
+    return pointer.getAddress();
+  } else {
+    return emitLoadOfRelativePointer(addr, isFar, expectedType, name);
+  }
+}
+
+llvm::Value *
 IRGenFunction::emitLoadOfRelativeIndirectablePointer(Address addr,
                                                 bool isFar,
                                                 llvm::PointerType *expectedType,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -266,6 +266,10 @@ public:
   llvm::Value *emitLoadOfRelativePointer(Address addr, bool isFar,
                                          llvm::PointerType *expectedType,
                                          const llvm::Twine &name = "");
+  llvm::Value *
+  emitLoadOfCompactFunctionPointer(Address addr, bool isFar,
+                                   llvm::PointerType *expectedType,
+                                   const llvm::Twine &name = "");
 
   llvm::Value *emitAllocObjectCall(llvm::Value *metadata, llvm::Value *size,
                                    llvm::Value *alignMask,

--- a/test/IRGen/wasm-absolute-func-ptr.swift
+++ b/test/IRGen/wasm-absolute-func-ptr.swift
@@ -1,0 +1,6 @@
+// RUN: %swift -target wasm32-unknown-wasi -parse-stdlib -emit-ir -o - %s | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+// CHECK: @"\01l_entry_point" = private constant { i32 } { i32 ptrtoint (i32 (i32, i8*)* @main to i32) }, section "swift5_entry", align 4
+


### PR DESCRIPTION
I discussed this with @rjmccall and @jckarter on [a forum thread](https://forums.swift.org/t/wasm-support/16087/49),
and we've got a consensus on how to upstream the relative pointer
support for Wasm.
The runtime part and id resolution of KeyPath will come in another PR.


On some Harvard architectures like WebAssembly that allow sliding code
and data address space offsets independently, it's impossible to make
direct relative reference to code from data because the relative offset
between them is not representable.
Use absolute function references instead of relative ones on such targets.



