### PR TITLE
[Wasm][Runtime] Interpret absolute function pointer in runtime structures

### DIFF
--- a/include/swift/ABI/CompactFunctionPointer.h
+++ b/include/swift/ABI/CompactFunctionPointer.h
@@ -1,0 +1,62 @@
+//===--- CompactFunctionPointer.h - Compact Function Pointers ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift's runtime structures often use relative function pointers to reduce the
+// size of metadata and also to minimize load-time overhead in PIC.
+// This file defines pointer types whose size and interface are compatible with
+// the relative pointer types for targets that do not support relative references
+// to code from data.
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_COMPACTFUNCTIONPOINTER_H
+#define SWIFT_ABI_COMPACTFUNCTIONPOINTER_H
+
+namespace swift {
+
+/// A compact unconditional absolute function pointer that can fit in a 32-bit
+/// integer.
+/// As a trade-off compared to relative pointers, this has load-time overhead in PIC
+/// and is only available on 32-bit targets.
+template <typename T>
+class AbsoluteFunctionPointer {
+  T *Pointer;
+  static_assert(sizeof(T *) == sizeof(int32_t),
+                "Function pointer must be 32-bit when using compact absolute pointer");
+
+public:
+  using PointerTy = T *;
+
+  PointerTy get() const & { return Pointer; }
+
+  operator PointerTy() const & { return this->get(); }
+
+  bool isNull() const & { return Pointer == nullptr; }
+
+  /// Resolve a pointer from a `base` pointer and a value loaded from `base`.
+  template <typename BasePtrTy, typename Value>
+  static PointerTy resolve(BasePtrTy *base, Value value) {
+    return reinterpret_cast<PointerTy>(value);
+  }
+
+  template <typename... ArgTy>
+  typename std::result_of<T *(ArgTy...)>::type operator()(ArgTy... arg) const {
+    static_assert(std::is_function<T>::value,
+                  "T must be an explicit function type");
+    return this->get()(std::forward<ArgTy>(arg)...);
+  }
+};
+
+// TODO(katei): Add another pointer structure for 64-bit targets and for efficiency on PIC
+
+} // namespace swift
+
+#endif // SWIFT_ABI_COMPACTFUNCTIONPOINTER_H

--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -241,7 +241,7 @@ template <class AsyncSignature>
 class AsyncFunctionPointer {
 public:
   /// The function to run.
-  RelativeDirectPointer<AsyncFunctionType<AsyncSignature>,
+  TargetCompactFunctionPointer<InProcess, AsyncFunctionType<AsyncSignature>,
                         /*nullable*/ false,
                         int32_t> Function;
 

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -611,6 +611,21 @@ public:
 
   int_type getIntValue() const { return Value; }
 
+  /// Is the method implementation is represented as a native function pointer?
+  bool isFunctionImpl() const {
+    switch (getKind()) {
+    case ProtocolRequirementFlags::Kind::Method:
+    case ProtocolRequirementFlags::Kind::Init:
+    case ProtocolRequirementFlags::Kind::Getter:
+    case ProtocolRequirementFlags::Kind::Setter:
+    case ProtocolRequirementFlags::Kind::ReadCoroutine:
+    case ProtocolRequirementFlags::Kind::ModifyCoroutine:
+      return !isAsync();
+    default:
+      return false;
+    }
+  }
+
   enum : uintptr_t {
     /// Bit used to indicate that an associated type witness is a pointer to
     /// a mangled name (vs. a pointer to metadata).

--- a/include/swift/ABI/TargetLayout.h
+++ b/include/swift/ABI/TargetLayout.h
@@ -31,6 +31,7 @@
 
 #include "swift/Runtime/Config.h"
 #include "swift/Basic/RelativePointer.h"
+#include "swift/ABI/CompactFunctionPointer.h"
 
 namespace swift {
 
@@ -101,6 +102,14 @@ struct InProcess {
   template <typename T, bool Nullable = true>
   using RelativeDirectPointer = RelativeDirectPointer<T, Nullable>;
 
+  template <typename T, bool Nullable = true, typename Offset = int32_t>
+#if SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER
+  using CompactFunctionPointer = AbsoluteFunctionPointer<T>;
+#else
+  using CompactFunctionPointer =
+      swift::RelativeDirectPointer<T, Nullable, Offset>;
+#endif
+
   template<typename T>
   T *getStrippedSignedPointer(const T *pointer) const {
     return swift_ptrauth_strip(pointer);
@@ -163,6 +172,9 @@ struct External {
   template <typename T, bool Nullable = true>
   using RelativeDirectPointer = int32_t;
 
+  template <typename T, bool Nullable = true, typename Offset = int32_t>
+  using CompactFunctionPointer = int32_t;
+
   StoredPointer getStrippedSignedPointer(const StoredSignedPointer pointer) const {
     return swift_ptrauth_strip(pointer);
   }
@@ -190,6 +202,12 @@ using TargetRelativeDirectPointer
 template <typename Runtime, typename Pointee, bool Nullable = true>
 using TargetRelativeIndirectablePointer
   = typename Runtime::template RelativeIndirectablePointer<Pointee,Nullable>;
+
+template <typename Runtime, typename Pointee, bool Nullable = true,
+          typename Offset = int32_t>
+using TargetCompactFunctionPointer =
+    typename Runtime::template CompactFunctionPointer<Pointee, Nullable,
+                                                      Offset>;
 
 } // end namespace swift
 

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -248,6 +248,16 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define SWIFT_VFORMAT(fmt)
 #endif
 
+/// Should we use absolute function pointers instead of relative ones?
+/// WebAssembly target uses it by default.
+#ifndef SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER
+# if defined(__wasm__)
+#  define SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER 1
+# else
+#  define SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER 0
+# endif
+#endif
+
 // Pointer authentication.
 #if __has_feature(ptrauth_calls)
 #define SWIFT_PTRAUTH 1

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -302,6 +302,10 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-DSWIFT_OBJC_INTEROP=0")
   endif()
 
+  if(SWIFT_STDLIB_COMPACT_ABSOLUTE_FUNCTION_POINTER)
+    list(APPEND result "-DSWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER=1")
+  endif()
+
   if(SWIFT_STDLIB_STABLE_ABI)
     list(APPEND result "-DSWIFT_LIBRARY_EVOLUTION=1")
   else()

--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -73,6 +73,10 @@ option(SWIFT_STDLIB_STABLE_ABI
        "Should stdlib be built with stable ABI (library evolution, resilience)."
        "${SWIFT_STDLIB_STABLE_ABI_default}")
 
+option(SWIFT_STDLIB_COMPACT_ABSOLUTE_FUNCTION_POINTER
+       "Force compact function pointer to always be absolute mainly for WebAssembly"
+       FALSE)
+
 option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"
        "${SWIFT_STDLIB_STABLE_ABI}")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -269,6 +269,10 @@ function(_add_target_variant_swift_compile_flags
     list(APPEND result "-D" "INTERNAL_CHECKS_ENABLED")
   endif()
 
+  if(SWIFT_STDLIB_COMPACT_ABSOLUTE_FUNCTION_POINTER)
+    list(APPEND result "-D" "SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER")
+  endif()
+
   if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
     list(APPEND result "-D" "SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY")
   endif()

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2762,7 +2762,7 @@ static void initClassVTable(ClassMetadata *self) {
     for (unsigned i = 0, e = vtable->VTableSize; i < e; ++i) {
       auto &methodDescription = descriptors[i];
       swift_ptrauth_init_code_or_data(
-          &classWords[vtableOffset + i], methodDescription.Impl.get(),
+          &classWords[vtableOffset + i], methodDescription.getImpl(),
           methodDescription.Flags.getExtraDiscriminator(),
           !methodDescription.Flags.isAsync());
     }
@@ -2802,9 +2802,8 @@ static void initClassVTable(ClassMetadata *self) {
       auto baseVTable = baseClass->getVTableDescriptor();
       auto offset = (baseVTable->getVTableOffset(baseClass) +
                      (baseMethod - baseClassMethods.data()));
-
       swift_ptrauth_init_code_or_data(&classWords[offset],
-                                      descriptor.Impl.get(),
+                                      descriptor.getImpl(),
                                       baseMethod->Flags.getExtraDiscriminator(),
                                       !baseMethod->Flags.isAsync());
     }
@@ -5139,7 +5138,7 @@ static void initializeResilientWitnessTable(
 
     auto &reqt = requirements[reqDescriptor - requirements.begin()];
     // This is an unsigned pointer formed from a relative address.
-    void *impl = witness.Witness.get();
+    void *impl = witness.getWitness(reqt.Flags);
     initProtocolWitness(&table[witnessIndex], impl, reqt);
   }
 
@@ -5153,7 +5152,7 @@ static void initializeResilientWitnessTable(
     auto &reqt = requirements[i];
     if (!table[witnessIndex]) {
       // This is an unsigned pointer formed from a relative address.
-      void *impl = reqt.DefaultImplementation.get();
+      void *impl = reqt.getDefaultImplementation();
       initProtocolWitness(&table[witnessIndex], impl, reqt);
     }
 
@@ -5622,7 +5621,7 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
     // Resolve the relative reference to the witness function.
     int32_t offset;
     memcpy(&offset, mangledName.data() + 1, 4);
-    uintptr_t ptr = detail::applyRelativeOffset(mangledName.data() + 1, offset);
+    void *ptr = TargetCompactFunctionPointer<InProcess, void>::resolve(mangledName.data() + 1, offset);
 
     // Call the witness function.
     AssociatedWitnessTableAccessFunction *witnessFn;


### PR DESCRIPTION
When `SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER` is enabled, relative direct
pointers whose pointees are functions will be turned into absolute
pointer at compile-time.

Based on https://github.com/apple/swift/pull/42094
