### PR TITLE
[Wasm][KeyPath] Resolve absolute function pointer as identity

### DIFF
--- a/include/swift/ABI/KeyPath.h
+++ b/include/swift/ABI/KeyPath.h
@@ -192,6 +192,7 @@ public:
   
   enum ComputedPropertyIDResolution {
     Resolved,
+    ResolvedAbsolute,
     IndirectPointer,
     FunctionCall,
   };
@@ -214,6 +215,7 @@ public:
            ? _SwiftKeyPathComponentHeader_ComputedIDByVTableOffsetFlag : 0)
       | (hasArguments ? _SwiftKeyPathComponentHeader_ComputedHasArgumentsFlag : 0)
       | (resolution == Resolved ? _SwiftKeyPathComponentHeader_ComputedIDResolved
+       : resolution == ResolvedAbsolute ? _SwiftKeyPathComponentHeader_ComputedIDResolvedAbsolute
        : resolution == IndirectPointer ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
        : resolution == FunctionCall ? _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFunctionCall
        : (assert(false && "invalid resolution"), 0)));

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -104,6 +104,8 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolutionM
   = 0x0000000FU;
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolved
   = 0x00000000U;
+static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDResolvedAbsolute
+  = 0x00000003U;
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
   = 0x00000002U;
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ComputedIDUnresolvedFunctionCall

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -874,6 +874,7 @@ internal enum KeyPathComputedIDKind {
 
 internal enum KeyPathComputedIDResolution {
   case resolved
+  case resolvedAbsolute
   case indirectPointer
   case functionCall
 }
@@ -1108,6 +1109,9 @@ internal struct RawKeyPathComponent {
     internal static var computedIDResolved: UInt32 {
       return _SwiftKeyPathComponentHeader_ComputedIDResolved
     }
+    internal static var computedIDResolvedAbsolute: UInt32 {
+      return _SwiftKeyPathComponentHeader_ComputedIDResolvedAbsolute
+    }
     internal static var computedIDUnresolvedIndirectPointer: UInt32 {
       return _SwiftKeyPathComponentHeader_ComputedIDUnresolvedIndirectPointer
     }
@@ -1118,6 +1122,8 @@ internal struct RawKeyPathComponent {
       switch payload & Header.computedIDResolutionMask {
       case Header.computedIDResolved:
         return .resolved
+      case Header.computedIDResolvedAbsolute:
+        return .resolvedAbsolute
       case Header.computedIDUnresolvedIndirectPointer:
         return .indirectPointer
       case Header.computedIDUnresolvedFunctionCall:
@@ -3381,35 +3387,39 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
       resolvedID = UnsafeRawPointer(bitPattern: value)
 
     case .pointer:
-      // Resolve the sign-extended relative reference.
-      var absoluteID: UnsafeRawPointer? = _resolveRelativeAddress(idValueBase, idValue)
-
       // If the pointer ID is unresolved, then it needs work to get to
       // the final value.
       switch idResolution {
       case .resolved:
+        resolvedID = _resolveRelativeAddress(idValueBase, idValue)
+        break
+
+      case .resolvedAbsolute:
+        let value = UInt(UInt32(bitPattern: idValue))
+        resolvedID = UnsafeRawPointer(bitPattern: value)
         break
 
       case .indirectPointer:
         // The pointer in the pattern is an indirect pointer to the real
         // identifier pointer.
-        absoluteID = absoluteID.unsafelyUnwrapped
+        let absoluteID = _resolveRelativeAddress(idValueBase, idValue)
+        resolvedID = absoluteID
           .load(as: UnsafeRawPointer?.self)
 
       case .functionCall:
         // The pointer in the pattern is to a function that generates the
         // identifier pointer.
         typealias Resolver = @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?
+        let absoluteID = _resolveCompactFunctionPointer(idValueBase, idValue)
         let resolverSigned = _PtrAuth.sign(
-          pointer: absoluteID.unsafelyUnwrapped,
+          pointer: absoluteID,
           key: .processIndependentCode,
           discriminator: _PtrAuth.discriminator(for: Resolver.self))
         let resolverFn = unsafeBitCast(resolverSigned,
                                        to: Resolver.self)
 
-        absoluteID = resolverFn(patternArgs)
+        resolvedID = resolverFn(patternArgs)
       }
-      resolvedID = absoluteID
     }
 
     // Bring over the header, getter, and setter.


### PR DESCRIPTION
Emit and resolve idValue of KeyPath as an absolute pointer if relative
function pointer is turned-off on Wasm target.
The existing ABI can't distinguish an idValue between function pointer
or data pointer in use-site at compile-time and also at runtime. So this
patch adds a new id resolution scheme `ResolvedAbsolute` to distinguish
them at runtime properly.


