### PR TITLE
[cxx-interop] emit correct parameter name in the inline C++ function …

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -881,7 +881,7 @@ private:
       size_t index = 1;
       interleaveComma(*params, os, [&](const ParamDecl *param) {
         if (param->hasName()) {
-          os << param->getName();
+          ClangSyntaxPrinter(os).printIdentifier(param->getName().str());
         } else {
           os << "_" << index;
         }

--- a/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK: inline void testKeywordArgument(swift::Int register_) noexcept
+// CHECK-NEXT: return _impl::$s9Functions19testKeywordArgument8registerySi_tF(register_);
+
+func testKeywordArgument(register: Int) {
+}


### PR DESCRIPTION
…when the identifier conflicts with a keyword