### PR TITLE
SILGen: Emit async let entry points at correct abstraction level.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -3897,6 +3897,32 @@ emitRetconCoroutineEntry(IRGenFunction &IGF, CanSILFunctionType fnType,
   IGF.setEarliestInsertionPoint(pt);
 }
 
+void IRGenModule::addAsyncCoroIDMapping(llvm::GlobalVariable *asyncFunctionPointer,
+                                        llvm::CallInst *coro_id_builtin) {
+  AsyncCoroIDsForPadding[asyncFunctionPointer] = coro_id_builtin;
+}
+
+llvm::CallInst *
+IRGenModule::getAsyncCoroIDMapping(llvm::GlobalVariable *asyncFunctionPointer) {
+  auto found = AsyncCoroIDsForPadding.find(asyncFunctionPointer);
+  if (found == AsyncCoroIDsForPadding.end())
+    return nullptr;
+  return found->second;
+}
+
+void IRGenModule::markAsyncFunctionPointerForPadding(
+                                   llvm::GlobalVariable *asyncFunctionPointer) {
+  AsyncCoroIDsForPadding[asyncFunctionPointer] = nullptr;
+}
+
+bool IRGenModule::isAsyncFunctionPointerMarkedForPadding(
+                                   llvm::GlobalVariable *asyncFunctionPointer) {
+  auto found = AsyncCoroIDsForPadding.find(asyncFunctionPointer);
+  if (found == AsyncCoroIDsForPadding.end())
+    return false;
+  return found->second == nullptr;
+}
+
 void irgen::emitAsyncFunctionEntry(IRGenFunction &IGF,
                                    const AsyncContextLayout &layout,
                                    LinkEntity asyncFunction,
@@ -3904,16 +3930,25 @@ void irgen::emitAsyncFunctionEntry(IRGenFunction &IGF,
   auto &IGM = IGF.IGM;
   auto size = layout.getSize();
   auto asyncFuncPointerVar = cast<llvm::GlobalVariable>(IGM.getAddrOfAsyncFunctionPointer(asyncFunction));
+  bool isPadded = IGM
+    .isAsyncFunctionPointerMarkedForPadding(asyncFuncPointerVar);
   auto asyncFuncPointer = IGF.Builder.CreateBitOrPointerCast(
                                            asyncFuncPointerVar, IGM.Int8PtrTy);
+  
+  if (isPadded) {
+    size = std::max(layout.getSize(),
+                    NumWords_AsyncLet * IGM.getPointerSize());
+  }
+  
   auto *id = IGF.Builder.CreateIntrinsicCall(
       llvm::Intrinsic::coro_id_async,
       {llvm::ConstantInt::get(IGM.Int32Ty, size.getValue()),
        llvm::ConstantInt::get(IGM.Int32Ty, 16),
        llvm::ConstantInt::get(IGM.Int32Ty, asyncContextIndex),
        asyncFuncPointer});
-  auto inserted = IGM.AsyncCoroIDs.insert({asyncFuncPointerVar, id});
-  assert(inserted.second);
+  
+  IGM.addAsyncCoroIDMapping(asyncFuncPointerVar, id);
+
   // Call 'llvm.coro.begin', just for consistency with the normal pattern.
   // This serves as a handle that we can pass around to other intrinsics.
   auto hdl = IGF.Builder.CreateIntrinsicCall(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5611,6 +5611,12 @@ llvm::GlobalValue *irgen::emitAsyncFunctionPointer(IRGenModule &IGM,
                                                    llvm::Function *function,
                                                    LinkEntity entity,
                                                    Size size) {
+  auto afp = cast<llvm::GlobalVariable>(IGM.getAddrOfAsyncFunctionPointer(entity));
+  if (IGM.isAsyncFunctionPointerMarkedForPadding(afp)) {
+    size = std::max(size,
+                    NumWords_AsyncLet * IGM.getPointerSize());
+  }
+  
   ConstantInitBuilder initBuilder(IGM);
   ConstantStructBuilder builder(
       initBuilder.beginStruct(IGM.AsyncFunctionPointerTy));

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1212,8 +1212,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
     if (auto tryExpr = dyn_cast<TryExpr>(init))
       init = tryExpr->getSubExpr();
     init = cast<CallExpr>(init)->getFn();
-    assert(isa<AutoClosureExpr>(init) &&
-           "Could not find async let autoclosure");
+    auto initClosure = cast<AutoClosureExpr>(init);
     bool isThrowing = init->getType()->castTo<AnyFunctionType>()->isThrowing();
 
     // Allocate space to receive the child task's result.
@@ -1240,8 +1239,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
       alet = emitAsyncLetStart(
           loc,
           options.forward(*this), // options is B.createManagedOptionalNone
-          init->getType(),
-          emitRValue(init).getScalarValue(),
+          initClosure,
           resultBufPtr
         ).forward(*this);
     }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1456,7 +1456,7 @@ public:
 
   ManagedValue emitAsyncLetStart(SILLocation loc,
                                  SILValue taskOptions,
-                                 Type functionType, ManagedValue taskFunction,
+                                 AbstractClosureExpr *asyncLetEntryPoint,
                                  SILValue resultBuf);
 
   void emitFinishAsyncLet(SILLocation loc, SILValue asyncLet, SILValue resultBuf);

--- a/test/IRGen/async_let_back_deploy_workaround.swift
+++ b/test/IRGen/async_let_back_deploy_workaround.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-ir -target x86_64-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-sans-workaround %s
-// RUN: %target-swift-frontend -emit-ir -target x86_64-apple-macos12.3 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-with-workaround %s
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos99.99 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-sans-workaround %s
+// RUN: %target-swift-frontend -emit-ir -target %target-cpu-apple-macos12.3 %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-with-workaround %s
 
 // REQUIRES: OS=macosx
  
@@ -11,12 +11,26 @@
 // initial context sizes of any async functions used as `async let` entry points
 // to ensure that the preallocated space is never used for the initial context.
 
-// CHECK: [[ASYNC_LET_ENTRY:@"\$sSiIeghHd_Sis5Error_pIegHrzo_TRTATu"]]
+// CHECK: [[ASYNC_LET_ENTRY_FOO:@"\$s32async_let_back_deploy_workaround3foo1x1yS2i_SitYaFSiyYaYbcfu_TATu"]]
 // CHECK-with-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 6{{[0-9][0-9]}} }>
 // CHECK-sans-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 {{[0-9][0-9]}} }>
 
-// CHECK: swift_asyncLet_begin{{.*}}[[ASYNC_LET_ENTRY]]
+// CHECK: [[ASYNC_LET_ENTRY_BAR:@"\$s32async_let_back_deploy_workaround3bar1x1yS2i_SitYaFSiyYaYbcfu_Tu"]]
+// CHECK-with-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 6{{[0-9][0-9]}} }>
+// CHECK-sans-workaround-SAME: = internal {{.*}} %swift.async_func_pointer <{ {{.*}}, i32 {{[0-9][0-9]}} }>
+
+// CHECK-LABEL: define {{.*}}3foo
+// CHECK: swift_asyncLet_begin{{.*}}[[ASYNC_LET_ENTRY_FOO]]
 public func foo(x: Int, y: Int) async -> Int {
     async let z = x + y
+    return await z
+}
+
+@_silgen_name("bar_work") func bar_work() -> Int
+
+// CHECK-LABEL: define {{.*}}3bar
+// CHECK: swift_asyncLet_begin{{.*}}[[ASYNC_LET_ENTRY_BAR]]
+public func bar(x: Int, y: Int) async -> Int {
+    async let z = bar_work()
     return await z
 }


### PR DESCRIPTION
Avoid a reabstraction thunk every time an async let entry point is emitted,
by setting the context abstraction level while we emit the implicit closure.
Adjust some surrounding logic that breaks when we do this:

- When lowering a non-throwing function type against a throwing abstraction
  pattern, include the error type in the lowered substituted type. Async
  throwing and nonthrowing functions would require another thunk to convert
  away the throwingness of the async context, which would defeat the purpose.
- Adjust the code in IRGen that pads the initial context size for `async let`
  entry points so that it works when the entry point has not yet emitted, by
  marking the async function pointer to be padded later if it isn't defined
  yet.