### PR TITLE
[SourceKit] Fix VFS overlay tests

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_clang_vfs_overlay.swift
+++ b/test/SourceKit/CursorInfo/cursor_clang_vfs_overlay.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+// RUN: sed -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/A@g" -e "s@NAME_DIR@%{/t:regex_replacement}/B@g" %t/base.yaml > %t/overlay.yaml
+
+//--- use.swift
+import MyMod
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+2):14 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-A %s
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %t/use.swift -- -Xcc -working-directory=%t -Xcc -IB -Xcc -ivfsoverlay -Xcc %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-A %s
+func f1(arg: A) {}
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+2):14 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-B %s
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %t/use.swift -- -Xcc -working-directory=%t -Xcc -IB -Xcc -ivfsoverlay -Xcc %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-B %s
+func f2(arg: B) {}
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+2):14 %t/use.swift -- -I%t/B -vfsoverlay %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-C %s
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %t/use.swift -- -Xcc -working-directory=%t -Xcc -IB -Xcc -ivfsoverlay -Xcc %t/overlay.yaml %t/use.swift | %FileCheck --check-prefix=CHECK-C %s
+func f3(arg: C) {}
+
+//--- A/A.h
+// CHECK-A: source.lang.swift.ref.struct ({{.*}}{{/|\\}}A{{/|\\}}A.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct A {
+  int a;
+};
+
+//--- A/B.h
+
+//--- A/C.h
+// CHECK-C: source.lang.swift.ref.struct ({{.*}}{{/|\\}}A{{/|\\}}C.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct C {
+  int c;
+};
+
+//--- B/B.h
+#include "C.h"
+
+// CHECK-B: source.lang.swift.ref.struct ({{.*}}{{/|\\}}B{{/|\\}}B.h:[[@LINE+1]]:8-[[@LINE+1]]:9)
+struct B {
+  int b;
+};
+
+//--- B/module.modulemap
+module MyMod {
+  header "A.h"
+  header "B.h"
+}
+
+//--- base.yaml
+{
+  version: 0,
+  redirecting-with: "fallback",
+  use-external-names: true,
+  roots: [
+    {
+      type: "directory-remap",
+      name: "NAME_DIR",
+      external-contents: "EXTERNAL_DIR"
+    }
+  ]
+}

--- a/test/SourceKit/CursorInfo/cursor_swift_vfs_overlay.swift
+++ b/test/SourceKit/CursorInfo/cursor_swift_vfs_overlay.swift
@@ -9,11 +9,7 @@ func a() {
 }
 
 //--- B/b.swift
-// TODO: This should be B/b.swift, but there's currently a bug with multiple overlays.
-//       See rdar://90578880 or https://github.com/llvm/llvm-project/issues/53306.
-//       Replace with CHECK-FIXED when that's fixed.
-// CHECK: source.lang.swift.ref.function.free ({{.*}}{{/|\\}}A{{/|\\}}b.swift:*missing file*)
-// CHECK-FIXED: source.lang.swift.ref.function.free ({{.*}}{{/|\\}}B{{/|\\}}b.swift:[[@LINE+1]]:6-[[@LINE+1]]:9)
+// CHECK: source.lang.swift.ref.function.free ({{.*}}{{/|\\}}B{{/|\\}}b.swift:[[@LINE+1]]:6-[[@LINE+1]]:9)
 func b() {}
 
 //--- base.yaml


### PR DESCRIPTION
The `RedirectingFileSystem` was fixed in LLVM, so paths from the VFS
overlays are now correct. Fix up a previously added test that depended
on the erroneous behaviour and add a new one to test clang modules.