### PR TITLE
[cxx-interop] Remove 'support' for importing C++ operators.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4129,6 +4129,11 @@ namespace {
       if (!dc)
         return nullptr;
 
+      // Support for importing operators is temporarily disabled: rdar://91070109
+      if (decl->getDeclName().getNameKind() == clang::DeclarationName::CXXOperatorName &&
+          decl->getDeclName().getCXXOverloadedOperator() != clang::OO_Subscript)
+        return nullptr;
+
       // Handle cases where 2 CXX methods differ strictly in "constness"
       // In such a case append a suffix ("Mutating") to the mutable version
       // of the method when importing to swift

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
@@ -8,6 +8,7 @@
 // that the operator decl can be found when at least one of the
 // modules is not `@_implementationOnly`.
 
+// XFAIL: *
 
 import UserA
 @_implementationOnly import UserB

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
@@ -8,6 +8,8 @@
 // that the operator decl can be found when at least one of the
 // modules is not `@_implementationOnly`.
 
+// XFAIL: *
+
 @_implementationOnly import UserA
 import UserB
 

--- a/test/Interop/Cxx/namespace/free-functions-module-interface.swift
+++ b/test/Interop/Cxx/namespace/free-functions-module-interface.swift
@@ -7,7 +7,8 @@
 // CHECK-NEXT:   struct X {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   static func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
+// TODO: check this again when operators are re-enabled: rdar://91070109 (also please enable this in the execution test "free-functions.swift")
+// CHECK-NOT:   static func +
 // CHECK-NEXT:   static func sameNameInChild() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   static func sameNameInSibling() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   enum FunctionsNS2 {
@@ -20,7 +21,8 @@
 // CHECK-NEXT:   static func definedInDefs() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
-// CHECK-NEXT: static func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
+// TODO: check this again when operators are re-enabled: rdar://91070109 (also please enable this in the execution test "free-functions.swift")
+// CHECK-NOT: static func +
 
 // CHECK-NEXT: enum FunctionsNS4 {
 // CHECK-NEXT:   static func sameNameInSibling() -> UnsafePointer<CChar>!

--- a/test/Interop/Cxx/namespace/free-functions.swift
+++ b/test/Interop/Cxx/namespace/free-functions.swift
@@ -20,9 +20,10 @@ NamespacesTestSuite.test("Basic functions") {
   expectEqual(String(cString: basicFunctionLowestLevelCString!),
               "FunctionsNS1::FunctionsNS2::FunctionsNS3::basicFunctionLowestLevel")
 
-  let x = FunctionsNS1.X()
-  expectEqual(String(cString: x + x),
-              "FunctionsNS1::operator+(X, X)")
+// TODO: check this again when operators are re-enabled: rdar://91070109
+//   let x = FunctionsNS1.X()
+//   expectEqual(String(cString: x + x),
+//               "FunctionsNS1::operator+(X, X)")
 }
 
 NamespacesTestSuite.test("Forward declared functions") {

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
-// XFAIL: OS=windows-msvc
+// XFAIL: *
 
 import MemberInline
 

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// XFAIL: *
 
 // CHECK: struct LoadableIntWrapper {
 // CHECK:   static func - (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// XFAIL: *
 
 import MemberInline
 

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// XFAIL: *
 
 import MemberInline
 

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 
 // REQUIRES: executable_test
-// XFAIL: OS=linux-android
+// XFAIL: *
 
 import MemberInline
 import StdlibUnittest

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
-// XFAIL: OS=windows-msvc
+// XFAIL: *
 
 import MemberOutOfLine
 

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s -check-prefix CHECK-%target-abi
 
+// XFAIL: *
+
 import MemberOutOfLine
 
 public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -6,6 +6,8 @@
 
 // REQUIRES: executable_test
 
+// XFAIL: *
+
 import MemberOutOfLine
 import StdlibUnittest
 

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NonMemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
+// XFAIL: *
+
 // CHECK:      func + (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func - (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func * (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
 
+// XFAIL: *
+
 import NonMemberInline
 
 let lhs = LoadableIntWrapper(value: 42)

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -2,6 +2,8 @@
 //
 // REQUIRES: executable_test
 
+// XFAIL: *
+
 import NonMemberInline
 import StdlibUnittest
 

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
 
+// XFAIL: *
+
 import NonMemberOutOfLine
 
 public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
 
+// XFAIL: *
+
 import NonMemberOutOfLine
 
 public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -6,6 +6,8 @@
 //
 // REQUIRES: executable_test
 
+// XFAIL: *
+
 import NonMemberOutOfLine
 import StdlibUnittest
 


### PR DESCRIPTION
This does not include subscript operators.

Before this is re-enabled operators need to be re-implemented. Right now they are the source of a lot of bugs. They cause frequent crashes and mis compiles. Also, templated operators insert a lot of names into global lookup which causes problems.

They also don't work on Windows.