### PR TITLE
[IRGen] Bail on opt when seeing non-ABI field.

### DIFF
--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -550,7 +550,7 @@ private:
       if (field.isEmpty()) continue;
 
       // If the field is not ABI-accessible, suppress this.
-      if (!field.isABIAccessible()) continue;
+      if (!field.isABIAccessible()) return 0;
 
       // If we've already found an index, then there isn't a
       // unique non-empty field.

--- a/validation-test/IRGen/Inputs/rdar79513293_Library.swift
+++ b/validation-test/IRGen/Inputs/rdar79513293_Library.swift
@@ -1,0 +1,15 @@
+enum E<Value> {
+    case s(Value)
+    case n
+}
+
+public struct S<Value> {
+    var e: E<Value>
+    var b: Bool = false
+
+    public init() {
+        self.e = .n
+    }
+}
+
+

--- a/validation-test/IRGen/Inputs/rdar79513293_Resilient.swift
+++ b/validation-test/IRGen/Inputs/rdar79513293_Resilient.swift
@@ -1,0 +1,4 @@
+public struct Unfixed {
+  var _value: String
+  var _another: Int
+}

--- a/validation-test/IRGen/rdar79513293.swift
+++ b/validation-test/IRGen/rdar79513293.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift \
+// RUN:     -emit-module \
+// RUN:     %S/Inputs/rdar79513293_Library.swift \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Library \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-build-swift \
+// RUN:     -c \
+// RUN:     %S/Inputs/rdar79513293_Library.swift \
+// RUN:     -parse-as-library \
+// RUN:     -module-name Library \
+// RUN:     -o %t/Library.o
+
+// RUN: %target-build-swift \
+// RUN:     -emit-module \
+// RUN:     %S/Inputs/rdar79513293_Resilient.swift \
+// RUN:     -parse-as-library \
+// RUN:     -enable-library-evolution \
+// RUN:     -module-name Resilient \
+// RUN:     -emit-module-path %t/Resilient.swiftmodule
+
+// RUN: %target-build-swift \
+// RUN:     -c \
+// RUN:     %S/Inputs/rdar79513293_Resilient.swift \
+// RUN:     -parse-as-library \
+// RUN:     -enable-library-evolution \
+// RUN:     -module-name Resilient \
+// RUN:     -o %t/Resilient.o
+
+// RUN: %target-build-swift \
+// RUN:     -c \
+// RUN:     %s \
+// RUN:     -o %t/main.o \
+// RUN:     -I %t
+
+// RUN: %target-swiftc_driver \
+// RUN:     %t/Resilient.o \
+// RUN:     %t/Library.o \
+// RUN:     %t/main.o \
+// RUN:     -o %t/main
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+import Library
+import Resilient
+
+protocol P {}
+
+struct I: P {
+  var s = S<Unfixed?>()
+}
+
+func main() {
+  let ps = [I() as P]
+  for _ in ps {}
+}
+
+main()
+print("ok")
+// CHECK: ok


### PR DESCRIPTION
When analyzing a struct's layout to determine whether it contains a single non-empty field, bail upon encountering a field that is not ABI accessible.

Previously, rather than bailing (though that was the intent), the field was ignored.  The result was that structs with a single non-empty field and any number of ABI inaccessible fields would be treated as if they only had a single non-empty field.  Trouble ensued.

rdar://79513293
