### PR TITLE
[Concurrency] Don't use getenv() unless SWIFT_STDLIB_HAS_ENVIRON is set.

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -332,6 +332,7 @@ static bool swift_task_isCurrentExecutorImpl(ExecutorRef executor) {
 static unsigned unexpectedExecutorLogLevel = 1;
 
 static void checkUnexpectedExecutorLogLevel(void *context) {
+#if SWIFT_STDLIB_HAS_ENVIRON
   const char *levelStr = getenv("SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL");
   if (!levelStr)
     return;
@@ -339,6 +340,7 @@ static void checkUnexpectedExecutorLogLevel(void *context) {
   long level = strtol(levelStr, nullptr, 0);
   if (level >= 0 && level < 3)
     unexpectedExecutorLogLevel = level;
+#endif // SWIFT_STDLIB_HAS_ENVIRON
 }
 
 SWIFT_CC(swift)


### PR DESCRIPTION
We don't necessarily have environment variables, which is why we have `SWIFT_STDLIB_HAS_ENVIRON`.  Calling `getenv()` outside of a check of this means Concurrency won't work in environments where `getenv()` cannot be used.

rdar://91050064
