### PR TITLE
LangOptions: Change default for RequirementMachineAbstractSignatures from Verify to Enabled

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -533,7 +533,7 @@ namespace swift {
     /// Enable the new experimental generic signature minimization algorithm
     /// for abstract generic signatures.
     RequirementMachineMode RequirementMachineAbstractSignatures =
-        RequirementMachineMode::Verify;
+        RequirementMachineMode::Enabled;
 
     /// Enable the new experimental generic signature minimization algorithm
     /// for user-written generic signatures.


### PR DESCRIPTION
We've only seen false positives from verification here, and this request
doesn't emit diagnostics.