### PR TITLE
Turn off the GenericSignatureBuilder

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -528,7 +528,7 @@ namespace swift {
     /// Enable the new experimental protocol requirement signature minimization
     /// algorithm.
     RequirementMachineMode RequirementMachineProtocolSignatures =
-        RequirementMachineMode::Verify;
+        RequirementMachineMode::Enabled;
 
     /// Enable the new experimental generic signature minimization algorithm
     /// for abstract generic signatures.
@@ -538,7 +538,7 @@ namespace swift {
     /// Enable the new experimental generic signature minimization algorithm
     /// for user-written generic signatures.
     RequirementMachineMode RequirementMachineInferredSignatures =
-        RequirementMachineMode::Verify;
+        RequirementMachineMode::Enabled;
 
     /// Enable preprocessing pass to eliminate conformance requirements
     /// on generic parameters which are made concrete. Usually you want this

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -469,11 +469,6 @@ function(_compile_swift_files
     endif()
   endif()
 
-  # The standard library and overlays are built with the Requirement Machine enabled.
-  if(SWIFTFILE_IS_STDLIB)
-    list(APPEND swift_flags "-Xfrontend" "-requirement-machine-inferred-signatures=verify")
-  endif()
-
   # The standard library and overlays are built resiliently when SWIFT_STDLIB_STABLE_ABI=On.
   if(SWIFTFILE_IS_STDLIB AND SWIFT_STDLIB_STABLE_ABI)
     list(APPEND swift_flags "-enable-library-evolution")


### PR DESCRIPTION
The Requirement Machine has been running in 'verify' mode for a while, where we run both the GenericSignatureBuilder and Requirement Machine minimization algorithm and compare the results, with the GenericSignatureBuilder being used to emit diagnostics.

Now, it's time to flip the flags to 'enabled' mode, where the GenericSignatureBuilder doesn't run at all, and the Requirement Machine emits diagnostics. This finally allows us to realize the correctness and performance gains from using the Requirement Machine.

See https://forums.swift.org/t/the-requirement-machine-a-new-generics-implementation-based-on-term-rewriting/55601/ for details.

Resolves rdar://88134788.

Correctness:

- https://bugs.swift.org/browse/SR-7353
- https://bugs.swift.org/browse/SR-9595
- https://bugs.swift.org/browse/SR-10532
- https://bugs.swift.org/browse/SR-10752
- https://bugs.swift.org/browse/SR-11100
- https://bugs.swift.org/browse/SR-11532
- https://bugs.swift.org/browse/SR-11997
- https://bugs.swift.org/browse/SR-12120
- https://bugs.swift.org/browse/SR-12736
- https://bugs.swift.org/browse/SR-12980
- https://bugs.swift.org/browse/SR-13018
- https://bugs.swift.org/browse/SR-13491
- https://bugs.swift.org/browse/SR-13502
- https://bugs.swift.org/browse/SR-14484
- https://bugs.swift.org/browse/SR-14485
- https://bugs.swift.org/browse/SR-14659
- https://bugs.swift.org/browse/SR-14776
- https://bugs.swift.org/browse/SR-14917
- https://bugs.swift.org/browse/SR-15009
- https://bugs.swift.org/browse/SR-15790
- https://bugs.swift.org/browse/SR-15920
- rdar://25065503
- rdar://39225307
- rdar://44590919
- rdar://45957015
- rdar://50169558
- rdar://51068593
- rdar://52921168
- rdar://54394068
- rdar://55758433
- rdar://58455439
- rdar://59132837
- rdar://62894047
- rdar://64953119
- rdar://65015626
- rdar://65558829
- rdar://68084643
- rdar://68376692
- rdar://75329340
- rdar://76646764
- rdar://77683844
- rdar://77794156
- rdar://78233378
- rdar://78481510
- rdar://78643612
- rdar://80820294
- rdar://81276358
- rdar://81425392
- rdar://83308672
- rdar://83373331
- rdar://83848546
- rdar://83955123
- rdar://88514540
- rdar://89641532
- rdar://90264856
- rdar://90343419

Performance:

- rdar://33654588
- rdar://47821930
- rdar://51908331
- rdar://59037195
- rdar://65131776
- rdar://73771235
- rdar://75188696

GSB crashes with no reduced test case that are likely fixed:

- https://bugs.swift.org/browse/SR-4872
- rdar://32144681
- rdar://42376632
- rdar://46270030
- rdar://47199993
- rdar://48648900
- rdar://49535930
- rdar://49712445
- rdar://49712637
- rdar://49713096
- rdar://49713107
- rdar://60334839
- rdar://66593156
- rdar://68982368
- rdar://76706682
- rdar://77794745
- rdar://84724541