### PR TITLE
Update -requirement-machine-* flags in various tests

### DIFF
--- a/test/AutoDiff/SILGen/differentiability_witness_generic_signature.swift
+++ b/test/AutoDiff/SILGen/differentiability_witness_generic_signature.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify -module-name main %s | %FileCheck %s
-// RUN: %target-swift-emit-sil -verify -module-name main %s
+// RUN: %target-swift-emit-silgen -verify -module-name main %s -requirement-machine-inferred-signatures=on | %FileCheck %s
+// RUN: %target-swift-emit-sil -verify -module-name main %s -requirement-machine-inferred-signatures=on
 
 // NOTE(SR-11950): SILParser crashes for SILGen round-trip.
 
@@ -84,7 +84,7 @@ extension AllConcrete where T == Float {
   // Derivative generic signature: `<T where T == Float>` (explicit `where` clause)
   //    Witness generic signature: none
   @_silgen_name("allconcrete_where_gensig")
-  @differentiable(reverse where T == Float)
+  @differentiable(reverse where T == Float) // expected-warning {{redundant same-type constraint 'T' == 'Float'}}
   func whereClauseGenericSignature() -> AllConcrete {
     return self
   }
@@ -158,7 +158,7 @@ extension NotAllConcrete where T == Float {
   // Derivative generic signature: `<T, U where T == Float>` (explicit `where` clause)
   //    Witness generic signature: `<T, U where T == Float>` (not all concrete)
   @_silgen_name("notallconcrete_where_gensig")
-  @differentiable(reverse where T == Float)
+  @differentiable(reverse where T == Float) // expected-warning {{redundant same-type constraint 'T' == 'Float'}}
   func whereClauseGenericSignature() -> NotAllConcrete {
     return self
   }

--- a/test/AutoDiff/SILOptimizer/generics.swift
+++ b/test/AutoDiff/SILOptimizer/generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify %s -requirement-machine-abstract-signatures=verify | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-emit-sil -verify %s -requirement-machine-inferred-signatures=on | %FileCheck %s -check-prefix=CHECK-SIL
 
 import _Differentiation
 
@@ -51,12 +51,12 @@ func foo<T>(_ x: Wrapper<T>) {
 
 // Test case where associated derivative function's requirements are met.
 extension Wrapper where Scalar : Numeric {
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
   func mean() -> Wrapper {
     return self
   }
 
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
+  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
   func variance() -> Wrapper {
     return mean() // ok
   }

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
-// RUN: not %target-swift-frontend -typecheck -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 4 -requirement-machine-protocol-signatures=on
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 -requirement-machine-protocol-signatures=on
 
 protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
 // expected-warning@-1{{redundant constraint 'Self' : 'AnyObject'}}
-// expected-note@-2{{constraint 'Self' : 'AnyObject' implied here}}

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -requirement-machine-protocol-signatures=on
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 
@@ -133,7 +133,6 @@ struct X { }
 
 protocol P {
 	associatedtype P1 where P1 == X
-	// expected-note@-1{{same-type constraint 'Self.P1' == 'X' written here}}
 	associatedtype P2 where P2 == P1, P2 == X
 	// expected-warning@-1{{redundant same-type constraint 'Self.P2' == 'X'}}
 }

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 // rdar://problem/23149063
 protocol P0 { }
@@ -13,8 +13,6 @@ protocol Q : P {
 
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}
 // expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
-// expected-note@-2{{conformance constraint 'T' : 'P' implied here}}
 
 func f<T>(t: T) where T : Q, T : P, T.A : P0 { } // expected-error{{invalid redeclaration of 'f(t:)'}}
 // expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
-// expected-note@-2{{conformance constraint 'T' : 'P' implied here}}

--- a/test/Generics/concrete_conformances_in_protocol.swift
+++ b/test/Generics/concrete_conformances_in_protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // rdar://problem/88135912
 // XFAIL: *

--- a/test/Generics/concrete_nesting_elimination_order.swift
+++ b/test/Generics/concrete_nesting_elimination_order.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T

--- a/test/Generics/concrete_protocol_typealias_minimization.swift
+++ b/test/Generics/concrete_protocol_typealias_minimization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P1a {
   typealias X = Int

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures -requirement-machine-inferred-signatures=on > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 {}
@@ -55,6 +55,7 @@ struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-NEXT: (normal_conformance type=RedundantSuper<T> protocol=P2)
 extension RedundantSuper: P2 where T: P1 {}
+// expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 
 struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
@@ -187,6 +188,7 @@ struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
 extension ClassLessSpecific: P2 where T: C1 {}
+// expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 
 
 // Inherited conformances:

--- a/test/Generics/conditional_requirement_inference.swift
+++ b/test/Generics/conditional_requirement_inference.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol Equatable {}
 

--- a/test/Generics/conditional_requirement_inference_2.swift
+++ b/test/Generics/conditional_requirement_inference_2.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-inferred-signatures=verify %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 // A more complicated example.
 protocol Equatable {}

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -requirement-machine-protocol-signatures=on
 
 protocol P0 { }
 protocol Q0: P0 { }
@@ -48,7 +48,7 @@ func testPaths3<V: P5>(_ v: V) {
 	acceptQ0(v.getAssocP3())
 }
 
-protocol P6Unordered: P5Unordered { // expected-note{{conformance constraint 'Self.A' : 'P0' implied here}}
+protocol P6Unordered: P5Unordered {
 	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A' : 'P0'}}
                        // expected-warning@-1{{redeclaration of associated type 'A'}}
 }

--- a/test/Generics/conformance_requirement_in_original_protocol.swift
+++ b/test/Generics/conformance_requirement_in_original_protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 public protocol P1 {
   associatedtype X

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,7 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=off
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
-
-// FIXME: Both RUN lines should pass 'on' once diagnostics are implemented.
 
 protocol P {}
 class C {}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift
 
 //===----------------------------------------------------------------------===//
 // Type-check function definitions

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 protocol MyFormattedPrintable {
   func myFormat() -> String
@@ -236,10 +236,13 @@ class Bottom<T : Bottom<Top>> {}
 
 struct UnsolvableInheritance1<T : T.A> {}
 // expected-error@-1 {{'A' is not a member type of type 'T'}}
+// expected-error@-2 {{type 'T' constrained to non-protocol, non-class type 'T.A'}}
 
 struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 // expected-error@-1 {{'A' is not a member type of type 'U'}}
 // expected-error@-2 {{'A' is not a member type of type 'T'}}
+// expected-error@-3 {{type 'T' constrained to non-protocol, non-class type 'U.A'}}
+// expected-error@-4 {{type 'U' constrained to non-protocol, non-class type 'T.A'}}
 
 enum X7<T> where X7.X : G { case X } // expected-error{{enum case 'X' is not a member type of 'X7<T>'}}
 // expected-error@-1{{cannot find type 'G' in scope}}

--- a/test/Generics/indirectly_concrete_generic_param.swift
+++ b/test/Generics/indirectly_concrete_generic_param.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 class S<T, U> where T : P, U == T.T {}
 

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures -requirement-machine-protocol-signatures=on > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 // CHECK-LABEL: .P1@
@@ -18,7 +18,7 @@ protocol P3 {}
 // CHECK-LABEL: .Q1@
 // CHECK-NEXT: Requirement signature: <Self where Self.[Q1]X : P1>
 protocol Q1 {
-    associatedtype X: P1 // expected-note {{declared here}}
+    associatedtype X: P1 // expected-note 3{{declared here}}
 }
 
 // inheritance
@@ -38,7 +38,6 @@ protocol Q3: Q1 {
 // CHECK-NEXT: Requirement signature: <Self where Self : Q1, Self.[Q1]X : P2>
 protocol Q4: Q1 {
     associatedtype X: P2 // expected-warning{{redeclaration of associated type 'X'}}
-                   // expected-note@-1 2{{'X' declared here}}
 }
 
 // multiple inheritance
@@ -49,10 +48,10 @@ protocol Q5: Q2, Q3, Q4 {}
 // multiple inheritance without any new requirements
 // CHECK-LABEL: .Q6@
 // CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
-protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X' : 'P1' implied here}}
+protocol Q6: Q2,
              Q3, Q4 {
     associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X' : 'P1'}}
-                   // expected-warning@-1{{redeclaration of associated type 'X' from protocol 'Q4' is}}
+                   // expected-warning@-1{{redeclaration of associated type 'X' from protocol 'Q1' is}}
 }
 
 // multiple inheritance with a new conformance

--- a/test/Generics/protocol_superclass_cycle.swift
+++ b/test/Generics/protocol_superclass_cycle.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -disable-requirement-machine-concrete-contraction 2>&1 | %FileCheck %s
 
 protocol P : C {}
 class C : P {}

--- a/test/Generics/protocol_typealias_same_type_requirement.swift
+++ b/test/Generics/protocol_typealias_same_type_requirement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A

--- a/test/Generics/rdar74890907.swift
+++ b/test/Generics/rdar74890907.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A : P2
@@ -12,7 +12,6 @@ protocol P2 {
 // CHECK: Generic signature: <T, U where T : P2, T == U.[P2]A.[P1]A, U == T.[P2]A.[P1]A, T.[P2]A : P1, U.[P2]A : P1>
 func testTU<T : P2, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}
 // expected-warning@-1 {{redundant conformance constraint 'U' : 'P2'}}
-// expected-note@-2 {{conformance constraint 'U' : 'P2' implied here}}
 
 // CHECK: Generic signature: <T, U where T == U.[P2]A.[P1]A, U : P2, U == T.[P2]A.[P1]A, T.[P2]A : P1, U.[P2]A : P1>
 func testU<T, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}

--- a/test/Generics/rdar79570734.swift
+++ b/test/Generics/rdar79570734.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 public protocol P1 {
   associatedtype A

--- a/test/Generics/rdar83687967.swift
+++ b/test/Generics/rdar83687967.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
 public protocol P1 {}
@@ -27,7 +27,6 @@ public func caller11<Child: P3>(_: Child)
 // CHECK: rdar83687967.(file).caller12@
 // CHECK: Generic signature: <Child where Child : P3, Child.[P3]B == G<Child.[P3]A>>
 public func caller12<Child: P3>(_: Child)
-    // expected-note@-1 {{conformance constraint 'Child.A' : 'P1' implied here}}
     where Child.B == G<Child.A>, Child.A : P1 {
     // expected-warning@-1 {{redundant conformance constraint 'Child.A' : 'P1'}}
 
@@ -48,7 +47,6 @@ public protocol X1 {
 
 public protocol X2 {
   associatedtype Child: P3
-    // expected-note@-1 {{conformance constraint 'Self.Child.A' : 'P1' implied here}}
     where Child.B == G<Child.A>, Child.A : P1
     // expected-warning@-1 {{redundant conformance constraint 'Self.Child.A' : 'P1'}}
 }

--- a/test/Generics/same_type_minimize_concrete.swift
+++ b/test/Generics/same_type_minimize_concrete.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 struct G<T> { }
 
@@ -8,34 +8,27 @@ protocol P {
   associatedtype B
 }
 
-// FIXME: We minimize the signatures correctly, but the warnings are
-// slightly bogus.
-
-// expected-warning@+2 {{redundant same-type constraint 'T.B' == 'Int'}}
-// expected-note@+1 {{same-type constraint 'T.B' == 'Int' written here}}
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test1<T: P>(_: T) where T.A == G<Int>, T.A == G<T.B>, T.B == Int { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
-// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test2<T: P>(_: T) where T.A == G<Int>, T.B == Int, T.A == G<T.B> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+2 {{redundant same-type constraint 'T.B' == 'Int'}}
-// expected-note@+1 {{same-type constraint 'T.B' == 'Int' written here}}
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test3<T: P>(_: T) where T.A == G<T.B>, T.A == G<Int>, T.B == Int { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test4<T: P>(_: T) where T.A == G<T.B>, T.B == Int, T.A == G<Int> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
-// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test5<T: P>(_: T) where T.B == Int, T.A == G<Int>, T.A == G<T.B> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
-// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test6<T: P>(_: T) where T.B == Int, T.A == G<T.B>, T.A == G<Int> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 

--- a/test/Generics/sr12531.swift
+++ b/test/Generics/sr12531.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift
 
 protocol AnyPropertyProtocol {
     associatedtype Root = Any

--- a/test/Generics/sr5726.swift
+++ b/test/Generics/sr5726.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 // SR-5726
 protocol Foo
@@ -7,7 +7,7 @@ protocol Foo
   var bar: Bar { get }
 }
 
-extension Foo where Self: Collection, Bar: Collection, Self.SubSequence == Bar.SubSequence, /*redundant: */Self.Index == Bar.Index
+extension Foo where Self: Collection, Bar: Collection, Self.SubSequence == Bar.SubSequence, /*redundant: */Self.Index == Bar.Index // expected-warning {{redundant same-type constraint 'Self.Index' == 'Self.Bar.Index'}}
 {
   subscript(_ bounds: Range<Index>) -> SubSequence
   {

--- a/test/Generics/sr8945.swift
+++ b/test/Generics/sr8945.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/sr8945-other.swift -emit-module-path %t/other.swiftmodule -module-name other
-// RUN: %target-swift-frontend -emit-silgen %s -I%t -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -I%t -debug-generic-signatures 2>&1 | %FileCheck %s
 
 import other
 

--- a/test/Generics/superclass_constraint_nested_type.swift
+++ b/test/Generics/superclass_constraint_nested_type.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // rdar://problem/39481178 - Introducing a superclass constraint does not add
 // same-type constraints on nested types

--- a/test/Generics/superclass_constraint_self_derived.swift
+++ b/test/Generics/superclass_constraint_self_derived.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P {
   associatedtype T : Q

--- a/test/Generics/where_clause_contextually_generic_decls.swift
+++ b/test/Generics/where_clause_contextually_generic_decls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -swift-version 4 -requirement-machine-inferred-signatures=on
 
 func bet() where A : B {} // expected-error {{'where' clause cannot be applied to a non-generic top-level declaration}}
 
@@ -91,12 +91,12 @@ extension Class {
 extension Class where T: Equatable {
   func extensionFunc() where T: Comparable { } // expected-note {{where 'T' = 'T'}}
 
-  // expected-error@+1 {{same-type constraint type 'Class<Int>' does not conform to required protocol 'Equatable'}}
+  // expected-error@+1 {{no type for 'T' can satisfy both 'T == Class<Int>' and 'T : Equatable'}}
   func badRequirement1() where T == Class<Int> { }
 }
 
 extension Class where T == Bool {
-  // expected-error@+1 {{generic parameter 'T' cannot be equal to both 'Int' and 'Bool'}}
+  // expected-error@+1 {{no type for 'T' can satisfy both 'T == Int' and 'T == Bool'}}
   func badRequirement2() where T == Int { }
 }
 

--- a/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
+++ b/test/IRGen/dynamic_replaceable_opaque_return_type_parameter.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -disable-availability-checking -enable-implicit-dynamic -enable-private-imports %S/Inputs/opaque_return_type_parameter.swift -module-name Repo -emit-module -emit-module-path %t/Repo.swiftmodule -requirement-machine-abstract-signatures=verify
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -emit-ir -requirement-machine-abstract-signatures=verify | %FileCheck %s
-// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -c -o %t/tmp.o -requirement-machine-abstract-signatures=verify
+// RUN: %target-swift-frontend -disable-availability-checking -enable-implicit-dynamic -enable-private-imports %S/Inputs/opaque_return_type_parameter.swift -module-name Repo -emit-module -emit-module-path %t/Repo.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -I %t -module-name A -swift-version 5 -primary-file %s -c -o %t/tmp.o
 @_private(sourceFile: "opaque_return_type_parameter.swift") import Repo
 
 // Make sure we are not emitting a replacement for the opaque result type used as parameter (Assoc).

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -1,10 +1,10 @@
-// RUN: %target-swift-emit-silgen -swift-version 4 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify | %FileCheck %s
-// RUN: %target-swift-emit-sil -swift-version 4 -O %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify
-// RUN: %target-swift-emit-ir -swift-version 4 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify
+// RUN: %target-swift-emit-silgen -swift-version 4 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil -swift-version 4 -O %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-emit-ir -swift-version 4 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
-// RUN: %target-swift-emit-silgen -swift-version 5 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify | %FileCheck %s
-// RUN: %target-swift-emit-sil -swift-version 5 -O %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify
-// RUN: %target-swift-emit-ir -swift-version 5 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop -requirement-machine-abstract-signatures=verify
+// RUN: %target-swift-emit-silgen -swift-version 5 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil -swift-version 5 -O %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-emit-ir -swift-version 5 %s -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 protocol P {
   func f() -> Self

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift -requirement-machine-abstract-signatures=verify
-// RUN: %target-swift-frontend -I %t -disable-availability-checking -emit-silgen %s -requirement-machine-abstract-signatures=verify | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -I %t -disable-availability-checking -emit-silgen %s | %FileCheck %s
 
 import resilient_struct
 

--- a/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
+++ b/test/SILGen/type_lowering_subst_function_type_requirement_machine.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -requirement-machine-abstract-signatures=verify | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct G<Key: CaseIterable, Value> where Key: RawRepresentable, Value: Codable {
   var key: Key.RawValue

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 protocol P1 { associatedtype AssocType }
 protocol P2 : P1 { }
@@ -150,7 +150,7 @@ extension GenericClass : P3 where T : P3 { }
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{covariant 'Self' or 'Self?' can only appear as the type of a property, subscript or method result; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
-// expected-error@-2{{'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
+// expected-warning@-2{{redundant conformance constraint 'GenericClass<T>' : 'P3'}}
 
 protocol P4 {
   associatedtype T

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 // ----------------------------------------------------------------------------
 // Using protocol requirements from inside protocol extensions
@@ -181,11 +181,11 @@ extension S1 {
 // ----------------------------------------------------------------------------
 
 protocol FooProtocol {}
-extension FooProtocol where Self: FooProtocol {} // expected-warning {{requirement of 'Self' to 'FooProtocol' is redundant in an extension of 'FooProtocol'}}
+extension FooProtocol where Self: FooProtocol {} // expected-warning {{redundant conformance constraint 'Self' : 'FooProtocol'}}
 
 protocol AnotherFooProtocol {}
 protocol BazProtocol {}
-extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{requirement of 'Self' to 'AnotherFooProtocol' is redundant in an extension of 'AnotherFooProtocol'}}
+extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{redundant conformance constraint 'Self' : 'AnotherFooProtocol'}}
 
 protocol AnotherBazProtocol {
   associatedtype BazValue

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 // Protocols with superclass-constrained Self.
 
@@ -27,7 +27,6 @@ func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
 func duplicateOverload<T : ProtoRefinesClass & Generic<Int>>(_: T) {}
 // expected-error@-1 {{invalid redeclaration of 'duplicateOverload'}}
 // expected-warning@-2 {{redundant superclass constraint 'T' : 'Generic<Int>'}}
-// expected-note@-3 {{superclass constraint 'T' : 'Generic<Int>' implied here}}
 
 extension ProtoRefinesClass {
   func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
@@ -279,10 +278,8 @@ extension HasMutableProperty {
 // Some pathological examples -- just make sure they don't crash.
 
 protocol RecursiveSelf : Generic<Self> {}
-// expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self>' is recursive}}
 
 protocol RecursiveAssociatedType : Generic<Self.X> {
-  // expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self.X>' is recursive}}
   associatedtype X
 }
 
@@ -326,9 +323,8 @@ class SecondConformer : SecondClass, SecondProtocol {}
 // Duplicate superclass
 // FIXME: Duplicate diagnostics
 protocol DuplicateSuper : Concrete, Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
-// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
-// expected-error@-3 {{duplicate inheritance from 'Concrete'}}
+// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
+// expected-error@-2 {{duplicate inheritance from 'Concrete'}}
 
 // Ambigous name lookup situation
 protocol Amb : Concrete {}

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 // Protocols with superclass-constrained Self.
 
@@ -28,7 +28,6 @@ func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
 func duplicateOverload<T : ProtoRefinesClass & Generic<Int>>(_: T) {}
 // expected-error@-1 {{invalid redeclaration of 'duplicateOverload'}}
 // expected-warning@-2 {{redundant superclass constraint 'T' : 'Generic<Int>'}}
-// expected-note@-3 {{superclass constraint 'T' : 'Generic<Int>' implied here}}
 
 extension ProtoRefinesClass {
   func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
@@ -280,10 +279,8 @@ extension HasMutableProperty {
 // Some pathological examples -- just make sure they don't crash.
 
 protocol RecursiveSelf where Self : Generic<Self> {}
-// expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self>' is recursive}}
 
 protocol RecursiveAssociatedType where Self : Generic<Self.X> {
-  // expected-error@-1 {{superclass constraint 'Self' : 'Generic<Self.X>' is recursive}}
   associatedtype X
 }
 
@@ -327,11 +324,9 @@ class SecondConformer : SecondClass, SecondProtocol {}
 // Duplicate superclass
 // FIXME: Should be an error here too
 protocol DuplicateSuper1 : Concrete where Self : Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
-// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
+// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
 protocol DuplicateSuper2 where Self : Concrete, Self : Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
-// expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
+// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
 
 // Ambiguous name lookup situation
 protocol Amb where Self : Concrete {}

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 // -----
 
@@ -53,7 +53,7 @@ protocol P3 {
 protocol P4 : P3 {}
 
 protocol DeclaredP : P3, // expected-warning{{redundant conformance constraint 'Self' : 'P3'}}
-P4 {} // expected-note{{conformance constraint 'Self' : 'P3' implied here}}
+P4 {}
 
 struct Y3 : DeclaredP {
 }
@@ -76,7 +76,7 @@ protocol Gamma {
   associatedtype Delta: Alpha
 }
 
-struct Epsilon<T: Alpha, // expected-note{{conformance constraint 'U' : 'Gamma' implied here}}
+struct Epsilon<T: Alpha,
                U: Gamma> // expected-warning{{redundant conformance constraint 'U' : 'Gamma'}}
   where T.Beta == U,
         U.Delta == T {}

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
 
 protocol P1 : class { }
 
@@ -6,6 +6,5 @@ protocol P2 : class, class { } // expected-error{{redundant 'class' requirement}
 
 protocol P3 : P2, class { } // expected-error{{'class' must come first in the requirement list}}{{15-15=class, }}{{17-24=}}
 // expected-warning@-1 {{redundant constraint 'Self' : 'AnyObject'}}
-// expected-note@-2 {{constraint 'Self' : 'AnyObject' implied here}}
 
 struct X : class { } // expected-error{{'class' constraint can only appear on protocol declarations}}

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -1,20 +1,19 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 protocol SomeProtocol {
 	associatedtype T
 }
 
-extension SomeProtocol where T == Optional<T> { } // expected-error{{same-type constraint 'Self.T' == 'Optional<Self.T>' is recursive}}
+extension SomeProtocol where T == Optional<T> { }
 // expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
 // expected-note@-2 {{failed rewrite rule is τ_0_0.[SomeProtocol:T].[concrete: Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<Optional<τ_0_0.[SomeProtocol:T]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0.[SomeProtocol:T]}}
 
 // rdar://problem/19840527
 
-class X<T> where T == X { // expected-error{{same-type constraint 'T' == 'X<T>' is recursive}}
+class X<T> where T == X {
 // expected-error@-1 {{cannot build rewrite system for generic signature; concrete nesting limit exceeded}}
 // expected-note@-2 {{failed rewrite rule is τ_0_0.[concrete: X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<X<τ_0_0>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => τ_0_0}}
-// expected-error@-3{{same-type requirement makes generic parameter 'T' non-generic}}
-// expected-error@-4 6{{generic class 'X' has self-referential generic requirements}}
+// expected-error@-3 3{{generic class 'X' has self-referential generic requirements}}
     var type: T { return Swift.type(of: self) } // expected-error{{cannot convert return expression of type 'X<T>.Type' to return type 'T'}}
 }
 
@@ -49,7 +48,7 @@ public protocol P {
 }
 
 public struct S<A: P> where A.T == S<A> {
-// expected-error@-1 6{{generic struct 'S' has self-referential generic requirements}}
+// expected-error@-1 3{{generic struct 'S' has self-referential generic requirements}}
   func f(a: A.T) {
     g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
     _ = A.T.self
@@ -74,7 +73,7 @@ protocol PI {
 }
 
 struct SI<A: PI> : I where A : I, A.T == SI<A> {
-// expected-error@-1 6{{generic struct 'SI' has self-referential generic requirements}}
+// expected-error@-1 3{{generic struct 'SI' has self-referential generic requirements}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }
@@ -101,9 +100,9 @@ struct S5<A: PI> : I where A : I, A.T == S4<A> { }
 
 // Used to hit ArchetypeBuilder assertions
 struct SU<A: P> where A.T == SU {
-// expected-error@-1 6{{generic struct 'SU' has self-referential generic requirements}}
+// expected-error@-1 3{{generic struct 'SU' has self-referential generic requirements}}
 }
 
 struct SIU<A: PI> : I where A : I, A.T == SIU {
-// expected-error@-1 6{{generic struct 'SIU' has self-referential generic requirements}}
+// expected-error@-1 3{{generic struct 'SIU' has self-referential generic requirements}}
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify -requirement-machine-abstract-signatures=verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
 
 protocol P {
   func paul()

--- a/test/type/opaque_generic_superclass_constraint.swift
+++ b/test/type/opaque_generic_superclass_constraint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify -requirement-machine-abstract-signatures=verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -verify %s
 
 // rdar://problem/53318811
 

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-parameterized-protocol-types -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-parameterized-protocol-types -disable-availability-checking -requirement-machine-inferred-signatures=on
 
 protocol P { }
 
@@ -18,7 +18,7 @@ extension Array: Q where Element: P, Element: Equatable {
   }
 }
 
-extension Set: Q where Element: P, Element: Equatable {
+extension Set: Q where Element: P, Element: Equatable { // expected-warning {{redundant conformance constraint 'Element' : 'Equatable'}}
   func f() -> Element {
     return first!
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28235248.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28235248.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend %s -typecheck -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol II {
   associatedtype E

--- a/validation-test/Sema/type_checker_crashers_fixed/sr13856.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr13856.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift
 
 protocol OptionalType {
   associatedtype Wrapped

--- a/validation-test/compiler_crashers_2_fixed/0064-rdar27627862.swift
+++ b/validation-test/compiler_crashers_2_fixed/0064-rdar27627862.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift
 
 enum Term<S> where S: Sequence, S.Iterator.Element == Term {
 // expected-error@-1 *{{generic enum 'Term' has self-referential generic requirements}}

--- a/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0083-rdar31163470-2.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 protocol C {
   associatedtype I

--- a/validation-test/compiler_crashers_2_fixed/0097-rdar32077627.swift
+++ b/validation-test/compiler_crashers_2_fixed/0097-rdar32077627.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck -primary-file %s -requirement-machine-inferred-signatures=verify -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -primary-file %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: .hexEncodeBytes@
 // CHECK-NEXT: <T where T : Collection, T.[Sequence]Element == UInt8>

--- a/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
+++ b/validation-test/compiler_crashers_2_fixed/0109-sr4737.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -typecheck -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: not %target-swift-frontend %s -typecheck
 
 //===----------------------------------------------------------------------===//
 extension UnicodeScalar {

--- a/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
+++ b/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
 protocol S {
   associatedtype I: IteratorProtocol
   typealias E = I.Element

--- a/validation-test/compiler_crashers_2_fixed/0162-sr8019.swift
+++ b/validation-test/compiler_crashers_2_fixed/0162-sr8019.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 protocol P {}
 struct A<C> {}
-extension A: P where A: P {} // expected-error {{type 'A<C>' in conformance requirement does not refer to a generic parameter or associated type}}
+extension A: P where A: P {} // expected-warning {{redundant conformance constraint 'A<C>' : 'P'}}

--- a/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
+++ b/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 protocol P1 {}
 protocol P2 {}
@@ -8,4 +8,4 @@ struct Var<N> {}
 extension Var : P2 where N : P1 { }
 
 protocol P3 {}
-extension Var : P3 where Self : P2 {} // expected-error {{type 'Var<N>' in conformance requirement does not refer to a generic parameter or associated type}}
+extension Var : P3 where Self : P2 {} // expected-warning {{redundant conformance constraint 'Var<N>' : 'P2'}}

--- a/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
+++ b/validation-test/compiler_crashers_2_fixed/0166-sr8240-2.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=verify
-
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 struct Box<Representation, T> {
     let value: Representation

--- a/validation-test/compiler_scale/explicit_requirements_perf.swift
+++ b/validation-test/compiler_scale/explicit_requirements_perf.swift
@@ -1,9 +1,0 @@
-// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumRedundantRequirementSteps --polynomial-threshold 2 %s
-
-protocol P {}
-
-func f<T>(_: T) where
-%for i in range(0, N):
-  T : P,
-%end
-  T : P {}


### PR DESCRIPTION
- Don't pass 'verify' since it's now the default
- Update tests where diagnostics changed in a correct way to pass 'on' instead
- Delete compiler_scale/explicit_requirements_perf.swift since it's not testing anything with the requirement machine
