### PR TITLE
An `@objc` protocol can inherit from a marker protocol

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1614,10 +1614,11 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
     if (auto attr = proto->getAttrs().getAttribute<ObjCAttr>()) {
       isObjC = objCReasonForObjCAttr(attr);
 
-      // If the protocol is @objc, it may only refine other @objc protocols.
+      // If the protocol is @objc, it may only refine other @objc protocols and
+      // marker protocols.
       // FIXME: Revisit this restriction.
       for (auto inherited : proto->getInheritedProtocols()) {
-        if (!inherited->isObjC()) {
+        if (!inherited->isObjC() && !inherited->isMarkerProtocol()) {
           proto->diagnose(diag::objc_protocol_inherits_non_objc_protocol,
                           proto->getDeclaredInterfaceType(),
                           inherited->getDeclaredInterfaceType());

--- a/test/Concurrency/sendable_obc_protocol.swift
+++ b/test/Concurrency/sendable_obc_protocol.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -parse-as-library
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+import Foundation
+
+@objc protocol P: Sendable { }


### PR DESCRIPTION
... because marker protocols have no witness tables.

Fixes rdar://91011153.
