### PR TITLE
Fix the "early" computation of a return type to respect `@preconcurrency`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2457,9 +2457,14 @@ Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
         }
       }
 
+      auto hasAppliedSelf =
+          doesMemberRefApplyCurriedSelf(overload.getBaseType(), decl);
+      unsigned numApplies = getNumApplications(
+          decl, hasAppliedSelf, overload.getFunctionRefKind());
+
       type = adjustFunctionTypeForConcurrency(
           type->castTo<FunctionType>(),
-          subscript, useDC, /*numApplies=*/2, /*isMainDispatchQueue=*/false)
+          decl, useDC, numApplies, /*isMainDispatchQueue=*/false)
         ->getResult();
     }
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -126,3 +126,29 @@ func aFailedExperiment(@_unsafeSendable _ body: @escaping () -> Void) { }
 
 func anothingFailedExperiment(@_unsafeMainActor _ body: @escaping () -> Void) { }
 // expected-warning@-1{{'_unsafeMainActor' attribute has been removed in favor of @preconcurrency}}
+
+// ---------------------------------------------------------------------------
+// Random bugs
+// ---------------------------------------------------------------------------
+
+public enum StringPlacement : Sendable {
+  public typealias StringPosition = @Sendable (_: [String]) -> Int
+
+  @preconcurrency
+  public static func position(before string: String) -> StringPosition {
+    return { _ in 0 }
+  }
+
+  @preconcurrency
+  public static func position(after string: String) -> StringPosition {
+    return { _ in 0 }
+  }
+}
+
+func testStringPlacement() {
+  let fn1 = StringPlacement.position(before: "Test")
+  let _: Int = fn1   // expected-error{{cannot convert value of type '([String]) -> Int' to specified type 'Int'}}
+
+  let fn2 = StringPlacement.position(before:)
+  let _: Int = fn2 // expected-error{{cannot convert value of type '(String) -> ([String]) -> Int' to specified type 'Int'}}
+}


### PR DESCRIPTION
Fixes rdar://91087622 / rdar://91092324.
