### PR TITLE
[ConstraintSystem] Fix a bug in existential Self erasure

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5694,7 +5694,6 @@ Expr *getArgumentLabelTargetExpr(Expr *fn);
 /// variable and anything that depends on it to their non-dependent bounds.
 Type typeEraseOpenedExistentialReference(Type type, Type existentialBaseType,
                                          TypeVariableType *openedTypeVar,
-                                         const DeclContext *useDC,
                                          TypePosition outermostPosition);
 
 /// Returns true if a reference to a member on a given base type will apply

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1872,7 +1872,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         for (const auto &opened : openedExistentials) {
           paramTy = typeEraseOpenedExistentialReference(
               paramTy, opened.second->getExistentialType(), opened.first,
-              /*FIXME*/cs.DC, TypePosition::Contravariant);
+              TypePosition::Contravariant);
         }
       }
 
@@ -11389,7 +11389,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
     if (result2->hasTypeVariable() && !openedExistentials.empty()) {
       for (const auto &opened : openedExistentials) {
         result2 = typeEraseOpenedExistentialReference(
-            result2, opened.second->getExistentialType(), opened.first, DC,
+            result2, opened.second->getExistentialType(), opened.first,
             TypePosition::Covariant);
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1795,16 +1795,16 @@ static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
 /// routine will recurse into the concrete type.
 static Type
 typeEraseExistentialSelfReferences(
-    Type refTy, Type baseTy, const DeclContext *useDC,
+    Type refTy, Type baseTy,
     TypePosition outermostPosition) {
   assert(baseTy->isExistentialType());
   if (!refTy->hasTypeParameter()) {
     return refTy;
   }
 
-  auto contextSig = useDC->getGenericSignatureOfContext();
   const auto existentialSig =
-      baseTy->getASTContext().getOpenedArchetypeSignature(baseTy, contextSig);
+      baseTy->getASTContext().getOpenedArchetypeSignature(baseTy,
+                                                          GenericSignature());
 
   unsigned metatypeDepth = 0;
 
@@ -1916,7 +1916,7 @@ typeEraseExistentialSelfReferences(
 
 Type constraints::typeEraseOpenedExistentialReference(
     Type type, Type existentialBaseType, TypeVariableType *openedTypeVar,
-    const DeclContext *useDC, TypePosition outermostPosition) {
+    TypePosition outermostPosition) {
   Type selfGP = GenericTypeParamType::get(false, 0, 0, type->getASTContext());
 
   // First, temporarily reconstitute the 'Self' generic parameter.
@@ -1933,8 +1933,8 @@ Type constraints::typeEraseOpenedExistentialReference(
   });
 
   // Then, type-erase occurrences of covariant 'Self'-rooted type parameters.
-  type = typeEraseExistentialSelfReferences(
-      type, existentialBaseType, useDC, outermostPosition);
+  type = typeEraseExistentialSelfReferences(type, existentialBaseType,
+                                            outermostPosition);
 
   // Finally, swap the 'Self'-corresponding type variable back in.
   return type.transformRec([&](TypeBase *t) -> Optional<Type> {
@@ -2260,9 +2260,8 @@ ConstraintSystem::getTypeOfMemberReference(
     const auto selfGP = cast<GenericTypeParamType>(
         outerDC->getSelfInterfaceType()->getCanonicalType());
     auto openedTypeVar = replacements.lookup(selfGP);
-    type =
-        typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar, DC,
-                                            TypePosition::Covariant);
+    type = typeEraseOpenedExistentialReference(type, baseObjTy, openedTypeVar,
+                                               TypePosition::Covariant);
   }
 
   // Construct an idealized parameter type of the initializer associated

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar91110069.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar91110069.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Schema: RawRepresentable {
+  var rawValue: String { get }
+}
+
+enum MySchema: String, Schema {
+  case hello = "hello"
+}
+
+struct Parser<S: Schema> :  Equatable {
+}
+
+protocol Entity {
+}
+
+protocol MyInitializable {
+  init() throws
+}
+
+typealias MyInitializableEntity = MyInitializable & Entity
+
+extension Parser where S == MySchema {
+  func test(kind: Entity.Type) throws {
+    guard let entityType = kind as? MyInitializableEntity.Type else {
+      return
+    }
+
+    let _ = try entityType.init() // Ok
+  }
+}


### PR DESCRIPTION
`typeEraseExistentialSelfReferences` shouldn't account for
contextual signature because that signature could have
generic parameters of it's own unrelated to the reference
which would be located before generic parameters of the
member, e.g. when the code is located in a protocol extension,
which invalidates the assumption that `Self` is located at
depth = 0, index = 0.

Resolves: rdar://91110069

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
