### PR TITLE
[Runtime] Fixed multi-payload empty-case masking.

### DIFF
--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -325,7 +325,7 @@ swift::swift_storeEnumTagMultiPayload(OpaqueValue *value,
     } else {
       unsigned numPayloadBits = layout.payloadSize * CHAR_BIT;
       whichTag = numPayloads + (whichEmptyCase >> numPayloadBits);
-      whichPayloadValue = whichEmptyCase & ((1U << numPayloads) - 1U);
+      whichPayloadValue = whichEmptyCase & ((1U << numPayloadBits) - 1U);
     }
     storeMultiPayloadTag(value, layout, whichTag);
     storeMultiPayloadValue(value, layout, whichPayloadValue);

--- a/validation-test/Runtime/Inputs/rdar87914343_Resilient.swift
+++ b/validation-test/Runtime/Inputs/rdar87914343_Resilient.swift
@@ -1,0 +1,6 @@
+public enum ResilientEnum : Comparable {
+  case a
+  case b
+  case c
+}
+

--- a/validation-test/Runtime/rdar87914343.swift
+++ b/validation-test/Runtime/rdar87914343.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift \
+// RUN:     -emit-module \
+// RUN:     %S/Inputs/rdar87914343_Resilient.swift \
+// RUN:     -parse-as-library \
+// RUN:     -enable-library-evolution \
+// RUN:     -module-name Resilient \
+// RUN:     -emit-module-path %t/Resilient.swiftmodule
+
+// RUN: %target-build-swift \
+// RUN:     -c \
+// RUN:     %S/Inputs/rdar87914343_Resilient.swift \
+// RUN:     -parse-as-library \
+// RUN:     -enable-library-evolution \
+// RUN:     -module-name Resilient \
+// RUN:     -o %t/Resilient.o
+
+// RUN: %target-build-swift \
+// RUN:     -c \
+// RUN:     %s \
+// RUN:     -o %t/main.o \
+// RUN:     -I %t
+
+// RUN: %target-swiftc_driver \
+// RUN:     %t/Resilient.o \
+// RUN:     %t/main.o \
+// RUN:     -o %t/main
+
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import Resilient
+
+func dump<T>(_ value: T) {
+  print(value)
+}
+
+enum ProblematicEnumeration {
+    case zero(ResilientEnum)
+    case one(Bool)
+    case two
+    case three
+    case four
+    case five
+    case six
+}
+
+func doit() {
+    dump(ProblematicEnumeration.six)
+}
+
+doit()
+// CHECK: six


### PR DESCRIPTION
When storing a tag into a multi-payload enum for an empty case via `swift_storeEnumTagMultiPayload`, the tag is split between the storage for payloads (i.e. the associated values of the non-empty cases) and the storage for tags (i.e. the integers which refer to the non-empty cases).

Typically, the number of non-empty cases (i.e. one beyond the tag that refers to the last non-empty case) is stored into the tag storage and the integer which distinguishes which among the empty cases the enum is in is stored into storage for payloads.  When the enum is small, however--specifically, when the payload size is less than four bytes--that information is packaged differently via masking.

Previously, there was a problem with that masking.  While the value stored into the tag storage was correct (and correctly indicated that the enum was in some empty case), the value stored into the payload storage was not.  The result was that which empty case an enum was in would be corrupted.

Here, that is fixed by fixing the masking.

rdar://87914343
