### PR TITLE
SIL linker: don't try to synthesize witness tables for marker protocols.

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -259,6 +259,10 @@ void SILLinkerVisitor::visitProtocolConformance(ProtocolConformanceRef ref) {
   if ((!WT || WT->isDeclaration()) &&
       (mustDeserialize || Mode == SILModule::LinkingMode::LinkAll)) {
     if (!WT) {
+      // Marker protocols should never have witness tables.
+      if (C->getProtocol()->isMarkerProtocol())
+        return;
+
       RootProtocolConformance *rootC = C->getRootConformance();
       SILLinkage linkage = getLinkageForProtocolConformance(rootC, NotForDefinition);
       WT = SILWitnessTable::create(Mod, linkage,


### PR DESCRIPTION
We never have them, we never need them, and we'll crash if there were
one for a conformance of a non-nominal type to such a protocol.

Fixes rdar://91126885 .
