### PR TITLE
[Distributed] ID synthesis must be eager, or we run into issues in real projects

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4358,6 +4358,7 @@ enum class KnownDerivableProtocolKind : uint8_t {
   Decodable,
   AdditiveArithmetic,
   Differentiable,
+  Identifiable,
   Actor,
   DistributedActor,
   DistributedActorSystem,

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -60,6 +60,7 @@
 
 PROTOCOL(Actor)
 PROTOCOL(Sequence)
+PROTOCOL(Identifiable)
 PROTOCOL(IteratorProtocol)
 PROTOCOL(RawRepresentable)
 PROTOCOL(Equatable)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5622,6 +5622,8 @@ Optional<KnownDerivableProtocolKind>
     return KnownDerivableProtocolKind::AdditiveArithmetic;
   case KnownProtocolKind::Differentiable:
     return KnownDerivableProtocolKind::Differentiable;
+  case KnownProtocolKind::Identifiable:
+    return KnownDerivableProtocolKind::Identifiable;
   case KnownProtocolKind::Actor:
     return KnownDerivableProtocolKind::Actor;
   case KnownProtocolKind::DistributedActor:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5358,6 +5358,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::AdditiveArithmetic:
   case KnownProtocolKind::Differentiable:
   case KnownProtocolKind::FloatingPoint:
+  case KnownProtocolKind::Identifiable:
   case KnownProtocolKind::Actor:
   case KnownProtocolKind::DistributedActor:
   case KnownProtocolKind::DistributedActorSystem:

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -24,10 +24,27 @@
 
 using namespace swift;
 
+bool DerivedConformance::canDeriveIdentifiable(
+    NominalTypeDecl *nominal, DeclContext *dc) {
+  // we only synthesize for concrete 'distributed actor' decls (which are class)
+  if (!isa<ClassDecl>(nominal))
+    return false;
+
+  auto &C = nominal->getASTContext();
+  if (!C.getLoadedModule(C.Id_Distributed))
+    return false;
+
+  return nominal->isDistributedActor();
+}
+
 bool DerivedConformance::canDeriveDistributedActor(
     NominalTypeDecl *nominal, DeclContext *dc) {
+  auto &C = nominal->getASTContext();
   auto classDecl = dyn_cast<ClassDecl>(nominal);
-  return classDecl && classDecl->isDistributedActor() && dc == nominal;
+
+  return C.getLoadedModule(C.Id_Distributed) &&
+         classDecl && classDecl->isDistributedActor() &&
+         dc == nominal;
 }
 
 bool DerivedConformance::canDeriveDistributedActorSystem(
@@ -500,6 +517,26 @@ deriveDistributedActorType_ActorSystem(
   return defaultDistributedActorSystemTypeDecl->getDeclaredInterfaceType();
 }
 
+static Type
+deriveDistributedActorType_ID(
+    DerivedConformance &derived) {
+  if (!derived.Nominal->isDistributedActor())
+    return nullptr;
+
+  // Look for a type DefaultDistributedActorSystem within the parent context.
+  auto systemTy = getDistributedActorSystemType(derived.Nominal);
+
+  // There is no known actor system type, so fail to synthesize.
+  if (!systemTy || systemTy->hasError())
+    return nullptr;
+
+  if (auto systemNominal = systemTy->getAnyNominal()) {
+    return getDistributedActorSystemActorIDType(systemNominal);
+  }
+
+  return nullptr;
+}
+
 /******************************************************************************/
 /**************************** ENTRY POINTS ************************************/
 /******************************************************************************/
@@ -536,6 +573,10 @@ std::pair<Type, TypeDecl *> DerivedConformance::deriveDistributedActor(
 
   if (assocType->getName() == Context.Id_ActorSystem) {
     return std::make_pair(deriveDistributedActorType_ActorSystem(*this), nullptr);
+  }
+
+  if (assocType->getName() == Context.Id_ID) {
+    return std::make_pair(deriveDistributedActorType_ID(*this), nullptr);
   }
 
   Context.Diags.diagnose(assocType->getLoc(),

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -77,6 +77,9 @@ bool DerivedConformance::derivesProtocolConformance(DeclContext *DC,
 
   if (*derivableKind == KnownDerivableProtocolKind::Actor)
     return canDeriveActor(DC, Nominal);
+
+  if (*derivableKind == KnownDerivableProtocolKind::Identifiable)
+    return canDeriveIdentifiable(Nominal, DC);
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActor)
     return canDeriveDistributedActor(Nominal, DC);
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActorSystem)

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -323,6 +323,10 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveDecodable(ValueDecl *requirement);  
 
+  /// Identifiable may need to have the `ID` type witness synthesized explicitly
+  static bool canDeriveIdentifiable(NominalTypeDecl *nominal,
+                                    DeclContext *dc);
+
   /// Whether we can derive the given DistributedActor requirement in the given context.
   static bool canDeriveDistributedActor(NominalTypeDecl *nominal,
                                         DeclContext *dc);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6911,6 +6911,15 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   case KnownDerivableProtocolKind::Differentiable:
     return derived.deriveDifferentiable(Requirement);
 
+  case KnownDerivableProtocolKind::Identifiable:
+    if (derived.Nominal->isDistributedActor()) {
+      return derived.deriveDistributedActor(Requirement);
+    } else {
+      // No synthesis is required for other types; we should only end up
+      // attempting synthesis if the nominal was a distributed actor.
+      llvm_unreachable("Identifiable is synthesized for distributed actors");
+    }
+
   case KnownDerivableProtocolKind::DistributedActor:
     return derived.deriveDistributedActor(Requirement);
   case KnownDerivableProtocolKind::DistributedActorSystem:
@@ -6946,6 +6955,12 @@ TypeChecker::deriveTypeWitness(DeclContext *DC,
   case KnownProtocolKind::Differentiable:
     return derived.deriveDifferentiable(AssocType);
   case KnownProtocolKind::DistributedActor:
+    return derived.deriveDistributedActor(AssocType);
+  case KnownProtocolKind::Identifiable:
+    // Identifiable only has derivation logic for distributed actors,
+    // because how it depends on the ActorSystem the actor is associated with.
+    // If the nominal wasn't a distributed actor, we should not end up here,
+    // but either way, then we'd return null (fail derivation).
     return derived.deriveDistributedActor(AssocType);
   default:
     return std::make_pair(nullptr, nullptr);

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -1198,6 +1198,20 @@ private:
                 ConformanceChecker &checker,
                 SmallVectorImpl<InferredTypeWitnessesSolution> &solutions);
 
+  /// We may need to determine a type witness, regardless of the existence of a
+  /// default value for it, e.g. when a 'distributed actor' is looking up its
+  /// 'ID', the default defined in an extension for 'Identifiable' would be
+  /// located using the lookup resolve. This would not be correct, since the
+  /// type actually must be based on the associated 'ActorSystem'.
+  ///
+  /// TODO(distributed): perhaps there is a better way to avoid this mixup?
+  ///   Note though that this issue seems to only manifest in "real" builds
+  ///   involving multiple files/modules, and not in tests within the Swift
+  ///   project itself.
+  bool canAttemptEagerTypeWitnessDerivation(
+      ConformanceChecker &checker,
+      AssociatedTypeDecl *assocType);
+
 public:
   /// Describes a mapping from associated type declarations to their
   /// type witnesses (as interface types).

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -23,6 +23,17 @@ class X: Identifiable {
   }
 }
 
+protocol DAP: DistributedActor {
+  // should work as expected, synthesis not triggering
+  func test()
+}
+
+extension DAP where ActorSystem.ActorID == String {
+  func test() {
+    _ = self.id == ""
+  }
+}
+
 distributed actor D2 {
   // expected-error@-1{{actor 'D2' has no initializers}}
   let actorSystem: String

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -7,8 +7,20 @@ import Distributed
 /// Use the existential wrapper as the default actor system.
 typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
 
+distributed actor D0 {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  var x: Int = 17
+}
+
 distributed actor D1 {
   var x: Int = 17
+}
+
+class X: Identifiable {
+  // should work as expected, synthesis not triggering
+  func test() {
+    let _: ObjectIdentifier = self.id
+  }
 }
 
 distributed actor D2 {
@@ -20,37 +32,24 @@ distributed actor D2 {
 }
 
 distributed actor D3 {
-  // expected-error@-1{{type 'D3' does not conform to protocol 'Identifiable'}}
-  // expected-error@-2{{type 'D3' does not conform to protocol 'DistributedActor'}}
-  // Codable synthesis also will fail since the ID mismatch:
-  // expected-error@-4{{type 'D3' does not conform to protocol 'Decodable'}}
-  // expected-error@-5{{type 'D3' does not conform to protocol 'Encodable'}}
-
   var id: Int { 0 }
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized property 'id'}}
-  // expected-note@-3{{matching requirement 'id' to this declaration inferred associated type to 'Int'}}
+  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'id'}}
 }
 
 struct OtherActorIdentity: Sendable, Hashable, Codable {}
 
 distributed actor D4 {
   // expected-error@-1{{actor 'D4' has no initializers}}
-  // expected-error@-2{{type 'D4' does not conform to protocol 'DistributedActor'}}
-  // expected-error@-3{{type 'D4' does not conform to protocol 'Identifiable'}}
-  // Codable synthesis also will fail since the ID errors:
-  // expected-error@-5{{type 'D4' does not conform to protocol 'Decodable'}}
-  // expected-error@-6{{type 'D4' does not conform to protocol 'Encodable'}}
 
   let actorSystem: String
   // expected-error@-1{{property 'actorSystem' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2 {{invalid redeclaration of synthesized property 'actorSystem'}}
+  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'actorSystem'}}
   // expected-note@-3{{stored property 'actorSystem' without initial value prevents synthesized initializers}}
   let id: OtherActorIdentity
   // expected-error@-1{{property 'id' cannot be defined explicitly, as it conflicts with distributed actor synthesized stored property}}
-  // expected-error@-2{{invalid redeclaration of synthesized property 'id'}}
+  // expected-error@-2{{invalid redeclaration of synthesized implementation for protocol requirement 'id'}}
   // expected-note@-3{{stored property 'id' without initial value prevents synthesized initializers}}
-  // expected-note@-4{{matching requirement 'id' to this declaration inferred associated type to 'OtherActorIdentity'}}
 }
 
 protocol P1: DistributedActor {


### PR DESCRIPTION
Without this, in real, multi module, multi file, projects we end up with issues as follows:

```
Greeter.swift:9:19: error: type 'Greeter' does not conform to protocol 'DistributedActor'
distributed actor Greeter {
                  ^
Greeter.swift:9:19: error: 'DistributedActor' requires the types 'ObjectIdentifier' and 'BonjourActorSystem.ActorID' (aka 'ActorIdentity') be equivalent
distributed actor Greeter {
                  ^
Greeter.swift:9:19: note: requirement specified as 'Self.ID' == 'Self.ActorSystem.ActorID' [with Self = Greeter]
distributed actor Greeter {
                  ^
Greeter.swift:9:19: error: protocol 'DistributedActor' is broken; cannot derive conformance for type 'Greeter'
distributed actor Greeter {
                  ^
```

From debugging it seems that the reason is that the resolve by lookup triggers early and determines that the `ID` shall be taken from the `extension Identifiable { var id: ObjectIdentifier {...} }` and only then other synthesis is run.

In order to avoid such mixups, we can be eager about the ID type synthesis.

This is limited to `distributed actor` decls, because in all other cases the default would be right and follow the usual rules, but because we synthesize the `ActorSystem` typealias and `ID` types later on, things got tricky here.

If there is a cleaner way to do this I'd happily revisit but this seems not to terrible for now at least and unbreaks projects.


Resolves rdar://91020060