### PR TITLE
SILGen: Handle key paths with `@objc optional` property and subscript components

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6255,17 +6255,14 @@ RValue SILGenFunction::emitDynamicMemberRef(SILLocation loc, SILValue operand,
                 emitManagedRValueWithCleanup(optResult, optTL));
 }
 
-RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
+RValue
+SILGenFunction::emitDynamicSubscriptGetterApply(SILLocation loc,
+                                                SILValue operand,
+                                                ConcreteDeclRef subscriptRef,
+                                                PreparedArguments &&indexArgs,
+                                                CanType resultTy,
                                                 SGFContext c) {
-  // Emit the base operand.
-  ManagedValue managedBase = emitRValueAsSingleValue(e->getBase());
-
-  SILValue base = managedBase.getValue();
-
-  // Emit the index.
-  auto *indexExpr = e->getArgs()->getUnaryExpr();
-  assert(indexExpr);
-  RValue index = emitRValue(indexExpr);
+  assert(resultTy->isOptional());
 
   // Create the continuation block.
   SILBasicBlock *contBB = createBasicBlock();
@@ -6276,72 +6273,77 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
   // Create the has-member block.
   SILBasicBlock *hasMemberBB = createBasicBlock();
 
-  const TypeLowering &optTL = getTypeLowering(e->getType());
-  auto loweredOptTy = optTL.getLoweredType();
-  SILValue optTemp = emitTemporaryAllocation(e, loweredOptTy);
+  const TypeLowering &optTL = getTypeLowering(resultTy);
+  const SILValue optTemp = emitTemporaryAllocation(loc, optTL.getLoweredType());
 
   // Create the branch.
-  auto subscriptDecl = cast<SubscriptDecl>(e->getMember().getDecl());
+  auto *subscriptDecl = cast<SubscriptDecl>(subscriptRef.getDecl());
   auto member = SILDeclRef(subscriptDecl->getOpaqueAccessor(AccessorKind::Get),
                            SILDeclRef::Kind::Func)
     .asForeign();
-  B.createDynamicMethodBranch(e, base, member, hasMemberBB, noMemberBB);
+  B.createDynamicMethodBranch(loc, operand, member, hasMemberBB, noMemberBB);
 
   // Create the has-member branch.
   {
     B.emitBlock(hasMemberBB);
 
-    FullExpr hasMemberScope(Cleanups, CleanupLocation(e));
+    FullExpr hasMemberScope(Cleanups, CleanupLocation(loc));
 
     // The argument to the has-member block is the uncurried method.
     // Build the substituted getter type from the AST nodes.
-    auto valueTy = e->getType()->getCanonicalType().getOptionalObjectType();
+    const CanType valueTy = resultTy.getOptionalObjectType();
 
-    // Objective-C subscripts only ever have a single parameter.
-    //
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     CanFunctionType::ExtInfo methodInfo;
-    FunctionType::Param indexArg(indexExpr->getType()->getCanonicalType());
-    auto methodTy = CanFunctionType::get({indexArg}, valueTy, methodInfo);
+    const auto methodTy =
+        CanFunctionType::get(indexArgs.getParams(), valueTy, methodInfo);
     auto foreignMethodTy =
-      getPartialApplyOfDynamicMethodFormalType(SGM, member, e->getMember());
+        getPartialApplyOfDynamicMethodFormalType(SGM, member, subscriptRef);
 
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     CanFunctionType::ExtInfo functionInfo;
-    FunctionType::Param baseArg(base->getType().getASTType());
+    FunctionType::Param baseArg(operand->getType().getASTType());
     auto functionTy = CanFunctionType::get({baseArg}, methodTy, functionInfo);
     auto loweredMethodTy = getDynamicMethodLoweredType(SGM.M, member,
                                                        functionTy);
     SILValue memberArg =
         hasMemberBB->createPhiArgument(loweredMethodTy, OwnershipKind::Owned);
     // Emit the application of 'self'.
-    Scope applyScope(Cleanups, CleanupLocation(e));
-    ManagedValue result = emitDynamicPartialApply(*this, e, memberArg, base,
-                                                  foreignMethodTy, methodTy);
-    // Emit the index.
-    llvm::SmallVector<ManagedValue, 2> indexArgs;
-    std::move(index).getAll(indexArgs);
-    
-    auto resultRV = emitMonomorphicApply(e, result, indexArgs,
+    Scope applyScope(Cleanups, CleanupLocation(loc));
+    ManagedValue result = emitDynamicPartialApply(
+        *this, loc, memberArg, operand, foreignMethodTy, methodTy);
+
+    // Collect the index values for application.
+    llvm::SmallVector<ManagedValue, 2> indexValues;
+    for (auto &source : std::move(indexArgs).getSources()) {
+      // @objc subscripts cannot have 'inout' indices.
+      RValue rVal = std::move(source).asKnownRValue(*this);
+
+      // @objc subscripts cannot have tuple indices.
+      indexValues.push_back(std::move(rVal).getScalarValue());
+    }
+
+    auto resultRV = emitMonomorphicApply(loc, result, indexValues,
                                          foreignMethodTy.getResult(), valueTy,
                                          ApplyOptions(), None, None);
 
     // Package up the result in an optional.
-    emitInjectOptionalValueInto(e, {e, std::move(resultRV)}, optTemp, optTL);
+    emitInjectOptionalValueInto(loc, {loc, std::move(resultRV)}, optTemp,
+                                optTL);
 
     applyScope.pop();
     // Branch to the continuation block.
-    B.createBranch(e, contBB);
+    B.createBranch(loc, contBB);
   }
 
   // Create the no-member branch.
   {
     B.emitBlock(noMemberBB);
 
-    emitInjectOptionalNothingInto(e, optTemp, optTL);
+    emitInjectOptionalNothingInto(loc, optTemp, optTL);
 
     // Branch to the continuation block.
-    B.createBranch(e, contBB);
+    B.createBranch(loc, contBB);
   }
 
   // Emit the continuation block.
@@ -6350,8 +6352,9 @@ RValue SILGenFunction::emitDynamicSubscriptExpr(DynamicSubscriptExpr *e,
   // Package up the result.
   auto optResult = optTemp;
   if (optTL.isLoadable())
-    optResult = optTL.emitLoad(B, e, optResult, LoadOwnershipQualifier::Take);
-  return RValue(*this, e, emitManagedRValueWithCleanup(optResult, optTL));
+    optResult = optTL.emitLoad(B, loc, optResult, LoadOwnershipQualifier::Take);
+  return RValue(*this, loc, resultTy,
+                emitManagedRValueWithCleanup(optResult, optTL));
 }
 
 SmallVector<ManagedValue, 4> SILGenFunction::emitKeyPathSubscriptOperands(

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6160,9 +6160,6 @@ RValue SILGenFunction::emitDynamicMemberRef(SILLocation loc, SILValue operand,
   // Create the has-member block.
   SILBasicBlock *hasMemberBB = createBasicBlock();
 
-  // The continuation block
-  CanType memberMethodTy = refTy.getOptionalObjectType();
-
   const TypeLowering &optTL = getTypeLowering(refTy);
   auto loweredOptTy = optTL.getLoweredType();
 
@@ -6172,9 +6169,6 @@ RValue SILGenFunction::emitDynamicMemberRef(SILLocation loc, SILValue operand,
   FuncDecl *memberFunc;
   if (auto *VD = dyn_cast<VarDecl>(memberRef.getDecl())) {
     memberFunc = VD->getOpaqueAccessor(AccessorKind::Get);
-    // FIXME: Verify ExtInfo state is correct, not working by accident.
-    CanFunctionType::ExtInfo info;
-    memberMethodTy = CanFunctionType::get({}, memberMethodTy, info);
   } else {
     memberFunc = cast<FuncDecl>(memberRef.getDecl());
   }
@@ -6210,7 +6204,7 @@ RValue SILGenFunction::emitDynamicMemberRef(SILLocation loc, SILValue operand,
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     CanFunctionType::ExtInfo info;
     FunctionType::Param arg(operand->getType().getASTType());
-    auto memberFnTy = CanFunctionType::get({arg}, memberMethodTy, info);
+    auto memberFnTy = CanFunctionType::get({arg}, methodTy, info);
 
     auto loweredMethodTy = getDynamicMethodLoweredType(SGM.M, member,
                                                        memberFnTy);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2219,7 +2219,13 @@ RValue RValueEmitter::visitDynamicMemberRefExpr(DynamicMemberRefExpr *E,
                                                 SGFContext C) {
   assert(!E->isImplicitlyAsync() && "an actor-isolated @objc member?");
   assert(!E->isImplicitlyThrows() && "an distributed-actor-isolated @objc member?");
-  return SGF.emitDynamicMemberRefExpr(E, C);
+
+  // Emit the operand (the base).
+  SILValue Operand = SGF.emitRValueAsSingleValue(E->getBase()).getValue();
+
+  // Emit the member reference.
+  return SGF.emitDynamicMemberRef(E, Operand, E->getMember(),
+                                  E->getType()->getCanonicalType(), C);
 }
 
 RValue RValueEmitter::

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1755,8 +1755,11 @@ public:
                               ConcreteDeclRef memberRef, CanType refTy,
                               SGFContext C);
 
-  /// Emit a dynamic subscript.
-  RValue emitDynamicSubscriptExpr(DynamicSubscriptExpr *e, SGFContext c);
+  /// Emit a dynamic subscript getter application.
+  RValue emitDynamicSubscriptGetterApply(SILLocation loc, SILValue operand,
+                                         ConcreteDeclRef subscriptRef,
+                                         PreparedArguments &&indexArgs,
+                                         CanType resultTy, SGFContext C);
 
   /// Open up the given existential expression and emit its
   /// subexpression in a caller-specified manner.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1751,7 +1751,9 @@ public:
                                       bool isSuppressed);
 
   /// Emit a dynamic member reference.
-  RValue emitDynamicMemberRefExpr(DynamicMemberRefExpr *e, SGFContext c);
+  RValue emitDynamicMemberRef(SILLocation loc, SILValue operand,
+                              ConcreteDeclRef memberRef, CanType refTy,
+                              SGFContext C);
 
   /// Emit a dynamic subscript.
   RValue emitDynamicSubscriptExpr(DynamicSubscriptExpr *e, SGFContext c);

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -160,10 +160,13 @@ func dynamicMemberLookupMixedKeypaths(foo: DynamicClass<Foo>) {
 
 @objc protocol ObjCProtoOptional {
   @objc optional var optionalProperty: Bool { get }
+
+  @objc optional subscript(_: Int) -> Bool { get }
 }
 
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}0B28ProtocolOptionalRequirementsyyF
 // CHECK: keypath $KeyPath<ObjCProtoOptional, Optional<Bool>>, (objc "optionalProperty"; root $ObjCProtoOptional; gettable_property $Optional<Bool>,  id #ObjCProtoOptional.optionalProperty!getter.foreign : <Self where Self : ObjCProtoOptional> (Self) -> () -> Bool, getter @$[[PROP_GETTER:[_a-zA-Z0-9]+]]
+// CHECK: keypath $KeyPath<ObjCProtoOptional, Optional<Bool>>, (root $ObjCProtoOptional; gettable_property $Optional<Bool>,  id #ObjCProtoOptional.subscript!getter.foreign : <Self where Self : ObjCProtoOptional> (Self) -> (Int) -> Bool, getter @$[[SUBSCR_GETTER:[_a-zA-Z0-9]+]]
 // CHECK: } // end sil function '${{.*}}0B28ProtocolOptionalRequirementsyyF'
 //
 // CHECK: sil shared [thunk] [ossa] @$[[PROP_GETTER]] : $@convention(thin) (@in_guaranteed ObjCProtoOptional) -> @out Optional<Bool> {
@@ -171,6 +174,16 @@ func dynamicMemberLookupMixedKeypaths(foo: DynamicClass<Foo>) {
 // CHECK:   dynamic_method_br [[BASE]] : $[[OPENED_TY]], #ObjCProtoOptional.optionalProperty!getter.foreign, bb1
 // CHECK: bb1({{%[0-9]+}} : $@convention(objc_method) ([[OPENED_TY]]) -> ObjCBool)
 // CHECK: } // end sil function '$[[PROP_GETTER]]'
+//
+// CHECK: sil shared [thunk] [ossa] @$[[SUBSCR_GETTER]] : $@convention(thin) (@in_guaranteed ObjCProtoOptional, UnsafeRawPointer) -> @out Optional<Bool> {
+// CHECK:   [[BASE:%[0-9]+]] = open_existential_ref {{%[0-9]+}} : $ObjCProtoOptional to $[[OPENED_TY:@opened\("[-A-F0-9]+"\) ObjCProtoOptional]]
+// CHECK:   [[INDEX:%[0-9]+]] = load [trivial] {{%[0-9]+}} : $*Int
+// CHECK:   dynamic_method_br [[BASE]] : $[[OPENED_TY]], #ObjCProtoOptional.subscript!getter.foreign, bb1, bb2
+// CHECK: bb1({{%[0-9]+}} : $@convention(objc_method) (Int, [[OPENED_TY]]) -> ObjCBool):
+// CHECK:   %17 = apply {{%[0-9]+}}([[INDEX]]) : $@callee_guaranteed (Int) -> Bool
+// CHECK: bb2:
+// CHECK: } // end sil function '$[[SUBSCR_GETTER]]'
 func objcProtocolOptionalRequirements() {
   _ = \ObjCProtoOptional.optionalProperty
+  _ = \ObjCProtoOptional.[0]
 }

--- a/test/SILGen/keypaths_objc.swift
+++ b/test/SILGen/keypaths_objc.swift
@@ -157,3 +157,20 @@ func dynamicMemberLookupMixedKeypaths(foo: DynamicClass<Foo>) {
   // CHECK: keypath $KeyPath<NonObjC, NSObject>, (root
   _ = foo.bar.foo.nonobjc.y 
 }
+
+@objc protocol ObjCProtoOptional {
+  @objc optional var optionalProperty: Bool { get }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @{{.*}}0B28ProtocolOptionalRequirementsyyF
+// CHECK: keypath $KeyPath<ObjCProtoOptional, Optional<Bool>>, (objc "optionalProperty"; root $ObjCProtoOptional; gettable_property $Optional<Bool>,  id #ObjCProtoOptional.optionalProperty!getter.foreign : <Self where Self : ObjCProtoOptional> (Self) -> () -> Bool, getter @$[[PROP_GETTER:[_a-zA-Z0-9]+]]
+// CHECK: } // end sil function '${{.*}}0B28ProtocolOptionalRequirementsyyF'
+//
+// CHECK: sil shared [thunk] [ossa] @$[[PROP_GETTER]] : $@convention(thin) (@in_guaranteed ObjCProtoOptional) -> @out Optional<Bool> {
+// CHECK:   [[BASE:%[0-9]+]] = open_existential_ref {{%[0-9]+}} : $ObjCProtoOptional to $[[OPENED_TY:@opened\("[-A-F0-9]+"\) ObjCProtoOptional]]
+// CHECK:   dynamic_method_br [[BASE]] : $[[OPENED_TY]], #ObjCProtoOptional.optionalProperty!getter.foreign, bb1
+// CHECK: bb1({{%[0-9]+}} : $@convention(objc_method) ([[OPENED_TY]]) -> ObjCBool)
+// CHECK: } // end sil function '$[[PROP_GETTER]]'
+func objcProtocolOptionalRequirements() {
+  _ = \ObjCProtoOptional.optionalProperty
+}

--- a/validation-test/compiler_crashers_2_fixed/sr16076.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr16076.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil -O %s
+
+// REQUIRES: objc_interop
+import Foundation
+
+@objc protocol OptionalVar {
+    @objc optional var name: String { get }
+}
+
+extension NSObject: OptionalVar { }
+
+do {
+  let objects = [NSObject()] as Array<OptionalVar>
+
+  let names = objects.compactMap(\.name)
+  print("Names: \(names)")
+}


### PR DESCRIPTION
Resolves #58337
