### PR TITLE
[ConstraintSystem] Cache types of `~=` components

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8774,7 +8774,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     if (auto *enumElement = dyn_cast<EnumElementPattern>(info.pattern)) {
       if (auto target = cs.getSolutionApplicationTarget(enumElement)) {
         auto *EP = target->getExprPattern();
-        auto enumType = solution.simplifyType(EP->getType());
+        auto enumType = solution.getResolvedType(EP);
 
         auto *matchCall = target->getAsExpr();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8940,6 +8940,9 @@ static bool inferEnumMemberThroughTildeEqualsOperator(
 
   std::tie(matchVar, matchCall) = *tildeEqualsApplication;
 
+  cs.setType(matchVar, enumTy);
+  cs.setType(EP, enumTy);
+
   // result of ~= operator is always a `Bool`.
   auto target = SolutionApplicationTarget::forExprPattern(
       matchCall, DC, EP, ctx.getBoolDecl()->getDeclaredInterfaceType());
@@ -8968,7 +8971,6 @@ static bool inferEnumMemberThroughTildeEqualsOperator(
   // Store the $match variable and binary expression for solution application.
   EP->setMatchVar(matchVar);
   EP->setMatchExpr(matchCall);
-  EP->setType(enumTy);
 
   cs.setSolutionApplicationTarget(pattern, target);
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -880,6 +880,8 @@ bool TypeChecker::typeCheckExprPattern(ExprPattern *EP, DeclContext *DC,
 
   std::tie(matchVar, matchCall) = *tildeEqualsApplication;
 
+  matchVar->setInterfaceType(rhsType->mapTypeOutOfContext());
+
   // Result of `~=` should always be a boolean.
   auto contextualTy = Context.getBoolDecl()->getDeclaredInterfaceType();
   auto target = SolutionApplicationTarget::forExprPattern(matchCall, DC, EP,
@@ -908,7 +910,6 @@ TypeChecker::synthesizeTildeEqualsOperatorApplication(ExprPattern *EP,
   auto *matchVar =
       new (Context) VarDecl(/*IsStatic*/ false, VarDecl::Introducer::Let,
                             EP->getLoc(), Context.Id_PatternMatchVar, DC);
-  matchVar->setInterfaceType(enumType->mapTypeOutOfContext());
 
   matchVar->setImplicit();
 


### PR DESCRIPTION
While synthesizing `~=` application for multi-statement closures or
result builder, solver shouldn't set types directly to newly
created AST nodes because they might not be fully resolved, instead
such types have to be recorded in the constraint system and then
set during solution application.

Resolves: rdar://91145060.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
