### PR TITLE
Revert "Merge pull request #42140 from artemcm/EnableRegexLiteralFlag"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -561,9 +561,6 @@ namespace swift {
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 
-    /// Enables `/.../` syntax regular-expression literals
-    bool EnableForwardSlashRegexLiterals = false;
-
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -676,10 +676,6 @@ def disable_actor_data_race_checks :
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Disable runtime checks for actor data races">;
 
-def enable_regex_literals : Flag<["-"], "enable-regex-literals">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
-  HelpText<"Enable the use of regular-expression literals">;
-
 def warn_implicit_overrides :
   Flag<["-"], "warn-implicit-overrides">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -298,7 +298,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
   inputArgs.AddLastArg(arguments, options::OPT_library_level);
-  inputArgs.AddLastArg(arguments, options::OPT_enable_regex_literals);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1004,9 +1004,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_requirement_machine_reuse))
     Opts.EnableRequirementMachineReuse = false;
 
-  if (Args.hasArg(OPT_enable_regex_literals))
-    Opts.EnableForwardSlashRegexLiterals = true;
-
   if (Args.hasArg(OPT_enable_requirement_machine_opaque_archetypes))
     Opts.EnableRequirementMachineOpaqueArchetypes = true;
 

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -20,9 +20,6 @@
     },
     {
       "name": "empty-abi-descriptor"
-    },
-    {
-      "name": "enable-regex-literals"
-    }    
+    }
   ]
 }

--- a/test/Driver/enable_regex_literals_flag.swift
+++ b/test/Driver/enable_regex_literals_flag.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swiftc_driver  -enable-regex-literals -disallow-use-new-driver -driver-print-jobs  %s 2>^1 | %FileCheck %s
-// The new driver has its own test for this
-// REQUIRES: cplusplus_driver
-// CHECK: {{.*}}/swift-frontend -frontend{{.*}}-enable-regex-literals
-
-public func foo() -> Int {
-    return 42
-}

--- a/test/ModuleInterface/option-preservation.swift
+++ b/test/ModuleInterface/option-preservation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load -enable-regex-literals
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
@@ -10,7 +10,6 @@
 // CHECK-SWIFTINTERFACE-SAME: -autolink-force-load
 // CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
 // CHECK-SWIFTINTERFACE-SAME: -target-min-inlining-version 42
-// CHECK-SWIFTINTERFACE-SAME: -enable-regex-literals
 
 // Make sure flags show up when filelists are enabled
 


### PR DESCRIPTION
This reverts commit aaee1c4bcfb7af21c2563b5caa564727a34db3f6, reversing
changes made to 16d204bc51efbef03c3373a1f7bc496166ea8e95.

This is causing build failures on Windows.
https://ci-external.swift.org/job/swift-PR-windows/270/