### PR TITLE
[SILGen] Fix `swift_once` initializer signature for lazy global var

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -699,7 +699,7 @@ BUILTIN_MISC_OPERATION(IntToFPWithOverflow, "itofp_with_overflow", "n", Special)
 /// zeroInitializer has type <T> () -> T
 BUILTIN_MISC_OPERATION(ZeroInitializer, "zeroInitializer", "n", Special)
 
-/// once has type (Builtin.RawPointer, () -> ())
+/// once has type (Builtin.RawPointer, (Builtin.RawPointer) -> ())
 BUILTIN_MISC_OPERATION(Once, "once", "", Special)
 /// onceWithContext has type (Builtin.RawPointer, (Builtin.RawPointer) -> (), Builtin.RawPointer)
 BUILTIN_MISC_OPERATION(OnceWithContext, "onceWithContext", "", Special)

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1650,9 +1650,7 @@ SILFunction *SILGenModule::emitLazyGlobalInitializer(StringRef funcName,
   auto *onceBuiltin =
       cast<FuncDecl>(getBuiltinValueDecl(C, C.getIdentifier("once")));
   auto blockParam = onceBuiltin->getParameters()->get(1);
-  auto *type = blockParam->getType()->castTo<FunctionType>();
-  Type initType = FunctionType::get({}, TupleType::getEmpty(C),
-                                    type->getExtInfo());
+  auto *initType = blockParam->getType()->castTo<FunctionType>();
   auto initSILType = cast<SILFunctionType>(
       Types.getLoweredRValueType(TypeExpansionContext::minimal(), initType));
 

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -228,6 +228,12 @@ void SILGenFunction::emitLazyGlobalInitializer(PatternBindingDecl *binding,
                                                unsigned pbdEntry) {
   MagicFunctionName = SILGenModule::getMagicFunctionName(binding->getDeclContext());
 
+  // Add unused context pointer argument required to pass to `Builtin.once`
+  SILBasicBlock &entry = *F.begin();
+  SILType rawPointerSILTy =
+      getLoweredLoadableType(getASTContext().TheRawPointerType);
+  entry.createFunctionArgument(rawPointerSILTy);
+
   {
     Scope scope(Cleanups, binding);
 

--- a/test/IRGen/lazy_globals.swift
+++ b/test/IRGen/lazy_globals.swift
@@ -7,7 +7,7 @@
 // CHECK: @"$s12lazy_globals1ySivp" = hidden global %TSi zeroinitializer, align 8
 // CHECK: @"$s12lazy_globals1zSivp" = hidden global %TSi zeroinitializer, align 8
 
-// CHECK: define internal void @"[[T]]WZ"() {{.*}} {
+// CHECK: define internal void @"[[T]]WZ"(i8* %0) {{.*}} {
 // CHECK: entry:
 // CHECK:   store i64 1, i64* getelementptr inbounds (%TSi, %TSi* @"$s12lazy_globals1xSivp", i32 0, i32 0), align 8
 // CHECK:   store i64 2, i64* getelementptr inbounds (%TSi, %TSi* @"$s12lazy_globals1ySivp", i32 0, i32 0), align 8
@@ -17,17 +17,17 @@
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1xSivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void (i8*)* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1ySivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void (i8*)* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 
 // CHECK: define hidden swiftcc i8* @"$s12lazy_globals1zSivau"() {{.*}} {
 // CHECK: entry:
-// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void ()* @"[[T]]WZ" to i8*), i8* undef)
+// CHECK:   call void @swift_once(i64* @"[[T]]Wz", i8* bitcast (void (i8*)* @"[[T]]WZ" to i8*), i8* undef)
 // CHECK: }
 var (x, y, z) = (1, 2, 3)
 

--- a/test/SILGen/lazy_globals.swift
+++ b/test/SILGen/lazy_globals.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -parse-as-library %s | %FileCheck %s
 
-// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK:   alloc_global @$s12lazy_globals1xSiv
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals1xSivp : $*Int
 // CHECK:   store {{%.*}} to [trivial] [[XADDR]] : $*Int
@@ -8,15 +8,15 @@
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals1xSivau : $@convention(thin) () -> Builtin.RawPointer {
 // CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
-// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) (Builtin.RawPointer) -> ()
+// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) (Builtin.RawPointer) -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals1xSivp : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
 // CHECK:   return [[GLOBAL_PTR]] : $Builtin.RawPointer
 // CHECK: }
 var x: Int = 0
 
-// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*]]WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK:   alloc_global @$s12lazy_globals3FooV3fooSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3FooV3fooSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -26,8 +26,8 @@ struct Foo {
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals3FooV3fooSivau : $@convention(thin) () -> Builtin.RawPointer {
 // CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
-// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) (Builtin.RawPointer) -> ()
+// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) (Builtin.RawPointer) -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals3FooV3fooSivpZ : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
 // CHECK:   return [[GLOBAL_PTR]] : $Builtin.RawPointer
@@ -40,7 +40,7 @@ struct Foo {
   static var initialized: Int = 57
 }
 
-// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*3bar.*]]WZ : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*3bar.*]]WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK:   alloc_global @$s12lazy_globals3BarO3barSivpZ
 // CHECK:   [[XADDR:%.*]] = global_addr @$s12lazy_globals3BarO3barSivpZ : $*Int
 // CHECK:   store {{.*}} to [trivial] [[XADDR]] : $*Int
@@ -50,8 +50,8 @@ enum Bar {
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals3BarO3barSivau : $@convention(thin) () -> Builtin.RawPointer {
 // CHECK:   [[TOKEN_ADDR:%.*]] = global_addr @[[T]]Wz : $*Builtin.Word
 // CHECK:   [[TOKEN_PTR:%.*]] = address_to_pointer [[TOKEN_ADDR]] : $*Builtin.Word to $Builtin.RawPointer
-// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) () -> ()
-// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) () -> ()) : $()
+// CHECK:   [[INIT_FUNC:%.*]] = function_ref @[[T]]WZ : $@convention(c) (Builtin.RawPointer) -> ()
+// CHECK:   builtin "once"([[TOKEN_PTR]] : $Builtin.RawPointer, [[INIT_FUNC]] : $@convention(c) (Builtin.RawPointer) -> ()) : $()
 // CHECK:   [[GLOBAL_ADDR:%.*]] = global_addr @$s12lazy_globals3BarO3barSivpZ : $*Int
 // CHECK:   [[GLOBAL_PTR:%.*]] = address_to_pointer [[GLOBAL_ADDR]] : $*Int to $Builtin.RawPointer
 // CHECK:   return [[GLOBAL_PTR]] : $Builtin.RawPointer
@@ -63,13 +63,13 @@ enum Bar {
 
 func f() -> (Int, Int) { return (1, 2) }
 
-// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*2a1.*2b1.*]]WZ : $@convention(c) () -> () {
+// CHECK: sil private [global_init_once_fn] [ossa] @[[T:.*2a1.*2b1.*]]WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK:   function_ref @$s12lazy_globals1fSi_SityF : $@convention(thin) () -> (Int, Int)
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals2a1Sivau : $@convention(thin) () -> Builtin.RawPointer
-// CHECK:   function_ref @[[T]]WZ : $@convention(c) () -> ()
+// CHECK:   function_ref @[[T]]WZ : $@convention(c) (Builtin.RawPointer) -> ()
 // CHECK:   global_addr @$s12lazy_globals2a1Sivp : $*Int
 // CHECK: sil hidden [global_init] [ossa] @$s12lazy_globals2b1Sivau : $@convention(thin) () -> Builtin.RawPointer {
-// CHECK:   function_ref @[[T]]WZ : $@convention(c) () -> ()
+// CHECK:   function_ref @[[T]]WZ : $@convention(c) (Builtin.RawPointer) -> ()
 // CHECK:   global_addr @$s12lazy_globals2b1Sivp : $*Int
 var (a1, b1) = f()
 

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -251,10 +251,10 @@ class BBQ {
 
 var global_observing_property : Int = zero {
   // The variable is initialized with "zero".
-  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
-  // CHECK: bb0:
+  // CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
+  // CHECK: bb0(%0 : $Builtin.RawPointer):
   // CHECK-NEXT: alloc_global @$s9observers25global_observing_propertySiv
-  // CHECK-NEXT: %1 = global_addr @$s9observers25global_observing_propertySivp : $*Int
+  // CHECK-NEXT: %2 = global_addr @$s9observers25global_observing_propertySivp : $*Int
   // CHECK: observers.zero.unsafeMutableAddressor
   // CHECK: return
 

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -635,7 +635,7 @@ func testShims() -> UInt32 {
 
 // --- global variable initialization.
 var globalString1 = "⓪" // start non-empty
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString1SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString1SSvp : $*String
 // CHECK: apply
@@ -645,7 +645,7 @@ var globalString1 = "⓪" // start non-empty
 // CHECK-LABEL: } // end sil function '{{.*}}WZ'
 
 var globalString2 = globalString1
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK: alloc_global @$s20access_marker_verify13globalString2SSvp
 // CHECK: [[GA:%.*]] = global_addr @$s20access_marker_verify13globalString2SSvp : $*String
 // CHECK: apply
@@ -1045,7 +1045,7 @@ func testPointerInit(x: Int, y: UnsafeMutablePointer<Int>) {
 class testInitExistentialGlobal {
   static var testProperty: P = StructP()
 }
-// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) () -> () {
+// CHECK-LABEL: sil private [global_init_once_fn] [ossa] @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK:   alloc_global @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ
 // CHECK:   [[GADR:%.*]] = global_addr @$s20access_marker_verify25testInitExistentialGlobalC0D8PropertyAA1P_pvpZ : $*P
 // CHECK:   %{{.*}} = apply %{{.*}}({{.*}}) : $@convention(method) (@thin StructP.Type) -> StructP

--- a/test/SILOptimizer/access_marker_verify_objc.swift
+++ b/test/SILOptimizer/access_marker_verify_objc.swift
@@ -12,8 +12,8 @@ import Foundation
 // --- initializer `let` of CFString.
 // The verifier should ignore this.
 
-// CHECK_LABEL: sil private @{{.*}}WZ : $@convention(c) () -> () {
-// CHECK: bb0:
+// CHECK_LABEL: sil private @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
+// CHECK: bb0(%0 : $Builtin.RawPointer):
 // CHECK:   alloc_global @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ
 // CHECK:   [[GA:%.*]] = global_addr @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ : $*CFString
 // CHECK-NOT: begin_access


### PR DESCRIPTION
`Builtin.once` has type `(Builtin.RawPointer, (Builtin.RawPointer) -> ())`
at Swift level, but lazy global init passes its initializer as `() -> ()`,
so their callee and caller signatures doesn't match.

https://github.com/apple/swift/blob/f834a51ff57ea2514bfed18f1bc9aa33a875eaed/lib/AST/Builtins.cpp#L1837

This PR adds an explicit context argument to the initializer function implementation.
This is to avoid runtime crash in WebAssembly
