### PR TITLE
IRGen: setup foreign calls properly

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1450,8 +1450,9 @@ public:
   void finishEmitAfterTopLevel();
 
   Signature getSignature(CanSILFunctionType fnType);
-  Signature getSignature(CanSILFunctionType fnType,
-                         FunctionPointerKind kind);
+  Signature getSignature(CanSILFunctionType fnType, FunctionPointerKind kind,
+                         const clang::Decl *decl = nullptr);
+
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2619,7 +2619,7 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
 
-  auto sig = IGM.getSignature(fnType, fpKind);
+  auto sig = IGM.getSignature(fnType, fpKind, fn->getClangDecl());
 
   // Note that the pointer value returned by getAddrOfSILFunction doesn't
   // necessarily have element type sig.getType(), e.g. if it's imported.

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -126,7 +126,8 @@ public:
   /// IRGenModule::getSignature(CanSILFunctionType), which is what
   /// clients should generally be using.
   static Signature getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
-                               FunctionPointerKind kind);
+                               FunctionPointerKind kind,
+                               const clang::Decl *decl);
 
   /// Compute the signature of a coroutine's continuation function.
   static Signature forCoroutineContinuation(IRGenModule &IGM,

--- a/test/IRGen/Inputs/foreign/foreign.h
+++ b/test/IRGen/Inputs/foreign/foreign.h
@@ -1,0 +1,3 @@
+#pragma once
+int __attribute__((__stdcall__)) stdcall_add(int i, int j);
+int __attribute__((__fastcall__)) fastcall_add(int i, int j);

--- a/test/IRGen/Inputs/foreign/module.modulemap
+++ b/test/IRGen/Inputs/foreign/module.modulemap
@@ -1,0 +1,5 @@
+
+module foreign {
+  header "foreign.h"
+  export *
+}

--- a/test/IRGen/foreign_call.swift
+++ b/test/IRGen/foreign_call.swift
@@ -1,0 +1,66 @@
+// RUN: %swift_frontend_plain -target i686-unknown-windows-msvc -disable-objc-interop -parse-as-library -parse-stdlib -module-name Swift -static -O -S -emit-ir -o - -I%S/Inputs/foreign %s | %FileCheck %s -check-prefix CHECK-IR
+// RUN: %swift_frontend_plain -target i686-unknown-windows-msvc -disable-objc-interop -parse-as-library -parse-stdlib -module-name Swift -static -O -S -o - -I%S/Inputs/foreign %s | %FileCheck %s -check-prefix CHECK-ASM
+
+import foreign
+
+precedencegroup AssignmentPrecedence {
+  assignment: true
+}
+
+public typealias _MaxBuiltinIntegerType = Builtin.IntLiteral
+
+public protocol _ExpressibleByBuiltinIntegerLiteral {
+  init(_builtinIntegerLiteral value: _MaxBuiltinIntegerType)
+}
+
+public protocol ExpressibleByIntegerLiteral {
+  associatedtype IntegerLiteralType: _ExpressibleByBuiltinIntegerLiteral
+  init(integerLiteral value: IntegerLiteralType)
+}
+
+extension ExpressibleByIntegerLiteral where Self: _ExpressibleByBuiltinIntegerLiteral {
+  public init(integerLiteral value: Self) {
+    self = value
+  }
+}
+
+public protocol _ExpressibleByBuiltinFloatLiteral {
+  init(_builtinFloatLiteral value: Builtin.FPIEEE64)
+}
+
+public protocol ExpressibleByFloatLiteral {
+  init(floatLiteral value: _ExpressibleByBuiltinFloatLiteral)
+}
+
+public struct Int32 {
+  var _value: Builtin.Int32
+  init(_ _value: Builtin.Int32) {
+    self._value = _value
+  }
+}
+
+extension Int32: _ExpressibleByBuiltinIntegerLiteral {
+  public init(_builtinIntegerLiteral value: Builtin.IntLiteral) {
+    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Int32(value).0
+  }
+}
+
+extension Int32: ExpressibleByIntegerLiteral {
+}
+
+public typealias CInt = Int32
+
+public func stdcall() -> CInt {
+  return stdcall_add(1, 2)
+}
+
+// CHECK-IR-LABEL: $ss7stdcalls5Int32VyF
+// CHECK-IR: %0 = tail call x86_stdcallcc i32 @"\01_stdcall_add@8"(i32 1, i32 2)
+// CHECK-IR: ret i32 %0
+
+// CHECK-ASM-LABEL: _$ss7stdcalls5Int32VyF
+// CHECK-ASM: pushl $2
+// CHECK-ASM: pushl $1
+// CHECK-ASM: calll _stdcall_add@8
+// CHECK-ASM-NOT: addl $8, %esp
+// CHECK-ASM: retl


### PR DESCRIPTION
We would previously drop all calling convention information for foreign
calls on the floor when arranging a function call.  This could (would in
the case of many Windows i686 system calls) construct invalid function
calls.  We would simply mark everything as being cdecl rather than the
effective calling convention of the function call.  In the case of
windows i686, this is problematic as many functions are callee cleanup
with pass by stack, aka, `__stdcall`.  We would as a result of the
missing information pass arguments incorrectly, or in the worst case
(like on Windows i686), corrupt the stack.

The heart of this change is that when arranging the function call, if we
are calling a foreign function, we should consult clang for the extended
information for the call.  Given that SIL does not preserve this
information, we need to go back to the original foreign function
declaration and query the information.  This declaration is only
available significantly earlier in the call stack.  The newly introduced
parameters are to help identify potential gaps where we may be leaking a
calling convention attribute on the foreign call.  However, the current
state is sufficient to enable loading Foundation on Windows i686 which
uses a number of foreign calls with different conventions.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
