### PR TITLE
Revise SE-0346 implementation for core team decision

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3770,6 +3770,11 @@ ERROR(not_a_generic_definition,none,
       "cannot specialize a non-generic definition", ())
 ERROR(not_a_generic_type,none,
       "cannot specialize non-generic type %0", (Type))
+ERROR(protocol_declares_unknown_primary_assoc_type,none,
+      "an associated type named %0 must be declared in the protocol %1 or a protocol it inherits",
+      (Identifier, Type))
+ERROR(protocol_declares_duplicate_primary_assoc_type,none,
+      "duplicate primary associated type name %0", (Identifier))
 ERROR(parameterized_protocol_not_supported,none,
       "protocol type with generic arguments can only be used as a generic constraint", ())
 ERROR(protocol_does_not_have_primary_assoc_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3776,13 +3776,13 @@ ERROR(protocol_declares_unknown_primary_assoc_type,none,
 ERROR(protocol_declares_duplicate_primary_assoc_type,none,
       "duplicate primary associated type name %0", (Identifier))
 ERROR(parameterized_protocol_not_supported,none,
-      "protocol type with generic arguments can only be used as a generic constraint", ())
+      "protocol type with type arguments can only be used as a generic constraint", ())
 ERROR(protocol_does_not_have_primary_assoc_type,none,
       "cannot specialize protocol type %0", (Type))
-ERROR(parameterized_protocol_too_many_type_arguments,none,
-      "protocol type %0 can specialized with too many type parameters "
-      "(got %1, but expected at most %2)",
-      (Type, unsigned, unsigned))
+ERROR(parameterized_protocol_type_argument_count_mismatch,none,
+      "protocol type %0 specialized with %select{too many|too few}3 type arguments "
+      "(got %1, but expected %2)",
+      (Type, unsigned, unsigned, unsigned))
 ERROR(cannot_specialize_self,none,
       "cannot specialize 'Self'", ())
 NOTE(specialize_explicit_type_instead,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1213,9 +1213,9 @@ public:
   parseAbstractFunctionBodyDelayed(AbstractFunctionDecl *AFD);
 
   ParserStatus parsePrimaryAssociatedTypes(
-      SmallVectorImpl<AssociatedTypeDecl *> &AssocTypes);
+      SmallVectorImpl<PrimaryAssociatedTypeName> &AssocTypeNames);
   ParserStatus parsePrimaryAssociatedTypeList(
-      SmallVectorImpl<AssociatedTypeDecl *> &AssocTypes);
+      SmallVectorImpl<PrimaryAssociatedTypeName> &AssocTypeNames);
   ParserResult<ProtocolDecl> parseDeclProtocol(ParseDeclOptions Flags,
                                                DeclAttributes &Attributes);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4557,9 +4557,7 @@ AssociatedTypeDecl::AssociatedTypeDecl(DeclContext *dc, SourceLoc keywordLoc,
                                        TrailingWhereClause *trailingWhere)
     : AbstractTypeParamDecl(DeclKind::AssociatedType, dc, name, nameLoc),
       KeywordLoc(keywordLoc), DefaultDefinition(defaultDefinition),
-      TrailingWhere(trailingWhere) {
-  Bits.AssociatedTypeDecl.IsPrimary = 0;
-}
+      TrailingWhere(trailingWhere) {}
 
 AssociatedTypeDecl::AssociatedTypeDecl(DeclContext *dc, SourceLoc keywordLoc,
                                        Identifier name, SourceLoc nameLoc,
@@ -5305,11 +5303,13 @@ bool EnumDecl::hasCircularRawValue() const {
 
 ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
                            SourceLoc NameLoc, Identifier Name,
+                           ArrayRef<PrimaryAssociatedTypeName> PrimaryAssociatedTypeNames,
                            ArrayRef<InheritedEntry> Inherited,
                            TrailingWhereClause *TrailingWhere)
     : NominalTypeDecl(DeclKind::Protocol, DC, Name, NameLoc, Inherited,
                       nullptr),
-      ProtocolLoc(ProtocolLoc) {
+      ProtocolLoc(ProtocolLoc),
+      PrimaryAssociatedTypeNames(PrimaryAssociatedTypeNames) {
   Bits.ProtocolDecl.RequiresClassValid = false;
   Bits.ProtocolDecl.RequiresClass = false;
   Bits.ProtocolDecl.ExistentialConformsToSelfValid = false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5677,7 +5677,8 @@ namespace {
       auto result = Impl.createDeclWithClangNode<ProtocolDecl>(
           decl, AccessLevel::Public, dc,
           Impl.importSourceLoc(decl->getBeginLoc()),
-          Impl.importSourceLoc(decl->getLocation()), name, None,
+          Impl.importSourceLoc(decl->getLocation()), name,
+          ArrayRef<PrimaryAssociatedTypeName>(), None,
           /*TrailingWhere=*/nullptr);
 
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2648,9 +2648,13 @@ public:
     checkUnsupportedNestedType(PD);
 
     // Check for circular inheritance within the protocol.
-    (void)PD->hasCircularInheritedProtocols();
+    (void) PD->hasCircularInheritedProtocols();
 
     TypeChecker::checkDeclAttributes(PD);
+
+    // Check that all named primary associated types are valid.
+    if (!PD->getPrimaryAssociatedTypeNames().empty())
+      (void) PD->getPrimaryAssociatedTypes();
 
     // Explicity compute the requirement signature to detect errors.
     // Do this before visiting members, to avoid a request cycle if

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -649,9 +649,11 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
 
       auto genericArgs = generic->getGenericArgs();
 
-      if (genericArgs.size() > assocTypes.size()) {
-        diags.diagnose(loc, diag::parameterized_protocol_too_many_type_arguments,
-                       protoType, genericArgs.size(), assocTypes.size());
+      if (genericArgs.size() != assocTypes.size()) {
+        diags.diagnose(loc,
+                       diag::parameterized_protocol_type_argument_count_mismatch,
+                       protoType, genericArgs.size(), assocTypes.size(),
+                       (genericArgs.size() < assocTypes.size()) ? 1 : 0);
 
         return ErrorType::get(ctx);
       }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2777,13 +2777,11 @@ public:
     TypeID defaultDefinitionID;
     bool isImplicit;
     ArrayRef<uint64_t> rawOverriddenIDs;
-    bool isPrimary;
 
     decls_block::AssociatedTypeDeclLayout::readRecord(scratch, nameID,
                                                       contextID,
                                                       defaultDefinitionID,
                                                       isImplicit,
-                                                      isPrimary,
                                                       rawOverriddenIDs);
 
     auto DC = MF.getDeclContext(contextID);
@@ -2817,9 +2815,6 @@ public:
       }
     }
     assocType->setOverriddenDecls(overriddenAssocTypes);
-
-    if (isPrimary)
-      assocType->setPrimary();
 
     return assocType;
   }
@@ -3666,8 +3661,10 @@ public:
     if (declOrOffset.isComplete())
       return declOrOffset;
 
-    auto proto = MF.createDecl<ProtocolDecl>(DC, SourceLoc(), SourceLoc(), name,
-                                             None, /*TrailingWhere=*/nullptr);
+    auto proto = MF.createDecl<ProtocolDecl>(
+        DC, SourceLoc(), SourceLoc(), name,
+        ArrayRef<PrimaryAssociatedTypeName>(), None,
+        /*TrailingWhere=*/nullptr);
     declOrOffset = proto;
 
     ctx.evaluator.cacheOutput(ProtocolRequiresClassRequest{proto},

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 682; // Remove unused instructions
+const uint16_t SWIFTMODULE_VERSION_MINOR = 683; // Remove associatedtype primary bit
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1234,7 +1234,6 @@ namespace decls_block {
     DeclContextIDField,  // context decl
     TypeIDField,         // default definition
     BCFixed<1>,          // implicit flag
-    BCFixed<1>,          // is primary
     BCArray<DeclIDField> // overridden associated types
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3487,7 +3487,6 @@ public:
       contextID.getOpaqueValue(),
       S.addTypeRef(assocType->getDefaultDefinitionType()),
       assocType->isImplicit(),
-      assocType->isPrimary(),
       overriddenAssocTypeIDs);
   }
 

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -2,15 +2,19 @@
 // RUN: %target-swift-frontend -typecheck -module-name ParameterizedProtocols -emit-module-interface-path %t/ParameterizedProtocols.swiftinterface -enable-parameterized-protocol-types %s
 // RUN: %FileCheck %s < %t/ParameterizedProtocols.swiftinterface
 
-public protocol HasPrimaryAssociatedTypes<T, U : Collection, V : Equatable = Int> where U.Element == Int {}
+public protocol HasPrimaryAssociatedTypes<T, U> {
+  associatedtype T : Collection where T.Element == U
+  associatedtype U : Equatable
+}
 
 // CHECK: #if compiler(>=5.3) && $PrimaryAssociatedTypes
-// CHECK-NEXT: public protocol HasPrimaryAssociatedTypes<T, U : Swift.Collection, V : Swift.Equatable = Swift.Int> where Self.U.Element == Swift.Int {
+// CHECK-NEXT: public protocol HasPrimaryAssociatedTypes<T, U> {
+// CHECK-NEXT:   associatedtype T : Swift.Collection
+// CHECK-NEXT:   associatedtype U : Swift.Equatable where Self.U == Self.T.Element
 // CHECK-NEXT: }
 // CHECK-NEXT: #else
 // CHECK-NEXT: public protocol HasPrimaryAssociatedTypes {
-// CHECK-NEXT:   associatedtype T
-// CHECK-NEXT:   associatedtype U : Swift.Collection where Self.U.Element == Swift.Int
-// CHECK-NEXT:   associatedtype V : Swift.Equatable = Swift.Int
+// CHECK-NEXT:   associatedtype T : Swift.Collection
+// CHECK-NEXT:   associatedtype U : Swift.Equatable where Self.U == Self.T.Element
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif

--- a/test/SILGen/existential_parameters.swift
+++ b/test/SILGen/existential_parameters.swift
@@ -1,8 +1,16 @@
 // RUN: %target-swift-emit-silgen -module-name parameterized -enable-parameterized-protocol-types %s | %FileCheck %s
 
-protocol P<T, U, V> {}
+protocol P<T, U, V> {
+  associatedtype T
+  associatedtype U
+  associatedtype V
+}
 
-protocol Q<X, Y, Z> : P {}
+protocol Q<X, Y, Z> : P {
+  associatedtype X
+  associatedtype Y
+  associatedtype Z
+}
 
 struct S: Q {
   typealias T = Int

--- a/test/SILGen/existential_parameters.swift
+++ b/test/SILGen/existential_parameters.swift
@@ -44,48 +44,16 @@ func upupupupcast(_ x: S) -> any P {
   // CHECK: store [[CONCRETE_VAL]] to [trivial] [[INIT_INT_STRING_FLOAT]] : $*S
   // CHECK: [[OPEN_INT_STRING_FLOAT:%.*]] = open_existential_addr immutable_access %3 : $*P<Int, String, Float> to $*[[OPENED_P_INT_STRING_FLOAT:@opened(.*) P<Int, String, Float>]]
 
-  // CHECK: [[P_INT_STRING:%.*]] = alloc_stack $P<Int, String>
-  // CHECK: [[INIT_INT_STRING:%.*]] = init_existential_addr [[P_INT_STRING]] : $*P<Int, String>, $[[OPENED_P_INT_STRING_FLOAT]]
-  // CHECK: copy_addr [[OPEN_INT_STRING_FLOAT]] to [initialization] [[INIT_INT_STRING]] : $*[[OPENED_P_INT_STRING_FLOAT]]
-  // CHECK: [[OPEN_INT_STRING:%.*]] = open_existential_addr immutable_access [[P_INT_STRING]] : $*P<Int, String> to $*[[OPENED_P_INT_STRING:@opened(.*) P<Int, String>]]
-
-  // CHECK: [[P_INT:%.*]] = alloc_stack $P<Int>
-  // CHECK: [[INIT_INT:%.*]] = init_existential_addr [[P_INT]] : $*P<Int>, $[[OPENED_P_INT_STRING]]
-  // CHECK: copy_addr [[OPEN_INT_STRING]] to [initialization] [[INIT_INT]] : $*[[OPENED_P_INT_STRING]]
-  // CHECK: [[OPEN_INT:%.*]] = open_existential_addr immutable_access [[P_INT]] : $*P<Int> to $*[[OPENED_P_INT:@opened(.*) P<Int>]]
-
-  // CHECK: [[RESULT_INIT:%.*]] = init_existential_addr [[RESULT_PARAM]] : $*P, $[[OPENED_P_INT]]
-  // CHECK: copy_addr [[OPEN_INT]] to [initialization] [[RESULT_INIT]] : $*[[OPENED_P_INT]]
-  return x as any P<Int, String, Float> as any P<Int, String> as any P<Int> as any P
+  // CHECK: [[RESULT_INIT:%.*]] = init_existential_addr [[RESULT_PARAM]] : $*P, $[[OPENED_P_INT_STRING_FLOAT]]
+  // CHECK: copy_addr [[OPEN_INT_STRING_FLOAT]] to [initialization] [[RESULT_INIT]] : $*[[OPENED_P_INT_STRING_FLOAT]]
+  return x as any P<Int, String, Float> as any P
 }
 
 func use(_ k: (S) -> Void) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s13parameterized11upcastInputyyF : $@convention(thin) () -> () {
 func upcastInput() {
-  // CHECK: [[INT_STRING_FN:%.*]] = function_ref @$s13parameterized11upcastInputyyFyAA1P_pySiSSXPXEfU_ : $@convention(thin) (@in_guaranteed P<Int, String>) -> ()
-  // CHECK: [[NOESCAPE_INT_STRING_FN:%.*]] = convert_function [[INT_STRING_FN]] : $@convention(thin) (@in_guaranteed P<Int, String>) -> () to $@convention(thin) @noescape (@in_guaranteed P<Int, String>) -> ()
-  // CHECK: [[THICK_INT_STRING_FN:%.*]] = thin_to_thick_function [[NOESCAPE_INT_STRING_FN]] : $@convention(thin) @noescape (@in_guaranteed P<Int, String>) -> () to $@noescape @callee_guaranteed (@in_guaranteed P<Int, String>) -> ()
-  // CHECK: [[S_TO_INT_STRING_THUNK_FN:%.*]] = function_ref @$s13parameterized1P_pySiSSXPIgn_AA1SVIegy_TR : $@convention(thin) (S, @noescape @callee_guaranteed (@in_guaranteed P<Int, String>) -> ()) -> ()
-  // CHECK: [[PARTIAL_INT_STRING_THUNK_FN:%.*]] = partial_apply [callee_guaranteed] [[S_TO_INT_STRING_THUNK_FN]]([[THICK_INT_STRING_FN]]) : $@convention(thin) (S, @noescape @callee_guaranteed (@in_guaranteed P<Int, String>) -> ()) -> ()
-  // CHECK: [[NOESCAPE_INT_STRING_THUNK_FN:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_INT_STRING_THUNK_FN]] : $@callee_guaranteed (S) -> () to $@noescape @callee_guaranteed (S) -> ()
-  // CHECK: [[USE_FN:%.*]] = function_ref @$s13parameterized3useyyyAA1SVXEF : $@convention(thin) (@noescape @callee_guaranteed (S) -> ()) -> ()
-  // CHECK: {{%.*}} = apply [[USE_FN]]([[NOESCAPE_INT_STRING_THUNK_FN]]) : $@convention(thin) (@noescape @callee_guaranteed (S) -> ()) -> ()
-
-  use({ (p: any P<Int, String>) -> Void in })
-
-  // CHECK: [[INT_FN:%.*]] = function_ref @$s13parameterized11upcastInputyyFyAA1P_pySiXPXEfU0_ : $@convention(thin) (@in_guaranteed P<Int>) -> ()
-  // CHECK: [[NOESCAPE_INT_FN:%.*]] = convert_function [[INT_FN]] : $@convention(thin) (@in_guaranteed P<Int>) -> () to $@convention(thin) @noescape (@in_guaranteed P<Int>) -> ()
-  // CHECK: [[THICK_INT_FN:%.*]] = thin_to_thick_function [[NOESCAPE_INT_FN]] : $@convention(thin) @noescape (@in_guaranteed P<Int>) -> () to $@noescape @callee_guaranteed (@in_guaranteed P<Int>) -> ()
-  // CHECK: [[S_TO_INT_THUNK_FN:%.*]] = function_ref @$s13parameterized1P_pySiXPIgn_AA1SVIegy_TR : $@convention(thin) (S, @noescape @callee_guaranteed (@in_guaranteed P<Int>) -> ()) -> ()
-  // CHECK: [[PARTIAL_INT_THUNK_FN:%.*]] = partial_apply [callee_guaranteed] [[S_TO_INT_THUNK_FN]]([[THICK_INT_FN]]) : $@convention(thin) (S, @noescape @callee_guaranteed (@in_guaranteed P<Int>) -> ()) -> ()
-  // CHECK: [[NOESCAPE_INT_THUNK_FN:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PARTIAL_INT_THUNK_FN]] : $@callee_guaranteed (S) -> () to $@noescape @callee_guaranteed (S) -> ()
-  // CHECK: [[USE_FN:%.*]] = function_ref @$s13parameterized3useyyyAA1SVXEF : $@convention(thin) (@noescape @callee_guaranteed (S) -> ()) -> ()
-  // CHECK: {{%.*}} = apply [[USE_FN]]([[NOESCAPE_INT_THUNK_FN]]) : $@convention(thin) (@noescape @callee_guaranteed (S) -> ()) -> ()
-
-  use({ (p: any P<Int>) -> Void in })
-
-  // CHECK: [[P_FN:%.*]] = function_ref @$s13parameterized11upcastInputyyFyAA1P_pXEfU1_ : $@convention(thin) (@in_guaranteed P) -> ()
+  // CHECK: [[P_FN:%.*]] = function_ref @$s13parameterized11upcastInputyyFyAA1P_pXEfU_ : $@convention(thin) (@in_guaranteed P) -> ()
   // CHECK: [[NOESCAPE_P_FN:%.*]] = convert_function [[P_FN]] : $@convention(thin) (@in_guaranteed P) -> () to $@convention(thin) @noescape (@in_guaranteed P) -> ()
   // CHECK: [[THICK_P_FN:%.*]] = thin_to_thick_function [[NOESCAPE_P_FN]] : $@convention(thin) @noescape (@in_guaranteed P) -> () to $@noescape @callee_guaranteed (@in_guaranteed P) -> ()
   // CHECK: [[S_TO_P_THUNK_FN:%.*]] = function_ref @$s13parameterized1P_pIgn_AA1SVIegy_TR : $@convention(thin) (S, @noescape @callee_guaranteed (@in_guaranteed P) -> ()) -> ()

--- a/test/SILOptimizer/cast_folding_parameterized_protocol.swift
+++ b/test/SILOptimizer/cast_folding_parameterized_protocol.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-sil -enable-parameterized-protocol-types -O -o - | %FileCheck %s
 
-public protocol P<T> {}
+public protocol P<T> {
+  associatedtype T
+}
 public protocol Q: P where T == Int {}
 public struct X: Q {
   public typealias T = Int

--- a/test/type/parameterized_protocol.swift
+++ b/test/type/parameterized_protocol.swift
@@ -132,8 +132,10 @@ protocol Collection<Element, Index> : Sequence {
 }
 
 func testCollectionBad1<T : Collection<String>>(_: T) {}
+// expected-error@-1 {{protocol type 'Collection' specialized with too few type arguments (got 1, but expected 2)}}
+
 func testCollectionBad2<T : Collection<String, Int, Float>>(_: T) {}
-// expected-error@-1 {{protocol type 'Collection' can specialized with too many type parameters (got 3, but expected at most 2)}}
+// expected-error@-1 {{protocol type 'Collection' specialized with too many type arguments (got 3, but expected 2)}}
 
 // CHECK-LABEL: .testCollectionGood@
 // CHECK-NEXT: Generic signature: <T where T : Collection, T.[Sequence]Element == String, T.[Collection]Index == Int>
@@ -181,10 +183,10 @@ extension Sequence<Int> {
 /// Cannot use parameterized protocol as the type of a value
 
 func takesSequenceOfInt1(_: Sequence<Int>) {}
-// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with type arguments can only be used as a generic constraint}}
 
 func returnsSequenceOfInt1() -> Sequence<Int> {}
-// expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
+// expected-error@-1 {{protocol type with type arguments can only be used as a generic constraint}}
 
 func takesSequenceOfInt2(_: any Sequence<Int>) {}
 
@@ -192,7 +194,7 @@ func returnsSequenceOfInt2() -> any Sequence<Int> {}
 
 func typeExpr() {
   _ = Sequence<Int>.self
-  // expected-error@-1 {{protocol type with generic arguments can only be used as a generic constraint}}
+  // expected-error@-1 {{protocol type with type arguments can only be used as a generic constraint}}
 }
 
 /// Not supported as a protocol composition term for now

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -116,7 +116,9 @@ ProtocolType *SemaTest::createProtocol(llvm::StringRef protocolName,
                                        Type parent) {
   auto *PD = new (Context)
       ProtocolDecl(DC, SourceLoc(), SourceLoc(),
-                   Context.getIdentifier(protocolName), /*Inherited=*/{},
+                   Context.getIdentifier(protocolName),
+                   /*PrimaryAssociatedTypeNames=*/{},
+                   /*Inherited=*/{},
                    /*trailingWhere=*/nullptr);
   PD->setImplicit();
 

--- a/validation-test/compiler_crashers_2_fixed/unsupported_recursive_opaque_conformance.swift
+++ b/validation-test/compiler_crashers_2_fixed/unsupported_recursive_opaque_conformance.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend -disable-availability-checking -emit-ir -enable-parameterized-protocol-types %s
 
-protocol P<X: P, Y: P> {
+protocol P<X, Y> {
+  associatedtype X : P
+  associatedtype Y : P
+
   var x: X { get }
   var y: Y { get }
 }
@@ -8,6 +11,7 @@ protocol P<X: P, Y: P> {
 extension Int: P {
   typealias X = Int
   typealias Y = Int
+
   var x: X { 0 }
   var y: X { 0 }
 }


### PR DESCRIPTION
https://forums.swift.org/t/se-0346-second-review-lightweight-same-type-requirements-for-primary-associated-types/56414

In short:
- The primary associated type list now references existing associated types, instead of declaring new ones. The existing type can be defined in the protocol itself, or some protocol it inherits
- Specifying fewer type arguments than the number of primary associated types is no longer allowed; you must either omit all type arguments, or specify exactly the right number