### PR TITLE
[TypeChecker] SE-0326: Check whether function declaration is a result…

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1005,6 +1005,12 @@ bool ConstraintSystem::isInResultBuilderContext(ClosureExpr *closure) const {
   if (!closure->hasSingleExpressionBody()) {
     auto *DC = closure->getParent();
     do {
+      // Result builder is applied to a function/getter body.
+      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
+        if (resultBuilderTransformed.count(AFD))
+          return true;
+      }
+
       if (auto *parentClosure = dyn_cast<ClosureExpr>(DC)) {
         if (resultBuilderTransformed.count(parentClosure))
           return true;

--- a/validation-test/Sema/SwiftUI/rdar91150414.swift
+++ b/validation-test/Sema/SwiftUI/rdar91150414.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+import Foundation
+
+protocol P {
+  var info: Info? { get }
+}
+
+protocol Q : P {
+  func makeView() -> AnyView
+}
+
+struct Info {
+  var kind: Kind
+
+  var size: CGSize { fatalError() }
+}
+
+enum Kind {
+  case supported([Int])
+  case unsupported
+}
+
+struct Settings {
+  var setting = Setting.defaultValue
+}
+
+struct Setting {
+  static let defaultValue = Setting()
+
+  func scale(_: CGFloat) -> Setting {
+     fatalError()
+  }
+
+  func scale(_: CGSize) -> CGSize {
+     fatalError()
+  }
+}
+
+struct Test: View {
+  var res: P
+  var enable: Bool
+  var settings: Settings
+
+  var body: some View {
+    if let result = res as? Q {
+      let view = result.makeView()
+
+      if let info = result.info {
+        let show: Bool = {
+          guard enable else { return false }
+
+          switch info.kind {
+          case .supported: return true
+          case .unsupported: return false
+          }
+        }()
+
+        if show {
+          let size = settings.setting.scale(info.size)
+          view.frame(width: size.width, height: size.height)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
… builder context

This is a follow-up to https://github.com/apple/swift/pull/40708 which only considers
closures, but it missed the case when builder is applied to function body - in such
cases the declaration context is going to be a function/getter declaration.

Resolves: rdar://91150414

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
