### PR TITLE
[CodeCompletion] Allow references to top-level functions with error parameters

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1346,7 +1346,11 @@ namespace {
 
       // If declaration is invalid, let's turn it into a potential hole
       // and keep generating constraints.
-      if (!knownType && E->getDecl()->isInvalid()) {
+      // For code completion, we still resolve the overload and replace error
+      // types inside the function decl with placeholders
+      // (in getTypeOfReference) so we can match non-error param types.
+      if (!knownType && E->getDecl()->isInvalid() &&
+          !CS.isForCodeCompletion()) {
         auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
         (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
         CS.setType(E, hole);

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1383,8 +1383,19 @@ func testVarInitializedByCallingClosure() {
       Bundle_main.vrl(forResource: "turnips", #^VAR_INITIALIZED_BY_CALLING_CLOSURE^#withExtension: "js")
     }()
   }
+}
 
 // VAR_INITIALIZED_BY_CALLING_CLOSURE: Begin completions, 1 items
 // VAR_INITIALIZED_BY_CALLING_CLOSURE-DAG: Pattern/Local/Flair[ArgLabels]:     {#withExtension: String?#}[#String?#];
 // VAR_INITIALIZED_BY_CALLING_CLOSURE: End completions
+
+func testTopLevelFuncWithErrorParam() {
+  enum A { case a }
+  func foo(x: A, b: Undefined) {}
+
+  foo(x: .#^TOP_LEVEL_FUNC_WITH_ERROR_PARAM^#)
+// TOP_LEVEL_FUNC_WITH_ERROR_PARAM: Begin completions, 2 items
+// TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#A#]; name=a
+// TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]; name=hash(:)
+// TOP_LEVEL_FUNC_WITH_ERROR_PARAM: End completions
 }


### PR DESCRIPTION
During normal type-checking we ignore functions that contain an error. During code completion, we want to consider them and replace all error types by placeholders so we can match up the known types.

We already do this for member types (see `getTypeOfMemberReference`). We should also do it for top-level functions.

Fixes rdar://81425383 [SR-14992]