### PR TITLE
stdlib: Remove some redundant generic requirements

### DIFF
--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -119,8 +119,7 @@ where Indices == Range<Int> {
   var identity: UnsafeRawPointer { get }
 }
 
-extension _ArrayBufferProtocol where Indices == Range<Int>{
-
+extension _ArrayBufferProtocol {
   @inlinable
   internal var subscriptBaseAddress: UnsafeMutablePointer<Element> {
     return firstElementAddress

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -191,4 +191,4 @@ extension Result: Equatable where Success: Equatable, Failure: Equatable { }
 
 extension Result: Hashable where Success: Hashable, Failure: Hashable { }
 
-extension Result: Sendable where Success: Sendable, Failure: Sendable { }
+extension Result: Sendable where Success: Sendable { }


### PR DESCRIPTION
The GSB didn't emit warnings for these for some reason. There's no harm in leaving them in, but you'll get warnings now.

Proof that they're really redundant:
- _ArrayBufferProtocol declares `where Indices == Range<Int>` already so there's no point restating it in the extension.
- Result requires that Failure conform to Error which inherits from Sendable, so again it's redundant to restate in the extension.