### PR TITLE
Add frontend flag `-disable-implicit-string-processing-module-import`.

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -28,9 +28,16 @@ let package = Package(
     .target(
       name: "_RegexParser",
       dependencies: [],
-      swiftSettings: [SwiftSetting.unsafeFlags([
+      swiftSettings: [
+        .unsafeFlags([
           "-I", "../include/swift",
-          "-cross-module-optimization"
+          "-cross-module-optimization",
+        ]),
+        // Workaround until `_RegexParser` is imported as implementation-only
+        // by `_StringProcessing`.
+        .unsafeFlags([
+          "-Xfrontend",
+          "-disable-implicit-string-processing-module-import"
         ])]),
     .target(
       name: "Optimizer",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -363,6 +363,9 @@ namespace swift {
     bool DisableImplicitConcurrencyModuleImport =
         !SWIFT_IMPLICIT_CONCURRENCY_IMPORT;
 
+    /// Disable the implicit import of the _StringProcessing module.
+    bool DisableImplicitStringProcessingModuleImport = false;
+
     /// Should we check the target OSs of serialized modules to see that they're
     /// new enough?
     bool EnableTargetOSChecking = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -422,6 +422,10 @@ def disable_implicit_distributed_module_import : Flag<["-"],
   "disable-implicit-distributed-module-import">,
   HelpText<"Disable the implicit import of the Distributed module.">;
 
+def disable_implicit_string_processing_module_import : Flag<["-"],
+  "disable-implicit-string-processing-module-import">,
+  HelpText<"Disable the implicit import of the _StringProcessing module.">;
+
 def disable_arc_opts : Flag<["-"], "disable-arc-opts">,
   HelpText<"Don't run SIL ARC optimization passes.">;
 def disable_ossa_opts : Flag<["-"], "disable-ossa-opts">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -485,6 +485,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 
+  Opts.DisableImplicitStringProcessingModuleImport |=
+    Args.hasArg(OPT_disable_implicit_string_processing_module_import);
+
   if (Args.hasArg(OPT_enable_experimental_async_top_level))
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
                    "-enable-experimental-async-top-level");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -793,7 +793,8 @@ bool CompilerInvocation::shouldImportSwiftConcurrency() const {
 }
 
 bool CompilerInvocation::shouldImportSwiftStringProcessing() const {
-  return getLangOptions().EnableExperimentalStringProcessing;
+  return getLangOptions().EnableExperimentalStringProcessing &&
+      !getLangOptions().DisableImplicitStringProcessingModuleImport;
 }
 
 /// Implicitly import the SwiftOnoneSupport module in non-optimized

--- a/stdlib/public/RegexParser/CMakeLists.txt
+++ b/stdlib/public/RegexParser/CMakeLists.txt
@@ -38,6 +38,9 @@ add_swift_target_library(swift_RegexParser ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     -Dswift_RegexParser_EXPORTS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    # Workaround until `_RegexParser` is imported as implementation-only
+    # by `_StringProcessing`.
+    -Xfrontend -disable-implicit-string-processing-module-import
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   INSTALL_IN_COMPONENT stdlib

--- a/test/StringProcessing/Sema/string_processing_import.swift
+++ b/test/StringProcessing/Sema/string_processing_import.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-implicit-string-processing-module-import
+// REQUIRES: swift_in_compiler
+
+// expected-error @+1 {{missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly}}
+let r0 = #/./#
+// expected-error @+1 {{cannot find type 'Regex' in scope}}
+let _: Regex<Substring> = r0

--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -69,6 +69,7 @@ struct TestOptions {
   bool rawOutput = false;
   bool structureOutput = false;
   bool disableImplicitConcurrencyModuleImport = false;
+  bool disableImplicitStringProcessingModuleImport = false;
   ArrayRef<const char *> compilerArgs;
 };
 } // end anonymous namespace
@@ -257,6 +258,8 @@ static bool parseOptions(ArrayRef<const char *> args, TestOptions &options,
       options.moduleCachePath = value.str();
     } else if (opt == "disable-implicit-concurrency-module-import") {
       options.disableImplicitConcurrencyModuleImport = true;
+    } else if (opt == "disable-implicit-string-processing-module-import") {
+      options.disableImplicitStringProcessingModuleImport = true;
     }
   }
 
@@ -692,6 +695,12 @@ static bool codeCompleteRequest(sourcekitd_uid_t requestUID, const char *name,
           "-Xfrontend");
       sourcekitd_request_array_set_string(args, SOURCEKITD_ARRAY_APPEND,
           "-disable-implicit-concurrency-module-import");
+    }
+    if (options.disableImplicitStringProcessingModuleImport) {
+      sourcekitd_request_array_set_string(args, SOURCEKITD_ARRAY_APPEND,
+          "-Xfrontend");
+      sourcekitd_request_array_set_string(args, SOURCEKITD_ARRAY_APPEND,
+          "-disable-implicit-string-processing-module-import");
     }
   }
   sourcekitd_request_dictionary_set_value(request, KeyCompilerArgs, args);

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -109,6 +109,10 @@ def disable_implicit_concurrency_module_import : Flag<["-"],
     "disable-implicit-concurrency-module-import">,
   HelpText<"Disable implicit import of the _Concurrency module">;
 
+def disable_implicit_string_processing_module_import : Flag<["-"],
+    "disable-implicit-string-processing-module-import">,
+  HelpText<"Disable implicit import of the _StringProcessing module">;
+
 def end_pos : Separate<["-"], "end-pos">, HelpText<"line:col">;
 def end_pos_EQ : Joined<["-"], "end-pos=">, Alias<end_pos>;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -444,6 +444,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       DisableImplicitConcurrencyModuleImport = true;
       break;
 
+    case OPT_disable_implicit_string_processing_module_import:
+      DisableImplicitStringProcessingModuleImport = true;
+      break;
+
     case OPT_UNKNOWN:
       llvm::errs() << "error: unknown argument: "
                    << InputArg->getAsString(ParsedArgs) << '\n'

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -126,6 +126,7 @@ struct TestOptions {
   bool timeRequest = false;
   bool measureInstructions = false;
   bool DisableImplicitConcurrencyModuleImport = false;
+  bool DisableImplicitStringProcessingModuleImport = false;
   llvm::Optional<unsigned> CompletionCheckDependencyInterval;
   unsigned repeatRequest = 1;
   struct VFSFile {

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1145,6 +1145,13 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
       sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND,
           "-disable-implicit-concurrency-module-import");
     }
+    if (Opts.DisableImplicitStringProcessingModuleImport &&
+        !compilerArgsAreClang) {
+      sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND,
+                                          "-Xfrontend");
+      sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND,
+          "-disable-implicit-string-processing-module-import");
+    }
 
     for (auto Arg : Opts.CompilerArgs)
       sourcekitd_request_array_set_string(Args, SOURCEKITD_ARRAY_APPEND, Arg);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -795,6 +795,11 @@ DisableImplicitConcurrencyImport("disable-implicit-concurrency-module-import",
                                  llvm::cl::desc("Disable implicit import of _Concurrency module"),
                                  llvm::cl::init(false));
 
+static llvm::cl::opt<bool>
+DisableImplicitStringProcessingImport("disable-implicit-string-processing-module-import",
+                                      llvm::cl::desc("Disable implicit import of _StringProcessing module"),
+                                      llvm::cl::init(false));
+
 static llvm::cl::opt<bool> EnableExperimentalNamedOpaqueTypes(
     "enable-experimental-named-opaque-types",
     llvm::cl::desc("Enable experimental support for named opaque result types"),
@@ -4275,6 +4280,9 @@ int main(int argc, char *argv[]) {
   }
   if (options::DisableImplicitConcurrencyImport) {
     InitInvok.getLangOptions().DisableImplicitConcurrencyModuleImport = true;
+  }
+  if (options::DisableImplicitStringProcessingImport) {
+    InitInvok.getLangOptions().DisableImplicitStringProcessingModuleImport = true;
   }
   if (options::EnableExperimentalNamedOpaqueTypes) {
     InitInvok.getLangOptions().EnableExperimentalNamedOpaqueTypes = true;


### PR DESCRIPTION
We add a new flag to disable the implicit import of `_StringProcessing`, similar to `-disable-implicit-concurrency-module-import`. We need this to build `_RegexParser` when `-enable-experimental-string-processing` is enabled by default, because `_StringProcessing` currently imports `_RegexParser` publicly (non-implementation-only).