### PR TITLE
[Test] Mark two unsupported for backdeploy.

### DIFF
--- a/validation-test/Runtime/enum-multipayload-emptycase-storetag.swift
+++ b/validation-test/Runtime/enum-multipayload-emptycase-storetag.swift
@@ -31,6 +31,8 @@
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import Resilient
 

--- a/validation-test/Runtime/rdar87914343.swift
+++ b/validation-test/Runtime/rdar87914343.swift
@@ -31,6 +31,8 @@
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import Resilient
 


### PR DESCRIPTION
They depend on new runtime changes.
