### PR TITLE
[5.6][SourceKit] Disable cancellation of in-flight non-completion requests

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -1050,7 +1050,6 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
     Error = "compilation setup failed";
     return nullptr;
   }
-  CompIns.getASTContext().CancellationFlag = CancellationFlag;
   if (CompIns.loadStdlibIfNeeded()) {
     LOG_WARN_FUNC("Loading the stdlib failed");
     Error = "Loading the stdlib failed";

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -417,7 +417,8 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueTokenRace) {
   EXPECT_EQ(strlen("fog"), Info.Length);
 }
 
-TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
+// Disabled until we re-enable cancellation (rdar://91251055)
+TEST_F(CursorInfoTest, DISABLED_CursorInfoCancelsPreviousRequest) {
   // TODO: This test case relies on the following snippet being slow to type 
   // check so that the first cursor info request takes longer to execute than it 
   // takes time to schedule the second request. If that is fixed, we need to 
@@ -467,7 +468,8 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
     llvm::report_fatal_error("Did not receive a resonse for the first request");
 }
 
-TEST_F(CursorInfoTest, CursorInfoCancellation) {
+// Disabled until we re-enable cancellation (rdar://91251055)
+TEST_F(CursorInfoTest, DISABLED_CursorInfoCancellation) {
   // TODO: This test case relies on the following snippet being slow to type
   // check so that the first cursor info request takes longer to execute than it
   // takes time to schedule the second request. If that is fixed, we need to


### PR DESCRIPTION
Cherry-picks 7cd49372904b8a89e829de75ad195d104cd0f204

-----

We need to run SILGen for diagnostics (to actually get all diagnostics).
All non-completion requests share an AST and thus they too run SILGen.
Any lazy typechecking run in SILGen assumes that it succeeds.

Cancellation can cause typechecking to fail here though, since we simply
check the flag and error if it's set. This unfortunately has the ability
to cause any any number of crashes since various invariants in SILGen
are then broken.

Disable cancellation of in-flight non-completion requests for now until
we have a proper fix in place.

Resolves rdar://91251017.