### PR TITLE
[IRGen] Use condbrs for big int switches.

### DIFF
--- a/test/IRGen/enum_large.swift
+++ b/test/IRGen/enum_large.swift
@@ -1,0 +1,61 @@
+// RUN: %swift-target-frontend -emit-irgen %s | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+public struct SpareBits {
+    var o: UInt64 = 0
+    var x: UInt8 = 0
+    var y: UInt64 = 0
+    var x_2: UInt8 = 0
+    var y_2: UInt64 = 0
+    var x_3: UInt8 = 0
+    var y_3: UInt64 = 0
+    var x_4: UInt8 = 0
+    var y_4: UInt64 = 0
+    var x_5: UInt8 = 0
+    var y_5: UInt64 = 0
+    var x_6: UInt8 = 0
+    var y_6: UInt64 = 0
+}
+
+public class MyClass {}
+
+public enum Multipayload {
+    case a
+    case b(MyClass)
+    case c(SpareBits)
+    case e
+    case f
+    case g
+}
+
+@inline(never)
+func dump<T>(_ t : T) {}
+func dumpInt(_ i: Int) {}
+
+// CHECK-LABEL: define{{.*}} @"$s10enum_large6testIt1eyAA12MultipayloadO_tF"{{.*}}{
+// CHECK:         switch i8 {{%[^,]+}}, label {{%[^,]+}} [
+// CHECK:           i8 0, label {{%[^,]+}}
+// CHECK:           i8 1, label {{%[^,]+}}
+// CHECK:           i8 2, label %[[REGISTER_41:[^,]+]]
+// CHECK:       [[REGISTER_41]]:
+// CHECK:         br i1 {{%[^,]+}}, label {{%[^,]+}}, label %[[REGISTER_67:[^,]+]]
+// CHECK:       [[REGISTER_67]]:
+// CHECK:         br i1 {{%[^,]+}}, label {{%[^,]+}}, label %[[REGISTER_93:[^,]+]]
+// CHECK:       [[REGISTER_93]]:
+// CHECK:         br i1 {{%[^,]+}}, label {{%[^,]+}}, label %[[REGISTER_119:[^,]+]]
+// CHECK:       [[REGISTER_119]]:
+// CHECK:         br i1 {{%[^,]+}}, label %[[REGISTER_149:[^,]+]], label {{%[^,]+}}
+// CHECK:       [[REGISTER_149]]
+// CHECK:         call swiftcc void @"$s10enum_large7dumpIntyySiF"(i64 8675309)
+public func testIt(e : Multipayload) {
+    switch e {
+        case .a, .e, .f, .g:
+          dumpInt(8675309)
+        case .b(let c):
+          dump(c)
+        case .c(let s):
+          dump(s)
+    }
+}
+

--- a/validation-test/IRGen/rdar83158525.swift
+++ b/validation-test/IRGen/rdar83158525.swift
@@ -1,0 +1,63 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+public struct SpareBits {
+    var o: UInt64 = 0
+    var x: UInt8 = 0
+    var y: UInt64 = 0
+    var x_2: UInt8 = 0
+    var y_2: UInt64 = 0
+    var x_3: UInt8 = 0
+    var y_3: UInt64 = 0
+    var x_4: UInt8 = 0
+    var y_4: UInt64 = 0
+    var x_5: UInt8 = 0
+    var y_5: UInt64 = 0
+    var x_6: UInt8 = 0
+    var y_6: UInt64 = 0
+}
+
+public class MyClass {}
+
+public enum Multipayload {
+    case a
+    case b(MyClass)
+    case c(SpareBits)
+    case e
+    case f
+    case g
+}
+
+public func testIt(_ e : Multipayload) {
+    switch e {
+        case .a:
+          print(".a (no payload)")
+        case .e:
+          print(".e (no payload)")
+        case .f:
+          print(".f (no payload)")
+        case .g:
+          print(".g (no payload)")
+        case .b(let s):
+          print(".b(\(s))")
+        case .c(let x):
+          print(".c(\(x))")
+    }
+}
+
+func doit() {
+  testIt(Multipayload.a)
+  testIt(Multipayload.e)
+  testIt(Multipayload.f)
+  testIt(Multipayload.g)
+  testIt(Multipayload.b(MyClass()))
+  testIt(Multipayload.c(SpareBits()))
+}
+doit()
+
+// CHECK: .a (no payload)
+// CHECK: .e (no payload)
+// CHECK: .f (no payload)
+// CHECK: .g (no payload)
+// CHECK: .b(main.MyClass)
+// CHECK: .c(SpareBits(o: 0, x: 0, y: 0, x_2: 0, y_2: 0, x_3: 0, y_3: 0, x_4: 0, y_4: 0, x_5: 0, y_5: 0, x_6: 0, y_6: 0))


### PR DESCRIPTION
Previously, switches over extremely large integers (e.g. i832) were emitted when emitting switches with many spare bits.  Such switches result in unfortunate downstream codegen.

Here, for large enums (currently, more than two words) the preexisting EnumPayload::emitCompare function is used to compare each of the enum cases in turn with the payload's value.  The result is a series of cond_br where the conditional is made by anding together word-size chunks of the payload value with word-size chunks of each enum case's tag, subject to masking.

rdar://83158525
