### PR TITLE
Sema: Diagnose missing entries in protocol inheritance clause when requirement machine is enabled

### DIFF
--- a/test/Generics/rdar51908331.swift
+++ b/test/Generics/rdar51908331.swift
@@ -32,6 +32,10 @@ protocol PH {
 }
 
 protocol PI {
+// expected-warning@-1 {{protocol 'PI' should be declared to refine 'Decodable' due to a same-type constraint on 'Self'}}
+// expected-warning@-2 {{protocol 'PI' should be declared to refine 'Encodable' due to a same-type constraint on 'Self'}}
+// expected-warning@-3 {{protocol 'PI' should be declared to refine 'Hashable' due to a same-type constraint on 'Self'}}
+// expected-warning@-4 {{protocol 'PI' should be declared to refine 'SIMDScalar' due to a same-type constraint on 'Self'}}
   associatedtype A8 where A8.A7 == Self // expected-warning {{redundant same-type constraint 'Self.A8.A7' == 'Self'}}
   associatedtype A9 where A9.A7 == Self, A9.A8 == A8
   associatedtype A10 where A10.A7 == Self, A10.A8 == A8, A10.A9 == A9 // expected-warning {{redundant same-type constraint 'Self.A10.A7' == 'Self'}}

--- a/test/Generics/redundant_protocol_refinement.swift
+++ b/test/Generics/redundant_protocol_refinement.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-protocol-signatures=verify %s 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures -requirement-machine-protocol-signatures=on %s 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: redundant_protocol_refinement.(file).Base@
 // CHECK-LABEL: Requirement signature: <Self>
@@ -12,8 +12,7 @@ protocol Middle : Base {}
 // CHECK-LABEL: redundant_protocol_refinement.(file).Derived@
 // CHECK-LABEL: Requirement signature: <Self where Self : Middle>
 protocol Derived : Middle, Base {}
-// expected-note@-1 {{conformance constraint 'Self' : 'Base' implied here}}
-// expected-warning@-2 {{redundant conformance constraint 'Self' : 'Base'}}
+// expected-warning@-1 {{redundant conformance constraint 'Self' : 'Base'}}
 
 // CHECK-LABEL: redundant_protocol_refinement.(file).Derived2@
 // CHECK-LABEL: Requirement signature: <Self where Self : Middle>
@@ -22,8 +21,7 @@ protocol Derived2 : Middle {}
 // CHECK-LABEL: redundant_protocol_refinement.(file).MoreDerived@
 // CHECK-LABEL: Requirement signature: <Self where Self : Derived2>
 protocol MoreDerived : Derived2, Base {}
-// expected-note@-1 {{conformance constraint 'Self' : 'Base' implied here}}
-// expected-warning@-2 {{redundant conformance constraint 'Self' : 'Base'}}
+// expected-warning@-1 {{redundant conformance constraint 'Self' : 'Base'}}
 
 protocol P1 {}
 
@@ -40,7 +38,6 @@ protocol Good: P2, P1 where Assoc == Self {}
 // missing refinement of 'P1'
 protocol Bad: P2 where Assoc == Self {}
 // expected-warning@-1 {{protocol 'Bad' should be declared to refine 'P1' due to a same-type constraint on 'Self'}}
-// expected-note@-2 {{conformance constraint 'Self' : 'P1' implied here}}
 
 // CHECK-LABEL: redundant_protocol_refinement.(file).Bad@
 // CHECK-LABEL: Requirement signature: <Self where Self : P2, Self == Self.[P2]Assoc>


### PR DESCRIPTION
This diagnostic used to be emitted by the GenericSignatureBuilder when
building a requirement signature, but we can just do the check in
Sema using generic signature queries instead.

Fixes rdar://problem/90192939.