### PR TITLE
Some small optimizer tweaks

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
@@ -82,7 +82,7 @@ private func tryDevirtualizeReleaseOfObject(
 
   let type = allocRefInstruction.type
 
-  guard let dealloc = context.getDestructor(ofClass: type) else {
+  guard let dealloc = context.calleeAnalysis.getDestructor(ofExactType: type) else {
     return
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
@@ -112,10 +112,6 @@ struct PassContext {
     PassContext_fixStackNesting(_bridged, function.bridged)
   }
 
-  func getDestructor(ofClass type: Type) -> Function? {
-    PassContext_getDestructor(_bridged, type.bridged).function
-  }
-
   func getContextSubstitutionMap(for type: Type) -> SubstitutionMap {
     SubstitutionMap(PassContext_getContextSubstitutionMap(_bridged, type.bridged))
   }

--- a/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h
@@ -147,7 +147,7 @@ public:
 
   /// Return the list of callees that can potentially be called at the
   /// given instruction. E.g. it could be destructors.
-  CalleeList getCalleeList(SILInstruction *I) const;
+  CalleeList getDestructors(SILType type, bool isExactType) const;
 
   CalleeList getCalleeList(SILDeclRef Decl) const;
 
@@ -224,9 +224,9 @@ public:
     return Cache->getCalleeListOfValue(callee);
   }
 
-  CalleeList getCalleeList(SILInstruction *I) {
+  CalleeList getDestructors(SILType type, bool isExactType) {
     updateCache();
-    return Cache->getCalleeList(I);
+    return Cache->getDestructors(type, isExactType);
   }
 };
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -96,8 +96,9 @@ BridgedCalleeAnalysis PassContext_getCalleeAnalysis(BridgedPassContext context);
 
 BridgedCalleeList CalleeAnalysis_getCallees(BridgedCalleeAnalysis calleeAnalysis,
                                             BridgedValue callee);
-BridgedCalleeList CalleeAnalysis_getInstCallees(BridgedCalleeAnalysis calleeAnalysis,
-                                                BridgedInstruction inst);
+BridgedCalleeList CalleeAnalysis_getDestructors(BridgedCalleeAnalysis calleeAnalysis,
+                                                BridgedType type,
+                                                SwiftInt isExactType);
 SwiftInt BridgedFunctionArray_size(BridgedCalleeList callees);
 BridgedFunction BridgedFunctionArray_get(BridgedCalleeList callees,
                                          SwiftInt index);
@@ -139,9 +140,6 @@ void BasicBlockSet_erase(BridgedBasicBlockSet set, BridgedBasicBlock block);
 BridgedFunction BasicBlockSet_getFunction(BridgedBasicBlockSet set);
 
 void AllocRefInstBase_setIsStackAllocatable(BridgedInstruction arb);
-
-OptionalBridgedFunction PassContext_getDestructor(BridgedPassContext context,
-                                                  BridgedType type);
 
 BridgedSubstitutionMap
 PassContext_getContextSubstitutionMap(BridgedPassContext context,

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -40,7 +40,8 @@ void BottomUpFunctionOrder::DFS(SILFunction *Start) {
   for (auto &B : *Start) {
     for (auto &I : B) {
       auto FAS = FullApplySite::isa(&I);
-      if (!FAS && !isa<StrongReleaseInst>(&I) && !isa<ReleaseValueInst>(&I))
+      if (!FAS && !isa<StrongReleaseInst>(&I) && !isa<ReleaseValueInst>(&I) &&
+                  !isa<DestroyValueInst>(&I))
         continue;
 
       auto Callees = FAS ? BCA->getCalleeList(FAS)

--- a/lib/SILOptimizer/Analysis/FunctionOrder.cpp
+++ b/lib/SILOptimizer/Analysis/FunctionOrder.cpp
@@ -43,7 +43,9 @@ void BottomUpFunctionOrder::DFS(SILFunction *Start) {
       if (!FAS && !isa<StrongReleaseInst>(&I) && !isa<ReleaseValueInst>(&I))
         continue;
 
-      auto Callees = FAS ? BCA->getCalleeList(FAS) : BCA->getCalleeList(&I);
+      auto Callees = FAS ? BCA->getCalleeList(FAS)
+                         : BCA->getDestructors(I.getOperand(0)->getType(),
+                                               /*isExactType*/ false);
       for (auto *CalleeFn : Callees) {
         // If not yet visited, visit the callee.
         if (DFSNum.find(CalleeFn) == DFSNum.end()) {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1391,19 +1391,6 @@ void AllocRefInstBase_setIsStackAllocatable(BridgedInstruction arb) {
   castToInst<AllocRefInstBase>(arb)->setStackAllocatable();
 }
 
-OptionalBridgedFunction PassContext_getDestructor(BridgedPassContext context,
-                                                  BridgedType type) {
-  auto *cd = castToSILType(type).getClassOrBoundGenericClass();
-  assert(cd && "no class type allocated with alloc_ref");
-
-  auto *pm = castToPassInvocation(context)->getPassManager();
-  // Find the destructor of the type.
-  auto *destructor = cd->getDestructor();
-  SILDeclRef deallocRef(destructor, SILDeclRef::Kind::Deallocator);
-
-  return {pm->getModule()->lookUpFunction(deallocRef)};
-}
-
 BridgedSubstitutionMap
 PassContext_getContextSubstitutionMap(BridgedPassContext context,
                                       BridgedType bridgedType) {

--- a/test/SILOptimizer/sil_combine_inst_passes.sil
+++ b/test/SILOptimizer/sil_combine_inst_passes.sil
@@ -104,3 +104,26 @@ bb0:
   return %t : $(Builtin.Int1, Builtin.BridgeObject)
 }
 
+sil_global private @outlined_global : $_ContiguousArrayStorage<Int>
+
+// CHECK-LABEL: sil @remove_arc_of_global_value
+// CHECK-NOT:   retain
+// CHECK-NOT:   release
+// CHECK-NOT:   fix_lifetime
+// CHECK-NOT:   debug_value
+// CHECK:     } // end sil function 'remove_arc_of_global_value'
+sil @remove_arc_of_global_value : $@convention(thin) () -> Int {
+bb0:
+  %0 = global_value @outlined_global : $_ContiguousArrayStorage<Int>
+  strong_retain %0 : $_ContiguousArrayStorage<Int>
+  debug_value %0 : $_ContiguousArrayStorage<Int>, let, name "x"
+  %2 = upcast %0 : $_ContiguousArrayStorage<Int> to $__ContiguousArrayStorageBase
+  strong_retain %2 : $__ContiguousArrayStorageBase
+  %13 = ref_tail_addr [immutable] %2 : $__ContiguousArrayStorageBase, $Int
+  %16 = load %13 : $*Int
+  fix_lifetime %0 : $_ContiguousArrayStorage<Int>
+  strong_release %2 : $__ContiguousArrayStorageBase
+  strong_release %0 : $_ContiguousArrayStorage<Int>
+  return %16 : $Int
+}
+


### PR DESCRIPTION
* SimplifyGlobalValue: handle fix_lifetime instruction
* BasicCalleeAnalysis: improve finding the actual called deinits of a destroy/release instruction
* FunctionOrder: consider destructor calls for `destroy_value`

These small improvements are a preparation for the new escape analysis (https://github.com/apple/swift/pull/39438) - and will be mostly tested by that changes.