### PR TITLE
Make overloads and witnesses permit @Sendable variance

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2155,6 +2155,13 @@ ERROR(witness_not_accessible_proto,none,
       "requirement in %select{private|fileprivate|internal|public|%error}4 protocol "
       "%5",
       (RequirementKind, DeclName, bool, AccessLevel, AccessLevel, Identifier))
+ERROR(witness_not_as_sendable,none,
+      "sendability of function types in %0 %1 does not match requirement in "
+      "protocol %2",
+      (DescriptiveDeclKind, DeclName, Identifier))
+NOTE(less_sendable_reqt_here,none,
+     "expected sendability to match requirement here",
+     ())
 ERROR(witness_not_accessible_type,none,
       "%select{initializer %1|method %1|%select{|setter for }2property %1"
       "|subscript%select{| setter}2}0 must be as accessible as its enclosing "
@@ -2303,6 +2310,9 @@ NOTE(ambiguous_witnesses_type,none,
      "multiple matching types named %0", (Identifier))
 NOTE(protocol_witness_exact_match,none,
      "candidate exactly matches%0", (StringRef))
+NOTE(protocol_witness_non_sendable,none,
+     "candidate matches except for closure sendability%0%select{; this will be "
+     "an error in Swift 6|}1", (StringRef, bool))
 NOTE(protocol_witness_renamed,none,
      "rename to %0 to satisfy this requirement%1", (DeclName, StringRef))
 NOTE(protocol_witness_kind_conflict,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2596,6 +2596,9 @@ WARNING(generic_param_usable_from_inline_warn,none,
 ERROR(override_multiple_decls_base,none,
       "declaration %0 cannot override more than one superclass declaration",
       (DeclName))
+ERROR(override_sendability_mismatch,none,
+      "declaration %0 has a type with different sendability from any potential "
+      "overrides", (DeclName))
 ERROR(override_multiple_decls_arg_mismatch,none,
       "declaration %0 has different argument labels from any potential "
       "overrides", (DeclName))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -295,7 +295,9 @@ enum class TypeMatchFlags {
   /// to be non-escaping, but Swift currently does not.
   IgnoreNonEscapingForOptionalFunctionParam = 1 << 4,
   /// Allow compatible opaque archetypes.
-  AllowCompatibleOpaqueTypeArchetypes = 1 << 5
+  AllowCompatibleOpaqueTypeArchetypes = 1 << 5,
+  /// Ignore the @Sendable attributes on functions when matching types.
+  IgnoreFunctionSendability = 1 << 6,
 };
 using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3167,6 +3167,11 @@ static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
           matchMode.contains(TypeMatchFlags::AllowABICompatible))) {
       ext1 = ext1.withThrows(true);
     }
+
+    // Removing '@Sendable' is ABI-compatible because there's nothing wrong with
+    // a function being sendable when it doesn't need to be.
+    if (!ext2.isSendable())
+      ext1 = ext1.withConcurrent(false);
   }
 
   // If specified, allow an escaping function parameter to override a

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3174,6 +3174,11 @@ static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
       ext1 = ext1.withConcurrent(false);
   }
 
+  if (matchMode.contains(TypeMatchFlags::IgnoreFunctionSendability)) {
+    ext1 = ext1.withConcurrent(false);
+    ext2 = ext2.withConcurrent(false);
+  }
+
   // If specified, allow an escaping function parameter to override a
   // non-escaping function parameter when the parameter is optional.
   // Note that this is checking 'ext2' rather than 'ext1' because parameters

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1162,15 +1162,26 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
           return *result;
       }
     }
-    if (!solution || solution->Fixes.size())
-      return RequirementMatch(witness, MatchKind::TypeConflict,
-                              witnessType);
+    bool requiresNonSendable = false;
+    if (!solution || solution->Fixes.size()) {
+      /// If the *only* problems are that `@Sendable` attributes are missing,
+      /// allow the match in some circumstances.
+      requiresNonSendable = solution
+          && llvm::all_of(solution->Fixes, [](constraints::ConstraintFix *fix) {
+            return fix->getKind() == constraints::FixKind::AddSendableAttribute;
+          });
+      if (!requiresNonSendable)
+        return RequirementMatch(witness, MatchKind::TypeConflict,
+                                witnessType);
+    }
 
     MatchKind matchKind = MatchKind::ExactMatch;
     if (hasAnyError(optionalAdjustments))
       matchKind = MatchKind::OptionalityConflict;
     else if (anyRenaming)
       matchKind = MatchKind::RenamedMatch;
+    else if (requiresNonSendable)
+      matchKind = MatchKind::RequiresNonSendable;
     else if (getEffects(witness).containsOnly(getEffects(req)))
       matchKind = MatchKind::FewerEffects;
 
@@ -2528,6 +2539,12 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
   case MatchKind::FewerEffects:
     diags.diagnose(match.Witness, diag::protocol_witness_exact_match,
                    withAssocTypes);
+    break;
+
+  case MatchKind::RequiresNonSendable:
+    diags.diagnose(match.Witness, diag::protocol_witness_non_sendable,
+                   withAssocTypes,
+                   module->getASTContext().isSwiftVersionAtLeast(6));
     break;
 
   case MatchKind::RenamedMatch: {
@@ -4271,6 +4288,19 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                          requirement->getName());
         });
     }
+    if (best.Kind == MatchKind::RequiresNonSendable)
+      diagnoseOrDefer(requirement, getASTContext().isSwiftVersionAtLeast(6),
+                      [this, requirement, witness]
+                          (NormalProtocolConformance *conformance) {
+        auto &diags = DC->getASTContext().Diags;
+
+        diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
+                       diag::witness_not_as_sendable,
+                       witness->getDescriptiveKind(), witness->getName(),
+                       conformance->getProtocol()->getName())
+            .warnUntilSwiftVersion(6);
+        diags.diagnose(requirement, diag::less_sendable_reqt_here);
+      });
 
     auto check = checkWitness(requirement, best);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -155,13 +155,25 @@ getTypesToCompare(ValueDecl *reqt, Type reqtType, bool reqtTypeIsIUO,
     // function types that aren't in a parameter can be Sendable or not.
     // FIXME: Should we check for a Sendable bound on the requirement type?
     bool inRequirement = (adjustment != TypeAdjustment::NoescapeToEscaping);
-    (void)adjustInferredAssociatedType(adjustment, reqtType, inRequirement);
+    Type adjustedReqtType =
+      adjustInferredAssociatedType(adjustment, reqtType, inRequirement);
 
     bool inWitness = false;
     Type adjustedWitnessType =
       adjustInferredAssociatedType(adjustment, witnessType, inWitness);
-    if (inWitness && !inRequirement)
-      witnessType = adjustedWitnessType;
+
+    switch (variance) {
+    case VarianceKind::None:
+      break;
+    case VarianceKind::Covariant:
+      if (inRequirement && !inWitness)
+        reqtType = adjustedReqtType;
+      break;
+    case VarianceKind::Contravariant:
+      if (inWitness && !inRequirement)
+        witnessType = adjustedWitnessType;
+      break;
+    }
   };
 
   applyAdjustment(TypeAdjustment::NoescapeToEscaping);

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -189,6 +189,10 @@ enum class MatchKind : uint8_t {
   /// The witness has fewer effects than the requirement, which is okay.
   FewerEffects,
 
+  /// The witness is @Sendable and the requirement is not. Okay in certain
+  /// language modes.
+  RequiresNonSendable,
+
   /// There is a difference in optionality.
   OptionalityConflict,
 
@@ -474,6 +478,7 @@ struct RequirementMatch {
     switch(Kind) {
     case MatchKind::ExactMatch:
     case MatchKind::FewerEffects:
+    case MatchKind::RequiresNonSendable:
       return true;
 
     case MatchKind::OptionalityConflict:
@@ -510,6 +515,7 @@ struct RequirementMatch {
     switch(Kind) {
     case MatchKind::ExactMatch:
     case MatchKind::FewerEffects:
+    case MatchKind::RequiresNonSendable:
     case MatchKind::OptionalityConflict:
     case MatchKind::RenamedMatch:
       return true;
@@ -545,6 +551,7 @@ struct RequirementMatch {
     switch(Kind) {
     case MatchKind::ExactMatch:
     case MatchKind::FewerEffects:
+    case MatchKind::RequiresNonSendable:
     case MatchKind::RenamedMatch:
     case MatchKind::TypeConflict:
     case MatchKind::MissingRequirement:

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -125,3 +125,17 @@ func testExplicitConcurrentClosure() {
   }
   let _: String = fn // expected-error{{cannot convert value of type '@Sendable () -> Int' to specified type 'String'}}
 }
+
+class SuperSendable {
+  func runsInBackground(_: @Sendable () -> Void) {}
+  func runsInForeground(_: () -> Void) {} // expected-note {{potential overridden instance method 'runsInForeground' here}}
+  func runnableInBackground() -> @Sendable () -> Void { fatalError() } // expected-note {{potential overridden instance method 'runnableInBackground()' here}}
+  func runnableInForeground() -> () -> Void { fatalError() }
+}
+
+class SubSendable: SuperSendable {
+  override func runsInBackground(_: () -> Void) {}
+  override func runsInForeground(_: @Sendable () -> Void) {} // expected-error {{method does not override any method from its superclass}}
+  override func runnableInBackground() -> () -> Void { fatalError() }  // expected-error {{method does not override any method from its superclass}}
+  override func runnableInForeground() -> @Sendable () -> Void { fatalError() }
+}

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -139,3 +139,17 @@ class SubSendable: SuperSendable {
   override func runnableInBackground() -> () -> Void { fatalError() }  // expected-error {{method does not override any method from its superclass}}
   override func runnableInForeground() -> @Sendable () -> Void { fatalError() }
 }
+
+protocol AbstractSendable {
+  func runsInBackground(_: @Sendable () -> Void)
+  func runsInForeground(_: () -> Void) // expected-note {{protocol requires function 'runsInForeground' with type '(() -> Void) -> ()'; do you want to add a stub?}}
+  func runnableInBackground() -> @Sendable () -> Void // expected-note {{protocol requires function 'runnableInBackground()' with type '() -> @Sendable () -> Void'; do you want to add a stub?}}
+  func runnableInForeground() -> () -> Void
+}
+
+struct ConcreteSendable: AbstractSendable { // expected-error {{type 'ConcreteSendable' does not conform to protocol 'AbstractSendable'}}
+  func runsInBackground(_: () -> Void) {}
+  func runsInForeground(_: @Sendable () -> Void) {} // expected-note {{candidate has non-matching type '(@Sendable () -> Void) -> ()'}}
+  func runnableInBackground() -> () -> Void { fatalError() } // expected-note {{candidate has non-matching type '() -> () -> Void'}}
+  func runnableInForeground() -> @Sendable () -> Void { fatalError() }
+}

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -128,15 +128,15 @@ func testExplicitConcurrentClosure() {
 
 class SuperSendable {
   func runsInBackground(_: @Sendable () -> Void) {}
-  func runsInForeground(_: () -> Void) {} // expected-note {{potential overridden instance method 'runsInForeground' here}}
-  func runnableInBackground() -> @Sendable () -> Void { fatalError() } // expected-note {{potential overridden instance method 'runnableInBackground()' here}}
+  func runsInForeground(_: () -> Void) {} // expected-note {{overridden declaration is here}}
+  func runnableInBackground() -> @Sendable () -> Void { fatalError() } // expected-note {{overridden declaration is here}}
   func runnableInForeground() -> () -> Void { fatalError() }
 }
 
 class SubSendable: SuperSendable {
   override func runsInBackground(_: () -> Void) {}
-  override func runsInForeground(_: @Sendable () -> Void) {} // expected-error {{method does not override any method from its superclass}}
-  override func runnableInBackground() -> () -> Void { fatalError() }  // expected-error {{method does not override any method from its superclass}}
+  override func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{declaration 'runsInForeground' has a type with different sendability from any potential overrides; this is an error in Swift 6}}
+  override func runnableInBackground() -> () -> Void { fatalError() }  // expected-warning {{declaration 'runnableInBackground()' has a type with different sendability from any potential overrides; this is an error in Swift 6}}
   override func runnableInForeground() -> @Sendable () -> Void { fatalError() }
 }
 

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -142,14 +142,14 @@ class SubSendable: SuperSendable {
 
 protocol AbstractSendable {
   func runsInBackground(_: @Sendable () -> Void)
-  func runsInForeground(_: () -> Void) // expected-note {{protocol requires function 'runsInForeground' with type '(() -> Void) -> ()'; do you want to add a stub?}}
-  func runnableInBackground() -> @Sendable () -> Void // expected-note {{protocol requires function 'runnableInBackground()' with type '() -> @Sendable () -> Void'; do you want to add a stub?}}
+  func runsInForeground(_: () -> Void) // expected-note {{expected sendability to match requirement here}}
+  func runnableInBackground() -> @Sendable () -> Void // expected-note {{expected sendability to match requirement here}}
   func runnableInForeground() -> () -> Void
 }
 
-struct ConcreteSendable: AbstractSendable { // expected-error {{type 'ConcreteSendable' does not conform to protocol 'AbstractSendable'}}
+struct ConcreteSendable: AbstractSendable {
   func runsInBackground(_: () -> Void) {}
-  func runsInForeground(_: @Sendable () -> Void) {} // expected-note {{candidate has non-matching type '(@Sendable () -> Void) -> ()'}}
-  func runnableInBackground() -> () -> Void { fatalError() } // expected-note {{candidate has non-matching type '() -> () -> Void'}}
+  func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'runsInForeground' does not match requirement in protocol 'AbstractSendable'; this is an error in Swift 6}}
+  func runnableInBackground() -> () -> Void { fatalError() } // expected-warning {{sendability of function types in instance method 'runnableInBackground()' does not match requirement in protocol 'AbstractSendable'; this is an error in Swift 6}}
   func runnableInForeground() -> @Sendable () -> Void { fatalError() }
 }

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -37,7 +37,7 @@ class Foo: FooType {
 protocol P1 {
   associatedtype A
 
-  func f(_: A) // expected-note {{protocol requires function 'f' with type '(@escaping SendableX1b.A) -> ()' (aka '(@escaping @Sendable (Int) -> Int) -> ()'); do you want to add a stub?}}
+  func f(_: A) // expected-note {{expected sendability to match requirement here}}
 }
 
 struct X1a : P1 {
@@ -61,10 +61,10 @@ struct X1b : P1 {
 //        instead of adjusting types before adding them to the constraint
 //        graph, we should introduce a new constraint kind that allows only a
 //        witness's adjustments.
-struct SendableX1b : P1 { // expected-error {{type 'SendableX1b' does not conform to protocol 'P1'}}
+struct SendableX1b : P1 {
   typealias A = @Sendable (Int) -> Int
 
-  func f(_: (Int) -> Int) { } // expected-note {{candidate has non-matching type '((Int) -> Int) -> ()'}}
+  func f(_: (Int) -> Int) { } // expected-warning {{sendability of function types in instance method 'f' does not match requirement in protocol 'P1'; this is an error in Swift 6}}
 }
 
 struct X1c : P1 {
@@ -78,8 +78,8 @@ struct X1d : P1 {
 }
 
 protocol P2 {
-  func f(_: (Int) -> Int) // expected-note 3 {{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
-  func g(_: @escaping (Int) -> Int) // expected-note 2 {{protocol requires function 'g' with type '(@escaping (Int) -> Int) -> ()'; do you want to add a stub?}}
+  func f(_: (Int) -> Int) // expected-note{{expected sendability to match requirement here}} expected-note 2{{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
+  func g(_: @escaping (Int) -> Int) // expected-note 2 {{expected sendability to match requirement here}}
   func h(_: @Sendable (Int) -> Int) // expected-note 2 {{protocol requires function 'h' with type '(@Sendable (Int) -> Int) -> ()'; do you want to add a stub?}}
   func i(_: @escaping @Sendable (Int) -> Int)
 }
@@ -98,16 +98,16 @@ struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2
   func i(_: @escaping (Int) -> Int) { }
 }
 
-struct X2c : P2 { // expected-error{{type 'X2c' does not conform to protocol 'P2'}}
-  func f(_: @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@Sendable (Int) -> Int) -> ()'}}
-  func g(_: @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@Sendable (Int) -> Int) -> ()'}}
+struct X2c : P2 {
+  func f(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'f' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
+  func g(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
   func h(_: @Sendable (Int) -> Int) { }
   func i(_: @Sendable (Int) -> Int) { }
 }
 
 struct X2d : P2 { // expected-error{{type 'X2d' does not conform to protocol 'P2'}}
   func f(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
-  func g(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
+  func g(_: @escaping @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
   func h(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
   func i(_: @escaping @Sendable (Int) -> Int) { }
 }


### PR DESCRIPTION
For both overloaded methods and protocol witnesses, this PR:

* Allows a non-`@Sendable` function type in the override/witness's parameters to match an `@Sendable` function type in the base/requirement.
* Allows an `@Sendable` function type in the override/witness's results to match a non-`@Sendable` function type in the base/requirement.
* Specially diagnoses any other difference in sendability, and reduces it to a warning in Swift 5 mode.

We'd like these warnings to also go away when `@preconcurrency` is used, but this seems like a reasonable stopping point.

Fixes rdar://91109455.