### PR TITLE
[CSClosure] Handle wrapped variables without explicit initializers

### DIFF
--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -292,3 +292,27 @@ func test_pattern_matches_only_cases() {
     }
   }
 }
+
+// rdar://91225620 - type of expression is ambiguous without more context in closure
+func test_wrapped_var_without_initializer() {
+  @propertyWrapper
+  struct Wrapper {
+    private let name: String
+
+    var wrappedValue: Bool {
+      didSet {}
+    }
+
+    init(name: String) {
+      self.wrappedValue = false
+      self.name = name
+    }
+  }
+
+  func fn(_: () -> Void) {}
+
+  fn {
+    @Wrapper(name: "foo")
+    var v;
+  }
+}


### PR DESCRIPTION
All variables without explicit initializers were considered to be
uninitialized which is incorrect because if a variable has a property
wrapper attached to it that wrapper needs its initializer type-checked,
for example:

```
@propertyWrapper
struct Wrapper {
  var name: String

  ...
}

test {
  @wrapper(name: "wrapper")
  var v;
}
```

`v` gets initialized via a call to `Wrapper(name: "wrapper")`.

Resolves: rdar://91225620

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
