### PR TITLE
[Serialization] Always print the `name` associated to an `XRefError`

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1891,7 +1891,7 @@ giveUpFastPath:
       XRefExtensionPathPieceLayout::readRecord(scratch, ownerID, rawGenericSig);
       M = getModule(ownerID);
       if (!M) {
-        return llvm::make_error<XRefError>("module is not loaded",
+        return llvm::make_error<XRefError>("module with extension is not loaded",
                                            pathTrace, getIdentifier(ownerID));
       }
       pathTrace.addExtension(M);

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -282,7 +282,7 @@ public:
   }
 
   void log(raw_ostream &OS) const override {
-    OS << message << "\n";
+    OS << message << " (" << name << ")\n";
     path.print(OS);
 
     if (!notes.empty()) {


### PR DESCRIPTION
Printing the name will help in the case of xrefs for an extension member and more. This will create errors messages like this in the case of a module with an extension not being loaded:

```
*** DESERIALIZATION FAILURE ***
module 'SomeModule' with full misc version ...
module with extension is not loaded (MyExtensionModule)
Cross-reference to module 'TypesOriginalModule'
... TypeBeingExtended
```

rdar://91316948