### PR TITLE
[CodeCompletion] Don't mark some undesirable imported default values

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -348,7 +348,7 @@ public:
 
   static bool hasInterestingDefaultValue(const ParamDecl *param);
 
-  bool addItemWithoutDefaultArgs(const AbstractFunctionDecl *func);
+  bool shouldAddItemWithoutDefaultArgs(const AbstractFunctionDecl *func);
 
   /// Build argument patterns for calling. Returns \c true if any content was
   /// added to \p Builder. If \p declParams is non-empty, the size must match

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -894,7 +894,7 @@ bool CompletionLookup::hasInterestingDefaultValue(const ParamDecl *param) {
   }
 }
 
-bool CompletionLookup::addItemWithoutDefaultArgs(
+bool CompletionLookup::shouldAddItemWithoutDefaultArgs(
     const AbstractFunctionDecl *func) {
   if (!func || !Sink.addCallWithNoDefaultArgs)
     return false;
@@ -1189,7 +1189,7 @@ void CompletionLookup::addFunctionCallPattern(
     if (isImplicitlyCurriedInstanceMethod) {
       addPattern({AFD->getImplicitSelfDecl()}, /*includeDefaultArgs=*/true);
     } else {
-      if (addItemWithoutDefaultArgs(AFD))
+      if (shouldAddItemWithoutDefaultArgs(AFD))
         addPattern(AFD->getParameters()->getArray(),
                    /*includeDefaultArgs=*/false);
       addPattern(AFD->getParameters()->getArray(),
@@ -1385,7 +1385,7 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
     if (trivialTrailingClosure)
       addMethodImpl(/*includeDefaultArgs=*/false,
                     /*trivialTrailingClosure=*/true);
-    if (addItemWithoutDefaultArgs(FD))
+    if (shouldAddItemWithoutDefaultArgs(FD))
       addMethodImpl(/*includeDefaultArgs=*/false);
     addMethodImpl(/*includeDefaultArgs=*/true);
   }
@@ -1475,7 +1475,7 @@ void CompletionLookup::addConstructorCall(const ConstructorDecl *CD,
     }
   };
 
-  if (ConstructorType && addItemWithoutDefaultArgs(CD))
+  if (ConstructorType && shouldAddItemWithoutDefaultArgs(CD))
     addConstructorImpl(/*includeDefaultArgs=*/false);
   addConstructorImpl();
 }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -873,6 +873,71 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
     Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
 }
 
+/// Return whether \p param has a non-desirable default value for code
+/// completion.
+///
+/// 'ClangImporter::Implementation::inferDefaultArgument()' automatically adds
+/// default values for some parameters;
+///   * NS_OPTIONS enum type with the name '...Options'.
+///   * NSDictionary and labeled 'options', 'attributes', or 'userInfo'.
+///
+/// But sometimes, this behavior isn't really desirable. This function add a
+/// heuristic where if a parameter matches all the following condition, we
+/// consider the imported default value is _not_ desirable:
+///   * it is the first parameter,
+///   * it doesn't have an argument label, and
+///   * the imported function base name ends with those words
+/// For example, ClangImporter imports:
+///
+///   -(void)addAttributes:(NSDictionary *)attrs, options:(NSDictionary *)opts;
+///
+/// as:
+///
+///   func addAttributes(_ attrs: [AnyHashable:Any] = [:],
+///                      options opts: [AnyHashable:Any] = [:])
+///
+/// In this case, we don't want 'attrs' defaulted because the function name have
+/// 'Attribute' in its name so calling 'value.addAttribute()' doesn't make
+/// sense, but we _do_ want to keep 'opts' defaulted.
+///
+/// Note that:
+///
+///   -(void)performWithOptions:(NSDictionary *) opts;
+///
+/// This doesn't match the condition because the base name of the function in
+/// Swift is 'peform':
+///
+///   func perform(options opts: [AnyHashable:Any] = [:])
+///
+bool isNonDesirableImportedDefaultArg(const ParamDecl *param) {
+  auto kind = param->getDefaultArgumentKind();
+  if (kind != DefaultArgumentKind::EmptyArray &&
+      kind != DefaultArgumentKind::EmptyDictionary)
+    return false;
+
+  if (!param->getArgumentName().empty())
+    return false;
+
+  auto *func = dyn_cast<FuncDecl>(param->getDeclContext());
+  if (!func->hasClangNode())
+    return false;
+  if (func->getParameters()->front() != param)
+    return false;
+  if (func->getBaseName().isSpecial())
+    return false;
+
+  auto baseName = func->getBaseName().getIdentifier().str();
+  switch (kind) {
+  case DefaultArgumentKind::EmptyArray:
+    return (baseName.endswith("Options"));
+  case DefaultArgumentKind::EmptyDictionary:
+    return (baseName.endswith("Options") || baseName.endswith("Attributes") ||
+            baseName.endswith("UserInfo"));
+  default:
+    llvm_unreachable("unhandled DefaultArgumentKind");
+  }
+}
+
 bool CompletionLookup::hasInterestingDefaultValue(const ParamDecl *param) {
   if (!param)
     return false;
@@ -880,10 +945,14 @@ bool CompletionLookup::hasInterestingDefaultValue(const ParamDecl *param) {
   switch (param->getDefaultArgumentKind()) {
   case DefaultArgumentKind::Normal:
   case DefaultArgumentKind::NilLiteral:
-  case DefaultArgumentKind::EmptyArray:
-  case DefaultArgumentKind::EmptyDictionary:
   case DefaultArgumentKind::StoredProperty:
   case DefaultArgumentKind::Inherited:
+    return true;
+
+  case DefaultArgumentKind::EmptyArray:
+  case DefaultArgumentKind::EmptyDictionary:
+    if (isNonDesirableImportedDefaultArg(param))
+      return false;
     return true;
 
   case DefaultArgumentKind::None:
@@ -924,7 +993,8 @@ bool CompletionLookup::addCallArgumentPatterns(
     bool hasDefault = false;
     if (!declParams.empty()) {
       const ParamDecl *PD = declParams[i];
-      hasDefault = PD->isDefaultArgument();
+      hasDefault =
+          PD->isDefaultArgument() && !isNonDesirableImportedDefaultArg(PD);
       // Skip default arguments if we're either not including them or they
       // aren't interesting
       if (hasDefault &&

--- a/test/IDE/complete_default_arguments_rdar89051832.swift
+++ b/test/IDE/complete_default_arguments_rdar89051832.swift
@@ -1,0 +1,69 @@
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -batch-code-completion -source-filename %t/test.swift -filecheck %raw-FileCheck -completion-output-dir %t/out -code-completion-annotate-results -import-objc-header %t/ObjC.h -enable-objc-interop %t/Lib.swift 
+// REQUIRES: objc_interop
+
+
+//--- ObjC.h
+@import Foundation;
+
+typedef NS_OPTIONS(NSInteger, MyOptions) {
+  MyOptOne = 1 << 0,
+  MyOptTwo = 1 << 1,
+};
+
+@interface MyObj : NSObject
+// 'opt' should not be defaulted.
+// FIXME: Currently this is considered defaulted because the base name is 'store'.
+- (void)storeOptions:(MyOptions)opts;
+
+// 'opts' should not be defaulted.
+- (void)addOptions:(NSDictionary*)opts;
+
+// 'attrs' should not be defaulted.
+- (void)addAttributes:(NSDictionary *)attrs;
+
+// 'info' should not be defaulted but 'opts' should be.
+- (void)addUserInfo:(NSDictionary *)info options:(MyOptions)opts;
+
+// 'opts' should be defaulted because the base name is 'run'.
+- (void)runWithOptions:(MyOptions)opts;
+
+// 'attrs' should be defaulted because the base name is 'execute'. 
+- (void)executeWithAttributes:(NSDictionary *)attrs;
+@end
+
+//--- Lib.swift
+extension MyObj {
+  // 'attrs' should not be defaulted because this is explicitly written in Swift.
+  func swift_addAttributes(_ attrs : [AnyHashable:Any]! = [:]) {}
+}
+
+//--- test.swift
+func test(value: MyObj) {
+  value.#^COMPLETE^#
+// COMPLETE: Begin completions
+// COMPLETE-NOT: name=addOptions()
+// COMPLETE-NOT: name=addAttributes()
+
+// FIXME: we don't want to suggest 'store()'.
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>store</name>(); typename=<typeid.sys>Void</typeid.sys>; name=store()
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>store</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>opts</callarg.param>: <callarg.type><typeid.user>MyOptions</typeid.user></callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=store(:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>addOptions</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>opts</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=addOptions(:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>addAttributes</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>attrs</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=addAttributes(:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>addUserInfo</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>info</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=addUserInfo(:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>addUserInfo</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>info</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type></callarg>, <callarg><callarg.label>options</callarg.label> <callarg.param>opts</callarg.param>: <callarg.type><typeid.user>MyOptions</typeid.user></callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=addUserInfo(:options:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>run</name>(); typename=<typeid.sys>Void</typeid.sys>; name=run()
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>run</name>(<callarg><callarg.label>options</callarg.label> <callarg.param>opts</callarg.param>: <callarg.type><typeid.user>MyOptions</typeid.user></callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=run(options:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>execute</name>(); typename=<typeid.sys>Void</typeid.sys>; name=execute()
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>execute</name>(<callarg><callarg.label>attributes</callarg.label> <callarg.param>attrs</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=execute(attributes:)
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>swift_addAttributes</name>(); typename=<typeid.sys>Void</typeid.sys>; name=swift_addAttributes()
+// COMPLETE-DAG: Decl[InstanceMethod]/CurrNominal:   <name>swift_addAttributes</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>attrs</callarg.param>: <callarg.type>[<typeid.sys>AnyHashable</typeid.sys> : <keyword>Any</keyword>]!</callarg.type><callarg.default/></callarg>); typename=<typeid.sys>Void</typeid.sys>; name=swift_addAttributes(:)
+
+// COMPLETE-NOT: name=addOptions()
+// COMPLETE-NOT: name=addAttributes()
+// COMPLETE: End completions
+}
+


### PR DESCRIPTION
For ObjC `NS_OPTIONS`/`NSDictionary` parameters with some specific names, ClangImporter implicitly adds default values. However, that behavior is sometimes not really desirable. For example, for:
```objc
  -(void)addAttributes:(NSDictionary *)attrs;
```
`attrs` is defaulted, but calling `addAttributes()` doesn't make any sense. In code-completion, consider such paramters non-defaulted.

rdar://89051832