### PR TITLE
RequirementMachine: Two more minor diagnostics fixes

### DIFF
--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -649,6 +649,14 @@ void swift::rewriting::realizeInheritedRequirements(
                           Type());
     if (!inheritedType) continue;
 
+    // Ignore trivially circular protocol refinement (protocol P : P)
+    // since we diagnose that elsewhere. Adding a rule here would emit
+    // a useless redundancy warning.
+    if (auto *protoDecl = dyn_cast<ProtocolDecl>(decl)) {
+      if (inheritedType->isEqual(protoDecl->getDeclaredInterfaceType()))
+        continue;
+    }
+
     auto *typeRepr = inheritedTypes[index].getTypeRepr();
     SourceLoc loc = (typeRepr ? typeRepr->getStartLoc() : SourceLoc());
     if (shouldInferRequirements) {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -761,6 +761,9 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
 
     // If all rules derived from this structural requirement are redundant,
     // then the requirement is unnecessary in the source code.
+    //
+    // This means the rules derived from this requirement were all
+    // determined to be redundant by homotopy reduction.
     const auto &ruleIDs = pairIt->second;
     if (llvm::all_of(ruleIDs, isRedundantRule)) {
       auto requirement = WrittenRequirements[requirementID];

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -661,6 +661,15 @@ void RewriteSystem::computeRedundantRequirementDiagnostics(
     if (!isInMinimizationDomain(rule.getLHS().getRootProtocol()))
       continue;
 
+    // Concrete conformance rules do not map to requirements in the minimized
+    // signature; we don't consider them to be 'non-explicit non-redundant',
+    // so that a conformance rule (T.[P] => T) expressed in terms of a concrete
+    // conformance (T.[concrete: C : P] => T) is still diagnosed as redundant.
+    if (auto optSymbol = rule.isPropertyRule()) {
+      if (optSymbol->getKind() == Symbol::Kind::ConcreteConformance)
+        continue;
+    }
+
     auto requirementID = rule.getRequirementID();
 
     if (!requirementID.hasValue()) {

--- a/test/Generics/redundant_concrete_conformance.swift
+++ b/test/Generics/redundant_concrete_conformance.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+
+protocol P1 {}
+protocol P2 : P1 {}
+
+protocol P3 {
+  associatedtype A where A == S
+}
+
+struct S : P2 {}
+
+func f1<T : P3>(_: T) where T.A : P1 {}
+// expected-warning@-1 {{redundant conformance constraint 'T.A' : 'P1'}}
+
+func f2<T : P3>(_: T) where T.A : P2 {}
+// expected-warning@-1 {{redundant conformance constraint 'T.A' : 'P2'}}

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 class Left // expected-error {{'Left' inherits from itself}} expected-note {{through reference here}}
     : Right.Hand { // expected-note {{through reference here}}

--- a/test/decl/protocol/conforms/circular_validation.swift
+++ b/test/decl/protocol/conforms/circular_validation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 
 // With a bit of effort, we could make this work -- but for now, let's just
 // not crash.

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
 protocol EmptyProtocol { }
 
 protocol DefinitionsInProtocols {

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -o - -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o - -requirement-machine-inferred-signatures=on
 
 protocol P1 { }
 
@@ -13,7 +13,6 @@ protocol P2 {
 protocol P3 : P2 { }
 
 struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc' : 'P1'}}
-// expected-note@-1{{conformance constraint 'M.Assoc' : 'P1' implied here}}
 
 struct ConformsToP1: P1 { }
 


### PR DESCRIPTION
Remaining tests that still need GSB diagnostics to pass:

```
  Swift(macosx-x86_64) :: Generics/conditional_requirement_inference_in_protocol.swift
  Swift(macosx-x86_64) :: AutoDiff/Sema/differentiable_func_type.swift
  Swift(macosx-x86_64) :: Generics/associated_type_typo.swift
  Swift(macosx-x86_64) :: Generics/protocol_type_aliases.swift
  Swift(macosx-x86_64) :: Generics/requirement_inference.swift
  Swift(macosx-x86_64) :: Generics/rdar75656022.swift
  Swift(macosx-x86_64) :: Generics/rdar77462797.swift
  Swift(macosx-x86_64) :: Compatibility/accessibility.swift
  Swift(macosx-x86_64) :: Generics/function_defs.swift
  Swift(macosx-x86_64) :: Generics/superclass_constraint_nested_type.swift
  Swift(macosx-x86_64) :: IDE/print_usrs_opaque_types.swift
  Swift(macosx-x86_64) :: Sema/accessibility.swift
  Swift(macosx-x86_64) :: decl/typealias/generic.swift
  Swift(macosx-x86_64) :: decl/typealias/protocol.swift
  Swift(macosx-x86_64) :: Constraints/same_types.swift
```