### PR TITLE
[Changelog] fix formatting of recent items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,54 +71,54 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 * [SE-0343][]:
 
-Top-level scripts support asynchronous calls.
+  Top-level scripts support asynchronous calls.
 
-Using an `await` by calling an asynchronous function or accessing an isolated
-variable transitions the top-level to an asynchronous context. As an
-asynchronous context, top-level variables are `@MainActor`-isolated and the
-top-level is run on the `@MainActor`.
+  Using an `await` by calling an asynchronous function or accessing an isolated
+  variable transitions the top-level to an asynchronous context. As an
+  asynchronous context, top-level variables are `@MainActor`-isolated and the
+  top-level is run on the `@MainActor`.
 
-Note that the transition affects function overload resolution and starts an
-implicit run loop to drive the concurrency machinery.
+  Note that the transition affects function overload resolution and starts an
+  implicit run loop to drive the concurrency machinery.
 
-Unmodified scripts are not affected by this change unless `-warn-concurrency` is
-passed to the compiler invocation. With `-warn-concurrency`, variables in the
-top-level are isolated to the main actor and the top-level context is isolated
-to the main actor, but is not an asynchronous context.
+  Unmodified scripts are not affected by this change unless `-warn-concurrency` is
+  passed to the compiler invocation. With `-warn-concurrency`, variables in the
+  top-level are isolated to the main actor and the top-level context is isolated
+  to the main actor, but is not an asynchronous context.
 
 * [SE-0336][]:
 
-It is now possible to declare `distributed actor` and `distributed func`s inside of them.
+  It is now possible to declare `distributed actor` and `distributed func`s inside of them.
 
-Distributed actors provide stronger isolation guarantees than "local" actors, and enable additional checks to be made on return types and parameters of distributed methods, e.g. checking if they conform to `Codable`. Distributed methods can be called on "remote" references of distributed actors, turning those invocations into remote procedure calls, by means of pluggable and user extensible distributed actor system implementations. 
-
-Swift does not provide any specific distributed actor system by itself, however, packages in the ecosystem fulfil the role of providing those implementations.
-
-```swift
-distributed actor Greeter { 
-  var greetingsSent = 0
+  Distributed actors provide stronger isolation guarantees than "local" actors, and enable additional checks to be made on return types and parameters of distributed methods, e.g. checking if they conform to `Codable`. Distributed methods can be called on "remote" references of distributed actors, turning those invocations into remote procedure calls, by means of pluggable and user extensible distributed actor system implementations. 
   
-  distributed func greet(name: String) -> String {
-    greetingsSent += 1
-    return "Hello, \(name)!"
+  Swift does not provide any specific distributed actor system by itself, however, packages in the ecosystem fulfil the role of providing those implementations.
+  
+  ```swift
+  distributed actor Greeter { 
+    var greetingsSent = 0
+    
+    distributed func greet(name: String) -> String {
+      greetingsSent += 1
+      return "Hello, \(name)!"
+    }
   }
-}
-
-func talkTo(greeter: Greeter) async throws {
-  // isolation of distributed actors is stronger, it is impossible to refer to
-  // any stored properties of distributed actors from outside of them:
-  greeter.greetingsSent // distributed actor-isolated property 'name' can not be accessed from a non-isolated context
   
-  // remote calls are implicitly throwing and async, 
-  // to account for the potential networking involved:
-  let greeting = try await greeter.greet(name: "Alice")
-  print(greeting) // Hello, Alice!
-}
-```
+  func talkTo(greeter: Greeter) async throws {
+    // isolation of distributed actors is stronger, it is impossible to refer to
+    // any stored properties of distributed actors from outside of them:
+    greeter.greetingsSent // distributed actor-isolated property 'name' can not be accessed from a non-isolated context
+    
+    // remote calls are implicitly throwing and async, 
+    // to account for the potential networking involved:
+    let greeting = try await greeter.greet(name: "Alice")
+    print(greeting) // Hello, Alice!
+  }
+  ```
 
 * The compiler now emits a warning when a non-final class conforms to a protocol that imposes a same-type requirement between `Self` and an associated type. This is because such a requirement makes the conformance unsound for subclasses.
 
-For example, Swift 5.6 would allow the following code, which at runtime would construct an instance of `C` and not `SubC` as expected:
+  For example, Swift 5.6 would allow the following code, which at runtime would construct an instance of `C` and not `SubC` as expected:
 
   ```swift
   protocol P {
@@ -226,24 +226,24 @@ Swift 5.6
 
 * [SE-0327][]:
 
-In Swift 5 mode, a warning is now emitted if the default-value expression of an
-instance-member property requires global-actor isolation. For example:
+  In Swift 5 mode, a warning is now emitted if the default-value expression of an
+  instance-member property requires global-actor isolation. For example:
 
-```swift
-@MainActor
-func partyGenerator() -> [PartyMember] { fatalError("todo") }
-
-class Party {
-  @MainActor var members: [PartyMember] = partyGenerator()
-  //                                      ^~~~~~~~~~~~~~~~
-  // warning: expression requiring global actor 'MainActor' cannot
-  //          appear in default-value expression of property 'members'
-}
-```
-
-Previously, the isolation granted by the type checker matched the isolation of
-the property itself, but at runtime that is not guaranteed. In Swift 6, 
-such default-value expressions will become an error if they require isolation.
+  ```swift
+  @MainActor
+  func partyGenerator() -> [PartyMember] { fatalError("todo") }
+  
+  class Party {
+    @MainActor var members: [PartyMember] = partyGenerator()
+    //                                      ^~~~~~~~~~~~~~~~
+    // warning: expression requiring global actor 'MainActor' cannot
+    //          appear in default-value expression of property 'members'
+  }
+  ```
+  
+  Previously, the isolation granted by the type checker matched the isolation of
+  the property itself, but at runtime that is not guaranteed. In Swift 6, 
+  such default-value expressions will become an error if they require isolation.
 
 * Actor isolation checking now understands that `defer` bodies share the isolation of their enclosing function.
 


### PR DESCRIPTION
Without these spaces the items break out of the listing.

With them they look correct and are aligned with the `*`

Before: 

The first one is good, the latter ones are bad:
![Screen Shot 2022-04-06 at 16 35 58](https://user-images.githubusercontent.com/120979/161920894-133da56b-b7fc-45f6-b36b-6d0f195bb515.png)


After:

All are good:

![Screen Shot 2022-04-06 at 16 37 05](https://user-images.githubusercontent.com/120979/161921103-ad2f1fb4-981c-4afe-996d-472a1a16f402.png)

