### PR TITLE
[DNM] A suspected Linux testing bug

### DIFF
--- a/test/stdlib/ExpectCrashWithMessage.swift
+++ b/test/stdlib/ExpectCrashWithMessage.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var CrashTest = TestSuite("CrashTest")
+
+CrashTest.test("expectCrashLater(withMessage:)") {
+  var i: Int? = nil
+  expectCrashLater(withMessage: "Unexpectedly found nil while unwrapping an Optional value")
+  _ = i!
+  expectUnreachable()
+  i = 0
+}
+
+runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
A separate attempt to use the function `expectCrashLater(withMessage:)` from `StdlibUnitTest` failed on Linux CI after having worked correctly on macOS. A cursory search suggests that `expectCrashLater(withMessage:)` is essentially unused in the project, despite its apparent long-standing existence.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No SR yet.
