### PR TITLE
[CodeCompletion] Record fixes while solving result builders for code completion

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5276,12 +5276,17 @@ public:
   /// \param allowFreeTypeVariables How to bind free type variables in
   /// the solution.
   ///
+  /// \param recordFixes Whether to record fixes while solving the constraint
+  /// system. Used in code completion so that fixed solutions are produced
+  /// alongside valid ones.
+  ///
   /// \returns true if an error occurred, false otherwise.  Note that multiple
   /// ambiguous solutions for the same constraint system are considered to be
   /// success by this API.
   bool solve(SmallVectorImpl<Solution> &solutions,
              FreeTypeVariableBinding allowFreeTypeVariables =
-                 FreeTypeVariableBinding::Disallow);
+                 FreeTypeVariableBinding::Disallow,
+             bool recordFixes = false);
 
   /// Solve the system of constraints.
   ///

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1390,10 +1390,12 @@ ConstraintSystem::solveImpl(SolutionApplicationTarget &target,
 }
 
 bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
-                             FreeTypeVariableBinding allowFreeTypeVariables) {
+                             FreeTypeVariableBinding allowFreeTypeVariables,
+                             bool recordFixes) {
   // Set up solver state.
   SolverState state(*this, allowFreeTypeVariables);
 
+  state.recordFixes = recordFixes;
   // Solve the system.
   solveImpl(solutions);
 


### PR DESCRIPTION
We record fixes while solving normal expressions for code completion and we should do the same when solving result builders if we are reporting the solutions to completion callbacks.

I noticed this while working on providing type relations inside result builders https://github.com/apple/swift/pull/42210. I chose to make a standalone PR to figure out if it has performance implications on its own.